### PR TITLE
feat(spice): move final places to using spice protocol version check

### DIFF
--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -580,7 +580,13 @@ impl ChunkProducer {
         prev_chunk_tx_hashes: HashSet<CryptoHash>,
         tx_validity_period_check: impl Fn(&SignedTransaction) -> bool + Send + 'static,
     ) {
-        if cfg!(feature = "protocol_feature_spice") {
+        // next_epoch_id is epoch_id of the current block (block for which height we are preparing
+        // transactions).
+        let protocol_version = self
+            .epoch_manager
+            .get_epoch_protocol_version(&prev_block_context.next_epoch_id)
+            .unwrap();
+        if ProtocolFeature::Spice.enabled(protocol_version) {
             return;
         }
 

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -465,7 +465,7 @@ impl Block {
         // With spice chunks wouldn't contain prev_state_roots.
         // TODO(spice): check that block's state_root matches state_root corresponding to chunks of
         // the appropriate executed block from the past.
-        if !cfg!(feature = "protocol_feature_spice") {
+        if !self.is_spice_block() {
             let state_root = self.chunks().compute_state_root();
             if self.header().prev_state_root() != &state_root {
                 return Err(InvalidStateRoot);


### PR DESCRIPTION
This migrates the last places in which at this time it's feasible to use protocol version instead of compilation flag.

Here is the summary of where we still use cargo feature:
- checks during gc: spice-only db columns are behind cargo feature;
- test-loop setup;
- saving all next block hashes: this is spice-only db columns which is behind cargo feature;
- creating spice actors for node and starting of spice actors: we want to enable this only in the release that would migrate to spice;
- state sync: we should disable this once we implement stat sync support for spice;
- view client actor querying: we would need to implement support for getting blocks by new references and decide what to do during transitional time.

Let me know if you think some of them can be migrated to depend on protocol version check right now as well.

Refs https://github.com/near/nearcore/issues/14489