### PR TITLE
fix(primitives): remove needless borrow

### DIFF
--- a/core/primitives/src/block_body.rs
+++ b/core/primitives/src/block_body.rs
@@ -73,7 +73,7 @@ impl SpiceCoreStatement {
     pub fn chunk_id(&self) -> &SpiceChunkId {
         match self {
             SpiceCoreStatement::Endorsement(endorsement) => endorsement.chunk_id(),
-            SpiceCoreStatement::ChunkExecutionResult { chunk_id, .. } => &chunk_id,
+            SpiceCoreStatement::ChunkExecutionResult { chunk_id, .. } => chunk_id,
         }
     }
 }


### PR DESCRIPTION
Replace returning &chunk_id with chunk_id in SpiceCoreStatement::chunk_id to avoid creating &&SpiceChunkId. This aligns with match ergonomics, improves readability