### PR TITLE
test(cloud_archive): basic tests for state snapshots in cloud archive

### DIFF
--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -233,7 +233,7 @@ impl<'a> ConfigValidator<'a> {
             }
             return;
         };
-        if self.config.state_sync.is_some() {
+        if self.config.state_sync.is_some() || self.config.state_sync_enabled {
             let error_message =
                 "State sync/dump cannot be configured when cloud archive is enabled; \
                 dump settings are derived from the cloud archival config."
@@ -468,6 +468,28 @@ mod tests {
         cloud_archival_config.location =
             ExternalStorageLocation::S3 { bucket: "".into(), region: "".into() };
         config.cloud_archival = Some(cloud_archival_config);
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "\\nconfig.json semantic issue: State sync/dump cannot be configured when cloud archive is enabled; dump settings are derived from the cloud archival config."
+    )]
+    fn test_cloud_archival_with_state_sync_enabled() {
+        let mut config = Config::default();
+        config.cloud_archival = Some(test_cloud_archival_config(""));
+        config.state_sync_enabled = true;
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "\\nconfig.json semantic issue: State sync/dump cannot be configured when cloud archive is enabled; dump settings are derived from the cloud archival config."
+    )]
+    fn test_cloud_archival_with_state_sync_configured() {
+        let mut config = Config::default();
+        config.cloud_archival = Some(test_cloud_archival_config(""));
+        config.state_sync = Some(Default::default());
         validate_config(&config).unwrap();
     }
 }

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -9,7 +9,7 @@ use near_primitives::types::{AccountId, BlockHeight, BlockHeightDelta};
 use crate::setup::builder::TestLoopBuilder;
 use crate::utils::cloud_archival::{
     gc_and_heads_sanity_checks, pause_and_resume_writer_with_sanity_checks, run_node_until,
-    test_view_client,
+    snapshots_sanity_check, test_view_client,
 };
 
 const MIN_GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
@@ -120,6 +120,7 @@ fn test_cloud_archival_base(params: TestCloudArchivalParameters) {
     if let Some(block_height) = params.test_view_client_at_height {
         test_view_client(&mut env, &archival_id, block_height);
     }
+    snapshots_sanity_check(&mut env, &archival_id, params.num_epochs_to_wait);
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(10));
 }

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -1,12 +1,23 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use borsh::BorshDeserialize;
+
+use itertools::Itertools;
 use near_async::messaging::Handler;
 use near_chain::types::Tip;
-use near_client::GetBlock;
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
+use near_client::{Client, GetBlock};
+use near_primitives::epoch_info::EpochInfo;
+use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::sharding::ChunkHash;
-use near_primitives::types::{AccountId, BlockHeight, BlockHeightDelta, BlockId, BlockReference};
+use near_primitives::types::{
+    AccountId, BlockHeight, BlockHeightDelta, BlockId, BlockReference, EpochHeight, EpochId,
+};
 use near_store::adapter::StoreAdapter;
+use near_store::archive::cloud_storage::CloudStorage;
 use near_store::db::CLOUD_HEAD_KEY;
-use near_store::{COLD_HEAD_KEY, DBCol};
+use near_store::{COLD_HEAD_KEY, DBCol, Store};
 
 use crate::setup::env::TestLoopEnv;
 use crate::utils::node::TestLoopNode;
@@ -14,6 +25,12 @@ use crate::utils::node::TestLoopNode;
 pub fn run_node_until(env: &mut TestLoopEnv, account_id: &AccountId, target_height: BlockHeight) {
     let node = TestLoopNode::for_account(&env.node_datas, account_id);
     node.run_until_head_height(&mut env.test_loop, target_height);
+}
+
+fn execute_future<F: Future>(fut: F) -> F::Output {
+    // If this causes issues, use the testloop future spawner and wait for 0 blocks so the
+    // event loop can run it.
+    futures::executor::block_on(fut)
 }
 
 /// Sanity checks: heads alignment, GC tail bounds, and optional minimum GC progress.
@@ -24,8 +41,7 @@ pub fn gc_and_heads_sanity_checks(
     num_gced_blocks: Option<BlockHeightDelta>,
 ) {
     let cloud_head = get_cloud_head(&env, &writer_id);
-    let archival_node = TestLoopNode::for_account(&env.node_datas, &writer_id);
-    let client = archival_node.client(env.test_loop_data());
+    let client = get_client(env, writer_id);
     let chain_store = client.chain.chain_store();
     let epoch_store = chain_store.epoch_store();
 
@@ -84,6 +100,11 @@ fn stop_and_restart_node(env: &mut TestLoopEnv, node_identifier: &str) {
     env.restart_node(&new_identifier, node_state);
 }
 
+fn get_client<'a>(env: &'a TestLoopEnv, account_id: &'a AccountId) -> &'a Client {
+    let archival_node = TestLoopNode::for_account(&env.node_datas, &account_id);
+    archival_node.client(env.test_loop_data())
+}
+
 /// Returns the cloud archival writer handle for `archival_id`.
 fn get_writer_handle<'a>(
     env: &'a TestLoopEnv,
@@ -94,9 +115,20 @@ fn get_writer_handle<'a>(
     env.test_loop.data.get(writer_handle).as_ref().unwrap()
 }
 
+fn get_hot_store(env: &TestLoopEnv, account_id: &AccountId) -> Store {
+    let node = TestLoopNode::for_account(&env.node_datas, account_id);
+    node.client(env.test_loop_data()).chain.chain_store().store()
+}
+
+fn get_cloud_storage(env: &TestLoopEnv, archival_id: &AccountId) -> Arc<CloudStorage> {
+    let archival_node = TestLoopNode::for_account(&env.node_datas, archival_id);
+    let cloud_storage_handle = &archival_node.data().cloud_storage_sender;
+    let cloud_storage = env.test_loop.data.get(&cloud_storage_handle);
+    cloud_storage.clone().unwrap()
+}
+
 fn get_cloud_head(env: &TestLoopEnv, writer_id: &AccountId) -> BlockHeight {
-    let archival_node = TestLoopNode::for_account(&env.node_datas, writer_id);
-    let hot_store = archival_node.client(env.test_loop_data()).chain.chain_store().store();
+    let hot_store = get_hot_store(env, writer_id);
     hot_store.get_ser::<Tip>(DBCol::BlockMisc, CLOUD_HEAD_KEY).unwrap().unwrap().height
 }
 
@@ -112,4 +144,48 @@ pub fn test_view_client(env: &mut TestLoopEnv, archival_id: &AccountId, height: 
         // TODO(cloud_archival) Implement shard data retrieval from cloud archive
         //let _chunk = view_client.handle(GetChunk::ChunkHash(chunk_hash)).unwrap();
     }
+}
+
+/// Checks that each epoch (except the final one) has a state header uploaded for each
+/// shards. Panics if headers are missing for some shards within an epoch.
+pub fn snapshots_sanity_check(
+    env: &TestLoopEnv,
+    archival_id: &AccountId,
+    final_epoch_height: EpochHeight,
+) {
+    let store = get_hot_store(env, archival_id);
+    let cloud_storage = get_cloud_storage(env, archival_id);
+    let client = get_client(env, archival_id);
+    let mut epoch_heights_with_snapshot = HashSet::<EpochHeight>::new();
+    for entry in store.iter(DBCol::EpochInfo) {
+        let (epoch_id, epoch_info) = entry.unwrap();
+        if epoch_id.as_ref() == AGGREGATOR_KEY {
+            continue;
+        }
+        let epoch_id = EpochId::try_from_slice(epoch_id.as_ref()).unwrap();
+        let epoch_info = EpochInfo::try_from_slice(epoch_info.as_ref()).unwrap();
+        let epoch_height = epoch_info.epoch_height();
+        let shards =
+            client.epoch_manager.get_shard_layout(&epoch_id).unwrap().shard_ids().collect_vec();
+        let mut num_shards_with_snapshot = 0;
+        for shard_id in &shards {
+            let fut = cloud_storage.retrieve_state_header(epoch_height, epoch_id, *shard_id);
+            let state_header = execute_future(fut);
+            if state_header.is_ok() {
+                num_shards_with_snapshot += 1;
+            }
+        }
+        if num_shards_with_snapshot == shards.len() {
+            epoch_heights_with_snapshot.insert(epoch_height);
+        } else if num_shards_with_snapshot > 0 {
+            panic!(
+                "Missing snapshots for some shards at epoch height {} (uploaded {} of {})",
+                epoch_height,
+                num_shards_with_snapshot,
+                shards.len(),
+            )
+        }
+    }
+    // Snapshots for the most recent epoch have not been uploaded yet.
+    assert_eq!(epoch_heights_with_snapshot, HashSet::from_iter(1..final_epoch_height));
 }


### PR DESCRIPTION
**Changes**
- Add tests for config validation to ensure that state sync is disabled when cloud archive is configured.
- Refactor the testloop builder and enable the dumper when the cloud archive writer is configured.
- Add `snapshots_sanity_check` test within the cloud archive testloop as a basic verification that state snapshot upload works with cloud archive.

**Follow-ups**
- Add a test verifying that state parts are correctly uploaded and can be used to reconstruct the state at a given height.