### PR TITLE
fix(trie): correct TrieQueue::pop_n docs and assertion

### DIFF
--- a/core/store/src/trie/receipts_column_helper.rs
+++ b/core/store/src/trie/receipts_column_helper.rs
@@ -183,8 +183,8 @@ pub trait TrieQueue {
         Ok(())
     }
 
-    /// Remove up to `n` values from the end of the queue and return how many
-    /// were actually remove.
+    /// Remove up to `n` values from the front of the queue and return how many
+    /// were actually removed.
     ///
     /// Unlike `pop`, this method does not return the actual items or even
     /// check if they existed in state.
@@ -206,7 +206,7 @@ pub trait TrieQueue {
             self.indices_mut().first_index = indices
                 .first_index
                 .checked_add(to_remove)
-                .expect("first_index + to_remove should be < next_available_index");
+                .expect("first_index + to_remove should be <= next_available_index");
             self.write_indices(state_update);
         }
         Ok(to_remove)


### PR DESCRIPTION
`TrieQueue::pop_n` was documented as removing items from the end of the queue, but the implementation and all callers (including congestion control and randomized tests) treat it as a batched removal from the front. This change updates the comment to describe removal from the front and fixes the internal expect message to use the correct `<= next_available_index` invariant, keeping behavior unchanged but making the API contract and diagnostics accurate.