### PR TITLE
feat(spice): add BlockExecuted column for tracking executed blocks

### DIFF
--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -696,4 +696,9 @@ impl<'a> ChainUpdate<'a> {
         let tip = Tip::from_header(&header);
         self.chain_store_update.save_spice_execution_head(tip)
     }
+
+    /// Marks a block as executed (SPICE only).
+    pub fn save_block_executed(&mut self, block_hash: CryptoHash) {
+        self.chain_store_update.save_block_executed(block_hash);
+    }
 }

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -799,6 +799,7 @@ impl<'a> ChainStoreUpdate<'a> {
         }
         if cfg!(feature = "protocol_feature_spice") {
             self.gc_col(DBCol::all_next_block_hashes(), block_hash.as_bytes());
+            self.gc_col(DBCol::block_executed(), block_hash.as_bytes());
         }
         self.gc_col(DBCol::ChallengedBlocks, block_hash.as_bytes());
         self.gc_col(DBCol::BlocksToCatchup, block_hash.as_bytes());
@@ -1247,6 +1248,10 @@ impl<'a> ChainStoreUpdate<'a> {
             }
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::UncertifiedChunks => {
+                store_update.delete(col, key);
+            }
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::BlockExecuted => {
                 store_update.delete(col, key);
             }
             DBCol::DbVersion

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -650,6 +650,7 @@ impl ChunkExecutorActor {
         )?;
         let final_execution_head = chain_update.update_spice_final_execution_head(&block)?;
         chain_update.save_spice_execution_head(block.header())?;
+        chain_update.save_block_executed(*block.hash());
         chain_update.commit()?;
         if let Some(final_execution_head) = final_execution_head {
             self.update_flat_storage_head(&shard_layout, &final_execution_head)?;

--- a/chain/client/src/tests/spice_chunk_executor_actor.rs
+++ b/chain/client/src/tests/spice_chunk_executor_actor.rs
@@ -505,11 +505,11 @@ fn test_executing_blocks() {
     for (i, block) in blocks.iter().enumerate() {
         for actor in &mut actors {
             assert!(!block_executed(&actor, &block), "block #{} is already executed", i + 1);
-            assert!(!actor.chain.chain_store().is_block_executed(block.hash()), i + 1);
+            assert!(!actor.chain.chain_store().is_block_executed(block.hash()));
             actor
                 .handle_with_internal_events(ProcessedBlock { block_hash: *block.header().hash() });
             assert!(block_executed(&actor, &block), "failed to execute block #{}", i + 1);
-            assert!(actor.chain.chain_store().is_block_executed(block.hash()), i + 1);
+            assert!(actor.chain.chain_store().is_block_executed(block.hash()));
         }
         simulate_outgoing_messages(&mut actors, &mut outgoing_rc);
         record_endorsements(&mut actors, &block);

--- a/chain/client/src/tests/spice_chunk_executor_actor.rs
+++ b/chain/client/src/tests/spice_chunk_executor_actor.rs
@@ -505,9 +505,11 @@ fn test_executing_blocks() {
     for (i, block) in blocks.iter().enumerate() {
         for actor in &mut actors {
             assert!(!block_executed(&actor, &block), "block #{} is already executed", i + 1);
+            assert!(!actor.chain.chain_store().is_block_executed(block.hash()), i + 1);
             actor
                 .handle_with_internal_events(ProcessedBlock { block_hash: *block.header().hash() });
             assert!(block_executed(&actor, &block), "failed to execute block #{}", i + 1);
+            assert!(actor.chain.chain_store().is_block_executed(block.hash()), i + 1);
         }
         simulate_outgoing_messages(&mut actors, &mut outgoing_rc);
         record_endorsements(&mut actors, &block);

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -158,6 +158,11 @@ impl ChainStoreAdapter {
         self.store.exists(DBCol::Block, h.as_ref())
     }
 
+    /// Has this block been executed? (SPICE only)
+    pub fn is_block_executed(&self, h: &CryptoHash) -> bool {
+        self.store.exists(DBCol::block_executed(), h.as_ref())
+    }
+
     /// Get block header.
     pub fn get_block_header(&self, h: &CryptoHash) -> Result<Arc<BlockHeader>, Error> {
         option_to_not_found(

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -375,6 +375,11 @@ pub enum DBCol {
     /// - *Content type*: Vec<[near_primitives::types::SpiceUncertifiedChunkInfo]>
     #[cfg(feature = "protocol_feature_spice")]
     UncertifiedChunks,
+    /// For spice, marks blocks that have been executed.
+    /// - *Rows*: BlockHash (CryptoHash)
+    /// - *Content type*: empty (unit marker)
+    #[cfg(feature = "protocol_feature_spice")]
+    BlockExecuted,
 }
 
 /// Defines different logical parts of a db key.
@@ -443,7 +448,8 @@ impl DBCol {
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::UncertifiedChunks
             | DBCol::ExecutionResults
-            | DBCol::UncertifiedExecutionResults => true,
+            | DBCol::UncertifiedExecutionResults
+            | DBCol::BlockExecuted => true,
             _ => false,
         }
     }
@@ -542,6 +548,8 @@ impl DBCol {
             | DBCol::UncertifiedExecutionResults => false,
             #[cfg(feature = "protocol_feature_spice")]
             | DBCol::UncertifiedChunks => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            | DBCol::BlockExecuted => false,
             // TODO
             DBCol::ChallengedBlocks => false,
             DBCol::Misc => false,
@@ -699,6 +707,8 @@ impl DBCol {
             DBCol::UncertifiedExecutionResults => &[DBKeyType::ChunkExecutionResultHash],
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::UncertifiedChunks => &[DBKeyType::BlockHash],
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::BlockExecuted => &[DBKeyType::BlockHash],
         }
     }
 
@@ -747,6 +757,13 @@ impl DBCol {
     pub fn uncertified_chunks() -> DBCol {
         #[cfg(feature = "protocol_feature_spice")]
         return DBCol::UncertifiedChunks;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn block_executed() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::BlockExecuted;
         #[cfg(not(feature = "protocol_feature_spice"))]
         panic!("Expected protocol_feature_spice to be enabled")
     }


### PR DESCRIPTION
This PR adds a new spice specific column that gets set when the block is executed.

See https://github.com/near/nearcore/pull/14941 for the rationale and use case. In short, the RPC can use this column to determine if a block was executed or not and it could be useful for other purposes.