### PR TITLE
perf: avoid recompiling state part filename regex

### DIFF
--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -2,7 +2,9 @@ use crate::metrics;
 use near_chain_configs::ExternalStorageLocation;
 use near_external_storage::{ExternalConnection, S3AccessConfig};
 use near_primitives::types::{EpochId, ShardId};
+use regex::Regex;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use std::time::Instant;
 
 #[derive(Debug, Clone)]
@@ -204,9 +206,11 @@ pub fn part_filename(part_id: u64, num_parts: u64) -> String {
     format!("state_part_{:06}_of_{:06}", part_id, num_parts)
 }
 
+static STATE_PART_FILENAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^state_part_(\d{6})_of_(\d{6})$").unwrap());
+
 pub fn match_filename(s: &str) -> Option<regex::Captures> {
-    let re = regex::Regex::new(r"^state_part_(\d{6})_of_(\d{6})$").unwrap();
-    re.captures(s)
+    STATE_PART_FILENAME_RE.captures(s)
 }
 
 pub fn is_part_filename(s: &str) -> bool {


### PR DESCRIPTION
Use a lazily initialized Regex for state part filename parsing in chain/client/src/sync/external.rs instead of compiling the same pattern on every call. This code runs in tight loops over many objects in external storage (state sync dumper and related tools), so repeated Regex::new calls were wasting CPU and allocations.

The change introduces a static LazyLock<Regex> and reuses it in match_filename, without changing the public API or behavior of any helpers. This follows the regex crate’s recommendation to avoid recompiling patterns in a loop while keeping the implementation simple and thread-safe.