### PR TITLE
feat(epoch-sync): implement cold store db migration for continuous epoch sync

### DIFF
--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -47,11 +47,6 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
                 &self.config.genesis.config,
                 &self.config.config.store,
             ),
-            47 => migrate_47_to_48(
-                hot_store,
-                cold_db,
-                self.config.genesis.config.transaction_validity_period,
-            ),
             DB_VERSION.. => unreachable!(),
         }
     }


### PR DESCRIPTION
This is a follow up of PR https://github.com/near/nearcore/pull/14749 to implement the cold store db migration.

Right now, we have  `DBCol::BlockHeader` populated for the hot store from genesis to blockchain head. As part of the cold store migration, we need to transfer this data from the hot store to the cold store.

This is done by having a raw iterator on top of of the hot_db `DBCol::BlockHeader` column and writing data directly to the cold_db `DBCol::BlockHeader` column.

I tested this on mainnet archival nodes and the process takes about 3 hours. It's possible to potentially parallelize this make this faster, but we would need to be careful about RocksDB cache etc.

As next steps, we would implement
- GC for block headers
- Continuous epoch sync, updating the proof