### PR TITLE
build: feature gate dumps for neard

### DIFF
--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -60,7 +60,7 @@ rustc_version = "0.4"
 
 [features]
 tx_generator = ["nearcore/tx_generator"]
-default = ["json_rpc", "rosetta_rpc", "dump-contract"]
+default = ["json_rpc", "rosetta_rpc", "dump-test-contract"]
 protocol_feature_spice = [
   "near-client/protocol_feature_spice",
   "near-primitives/protocol_feature_spice",
@@ -68,7 +68,7 @@ protocol_feature_spice = [
   "nearcore/protocol_feature_spice",
   "near-mirror/protocol_feature_spice",
 ]
-dump-contract = ["near-dump-test-contract"]
+dump-test-contract = ["near-dump-test-contract"]
 
 test_features = [
   "nearcore/test_features",

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::Receiver;
 
-#[cfg(feature = "dump-contract")]
+#[cfg(feature = "dump-test-contract")]
 use {
     near_dump_test_contract::DumpTestContractCommand, near_network::tcp,
     near_primitives::epoch_manager::EpochConfigStore,
@@ -154,11 +154,11 @@ impl NeardCmd {
             NeardSubCommand::ReplayArchive(cmd) => {
                 cmd.run(&home_dir, genesis_validation)?;
             }
-            #[cfg(feature = "dump-contract")]
+            #[cfg(feature = "dump-test-contract")]
             NeardSubCommand::DumpTestContracts(cmd) => {
                 cmd.run()?;
             }
-            #[cfg(feature = "dump-contract")]
+            #[cfg(feature = "dump-test-contract")]
             NeardSubCommand::DumpEpochConfigs(cmd) => {
                 cmd.run(&home_dir)?;
             }
@@ -269,11 +269,11 @@ pub(super) enum NeardSubCommand {
     /// Replays the blocks in the chain from an archival node.
     ReplayArchive(ReplayArchiveCommand),
 
-    #[cfg(feature = "dump-contract")]
+    #[cfg(feature = "dump-test-contract")]
     /// Placeholder for test contracts subcommand
     DumpTestContracts(DumpTestContractCommand),
 
-    #[cfg(feature = "dump-contract")]
+    #[cfg(feature = "dump-test-contract")]
     /// Dump hard-coded epoch configs into JSON files
     DumpEpochConfigs(DumpEpochConfigsCommand),
 }
@@ -843,7 +843,7 @@ pub(super) struct DumpEpochConfigsCommand {
     output_dir: Option<PathBuf>,
 }
 
-#[cfg(feature = "dump-contract")]
+#[cfg(feature = "dump-test-contract")]
 impl DumpEpochConfigsCommand {
     pub fn run(self, home_dir: &Path) -> anyhow::Result<()> {
         let output_dir = self.output_dir.unwrap_or_else(|| home_dir.join("epoch_configs"));


### PR DESCRIPTION
`neard` is depending on `near-dump-test-contract"` for the build release.

This is problematic when trying to do sandboxed builds of neard as the build.rs script of `ner-dump-test-contract` is calling cargo recursively with hard coded paths.

To avoid this problem, this PR puts `dump` functionality which is for testing, behind a feature flag of `neard` which is in the default feature set.