### PR TITLE
scripts: refine unsafe shell execution and URL handling

### DIFF
--- a/scripts/nodelib.py
+++ b/scripts/nodelib.py
@@ -140,6 +140,10 @@ def check_and_setup(nodocker,
             url = (
                 "https://s3-us-west-1.amazonaws.com/testnet.nearprotocol.com/testnet_genesis_records_%s.json"
                 % testnet_genesis_hash)
+            # Basic scheme check to ensure we only fetch via http/https
+            if not url.startswith(("http://", "https://")):
+                print("Error: Invalid genesis URL scheme.")
+                exit(1)
             urllib.urlretrieve(url, testnet_genesis_records)
         init_flags.extend([
             "--genesis-config",


### PR DESCRIPTION
Cleaned up some brittle logic in the support scripts.

The coverage script was using shell=True with wildcards for cleanup, which can fail or behave unexpectedly depending on the environment. Switched that over to native Python glob and directory handling.

Also updated nodelib to be more careful with external fetches. Using urlretrieve directly without checking schemes is a bit risky if the source URL is ever influenced by external configs. Added a basic check to ensure we're only dealing with http/https.