### PR TITLE
fix(indexer): properly set actions for local receipts

### DIFF
--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -3,7 +3,7 @@ use near_parameters::RuntimeConfig;
 use near_primitives::action::Action;
 use near_primitives::receipt::Receipt;
 use near_primitives::types::Balance;
-use near_primitives::views::{ExecutionStatusView, ReceiptView};
+use near_primitives::views::{ExecutionStatusView, ReceiptEnumView, ReceiptView};
 use node_runtime::config::calculate_tx_cost;
 
 use crate::INDEXER;
@@ -33,15 +33,23 @@ pub(crate) fn convert_transactions_sir_into_local_receipts<'a>(
         let cost =
             calculate_tx_cost(&tx.receiver_id, &tx.signer_id, &actions, &runtime_config, gas_price)
                 .unwrap();
+        // Use empty actions here and clone actions from transactions later.
+        // Note that we cannot just pass `actions` here since conversion
+        // ActionView -> Action -> ActionView does not always preserve the
+        // content of the action.
         let receipt = Receipt::from_tx(
             receipt_id,
             tx.signer_id.clone(),
             tx.receiver_id.clone(),
             tx.public_key.clone(),
             cost.receipt_gas_price,
-            actions,
+            vec![],
         );
-        let receipt_view: ReceiptView = receipt.into();
+        let mut receipt_view: ReceiptView = receipt.into();
+        let ReceiptEnumView::Action { actions, .. } = &mut receipt_view.receipt else {
+            unreachable!("transaction is expected to be converted to an action receipt");
+        };
+        actions.clone_from(&indexer_tx.transaction.actions);
         local_receipts.push(receipt_view);
     }
     local_receipts

--- a/test-loop-tests/src/tests/indexer.rs
+++ b/test-loop-tests/src/tests/indexer.rs
@@ -8,7 +8,10 @@ use near_async::time::Duration;
 use near_client::NetworkAdversarialMessage;
 use near_client::client_actor::AdvProduceChunksMode;
 use near_crypto::Signer;
-use near_indexer::{AwaitForNodeSyncedEnum, IndexerConfig, StreamerMessage, SyncModeEnum, start};
+use near_indexer::{
+    AwaitForNodeSyncedEnum, IndexerConfig, IndexerExecutionOutcomeWithReceipt, StreamerMessage,
+    SyncModeEnum, start,
+};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
@@ -17,7 +20,7 @@ use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
 use near_primitives::types::{AccountId, Balance, Finality, Nonce, NumBlocks};
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
-use near_primitives::views::ExecutionStatusView;
+use near_primitives::views::{ActionView, ExecutionStatusView, ReceiptEnumView, ReceiptView};
 use near_store::StoreConfig;
 use tokio::sync::mpsc;
 
@@ -170,6 +173,38 @@ fn test_indexer_failed_local_tx() {
     assert_matches!(outcome.status, ExecutionStatusView::Failure(_));
     assert!(outcome.receipt_ids.is_empty());
     assert!(indexer_shard.receipt_execution_outcomes.is_empty());
+
+    shutdown(env);
+}
+
+#[test]
+// TODO(spice): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_indexer_deploy_contract_local_tx() {
+    init_test_logger();
+    let mut env = setup();
+    deploy_test_contract(&mut env);
+    let validator_node = TestLoopNode::from(&env.node_datas[0]);
+    let deploy_contract_height = validator_node.head(env.test_loop_data()).height;
+
+    let mut indexer_receiver =
+        start_indexer(&env, SyncModeEnum::BlockHeight(deploy_contract_height));
+    let msg = receive_indexer_message(&mut env, &mut indexer_receiver);
+    let indexer_shard = &msg.shards[0];
+    assert_eq!(indexer_shard.chunk.as_ref().unwrap().transactions.len(), 1);
+    let [
+        IndexerExecutionOutcomeWithReceipt {
+            receipt: ReceiptView { receipt: ReceiptEnumView::Action { actions, .. }, .. },
+            ..
+        },
+    ] = indexer_shard.receipt_execution_outcomes.as_slice()
+    else {
+        panic!("expected single action receipt")
+    };
+    let [ActionView::DeployContract { code }] = actions.as_slice() else {
+        panic!("expected single deploy contract action")
+    };
+    assert_eq!(code, CryptoHash::hash_bytes(near_test_contracts::rs_contract()).as_bytes());
 
     shutdown(env);
 }


### PR DESCRIPTION
Currently we convert action views from transaction view to `Action` and then back to `ActionView` when creating `ReceiptView`:
```
        let actions: Vec<_> =
            tx.actions.iter().cloned().map(Action::try_from).map(Result::unwrap).collect();
        ...
        let receipt = Receipt::from_tx(
            ...
            actions,
        );
        let receipt_view: ReceiptView = receipt.into();
```

This results in `code` as part of `ActionView::DeployContract` being set to `hash(hash(contract_code))` instead of intended `hash(code)`. The same applies to `DeployGlobalContract` and `DeployGlobalContractByAccountId` actions.

The regression was introduced in #14426. Also see [zulip](https://near.zulipchat.com/#narrow/channel/295558-core/topic/nearblocks.20Deploy.20Global.20Contract.20code_hash.20mismatch/with/565061377) for additional context.