### PR TITLE
feat(release): add continuous release scenario

### DIFF
--- a/pytest/tests/mocknet/forknet_scenarios/base.py
+++ b/pytest/tests/mocknet/forknet_scenarios/base.py
@@ -77,25 +77,41 @@ class TestSetup:
     def __init__(self, args):
         self.args = args
         # The forknet image height.
-        self.args.start_height = None
-        self.start_height = None
+        self.start_height = args.start_height
         # The unique id of the forknet.
         self.unique_id = args.unique_id
-
+        # The genesis protocol version.
+        self.genesis_protocol_version = getattr(args,
+                                                'genesis_protocol_version',
+                                                None)
         self.has_archival = False
         self.has_state_dumper = False
         self.tracing_server = False
         # The GCP regions to be used for the nodes.
         self.regions = None
         # Hardware configuration for validators
-        self.node_hardware_config = NodeHardware.SameConfig(
-            num_chunk_producer_seats=0, num_chunk_validator_seats=0)
+        self.node_hardware_config = None
         # The base binary url to be used for the nodes.
-        self.neard_binary_url = getattr(args, 'neard_binary_url', '')
+        self.neard_binary_url = getattr(args, 'neard_binary_url', None)
         self.upgrade_delay_minutes = 0
         # The new binary url to be used for the nodes.
         self.neard_upgrade_binary_url = getattr(args,
-                                                'neard_upgrade_binary_url', '')
+                                                'neard_upgrade_binary_url',
+                                                None)
+
+    def fail_if_args_not_set(self):
+        """
+        Fail if the required arguments are not set.
+        """
+        if self.start_height is None:
+            raise ValueError("Start height is not set")
+        if self.genesis_protocol_version is None:
+            raise ValueError("Genesis protocol version is not set")
+        if self.neard_binary_url is None:
+            raise ValueError("Neard binary url is not set")
+        if self.node_hardware_config is None:
+            raise ValueError("Node hardware config is not set")
+        return self
 
     def _needs_upgrade(self):
         """

--- a/pytest/tests/mocknet/forknet_scenarios/test_release_candidate.py
+++ b/pytest/tests/mocknet/forknet_scenarios/test_release_candidate.py
@@ -1,0 +1,79 @@
+"""
+Test case classes for release tests on forknet.
+"""
+from .base import TestSetup, NodeHardware
+
+import copy
+from utils import PartitionSelector
+from datetime import datetime, timedelta
+
+
+class TestReleaseCandidate(TestSetup):
+    """
+    Test case:
+    - Runs an upgrade test from the previous release to the current release candidate.
+    Features:
+        - Shard shuffle for chunk producers to enable state sync.
+        - No state dumper.
+        - Upgrade happens over 2 epochs.
+        - Archival nodes.
+        - 1 producer per shard
+        - 2 validators.
+
+    Required arguments:
+        - neard_binary_url: The URL of the starting neard binary.
+        - neard_upgrade_binary_url: The URL of the neard binary to upgrade to.
+        - genesis_protocol_version: The starting protocol version to use for the network.
+    """
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.node_hardware_config = NodeHardware.SameConfig(
+            num_chunk_producer_seats=9, num_chunk_validator_seats=11)
+        self.epoch_len = 10000  # 10000 blocks / 2 bps / 60 / 60 = 1h 40m
+        self.has_state_dumper = False
+        self.has_archival = True
+        self.regions = "us-east1,europe-west4,asia-east1,us-west1"
+
+        # Upgrade 1/2 nodes in the second epoch. A quarter at a time.
+        self.upgrade_interval_minutes = 15  # 15 minutes between each upgrade batch.
+        self.upgrade_delay_minutes = 120  # 2 hours after the test starts. This falls in the second and third epochs.
+
+    def amend_epoch_config(self):
+        super().amend_epoch_config()
+        self._amend_epoch_config(
+            ".shuffle_shard_assignment_for_chunk_producers = true")
+
+    def _upgrade_nodes_in_four_batches(self):
+        """
+        Upgrade the nodes in two steps, upgrade_delay_minutes apart.
+        At each step, we upgrade half of the nodes at a time.
+        In total, we upgrade in 4 batches.
+        """
+        first_upgrade_time = datetime.now() + timedelta(
+            minutes=self.upgrade_delay_minutes)
+        second_upgrade_time = first_upgrade_time + timedelta(
+            minutes=self.upgrade_delay_minutes)
+
+        upgrade_time = [
+            batch_start_time +
+            timedelta(minutes=i * self.upgrade_interval_minutes)
+            for batch_start_time in [first_upgrade_time, second_upgrade_time]
+            for i in range(0, 2)
+        ]
+        batches = len(upgrade_time)
+        for quarter, batch_start_time in enumerate(upgrade_time):
+            self.schedule_binary_upgrade(batch_start_time,
+                                         0,
+                                         binary_idx=1,
+                                         partition=PartitionSelector(
+                                             partitions_range=(quarter + 1,
+                                                               quarter + 1),
+                                             total_partitions=batches))
+
+    def after_test_start(self):
+        """
+        Use this event to run any commands after the test is started.
+        """
+        super().after_test_start()
+        self._upgrade_nodes_in_four_batches()


### PR DESCRIPTION
This scenario is parameterized by the source binary, destination binary, starting protocol version, and the node image.

Below is an example invocation that the GitHub Action will run, using the parameters available at execution time.
```
python tests/mocknet/forknet_scenario.py 
    --unique-id rc-test 
    --start-height 160684617 
    --test-case TestReleaseCandidate 
    start 
    --genesis-protocol-version 82 
    --neard-binary-url https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux-x86_64/2.10.2/neard 
    --neard-upgrade-binary-url https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux-x86_64/master/neard
```


- `neard-binary-url` points to the most recent version currently going through the release process, from either testnet or mainnet (whichever is newer).

- `neard-upgrade-binary-url` points to the binary built from the current master branch.

- `genesis-protocol-version` is the latest protocol version supported by `neard-binary-url`.