### PR TITLE
perf: avoid double iteration over chunk transactions in store validator

### DIFF
--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -360,9 +360,6 @@ pub(crate) fn chunk_tx_exists(
     for tx in shard_chunk.to_transactions() {
         let tx_hash = tx.get_hash();
         sv.inner.tx_refcount.entry(tx_hash).and_modify(|x| *x += 1).or_insert(1);
-    }
-    for tx in shard_chunk.to_transactions() {
-        let tx_hash = tx.get_hash();
         unwrap_or_err_db!(
             sv.store.get_ser::<SignedTransaction>(DBCol::Transactions, tx_hash.as_ref()),
             "Can't get Tx from storage for Tx Hash {:?}",


### PR DESCRIPTION
Updated chunk_tx_exists in chain/chain/src/store_validator/validate.rs to iterate over ShardChunk::to_transactions() only once. Previously the function made two full passes over the same slice of transactions, recomputing each transaction hash twice: first to update tx_refcount and then to check existence in DBCol::Transactions. The new implementation performs both the refcount update and the storage lookup inside a single loop, preserving existing error semantics while reducing redundant work and bringing the pattern in line with how receipt refcounts are handled.