### PR TITLE
feat(ci): disambiguate publishable_packages_check name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,7 +530,7 @@ jobs:
       # We don't use job-level condition so that matrix.name in the name is pretty-expended even when the job is skipped.
       - id: run-job
         if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-        name: Checking if job should be skipped
+        name: Check if job should be skipped
         run: true
       - uses: actions/checkout@v4
         if: steps.run-job.outcome == 'success'


### PR DESCRIPTION
This should allow us to make the check required on merging, but not required during PR review.

Since matrix is not expanded when job is skipped I added skip check for each step.