### PR TITLE
chore(test): non-nightly contract in test as DeterministicAccountId is stable

### DIFF
--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -69,7 +69,6 @@ extern "C" {
     fn promise_and(promise_idx_ptr: u64, promise_idx_count: u64) -> u64;
     fn promise_batch_create(account_id_len: u64, account_id_ptr: u64) -> u64;
     fn promise_batch_then(promise_index: u64, account_id_len: u64, account_id_ptr: u64) -> u64;
-    #[cfg(feature = "nightly")]
     fn promise_set_refund_to(promise_index: u64, account_id_len: u64, account_id_ptr: u64);
     // #######################
     // # Promise API actions #
@@ -1918,7 +1917,3 @@ pub unsafe fn resume_with_large_payload() {
     );
     assert_eq!(success, 1);
 }
-
-/// local NO-OP placeholder function, to be removed on stabilization of DeterministicAccountIds
-#[cfg(not(feature = "nightly"))]
-fn promise_set_refund_to(_promise_index: u64, _account_id_len: u64, _account_id_ptr: u64) {}

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -1218,12 +1218,7 @@ fn test_create_transfer_64len_hex_fail() {
 // redirect the balance refund using `promise_refund_to`
 #[test]
 fn test_refund_to() {
-    let test_contract = if ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
-        near_test_contracts::nightly_rs_contract()
-    } else {
-        near_test_contracts::rs_contract()
-    };
-    let group = RuntimeGroup::new(4, 4, &test_contract);
+    let group = RuntimeGroup::new(4, 4, near_test_contracts::rs_contract());
 
     let signer_sender = group.signers[0].clone();
     let signer_receiver = group.signers[1].clone();


### PR DESCRIPTION
DeterministicAccountId is already stable so we don't need this switch anymore.