### PR TITLE
fix(tests): fix error when running cargo test

### DIFF
--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::sync::Arc;
 use std::task::Poll;
 
-#[cfg(feature = "test_features")]
 use near_async::messaging::CanSend;
 use near_async::test_loop::TestLoopV2;
 use near_async::test_loop::data::TestLoopData;


### PR DESCRIPTION
On current `master`, trying to run `cargo test` or `cargo nextest run` produces an error:
```shell
$ cargo nextest run slow_test_repro_1183
warning: ignoring unknown configuration keys in config file /home/jan/code/nearcore/.config/nextest.toml:
  - profile.ci.default-filter
  - profile.default.default-filter
   Compiling near-vm-test-generator v0.0.0 (/home/jan/code/nearcore/runtime/near-vm/test-generator)
   Compiling neard v0.0.0 (/home/jan/code/nearcore/neard)
   Compiling near-transactions-generator v0.0.0 (/home/jan/code/nearcore/benchmarks/transactions-generator)
   Compiling near-jsonrpc-adversarial-primitives v0.0.0 (/home/jan/code/nearcore/chain/jsonrpc-adversarial-primitives)
   Compiling test-loop-tests v0.0.0 (/home/jan/code/nearcore/test-loop-tests)
   Compiling restaked v0.0.0 (/home/jan/code/nearcore/tools/restaked)
   Compiling near-fork-network v0.0.0 (/home/jan/code/nearcore/tools/fork-network)
   Compiling near-vm-test-api v0.0.0 (/home/jan/code/nearcore/runtime/near-vm/test-api)
error[E0599]: no method named `send` found for struct `TestLoopSender` in the current scope
   --> test-loop-tests/src/utils/node.rs:184:40
    |
184 |         self.data().rpc_handler_sender.send(process_tx_request);
    |                                        ^^^^ method not found in `TestLoopSender<RpcHandlerActor>`
    |
   ::: /home/jan/code/nearcore/core/async/src/messaging.rs:73:8
    |
73  |     fn send(&self, message: M);
    |        ---- the method is available for `TestLoopSender<RpcHandlerActor>` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `CanSend` which provides `send` is implemented but not in scope; perhaps you want to import it
    |
1   + use near_async::messaging::CanSend;
    |

   Compiling near-vm-wast v0.0.0 (/home/jan/code/nearcore/runtime/near-vm/wast)
For more information about this error, try `rustc --explain E0599`.
error: could not compile `test-loop-tests` (lib test) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: command `/home/jan/.rustup/toolchains/1.86.0-x86_64-unknown-linux-gnu/bin/cargo test --no-run --message-format json-render-diagnostics` exited with code 101
```

To fix that, let's always import `CanSend`.
