### PR TITLE
fix(state-sync): use a multi-thread spawner

### DIFF
--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -623,7 +623,7 @@ pub async fn start_with_config_and_synchronization_impl(
         shard_tracker.clone(),
         runtime.clone(),
         node_id,
-        state_sync_spawner.clone(),
+        state_sync_spawner,
         network_adapter.as_multi_sender(),
         shards_manager_adapter.as_sender(),
         config.validator_signer.clone(),
@@ -701,7 +701,7 @@ pub async fn start_with_config_and_synchronization_impl(
         shard_tracker: shard_tracker.clone(),
         runtime,
         validator: config.validator_signer.clone(),
-        future_spawner: state_sync_spawner,
+        future_spawner: actor_system.new_future_spawner("state sync dumper").into(),
     };
     state_sync_dumper.start()?;
 


### PR DESCRIPTION
This PR switches state sync to having its own tokio runtime as a temporary fix, restoring 2.9.x behavior.

When switching to the actor framework, the runtime that is created and used to drive futures has only 1 thread.
This is problematic for state-sync performance.