### PR TITLE
fix(ci): reintroduce neard_assertion_binary workflow 

### DIFF
--- a/.github/workflows/neard_assertion_binary.yml
+++ b/.github/workflows/neard_assertion_binary.yml
@@ -1,0 +1,50 @@
+name: Neard Assertion binary release
+
+on:
+  schedule:
+    - cron: '23 */8 * * *'
+
+  workflow_dispatch:
+    inputs:
+      branch:
+        default: 'master'
+        description: "Nearcore branch to build and publish"
+        type: string
+        required: true
+
+jobs:
+  binary-release:
+    name: "Build and publish neard binary"
+    runs-on: warp-ubuntu-2404-x64-16x
+    environment: deploy
+    permissions:
+      id-token: write # required to use OIDC authentication
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::590184106962:role/GitHubActionsRunner
+          aws-region: us-west-1
+
+      - name: Checkout ${{ github.event.inputs.branch }} branch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          persist-credentials: false
+
+      - name: Checkout nearcore repository
+        if: ${{ github.event_name != 'workflow_dispatch'}}
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Neard binary build and upload to S3
+        run: ./scripts/binary_release.sh assertions-release
+
+      - name: Update latest version metadata in S3
+        run: |
+          echo $(git rev-parse HEAD) > latest
+          BRANCH=$(git branch --show-current)
+          aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest-assertions


### PR DESCRIPTION
Was removed #14945 but apparently [it is used on the canary nodes](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/nearcore-private.20CI/near/570995631). Reintroducing as it is for now.