### PR TITLE
feat(spice): epoch transition with uncertified chunks last_proposal

### DIFF
--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -6,12 +6,14 @@ use near_primitives::block_body::SpiceCoreStatement;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::stateless_validation::spice_chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
 };
+use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, ShardId,
-    SpiceChunkId, SpiceUncertifiedChunkInfo,
+    AccountId, BlockExecutionResults, BlockHeight, ChunkExecutionResult, ChunkExecutionResultHash,
+    ShardId, SpiceChunkId, SpiceUncertifiedChunkInfo,
 };
 use near_primitives::utils::{get_endorsements_key, get_execution_results_key};
 use near_store::adapter::StoreAdapter as _;
@@ -107,6 +109,49 @@ impl SpiceCoreReader {
         block_hash: &CryptoHash,
     ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {
         get_uncertified_chunks(&self.chain_store, block_hash)
+    }
+
+    /// Returns the most recent validator proposals from uncertified chunks for a
+    /// given shard. These are proposals that have not yet made it to consensus
+    /// and need to be accounted for in `last_proposals` at epoch boundaries.
+    ///
+    /// Proposals are sorted ascending by block height. If multiple uncertified
+    /// chunks contain proposals for the same account, the most recent one (last
+    /// in iteration order) should be kept by the caller's fold/insert logic.
+    pub fn get_uncertified_validator_proposals(
+        &self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+    ) -> Result<Vec<ValidatorStake>, Error> {
+        let uncertified_chunks = self.get_uncertified_chunks(block_hash)?;
+        let matching: Vec<_> = uncertified_chunks
+            .into_iter()
+            .filter(|info| info.chunk_id.shard_id == shard_id)
+            .collect();
+        if matching.is_empty() {
+            return Ok(vec![]);
+        }
+        // Collect (height, proposals) for each uncertified chunk.
+        let chunk_store = self.chain_store.chunk_store();
+        let mut height_proposals: Vec<(BlockHeight, Vec<ValidatorStake>)> = Vec::new();
+        for info in &matching {
+            let height = self.chain_store.get_block_height(&info.chunk_id.block_hash)?;
+            let epoch_id = self.epoch_manager.get_epoch_id(&info.chunk_id.block_hash)?;
+            let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+            let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+            let chunk_extra = chunk_store.get_chunk_extra(&info.chunk_id.block_hash, &shard_uid)?;
+            let proposals: Vec<ValidatorStake> = chunk_extra.validator_proposals().collect();
+            if !proposals.is_empty() {
+                height_proposals.push((height, proposals));
+            }
+        }
+
+        height_proposals.sort_by_key(|(h, _)| *h);
+        debug_assert!(
+            height_proposals.windows(2).all(|w| w[0].0 != w[1].0),
+            "multiple uncertified chunks at the same height for shard {shard_id}"
+        );
+        Ok(height_proposals.into_iter().flat_map(|(_, proposals)| proposals).collect())
     }
 
     pub fn get_execution_results_by_shard_id(

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -142,9 +142,9 @@ impl Block {
         let mut gas_limit = Gas::ZERO;
         for chunk in &chunks {
             if chunk.height_included() == height {
-                prev_validator_proposals.extend(chunk.prev_validator_proposals());
                 gas_used = gas_used.checked_add(chunk.prev_gas_used()).unwrap();
                 if spice_info.is_none() {
+                    prev_validator_proposals.extend(chunk.prev_validator_proposals());
                     gas_limit = gas_limit.checked_add(chunk.gas_limit()).unwrap();
                 }
                 balance_burnt = balance_burnt.checked_add(chunk.prev_balance_burnt()).unwrap();
@@ -159,6 +159,7 @@ impl Block {
             for (_shard_id, execution_result) in
                 &spice_info.last_certified_block_execution_results.0
             {
+                prev_validator_proposals.extend(execution_result.chunk_extra.validator_proposals());
                 gas_limit =
                     gas_limit.checked_add(execution_result.chunk_extra.gas_limit()).unwrap();
             }

--- a/cspell.json
+++ b/cspell.json
@@ -422,6 +422,7 @@
         "unrequested",
         "unstake",
         "unstaked",
+        "unstaker",
         "unstakes",
         "unstaking",
         "unsync",


### PR DESCRIPTION
- In SPICE, validator proposals come from execution results (not chunk headers). Block production and validation now source proposals from `SpiceCoreStatement::ChunkExecutionResult` entries instead of chunk headers. 
- At epoch boundaries, staking proposals from uncertified chunks are included in `last_proposals` to prevent incorrect stake return. Without this, a validator who re-stakes late in an epoch could have their locked stake incorrectly returned.
- Refactored block proposal validation into a validate_block_proposals helper that handles both SPICE and non-SPICE blocks.