### PR TITLE
chore: reject self-loop edges in network graph

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -18,7 +18,7 @@ use crate::network_protocol::{
 use crate::peer::stream;
 use crate::peer::tracker::Tracker;
 use crate::peer_manager::connection;
-use crate::peer_manager::network_state::{NetworkState, PRUNE_EDGES_AFTER};
+use crate::peer_manager::network_state::{EdgesWithSource, NetworkState, PRUNE_EDGES_AFTER};
 #[cfg(test)]
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_manager_actor::MAX_TIER2_PEERS;
@@ -1484,7 +1484,9 @@ impl PeerActor {
         conn: Arc<connection::Connection>,
         rtu: RoutingTableUpdate,
     ) {
-        if let Err(ban_reason) = network_state.add_edges(&clock, rtu.edges.clone()).await {
+        if let Err(ban_reason) =
+            network_state.add_edges(&clock, EdgesWithSource::Remote(rtu.edges.clone())).await
+        {
             conn.stop(Some(ban_reason));
         }
 

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -165,7 +165,7 @@ pub(crate) struct NetworkState {
     /// Mutex which prevents overlapping calls to tier1_advertise_proxies.
     tier1_advertise_proxies_mutex: tokio::sync::Mutex<()>,
     /// Demultiplexer aggregating calls to add_edges(), for V1 routing protocol
-    add_edges_demux: demux::Demux<Vec<Edge>, Result<(), ReasonForBan>>,
+    add_edges_demux: demux::Demux<EdgesWithSource, Result<(), ReasonForBan>>,
     /// Demultiplexer aggregating calls to update_routes(), for V2 routing protocol
     #[cfg(feature = "distance_vector_routing")]
     update_routes_demux:
@@ -174,6 +174,22 @@ pub(crate) struct NetworkState {
     /// Mutex serializing calls to set_chain_info(), which mutates a bunch of stuff non-atomically.
     /// TODO(gprusak): make it use synchronization primitives in some more canonical way.
     set_chain_info_mutex: Mutex<()>,
+}
+
+#[derive(Debug)]
+/// Edges along with their source (constructed locally or received from a remote peer).
+/// Self-connected edges are not allowed from remote peers.
+pub(crate) enum EdgesWithSource {
+    Local(Vec<Edge>),
+    Remote(Vec<Edge>),
+}
+
+impl EdgesWithSource {
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            EdgesWithSource::Local(edges) | EdgesWithSource::Remote(edges) => edges.is_empty(),
+        }
+    }
 }
 
 impl NetworkState {
@@ -378,7 +394,7 @@ impl NetworkState {
                     // First verify and broadcast the edge of the connection, so that in case
                     // it is invalid, the connection is not added to the pool.
                     // TODO(gprusak): consider actually banning the peer for consistency.
-                    this.add_edges(&clock, vec![edge.clone()])
+                    this.add_edges(&clock, EdgesWithSource::Local(vec![edge.clone()]))
                         .await
                         .map_err(|_: ReasonForBan| RegisterPeerError::InvalidEdge)?;
                     // Insert to the local connection pool
@@ -442,7 +458,9 @@ impl NetworkState {
                 if edge.edge_type() == EdgeState::Active {
                     let edge_update =
                         edge.remove_edge(this.config.node_id(), &this.config.node_key);
-                    this.add_edges(&clock, vec![edge_update.clone()]).await.unwrap();
+                    this.add_edges(&clock, EdgesWithSource::Local(vec![edge_update.clone()]))
+                        .await
+                        .unwrap();
                 }
             }
 
@@ -1030,7 +1048,9 @@ impl NetworkState {
                             // Unwrap is safe, because new_edge is always valid.
                             let new_edge =
                                 edge.remove_edge(this.config.node_id(), &this.config.node_key);
-                            this.add_edges(&clock, vec![new_edge.clone()]).await.unwrap()
+                            this.add_edges(&clock, EdgesWithSource::Local(vec![new_edge.clone()]))
+                                .await
+                                .unwrap()
                         }
                     })),
                     // OK

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -1,6 +1,7 @@
 use super::{Graph, GraphConfig};
 use crate::network_protocol::Edge;
 use crate::network_protocol::testonly as data;
+use crate::peer_manager::network_state::EdgesWithSource;
 use crate::testonly::make_rng;
 use near_async::time;
 use near_crypto::SecretKey;
@@ -11,6 +12,7 @@ use std::sync::Arc;
 
 impl Graph {
     async fn simple_update(self: &Arc<Self>, edges: Vec<Edge>) {
+        let edges = EdgesWithSource::Local(edges);
         assert_eq!(vec![true], self.update(vec![edges]).await.1);
     }
 

--- a/chain/network/src/routing/graph_v2/mod.rs
+++ b/chain/network/src/routing/graph_v2/mod.rs
@@ -68,7 +68,7 @@ impl Inner {
     /// Returns true iff all the edges provided were valid.
     ///
     /// This method implements a security measure against an adversary sending invalid edges.
-    /// It verifies edges in parallel until the first invalid edge is found. It adds nonces
+    /// It verifies edges until the first invalid edge is found. It adds nonces
     /// for all the edges verified so far to the cache, but drops all the remaining ones. This way
     /// the wasted work (verification of invalid edges) is constant, no matter how large the input
     /// size is.


### PR DESCRIPTION
This avoids an edge case issue where we receive self-loops from peers but do not reject or ban them properly, as self-loops should not be sent over the network.