### PR TITLE
perf: Avoid unnecessary parsing for invalid send_tx params arrays

### DIFF
--- a/chain/jsonrpc/src/api/transactions.rs
+++ b/chain/jsonrpc/src/api/transactions.rs
@@ -21,7 +21,7 @@ impl RpcRequest for RpcSendTransactionRequest {
                     wait_until: Default::default(),
                 })
             })
-            .try_pair(|_: String, _: String| {
+            .try_pair(|_: Value, _: Value| {
                 // Here, we restrict serde parsing object from the array
                 // `wait_until` is a new feature supported only in object
                 Err(RpcParseError(


### PR DESCRIPTION
Changed RpcSendTransactionRequest::parse to stop deserializing two-element params arrays into String values that are immediately discarded. The try_pair closure now operates on serde_json::Value, so invalid [signed_tx_base64, wait_until] arrays are still rejected with the same RpcParseError, but we avoid extra serde_json::from_value::<String> calls and allocations on an error path. Supported request formats ([signed_tx_base64] and the object form with optional wait_until) remain unchanged.