### PR TITLE
feat(runtime): instant receipts

### DIFF
--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -31,7 +31,7 @@ use node_runtime::{
     ApplyState, Runtime, SignedValidPeriodTransactions, get_signer_and_access_key,
     set_tx_state_changes, verify_and_charge_tx_ephemeral,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::iter;
 use std::sync::Arc;
 
@@ -482,6 +482,7 @@ impl Testbed<'_> {
     pub(crate) fn apply_action_receipt(&self, receipt: &Receipt, metric: GasMetric) -> GasCost {
         let mut state_update = TrieUpdate::new(self.trie());
         let mut outgoing_receipts = vec![];
+        let mut instant_receipts = VecDeque::new();
         let mut validator_proposals = vec![];
         let mut stats =
             ChunkApplyStatsV0::new(self.apply_state.block_height, self.apply_state.shard_id);
@@ -493,6 +494,7 @@ impl Testbed<'_> {
             &self.apply_state,
             receipt,
             &mut outgoing_receipts,
+            &mut instant_receipts,
             &mut validator_proposals,
             &mut stats,
             &epoch_info_provider,


### PR DESCRIPTION
This PR adds a concept of "instant receipts" to the runtime. Instant receipts are receipts which should be applied immediately after they are created. They are not sent out as outgoing receipts, instead they're added to a local list and executed right after the parent receipt. They can't be postponed by gas limits, they are always executed right after the parent.

The main purpose of this feature is to support executing `PromiseYield` receipts immediately after they're created. See https://github.com/near/nearcore/pull/14926 for more details.
I'm also hoping that the concept of instant receipts will be useful for the "Instant delete" feature that was discussed recently.

One thing that is missing from this PR is saving instant receipts to make them available to the RPC and the indexer. Anton volunteered to implement it in a follow up PR. (https://github.com/near/nearcore/pull/14926#pullrequestreview-3710161215)