### PR TITLE
feat(state_sync): introduce newtypes for validated state parts

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -492,6 +492,39 @@ impl NightshadeRuntime {
         }
     }
 
+    fn validate_state_part_bytes_impl(
+        &self,
+        _shard_id: ShardId,
+        state_root: &StateRoot,
+        part_id: PartId,
+        protocol_version: ProtocolVersion,
+        bytes: &[u8],
+    ) -> Result<
+        near_primitives::state_part::ValidatedStatePart,
+        near_primitives::state_part::ValidationError,
+    > {
+        use near_primitives::state_part::RawStatePart;
+
+        // Parse raw bytes into a StatePart
+        let raw_part = RawStatePart(bytes.to_vec());
+        let parsed_part = raw_part
+            .parse(protocol_version)
+            .map_err(|_| near_primitives::state_part::ValidationError::DeserializationFailed)?;
+
+        // Convert to PartialState and validate via Trie to ensure correctness
+        let partial_state = parsed_part
+            .state_part()
+            .to_partial_state()
+            .map_err(|_| near_primitives::state_part::ValidationError::DeserializationFailed)?;
+
+        match Trie::validate_state_part(state_root, part_id, partial_state) {
+            Ok(()) => Ok(near_primitives::state_part::ValidatedStatePart(
+                parsed_part.state_part().clone(),
+            )),
+            Err(_) => Err(near_primitives::state_part::ValidationError::TrieValidationFailed),
+        }
+    }
+
     fn query_view_global_contract_code(
         &self,
         identifier: GlobalContractIdentifier,
@@ -1390,21 +1423,50 @@ impl RuntimeAdapter for NightshadeRuntime {
         res
     }
 
+    fn validate_state_part_bytes(
+        &self,
+        shard_id: ShardId,
+        state_root: &StateRoot,
+        part_id: PartId,
+        protocol_version: ProtocolVersion,
+        bytes: &[u8],
+    ) -> Result<
+        near_primitives::state_part::ValidatedStatePart,
+        near_primitives::state_part::ValidationError,
+    > {
+        let instant = Instant::now();
+        let res = self.validate_state_part_bytes_impl(
+            shard_id,
+            state_root,
+            part_id,
+            protocol_version,
+            bytes,
+        );
+        let elapsed = instant.elapsed();
+        let is_ok = if res.is_ok() { "ok" } else { "error" };
+        metrics::STATE_SYNC_VALIDATE_PART_DELAY
+            .with_label_values(&[&shard_id.to_string(), is_ok])
+            .observe(elapsed.as_secs_f64());
+        res
+    }
+
     fn apply_state_part(
         &self,
         shard_id: ShardId,
         state_root: &StateRoot,
         part_id: PartId,
-        part: &StatePart,
+        part: &near_primitives::state_part::ValidatedStatePart,
         epoch_id: &EpochId,
     ) -> Result<(), Error> {
         let _timer = metrics::STATE_SYNC_APPLY_PART_DELAY
             .with_label_values(&[&shard_id.to_string()])
             .start_timer();
 
+        // ValidatedStatePart guarantees the part was validated, so this cannot fail
         let part = part
+            .state_part()
             .to_partial_state()
-            .expect("Part was already validated earlier, so could never fail here");
+            .expect("ValidatedStatePart guarantees the part structure is valid");
         let ApplyStatePartResult { trie_changes, flat_state_delta, contract_codes } =
             Trie::apply_state_part(state_root, part_id, part);
         let tries = self.get_tries();

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -913,16 +913,28 @@ fn test_state_sync() {
         ),
         StatePartValidationResult::Invalid
     ));
-    new_env.runtime.validate_state_part(
-        ShardId::new(0),
-        &env.state_roots[0],
-        PartId::new(0, 1),
-        &state_part,
-    );
+    assert!(matches!(
+        new_env.runtime.validate_state_part(
+            ShardId::new(0),
+            &env.state_roots[0],
+            PartId::new(0, 1),
+            &state_part,
+        ),
+        StatePartValidationResult::Valid
+    ));
+    // After validation succeeds, wrap as ValidatedStatePart
+    let validated_part =
+        near_primitives::state_part::ValidatedStatePart::from_trusted_source(state_part);
     let epoch_id = &new_env.head.epoch_id;
     new_env
         .runtime
-        .apply_state_part(shard_id, &env.state_roots[0], PartId::new(0, 1), &state_part, epoch_id)
+        .apply_state_part(
+            shard_id,
+            &env.state_roots[0],
+            PartId::new(0, 1),
+            &validated_part,
+            epoch_id,
+        )
         .unwrap();
     new_env.state_roots[0] = env.state_roots[0];
     for _ in 3..=5 {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -608,13 +608,28 @@ pub trait RuntimeAdapter: Send + Sync {
         part: &StatePart,
     ) -> StatePartValidationResult;
 
+    /// Validate raw state part bytes and return a ValidatedStatePart if successful.
+    /// This is the new validation method that encapsulates parsing and validation.
+    fn validate_state_part_bytes(
+        &self,
+        shard_id: ShardId,
+        state_root: &StateRoot,
+        part_id: PartId,
+        protocol_version: near_primitives::version::ProtocolVersion,
+        bytes: &[u8],
+    ) -> Result<
+        near_primitives::state_part::ValidatedStatePart,
+        near_primitives::state_part::ValidationError,
+    >;
+
     /// Should be executed after accepting all the parts to set up a new state.
+    /// Takes a ValidatedStatePart to ensure the part was validated before being applied.
     fn apply_state_part(
         &self,
         shard_id: ShardId,
         state_root: &StateRoot,
         part_id: PartId,
-        part: &StatePart,
+        part: &near_primitives::state_part::ValidatedStatePart,
         epoch_id: &EpochId,
     ) -> Result<(), Error>;
 

--- a/cspell.json
+++ b/cspell.json
@@ -249,6 +249,7 @@
         "nearvm",
         "netdev",
         "newtype",
+        "newtypes",
         "nextest",
         "nikurt",
         "nocapture",

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -387,17 +387,21 @@ async fn load_state_parts(
 
         match action {
             LoadAction::Apply => {
+                // set_state_part validates the part internally before storing
                 chain
                     .state_sync_adapter
                     .set_state_part(shard_id, sync_hash, PartId::new(part_id, num_parts), &part)
                     .unwrap();
+                // After set_state_part succeeds, we know the part is valid
+                let validated_part =
+                    near_primitives::state_part::ValidatedStatePart::from_trusted_source(part);
                 chain
                     .runtime_adapter
                     .apply_state_part(
                         shard_id,
                         &state_root,
                         PartId::new(part_id, num_parts),
-                        &part,
+                        &validated_part,
                         &epoch_id,
                     )
                     .unwrap();


### PR DESCRIPTION
This PR introduces type-safe newtypes for state parts to ensure compile-time enforcement that only       
  validated parts can be applied.                                                                          
                                                                                                           
  Builds on the work from #14610 (which changed bool → StatePartValidationResult enum) by adding newtypes  
  that make the validation state part of the type itself:                                                  
                                                                                                           
  - RawStatePart - Unvalidated bytes from network/disk                                                     
  - ParsedStatePart - Deserialized but not trie-validated                                                  
  - ValidatedStatePart - Validated and safe to apply                                                       
                                                                                                           
  Now apply_state_part() only accepts ValidatedStatePart, so the compiler prevents accidental use of       
  unvalidated data.                                                                                        
                                                                                                           
  This addresses the suggestion from https://github.com/near/nearcore/pull/14013#discussion_r2297493847.   
                                                                                                           
  Fixes #14124                                                                                             
                                                                                                           
  Test plan                                                                                                
                                                                                                           
  - Existing unit tests pass                                                                               
  - Integration tests updated and pass 