### PR TITLE
fix: do not wait for py tests coverage reporting on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,11 +499,6 @@ jobs:
           flags: unittests-nightly
       - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
         with:
-          files: py.json
-          fail_ci_if_error: false
-          flags: pytests
-      - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
-        with:
           files: py-nightly.json
           fail_ci_if_error: false
           flags: pytests-nightly

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 4 # Keep in sync with .github/workflows/ci.yml
+    after_n_builds: 3 # Keep in sync with .github/workflows/ci.yml
   # Dear h4xx0rz reading this,
   # Feel free to use this token to upload arbitrary coverage information to codecov.
   # We do not care. The best you can do is make us facepalm.


### PR DESCRIPTION
Since
https://github.com/near/nearcore/commit/d063bd0d11ada838d29c411d056405717877004d we don't run large pytests as part of PR CI. However in that change we missed to adjust coverage configuration to stop waiting for coverage data for large pytests. Because of this coverage reporting on PRs was broken since.

Here is a sample recent run to illustrate missing artifacts: https://github.com/near/nearcore/actions/runs/20646203053?pr=14837 and related codecov link: https://app.codecov.io/github/near/nearcore/commit/125e6159f3f4f60e80b430faf2c102ac6ffee3b4