### PR TITLE
feat(rpc): use execution head for spice block queries (re-applies #14941)

### DIFF
--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -49,6 +49,7 @@ use near_primitives::types::{
     Finality, MaybeBlockId, ShardId, SyncCheckpoint, TransactionOrReceiptId,
     ValidatorInfoIdentifier,
 };
+use near_primitives::version::ProtocolFeature;
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView, ExecutionStatusView,
@@ -201,11 +202,74 @@ impl ViewClientActor {
         &self,
         finality: &Finality,
     ) -> Result<CryptoHash, near_chain::Error> {
-        match finality {
-            Finality::None => Ok(self.chain.head()?.last_block_hash),
-            Finality::DoomSlug => Ok(*self.chain.head_header()?.last_ds_final_block()),
-            Finality::Final => Ok(self.chain.final_head()?.last_block_hash),
+        let head = self.chain.head()?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&head.epoch_id)?;
+        let chain_head = match finality {
+            Finality::None => head.last_block_hash,
+            Finality::DoomSlug => *self.chain.head_header()?.last_ds_final_block(),
+            Finality::Final => self.chain.final_head()?.last_block_hash,
+        };
+        // TODO(spice): consider using `get_last_certified_block_header(chain_head)`
+        // for Finality::Final and Finality::DoomSlug.
+        if ProtocolFeature::Spice.enabled(protocol_version) {
+            self.find_first_executed_ancestor(&chain_head)
+        } else {
+            Ok(chain_head)
         }
+    }
+
+    /// Finds the first executed block walking back from `start_hash`.
+    fn find_first_executed_ancestor(
+        &self,
+        start_hash: &CryptoHash,
+    ) -> Result<CryptoHash, near_chain::Error> {
+        let final_execution_head = self.chain.chain_store().spice_final_execution_head().ok();
+        let mut header = self.chain.get_block_header(start_hash)?;
+        loop {
+            if self.is_block_executed(&header)? {
+                return Ok(*header.hash());
+            }
+            if header.is_genesis() {
+                return Ok(*header.hash());
+            }
+            // Don't go past the final execution head. This is a defensive
+            // check, in normal operation we should always find an executed
+            // ancestor within a few blocks.
+            if let Some(final_execution_head) = &final_execution_head {
+                if header.height() <= final_execution_head.height {
+                    return Err(near_chain::Error::DBNotFoundErr(
+                        "no executed ancestor found".to_string(),
+                    ));
+                }
+            }
+            header = self.chain.get_block_header(header.prev_hash())?;
+        }
+    }
+
+    /// Checks if a block has been executed by looking for chunk_extra on any
+    /// tracked shard. Non-spice blocks are always considered executed since
+    /// execution is synchronous with block processing.
+    fn is_block_executed(&self, header: &BlockHeader) -> Result<bool, near_chain::Error> {
+        let epoch_id = header.epoch_id();
+        let protocol_version =
+            self.epoch_manager.get_epoch_protocol_version(epoch_id).into_chain_error()?;
+        if !ProtocolFeature::Spice.enabled(protocol_version) {
+            return Ok(true);
+        }
+        let shard_ids = self.epoch_manager.shard_ids(epoch_id).into_chain_error()?;
+        for shard_id in shard_ids {
+            if !self.shard_tracker.cares_about_shard(header.hash(), shard_id) {
+                continue;
+            }
+            let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, epoch_id)
+                .into_chain_error()?;
+            match self.chain.chain_store().get_chunk_extra(header.hash(), &shard_uid) {
+                Ok(_) => return Ok(true),
+                Err(near_chain_primitives::Error::DBNotFoundErr(_)) => return Ok(false),
+                Err(err) => return Err(err.into()),
+            }
+        }
+        Ok(false)
     }
 
     /// Returns block header by reference.
@@ -217,18 +281,7 @@ impl ViewClientActor {
         &self,
         reference: &BlockReference,
     ) -> Result<Option<Arc<BlockHeader>>, near_chain::Error> {
-        // TODO(spice): Implement support for getting different finalities from execution.
-        if cfg!(feature = "protocol_feature_spice")
-            && matches!(reference, BlockReference::Finality(_))
-        {
-            return match self.chain.chain_store().spice_execution_head() {
-                Ok(tip) => self.chain.get_block_header(&tip.last_block_hash).map(Some),
-                Err(near_chain::Error::DBNotFoundErr(_)) => {
-                    Ok(Some(self.chain.genesis().clone().into()))
-                }
-                Err(err) => Err(err),
-            };
-        }
+        // TODO(spice): Return "unknown block" for height/hash queries past execution_head.
         match reference {
             BlockReference::BlockId(BlockId::Height(block_height)) => {
                 self.chain.get_block_header_by_height(*block_height).map(Some)
@@ -262,6 +315,7 @@ impl ViewClientActor {
         &self,
         reference: &BlockReference,
     ) -> Result<Option<Arc<Block>>, near_chain::Error> {
+        // TODO(spice): Return "unknown block" for height/hash queries past execution_head.
         match reference {
             BlockReference::BlockId(BlockId::Height(block_height)) => {
                 self.chain.get_block_by_height(*block_height).map(Some)

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -105,6 +105,8 @@ async fn test_send_tx_commit() {
 
 /// Test that expired transaction should be rejected
 #[tokio::test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 async fn test_expired_tx() {
     // Create setup with very short transaction validity period (1 block)
     let accounts = vec!["test1".parse().unwrap(), "test2".parse().unwrap()];

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -8,7 +8,7 @@ use near_async::test_loop::data::TestLoopData;
 use near_async::time::Duration;
 use near_chain::spice_core::get_last_certified_block_header;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
-use near_client::{ProcessTxRequest, Query, ViewClientActor};
+use near_client::{GetBlock, ProcessTxRequest, Query, ViewClientActor};
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::types::NetworkRequests;
 use near_o11y::testonly::init_test_logger;
@@ -17,7 +17,7 @@ use near_primitives::shard_layout::ShardLayout;
 use near_primitives::stateless_validation::spice_chunk_endorsement::SpiceChunkEndorsement;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, Balance, BlockHeight, BlockReference, ShardId};
+use near_primitives::types::{AccountId, Balance, BlockHeight, BlockReference, Finality, ShardId};
 use near_primitives::utils::get_block_shard_id_rev;
 use near_primitives::views::{AccountView, QueryRequest, QueryResponseKind};
 use near_store::DBCol;
@@ -256,6 +256,62 @@ fn delay_endorsements_propagation(env: &mut TestLoopEnv, delay_height: u64) {
             }
         }));
     }
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_rpc_get_block_by_finality() {
+    init_test_logger();
+
+    let num_producers = 2;
+    let num_validators = 0;
+    let validators_spec = create_validators_spec(num_producers, num_validators);
+    let clients = validators_spec_clients(&validators_spec);
+
+    let genesis = TestLoopBuilder::new_genesis_builder().validators_spec(validators_spec).build();
+
+    let producer_account = clients[0].clone();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(clients)
+        .build();
+
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+
+    env = env.warmup();
+
+    let node = TestLoopNode::for_account(&env.node_datas, &producer_account);
+
+    // Run until we have a gap between consensus and execution
+    env.test_loop.run_until(
+        |test_loop_data| {
+            let head = node.head(test_loop_data);
+            let execution_head = node.last_executed(test_loop_data);
+            head.height > execution_head.height + 2
+        },
+        Duration::seconds(20),
+    );
+
+    let test_loop_data = env.test_loop_data();
+    let execution_head = node.last_executed(test_loop_data);
+    let final_head = node.client(test_loop_data).chain.final_head().unwrap();
+
+    // Check that different finality queries return expected blocks
+    let view_client = env.test_loop.data.get_mut(&node.data().view_client_sender.actor_handle());
+    let block_none =
+        view_client.handle(GetBlock(BlockReference::Finality(Finality::None))).unwrap();
+    assert_eq!(block_none.header.height, execution_head.height);
+    let block_final =
+        view_client.handle(GetBlock(BlockReference::Finality(Finality::Final))).unwrap();
+    assert!(block_final.header.height <= execution_head.height);
+    assert!(block_final.header.height <= final_head.height);
+    let block_doomslug =
+        view_client.handle(GetBlock(BlockReference::Finality(Finality::DoomSlug))).unwrap();
+    assert!(block_doomslug.header.height <= execution_head.height);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }
 
 #[test]


### PR DESCRIPTION
https://github.com/near/nearcore/pull/14953 resolves the root cause of the test flakiness that was introduced by the original attempt in #14941. So now it can be merged again. Original description for context:

------------------------

This PR partially addresses #13592 by looking at the relevant finality from the chain head (consensus) and finding the most recent executed block. It's partial since I did not yet "filter out" un-executed queries by hash or height, which I added a TODO for.

To detect execution, we use epoch manager and chunk extra. If the node has chunk extra for any of the shards its tracking, we know it has executed the block.

Alternatives we considered:
1. Using a separate column to track executed blocks. It seemed overkill for just this usecase, but if other usecases emerge we can switch this code to using it.
2. We could try to find a common ancestor with the execution head. However, this means we couldn't return information about forks other than current execution head (if we try to "filter out" specific block hashes that are not executed), I find this approach too hack-y.