### PR TITLE
chore: return GasKeyNonceUpdated in {Single,All}AccessKeyChanges

### DIFF
--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -696,7 +696,7 @@ impl ChainStore {
                         public_key: key.public_key.clone(),
                     };
                     let storage_key = KeyForStateChanges::from_trie_key(block_hash, &data_key);
-                    let changes_per_key = storage_key.find_exact_iter(&store);
+                    let changes_per_key = storage_key.find_iter(&store);
                     changes.extend(StateChanges::from_access_key_changes(changes_per_key)?);
                 }
                 changes

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -258,7 +258,6 @@ pub enum StateChangesRequest {
     AllAccessKeyChanges { account_ids: Vec<AccountId> },
     ContractCodeChanges { account_ids: Vec<AccountId> },
     DataChanges { account_ids: Vec<AccountId>, key_prefix: StoreKey },
-    // TODO(gas-keys): Add state changes request for gas key nonces.
 }
 
 #[derive(Debug)]
@@ -475,6 +474,7 @@ impl StateChanges {
                     state_change.value,
                     StateChangeValue::AccessKeyUpdate { .. }
                         | StateChangeValue::AccessKeyDeletion { .. }
+                        | StateChangeValue::GasKeyNonceUpdate { .. }
                 )
             })
             .collect())

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -40,4 +40,5 @@ mod single_shard_tracking;
 mod spice;
 mod state_sync;
 mod syncing;
+mod view_requests;
 mod view_requests_to_archival_node;

--- a/test-loop-tests/src/tests/view_requests.rs
+++ b/test-loop-tests/src/tests/view_requests.rs
@@ -1,0 +1,114 @@
+use near_async::messaging::Handler;
+use near_async::time::Duration;
+use near_chain_configs::test_genesis::ValidatorsSpec;
+use near_client::GetStateChanges;
+use near_crypto::{KeyType, SecretKey};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::action::{Action, AddKeyAction};
+use near_primitives::test_utils::create_user_test_signer;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::{AccountId, AccountWithPublicKey, Balance, NonceIndex};
+use near_primitives::views::{StateChangeValueView, StateChangesRequestView};
+use near_primitives_core::account::AccessKey;
+
+use crate::setup::builder::TestLoopBuilder;
+use crate::utils::account::validators_spec_clients_with_rpc;
+use crate::utils::node::TestLoopNode;
+use crate::utils::transactions::get_shared_block_hash;
+
+#[test]
+#[cfg_attr(not(feature = "nightly"), ignore)]
+fn test_access_key_changes_includes_gas_key_nonces() {
+    init_test_logger();
+
+    let epoch_length = 10;
+    let accounts: Vec<AccountId> = (0..3).map(|i| format!("account{i}").parse().unwrap()).collect();
+    let validators: Vec<&str> = accounts.iter().take(2).map(|a| a.as_str()).collect();
+    let submitter = accounts[2].clone();
+    let validators_spec = ValidatorsSpec::desired_roles(&validators, &[]);
+    let clients = validators_spec_clients_with_rpc(&validators_spec);
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, Balance::from_near(1_000_000))
+        .build();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(clients)
+        .build()
+        .warmup();
+    let rpc_node = TestLoopNode::rpc(&env.node_datas);
+
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    // TODO(spice): Replace with get_next_nonce once it works with spice.
+    // let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, &submitter);
+    let nonce = 1;
+
+    let num_nonces: NonceIndex = 2;
+    let gas_key_secret = SecretKey::from_seed(KeyType::ED25519, "gas_key");
+    let gas_key_public = gas_key_secret.public_key();
+    let tx = SignedTransaction::from_actions(
+        nonce,
+        submitter.clone(),
+        submitter.clone(),
+        &create_user_test_signer(&submitter),
+        vec![Action::AddKey(Box::new(AddKeyAction {
+            public_key: gas_key_public.clone(),
+            access_key: AccessKey::gas_key_full_access(num_nonces),
+        }))],
+        block_hash,
+    );
+    let outcome = rpc_node.execute_tx(&mut env.test_loop, tx, Duration::seconds(5)).unwrap();
+    let tx_block_hash = outcome.transaction_outcome.block_hash;
+    let tx_block_header =
+        rpc_node.client(&env.test_loop.data).chain.get_block_header(&tx_block_hash).unwrap();
+    rpc_node.run_until_block_executed(&mut env.test_loop, &tx_block_header, Duration::seconds(10));
+    let view_client = rpc_node.view_client_actor(&mut env.test_loop.data);
+
+    // Test AllAccessKey changes request
+    let state_changes = view_client
+        .handle(GetStateChanges {
+            block_hash: tx_block_hash,
+            state_changes_request: StateChangesRequestView::AllAccessKeyChanges {
+                account_ids: vec![submitter.clone()],
+            },
+        })
+        .unwrap();
+
+    let access_key_updates = state_changes
+        .iter()
+        .filter(|sc| matches!(&sc.value, StateChangeValueView::AccessKeyUpdate { .. }))
+        .count();
+    let gas_key_nonce_updates = state_changes
+        .iter()
+        .filter(|sc| matches!(&sc.value, StateChangeValueView::GasKeyNonceUpdate { .. }))
+        .count();
+    assert_eq!(access_key_updates, 2); // One for the new gas key, one for the access key used to submit the tx.
+    assert_eq!(gas_key_nonce_updates, num_nonces as usize);
+
+    // Test SingleAccessKey changes request
+    let state_changes = view_client
+        .handle(GetStateChanges {
+            block_hash: tx_block_hash,
+            state_changes_request: StateChangesRequestView::SingleAccessKeyChanges {
+                keys: vec![AccountWithPublicKey {
+                    account_id: submitter,
+                    public_key: gas_key_public,
+                }],
+            },
+        })
+        .unwrap();
+    let access_key_updates = state_changes
+        .iter()
+        .filter(|sc| matches!(&sc.value, StateChangeValueView::AccessKeyUpdate { .. }))
+        .count();
+    let gas_key_nonce_updates = state_changes
+        .iter()
+        .filter(|sc| matches!(&sc.value, StateChangeValueView::GasKeyNonceUpdate { .. }))
+        .count();
+    assert_eq!(access_key_updates, 1); // Only for the new gas key.
+    assert_eq!(gas_key_nonce_updates, num_nonces as usize);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -10,7 +10,7 @@ use near_async::time::Duration;
 use near_chain::types::Tip;
 use near_chain::{Block, BlockHeader};
 use near_client::client_actor::ClientActor;
-use near_client::{Client, ProcessTxRequest};
+use near_client::{Client, ProcessTxRequest, ViewClientActor};
 use near_epoch_manager::shard_assignment::{account_id_to_shard_id, shard_id_to_uid};
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
@@ -79,6 +79,14 @@ impl<'a> TestLoopNode<'a> {
     pub fn client_actor<'b>(&self, test_loop_data: &'b mut TestLoopData) -> &'b mut ClientActor {
         let client_handle = self.data().client_sender.actor_handle();
         test_loop_data.get_mut(&client_handle)
+    }
+
+    pub fn view_client_actor<'b>(
+        &self,
+        test_loop_data: &'b mut TestLoopData,
+    ) -> &'b mut ViewClientActor {
+        let handle = self.data().view_client_sender.actor_handle();
+        test_loop_data.get_mut(&handle)
     }
 
     pub fn tail(&self, test_loop_data: &TestLoopData) -> BlockHeight {


### PR DESCRIPTION
Resolves a gas-keys TODO by returning GasKeyNonceUpdates as part of `StateChangesRequest::{Single,All}AccessKeyChanges`.

Alternative to: https://github.com/near/nearcore/pull/14932
Also added a test-loop test for it. 