### PR TITLE
chore: remove unused DebugRpcEpochInfoRequest

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1885,13 +1885,6 @@ async fn deprecated_debug_block_status_handler(
         Err(_) => StatusCode::SERVICE_UNAVAILABLE.into_response(),
     }
 }
-
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
-pub struct DebugRpcEpochInfoRequest {
-    #[serde(flatten)]
-    pub epoch_id: near_primitives::types::EpochId,
-}
-
 async fn debug_epoch_info_handler(
     State(handler): State<Arc<JsonRpcHandler>>,
     Path(epoch_id_str): Path<String>,


### PR DESCRIPTION
The DebugRpcEpochInfoRequest struct was never referenced in the codebase, not wired into any Axum handler or OpenAPI schema, and had no callers in other crates. The debug epoch info endpoints use path parameters directly instead. Removing this dead type simplifies the jsonrpc crate without changing any RPC behavior.