### PR TITLE
docs: clarify highest_height_peers and unreliable_peers comments

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -447,7 +447,7 @@ impl PeerManagerActor {
             .filter_map(|p| p.full_peer_info().into())
             .collect();
 
-        // This finds max height among peers, and returns one peer close to such height.
+        // This finds max height among peers, and returns all peers close to such height.
         let max_height = match infos.iter().map(|i| i.highest_block_height).max() {
             Some(height) => height,
             None => return vec![],
@@ -475,8 +475,9 @@ impl PeerManagerActor {
             return HashSet::new();
         };
         let my_height = chain_info.block.header().height();
-        // Find all peers whose height is below `highest_peer_horizon` from max height peer(s).
-        // or the ones we don't have height information yet
+        // Find all peers whose last known height lags behind our height by more than
+        // UNRELIABLE_PEER_HORIZON blocks. Peers without known height are currently treated
+        // as reliable.
         self.state
             .tier2
             .load()


### PR DESCRIPTION
Align comments in PeerManagerActor with the actual behavior of highest_height_peers and unreliable_peers. The highest_height_peers helper now explicitly states that it returns all peers close to the maximum height, not just one. The unreliable_peers comment now describes selection based on our own head height and UNRELIABLE_PEER_HORIZON, and clarifies that peers without known height are not treated as unreliable