### PR TITLE
fix: correct state sync compression level error message

### DIFF
--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -150,7 +150,7 @@ impl<'a> ConfigValidator<'a> {
         }
         if state_sync.parts_compression_lvl < -22 || state_sync.parts_compression_lvl > 22 {
             let error_message = format!(
-                "'config.state_sync.dump.parts_compression_lvl': {}, should be an integer between -22 and 22.",
+                "'config.state_sync.parts_compression_lvl': {}, should be an integer between -22 and 22.",
                 state_sync.parts_compression_lvl,
             );
             self.validation_errors.push_config_semantics_error(error_message);


### PR DESCRIPTION
The error message for parts_compression_lvl incorrectly referenced config.state_sync.dump.parts_compression_lvl, while the field actually lives on StateSyncConfig as config.state_sync.parts_compression_lvl. This change updates the message to point to the real config path so users can quickly locate and fix the offending field in their config.json.