### PR TITLE
refactor: remove unused StakeFirstShardAssignmentItem helper

### DIFF
--- a/chain/epoch-manager/src/shard_assignment.rs
+++ b/chain/epoch-manager/src/shard_assignment.rs
@@ -35,22 +35,6 @@ struct ValidatorsFirstShardAssignmentItem {
 }
 
 type ValidatorsFirstShardAssignment = MinHeap<ValidatorsFirstShardAssignmentItem>;
-
-/// A helper struct to maintain the shard assignment sorted by the stake
-/// assigned to each shard.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct StakeFirstShardAssignmentItem {
-    stake: Balance,
-    validators: usize,
-    shard_index: ShardIndex,
-}
-
-impl From<ValidatorsFirstShardAssignmentItem> for StakeFirstShardAssignmentItem {
-    fn from(v: ValidatorsFirstShardAssignmentItem) -> Self {
-        Self { validators: v.validators, stake: v.stake, shard_index: v.shard_index }
-    }
-}
-
 fn assign_to_satisfy_shards_inner<T: HasStake + Eq, I: Iterator<Item = (usize, T)>>(
     shard_assignment: &mut ValidatorsFirstShardAssignment,
     result: &mut Vec<Vec<T>>,


### PR DESCRIPTION
`StakeFirstShardAssignmentItem` and its `From<ValidatorsFirstShardAssignmentItem>` implementation were never used anywhere in the codebase. They appear to be a leftover from an earlier version of the shard assignment algorithm that was not fully adopted.
Removing this dead helper type simplifies shard_assignment.rs, reduces cognitive load for future readers and makes it clearer which data structures are actually involved in the shard assignment logic