### PR TITLE
feat(epoch-sync): implement function to extend epoch sync proof by one epoch

### DIFF
--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -9,7 +9,7 @@ use near_client_primitives::types::{EpochSyncStatus, SyncStatus};
 use near_crypto::Signature;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::epoch_sync::{
-    derive_epoch_sync_proof_from_last_final_block, find_target_epoch_to_produce_proof_for,
+    derive_epoch_sync_proof_from_last_block, find_target_epoch_to_produce_proof_for,
     get_epoch_info_block_producers,
 };
 use near_network::client::{EpochSyncRequestMessage, EpochSyncResponseMessage};
@@ -106,7 +106,7 @@ impl EpochSync {
         }
         // We're purposefully not releasing the lock here. This is so that if the cache
         // is out of date, only one thread should be doing the computation.
-        let proof = derive_epoch_sync_proof_from_last_final_block(
+        let proof = derive_epoch_sync_proof_from_last_block(
             &store.epoch_store(),
             &target_epoch_last_block_hash,
         );

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -1,6 +1,6 @@
 use near_chain::{Error, LatestKnown};
 use near_epoch_manager::epoch_sync::{
-    derive_epoch_sync_proof_from_last_final_block, find_target_epoch_to_produce_proof_for,
+    derive_epoch_sync_proof_from_last_block, find_target_epoch_to_produce_proof_for,
 };
 use near_primitives::epoch_sync::EpochSyncProof;
 use near_primitives::types::BlockHeightDelta;
@@ -128,7 +128,7 @@ fn update_epoch_sync_proof(
         find_target_epoch_to_produce_proof_for(&store, transaction_validity_period)?;
 
     tracing::info!(target: "migrations", ?last_block_hash, "deriving epoch sync proof from last final block");
-    let proof = derive_epoch_sync_proof_from_last_final_block(&epoch_store, &last_block_hash)?;
+    let proof = derive_epoch_sync_proof_from_last_block(&epoch_store, &last_block_hash)?;
 
     tracing::info!(target: "migrations", "storing latest epoch sync proof");
     let mut store_update = epoch_store.store_update();


### PR DESCRIPTION
This PR adds the core functionality of adding the function `extend_epoch_sync_proof`.

While at it, the function `derive_epoch_sync_proof_from_last_final_block` is also updated to take the `last_block_hash` as parameter instead of `next_block_header_after_last_final_block_of_current_epoch`.

There is some refactoring involved for the function `derive_epoch_sync_proof_from_last_final_block` to reuse some of the functions between itself and `extend_epoch_sync_proof` but there should be functionality or logic change for `derive_epoch_sync_proof_from_last_final_block`.

**_This PR requires careful review._**

For testing these changes I plan to do the following in **follow up PRs**
- Write a test loop test to verify the extend epoch sync proof functionality. A part of it is already implemented in https://github.com/near/nearcore/compare/master...shreyan/epoch-sync/all-changes
- Add a debug assert that verifies the extended proof is the same as the proof generated from scratch. Over time once we gain confidence, we can remove the debug assert.