### PR TITLE
fix(jsonrpc): handle invalid epoch id in debug handler

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1889,7 +1889,10 @@ async fn debug_epoch_info_handler(
     State(handler): State<Arc<JsonRpcHandler>>,
     Path(epoch_id_str): Path<String>,
 ) -> Response {
-    let epoch_id: near_primitives::types::EpochId = epoch_id_str.parse().unwrap();
+    let epoch_id: near_primitives::types::EpochId = match epoch_id_str.parse() {
+        Ok(epoch_id) => epoch_id,
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
+    };
     match handler.debug_epoch_info(Some(epoch_id)).await {
         Ok(Some(value)) => (StatusCode::OK, Json(value)).into_response(),
         Ok(None) => StatusCode::METHOD_NOT_ALLOWED.into_response(),


### PR DESCRIPTION
The debug_epoch_info_handler used epoch_id_str.parse().unwrap(), which allowed a malformed epoch_id path segment to panic the process when debug RPC endpoints are enabled. This change parses EpochId safely and returns HTTP 400 Bad Request on invalid input, preserving node stability while keeping the existing behavior for valid epoch ids.