### PR TITLE
debug: instrumentation for sandbox_patch_state race condition

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1582,6 +1582,15 @@ impl JsonRpcHandler {
             .await
             .map_err(RpcFrom::rpc_from)?;
 
+        {
+            use std::io::Write;
+            if let Ok(mut f) =
+                std::fs::OpenOptions::new().create(true).append(true).open("/tmp/sandbox_debug.log")
+            {
+                let _ = writeln!(f, "[RPC_WAIT_START] waiting for patch_state_in_progress=false");
+            }
+        }
+
         timeout(self.polling_config.polling_timeout, async {
             loop {
                 let patch_state_finished = self
@@ -1594,6 +1603,15 @@ impl JsonRpcHandler {
                     near_client_primitives::types::SandboxResponse::SandboxPatchStateFinished(true),
                 ) = patch_state_finished
                 {
+                    use std::io::Write;
+                    if let Ok(mut f) = std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open("/tmp/sandbox_debug.log")
+                    {
+                        let _ =
+                            writeln!(f, "[RPC_FINISHED] patch_state_in_progress=false, returning");
+                    }
                     break;
                 }
                 let _ = sleep(self.polling_config.polling_interval).await;

--- a/core/primitives/src/sandbox.rs
+++ b/core/primitives/src/sandbox.rs
@@ -23,6 +23,10 @@ pub mod state_patch {
             self.records.is_empty()
         }
 
+        pub fn len(&self) -> usize {
+            self.records.len()
+        }
+
         pub fn clear(&mut self) {
             self.records.clear();
         }
@@ -57,6 +61,10 @@ pub mod state_patch {
         #[inline(always)]
         pub fn is_empty(&self) -> bool {
             true
+        }
+        #[inline(always)]
+        pub fn len(&self) -> usize {
+            0
         }
         #[inline(always)]
         pub fn clear(&self) {}

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1464,6 +1464,14 @@ impl Runtime {
         if state_patch.is_empty() {
             return;
         }
+        {
+            use std::io::Write;
+            if let Ok(mut f) =
+                std::fs::OpenOptions::new().create(true).append(true).open("/tmp/sandbox_debug.log")
+            {
+                let _ = writeln!(f, "[PATCH_APPLIED] patch_len={}", state_patch.len());
+            }
+        }
         for record in state_patch {
             match record {
                 StateRecord::Account { account_id, account } => {


### PR DESCRIPTION
## Summary

Adds instrumentation to trace the sandbox_patch_state race condition. This is a **debug branch** - not intended to be merged, but useful for understanding the bug.

Related fix: #14893

## What it traces

Writes to `/tmp/sandbox_debug.log`:

- `[PATCH_SUBMITTED]` - when a patch is submitted via RPC  
- `[PATCH_TAKEN]` - when a block takes the pending patch
- `[PATCH_APPLIED]` - when the runtime applies the patch to state
- `[BUG_PATCH_DROPPED]` - when clear() is about to wipe a pending patch (the bug!)
- `[RPC_WAIT_START]` - when RPC starts waiting for patch completion
- `[RPC_FINISHED]` - when RPC returns to caller

## How to use

```bash
# Build instrumented nearcore
git fetch origin sandbox-patch-state-instrumentation
git checkout sandbox-patch-state-instrumentation
cargo build -p neard --features sandbox

# Run the stress test from near-sandbox-rs
NEAR_SANDBOX_BIN_PATH=/path/to/nearcore/target/debug/neard \
  cargo test --test patch_state_race_condition -- --nocapture

# Examine the trace
cat /tmp/sandbox_debug.log
```

## What the bug looks like

```
[PATCH_SUBMITTED] patch.len=2, pending_before=0
[RPC_WAIT_START] waiting for patch_state_in_progress=false
[PATCH_TAKEN] block_height=109, patch.len=0, pending_after_take=0
[PATCH_SUBMITTED] patch.len=2, pending_before=0           <- new patch arrives
[BUG_PATCH_DROPPED] block_height=109, pending_len=2       <- clear() wipes it!
[RPC_FINISHED] patch_state_in_progress=false, returning   <- RPC returns "success"
# But the patch was never applied!
```