### PR TITLE
refactor(tracing): remove explicit target from all tracing macros

### DIFF
--- a/benchmarks/transactions-generator/src/actor.rs
+++ b/benchmarks/transactions-generator/src/actor.rs
@@ -18,11 +18,10 @@ impl GeneratorActor {
     pub fn start(&mut self, _ctx: &mut dyn DelayedActionRunner<Self>) {
         match self.tx_generator.start() {
             Err(err) => {
-                tracing::error!(target: "transaction-generator", ?err);
+                tracing::error!(?err);
             }
             Ok(_) => {
-                tracing::info!(target: "transaction-generator",
-                    schedule=?self.tx_generator.params.schedule, "started");
+                tracing::info!(schedule=?self.tx_generator.params.schedule, "started");
             }
         };
     }

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -275,7 +275,7 @@ pub trait LogTransientStorageError {
 impl<T> LogTransientStorageError for Result<T, Error> {
     fn log_storage_error(self, message: &str) -> Self {
         if let Err(err) = &self {
-            tracing::error!(target: "chain", %message, ?err, "transient storage error");
+            tracing::error!(%message, ?err, "transient storage error");
         }
         self
     }

--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -244,7 +244,7 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.dropped = Some(reason);
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was dropped but was not marked received");
+            tracing::error!(?block_hash, "block was dropped but was not marked received");
         }
     }
 
@@ -252,7 +252,7 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.error = Some(err);
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was errored but was not marked received");
+            tracing::error!(?block_hash, "block was errored but was not marked received");
         }
     }
 
@@ -260,7 +260,7 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.orphaned_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was orphaned but was not marked received");
+            tracing::error!(?block_hash, "block was orphaned but was not marked received");
         }
     }
 
@@ -268,7 +268,7 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_orphan_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was unorphaned but was not marked received");
+            tracing::error!(?block_hash, "block was unorphaned but was not marked received");
         }
     }
 
@@ -276,7 +276,10 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.missing_chunks_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as having missing chunks but was not marked received");
+            tracing::error!(
+                ?block_hash,
+                "block was marked as having missing chunks but was not marked received"
+            );
         }
     }
 
@@ -284,7 +287,10 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.pending_execution_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as pending execution but was not marked received");
+            tracing::error!(
+                ?block_hash,
+                "block was marked as pending execution but was not marked received"
+            );
         }
     }
 
@@ -292,7 +298,10 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_pending_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as completed pending execution but was not marked received");
+            tracing::error!(
+                ?block_hash,
+                "block was marked as completed pending execution but was not marked received"
+            );
         }
     }
 
@@ -300,7 +309,10 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_missing_chunks_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as having no missing chunks but was not marked received");
+            tracing::error!(
+                ?block_hash,
+                "block was marked as having no missing chunks but was not marked received"
+            );
         }
     }
 
@@ -360,7 +372,7 @@ impl BlocksDelayTracker {
                     }
                 } else {
                     debug_assert!(false);
-                    tracing::error!(target: "block_delay_tracker", ?block_hash, "block in height map but not in blocks");
+                    tracing::error!(?block_hash, "block in height map but not in blocks");
                 }
             }
 
@@ -395,7 +407,7 @@ impl BlocksDelayTracker {
                 if let Some(chunk_hash) = chunk_hash {
                     if let Some(processed_chunk) = self.chunks.get(&chunk_hash) {
                         let Ok(shard_id) = shard_layout.get_shard_id(shard_index) else {
-                            tracing::error!(target: "block_delay_tracker", ?shard_index, "invalid shard index");
+                            tracing::error!(?shard_index, "invalid shard index");
                             continue;
                         };
                         self.update_chunk_metrics(processed_chunk, shard_id);

--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -726,32 +726,32 @@ impl Doomslug {
         verbose: bool,
     ) -> bool {
         let span = debug_span!(
-            target: "doomslug",
             "ready_to_produce_block",
             target_height,
             enough_chunks_for = field::Empty,
             enough_approvals_for = field::Empty,
             ready_to_produce_block = field::Empty,
-            need_to_wait = field::Empty)
+            need_to_wait = field::Empty
+        )
         .entered();
         let now = self.clock.now();
         let hash_or_height =
             ApprovalInner::new(&self.tip.block_hash, self.tip.height, target_height);
         let Some(approval_trackers_at_height) = self.approval_trackers.get_mut(&target_height)
         else {
-            tracing::debug!(target: "doomslug", target_height, "no approval trackers at height");
+            tracing::debug!(target_height, "no approval trackers at height");
             return false;
         };
         let Some(approval_tracker) =
             approval_trackers_at_height.approval_trackers.get_mut(&hash_or_height)
         else {
-            tracing::debug!(target: "doomslug", target_height, ?hash_or_height, "no approval tracker");
+            tracing::debug!(target_height, ?hash_or_height, "no approval tracker");
             return false;
         };
 
         let when = match approval_tracker.get_block_production_readiness() {
             DoomslugBlockProductionReadiness::NotReady => {
-                tracing::debug!(target: "doomslug", target_height, ?hash_or_height, "not ready to produce block");
+                tracing::debug!(target_height, ?hash_or_height, "not ready to produce block");
                 return false;
             }
             DoomslugBlockProductionReadiness::ReadySince(when) => when,
@@ -766,7 +766,9 @@ impl Doomslug {
             metrics::BLOCK_APPROVAL_DELAY.observe(enough_chunks_for.as_seconds_f64());
             if verbose {
                 tracing::info!(
-                    target: "doomslug", target_height, ?enough_approvals_for, ?enough_chunks_for,
+                    target_height,
+                    ?enough_approvals_for,
+                    ?enough_chunks_for,
                     "ready to produce block, has enough approvals, has enough chunks"
                 );
             }
@@ -783,12 +785,13 @@ impl Doomslug {
         if verbose {
             if ready {
                 tracing::info!(
-                    target: "doomslug", target_height, ?enough_approvals_for,
+                    target_height,
+                    ?enough_approvals_for,
                     "ready to produce block, but does not have enough chunks"
                 );
             } else {
                 tracing::info!(
-                    target: "doomslug", target_height, need_to_wait_for = ?(when + delay - now),
+                    target_height, need_to_wait_for = ?(when + delay - now),
                     ?enough_approvals_for, "not ready to produce block, need to wait"
                 );
             }

--- a/chain/chain/src/flat_storage_init.rs
+++ b/chain/chain/src/flat_storage_init.rs
@@ -38,7 +38,7 @@ fn init_flat_storage_for_current_epoch(
     flat_storage_manager: &FlatStorageManager,
 ) -> Result<(), Error> {
     let epoch_id = &chain_head.epoch_id;
-    tracing::debug!(target: "chain", ?epoch_id, "init flat storage for the current epoch");
+    tracing::debug!(?epoch_id, "init flat storage for the current epoch");
 
     let shard_ids = epoch_manager.shard_ids(epoch_id)?;
     for shard_id in shard_ids {
@@ -70,7 +70,7 @@ fn init_flat_storage_for_next_epoch(
     }
 
     let next_epoch_id = &chain_head.next_epoch_id;
-    tracing::debug!(target: "chain", ?next_epoch_id, "init flat storage for the next epoch");
+    tracing::debug!(?next_epoch_id, "init flat storage for the next epoch");
 
     let shard_ids = epoch_manager.shard_ids(next_epoch_id)?;
     for shard_id in shard_ids {

--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -160,7 +160,7 @@ impl Chain {
         }
         store_update.merge(tmp_store_update);
         store_update.commit()?;
-        tracing::info!(target: "chain", height = %block_head.height, ?block_head.last_block_hash, ?state_roots, "genesis has been saved");
+        tracing::info!(height = %block_head.height, ?block_head.last_block_hash, ?state_roots, "genesis has been saved");
         Ok(())
     }
 
@@ -278,7 +278,7 @@ pub fn get_genesis_congestion_infos(
     state_roots: &Vec<CryptoHash>,
 ) -> Result<Vec<CongestionInfo>, Error> {
     get_genesis_congestion_infos_impl(epoch_manager, runtime, state_roots).map_err(|err| {
-        tracing::error!(target: "chain", ?err, "failed to get the genesis congestion infos");
+        tracing::error!(?err, "failed to get the genesis congestion infos");
         err
     })
 }
@@ -295,7 +295,7 @@ fn get_genesis_congestion_infos_impl(
 
     // Check we had already computed the congestion infos from the genesis state roots.
     if let Some(saved_infos) = near_store::get_genesis_congestion_infos(runtime.store())? {
-        tracing::debug!(target: "chain", "reading genesis congestion infos from database");
+        tracing::debug!("reading genesis congestion infos from database");
         return Ok(saved_infos);
     }
 
@@ -312,7 +312,6 @@ fn get_genesis_congestion_infos_impl(
             Ok(info) => info,
             Err(_) => {
                 tracing::info!(
-                    target: "chain",
                     %shard_id,
                     "genesis state unavailable, using default congestion info"
                 );
@@ -325,7 +324,7 @@ fn get_genesis_congestion_infos_impl(
     // Store it in DB so that we can read it later, instead of recomputing from genesis state roots.
     // Note that this is necessary because genesis state roots will be garbage-collected and will not
     // be available, for example, when the node restarts later.
-    tracing::debug!(target: "chain", "saving genesis congestion infos to database");
+    tracing::debug!("saving genesis congestion infos to database");
     let mut store_update = runtime.store().store_update();
     near_store::set_genesis_congestion_infos(&mut store_update, &new_infos);
     store_update.commit()?;
@@ -345,7 +344,7 @@ fn get_genesis_congestion_info(
     let trie = runtime.get_view_trie_for_shard(shard_id, prev_hash, state_root)?;
     let runtime_config = runtime.get_runtime_config(protocol_version);
     let congestion_info = bootstrap_congestion_info(&trie, runtime_config, shard_id)?;
-    tracing::debug!(target: "chain", %shard_id, ?state_root, ?congestion_info, "computed genesis congestion info");
+    tracing::debug!(%shard_id, ?state_root, ?congestion_info, "computed genesis congestion info");
     Ok(congestion_info)
 }
 

--- a/chain/chain/src/pending.rs
+++ b/chain/chain/src/pending.rs
@@ -25,7 +25,7 @@ impl<Block: BlockLike> PendingBlocksPool<Block> {
     pub fn add_block(&mut self, block: Block) {
         let height = block.height();
         if self.blocks.contains_key(&height) {
-            tracing::debug!(target: "chain", block_hash = ?block.hash(), "block already exists in pending blocks pool");
+            tracing::debug!(block_hash = ?block.hash(), "block already exists in pending blocks pool");
             return;
         }
         self.block_hashes.insert(block.hash());

--- a/chain/chain/src/resharding/event_type.rs
+++ b/chain/chain/src/resharding/event_type.rs
@@ -50,7 +50,7 @@ impl ReshardingEventType {
         resharding_block: BlockInfo,
     ) -> Result<Option<ReshardingEventType>, Error> {
         let log_and_error = |err_msg: &str| {
-            tracing::error!(target: "resharding", ?next_shard_layout, err_msg);
+            tracing::error!(?next_shard_layout, err_msg);
             Err(Error::ReshardingError(err_msg.to_owned()))
         };
 

--- a/chain/chain/src/resharding/migrations.rs
+++ b/chain/chain/src/resharding/migrations.rs
@@ -41,17 +41,17 @@ pub fn migrate_46_to_47(
     store_config: &StoreConfig,
 ) -> anyhow::Result<()> {
     let Some(cold_db) = cold_db else {
-        tracing::info!(target: "migrations", "skipping migration 46->47 for hot store only",);
+        tracing::info!("skipping migration 46->47 for hot store only",);
         return Ok(());
     };
 
     // Current migration is targeted only for mainnet
     if genesis_config.chain_id != MAINNET {
-        tracing::info!(target: "migrations", chain_id = ?genesis_config.chain_id, "skipping migration 46->47",);
+        tracing::info!(chain_id = ?genesis_config.chain_id, "skipping migration 46->47",);
         return Ok(());
     }
 
-    tracing::info!(target: "migrations", "starting migration 46->47 for cold store");
+    tracing::info!("starting migration 46->47 for cold store");
 
     let cold_store = cold_db.as_store();
     let epoch_config_store =
@@ -65,7 +65,7 @@ pub fn migrate_46_to_47(
 
     let mut transaction = DBTransaction::new();
     for (protocol_version, resharding_block_hash) in MAINNET_RESHARDING_BLOCK_HASHES {
-        tracing::info!(target: "migrations", ?resharding_block_hash, "processing resharding block");
+        tracing::info!(?resharding_block_hash, "processing resharding block");
 
         let resharding_block_hash = CryptoHash::from_str(resharding_block_hash).unwrap();
         let shard_layout = &epoch_config_store.get_config(protocol_version).static_shard_layout();
@@ -108,7 +108,7 @@ pub fn migrate_46_to_47(
         }
     }
 
-    tracing::info!(target: "migrations", "Writing changes to the database");
+    tracing::info!("Writing changes to the database");
     cold_db.write(transaction);
 
     Ok(())

--- a/chain/chain/src/resharding/resharding_actor.rs
+++ b/chain/chain/src/resharding/resharding_actor.rs
@@ -89,12 +89,12 @@ impl ReshardingActor {
         split_shard_event: ReshardingSplitShardParams,
         ctx: &mut dyn DelayedActionRunner<Self>,
     ) {
-        tracing::info!(target: "resharding", ?split_shard_event, "handle_schedule_resharding");
+        tracing::info!(?split_shard_event, "handle_schedule_resharding");
 
         let parent_shard = split_shard_event.parent_shard;
         if self.resharding_started.contains(&parent_shard) {
             // The event is already in progress, no need to reschedule.
-            tracing::info!(target: "resharding", "resharding already in progress");
+            tracing::info!("resharding already in progress");
             return;
         }
 
@@ -145,11 +145,11 @@ impl ReshardingActor {
         &self,
         parent_shard_uid: ShardUId,
     ) -> ReshardingSchedulingStatus {
-        tracing::info!(target: "resharding", ?parent_shard_uid, "get_resharding_scheduling_status");
+        tracing::info!(?parent_shard_uid, "get_resharding_scheduling_status");
 
         if self.resharding_started.contains(&parent_shard_uid) {
             // The event is already in progress, no need to reschedule.
-            tracing::info!(target: "resharding", "resharding already in progress");
+            tracing::info!("resharding already in progress");
             return ReshardingSchedulingStatus::AlreadyStarted;
         }
 
@@ -185,7 +185,7 @@ impl ReshardingActor {
             // This behavior is configured through `adv_task_delay_by_blocks`
             #[cfg(feature = "test_features")]
             if event.resharding_block.height + self.adv_task_delay_by_blocks > chain_final_height {
-                tracing::info!(target: "resharding", "resharding has been artificially postponed");
+                tracing::info!("resharding has been artificially postponed");
                 return ReshardingSchedulingStatus::WaitForFinalBlock;
             }
 
@@ -205,19 +205,19 @@ impl ReshardingActor {
         if let Err(err) =
             self.trie_state_resharder.initialize_trie_state_resharding_status(&resharding_event)
         {
-            tracing::error!(target: "resharding", ?err, "failed to initialize trie state resharding status");
+            tracing::error!(?err, "failed to initialize trie state resharding status");
             return;
         }
 
         // This is a long running task and would block the actor
         if let Err(err) = self.flat_storage_resharder.start_resharding_blocking(&resharding_event) {
-            tracing::error!(target: "resharding", ?err, "failed to start flat storage resharding");
+            tracing::error!(?err, "failed to start flat storage resharding");
             return;
         }
 
-        tracing::info!(target: "resharding", "trie state resharder starting");
+        tracing::info!("trie state resharder starting");
         if let Err(err) = self.trie_state_resharder.start_resharding_blocking(&resharding_event) {
-            tracing::error!(target: "resharding", ?err, "failed to start trie state resharding");
+            tracing::error!(?err, "failed to start trie state resharding");
             return;
         }
     }

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -147,7 +147,6 @@ impl TrieStateResharder {
         // regular node operation.
         std::thread::sleep(batch_delay);
         let _span = tracing::debug_span!(
-            target: "resharding",
             "TrieStateResharder::process_batch_and_update_status",
             parent_shard_uid = ?status.parent_shard_uid,
             child_shard_uid = ?child.shard_uid,
@@ -275,7 +274,6 @@ impl TrieStateResharder {
             *store.get_chunk_extra(&block_hash, &event.parent_shard)?.state_root();
 
         tracing::debug!(
-            target: "resharding",
             ?left_state_root,
             ?right_state_root,
             ?parent_state_root,
@@ -328,7 +326,7 @@ impl TrieStateResharder {
             );
         };
 
-        tracing::info!(target: "resharding", ?status, ?event, "start_resharding_blocking");
+        tracing::info!(?status, ?event, "start_resharding_blocking");
 
         let mut status = status.with_metrics();
         self.resharding_blocking_impl(&mut status)
@@ -337,7 +335,7 @@ impl TrieStateResharder {
     /// Resume an interrupted resharding operation.
     pub fn resume(&self, parent_shard_uid: ShardUId) -> Result<(), Error> {
         let Some(status) = self.load_status()? else {
-            tracing::info!(target: "resharding", "resharding status not found, nothing to resume");
+            tracing::info!("resharding status not found, nothing to resume");
             return Ok(());
         };
 
@@ -388,7 +386,6 @@ impl TrieStateResharder {
         // Parent memtrie must be loaded before proceeding.
         if tries.get_memtries(parent_shard_uid).is_none() {
             tracing::info!(
-                target: "resharding",
                 ?parent_shard_uid,
                 parent_state_root = ?status.parent_state_root,
                 "parent memtrie not loaded, loading it now"
@@ -413,7 +410,6 @@ impl TrieStateResharder {
         // Recreate each missing child memtrie.
         for (child_shard_uid, retain_mode) in &missing_children {
             tracing::info!(
-                target: "resharding",
                 ?child_shard_uid,
                 ?parent_shard_uid,
                 ?boundary_account,
@@ -429,7 +425,6 @@ impl TrieStateResharder {
             tries.apply_memtrie_changes(&trie_changes, parent_shard_uid, block_height);
 
             tracing::info!(
-                target: "resharding",
                 ?child_shard_uid,
                 new_root = ?trie_changes.new_root,
                 "successfully recreated child memtrie from parent"
@@ -464,7 +459,6 @@ impl TrieStateResharder {
     /// Cleans up parent flat storage after trie state resharding is complete.
     fn cleanup_parent_flat_storage(&self, parent_shard_uid: ShardUId) {
         tracing::info!(
-            target: "resharding",
             ?parent_shard_uid,
             "trie state resharding complete, cleaning up parent flat storage"
         );

--- a/chain/chain/src/soft_realtime_thread_pool.rs
+++ b/chain/chain/src/soft_realtime_thread_pool.rs
@@ -80,10 +80,11 @@ impl ThreadPool {
             .priority(self.priority)
             .spawn(move |res| {
                 if let Err(err) = res {
-                    tracing::debug!(target: "chain::soft_realtime_thread_pool", name = name, err = %err, "setting scheduler policy failed");
+                    tracing::debug!(name = name, err = %err, "setting scheduler policy failed");
                 };
                 run_worker(job, idle_timeout, idle_queue, counter_guard)
-            }).expect("Failed to spawn thread");
+            })
+            .expect("Failed to spawn thread");
     }
 }
 
@@ -115,7 +116,6 @@ impl WorkerCounter {
         let num_threads = self.num_threads.fetch_add(1, Ordering::SeqCst);
         if num_threads > self.limit {
             tracing::debug!(
-                target: "chain::soft_realtime_thread_pool",
                 name = self.name,
                 limit = self.limit,
                 num_threads = num_threads,

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -207,7 +207,7 @@ impl SpiceCoreReader {
         let prev_uncertified_chunks = self
             .get_uncertified_chunks(block.header().prev_hash())
             .map_err(|err| {
-                tracing::debug!(target: "spice_core", prev_hash=?block.header().prev_hash(), ?err, "failed getting uncertified_chunks");
+                tracing::debug!(prev_hash=?block.header().prev_hash(), ?err, "failed getting uncertified_chunks");
                 NoPrevUncertifiedChunks
             })?;
         let waiting_on_endorsements: HashSet<_> = prev_uncertified_chunks

--- a/chain/chain/src/spice_core_writer_actor.rs
+++ b/chain/chain/src/spice_core_writer_actor.rs
@@ -58,7 +58,7 @@ impl near_async::messaging::Actor for SpiceCoreWriterActor {}
 impl Handler<ProcessedBlock> for SpiceCoreWriterActor {
     fn handle(&mut self, ProcessedBlock { block_hash }: ProcessedBlock) {
         if let Err(err) = self.handle_processed_block(block_hash) {
-            tracing::error!(target: "spice_core_writer", ?err, "error handling processed block");
+            tracing::error!(?err, "error handling processed block");
         }
     }
 }
@@ -66,7 +66,7 @@ impl Handler<ProcessedBlock> for SpiceCoreWriterActor {
 impl Handler<SpiceChunkEndorsementMessage> for SpiceCoreWriterActor {
     fn handle(&mut self, msg: SpiceChunkEndorsementMessage) {
         if let Err(err) = self.process_chunk_endorsement(msg.0) {
-            tracing::error!(target: "spice_core_writer", ?err, "error processing spice chunk endorsement");
+            tracing::error!(?err, "error processing spice chunk endorsement");
         }
     }
 }
@@ -355,7 +355,6 @@ impl SpiceCoreWriterActor {
                     Ok(()) => true,
                     Err(err) => {
                         tracing::info!(
-                            target: "spice_core_writer",
                             chunk_id = ?endorsement.chunk_id(),
                             ?err,
                             "encountered invalid pending endorsement"
@@ -391,7 +390,6 @@ impl SpiceCoreWriterActor {
             Ok(block) => block,
             Err(Error::DBNotFoundErr(_)) => {
                 tracing::debug!(
-                    target: "spice_core_writer",
                     block_hash = ?endorsement.block_hash(),
                     "not processing endorsement immediately since haven't received relevant block yet"
                 );

--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -281,7 +281,6 @@ impl ChainStateSyncAdapter {
         sync_hash: CryptoHash,
     ) -> Result<StatePart, Error> {
         let _span = tracing::debug_span!(
-            target: "sync",
             "get_state_response_part",
             %shard_id,
             part_id,

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -263,12 +263,7 @@ impl Chain {
         };
 
         let genesis_hash = self.genesis().hash();
-        tracing::debug!(
-            target: "sync",
-            ?header_head,
-            ?sync_hash,
-            ?genesis_hash,
-            "find_sync_hash");
+        tracing::debug!(?header_head, ?sync_hash, ?genesis_hash, "find_sync_hash");
         assert_ne!(&sync_hash, genesis_hash);
         Ok(Some(sync_hash))
     }
@@ -289,7 +284,7 @@ impl Chain {
         };
 
         let Some(min_height_included) = sync_prev_block.chunks().min_height_included() else {
-            tracing::warn!(target: "sync", ?sync_prev_hash, "cannot find the min block height to sync from");
+            tracing::warn!(?sync_prev_hash, "cannot find the min block height to sync from");
             return vec![];
         };
 
@@ -298,7 +293,7 @@ impl Chain {
         loop {
             let next_header = self.get_block_header(&next_hash);
             let Ok(next_header) = next_header else {
-                tracing::error!(target: "sync", hash=?next_hash, "cannot get block header to sync");
+                tracing::error!(hash=?next_hash, "cannot get block header to sync");
                 break;
             };
 

--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -24,7 +24,6 @@ pub fn validate_chunk_endorsements_in_block(
     // Number of chunks and chunk endorsements must match and must be equal to number of shards
     if block.chunks().len() != block.chunk_endorsements().len() {
         tracing::error!(
-            target: "chain",
             num_chunks = block.chunks().len(),
             num_chunk_endorsement_shards = block.chunk_endorsements().len(),
             "number of chunks and chunk endorsements does not match",
@@ -51,7 +50,6 @@ pub fn validate_chunk_endorsements_in_block(
         if chunk_header.height_included() != block.header().height() {
             if !signatures.is_empty() {
                 tracing::error!(
-                    target: "chain",
                     chunk_header_height_included = chunk_header.height_included(),
                     block_header_height = block.header().height(),
                     "expected chunk endorsements to be empty for old chunks in current block",
@@ -74,7 +72,6 @@ pub fn validate_chunk_endorsements_in_block(
         let ordered_chunk_validators = chunk_validator_assignments.ordered_chunk_validators();
         if ordered_chunk_validators.len() != signatures.len() {
             tracing::error!(
-                target: "chain",
                 num_ordered_chunk_validators = ordered_chunk_validators.len(),
                 num_chunk_endorsement_signatures = signatures.len(),
                 "number of ordered chunk validators and chunk endorsement signatures does not match",
@@ -97,7 +94,6 @@ pub fn validate_chunk_endorsements_in_block(
                 validator.public_key(),
             ) {
                 tracing::error!(
-                    target: "chain",
                     chunk_hash = ?chunk_header.chunk_hash(),
                     validator = ?validator.account_id(),
                     "invalid chunk endorsement signature"
@@ -112,7 +108,7 @@ pub fn validate_chunk_endorsements_in_block(
         let endorsement_state =
             chunk_validator_assignments.compute_endorsement_state(endorsed_chunk_validators);
         if !endorsement_state.is_endorsed {
-            tracing::error!(target: "chain", ?endorsement_state, "chunk does not have enough stake to be endorsed");
+            tracing::error!(?endorsement_state, "chunk does not have enough stake to be endorsed");
             return Err(Error::InvalidChunkEndorsement);
         }
 

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -551,7 +551,6 @@ pub fn validate_chunk_state_witness_impl(
         .with_label_values(&[&witness_chunk_shard_id.to_string()])
         .start_timer();
     let span = tracing::debug_span!(
-        target: "client",
         "validate_chunk_state_witness",
         height = height_created,
         shard_id = %witness_chunk_shard_id,
@@ -782,11 +781,7 @@ pub fn validate_chunk_state_witness(
     );
     if result.is_err() {
         if let Err(storage_err) = save_invalid_chunk_state_witness(store, &state_witness) {
-            tracing::error!(
-                target: "stateless_validation",
-                ?storage_err,
-                "failed to store invalid state witness"
-            );
+            tracing::error!(?storage_err, "failed to store invalid state witness");
         }
     }
     result
@@ -804,7 +799,7 @@ impl Chain {
         let height_created = witness.chunk_header().height_created();
         let chunk_hash = witness.chunk_header().chunk_hash().clone();
         let parent_span = tracing::debug_span!(
-            target: "chain", "shadow_validate", %shard_id, height_created);
+            "shadow_validate", %shard_id, height_created);
         let (encoded_witness, raw_witness_size) = {
             let shard_id_label = shard_id.to_string();
             let encode_timer =

--- a/chain/chain/src/stateless_validation/metrics.rs
+++ b/chain/chain/src/stateless_validation/metrics.rs
@@ -203,7 +203,7 @@ pub fn record_witness_size_metrics(
     witness: &ChunkStateWitness,
 ) {
     if let Err(err) = record_witness_size_metrics_fallible(decoded_size, encoded_size, witness) {
-        tracing::warn!(target: "client", ?err, "failed to record witness size metrics");
+        tracing::warn!(?err, "failed to record witness size metrics");
     }
 }
 

--- a/chain/chain/src/stateless_validation/spice_chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/spice_chunk_validation.rs
@@ -165,7 +165,6 @@ pub fn spice_pre_validate_chunk_state_witness(
 #[tracing::instrument(
     level = tracing::Level::DEBUG,
     skip_all,
-    target = "spice_chunk_validator",
     fields(
         chunk_id = ?state_witness.chunk_id(),
     )

--- a/chain/chain/src/stateless_validation/state_witness.rs
+++ b/chain/chain/src/stateless_validation/state_witness.rs
@@ -51,7 +51,6 @@ impl ChainStore {
     ) -> Result<CreateWitnessResult, Error> {
         let chunk_header = chunk.cloned_header();
         let _span = tracing::debug_span!(
-            target: "client",
             "create_state_witness",
             chunk_hash = ?chunk_header.chunk_hash(),
             height = chunk_header.height_created(),

--- a/chain/chain/src/store/latest_witnesses.rs
+++ b/chain/chain/src/store/latest_witnesses.rs
@@ -150,7 +150,9 @@ impl ChainStore {
         let start_time = std::time::Instant::now();
         let ChunkProductionKey { shard_id, epoch_id, height_created } =
             witness.chunk_production_key();
-        let _span = tracing::info_span!(target: "client", "save_latest_chunk_state_witness", ?height_created, %shard_id).entered();
+        let _span =
+            tracing::info_span!("save_latest_chunk_state_witness", ?height_created, %shard_id)
+                .entered();
 
         let serialized_witness = borsh::to_vec(witness)?;
         let witness_size: u64 =
@@ -330,7 +332,6 @@ pub fn save_invalid_chunk_state_witness(
 ) -> Result<(), std::io::Error> {
     let start_time = std::time::Instant::now();
     let _span = tracing::info_span!(
-        target: "client",
         "save_invalid_chunk_state_witness",
         witness_height = witness.chunk_header().height_created(),
         witness_shard = ?witness.chunk_header().shard_id(),

--- a/chain/chain/src/store/utils.rs
+++ b/chain/chain/src/store/utils.rs
@@ -169,8 +169,13 @@ pub fn get_incoming_receipts_for_shard(
     last_chunk_height_included: BlockHeight,
     receipts_filter: ReceiptFilter,
 ) -> Result<Vec<ReceiptProofResponse>, Error> {
-    let _span =
-            tracing::debug_span!(target: "chain", "get_incoming_receipts_for_shard", ?target_shard_id, ?block_hash, last_chunk_height_included).entered();
+    let _span = tracing::debug_span!(
+        "get_incoming_receipts_for_shard",
+        ?target_shard_id,
+        ?block_hash,
+        last_chunk_height_included
+    )
+    .entered();
 
     let mut ret = vec![];
 
@@ -195,7 +200,6 @@ pub fn get_incoming_receipts_for_shard(
         if prev_shard_layout != current_shard_layout {
             let parent_shard_id = current_shard_layout.get_parent_shard_id(current_shard_id)?;
             tracing::info!(
-                target: "chain",
                 version = current_shard_layout.version(),
                 prev_version = prev_shard_layout.version(),
                 ?current_shard_id,
@@ -210,18 +214,11 @@ pub fn get_incoming_receipts_for_shard(
             chain_store.get_incoming_receipts(&current_block_hash, current_shard_id);
         let receipts_proofs = match maybe_receipts_proofs {
             Ok(receipts_proofs) => {
-                tracing::debug!(
-                    target: "chain",
-                    "found receipts from block with missing chunks",
-                );
+                tracing::debug!("found receipts from block with missing chunks",);
                 receipts_proofs
             }
             Err(err) => {
-                tracing::debug!(
-                    target: "chain",
-                    ?err,
-                    "could not find receipts from block with missing chunks"
-                );
+                tracing::debug!(?err, "could not find receipts from block with missing chunks");
 
                 // This can happen when all chunks are missing in a block
                 // and then we can safely assume that there aren't any

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -349,7 +349,7 @@ impl StoreValidator {
             }
             if let Some(timeout) = self.timeout {
                 if self.start_time.elapsed() > Duration::milliseconds(timeout) {
-                    tracing::warn!(target: "adversary", %col, col_index = %col.into_usize(), col_length = %DBCol::LENGTH, "store validator hit timeout");
+                    tracing::warn!(%col, col_index = %col.into_usize(), col_length = %DBCol::LENGTH, "store validator hit timeout");
                     return;
                 }
             }
@@ -357,7 +357,7 @@ impl StoreValidator {
         if let Some(timeout) = self.timeout {
             // We didn't complete all Column checks and cannot do final checks, returning here
             if self.start_time.elapsed() > Duration::milliseconds(timeout) {
-                tracing::warn!(target: "adversary", "store validator hit timeout before final checks");
+                tracing::warn!("store validator hit timeout before final checks");
                 return;
             }
         }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -142,7 +142,7 @@ pub struct ApplyChunkResult {
 
 impl ApplyChunkResult {
     /// Returns root and paths for all the outcomes in the result.
-    #[instrument(target = "runtime", level = "debug", "compute_outcomes_proof", skip_all, fields(
+    #[instrument(level = "debug", "compute_outcomes_proof", skip_all, fields(
         num_outcomes = outcomes.len()
     ))]
     pub fn compute_outcomes_proof(

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -137,7 +137,6 @@ pub fn apply_new_chunk(
     } = data;
     let shard_id = shard_context.shard_uid.shard_id();
     let _span = tracing::debug_span!(
-        target: "chain",
         parent: parent_span,
         "apply_new_chunk",
         height = block.height,
@@ -191,7 +190,6 @@ pub fn apply_old_chunk(
     let OldChunkData { prev_chunk_extra, block, storage_context } = data;
     let shard_id = shard_context.shard_uid.shard_id();
     let _span = tracing::debug_span!(
-        target: "chain",
         parent: parent_span,
         "apply_old_chunk",
         height = block.height,

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -145,7 +145,7 @@ impl EncodedChunksCache {
             let previous_block_hash = &entry.header.prev_block_hash().clone();
             self.remove_chunk_from_incomplete_chunks(previous_block_hash, chunk_hash);
         } else {
-            tracing::warn!(target: "chunks", ?chunk_hash, "cannot mark non-existent entry as complete");
+            tracing::warn!(?chunk_hash, "cannot mark non-existent entry as complete");
         }
     }
 

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -124,7 +124,6 @@ impl ShardedTransactionPool {
     /// transactions back to the pool with the new shard uids.
     pub fn reshard(&mut self, old_shard_layout: &ShardLayout, new_shard_layout: &ShardLayout) {
         tracing::debug!(
-            target: "resharding",
             old_shard_layout_version = old_shard_layout.version(),
             new_shard_layout_version = new_shard_layout.version(),
             "resharding the transaction pool"

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -124,7 +124,7 @@ pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts(
     }
 }
 
-#[instrument(target = "chunks", level = "debug", "create_partial_chunk", skip_all, fields(
+#[instrument(level = "debug", "create_partial_chunk", skip_all, fields(
     height = chunk.to_shard_chunk().height_created(),
     shard_id = %chunk.to_shard_chunk().shard_id(),
     chunk_hash = ?chunk.to_shard_chunk().chunk_hash(),
@@ -180,7 +180,7 @@ pub fn create_partial_chunk(
     ))
 }
 
-#[instrument(target = "client", level = "debug", "persist_chunk", skip_all, fields(
+#[instrument(level = "debug", "persist_chunk", skip_all, fields(
     height = partial_chunk.height_created(),
     shard_id = %partial_chunk.shard_id(),
     chunk_hash = ?partial_chunk.chunk_hash(),

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -191,8 +191,7 @@ impl SyncStatus {
 
     pub fn update(&mut self, new_value: Self) {
         let _span =
-            tracing::debug_span!(target: "sync", "update_sync_status", old_value = ?self, ?new_value)
-                .entered();
+            tracing::debug_span!("update_sync_status", old_value = ?self, ?new_value).entered();
         *self = new_value;
     }
 }

--- a/chain/client/src/archive/cold_store_actor.rs
+++ b/chain/client/src/archive/cold_store_actor.rs
@@ -113,7 +113,7 @@ pub struct ColdStoreActor {
 
 impl Actor for ColdStoreActor {
     fn start_actor(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
-        tracing::info!(target: "cold_store", "starting the cold store actor");
+        tracing::info!("starting the cold store actor");
         // Note that we start with the cold store migration loop which later spawns the cold store loop.
         self.cold_store_migration_loop(ctx);
     }
@@ -169,31 +169,31 @@ impl ColdStoreActor {
         // Migration is only needed if cold storage is not properly initialized,
         // i.e. if cold head is not set.
         if self.cold_db.as_store().chain_store().head().is_ok() {
-            tracing::info!(target: "cold_store", "cold store already has a head set, no migration needed");
+            tracing::info!("cold store already has a head set, no migration needed");
             return Ok(ColdStoreMigrationResult::NoNeedForMigration);
         }
 
-        tracing::info!(target: "cold_store", "starting population of cold store");
+        tracing::info!("starting population of cold store");
         let new_cold_height = match self.hot_store.get_db_kind()? {
             None => {
-                tracing::error!(target: "cold_store", "hot store kind is unknown");
+                tracing::error!("hot store kind is unknown");
                 return Err(anyhow::anyhow!("Hot store DBKind is not set"));
             }
             Some(DbKind::Hot) => {
-                tracing::info!(target: "cold_store", "hot store kind is hot");
+                tracing::info!("hot store kind is hot");
                 self.genesis_height
             }
             Some(DbKind::Archive) => {
-                tracing::info!(target: "cold_store", "hot store kind is archive");
+                tracing::info!("hot store kind is archive");
                 self.hot_store.chain_store().final_head()?.height
             }
             Some(kind) => {
-                tracing::error!(target: "cold_store", ?kind, "hot store kind not supported");
+                tracing::error!(?kind, "hot store kind not supported");
                 return Err(anyhow::anyhow!(format!("Hot store DBKind not {kind:?}.")));
             }
         };
 
-        tracing::info!(target: "cold_store", new_cold_height, "determined cold storage head height after migration");
+        tracing::info!(new_cold_height, "determined cold storage head height after migration");
 
         let batch_size = self.split_storage_config.cold_store_initial_migration_batch_size;
         match copy_all_data_to_cold(
@@ -203,12 +203,15 @@ impl ColdStoreActor {
             &self.keep_going,
         )? {
             CopyAllDataToColdStatus::EverythingCopied => {
-                tracing::info!(target: "cold_store", new_cold_height, "cold storage population was successful, writing cold head");
+                tracing::info!(
+                    new_cold_height,
+                    "cold storage population was successful, writing cold head"
+                );
                 update_cold_head(self.cold_db.as_ref(), &self.hot_store, &new_cold_height)?;
                 Ok(ColdStoreMigrationResult::SuccessfulMigration)
             }
             CopyAllDataToColdStatus::Interrupted => {
-                tracing::info!(target: "cold_store", "cold storage population was interrupted");
+                tracing::info!("cold storage population was interrupted");
                 Ok(ColdStoreMigrationResult::MigrationInterrupted)
             }
         }
@@ -219,7 +222,7 @@ impl ColdStoreActor {
     /// If migration returned any successful status (including interruption status) breaks the loop.
     fn cold_store_migration_loop(&self, ctx: &mut dyn DelayedActionRunner<Self>) {
         if !self.keep_going.load(std::sync::atomic::Ordering::Relaxed) {
-            tracing::debug!(target: "cold_store", "stopping the initial migration loop");
+            tracing::debug!("stopping the initial migration loop");
             return;
         }
 
@@ -229,7 +232,7 @@ impl ColdStoreActor {
                 // Here we pick the second option.
                 let duration =
                     self.split_storage_config.cold_store_initial_migration_loop_sleep_duration;
-                tracing::error!(target: "cold_store", ?err, ?duration, "migration failed, sleeping and trying again");
+                tracing::error!(?err, ?duration, "migration failed, sleeping and trying again");
                 ctx.run_later("cold_store_migration_loop", duration, move |actor, ctx| {
                     actor.cold_store_migration_loop(ctx);
                 });
@@ -237,13 +240,13 @@ impl ColdStoreActor {
             Ok(migration_status) => {
                 match migration_status {
                     ColdStoreMigrationResult::MigrationInterrupted => {
-                        tracing::info!(target: "cold_store", "cold storage migration was interrupted");
+                        tracing::info!("cold storage migration was interrupted");
                         return;
                     }
                     ColdStoreMigrationResult::NoNeedForMigration
                     | ColdStoreMigrationResult::SuccessfulMigration => {
                         // Migration was successful, we can start the cold store loop.
-                        tracing::info!(target: "cold_store", "starting the cold store loop");
+                        tracing::info!("starting the cold store loop");
                         self.cold_store_loop(ctx);
                     }
                 }
@@ -257,7 +260,7 @@ impl ColdStoreActor {
     // trying to copy data at the next height.
     fn cold_store_loop(&self, ctx: &mut dyn DelayedActionRunner<Self>) {
         if !self.keep_going.load(std::sync::atomic::Ordering::Relaxed) {
-            tracing::debug!(target: "cold_store", "stopping the cold store loop");
+            tracing::debug!("stopping the cold store loop");
             return;
         }
 
@@ -284,22 +287,22 @@ impl ColdStoreActor {
         let result_string = cold_store_copy_result_to_string(&result);
         metrics::COLD_STORE_COPY_RESULT.with_label_values(&[result_string]).inc();
         if duration > std::time::Duration::from_secs(1) {
-            tracing::debug!(target: "cold_store", ?duration, "cold store copy completed");
+            tracing::debug!(?duration, "cold store copy completed");
         }
 
         match &result {
             Err(err) => {
-                tracing::error!(target: "cold_store", ?err, "cold store copy failed");
+                tracing::error!(?err, "cold store copy failed");
             }
             Ok(copy_result) => match copy_result {
                 ColdStoreCopyResult::NoBlockCopied => {
-                    tracing::trace!(target: "cold_store", "cold head is up to date, no blocks were copied");
+                    tracing::trace!("cold head is up to date, no blocks were copied");
                 }
                 ColdStoreCopyResult::LatestBlockCopied => {
-                    tracing::trace!(target: "cold_store", "latest block was copied");
+                    tracing::trace!("latest block was copied");
                 }
                 ColdStoreCopyResult::OtherBlockCopied => {
-                    tracing::trace!(target: "cold_store", "other block was copied - more copying needed");
+                    tracing::trace!("other block was copied - more copying needed");
                 }
             },
         }
@@ -325,7 +328,13 @@ impl ColdStoreActor {
         let hot_tail = self.hot_store.get_ser::<u64>(DBCol::BlockMisc, TAIL_KEY)?;
         let hot_tail_height = hot_tail.unwrap_or(self.genesis_height);
 
-        let _span = tracing::debug_span!(target: "cold_store", "cold_store_copy", cold_head_height, hot_final_head_height, hot_tail_height).entered();
+        let _span = tracing::debug_span!(
+            "cold_store_copy",
+            cold_head_height,
+            hot_final_head_height,
+            hot_tail_height
+        )
+        .entered();
 
         sanity_check(cold_head_height, hot_final_head_height, hot_tail_height)?;
 
@@ -379,7 +388,7 @@ impl ColdStoreActor {
             Ok(ColdStoreCopyResult::OtherBlockCopied)
         };
 
-        tracing::trace!(target: "cold_store", ?result, "ending");
+        tracing::trace!(?result, "ending");
         result
     }
 
@@ -401,13 +410,15 @@ pub fn create_cold_store_actor(
     shard_tracker: ShardTracker,
 ) -> anyhow::Result<Option<(ColdStoreActor, Arc<AtomicBool>)>> {
     if save_trie_changes != Some(true) {
-        tracing::debug!(target: "cold_store", "not creating cold store actor because trie changes are not saved");
+        tracing::debug!("not creating cold store actor because trie changes are not saved");
         return Ok(None);
     }
     let cold_db = match cold_db {
         Some(cold_db) => cold_db.clone(),
         None => {
-            tracing::debug!(target: "cold_store", "not creating the cold store actor because cold store is not configured");
+            tracing::debug!(
+                "not creating the cold store actor because cold store is not configured"
+            );
             return Ok(None);
         }
     };
@@ -432,7 +443,7 @@ pub fn create_cold_store_actor(
     sanity_check(cold_head_height, hot_final_head_height, hot_tail_height)?;
     debug_assert!(shard_tracker.is_valid_for_cold_store());
 
-    tracing::info!(target: "cold_store", "creating the cold store actor");
+    tracing::info!("creating the cold store actor");
 
     let actor = ColdStoreActor::new(
         split_storage_config.clone(),

--- a/chain/client/src/chunk_distribution_network.rs
+++ b/chain/client/src/chunk_distribution_network.rs
@@ -97,7 +97,7 @@ fn request_missing_chunk<C>(
     C::Error: fmt::Debug,
 {
     let shard_id = header.shard_id();
-    tracing::debug!(target: "client", %shard_id, chunk_hash=?header.chunk_hash(), "request_missing_chunk");
+    tracing::debug!(%shard_id, chunk_hash=?header.chunk_hash(), "request_missing_chunk");
     // TODO(#14005): Use a TokioRuntimeHandle to spawn this future.
     tokio::spawn(async move {
         match client.lookup_chunk(prev_hash, shard_id).await {
@@ -115,7 +115,7 @@ fn request_missing_chunk<C>(
                 });
             }
             Err(err) => {
-                tracing::error!(target: "client", ?err, "failed to find chunk via chunk distribution network");
+                tracing::error!(?err, "failed to find chunk via chunk distribution network");
                 adapter.send(ShardsManagerRequestFromClient::RequestChunks {
                     chunks_to_request: vec![header],
                     prev_hash,
@@ -160,7 +160,7 @@ fn request_orphan_chunk<C>(
                 );
             }
             Err(err) => {
-                tracing::error!(target: "client", ?err, "failed to find chunk via chunk distribution network");
+                tracing::error!(?err, "failed to find chunk via chunk distribution network");
                 thread_local_shards_manager_adapter.send(
                     ShardsManagerRequestFromClient::RequestChunksForOrphan {
                         chunks_to_request: vec![header],

--- a/chain/client/src/chunk_endorsement_handler.rs
+++ b/chain/client/src/chunk_endorsement_handler.rs
@@ -10,7 +10,7 @@ use crate::stateless_validation::chunk_endorsement::ChunkEndorsementTracker;
 impl Handler<ChunkEndorsementMessage> for ChunkEndorsementHandlerActor {
     fn handle(&mut self, msg: ChunkEndorsementMessage) {
         if let Err(err) = self.chunk_endorsement_tracker.process_chunk_endorsement(msg.0) {
-            tracing::error!(target: "client", ?err, "error processing chunk endorsement");
+            tracing::error!(?err, "error processing chunk endorsement");
         }
     }
 }

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -146,7 +146,6 @@ impl ChunkInclusionTracker {
             self.banned_chunk_producers.contains(&(*epoch_id, chunk_info.chunk_producer.clone()));
         if banned {
             tracing::warn!(
-                target: "client",
                 chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
                 chunk_producer = ?chunk_info.chunk_producer,
                 "not including chunk from a banned validator");
@@ -176,7 +175,6 @@ impl ChunkInclusionTracker {
             let is_endorsed = chunk_info.endorsements.is_endorsed;
             if !is_endorsed {
                 tracing::debug!(
-                    target: "client",
                     chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
                     chunk_producer = ?chunk_info.chunk_producer,
                     "not including chunk because of insufficient chunk endorsements"

--- a/chain/client/src/config_updater.rs
+++ b/chain/client/src/config_updater.rs
@@ -42,14 +42,14 @@ impl ConfigUpdater {
                     if let Some(client_config) = updatable_configs.client_config {
                         update_result.client_config_updated |=
                             update_client_config_fn(client_config);
-                        tracing::info!(target: "config", "updated client config");
+                        tracing::info!("updated client config");
                     }
                     if let UpdatableValidatorSigner::MaybeKey(validator_signer) =
                         updatable_configs.validator_signer
                     {
                         update_result.validator_signer_updated |=
                             update_validator_signer_fn(validator_signer);
-                        tracing::info!(target: "config", "updated validator key");
+                        tracing::info!("updated validator key");
                     }
                     self.updatable_configs_error = None;
                 }
@@ -65,7 +65,6 @@ impl ConfigUpdater {
     pub fn report_status(&self) {
         if let Some(updatable_configs_error) = &self.updatable_configs_error {
             tracing::warn!(
-                target: "stats",
                 error = %*updatable_configs_error,
                 "dynamically updated configs are not valid, please fix this ASAP otherwise the node will probably crash after restart"
             );

--- a/chain/client/src/gc_actor.rs
+++ b/chain/client/src/gc_actor.rs
@@ -81,17 +81,17 @@ impl GCActor {
 
     fn gc(&mut self) {
         if self.no_gc {
-            tracing::warn!(target: "garbage collection", "GC is disabled");
+            tracing::warn!("GC is disabled");
             return;
         }
         if self.store.head().is_err() {
-            tracing::warn!(target: "garbage collection", "state not initialized yet, head doesn't exist");
+            tracing::warn!("state not initialized yet, head doesn't exist");
             return;
         }
 
         let timer = metrics::GC_TIME.start_timer();
         if let Err(e) = self.clear_data() {
-            tracing::error!(target: "garbage collection", ?e, "error in gc");
+            tracing::error!(?e, "error in gc");
             debug_assert!(false, "Error in GCActor");
         }
         timer.observe_duration();

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -255,7 +255,7 @@ impl InfoHelper {
                 let chunk_producers_settlement = &epoch_info.chunk_producers_settlement();
                 let chunk_producers = chunk_producers_settlement.get(shard_index);
                 let Some(chunk_producers) = chunk_producers else {
-                    tracing::warn!(target: "stats", %shard_id, ?chunk_producers_settlement, "invalid shard id, not found in the shard settlement");
+                    tracing::warn!(%shard_id, ?chunk_producers_settlement, "invalid shard id, not found in the shard settlement");
                     continue;
                 };
                 for &id in chunk_producers {
@@ -450,7 +450,7 @@ impl InfoHelper {
             blocks_info_log,
             machine_info_log
         );
-        tracing::info!(target: "stats", ?node_status);
+        tracing::info!(?node_status);
         log_catchup_status(catchup_status);
         if let Some(config_updater) = &config_updater {
             config_updater.report_status();
@@ -620,7 +620,6 @@ impl InfoHelper {
         let info = chain.get_chain_processing_info();
         let blocks_info = BlocksInfo { blocks_info: info.blocks_info };
         tracing::debug!(
-            target: "stats",
             "{:?} Orphans: {} With missing chunks: {} In processing {}{}",
             epoch_id,
             info.num_orphans,

--- a/chain/client/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement.rs
@@ -48,7 +48,7 @@ impl ChunkEndorsementTracker {
         {
             let cache = self.chunk_endorsements.lock();
             if cache.peek(&key).is_some_and(|entry| entry.contains_key(account_id)) {
-                tracing::debug!(target: "client", ?endorsement, "already received chunk endorsement");
+                tracing::debug!(?endorsement, "already received chunk endorsement");
                 return Ok(());
             }
         }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -26,7 +26,6 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
     network_sender: &Sender<PeerManagerMessageRequest>,
 ) -> Option<ChunkEndorsement> {
     let _span = tracing::debug_span!(
-        target: "client",
         "send_chunk_endorsement",
         chunk_hash = ?chunk_header.chunk_hash(),
         height = %chunk_header.height_created(),
@@ -52,7 +51,6 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
 
     let chunk_hash = chunk_header.chunk_hash();
     tracing::debug!(
-        target: "client",
         chunk_hash=?chunk_hash,
         shard_id=%chunk_header.shard_id(),
         ?block_producers,

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
@@ -28,7 +28,6 @@ impl OrphanStateWitnessPool {
     pub fn new(cache_capacity: usize) -> Self {
         if cache_capacity > 128 {
             tracing::warn!(
-                target: "client",
                 cache_capacity,
                 "orphan state witness cache capacity is larger than expected, this might lead to performance problems"
             );
@@ -54,7 +53,6 @@ impl OrphanStateWitnessPool {
             // Another witness has been ejected from the cache due to capacity limit
             let header = &ejected_entry.witness.chunk_header();
             tracing::debug!(
-                target: "client",
                 ejected_witness_height = header.height_created(),
                 ejected_witness_shard = ?header.shard_id(),
                 ejected_witness_chunk = ?header.chunk_hash(),
@@ -98,7 +96,6 @@ impl OrphanStateWitnessPool {
                 to_remove.push(cache_key.clone());
                 let header = &cache_entry.witness.chunk_header();
                 tracing::debug!(
-                    target: "client",
                     final_height,
                     ejected_witness_height = witness_height,
                     ejected_witness_shard = ?cache_key.shard_id,

--- a/chain/client/src/stateless_validation/partial_witness/partial_deploys_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_deploys_tracker.rs
@@ -38,7 +38,6 @@ impl CacheEntry {
         let part_ord = part.part_ord;
         if self.parts.encoded_length() != part.encoded_length {
             tracing::warn!(
-                target: "client",
                 expected = self.parts.encoded_length(),
                 actual = part.encoded_length,
                 part_ord,
@@ -50,7 +49,6 @@ impl CacheEntry {
             InsertPartResult::Accepted => None,
             InsertPartResult::PartAlreadyAvailable => {
                 tracing::warn!(
-                    target: "client",
                     ?key,
                     part_ord,
                     "received duplicate or redundant contract deploy part"
@@ -58,12 +56,7 @@ impl CacheEntry {
                 None
             }
             InsertPartResult::InvalidPartOrd => {
-                tracing::warn!(
-                    target: "client",
-                    ?key,
-                    part_ord,
-                    "received invalid contract deploys part ord"
-                );
+                tracing::warn!(?key, part_ord, "received invalid contract deploys part ord");
                 None
             }
             InsertPartResult::Decoded(decode_result) => Some(decode_result),
@@ -97,7 +90,6 @@ impl PartialEncodedContractDeploysTracker {
             .is_some_and(|entry| entry.parts.has_part(partial_deploys.part().part_ord))
         {
             tracing::warn!(
-                target: "client",
                 ?key,
                 part = ?partial_deploys.part(),
                 "received already processed partial deploys part"
@@ -119,7 +111,6 @@ impl PartialEncodedContractDeploysTracker {
                 self.parts_cache.push(key.clone(), new_entry)
             {
                 tracing::warn!(
-                    target: "client",
                     ?evicted_key,
                     data_parts_present = ?evicted_entry.parts.data_parts_present(),
                     data_parts_required = ?evicted_entry.parts.data_parts_required(),
@@ -138,12 +129,7 @@ impl PartialEncodedContractDeploysTracker {
             let deploys = match decode_result {
                 Ok(deploys) => deploys,
                 Err(err) => {
-                    tracing::warn!(
-                        target: "client",
-                        ?err,
-                        ?key,
-                        "failed to reed solomon decode deployed contracts"
-                    );
+                    tracing::warn!(?err, ?key, "failed to reed solomon decode deployed contracts");
                     return Ok(None);
                 }
             };

--- a/chain/client/src/stateless_validation/shadow_validate.rs
+++ b/chain/client/src/stateless_validation/shadow_validate.rs
@@ -14,7 +14,7 @@ impl Client {
             return Ok(());
         }
         let block_hash = block.hash();
-        tracing::debug!(target: "client", ?block_hash, "shadow validation for block chunks");
+        tracing::debug!(?block_hash, "shadow validation for block chunks");
         let prev_block = self.chain.get_block(block.header().prev_hash())?;
         let prev_block_chunks = prev_block.chunks();
         for (shard_index, chunk) in block.chunks().iter_new().enumerate() {
@@ -27,7 +27,6 @@ impl Client {
                 near_chain::stateless_validation::metrics::SHADOW_CHUNK_VALIDATION_FAILED_TOTAL
                     .inc();
                 tracing::error!(
-                    target: "client",
                     ?err,
                     shard_id = %chunk.shard_id(),
                     ?block_hash,

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -28,7 +28,6 @@ impl Client {
         let shard_id = chunk_header.shard_id();
         let height = chunk_header.height_created();
         let _span = tracing::debug_span!(
-            target: "client",
             "send_chunk_state_witness",
             chunk_hash=?chunk_header.chunk_hash(),
             height,
@@ -60,7 +59,7 @@ impl Client {
             .contains(my_signer.validator_id())
         {
             // Bypass state witness validation if we created state witness. Endorse the chunk immediately.
-            tracing::debug!(target: "client", chunk_hash=?chunk_header.chunk_hash(), %shard_id, "send_chunk_endorsement_from_chunk_producer");
+            tracing::debug!(chunk_hash=?chunk_header.chunk_hash(), %shard_id, "send_chunk_endorsement_from_chunk_producer");
             if let Some(endorsement) = send_chunk_endorsement_to_block_producers(
                 &chunk_header,
                 self.epoch_manager.as_ref(),

--- a/chain/client/src/stateless_validation/state_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/state_witness_tracker.rs
@@ -67,7 +67,7 @@ impl ChunkStateWitnessTracker {
         num_validators: usize,
     ) -> () {
         let key = ChunkStateWitnessKey::new(chunk_hash);
-        tracing::trace!(target: "state_witness_tracker", witness_key=?key,
+        tracing::trace!(witness_key=?key,
             size=witness_size_in_bytes, "recording state witness sent");
         self.witnesses.put(
             key,
@@ -83,7 +83,7 @@ impl ChunkStateWitnessTracker {
     /// records it in the corresponding metric.
     pub fn on_witness_ack_received(&mut self, ack: ChunkStateWitnessAck) -> () {
         let key = ChunkStateWitnessKey { chunk_hash: ack.chunk_hash };
-        tracing::trace!(target: "state_witness_tracker", witness_key=?key,
+        tracing::trace!(witness_key=?key,
             "received ack for state witness");
         if let Some(record) = self.witnesses.get_mut(&key) {
             debug_assert!(record.num_validators > 0);

--- a/chain/client/src/stateless_validation/validate.rs
+++ b/chain/client/src/stateless_validation/validate.rs
@@ -69,7 +69,6 @@ pub fn validate_partial_encoded_state_witness(
     let ChunkProductionKey { shard_id, epoch_id, height_created } =
         partial_witness.chunk_production_key();
     let _span = tracing::debug_span!(
-        target: "client",
         "validate_partial_encoded_state_witness",
         height = %height_created,
         shard_id = %shard_id,
@@ -135,7 +134,6 @@ pub fn validate_chunk_endorsement(
     store: &Store,
 ) -> Result<ChunkRelevance, Error> {
     let _span = tracing::debug_span!(
-        target: "stateless_validation",
         "validate_chunk_endorsement",
         height = endorsement.chunk_production_key().height_created,
         shard_id = %endorsement.chunk_production_key().shard_id,
@@ -236,11 +234,7 @@ fn validate_chunk_relevant(
     let height_created = chunk_production_key.height_created;
 
     if !epoch_manager.get_shard_layout(&epoch_id)?.shard_ids().contains(&shard_id) {
-        tracing::error!(
-            target: "stateless_validation",
-            ?chunk_production_key,
-            "shard id is not in the shard layout of the epoch"
-        );
+        tracing::error!(?chunk_production_key, "shard id is not in the shard layout of the epoch");
         return Err(Error::InvalidShardId(shard_id));
     }
 
@@ -257,7 +251,6 @@ fn validate_chunk_relevant(
     if let Some(final_head) = final_head {
         if height_created <= final_head.height {
             tracing::debug!(
-                target: "stateless_validation",
                 ?chunk_production_key,
                 final_head_height = final_head.height,
                 "skipping because height created is not greater than final head height",
@@ -268,7 +261,6 @@ fn validate_chunk_relevant(
     if let Some(head) = head {
         if height_created > head.height + MAX_HEIGHTS_AHEAD {
             tracing::debug!(
-                target: "stateless_validation",
                 ?chunk_production_key,
                 head_height = head.height,
                 %MAX_HEIGHTS_AHEAD,
@@ -286,7 +278,6 @@ fn validate_chunk_relevant(
             epoch_manager.possible_epochs_of_height_around_tip(&head, height_created)?;
         if !possible_epochs.contains(&epoch_id) {
             tracing::debug!(
-                target: "stateless_validation",
                 ?chunk_production_key,
                 ?possible_epochs,
                 "skipping because epoch id is not in the possible list of epochs"

--- a/chain/client/src/sync/block.rs
+++ b/chain/client/src/sync/block.rs
@@ -71,14 +71,13 @@ impl BlockSync {
         highest_height_peers: &[HighestHeightPeerInfo],
         max_block_requests: usize,
     ) -> Result<bool, near_chain::Error> {
-        let _span =
-            tracing::debug_span!(target: "sync", "run_sync", sync_type = "BlockSync").entered();
+        let _span = tracing::debug_span!("run_sync", sync_type = "BlockSync").entered();
         let head = chain.head()?;
         let header_head = chain.header_head()?;
 
         match self.block_sync_due(&head, &header_head) {
             BlockSyncDue::StateSync => {
-                tracing::debug!(target: "sync", "sync: transition to state sync");
+                tracing::debug!("sync: transition to state sync");
                 return Ok(true);
             }
             BlockSyncDue::RequestBlock => {
@@ -116,7 +115,6 @@ impl BlockSync {
             && head.height.saturating_add(self.block_fetch_horizon) < header_head.height;
         if prefer_state_sync {
             tracing::debug!(
-                target: "sync",
                 head_epoch_id = ?head.epoch_id,
                 header_head_epoch_id = ?header_head.epoch_id,
                 head_next_epoch_id = ?head.next_epoch_id,
@@ -173,7 +171,6 @@ impl BlockSync {
     /// Request recent blocks from a randomly chosen peer.
     /// pub for testing
     #[instrument(
-        target = "sync",
         level = "debug",
         skip_all,
         fields(head_last_block_hash, head_height, header_head_height, num_requests)
@@ -215,7 +212,6 @@ impl BlockSync {
                 Err(e) => match e {
                     near_chain::Error::DBNotFoundErr(_) => {
                         tracing::debug!(
-                            target: "sync",
                             block_hash = ?next_hash,
                             "next block hash is not found"
                         );
@@ -226,7 +222,6 @@ impl BlockSync {
             };
             if let BlockKnowledge::Known(err) = chain.check_block_known(&next_hash) {
                 tracing::debug!(
-                    target: "sync",
                     block_hash = ?next_hash,
                     ?err,
                     "block is known"
@@ -249,7 +244,6 @@ impl BlockSync {
 
             if let Some(peer) = peer {
                 tracing::debug!(
-                    target: "sync",
                     block_hash = ?next_hash,
                     block_height = next_height,
                     request_from_archival,
@@ -266,7 +260,6 @@ impl BlockSync {
                 num_requests += 1;
             } else {
                 tracing::warn!(
-                    target: "sync",
                     block_hash = ?next_hash,
                     block_height = next_height,
                     request_from_archival,

--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -70,13 +70,13 @@ impl StateSyncConnection {
         let result = self.connection.get(location).await;
         match &result {
             Ok(bytes) => {
-                tracing::debug!(target: "sync", %shard_id, location, num_bytes = bytes.len(), storage = self.storage_name, "request finished");
+                tracing::debug!(%shard_id, location, num_bytes = bytes.len(), storage = self.storage_name, "request finished");
                 metrics::STATE_SYNC_EXTERNAL_PARTS_SIZE_DOWNLOADED
                     .with_label_values(&[&shard_id.to_string(), &file_type.to_string()])
                     .inc_by(bytes.len() as u64);
             }
             Err(error) => {
-                tracing::debug!(target: "sync", %shard_id, location, ?error, storage = self.storage_name, "request failed");
+                tracing::debug!(%shard_id, location, ?error, storage = self.storage_name, "request failed");
             }
         }
         result
@@ -95,11 +95,11 @@ impl StateSyncConnection {
         let res = self.connection.put(location, data).await;
         let is_ok = match &res {
             Ok(()) => {
-                tracing::debug!(target: "state_sync_dump", %shard_id, part_length = data.len(), ?location, ?file_type, storage = self.storage_name, "wrote a state part");
+                tracing::debug!(%shard_id, part_length = data.len(), ?location, ?file_type, storage = self.storage_name, "wrote a state part");
                 "ok"
             }
             Err(error) => {
-                tracing::error!(target: "state_sync_dump", %shard_id, part_length = data.len(), ?location, ?file_type, storage = self.storage_name, ?error, "failed to write a state part");
+                tracing::error!(%shard_id, part_length = data.len(), ?location, ?file_type, storage = self.storage_name, ?error, "failed to write a state part");
                 "error"
             }
         };
@@ -121,7 +121,7 @@ impl StateSyncConnection {
         let _timer = metrics::STATE_SYNC_DUMP_LIST_OBJECT_ELAPSED
             .with_label_values(&[&shard_id.to_string()])
             .start_timer();
-        tracing::debug!(target: "state_sync_dump", %shard_id, directory_path, "list state parts");
+        tracing::debug!(%shard_id, directory_path, "list state parts");
         self.connection.list(directory_path).await
     }
 
@@ -144,7 +144,6 @@ impl StateSyncConnection {
         let file_names = self.list_objects(shard_id, &directory_path).await?;
         let header_exits = file_names.contains(&file_type.filename());
         tracing::debug!(
-            target: "state_sync_dump",
             ?directory_path,
             "{}",
             match header_exits {

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -104,8 +104,7 @@ impl HeaderSync {
         highest_height: BlockHeight,
         highest_height_peers: &[HighestHeightPeerInfo],
     ) -> Result<(), near_chain::Error> {
-        let _span =
-            tracing::debug_span!(target: "sync", "run_sync", sync_type = "HeaderSync").entered();
+        let _span = tracing::debug_span!("run_sync", sync_type = "HeaderSync").entered();
         let head = chain.head()?;
         let header_head = chain.header_head()?;
 
@@ -127,7 +126,7 @@ impl HeaderSync {
                 true
             }
             SyncStatus::NoSync | SyncStatus::AwaitingPeers => {
-                tracing::debug!(target: "sync", header_head_hash = ?header_head.last_block_hash, header_head_height = header_head.height, "initial transition to header sync");
+                tracing::debug!(header_head_hash = ?header_head.last_block_hash, header_head_height = header_head.height, "initial transition to header sync");
                 true
             }
             SyncStatus::EpochSync { .. } | SyncStatus::StateSync { .. } => false,
@@ -240,7 +239,7 @@ impl HeaderSync {
                                     && *highest_height == peer.highest_block_height
                                 {
                                     // The peer is one of the peers with the highest height, but we consider the peer stalling.
-                                    tracing::warn!(target: "sync", peer_info = %peer.peer_info, peer_height = peer.highest_block_height, "banning a peer for not providing enough headers");
+                                    tracing::warn!(peer_info = %peer.peer_info, peer_height = peer.highest_block_height, "banning a peer for not providing enough headers");
                                     // Ban the peer, which blocks all interactions with the peer for some time.
                                     // TODO: Consider not banning straightaway, but give a node a few attempts before banning it.
                                     // TODO: Prefer not to request the next batch of headers from the same peer.
@@ -313,7 +312,7 @@ impl HeaderSync {
         peer: &HighestHeightPeerInfo,
     ) -> Result<(), near_chain::Error> {
         let locator = self.get_locator(chain)?;
-        tracing::debug!(target: "sync", peer_id = %peer.peer_info.id, ?locator, "requesting headers");
+        tracing::debug!(peer_id = %peer.peer_info.id, ?locator, "requesting headers");
         self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
             NetworkRequests::BlockHeadersRequest {
                 hashes: locator,
@@ -355,11 +354,11 @@ impl HeaderSync {
                     if *ordinal == tip_ordinal {
                         return Err(e);
                     }
-                    tracing::debug!(target: "sync", ordinal, error = ?e, "failed to get block hash from ordinal, this is normal if we just finished epoch sync");
+                    tracing::debug!(ordinal, error = ?e, "failed to get block hash from ordinal, this is normal if we just finished epoch sync");
                 }
             }
         }
-        tracing::debug!(target: "sync", ?locator, ?ordinals);
+        tracing::debug!(?locator, ?ordinals);
         Ok(locator)
     }
 }

--- a/chain/client/src/sync/state/external.rs
+++ b/chain/client/src/sync/state/external.rs
@@ -43,11 +43,11 @@ impl StateSyncDownloadSourceExternal {
             StateFileType::StateHeader => "header",
             StateFileType::StatePart { .. } => "part",
         };
-        tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, "external download starting");
+        tracing::debug!(?shard_id, ?file_type, ?location, "external download starting");
         tokio::select! {
             _ = clock.sleep_until(deadline) => {
                 increment_download_count(shard_id, typ, "external", "timeout");
-                tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, "external download timed out");
+                tracing::debug!(?shard_id, ?file_type, ?location, "external download timed out");
                 Err(near_chain::Error::Other("Timeout".to_owned()))
             }
             _ = cancellation.cancelled() => {
@@ -58,7 +58,7 @@ impl StateSyncDownloadSourceExternal {
                 match result {
                     Err(err) => {
                         increment_download_count(shard_id, typ, "external", "download_error");
-                        tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, %err, "external download error");
+                        tracing::debug!(?shard_id, ?file_type, ?location, %err, "external download error");
                         Err(near_chain::Error::Other(format!("Failed to download: {}", err)))
                     }
                     Ok(res) => Ok(res)

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -205,8 +205,7 @@ impl StateSync {
         sync_status: &mut StateSyncStatus,
         tracking_shards: &[ShardId],
     ) -> Result<StateSyncResult, near_chain::Error> {
-        let _span =
-            tracing::debug_span!(target: "sync", "run_sync", sync_type = "StateSync").entered();
+        let _span = tracing::debug_span!("run_sync", sync_type = "StateSync").entered();
         tracing::debug!(%sync_hash, ?tracking_shards, "syncing state");
 
         let mut all_done = true;

--- a/chain/client/src/sync/state/network.rs
+++ b/chain/client/src/sync/state/network.rs
@@ -86,7 +86,7 @@ impl StateSyncDownloadSourcePeerSharedState {
         let key = PendingPeerRequestKey { shard_id, sync_hash: msg.sync_hash(), part_id_or_header };
 
         let Some(request) = self.pending_requests.get_mut(&key) else {
-            tracing::debug!(target: "sync", ?key, %peer_id, "unexpected state response, request may have timed out");
+            tracing::debug!(?key, %peer_id, "unexpected state response, request may have timed out");
             return Ok(());
         };
 
@@ -211,7 +211,7 @@ impl StateSyncDownloadSourcePeer {
             }
         };
 
-        tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request sent");
+        tracing::debug!(?key, ?request_sent_to_peer, "p2p request sent");
 
         let state_value = PendingPeerRequestValue { peer_id: request_sent_to_peer.clone(), sender };
 
@@ -227,7 +227,7 @@ impl StateSyncDownloadSourcePeer {
         select! {
             _ = clock.sleep_until(deadline) => {
                 increment_download_count(key.shard_id, typ, "network", "timeout");
-                tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request timed out");
+                tracing::debug!(?key, ?request_sent_to_peer, "p2p request timed out");
                 Err(near_chain::Error::Other("Timeout".to_owned()))
             }
             _ = cancel.cancelled() => {
@@ -237,7 +237,7 @@ impl StateSyncDownloadSourcePeer {
             result = receiver => {
                 match result {
                     Ok(result) => {
-                        tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request succeeded");
+                        tracing::debug!(?key, ?request_sent_to_peer, "p2p request succeeded");
                         increment_download_count(key.shard_id, typ, "network", "success");
                         Ok(result)
                     }

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -153,9 +153,13 @@ pub(super) async fn run_state_sync_for_shard(
         store.exists(DBCol::StatePartsApplied, &key_bytes)
     });
     if apply_parts_started {
-        tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "not clearing flat storage before applying state parts because some parts were already applied");
+        tracing::debug!(
+            ?shard_id,
+            ?sync_hash,
+            "not clearing flat storage before applying state parts because some parts were already applied"
+        );
     } else {
-        tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
+        tracing::debug!(?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
         let mut store_update = store.store_update();
         runtime
             .get_flat_storage_manager()
@@ -255,7 +259,12 @@ fn create_flat_storage_for_shard(
     let flat_head_prev_hash = *flat_head_header.prev_hash();
     let flat_head_height = flat_head_header.height();
 
-    tracing::debug!(target: "store", ?shard_uid, ?flat_head_hash, flat_head_height, "set_state_finalize - initialized flat storage");
+    tracing::debug!(
+        ?shard_uid,
+        ?flat_head_hash,
+        flat_head_height,
+        "set_state_finalize - initialized flat storage"
+    );
 
     let mut store_update = store.flat_store().store_update();
     store_update.set_flat_storage_status(
@@ -296,7 +305,7 @@ async fn apply_state_part(
     let key_bytes = borsh::to_vec(&key).unwrap();
     let already_applied = store.exists(DBCol::StatePartsApplied, &key_bytes);
     if already_applied {
-        tracing::debug!(target: "sync", ?key, "state part already applied, skipping");
+        tracing::debug!(?key, "state part already applied, skipping");
         return Ok(StatePartApplyResult::AlreadyApplied);
     }
     return_if_cancelled!(cancel);
@@ -322,7 +331,7 @@ async fn apply_state_part(
         &state_part,
         &epoch_id,
     )?;
-    tracing::debug!(target: "sync", ?key, "applied state part");
+    tracing::debug!(?key, "applied state part");
 
     // Mark part as applied.
     let mut store_update = store.store_update();

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -32,7 +32,7 @@ impl SyncJobsActor {
     }
 
     pub fn handle_block_catch_up_request(&mut self, msg: BlockCatchUpRequest) {
-        tracing::debug!(target: "sync", ?msg);
+        tracing::debug!(?msg);
         let results = do_apply_chunks(
             self.apply_chunks_iteration_mode,
             BlockToApply::Normal(msg.block_hash),

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -678,7 +678,7 @@ impl ViewClientActor {
                     }
                 }
                 Err(err) => {
-                    tracing::warn!(target: "client", ?err, "error trying to get transaction result");
+                    tracing::warn!(?err, "error trying to get transaction result");
                     Err(err.into())
                 }
             }
@@ -734,7 +734,7 @@ impl ViewClientActor {
 
 impl Handler<Query, Result<QueryResponse, QueryError>> for ViewClientActor {
     fn handle(&mut self, msg: Query) -> Result<QueryResponse, QueryError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["Query"]).start_timer();
         self.handle_query(msg)
     }
@@ -743,7 +743,7 @@ impl Handler<Query, Result<QueryResponse, QueryError>> for ViewClientActor {
 /// Handles retrieving block from the chain.
 impl Handler<GetBlock, Result<BlockView, GetBlockError>> for ViewClientActor {
     fn handle(&mut self, msg: GetBlock) -> Result<BlockView, GetBlockError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetBlock"]).start_timer();
         let block = self.get_block_by_reference(&msg.0)?.ok_or(GetBlockError::NotSyncedYet)?;
@@ -762,7 +762,7 @@ impl Handler<GetBlockWithMerkleTree, Result<(BlockView, Arc<PartialMerkleTree>),
         &mut self,
         msg: GetBlockWithMerkleTree,
     ) -> Result<(BlockView, Arc<PartialMerkleTree>), GetBlockError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetBlockWithMerkleTree"])
             .start_timer();
@@ -799,7 +799,7 @@ fn get_chunk_from_block(
 
 impl Handler<GetShardChunk, Result<ShardChunk, GetChunkError>> for ViewClientActor {
     fn handle(&mut self, msg: GetShardChunk) -> Result<ShardChunk, GetChunkError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetShardChunk"]).start_timer();
 
@@ -822,7 +822,7 @@ impl Handler<GetShardChunk, Result<ShardChunk, GetChunkError>> for ViewClientAct
 
 impl Handler<GetChunk, Result<ChunkView, GetChunkError>> for ViewClientActor {
     fn handle(&mut self, msg: GetChunk) -> Result<ChunkView, GetChunkError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetChunk"]).start_timer();
 
@@ -862,7 +862,7 @@ impl Handler<GetChunk, Result<ChunkView, GetChunkError>> for ViewClientActor {
 
 impl Handler<TxStatus, Result<TxStatusView, TxStatusError>> for ViewClientActor {
     fn handle(&mut self, msg: TxStatus) -> Result<TxStatusView, TxStatusError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["TxStatus"]).start_timer();
         self.get_tx_status(msg.tx_hash, msg.signer_account_id, msg.fetch_receipt)
@@ -876,7 +876,7 @@ impl Handler<GetValidatorInfo, Result<EpochValidatorInfo, GetValidatorInfoError>
         &mut self,
         msg: GetValidatorInfo,
     ) -> Result<EpochValidatorInfo, GetValidatorInfoError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetValidatorInfo"])
             .start_timer();
@@ -924,7 +924,7 @@ impl Handler<GetValidatorOrdered, Result<Vec<ValidatorStakeView>, GetValidatorIn
         &mut self,
         msg: GetValidatorOrdered,
     ) -> Result<Vec<ValidatorStakeView>, GetValidatorInfoError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetValidatorOrdered"])
             .start_timer();
@@ -941,7 +941,7 @@ impl Handler<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChang
         &mut self,
         msg: GetStateChangesInBlock,
     ) -> Result<StateChangesKindsView, GetStateChangesError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetStateChangesInBlock"])
             .start_timer();
@@ -958,7 +958,7 @@ impl Handler<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChang
 /// Returns a list of changes in a store for a given block filtering by the state changes request.
 impl Handler<GetStateChanges, Result<StateChangesView, GetStateChangesError>> for ViewClientActor {
     fn handle(&mut self, msg: GetStateChanges) -> Result<StateChangesView, GetStateChangesError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetStateChanges"]).start_timer();
         Ok(self
@@ -979,7 +979,7 @@ impl Handler<GetStateChangesWithCauseInBlock, Result<StateChangesView, GetStateC
         &mut self,
         msg: GetStateChangesWithCauseInBlock,
     ) -> Result<StateChangesView, GetStateChangesError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetStateChangesWithCauseInBlock"])
             .start_timer();
@@ -1005,7 +1005,7 @@ impl
         &mut self,
         msg: GetStateChangesWithCauseInBlockForTrackedShards,
     ) -> Result<HashMap<ShardId, StateChangesView>, GetStateChangesError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetStateChangesWithCauseInBlockForTrackedShards"])
             .start_timer();
@@ -1054,7 +1054,7 @@ impl
         &mut self,
         msg: GetNextLightClientBlock,
     ) -> Result<Option<Arc<LightClientBlockView>>, GetNextLightClientBlockError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetNextLightClientBlock"])
             .start_timer();
@@ -1095,7 +1095,7 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
         &mut self,
         msg: GetExecutionOutcome,
     ) -> Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetExecutionOutcome"])
             .start_timer();
@@ -1186,7 +1186,7 @@ impl
         &mut self,
         msg: GetExecutionOutcomesForBlock,
     ) -> Result<HashMap<ShardId, Vec<ExecutionOutcomeWithIdView>>, String> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetExecutionOutcomesForBlock"])
             .start_timer();
@@ -1203,7 +1203,7 @@ impl
 
 impl Handler<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>> for ViewClientActor {
     fn handle(&mut self, msg: GetReceipt) -> Result<Option<ReceiptView>, GetReceiptError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetReceipt"]).start_timer();
         Ok(self
@@ -1216,7 +1216,7 @@ impl Handler<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>> for ViewC
 
 impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> for ViewClientActor {
     fn handle(&mut self, msg: GetBlockProof) -> Result<GetBlockProofResponse, GetBlockProofError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetBlockProof"]).start_timer();
         let block_header = self.chain.get_block_header(&msg.block_hash)?;
@@ -1240,7 +1240,7 @@ impl Handler<GetProtocolConfig, Result<ProtocolConfigView, GetProtocolConfigErro
         &mut self,
         msg: GetProtocolConfig,
     ) -> Result<ProtocolConfigView, GetProtocolConfigError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetProtocolConfig"])
             .start_timer();
@@ -1270,21 +1270,21 @@ impl Handler<NetworkAdversarialMessage> for ViewClientActor {
 #[cfg(feature = "test_features")]
 impl Handler<NetworkAdversarialMessage, Option<u64>> for ViewClientActor {
     fn handle(&mut self, msg: NetworkAdversarialMessage) -> Option<u64> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["NetworkAdversarialMessage"])
             .start_timer();
         match msg {
             NetworkAdversarialMessage::AdvDisableDoomslug => {
-                tracing::info!(target: "adversary", "turning doomslug off");
+                tracing::info!("turning doomslug off");
                 self.adv.set_disable_doomslug(true);
             }
             NetworkAdversarialMessage::AdvDisableHeaderSync => {
-                tracing::info!(target: "adversary", "blocking header sync");
+                tracing::info!("blocking header sync");
                 self.adv.set_disable_header_sync(true);
             }
             NetworkAdversarialMessage::AdvSwitchToHeight(height) => {
-                tracing::info!(target: "adversary", "switching to height");
+                tracing::info!("switching to height");
                 let mut chain_store_update = self.chain.mut_chain_store().store_update();
                 chain_store_update.save_largest_target_height(height);
                 chain_store_update
@@ -1300,7 +1300,7 @@ impl Handler<NetworkAdversarialMessage, Option<u64>> for ViewClientActor {
 
 impl Handler<TxStatusRequest, Option<Box<FinalExecutionOutcomeView>>> for ViewClientActor {
     fn handle(&mut self, msg: TxStatusRequest) -> Option<Box<FinalExecutionOutcomeView>> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["TxStatusRequest"]).start_timer();
         let TxStatusRequest { tx_hash, signer_account_id } = msg;
@@ -1318,7 +1318,6 @@ impl Handler<TxStatusResponse> for ViewClientActor {
     fn handle(&mut self, msg: TxStatusResponse) {
         let TxStatusResponse(tx_result) = msg;
         tracing::debug!(
-            target: "client",
             tx_hash = %tx_result.transaction.hash, status = ?tx_result.status,
             tx_outcome_status = ?tx_result.transaction_outcome.outcome.status,
             num_receipt_outcomes = tx_result.receipts_outcome.len(),
@@ -1337,7 +1336,7 @@ impl Handler<TxStatusResponse> for ViewClientActor {
 
 impl Handler<BlockRequest, Option<Arc<Block>>> for ViewClientActor {
     fn handle(&mut self, msg: BlockRequest) -> Option<Arc<Block>> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["BlockRequest"]).start_timer();
         let BlockRequest(hash) = msg;
@@ -1347,7 +1346,7 @@ impl Handler<BlockRequest, Option<Arc<Block>>> for ViewClientActor {
 
 impl Handler<BlockHeadersRequest, Option<Vec<Arc<BlockHeader>>>> for ViewClientActor {
     fn handle(&mut self, msg: BlockHeadersRequest) -> Option<Vec<Arc<BlockHeader>>> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["BlockHeadersRequest"])
             .start_timer();
@@ -1370,7 +1369,7 @@ impl Handler<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>
         &mut self,
         msg: AnnounceAccountRequest,
     ) -> Result<Vec<AnnounceAccount>, ReasonForBan> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["AnnounceAccountRequest"])
             .start_timer();
@@ -1411,7 +1410,7 @@ impl Handler<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>
                 // We currently do NOT ban the peer for either.
                 // TODO(gprusak): consider whether we should change that.
                 Err(err) => {
-                    tracing::debug!(target: "view_client", ?err, "failed to validate account announce signature");
+                    tracing::debug!(?err, "failed to validate account announce signature");
                 }
             }
         }
@@ -1421,7 +1420,7 @@ impl Handler<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>
 
 impl Handler<GetGasPrice, Result<GasPriceView, GetGasPriceError>> for ViewClientActor {
     fn handle(&mut self, msg: GetGasPrice) -> Result<GasPriceView, GetGasPriceError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetGasPrice"]).start_timer();
         let header = self.maybe_block_id_to_block_header(msg.block_id);
@@ -1436,7 +1435,7 @@ impl Handler<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanc
         &mut self,
         msg: GetMaintenanceWindows,
     ) -> Result<MaintenanceWindowsView, GetMaintenanceWindowsError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         Ok(self.get_maintenance_windows(msg.account_id)?)
     }
 }
@@ -1449,7 +1448,7 @@ impl Handler<GetSplitStorageInfo, Result<SplitStorageInfoView, GetSplitStorageIn
         &mut self,
         msg: GetSplitStorageInfo,
     ) -> Result<SplitStorageInfoView, GetSplitStorageInfoError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
 
         let store = self.chain.chain_store().store();
         let head = store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -92,7 +92,7 @@ pub trait EpochManagerAdapter: Send + Sync {
             Err(err @ EpochError::IOErr(_)) => Err(err),
             Err(EpochError::EpochOutOfBounds(_) | EpochError::MissingBlock(_)) => Ok(false),
             Err(err) => {
-                tracing::warn!(target: "epoch_manager", ?err, "unexpected error in is_last_block_in_finished_epoch");
+                tracing::warn!(?err, "unexpected error in is_last_block_in_finished_epoch");
                 Ok(false)
             }
         }

--- a/chain/epoch-manager/src/epoch_info_aggregator.rs
+++ b/chain/epoch-manager/src/epoch_info_aggregator.rs
@@ -68,8 +68,7 @@ impl EpochInfoAggregator {
         shard_layout: &ShardLayout,
         prev_block_height: BlockHeight,
     ) {
-        let _span = tracing::debug_span!(target: "epoch_tracker", "update_tail", prev_block_height)
-            .entered();
+        let _span = tracing::debug_span!("update_tail", prev_block_height).entered();
 
         // Step 1: update block tracer (block-production stats)
 
@@ -86,7 +85,6 @@ impl EpochInfoAggregator {
                     .or_insert(ValidatorStats { produced: 1, expected: 1 });
             } else {
                 tracing::debug!(
-                    target: "epoch_tracker",
                     block_producer = ?epoch_info.validator_account_id(block_producer_id),
                     block_height = height, "missed block");
                 entry
@@ -113,7 +111,6 @@ impl EpochInfoAggregator {
                         *stats.produced_mut() += 1;
                     } else {
                         tracing::debug!(
-                            target: "epoch_tracker",
                             chunk_validator = ?epoch_info.validator_account_id(chunk_producer_id),
                             %shard_id,
                             block_height = prev_block_height + 1,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -490,7 +490,10 @@ impl EpochManager {
             }
         }
         if all_kicked_out {
-            tracing::info!(target: "epoch_manager", ?max_validator, "we are about to kick out all validators in the next two epochs, so we are going to save one");
+            tracing::info!(
+                ?max_validator,
+                "we are about to kick out all validators in the next two epochs, so we are going to save one"
+            );
             if let Some(validator) = max_validator {
                 validator_kickout.remove(&validator);
             }
@@ -541,7 +544,7 @@ impl EpochManager {
                 / U256::from(total_block_producer_stake.as_yoctonear()))
             .as_u128() as i64;
             PROTOCOL_VERSION_VOTES.with_label_values(&[&version.to_string()]).set(stake_percent);
-            tracing::info!(target: "epoch_manager", ?version, ?stake_percent, "protocol version voting");
+            tracing::info!(?version, ?stake_percent, "protocol version voting");
         }
 
         let protocol_version = next_epoch_info.protocol_version();
@@ -565,7 +568,7 @@ impl EpochManager {
         };
 
         PROTOCOL_VERSION_NEXT.set(next_next_epoch_version as i64);
-        tracing::info!(target: "epoch_manager", ?next_next_epoch_version, "protocol version voting");
+        tracing::info!(?next_next_epoch_version, "protocol version voting");
 
         let mut validator_kickout = HashMap::new();
 
@@ -613,7 +616,6 @@ impl EpochManager {
         );
         validator_kickout.extend(kickout);
         tracing::debug!(
-            target: "epoch_manager",
             ?proposals,
             ?validator_kickout,
             ?block_validator_tracker,
@@ -720,13 +722,13 @@ impl EpochManager {
         ) {
             Ok(next_next_epoch_info) => next_next_epoch_info,
             Err(EpochError::ThresholdError { stake_sum, num_seats }) => {
-                tracing::warn!(target: "epoch_manager", %stake_sum, %num_seats, "not enough stake for required number of seats (all validators tried to unstake?)");
+                tracing::warn!(%stake_sum, %num_seats, "not enough stake for required number of seats (all validators tried to unstake?)");
                 let mut epoch_info = EpochInfo::clone(&next_epoch_info);
                 *epoch_info.epoch_height_mut() += 1;
                 epoch_info
             }
             Err(EpochError::NotEnoughValidators { num_validators, num_shards }) => {
-                tracing::warn!(target: "epoch_manager", %num_validators, %num_shards, "not enough validators for required number of shards (all validators tried to unstake?)");
+                tracing::warn!(%num_validators, %num_shards, "not enough validators for required number of shards (all validators tried to unstake?)");
                 let mut epoch_info = EpochInfo::clone(&next_epoch_info);
                 *epoch_info.epoch_height_mut() += 1;
                 epoch_info
@@ -735,7 +737,6 @@ impl EpochManager {
         };
         let next_next_epoch_id = EpochId(*last_block_hash);
         tracing::debug!(
-            target: "epoch_manager",
             next_next_epoch_height = %next_next_epoch_info.epoch_height(),
             ?next_next_epoch_id,
             next_next_protocol_version = %next_next_epoch_info.protocol_version(),
@@ -1032,7 +1033,7 @@ impl EpochManager {
 
         let next_epoch_id = self.get_next_epoch_id(last_block_hash)?;
         let epoch_id = self.get_epoch_id(last_block_hash)?;
-        tracing::debug!(target: "epoch_manager",
+        tracing::debug!(
             epoch_id = ?next_next_epoch_id,
             prev_epoch_id = ?next_epoch_id,
             prev_prev_epoch_id= ?epoch_id,
@@ -1043,11 +1044,7 @@ impl EpochManager {
         let prev_prev_stake_change = self.get_epoch_info(&epoch_id)?.stake_change().clone();
         let prev_stake_change = self.get_epoch_info(&next_epoch_id)?.stake_change().clone();
         let stake_change = self.get_epoch_info(&next_next_epoch_id)?.stake_change().clone();
-        tracing::debug!(target: "epoch_manager",
-            ?prev_prev_stake_change,
-            ?prev_stake_change,
-            ?stake_change,
-        );
+        tracing::debug!(?prev_prev_stake_change, ?prev_stake_change, ?stake_change,);
         let all_stake_changes =
             prev_prev_stake_change.iter().chain(&prev_stake_change).chain(&stake_change);
         let all_keys: HashSet<&AccountId> = all_stake_changes.map(|(key, _)| key).collect();
@@ -1061,7 +1058,7 @@ impl EpochManager {
                 vec![prev_prev_stake, prev_stake, new_stake].into_iter().max().unwrap();
             stake_info.insert(account_id.clone(), max_of_stakes);
         }
-        tracing::debug!(target: "epoch_manager", ?stake_info, ?validator_reward);
+        tracing::debug!(?stake_info, ?validator_reward);
         Ok((stake_info, validator_reward))
     }
 
@@ -1318,7 +1315,7 @@ impl EpochManager {
         // Check that genesis block doesn't have any proposals.
         let prev_validator_proposals = block_info.proposals_iter().collect::<Vec<_>>();
         assert!(block_info.height() > 0 || prev_validator_proposals.is_empty());
-        tracing::debug!(target: "epoch_manager",
+        tracing::debug!(
             height = block_info.height(),
             proposals = ?prev_validator_proposals,
             "add_validator_proposals");

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -396,7 +396,7 @@ impl ShardTracker {
         if shards_to_state_sync.is_empty() {
             Ok(None)
         } else {
-            tracing::debug!(target: "chain", ?shards_to_state_sync, "downloading state");
+            tracing::debug!(?shards_to_state_sync, "downloading state");
             // Note that this block is the first block in an epoch because this function is only called
             // in get_catchup_and_state_sync_infos() when that is the case.
             let state_sync_info = StateSyncInfo::new(*block_hash, shards_to_state_sync);

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -3302,12 +3302,12 @@ fn test_possible_epochs_of_height_around_tip() {
     );
 
     let epoch1 = EpochId(h[0]);
-    tracing::info!(target: "test", ?epoch1);
+    tracing::info!(?epoch1);
 
     // Add blocks with heights 1..5, a standard epoch with no surprises
     for i in 1..=5 {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         record_block(&mut epoch_manager.write(), h[i - 1], h[i], height, vec![]);
         let tip = Tip {
             height,
@@ -3344,12 +3344,12 @@ fn test_possible_epochs_of_height_around_tip() {
     }
 
     let epoch2 = EpochId(h[5]);
-    tracing::info!(target: "test", ?epoch2);
+    tracing::info!(?epoch2);
 
     // Add blocks with heights 6..10, also a standard epoch with no surprises
     for i in 6..=10 {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         record_block(&mut epoch_manager.write(), h[i - 1], h[i], height, vec![]);
         let tip = Tip {
             height,
@@ -3390,7 +3390,7 @@ fn test_possible_epochs_of_height_around_tip() {
     }
 
     let epoch3 = EpochId(h[10]);
-    tracing::info!(target: "test", ?epoch3);
+    tracing::info!(?epoch3);
 
     // Now there is a very long epoch with no final blocks (all odd blocks are missing)
     // For all the blocks inside this for the last final block will be block #8, as it has #9 and #10
@@ -3399,7 +3399,7 @@ fn test_possible_epochs_of_height_around_tip() {
     let last_finalized_height = genesis_height + 8;
     for i in (12..=24).filter(|i| i % 2 == 0) {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         let block_info = block_info(
             h[i],
             height,
@@ -3462,7 +3462,7 @@ fn test_possible_epochs_of_height_around_tip() {
     // make block 24 final and finalize epoch2.
     for i in [25, 26] {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         let block_info = block_info(
             h[i],
             height,
@@ -3525,7 +3525,7 @@ fn test_possible_epochs_of_height_around_tip() {
     let epoch4 = EpochId(h[12]);
     for i in 27..=31 {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         record_block(&mut epoch_manager.write(), h[i - 1], h[i], height, vec![]);
         let tip = Tip {
             height,

--- a/chain/jsonrpc/src/api/blocks.rs
+++ b/chain/jsonrpc/src/api/blocks.rs
@@ -30,7 +30,7 @@ impl RpcFrom<GetBlockError> for RpcBlockError {
             GetBlockError::NotSyncedYet => Self::NotSyncedYet,
             GetBlockError::IOError { error_message } => Self::InternalError { error_message },
             GetBlockError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcBlockError"])
                     .inc();

--- a/chain/jsonrpc/src/api/changes.rs
+++ b/chain/jsonrpc/src/api/changes.rs
@@ -34,7 +34,7 @@ impl RpcFrom<GetBlockError> for RpcStateChangesError {
             GetBlockError::NotSyncedYet => Self::NotSyncedYet,
             GetBlockError::IOError { error_message } => Self::InternalError { error_message },
             GetBlockError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcStateChangesError"])
                     .inc();
@@ -55,7 +55,7 @@ impl RpcFrom<GetStateChangesError> for RpcStateChangesError {
             }
             GetStateChangesError::NotSyncedYet => Self::NotSyncedYet,
             GetStateChangesError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcStateChangesError"])
                     .inc();

--- a/chain/jsonrpc/src/api/chunks.rs
+++ b/chain/jsonrpc/src/api/chunks.rs
@@ -62,7 +62,7 @@ impl RpcFrom<GetChunkError> for RpcChunkError {
             }
             GetChunkError::UnknownChunk { chunk_hash } => Self::UnknownChunk { chunk_hash },
             GetChunkError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcChunkError"])
                     .inc();

--- a/chain/jsonrpc/src/api/client_config.rs
+++ b/chain/jsonrpc/src/api/client_config.rs
@@ -15,7 +15,7 @@ impl RpcFrom<GetClientConfigError> for RpcClientConfigError {
         match error {
             GetClientConfigError::IOError(error_message) => Self::InternalError { error_message },
             GetClientConfigError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcClientConfigError"])
                     .inc();

--- a/chain/jsonrpc/src/api/config.rs
+++ b/chain/jsonrpc/src/api/config.rs
@@ -26,7 +26,7 @@ impl RpcFrom<GetProtocolConfigError> for RpcProtocolConfigError {
             }
             GetProtocolConfigError::IOError(error_message) => Self::InternalError { error_message },
             GetProtocolConfigError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcProtocolConfigError"])
                     .inc();

--- a/chain/jsonrpc/src/api/gas_price.rs
+++ b/chain/jsonrpc/src/api/gas_price.rs
@@ -29,7 +29,7 @@ impl RpcFrom<GetGasPriceError> for RpcGasPriceError {
                 Self::InternalError { error_message }
             }
             GetGasPriceError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcGasPriceError"])
                     .inc();

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -65,7 +65,7 @@ impl RpcFrom<GetExecutionOutcomeError> for RpcLightClientProofError {
                 Self::InternalError { error_message }
             }
             GetExecutionOutcomeError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcLightClientProofError"])
                     .inc();
@@ -91,7 +91,7 @@ impl RpcFrom<GetBlockProofError> for RpcLightClientProofError {
                 Self::InternalError { error_message }
             }
             GetBlockProofError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcLightClientProofError"])
                     .inc();
@@ -120,7 +120,7 @@ impl RpcFrom<GetNextLightClientBlockError> for RpcLightClientNextBlockError {
                 Self::EpochOutOfBounds { epoch_id }
             }
             GetNextLightClientBlockError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcLightClientNextBlockError"])
                     .inc();

--- a/chain/jsonrpc/src/api/maintenance.rs
+++ b/chain/jsonrpc/src/api/maintenance.rs
@@ -28,7 +28,7 @@ impl RpcFrom<GetMaintenanceWindowsError> for RpcMaintenanceWindowsError {
                 Self::InternalError { error_message }
             }
             GetMaintenanceWindowsError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 Self::InternalError { error_message: error.to_string() }
             }
         }

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -122,7 +122,7 @@ impl RpcFrom<QueryError> for RpcQueryError {
                 Self::ContractExecutionError { vm_error, error, block_height, block_hash }
             }
             QueryError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcQueryError"])
                     .inc();

--- a/chain/jsonrpc/src/api/receipts.rs
+++ b/chain/jsonrpc/src/api/receipts.rs
@@ -31,7 +31,7 @@ impl RpcFrom<GetReceiptError> for RpcReceiptError {
             GetReceiptError::IOError(error_message) => Self::InternalError { error_message },
             GetReceiptError::UnknownReceipt(hash) => Self::UnknownReceipt { receipt_id: hash },
             GetReceiptError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcReceiptError"])
                     .inc();

--- a/chain/jsonrpc/src/api/split_storage.rs
+++ b/chain/jsonrpc/src/api/split_storage.rs
@@ -27,7 +27,7 @@ impl RpcFrom<GetSplitStorageInfoError> for RpcSplitStorageInfoError {
                 Self::InternalError { error_message }
             }
             GetSplitStorageInfoError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcSplitStorageInfoError"])
                     .inc();

--- a/chain/jsonrpc/src/api/status.rs
+++ b/chain/jsonrpc/src/api/status.rs
@@ -92,7 +92,7 @@ impl RpcFrom<StatusError> for RpcStatusError {
             StatusError::NoNewBlocks { elapsed } => Self::NoNewBlocks { elapsed },
             StatusError::EpochOutOfBounds { epoch_id } => Self::EpochOutOfBounds { epoch_id },
             StatusError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcStatusError"])
                     .inc();

--- a/chain/jsonrpc/src/api/validator.rs
+++ b/chain/jsonrpc/src/api/validator.rs
@@ -41,7 +41,7 @@ impl RpcFrom<GetValidatorInfoError> for RpcValidatorError {
             GetValidatorInfoError::ValidatorInfoUnavailable => Self::ValidatorInfoUnavailable,
             GetValidatorInfoError::IOError(error_message) => Self::InternalError { error_message },
             GetValidatorInfoError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcValidatorError"])
                     .inc();

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -651,7 +651,6 @@ impl JsonRpcHandler {
         .map_err(|_| {
             metrics::RPC_TIMEOUT_TOTAL.inc();
             tracing::warn!(
-                target: "jsonrpc",
                 ?tx_hash,
                 ?signer_account_id,
                 "timeout: tx_exists method"
@@ -721,7 +720,6 @@ impl JsonRpcHandler {
         .map_err(|_| {
             metrics::RPC_TIMEOUT_TOTAL.inc();
             tracing::warn!(
-                target: "jsonrpc",
                 ?tx_info,
                 ?fetch_receipt,
                 ?tx_status_result,
@@ -2035,7 +2033,7 @@ pub async fn start_http(
     let addr = config.addr;
     let prometheus_addr = config.prometheus_addr.clone().filter(|it| it != &addr.to_string());
     let cors_allowed_origins = config.cors_allowed_origins.clone();
-    tracing::info!(target: "network", %addr, "starting http server");
+    tracing::info!(%addr, "starting http server");
 
     // Create the axum app using the extracted function
     let app = create_jsonrpc_app(
@@ -2059,12 +2057,12 @@ pub async fn start_http(
     // Start main server
     future_spawner.spawn("JSON RPC", async move {
         if let Err(e) = axum::serve(listener, app).await {
-            tracing::error!(target: "network", ?e, "HTTP server error");
+            tracing::error!(?e, "HTTP server error");
         }
     });
 
     if let Some(prometheus_addr) = prometheus_addr {
-        tracing::info!(target: "network", %prometheus_addr, "starting http monitoring server");
+        tracing::info!(%prometheus_addr, "starting http monitoring server");
         // Export only the /metrics service. It's a read-only service and can have very relaxed
         // access restrictions.
         let prometheus_app = Router::new()
@@ -2079,7 +2077,7 @@ pub async fn start_http(
         // Start Prometheus server
         future_spawner.spawn("Prometheus Metrics", async move {
             if let Err(e) = axum::serve(listener, prometheus_app).await {
-                tracing::error!(target: "network", ?e, "prometheus server error");
+                tracing::error!(?e, "prometheus server error");
             }
         });
     }

--- a/chain/network/src/announce_accounts/mod.rs
+++ b/chain/network/src/announce_accounts/mod.rs
@@ -32,7 +32,7 @@ impl Inner {
 
         match self.store.get_account_announcement(&account_id) {
             Err(err) => {
-                tracing::warn!(target: "network", ?err, "error loading announce account from store");
+                tracing::warn!(?err, "error loading announce account from store");
                 None
             }
             Ok(None) => None,

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -481,7 +481,7 @@ impl PeerMessage {
     }
 
     pub(crate) fn deserialize(data: &[u8]) -> Result<PeerMessage, ParsePeerMessageError> {
-        let span = tracing::trace_span!(target: "network", "deserialize").entered();
+        let span = tracing::trace_span!("deserialize").entered();
         Ok({
             let proto_msg: proto::PeerMessage = proto::PeerMessage::parse_from_bytes(data)
                 .map_err(ParsePeerMessageError::ProtoDecode)?;
@@ -1139,10 +1139,7 @@ impl RoutedMessage {
                 ttl: msg.ttl,
                 body: msg.body.into(),
                 signature: msg.signature.unwrap_or_else(|| {
-                    tracing::error!(
-                        target: "network",
-                        "signature is missing, this should not yet happen"
-                    );
+                    tracing::error!("signature is missing, this should not yet happen");
                     Signature::default()
                 }),
             },

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -50,7 +50,7 @@ async fn test_peer_communication() -> anyhow::Result<()> {
         }
     };
 
-    tracing::info!(target:"test", "request update nonce");
+    tracing::info!("request update nonce");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::RequestUpdateNonce(PartialEdgeInfo::new(
         &outbound.cfg.network.node_id(),
@@ -61,13 +61,13 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "peers request");
+    tracing::info!("peers request");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::PeersRequest(PeersRequest { max_peers: None, max_direct_peers: None });
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "peers response");
+    tracing::info!("peers response");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::PeersResponse(PeersResponse {
         peers: (0..5).map(|_| data::make_peer_info(&mut rng)).collect(),
@@ -76,37 +76,37 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "block request");
+    tracing::info!("block request");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::BlockRequest(*chain.blocks[5].hash());
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target: "test", "block");
+    tracing::info!("block");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::Block(chain.blocks[5].clone());
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "block headers request");
+    tracing::info!("block headers request");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::BlockHeadersRequest(chain.blocks.iter().map(|b| *b.hash()).collect());
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "block headers");
+    tracing::info!("block headers");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::BlockHeaders(chain.get_block_headers().map(Into::into).collect());
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "sync routing table");
+    tracing::info!("sync routing table");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::SyncRoutingTable(data::make_routing_table(&mut rng));
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "partial encoded chunk request");
+    tracing::info!("partial encoded chunk request");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::Routed(Box::new(
         outbound.routed_message(
@@ -124,7 +124,7 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "partial encoded chunk response");
+    tracing::info!("partial encoded chunk response");
     let mut events = inbound.events.from_now();
     let want_hash = chain.blocks[3].chunks()[0].chunk_hash().clone();
     let want_parts = data::make_chunk_parts(chain.chunks[&want_hash].clone());
@@ -144,7 +144,7 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target: "test", "transaction");
+    tracing::info!("transaction");
     let mut events = inbound.events.from_now();
     let want = data::make_signed_transaction(&mut rng);
     let want = PeerMessage::Transaction(want);

--- a/chain/network/src/peer/tests/rate_limits.rs
+++ b/chain/network/src/peer/tests/rate_limits.rs
@@ -36,7 +36,7 @@ async fn test_message_rate_limits() -> anyhow::Result<()> {
     // Check how many messages of each type have been received.
     let messages_received =
         wait_for_similar_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
-    tracing::debug!(target:"test", ?messages_received, "received messages");
+    tracing::debug!(?messages_received, "received messages");
     // BlockRequest gets rate limited (7 sent vs 5 bucket_start).
     assert!(messages_received[0] < MESSAGES);
     // PartialEncodedChunkRequest gets rate limited (7 sent vs 5 bucket_start).
@@ -76,7 +76,7 @@ async fn slow_test_message_rate_limits_over_time() -> anyhow::Result<()> {
 
     let messages_received =
         wait_for_similar_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
-    tracing::debug!(target:"test", ?messages_received, "received messages");
+    tracing::debug!(?messages_received, "received messages");
     // BlockRequest and PartialEncodedChunkRequest don't get rate limited
     // 12 sent vs 5 bucket_start + 2.5 refilled * 4s
     assert_eq!(messages_received[0], MESSAGES * 3);
@@ -172,14 +172,14 @@ async fn send_messages(
 ) -> Vec<PeerMessage> {
     let mut messages_samples = Vec::new();
 
-    tracing::info!(target:"test", "send block request");
+    tracing::info!("send block request");
     let message = PeerMessage::BlockRequest(CryptoHash::default());
     for _ in 0..count {
         outbound.send(message.clone()).await;
     }
     messages_samples.push(message);
 
-    tracing::info!(target:"test", "send partial encoded chunk request");
+    tracing::info!("send partial encoded chunk request");
     // Duplicated routed messages are filtered out so we must tweak each message to make it unique.
 
     for i in 0..count {
@@ -202,7 +202,7 @@ async fn send_messages(
         }
     }
 
-    tracing::info!(target: "test", "send transaction");
+    tracing::info!("send transaction");
     let message = PeerMessage::Transaction(data::make_signed_transaction(rng));
     for _ in 0..count {
         outbound.send(message.clone()).await;

--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -165,7 +165,7 @@ impl Connection {
     // so that we can skip the actor queue when sending messages.
     pub fn send_message(&self, msg: Arc<PeerMessage>) {
         let msg_kind = msg.msg_variant().to_string();
-        tracing::trace!(target: "network", ?msg_kind, "sending message");
+        tracing::trace!(?msg_kind, "sending message");
         self.handle.send(SendMessage { message: msg }.span_wrap());
     }
 
@@ -448,7 +448,7 @@ impl Pool {
                     // however conflicting connections with the same account key indicate an
                     // incorrect validator setup, so we log it here as a warn!, rather than just
                     // info!.
-                    tracing::warn!(target:"network", %id, ?err, "pool register failed");
+                    tracing::warn!(%id, ?err, "pool register failed");
                     metrics::ALREADY_CONNECTED_ACCOUNT.inc();
                     return Err(err);
                 }
@@ -509,7 +509,7 @@ impl Pool {
             peer.send_message(msg);
             return true;
         }
-        tracing::debug!(target: "network",
+        tracing::debug!(
            to = ?peer_id,
            num_connected_peers = pool.ready.len(),
            ?msg,

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -48,7 +48,7 @@ impl NetworkState {
         let this = self.clone();
         self.spawn("add_accounts", async move {
             let new_accounts = this.account_announcements.add_accounts(accounts);
-            tracing::debug!(target: "network", account_id = ?this.config.validator.account_id(), ?new_accounts, "received new accounts");
+            tracing::debug!(account_id = ?this.config.validator.account_id(), ?new_accounts, "received new accounts");
             #[cfg(test)]
             this.config.event_sink.send(crate::peer_manager::peer_manager_actor::Event::AccountsAdded(new_accounts.clone()));
             this.broadcast_routing_table_update(RoutingTableUpdate::from_accounts(
@@ -215,7 +215,7 @@ impl NetworkState {
             return;
         }
 
-        tracing::trace!(target: "network", route_back = ?msg.clone(), "received peer message that requires response");
+        tracing::trace!(route_back = ?msg.clone(), "received peer message that requires response");
         let from = &conn.peer_info.id;
 
         match conn.tier {

--- a/chain/network/src/peer_manager/peer_store/mod.rs
+++ b/chain/network/src/peer_manager/peer_store/mod.rs
@@ -232,7 +232,7 @@ impl Inner {
             if peer_status.status != KnownPeerStatus::Connected
                 && now > peer_status.last_seen + self.config.peer_expiration_duration
             {
-                tracing::debug!(target: "network", last_seen = ?peer_status.last_seen, "removing expired peer");
+                tracing::debug!(last_seen = ?peer_status.last_seen, "removing expired peer");
                 to_remove.push(peer_id.clone());
             }
         }
@@ -246,13 +246,13 @@ impl Inner {
                 if now < ban_time + self.config.ban_window {
                     continue;
                 }
-                tracing::info!(target: "network", unbanned = ?peer_id, ?ban_time, "unbanning a peer");
+                tracing::info!(unbanned = ?peer_id, ?ban_time, "unbanning a peer");
                 to_unban.push(peer_id.clone());
             }
         }
         for peer_id in &to_unban {
             if let Err(err) = self.peer_unban(&peer_id) {
-                tracing::error!(target: "network", ?peer_id, ?err, "failed to unban a peer");
+                tracing::error!(?peer_id, ?err, "failed to unban a peer");
             }
         }
     }
@@ -417,7 +417,7 @@ impl PeerStore {
         peer_id: &PeerId,
         ban_reason: ReasonForBan,
     ) -> anyhow::Result<()> {
-        tracing::warn!(target: "network", %peer_id, ?ban_reason, "banning peer");
+        tracing::warn!(%peer_id, ?ban_reason, "banning peer");
         let mut inner = self.0.lock();
         if let Some(peer_state) = inner.peer_states.get_mut(peer_id) {
             let now = clock.now_utc();
@@ -499,7 +499,7 @@ impl PeerStore {
             }
         }
         if blacklisted != 0 {
-            tracing::info!(target: "network", %blacklisted, %total,
+            tracing::info!(%blacklisted, %total,
                   "ignored blacklisted peers out of indirect peers");
         }
     }

--- a/chain/network/src/peer_manager/tests/accounts_data.rs
+++ b/chain/network/src/peer_manager/tests/accounts_data.rs
@@ -54,13 +54,13 @@ async fn broadcast() {
     };
 
     let data = chain.make_tier1_data(rng, clock);
-    tracing::info!(target:"test", "connect peer, expect initial sync to be empty");
+    tracing::info!("connect peer, expect initial sync to be empty");
     let mut peer1 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let got1 = peer1.events.recv_until(take_full_sync).await;
     assert_eq!(got1.accounts_data, vec![]);
 
-    tracing::info!(target:"test", "send some data");
+    tracing::info!("send some data");
     let msg = SyncAccountsData {
         accounts_data: vec![data[0].clone(), data[1].clone()],
         incremental: true,
@@ -70,13 +70,13 @@ async fn broadcast() {
     peer1.send(PeerMessage::SyncAccountsData(msg)).await;
     pm.wait_for_accounts_data(&want).await;
 
-    tracing::info!(target:"test", "connect another peer and perform initial full sync");
+    tracing::info!("connect another peer and perform initial full sync");
     let mut peer2 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let got2 = peer2.events.recv_until(take_full_sync).await;
     assert_eq!(got2.accounts_data.as_set(), want.iter().collect::<HashSet<_>>());
 
-    tracing::info!(target:"test", "send a mix of new and old data, only new data should be broadcasted");
+    tracing::info!("send a mix of new and old data, only new data should be broadcasted");
     let msg = SyncAccountsData {
         accounts_data: vec![data[1].clone(), data[2].clone()],
         incremental: true,
@@ -87,7 +87,7 @@ async fn broadcast() {
     let got2 = peer2.events.recv_until(take_incremental_sync).await;
     assert_eq!(got2.accounts_data.as_set(), want.as_set());
 
-    tracing::info!(target:"test", "send a request for a full sync");
+    tracing::info!("send a request for a full sync");
     let want = vec![data[0].clone(), data[1].clone(), data[2].clone()];
     let mut events = peer1.events.from_now();
     peer1
@@ -134,7 +134,7 @@ async fn gradual_epoch_change() {
 
     // For every order of nodes.
     for ids in (0..pms.len()).permutations(pms.len()) {
-        tracing::info!(target:"test", ?ids, "permutation");
+        tracing::info!(?ids, "permutation");
         clock.advance(time::Duration::hours(1));
         let chain_info = testonly::make_chain_info(
             &chain,
@@ -142,7 +142,7 @@ async fn gradual_epoch_change() {
         );
 
         let mut want = HashSet::new();
-        tracing::info!(target:"test", "advance epoch in the given order");
+        tracing::info!("advance epoch in the given order");
         for id in ids {
             pms[id].set_chain_info(chain_info.clone()).await;
             // In this tests each node is its own proxy, so it can immediately
@@ -153,7 +153,7 @@ async fn gradual_epoch_change() {
             want.extend(pms[id].tier1_advertise_proxies(&clock.clock()).await);
         }
         for pm in &mut pms {
-            tracing::info!(target:"test", node_id = %pm.cfg.node_id(), "wait for data to arrive");
+            tracing::info!(node_id = %pm.cfg.node_id(), "wait for data to arrive");
             pm.wait_for_accounts_data(&want).await;
         }
     }
@@ -198,7 +198,7 @@ async fn slow_test_rate_limiting() {
             .await,
         );
     }
-    tracing::info!(target:"test", "construct a 4-layer bipartite graph");
+    tracing::info!("construct a 4-layer bipartite graph");
 
     let mut connections = 0;
     let mut tasks = vec![];
@@ -225,7 +225,7 @@ async fn slow_test_rate_limiting() {
     // the total number of SyncAccountsData messages exchanged in the process.
     let events: Vec<_> = pms.iter().map(|pm| pm.events.from_now()).collect();
 
-    tracing::info!(target:"test", "advance epoch in random order");
+    tracing::info!("advance epoch in random order");
     pms.shuffle(rng);
     let mut want = HashSet::new();
     for pm in &mut pms {
@@ -233,12 +233,12 @@ async fn slow_test_rate_limiting() {
         want.extend(pm.tier1_advertise_proxies(&clock.clock()).await);
     }
 
-    tracing::info!(target:"test", "wait for data to arrive");
+    tracing::info!("wait for data to arrive");
     for pm in &mut pms {
         pm.wait_for_accounts_data(&want).await;
     }
 
-    tracing::info!(target:"test", "count the sync accounts data messages exchanged");
+    tracing::info!("count the sync accounts data messages exchanged");
     let mut msgs = 0;
     for mut es in events {
         while let Some(ev) = es.try_recv() {
@@ -286,7 +286,7 @@ async fn validator_node_restart() {
         (2, ZERO),
         (2, SEC),
     ] {
-        tracing::info!(target:"test", %n, %downtime, "test case");
+        tracing::info!(%n, %downtime, "test case");
 
         let mut rng = make_rng(921853233);
         let rng = &mut rng;

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -269,7 +269,7 @@ async fn invalid_edge() {
 
     for (name, edge) in &testcases {
         for tier in [tcp::Tier::T1, tcp::Tier::T2, tcp::Tier::T3] {
-            tracing::info!(target:"test", %name, ?tier, "test case");
+            tracing::info!(%name, ?tier, "test case");
             let stream = tcp::Stream::connect(&pm.peer_info(), tier, &SocketOptions::default())
                 .await
                 .unwrap();

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -44,7 +44,7 @@ async fn test_nonces() {
     ];
 
     for test in test_cases {
-        tracing::info!(target: "test", test_name = test.2, "running test");
+        tracing::info!(test_name = test.2, "running test");
         // Start a PeerManager and connect a peer to it.
         let pm = peer_manager::testonly::start(
             clock.clock(),

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -35,24 +35,24 @@ async fn simple() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes");
+    tracing::info!("start two nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
 
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[]).await;
 
-    tracing::info!(target:"test", "connect the nodes");
+    tracing::info!("connect the nodes");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[(id1.clone(), vec![id1.clone()])]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[(id0.clone(), vec![id0.clone()])]).await;
 }
 
@@ -65,7 +65,7 @@ async fn three_nodes_path() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "connect three nodes in a line");
+    tracing::info!("connect three nodes in a line");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -77,19 +77,19 @@ async fn three_nodes_path() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -106,7 +106,7 @@ async fn three_nodes_star() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "connect three nodes in a line");
+    tracing::info!("connect three nodes in a line");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -118,41 +118,41 @@ async fn three_nodes_star() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
     ])
     .await;
 
-    tracing::info!(target:"test", %id0, %id2, "connect nodes");
+    tracing::info!(%id0, %id2, "connect nodes");
     pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -170,7 +170,7 @@ async fn join_components() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "create two connected components having two nodes each");
+    tracing::info!("create two connected components having two nodes each");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -184,42 +184,42 @@ async fn join_components() {
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm2.connect_to(&pm3.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[(id1.clone(), vec![id1.clone()])]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[(id0.clone(), vec![id0.clone()])]).await;
 
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[(id3.clone(), vec![id3.clone()])]).await;
-    tracing::info!(target:"test", %id3, "wait for routing table");
+    tracing::info!(%id3, "wait for routing table");
     pm3.wait_for_routing_table(&[(id2.clone(), vec![id2.clone()])]).await;
 
-    tracing::info!(target:"test", "join the two components into a square");
+    tracing::info!("join the two components into a square");
     pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
     pm3.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id2.clone()]),
         (id3.clone(), vec![id1.clone(), id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id0.clone(), id3.clone()]),
         (id3.clone(), vec![id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id1.clone(), vec![id0.clone(), id3.clone()]),
         (id3.clone(), vec![id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id3, "wait for routing table");
+    tracing::info!(%id3, "wait for routing table");
     pm3.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone(), id2.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -241,7 +241,7 @@ async fn simple_remove() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "connect 3 nodes in a line");
+    tracing::info!("connect 3 nodes in a line");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -253,31 +253,31 @@ async fn simple_remove() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
     ])
     .await;
 
-    tracing::info!(target:"test", %id1, "stop node");
+    tracing::info!(%id1, "stop node");
     drop(pm1);
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[]).await;
 }
 
@@ -332,7 +332,7 @@ async fn ping_simple() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes");
+    tracing::info!("start two nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
 
@@ -341,20 +341,20 @@ async fn ping_simple() {
 
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[(id1.clone(), vec![id1.clone()])]).await;
 
     // capture event streams before pinging
     let mut pm0_ev = pm0.events.from_now();
     let mut pm1_ev = pm1.events.from_now();
 
-    tracing::info!(target:"test", %id0, %id1, "send ping");
+    tracing::info!(%id0, %id1, "send ping");
     pm0.send_ping(&clock.clock(), 0, id1.clone()).await;
 
-    tracing::info!(target:"test", %id1, "await ping");
+    tracing::info!(%id1, "await ping");
     wait_for_ping(&mut pm1_ev, Ping { nonce: 0, source: id0.clone() }).await;
 
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 0, source: id1.clone() }).await;
 
     drop(pm0);
@@ -370,7 +370,7 @@ async fn ping_jump() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes");
+    tracing::info!("start three nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -379,23 +379,23 @@ async fn ping_jump() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", "connect nodes in a line");
+    tracing::info!("connect nodes in a line");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -406,13 +406,13 @@ async fn ping_jump() {
     let mut pm0_ev = pm0.events.from_now();
     let mut pm2_ev = pm2.events.from_now();
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
 
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 0, source: id0.clone() }).await;
 
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 0, source: id2.clone() }).await;
 }
 
@@ -425,7 +425,7 @@ async fn test_dont_drop_after_ttl() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes");
+    tracing::info!("start three nodes");
     let mut cfg0 = chain.make_config(rng);
     cfg0.routed_message_ttl = 2;
     let pm0 = start_pm(clock.clock(), TestDB::new(), cfg0, chain.clone()).await;
@@ -436,23 +436,23 @@ async fn test_dont_drop_after_ttl() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", "connect nodes in a line");
+    tracing::info!("connect nodes in a line");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -463,13 +463,13 @@ async fn test_dont_drop_after_ttl() {
     let mut pm0_ev = pm0.events.from_now();
     let mut pm2_ev = pm2.events.from_now();
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
 
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 0, source: id0.clone() }).await;
 
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 0, source: id2.clone() }).await;
 }
 
@@ -482,7 +482,7 @@ async fn test_drop_after_ttl() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes");
+    tracing::info!("start three nodes");
     let mut cfg0 = chain.make_config(rng);
     cfg0.routed_message_ttl = 1;
     let pm0 = start_pm(clock.clock(), TestDB::new(), cfg0, chain.clone()).await;
@@ -493,23 +493,23 @@ async fn test_drop_after_ttl() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", "connect nodes in a line");
+    tracing::info!("connect nodes in a line");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -519,10 +519,10 @@ async fn test_drop_after_ttl() {
     // capture event stream before pinging
     let mut pm1_ev = pm1.events.from_now();
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
 
-    tracing::info!(target:"test", %id1, "await message dropped");
+    tracing::info!(%id1, "await message dropped");
     wait_for_message_dropped(&mut pm1_ev).await;
 }
 
@@ -535,7 +535,7 @@ async fn test_dropping_duplicate_messages() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes");
+    tracing::info!("start three nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -544,23 +544,23 @@ async fn test_dropping_duplicate_messages() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", "connect nodes in a line");
+    tracing::info!("connect nodes in a line");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -573,33 +573,33 @@ async fn test_dropping_duplicate_messages() {
     let mut pm2_ev = pm2.events.from_now();
 
     // Send two identical messages. One will be dropped, because the delay between them was less than 50ms.
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 0, source: id0.clone() }).await;
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 0, source: id2.clone() }).await;
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
-    tracing::info!(target:"test", %id1, "await message dropped");
+    tracing::info!(%id1, "await message dropped");
     wait_for_message_dropped(&mut pm1_ev).await;
 
     // Send two identical messages but with 300ms delay so they don't get dropped.
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 1, id2.clone()).await;
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 1, source: id0.clone() }).await;
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 1, source: id2.clone() }).await;
 
     clock.advance(DROP_DUPLICATED_MESSAGES_PERIOD + time::Duration::milliseconds(1));
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 1, id2.clone()).await;
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 1, source: id0.clone() }).await;
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 1, source: id2.clone() }).await;
 }
 
@@ -655,7 +655,7 @@ async fn from_boot_nodes() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes");
+    tracing::info!("start two nodes");
     let configs = make_configs(&chain, rng, 2, 1, true);
     let pm0 = start_pm(clock.clock(), TestDB::new(), configs[0].clone(), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), configs[1].clone(), chain.clone()).await;
@@ -663,9 +663,9 @@ async fn from_boot_nodes() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[(id1.clone(), vec![id1.clone()])]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[(id0.clone(), vec![id0.clone()])]).await;
 }
 
@@ -678,7 +678,7 @@ async fn blacklist_01() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes with 0 blacklisting 1");
+    tracing::info!("start two nodes with 0 blacklisting 1");
     let mut configs = make_configs(&chain, rng, 2, 2, true);
     configs[0].peer_store.blacklist =
         [blacklist::Entry::from_addr(**configs[1].node_addr.as_ref().unwrap())]
@@ -691,16 +691,16 @@ async fn blacklist_01() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "wait for the connection to be attempted and rejected");
+    tracing::info!("wait for the connection to be attempted and rejected");
     wait_for_connection_closed(
         &mut pm0.events.clone(),
         ClosingReason::RejectedByPeerManager(RegisterPeerError::Blacklisted),
     )
     .await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[]).await;
 }
 
@@ -713,7 +713,7 @@ async fn blacklist_10() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes with 1 blacklisting 0");
+    tracing::info!("start two nodes with 1 blacklisting 0");
     let mut configs = make_configs(&chain, rng, 2, 2, true);
     configs[1].peer_store.blacklist =
         [blacklist::Entry::from_addr(**configs[0].node_addr.as_ref().unwrap())]
@@ -726,16 +726,16 @@ async fn blacklist_10() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "wait for the connection to be attempted and rejected");
+    tracing::info!("wait for the connection to be attempted and rejected");
     wait_for_connection_closed(
         &mut pm1.events.clone(),
         ClosingReason::RejectedByPeerManager(RegisterPeerError::Blacklisted),
     )
     .await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[]).await;
 }
 
@@ -748,7 +748,7 @@ async fn blacklist_all() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes with 0 blacklisting everything");
+    tracing::info!("start two nodes with 0 blacklisting everything");
     let mut configs = make_configs(&chain, rng, 2, 2, true);
     configs[0].peer_store.blacklist =
         [blacklist::Entry::from_ip(Ipv6Addr::LOCALHOST.into())].into_iter().collect();
@@ -759,16 +759,16 @@ async fn blacklist_all() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "wait for the connection to be attempted and rejected");
+    tracing::info!("wait for the connection to be attempted and rejected");
     wait_for_connection_closed(
         &mut pm0.events.clone(),
         ClosingReason::RejectedByPeerManager(RegisterPeerError::Blacklisted),
     )
     .await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[]).await;
 }
 
@@ -782,7 +782,7 @@ async fn max_num_peers_limit() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes with max_num_peers=2");
+    tracing::info!("start three nodes with max_num_peers=2");
     let mut configs = make_configs(&chain, rng, 4, 4, false);
     for config in &mut configs {
         config.max_num_peers = 2;
@@ -802,19 +802,19 @@ async fn max_num_peers_limit() {
     pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -825,26 +825,26 @@ async fn max_num_peers_limit() {
     let mut pm1_ev = pm1.events.from_now();
     let mut pm2_ev = pm2.events.from_now();
 
-    tracing::info!(target:"test", "start a fourth node");
+    tracing::info!("start a fourth node");
     let pm3 = start_pm(clock.clock(), TestDB::new(), configs[3].clone(), chain.clone()).await;
 
     let id3 = pm3.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait to reject attempted connection");
+    tracing::info!(%id0, "wait to reject attempted connection");
     pm3.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(
         &mut pm0_ev,
         ClosingReason::RejectedByPeerManager(RegisterPeerError::ConnectionLimitExceeded),
     )
     .await;
-    tracing::info!(target:"test", %id1, "wait to reject attempted connection");
+    tracing::info!(%id1, "wait to reject attempted connection");
     pm3.send_outbound_connect(&pm1.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(
         &mut pm1_ev,
         ClosingReason::RejectedByPeerManager(RegisterPeerError::ConnectionLimitExceeded),
     )
     .await;
-    tracing::info!(target:"test", %id2, "wait to reject attempted connection");
+    tracing::info!(%id2, "wait to reject attempted connection");
     pm3.send_outbound_connect(&pm2.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(
         &mut pm2_ev,
@@ -852,7 +852,7 @@ async fn max_num_peers_limit() {
     )
     .await;
 
-    tracing::info!(target:"test", %id3, "wait for routing table");
+    tracing::info!(%id3, "wait for routing table");
     pm3.wait_for_routing_table(&[]).await;
 
     // These drop() calls fix the place at which we want the values to be dropped,
@@ -959,7 +959,7 @@ async fn repeated_data_in_sync_routing_table() {
 
     // Gradually increment the amount of data in the system and then broadcast it.
     for i in 0..10 {
-        tracing::info!(target: "test", %i, "iteration");
+        tracing::info!(%i, "iteration");
         // Wait for the new data to be broadcasted.
         // Note that in the first iteration we expect just 1 edge, without sending anything before.
         // It is important because the first SyncRoutingTable contains snapshot of all data known to
@@ -1014,7 +1014,7 @@ async fn square() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "connect 4 nodes in a square");
+    tracing::info!("connect 4 nodes in a square");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -1034,21 +1034,21 @@ async fn square() {
         (id2.clone(), vec![id1.clone(), id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "stop node");
+    tracing::info!(%id1, "stop node");
     drop(pm1);
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id3.clone(), vec![id3.clone()]),
         (id2.clone(), vec![id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id3.clone(), vec![id3.clone()]),
         (id0.clone(), vec![id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id3, "wait for routing table");
+    tracing::info!(%id3, "wait for routing table");
     pm3.wait_for_routing_table(&[
         (id2.clone(), vec![id2.clone()]),
         (id0.clone(), vec![id0.clone()]),
@@ -1090,7 +1090,7 @@ async fn fix_local_edges() {
         edge2.clone(),
     ]));
 
-    tracing::info!(target:"test", "waiting for fake edges to be processed");
+    tracing::info!("waiting for fake edges to be processed");
     let mut events = pm.events.from_now();
     conn.send(msg.clone()).await;
     events
@@ -1100,7 +1100,7 @@ async fn fix_local_edges() {
         })
         .await;
 
-    tracing::info!(target:"test", "waiting for fake edges to be fixed");
+    tracing::info!("waiting for fake edges to be fixed");
     let mut events = pm.events.from_now();
     pm.fix_local_edges(&clock.clock(), time::Duration::ZERO).await;
     // TODO(gprusak): make fix_local_edges await closing of the connections, so
@@ -1112,7 +1112,7 @@ async fn fix_local_edges() {
         })
         .await;
 
-    tracing::info!(target:"test", "checking the consistency");
+    tracing::info!("checking the consistency");
     pm.check_consistency().await;
     drop(conn);
 }
@@ -1129,7 +1129,7 @@ async fn do_not_block_announce_account_broadcast() {
     let db1 = TestDB::new();
     let aa = data::make_announce_account(rng);
 
-    tracing::info!(target:"test", "spawn 2 nodes and announce the account");
+    tracing::info!("spawn 2 nodes and announce the account");
     let pm0 = start_pm(clock.clock(), db0.clone(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), db1.clone(), chain.make_config(rng), chain.clone()).await;
     pm1.connect_to(&pm0.peer_info(), tcp::Tier::T2).await;
@@ -1138,7 +1138,7 @@ async fn do_not_block_announce_account_broadcast() {
     drop(pm0);
     drop(pm1);
 
-    tracing::info!(target:"test", "spawn 3 nodes and re-announce the account");
+    tracing::info!("spawn 3 nodes and re-announce the account");
     // Even though the account was previously announced (pm0 and pm1 have it in DB),
     // the nodes should allow to let the broadcast through.
     let pm0 = start_pm(clock.clock(), db0, chain.make_config(rng), chain.clone()).await;
@@ -1174,7 +1174,7 @@ async fn archival_node() {
     configs[0].archive = true;
     configs[1].archive = true;
 
-    tracing::info!(target:"test", "start five nodes, the first two of which are archival nodes");
+    tracing::info!("start five nodes, the first two of which are archival nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), configs[0].clone(), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), configs[1].clone(), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), configs[2].clone(), chain.clone()).await;
@@ -1186,24 +1186,24 @@ async fn archival_node() {
     // capture pm0 event stream
     let mut pm0_ev = pm0.events.from_now();
 
-    tracing::info!(target:"test", "connect node 2 to node 0");
+    tracing::info!("connect node 2 to node 0");
     pm2.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
-    tracing::info!(target:"test", "connect node 3 to node 0");
+    tracing::info!("connect node 3 to node 0");
     pm3.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", "connect node 4 to node 0 and wait for pm0 to close a connection");
+    tracing::info!("connect node 4 to node 0 and wait for pm0 to close a connection");
     pm4.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(&mut pm0_ev, ClosingReason::PeerManagerRequest).await;
 
-    tracing::info!(target:"test", "connect node 1 to node 0 and wait for pm0 to close a connection");
+    tracing::info!("connect node 1 to node 0 and wait for pm0 to close a connection");
     pm1.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(&mut pm0_ev, ClosingReason::PeerManagerRequest).await;
 
-    tracing::info!(target:"test", "check that node 0 and node 1 are still connected");
+    tracing::info!("check that node 0 and node 1 are still connected");
     pm0.wait_for_direct_connection(id1.clone()).await;
 
     for _step in 0..10 {
-        tracing::info!(target:"test", %_step, "select a node which node 0 is not connected to");
+        tracing::info!(%_step, "select a node which node 0 is not connected to");
         let pm0_connections: HashSet<PeerId> =
             pm0.with_state(|s| async move { s.tier2.load().ready.keys().cloned().collect() }).await;
 
@@ -1214,14 +1214,14 @@ async fn archival_node() {
             .choose(rng)
             .unwrap();
 
-        tracing::info!(target:"test", %_step, "wait for the chosen node to finish disconnecting from node 0");
+        tracing::info!(%_step, "wait for the chosen node to finish disconnecting from node 0");
         chosen.wait_for_num_connected_peers(0).await;
 
-        tracing::info!(target:"test", %_step, "connect the chosen node to node 0 and wait for pm0 to close a connection");
+        tracing::info!(%_step, "connect the chosen node to node 0 and wait for pm0 to close a connection");
         chosen.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
         wait_for_connection_closed(&mut pm0_ev, ClosingReason::PeerManagerRequest).await;
 
-        tracing::info!(target:"test", %_step, "check that node 0 and node 1 are still connected");
+        tracing::info!(%_step, "check that node 0 and node 1 are still connected");
         pm0.wait_for_direct_connection(id1.clone()).await;
     }
 
@@ -1259,10 +1259,10 @@ async fn connect_to_unbanned_peer() {
     let mut pm1 =
         start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
 
-    tracing::info!(target:"test", "pm0 connects to pm1");
+    tracing::info!("pm0 connects to pm1");
     let stream_id = pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", "pm1 bans pm0");
+    tracing::info!("pm1 bans pm0");
     let ban_reason = ReasonForBan::BadBlock;
     pm1.disconnect_and_ban(&clock.clock(), &pm0.cfg.node_id(), ban_reason).await;
     wait_for_stream_closed(&mut pm0.events, stream_id).await;
@@ -1271,7 +1271,7 @@ async fn connect_to_unbanned_peer() {
         wait_for_stream_closed(&mut pm1.events, stream_id).await
     );
 
-    tracing::info!(target:"test", "pm0 fails to reconnect to pm1");
+    tracing::info!("pm0 fails to reconnect to pm1");
     let got_reason = pm1
         .start_inbound(chain.clone(), pm0.cfg.clone())
         .await
@@ -1280,11 +1280,11 @@ async fn connect_to_unbanned_peer() {
     assert_eq!(ClosingReason::RejectedByPeerManager(RegisterPeerError::Banned), got_reason);
 
     // cspell:words unbans
-    tracing::info!(target:"test", "pm1 unbans pm0");
+    tracing::info!("pm1 unbans pm0");
     clock.advance(pm1.cfg.peer_store.ban_window);
     pm1.peer_store_update(&clock.clock()).await;
 
-    tracing::info!(target:"test", "pm0 reconnects to pm1");
+    tracing::info!("pm0 reconnects to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
     drop(pm0);
@@ -1315,7 +1315,7 @@ async fn peer_connect_send_distance_vector() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes");
+    tracing::info!("start two nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
 
@@ -1326,7 +1326,7 @@ async fn peer_connect_send_distance_vector() {
     let mut pm0_ev = pm0.events.from_now();
     let mut pm1_ev = pm1.events.from_now();
 
-    tracing::info!(target:"test", "connect the nodes");
+    tracing::info!("connect the nodes");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
     wait_for_distance_vector(&mut pm0_ev, id1).await;

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -88,14 +88,14 @@ async fn broadcast() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect a peer, expect initial sync to be empty");
+    tracing::info!("connect a peer, expect initial sync to be empty");
     let peer1_config = chain.make_config(rng);
     let mut peer1 =
         pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
     let empty_sync_msg = peer1.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "connect two more peers");
+    tracing::info!("connect two more peers");
     let peer2_config = chain.make_config(rng);
     let mut peer2 =
         pm.start_inbound(chain.clone(), peer2_config.clone()).await.handshake(clock).await;
@@ -107,7 +107,9 @@ async fn broadcast() {
     let empty_sync_msg = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "send a sync snapshot hosts message from peer1, make sure that all peers receive it");
+    tracing::info!(
+        "send a sync snapshot hosts message from peer1, make sure that all peers receive it"
+    );
 
     let info1 = make_snapshot_host_info(&peer1_config.node_id(), &peer1_config.node_key, rng);
 
@@ -124,13 +126,17 @@ async fn broadcast() {
     let got3 = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(got3.hosts, vec![info1.clone()]);
 
-    tracing::info!(target:"test", "connect another peer, make sure that it receives the correct information on joining");
+    tracing::info!(
+        "connect another peer, make sure that it receives the correct information on joining"
+    );
     let mut peer4 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let peer4_sync_msg = peer4.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(peer4_sync_msg.hosts, vec![info1.clone()]);
 
-    tracing::info!(target:"test", "publish another piece of snapshot information, check that it's also broadcasted");
+    tracing::info!(
+        "publish another piece of snapshot information, check that it's also broadcasted"
+    );
     let info2 = make_snapshot_host_info(&peer2_config.node_id(), &peer2_config.node_key, rng);
 
     peer2
@@ -140,7 +146,7 @@ async fn broadcast() {
     let got1 = peer1.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(got1.hosts, vec![info2.clone()]);
 
-    tracing::info!(target:"test", "connect another peer, check that it receives all of the published information");
+    tracing::info!("connect another peer, check that it receives all of the published information");
     let mut peer5 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let peer5_sync_msg = peer5.events.recv_until(take_sync_snapshot_msg).await;
@@ -166,7 +172,7 @@ async fn invalid_signature_not_broadcast() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect peers, expect initial sync to be empty");
+    tracing::info!("connect peers, expect initial sync to be empty");
     let peer1_config = chain.make_config(rng);
     let mut peer1 =
         pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
@@ -184,7 +190,9 @@ async fn invalid_signature_not_broadcast() {
     let empty_sync_msg = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "send an invalid sync snapshot hosts message from peer1, one of the host infos has an invalid signature");
+    tracing::info!(
+        "send an invalid sync snapshot hosts message from peer1, one of the host infos has an invalid signature"
+    );
     let random_secret_key = SecretKey::from_random(near_crypto::KeyType::ED25519);
     let invalid_info = make_snapshot_host_info(&peer1_config.node_id(), &random_secret_key, rng);
 
@@ -196,7 +204,7 @@ async fn invalid_signature_not_broadcast() {
     });
     peer1.send(invalid_message).await;
 
-    tracing::info!(target:"test", "send a valid message from peer2 (as peer1 got banned), it should reach peer3");
+    tracing::info!("send a valid message from peer2 (as peer1 got banned), it should reach peer3");
 
     let info2 = make_snapshot_host_info(&peer2_config.node_id(), &peer2_config.node_key, rng);
 
@@ -204,7 +212,7 @@ async fn invalid_signature_not_broadcast() {
         .send(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts { hosts: vec![info2.clone()] }))
         .await;
 
-    tracing::info!(target:"test", "make sure that only the valid messages are broadcast");
+    tracing::info!("make sure that only the valid messages are broadcast");
 
     // Wait until peer2 receives info2. Ignore ok_info_a and ok_info_b,
     // as the PeerManager could accept and broadcast them despite the neighboring invalid_info.
@@ -230,7 +238,7 @@ async fn too_many_shards_not_broadcast() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect peers, expect initial sync to be empty");
+    tracing::info!("connect peers, expect initial sync to be empty");
     let peer1_config = chain.make_config(rng);
     let mut peer1 =
         pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
@@ -248,7 +256,9 @@ async fn too_many_shards_not_broadcast() {
     let empty_sync_msg = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "send an invalid sync snapshot hosts message from peer1, one of the host infos has more shard ids than allowed");
+    tracing::info!(
+        "send an invalid sync snapshot hosts message from peer1, one of the host infos has more shard ids than allowed"
+    );
     let too_many_shards: Vec<ShardId> =
         (0..(MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64 + 1)).map(Into::into).collect();
     let invalid_info = Arc::new(SnapshotHostInfo::new(
@@ -267,7 +277,7 @@ async fn too_many_shards_not_broadcast() {
     });
     peer1.send(invalid_message).await;
 
-    tracing::info!(target:"test", "send a valid message from peer2 (as peer1 got banned), it should reach peer3");
+    tracing::info!("send a valid message from peer2 (as peer1 got banned), it should reach peer3");
 
     let info2 = make_snapshot_host_info(&peer2_config.node_id(), &peer2_config.node_key, rng);
 
@@ -275,7 +285,7 @@ async fn too_many_shards_not_broadcast() {
         .send(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts { hosts: vec![info2.clone()] }))
         .await;
 
-    tracing::info!(target:"test", "make sure that only valid messages are broadcast");
+    tracing::info!("make sure that only valid messages are broadcast");
 
     // Wait until peer2 receives info2. Ignore ok_info_a and ok_info_b,
     // as the PeerManager could accept and broadcast them despite the neighboring invalid_info.
@@ -303,7 +313,7 @@ async fn propagate() {
         .set(std::cmp::min(limit.1, (1000 + 4 * FDS_PER_PEER * MAX_CONNECTIONS) as u64), limit.1)
         .unwrap();
 
-    tracing::info!(target:"test", "create four peer manager instances");
+    tracing::info!("create four peer manager instances");
     let mut pms = vec![];
     for _ in 0..4 {
         pms.push(
@@ -317,7 +327,7 @@ async fn propagate() {
         );
     }
 
-    tracing::info!(target:"test", "connect the four peer managers into a ring");
+    tracing::info!("connect the four peer managers into a ring");
     // [0] - [1]
     //  |     |
     // [2] - [3]
@@ -326,7 +336,7 @@ async fn propagate() {
     pms[1].connect_to(&pms[3].peer_info(), tcp::Tier::T2).await;
     pms[2].connect_to(&pms[3].peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", "send a snapshot host info message from peer manager #1");
+    tracing::info!("send a snapshot host info message from peer manager #1");
     let info1 = make_snapshot_host_info(&pms[1].peer_info().id, &pms[1].cfg.node_key, rng);
     let new_epoch_event =
         PeerManagerMessageRequest::NetworkRequests(NetworkRequests::SnapshotHostEvent(
@@ -342,7 +352,9 @@ async fn propagate() {
     let _: () = pms[1].actor.send_async(new_epoch_event).await.unwrap();
     let _: () = pms[1].actor.send_async(message).await.unwrap();
 
-    tracing::info!(target:"test", "make sure that the message sent from #1 reaches #2 on the other side of the ring");
+    tracing::info!(
+        "make sure that the message sent from #1 reaches #2 on the other side of the ring"
+    );
     let want: HashSet<Arc<SnapshotHostInfo>> = std::iter::once(info1).collect();
     pms[2].wait_for_snapshot_hosts(&want).await;
 }
@@ -359,7 +371,7 @@ async fn large_shard_id_in_cache() {
     let clock = clock.clock();
     let clock = &clock;
 
-    tracing::info!(target:"test", "create a peer manager");
+    tracing::info!("create a peer manager");
     let pm = peer_manager::testonly::start(
         clock.clone(),
         near_store::db::TestDB::new(),
@@ -368,11 +380,11 @@ async fn large_shard_id_in_cache() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect a peer");
+    tracing::info!("connect a peer");
     let peer1_config = chain.make_config(rng);
     let peer1 = pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
 
-    tracing::info!(target:"test", "send a snapshot host info message with very large shard ids");
+    tracing::info!("send a snapshot host info message with very large shard ids");
     let large_shard_id_1 = ShardId::new(u64::MAX - 1);
     let large_shard_id_2 = ShardId::new(u64::MAX);
     let big_shard_info = Arc::new(SnapshotHostInfo::new(
@@ -391,7 +403,7 @@ async fn large_shard_id_in_cache() {
         }))
         .await;
 
-    tracing::info!(target:"test", "make sure that the message is received and processed without any problems");
+    tracing::info!("make sure that the message is received and processed without any problems");
     let want: HashSet<Arc<SnapshotHostInfo>> = std::iter::once(big_shard_info).collect();
     pm.wait_for_snapshot_hosts(&want).await;
 }
@@ -409,7 +421,7 @@ async fn too_many_shards_truncate() {
     let clock = clock.clock();
     let clock = &clock;
 
-    tracing::info!(target:"test", "create a single peer manager");
+    tracing::info!("create a single peer manager");
     let pm = peer_manager::testonly::start(
         clock.clone(),
         near_store::db::TestDB::new(),
@@ -418,13 +430,15 @@ async fn too_many_shards_truncate() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect a peer, expect initial sync message to be empty");
+    tracing::info!("connect a peer, expect initial sync message to be empty");
     let mut peer1 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let empty_sync_msg = peer1.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "ask peer manager to send out an invalid sync snapshot hosts message, the info has more shard ids than allowed");
+    tracing::info!(
+        "ask peer manager to send out an invalid sync snapshot hosts message, the info has more shard ids than allowed"
+    );
     // Create a list of shards with twice as many shard ids as is allowed
     let too_many_shards: Vec<ShardId> =
         (0..(2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64)).map(Into::into).collect();
@@ -446,7 +460,9 @@ async fn too_many_shards_truncate() {
     let _: () = pm.actor.send_async(new_epoch_event).await.unwrap();
     let _: () = pm.actor.send_async(message).await.unwrap();
 
-    tracing::info!(target:"test", "receive the truncated snapshot host info message on peer1, make sure that the contents are correct");
+    tracing::info!(
+        "receive the truncated snapshot host info message on peer1, make sure that the contents are correct"
+    );
     let msg = peer1.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(msg.hosts.len(), 1);
     let info: &SnapshotHostInfo = &msg.hosts[0];
@@ -488,7 +504,7 @@ async fn no_shards_not_broadcast() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect peers, expect initial sync to be empty");
+    tracing::info!("connect peers, expect initial sync to be empty");
     let peer1_config = chain.make_config(rng);
     let mut peer1 =
         pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
@@ -501,7 +517,9 @@ async fn no_shards_not_broadcast() {
     let empty_sync_msg = peer2.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "send an empty sync snapshot host message from peer1, the host info has no shards");
+    tracing::info!(
+        "send an empty sync snapshot host message from peer1, the host info has no shards"
+    );
     let no_shards_info = Arc::new(SnapshotHostInfo::new(
         peer1_config.node_id(),
         CryptoHash::hash_borsh(rng.r#gen::<u64>()),
@@ -514,7 +532,7 @@ async fn no_shards_not_broadcast() {
         PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts { hosts: vec![no_shards_info.clone()] });
     peer1.send(no_shards_message).await;
 
-    tracing::info!(target:"test", "send a valid message from peer2");
+    tracing::info!("send a valid message from peer2");
 
     let info2 = make_snapshot_host_info(&peer2_config.node_id(), &peer2_config.node_key, rng);
 
@@ -522,7 +540,7 @@ async fn no_shards_not_broadcast() {
         .send(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts { hosts: vec![info2.clone()] }))
         .await;
 
-    tracing::info!(target:"test", "make sure that only valid messages are broadcast");
+    tracing::info!("make sure that only valid messages are broadcast");
 
     // Wait until peer2 receives info2. No other messages should be broadcast.
     wait_for_host_info(&mut peer2, &info2, &[]).await;

--- a/chain/network/src/peer_manager/tests/tier2.rs
+++ b/chain/network/src/peer_manager/tests/tier2.rs
@@ -53,19 +53,19 @@ async fn test_store_outbound_connection() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm2.connect_to(&pm0.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "check that pm1 does not store anything, as it has no outbound connections");
+    tracing::info!("check that pm1 does not store anything, as it has no outbound connections");
     check_recent_outbound_connections(&pm1, vec![]).await;
 
-    tracing::info!(target:"test", "check that pm2 stores the outbound connection to pm0");
+    tracing::info!("check that pm2 stores the outbound connection to pm0");
     pm2.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm2, vec![id0.clone()]).await;
 }
@@ -84,20 +84,20 @@ async fn test_storage_after_disconnect() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "have pm1 disconnect from pm0");
+    tracing::info!("have pm1 disconnect from pm0");
     let mut pm0_ev = pm0.events.from_now();
     pm1.disconnect(&id0).await;
     wait_for_connection_closed(&mut pm0_ev).await;
 
-    tracing::info!(target:"test", "check that pm0 retains the stored outbound connection to pm1 after disconnect");
+    tracing::info!("check that pm0 retains the stored outbound connection to pm1 after disconnect");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 }
@@ -116,19 +116,19 @@ async fn test_reconnect_after_restart_outbound_side() {
 
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "drop pm0 and start it again with the same db");
+    tracing::info!("drop pm0 and start it again with the same db");
     drop(pm0);
     let pm0 = start_pm(clock.clock(), pm0_db, chain.make_config(rng), chain.clone()).await;
 
-    tracing::info!(target:"test", "check that pm0 reconnects to pm1");
+    tracing::info!("check that pm0 reconnects to pm1");
     pm0.wait_for_direct_connection(id1.clone()).await;
 }
 
@@ -149,19 +149,19 @@ async fn test_skip_reconnect_after_restart_outbound_side() {
 
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "drop pm0 and start it again with the same db");
+    tracing::info!("drop pm0 and start it again with the same db");
     drop(pm0);
     let pm0 = start_pm(clock.clock(), pm0_db.clone(), pm0_cfg.clone(), chain.clone()).await;
 
-    tracing::info!(target:"test", "check that pm0 starts without attempting to reconnect to pm1");
+    tracing::info!("check that pm0 starts without attempting to reconnect to pm1");
     let mut pm0_ev = pm0.events.clone();
     pm0_ev
         .recv_until(|ev| match ev {
@@ -173,7 +173,7 @@ async fn test_skip_reconnect_after_restart_outbound_side() {
         })
         .await;
 
-    tracing::info!(target:"test", "check that pm0 has pm1 as a recent connection");
+    tracing::info!("check that pm0 has pm1 as a recent connection");
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 }
 
@@ -192,20 +192,20 @@ async fn test_reconnect_after_restart_inbound_side() {
 
     let id1 = pm1.cfg.node_id().clone();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "drop pm1");
+    tracing::info!("drop pm1");
     let mut pm0_ev = pm0.events.from_now();
     drop(pm1);
     wait_for_connection_closed(&mut pm0_ev).await;
 
-    tracing::info!(target:"test", "start pm1 again with the same config, check that pm0 reconnects");
+    tracing::info!("start pm1 again with the same config, check that pm0 reconnects");
     let _pm1 = start_pm(clock.clock(), TestDB::new(), pm1_cfg.clone(), chain.clone()).await;
     clock.advance(POLL_CONNECTION_STORE_INTERVAL + RECONNECT_ATTEMPT_INTERVAL);
     pm0.wait_for_direct_connection(id1.clone()).await;
@@ -227,20 +227,20 @@ async fn test_reconnect_after_disconnect_inbound_side() {
     let id0 = pm0.cfg.node_id().clone();
     let id1 = pm1.cfg.node_id().clone();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "have pm1 disconnect gracefully from pm0");
+    tracing::info!("have pm1 disconnect gracefully from pm0");
     let mut pm0_ev = pm0.events.from_now();
     pm1.disconnect(&id0).await;
     wait_for_connection_closed(&mut pm0_ev).await;
 
-    tracing::info!(target:"test", "check that pm0 reconnects");
+    tracing::info!("check that pm0 reconnects");
     clock.advance(POLL_CONNECTION_STORE_INTERVAL + RECONNECT_ATTEMPT_INTERVAL);
     pm0.wait_for_direct_connection(id1.clone()).await;
 }
@@ -265,7 +265,7 @@ async fn test_reconnect_after_restart_outbound_side_multi() {
     let id3 = pm3.cfg.node_id();
     let id4 = pm4.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to other pms");
+    tracing::info!("connect pm0 to other pms");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm0.wait_for_direct_connection(id1.clone()).await;
     pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
@@ -276,7 +276,7 @@ async fn test_reconnect_after_restart_outbound_side_multi() {
     pm0.wait_for_direct_connection(id4.clone()).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connections");
+    tracing::info!("check that pm0 stores the outbound connections");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(
         &pm0,
@@ -284,11 +284,11 @@ async fn test_reconnect_after_restart_outbound_side_multi() {
     )
     .await;
 
-    tracing::info!(target:"test", "drop pm0 and start it again with the same db");
+    tracing::info!("drop pm0 and start it again with the same db");
     drop(pm0);
     let pm0 = start_pm(clock.clock(), pm0_db, chain.make_config(rng), chain.clone()).await;
 
-    tracing::info!(target:"test", "wait for pm0 to reconnect to the other nodes");
+    tracing::info!("wait for pm0 to reconnect to the other nodes");
     pm0.wait_for_direct_connection(id1.clone()).await;
     pm0.wait_for_direct_connection(id2.clone()).await;
     pm0.wait_for_direct_connection(id3.clone()).await;

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -30,7 +30,7 @@ impl RateLimits {
             ) {
                 Ok(bucket) => buckets[*key] = Some(bucket),
                 Err(err) => {
-                    tracing::warn!(target: "network", ?key, ?err, "ignoring rate limit due to an error")
+                    tracing::warn!(?key, ?err, "ignoring rate limit due to an error")
                 }
             }
         }

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -201,12 +201,7 @@ impl Inner {
     /// 1. Prunes expired edges.
     /// 2. Prunes unreachable graph components.
     /// 3. Recomputes GraphSnapshot.
-    #[tracing::instrument(
-        target = "network::routing::graph",
-        level = "debug",
-        "GraphInner::update",
-        skip_all
-    )]
+    #[tracing::instrument(level = "debug", "GraphInner::update", skip_all)]
     pub fn update(
         &mut self,
         clock: &time::Clock,

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -69,22 +69,22 @@ async fn one_edge() {
     let e1 = data::make_edge(&node_key, &p1, 1);
     let e1v2 = e1.remove_edge(peer_id(&p1), &p1);
 
-    tracing::info!(target:"test", "add an active edge, update rt with pruning");
+    tracing::info!("add an active edge, update rt with pruning");
     // NOOP, since p1 is reachable.
     g.simple_update(vec![e1.clone()]).await;
     g.check(&[e1.clone()]);
 
-    tracing::info!(target:"test", "override with an inactive edge");
+    tracing::info!("override with an inactive edge");
     g.simple_update(vec![e1v2.clone()]).await;
     g.check(&[e1v2.clone()]);
 
-    tracing::info!(target:"test", "after 2s, simple_update rt with pruning unreachable for 3s");
+    tracing::info!("after 2s, simple_update rt with pruning unreachable for 3s");
     // NOOP, since p1 is unreachable for 2s.
     clock.advance(2 * SEC);
     g.simple_update(vec![]).await;
     g.check(&[e1v2.clone()]);
 
-    tracing::info!(target:"test", "update rt with pruning unreachable for 1s");
+    tracing::info!("update rt with pruning unreachable for 1s");
     // p1 should be moved to DB.
     clock.advance(2 * SEC);
     g.simple_update(vec![]).await;
@@ -123,30 +123,30 @@ async fn expired_edges() {
     let still_old_e2 = data::make_edge(&node_key, &p2, to_active_nonce(now - 90 * SEC));
     let fresh_e2 = data::make_edge(&node_key, &p2, to_active_nonce(now));
 
-    tracing::info!(target:"test", "add an active edge");
+    tracing::info!("add an active edge");
     g.simple_update(vec![e1.clone(), old_e2.clone()]).await;
     g.check(&[e1.clone(), old_e2.clone()]);
-    tracing::info!(target:"test", "update rt with pruning");
+    tracing::info!("update rt with pruning");
     // e1 should stay - as it is fresh, but old_e2 should be removed.
     clock.advance(40 * SEC);
     g.simple_update(vec![]).await;
     g.check(&[e1.clone()]);
 
-    tracing::info!(target:"test", "adding 'still old' edge to e2 should fail");
+    tracing::info!("adding 'still old' edge to e2 should fail");
     // (as it is older than the last prune_edges_older_than)
     g.simple_update(vec![still_old_e2.clone()]).await;
     g.check(&[e1.clone()]);
 
-    tracing::info!(target:"test", "but adding the fresh edge should work");
+    tracing::info!("but adding the fresh edge should work");
     g.simple_update(vec![fresh_e2.clone()]).await;
     g.check(&[e1.clone(), fresh_e2.clone()]);
 
-    tracing::info!(target:"test", "advance so that the edge is 'too old' and should be removed");
+    tracing::info!("advance so that the edge is 'too old' and should be removed");
     clock.advance(100 * SEC);
     g.simple_update(vec![]).await;
     g.check(&[]);
 
-    tracing::info!(target:"test", "let's create a removal edge");
+    tracing::info!("let's create a removal edge");
     let e1v2 = data::make_edge(&node_key, &p1, to_active_nonce(clock.now_utc()))
         .remove_edge(peer_id(&p1), &p1);
     g.simple_update(vec![e1v2.clone()]).await;

--- a/chain/network/src/routing/graph_v2/mod.rs
+++ b/chain/network/src/routing/graph_v2/mod.rs
@@ -580,11 +580,11 @@ impl Inner {
         distances: HashMap<PeerId, u32>,
     ) -> Option<network_protocol::DistanceVector> {
         if self.my_distances == distances {
-            tracing::debug!(target: "routing", "no change to routing distances after processing network updates");
+            tracing::debug!("no change to routing distances after processing network updates");
             return None;
         }
 
-        tracing::debug!(target: "routing", "routing distances have changed; reconstructing distance vector");
+        tracing::debug!("routing distances have changed; reconstructing distance vector");
 
         let distance_vector = self.construct_distance_vector_message(&distances)?;
 
@@ -623,7 +623,7 @@ impl Inner {
 
     /// Logs the state of the routing table
     pub(crate) fn log_state(&self) {
-        tracing::debug!(target: "routing", my_distances = ?self.my_distances, peer_labels = ?self.edge_cache.p2id, peer_distances = ?self.peer_distances);
+        tracing::debug!(my_distances = ?self.my_distances, peer_labels = ?self.edge_cache.p2id, peer_distances = ?self.peer_distances);
     }
 }
 
@@ -743,11 +743,7 @@ impl Handler<NetworkChanges, (Option<network_protocol::DistanceVector>, Vec<bool
         &mut self,
         msg: NetworkChanges,
     ) -> (Option<network_protocol::DistanceVector>, Vec<bool>) {
-        tracing::debug!(
-            target: "routing",
-            length = msg.0.len(),
-            "processing a batch of network topology changes",
-        );
+        tracing::debug!(length = msg.0.len(), "processing a batch of network topology changes",);
 
         let mut inner = self.inner.lock();
         let oks: Vec<bool> =
@@ -756,9 +752,9 @@ impl Handler<NetworkChanges, (Option<network_protocol::DistanceVector>, Vec<bool
         // Logs the given batch of updates and the results from processing them.
         for (update, ok) in msg.0.iter().zip(&oks) {
             if *ok {
-                tracing::debug!(target: "routing", ?update, "processed event");
+                tracing::debug!(?update, "processed event");
             } else {
-                tracing::debug!(target: "routing", ?update, "rejected invalid distance vector");
+                tracing::debug!(?update, "rejected invalid distance vector");
             }
         }
 

--- a/chain/network/src/store/mod.rs
+++ b/chain/network/src/store/mod.rs
@@ -28,7 +28,6 @@ pub(crate) struct Store(schema::Store);
 impl Store {
     /// Inserts (account_id,aa) to the AccountAnnouncements column.
     #[tracing::instrument(
-        target = "network::store",
         level = "trace",
         "Store::set_account_announcement",
         skip_all,
@@ -51,12 +50,7 @@ impl Store {
 
 // ConnectionStore storage.
 impl Store {
-    #[tracing::instrument(
-        target = "network::store",
-        level = "trace",
-        "Store::set_recent_outbound_connections",
-        skip_all
-    )]
+    #[tracing::instrument(level = "trace", "Store::set_recent_outbound_connections", skip_all)]
     pub fn set_recent_outbound_connections(
         &self,
         recent_outbound_connections: &Vec<ConnectionInfo>,

--- a/chain/network/src/store/schema/mod.rs
+++ b/chain/network/src/store/schema/mod.rs
@@ -207,12 +207,7 @@ impl Store {
         Default::default()
     }
 
-    #[tracing::instrument(
-        target = "network::store::schema",
-        level = "trace",
-        "Store::commit",
-        skip_all
-    )]
+    #[tracing::instrument(level = "trace", "Store::commit", skip_all)]
     pub fn commit(&self, update: StoreUpdate) {
         self.0.write(update.0);
     }

--- a/chain/network/src/tcp.rs
+++ b/chain/network/src/tcp.rs
@@ -87,7 +87,7 @@ impl Socket {
 impl Stream {
     fn new(stream: tokio::net::TcpStream, type_: StreamType) -> std::io::Result<Self> {
         if let Err(err) = stream.set_nodelay(true) {
-            tracing::warn!(target: "network", ?err, "failed to set TCP_NODELAY");
+            tracing::warn!(?err, "failed to set TCP_NODELAY");
         }
         Ok(Self { peer_addr: stream.peer_addr()?, local_addr: stream.local_addr()?, stream, type_ })
     }
@@ -111,12 +111,12 @@ impl Stream {
             Tier::T2 => {
                 if let Some(so_recv_buffer) = socket_options.recv_buffer_size {
                     socket.set_recv_buffer_size(so_recv_buffer)?;
-                    tracing::debug!(target: "network", wanted_recv_buffer = %so_recv_buffer, actual_recv_buffer = ?socket.recv_buffer_size());
+                    tracing::debug!(wanted_recv_buffer = %so_recv_buffer, actual_recv_buffer = ?socket.recv_buffer_size());
                 }
 
                 if let Some(so_send_buffer) = socket_options.send_buffer_size {
                     socket.set_send_buffer_size(so_send_buffer)?;
-                    tracing::debug!(target: "network", wanted_send_buffer = %so_send_buffer, actual_send_buffer = ?socket.send_buffer_size());
+                    tracing::debug!(wanted_send_buffer = %so_send_buffer, actual_send_buffer = ?socket.send_buffer_size());
                 }
             }
             _ => {}
@@ -238,7 +238,7 @@ impl ListenerAddr {
                 Ok(guard) => guard,
                 Err(named_lock::Error::WouldBlock) => {
                     // this port is already reserved, try another one
-                    tracing::trace!(target: "network", %port, "port is already reserved, trying another one");
+                    tracing::trace!(%port, "port is already reserved, trying another one");
                     continue;
                 }
                 Err(err) => {
@@ -249,7 +249,7 @@ impl ListenerAddr {
             let tcp_socket = std::net::TcpListener::bind(addr);
             if tcp_socket.is_err() {
                 // this port is already in use, try another one
-                tracing::trace!(target: "network", %port, "port is already in use, trying another one");
+                tracing::trace!(%port, "port is already in use, trying another one");
                 continue;
             }
             RESERVED_PORT_LOCKS.lock().push(guard);

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -125,7 +125,7 @@ impl StopSignal {
 
 impl Handler<StopSignal> for PeerManagerActor {
     fn handle(&mut self, msg: StopSignal) {
-        tracing::debug!(target: "network", "received stop signal");
+        tracing::debug!("received stop signal");
 
         if msg.should_panic {
             panic!("Node crashed");

--- a/chain/network/src/testonly/mod.rs
+++ b/chain/network/src/testonly/mod.rs
@@ -53,7 +53,7 @@ pub(crate) fn abort_on_panic() {
     if nextest != "1" || nextest_execution_mode != "process-per-test" {
         return;
     }
-    tracing::info!(target:"test", "[panic=abort] enabled");
+    tracing::info!("[panic=abort] enabled");
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         orig_hook(panic_info);

--- a/chain/telemetry/src/lib.rs
+++ b/chain/telemetry/src/lib.rs
@@ -86,7 +86,7 @@ impl TelemetryActor {
 
 impl Handler<TelemetryEvent> for TelemetryActor {
     fn handle(&mut self, msg: TelemetryEvent) {
-        tracing::debug!(target: "telemetry", ?msg);
+        tracing::debug!(?msg);
         let now = Instant::now();
         if now - self.last_telemetry_update < self.config.reporting_interval {
             // Throttle requests to the telemetry endpoints, to at most one
@@ -106,7 +106,6 @@ impl Handler<TelemetryEvent> for TelemetryActor {
                     .map(move |response| {
                         let result = if let Err(error) = response {
                             tracing::warn!(
-                                target: "telemetry",
                                 err = ?error,
                                 endpoint = ?endpoint,
                                 "failed to send telemetry data");

--- a/core/async/src/multithread/sender.rs
+++ b/core/async/src/multithread/sender.rs
@@ -15,7 +15,7 @@ where
     fn send(&self, message: M) {
         let seq = next_message_sequence_num();
         let message_type = pretty_type_name::<M>();
-        tracing::trace!(target: "multithread_runtime", seq, message_type, "sending sync message");
+        tracing::trace!(seq, message_type, "sending sync message");
 
         let function = |actor: &mut A| {
             actor.handle(message);
@@ -28,7 +28,7 @@ where
             function: Box::new(function),
         };
         if let Err(_) = self.send_message(message) {
-            tracing::info!(target: "multithread_runtime", seq, "ignoring sync message, receiving actor is being shut down");
+            tracing::info!(seq, "ignoring sync message, receiving actor is being shut down");
         }
     }
 }
@@ -42,7 +42,7 @@ where
     fn send_async(&self, message: M) -> BoxFuture<'static, Result<R, AsyncSendError>> {
         let seq = next_message_sequence_num();
         let message_type = pretty_type_name::<M>();
-        tracing::trace!(target: "multithread_runtime", seq, message_type, ?message, "sending async message");
+        tracing::trace!(seq, message_type, ?message, "sending async message");
 
         let (sender, receiver) = tokio::sync::oneshot::channel();
         let future = async move { receiver.await.map_err(|_| AsyncSendError::Dropped) };

--- a/core/async/src/test_loop/mod.rs
+++ b/core/async/src/test_loop/mod.rs
@@ -203,7 +203,7 @@ impl TestLoopV2 {
         });
         let shutting_down = Arc::new(AtomicBool::new(false));
         // Needed for the log visualizer to know when the test loop starts.
-        tracing::info!(target: "test_loop", "TEST_LOOP_INIT");
+        tracing::info!("TEST_LOOP_INIT");
         Self {
             data: TestLoopData::new(raw_pending_events_sender.clone(), shutting_down.clone()),
             events: BinaryHeap::new(),
@@ -363,7 +363,7 @@ impl TestLoopV2 {
         })
         .unwrap();
         // TODO(logging): testloop visualizer may have a dependency on seeing the trace in this specific format
-        tracing::info!(target: "test_loop", "TEST_LOOP_EVENT_START {}", start_json);
+        tracing::info!("TEST_LOOP_EVENT_START {}", start_json);
         assert_eq!(self.current_time, event.due);
 
         if !event_ignored {
@@ -382,7 +382,7 @@ impl TestLoopV2 {
             serde_json::to_string(&EventEndLogOutput { total_events: self.next_event_index })
                 .unwrap();
         // TODO(logging): testloop visualizer may have a dependency on seeing the trace in this specific format
-        tracing::info!(target: "test_loop", "TEST_LOOP_EVENT_END {}", end_json);
+        tracing::info!("TEST_LOOP_EVENT_END {}", end_json);
     }
 
     /// Runs the test loop for the given duration. This function may be called
@@ -456,7 +456,7 @@ impl Drop for TestLoopV2 {
             }
         }
         // Needed for the log visualizer to know when the test loop ends.
-        tracing::info!(target: "test_loop", "TEST_LOOP_SHUTDOWN");
+        tracing::info!("TEST_LOOP_SHUTDOWN");
     }
 }
 

--- a/core/async/src/tokio/futures.rs
+++ b/core/async/src/tokio/futures.rs
@@ -31,7 +31,7 @@ impl CancellableFutureSpawner {
 
 impl FutureSpawner for CancellableFutureSpawner {
     fn spawn_boxed(&self, description: &'static str, f: crate::futures::BoxFuture<'static, ()>) {
-        tracing::trace!(target: "cancellable_tokio_runtime", description, "spawning future");
+        tracing::trace!(description, "spawning future");
         self.runtime_handle.spawn(f);
     }
 }

--- a/core/async/src/tokio/runtime_handle.rs
+++ b/core/async/src/tokio/runtime_handle.rs
@@ -173,21 +173,21 @@ impl<A: Actor + Send + 'static> TokioRuntimeBuilder<A> {
             loop {
                 tokio::select! {
                     _ = self.system_cancellation_signal.cancelled() => {
-                        tracing::debug!(target: "tokio_runtime", actor_name, "shutting down tokio runtime due to actor system shutdown");
+                        tracing::debug!(actor_name, "shutting down tokio runtime due to actor system shutdown");
                         break;
                     }
                     _ = runtime_handle.cancel.cancelled() => {
-                        tracing::debug!(target: "tokio_runtime", actor_name, "shutting down tokio runtime due to targeted cancellation");
+                        tracing::debug!(actor_name, "shutting down tokio runtime due to targeted cancellation");
                         break;
                     }
                     _ = window_update_timer.tick() => {
-                        tracing::trace!(target: "tokio_runtime", "advancing instrumentation window");
+                        tracing::trace!("advancing instrumentation window");
                         shared_instrumentation.with_thread_local_writer(|writer| writer.advance_window_if_needed());
                     }
                     Some(message) = receiver.recv() => {
                         let seq = message.seq;
                         shared_instrumentation.queue().dequeue(message.name);
-                        tracing::trace!(target: "tokio_runtime", seq, actor_name, "executing message");
+                        tracing::trace!(seq, actor_name, "executing message");
                         let dequeue_time_ns = shared_instrumentation.current_time().saturating_sub(message.enqueued_time_ns);
                         shared_instrumentation.with_thread_local_writer(|writer| writer.start_event(message.name, dequeue_time_ns));
                         (message.function)(&mut actor.actor, &mut runtime_handle);

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -678,7 +678,7 @@ impl Genesis {
         match genesis_validation {
             GenesisValidationMode::Full => validate_genesis(self),
             GenesisValidationMode::UnsafeFast => {
-                tracing::warn!(target: "genesis", "skipped genesis validation");
+                tracing::warn!("skipped genesis validation");
                 Ok(())
             }
         }

--- a/core/chain-configs/src/genesis_validate.rs
+++ b/core/chain-configs/src/genesis_validate.rs
@@ -16,7 +16,7 @@ pub fn validate_genesis(genesis: &Genesis) -> Result<(), ValidationError> {
     }
     let mut validation_errors = ValidationErrors::new();
     let mut genesis_validator = GenesisValidator::new(&genesis.config, &mut validation_errors);
-    tracing::info!(target: "config", "validating genesis config and records, this could take a few minutes");
+    tracing::info!("validating genesis config and records, this could take a few minutes");
     genesis.for_each_record(|record: &StateRecord| {
         genesis_validator.process_record(record);
     });

--- a/core/chain-configs/src/updatable_config.rs
+++ b/core/chain-configs/src/updatable_config.rs
@@ -75,13 +75,13 @@ impl<T: Clone + PartialEq + Debug> MutableConfigValue<T> {
     pub fn update(&self, val: T) -> bool {
         let mut lock = self.value.lock();
         if *lock != val {
-            tracing::info!(target: "config", field_name = self.field_name, old_value = ?*lock, new_value = ?val, "updated config field");
+            tracing::info!(field_name = self.field_name, old_value = ?*lock, new_value = ?val, "updated config field");
             self.set_metric_value(lock.clone(), 0);
             *lock = val.clone();
             self.set_metric_value(val, 1);
             true
         } else {
-            tracing::info!(target: "config", field_name = self.field_name, value = ?val, "mutable config field remains the same");
+            tracing::info!(field_name = self.field_name, value = ?val, "mutable config field remains the same");
             false
         }
     }

--- a/core/external-storage/src/lib.rs
+++ b/core/external-storage/src/lib.rs
@@ -73,14 +73,17 @@ impl ExternalConnection {
             ExternalStorageLocation::GCS { bucket, .. } => {
                 if let Some(credentials_file) = credentials_file {
                     if let Ok(var) = std::env::var("SERVICE_ACCOUNT") {
-                        tracing::warn!(target: "external", %var, ?credentials_file, "environment variable `SERVICE_ACCOUNT` is set, but `credentials_file` in config.json overrides it");
+                        tracing::warn!(%var, ?credentials_file, "environment variable `SERVICE_ACCOUNT` is set, but `credentials_file` in config.json overrides it");
                         println!(
                             "Environment variable 'SERVICE_ACCOUNT' is set to {var}, but 'credentials_file' in config.json overrides it to '{credentials_file:?}'"
                         );
                     }
                     // SAFE: no threads *yet*.
                     unsafe { std::env::set_var("SERVICE_ACCOUNT", &credentials_file) };
-                    tracing::info!(target: "external", ?credentials_file, "set the environment variable `SERVICE_ACCOUNT`");
+                    tracing::info!(
+                        ?credentials_file,
+                        "set the environment variable `SERVICE_ACCOUNT`"
+                    );
                 }
                 ExternalConnection::GCS {
                     gcs_client: Arc::new(
@@ -100,7 +103,7 @@ impl ExternalConnection {
     pub async fn get(&self, path: &str) -> Result<Vec<u8>, anyhow::Error> {
         match self {
             ExternalConnection::S3 { bucket } => {
-                tracing::debug!(target: "external", path, "reading from S3");
+                tracing::debug!(path, "reading from S3");
                 let response = bucket.get_object(path).await?;
                 if response.status_code() == 200 {
                     Ok(response.bytes().to_vec())
@@ -110,7 +113,7 @@ impl ExternalConnection {
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(path);
-                tracing::debug!(target: "external", ?path, "reading a file");
+                tracing::debug!(?path, "reading a file");
                 let data = std::fs::read(&path)?;
                 Ok(data)
             }
@@ -122,7 +125,7 @@ impl ExternalConnection {
                     percent_encoding::percent_encode(bucket.as_bytes(), GCS_ENCODE_SET),
                     percent_encoding::percent_encode(path.as_bytes(), GCS_ENCODE_SET),
                 );
-                tracing::debug!(target: "external", url, "reading from GCS");
+                tracing::debug!(url, "reading from GCS");
                 let response = reqwest_client.get(&url).send().await?.error_for_status();
                 match response {
                     Err(e) => Err(e.into()),
@@ -139,13 +142,13 @@ impl ExternalConnection {
     pub async fn put(&self, path: &str, value: &[u8]) -> Result<(), anyhow::Error> {
         match self {
             ExternalConnection::S3 { bucket } => {
-                tracing::debug!(target: "external", path, "writing to S3");
+                tracing::debug!(path, "writing to S3");
                 bucket.put_object(path, value).await?;
                 Ok(())
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(path);
-                tracing::debug!(target: "external", ?path, "writing to a file");
+                tracing::debug!(?path, "writing to a file");
                 if let Some(parent_dir) = path.parent() {
                     std::fs::create_dir_all(parent_dir)?;
                 }
@@ -160,7 +163,7 @@ impl ExternalConnection {
             ExternalConnection::GCS { gcs_client, .. } => {
                 let path = object_store::path::Path::parse(path)
                     .with_context(|| format!("{path} isn't a valid path for GCP"))?;
-                tracing::debug!(target: "external", ?path, "writing to GCS");
+                tracing::debug!(?path, "writing to GCS");
                 gcs_client.put(&path, PutPayload::from_bytes(value.to_vec().into())).await?;
                 Ok(())
             }
@@ -176,7 +179,7 @@ impl ExternalConnection {
             ExternalConnection::S3 { bucket } => {
                 let prefix = format!("{}/", directory_path);
                 let list_results = bucket.list(prefix.clone(), Some("/".to_string())).await?;
-                tracing::debug!(target: "external", directory_path, "list directory in S3");
+                tracing::debug!(directory_path, "list directory in S3");
                 let mut file_names = vec![];
                 for res in list_results {
                     for obj in res.contents {
@@ -187,7 +190,7 @@ impl ExternalConnection {
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(directory_path);
-                tracing::debug!(target: "external", ?path, "list files in local directory");
+                tracing::debug!(?path, "list files in local directory");
                 std::fs::create_dir_all(&path)?;
                 let mut file_names = vec![];
                 let files = std::fs::read_dir(&path)?;
@@ -199,7 +202,7 @@ impl ExternalConnection {
             }
             ExternalConnection::GCS { gcs_client, .. } => {
                 let prefix = format!("{}/", directory_path);
-                tracing::debug!(target: "external", directory_path, "list directory in GCS");
+                tracing::debug!(directory_path, "list directory in GCS");
                 Ok(gcs_client
                     .list(Some(
                         &object_store::path::Path::parse(&prefix)

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -27,8 +27,8 @@ pub mod testonly;
 #[macro_export]
 #[cfg(feature = "io_trace")]
 macro_rules! io_trace {
-    (count: $name:expr) => { tracing::trace!( target: "io_tracer_count", counter = $name) };
-    ($($fields:tt)*) => { tracing::trace!( target: "io_tracer", $($fields)*) };
+    (count: $name:expr) => { tracing::trace!(target: "io_tracer_count", counter = $name) };
+    ($($fields:tt)*) => { tracing::trace!(target: "io_tracer", $($fields)*) };
 }
 
 #[macro_export]

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -184,7 +184,7 @@ impl Block {
         let (time, vrf_value, vrf_proof, random_value) = optimistic_block
             .as_ref()
             .map(|ob| {
-                tracing::debug!(target: "client", "taking metadata from optimistic block");
+                tracing::debug!("taking metadata from optimistic block");
                 (
                     ob.inner.block_timestamp,
                     ob.inner.vrf_value,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1387,7 +1387,6 @@ impl EncodedShardChunk {
 
     pub fn decode_chunk(&self) -> Result<ShardChunk, std::io::Error> {
         let _span = debug_span!(
-            target: "sharding",
             "decode_chunk",
             height_included = self.cloned_header().height_included(),
             shard_id = %self.cloned_header().shard_id(),

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -967,7 +967,7 @@ impl TestBlockBuilder {
     }
 
     pub fn build(self) -> Arc<Block> {
-        tracing::debug!(target: "test", height=self.height, ?self.epoch_id, "produce block");
+        tracing::debug!(height=self.height, ?self.epoch_id, "produce block");
         let last_certified_block_execution_results = BlockExecutionResults(
             self.chunks
                 .iter()

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -83,7 +83,6 @@ impl ProtocolUpgradeVotingSchedule {
                 client_protocol_version,
             )?;
             tracing::warn!(
-                target: "protocol_upgrade",
                 ?schedule,
                 "setting protocol upgrade override, this is fine in tests but should be avoided otherwise"
             );
@@ -119,7 +118,7 @@ impl ProtocolUpgradeVotingSchedule {
             }
         }
 
-        tracing::debug!(target: "protocol_upgrade", ?schedule, "created protocol upgrade schedule");
+        tracing::debug!(?schedule, "created protocol upgrade schedule");
 
         Ok(Self { client_protocol_version, schedule })
     }

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -373,7 +373,7 @@ macro_rules! unwrap_or_return {
         match $obj {
             Ok(value) => value,
             Err(err) => {
-                tracing::error!(target: "near", ?err, "unwrap error");
+                tracing::error!(?err, "unwrap error");
                 return $ret;
             }
         }
@@ -382,7 +382,7 @@ macro_rules! unwrap_or_return {
         match $obj {
             Ok(value) => value,
             Err(err) => {
-                tracing::error!(target: "near", ?err, "unwrap error");
+                tracing::error!(?err, "unwrap error");
                 return;
             }
         }
@@ -445,7 +445,7 @@ where
 /// it shows its json representation. It is used to display complex
 /// objects using tracing.
 ///
-/// tracing::debug!(target: "diagnostic", value=%ser(&object));
+/// tracing::debug!(value=%ser(&object));
 pub fn ser<T>(object: &T) -> Serializable<'_, T>
 where
     T: serde::Serialize,

--- a/core/store/src/adapter/flat_store.rs
+++ b/core/store/src/adapter/flat_store.rs
@@ -118,7 +118,7 @@ impl FlatStoreAdapter {
                         if flat_head.hash == prev_hash {
                             Some(BlockWithChangesInfo { hash: prev_hash, height: flat_head.height })
                         } else {
-                            tracing::error!(target: "store", ?block_hash, ?prev_hash, "missing delta metadata");
+                            tracing::error!(?block_hash, ?prev_hash, "missing delta metadata");
                             None
                         }
                     }

--- a/core/store/src/db/rocksdb/instance_tracker.rs
+++ b/core/store/src/db/rocksdb/instance_tracker.rs
@@ -58,7 +58,7 @@ impl State {
             inner.count += 1;
             inner.count
         };
-        tracing::info!(target: "db", num_instances, "opened a new rocksdb instance");
+        tracing::info!(num_instances, "opened a new rocksdb instance");
         Ok(())
     }
 
@@ -72,18 +72,20 @@ impl State {
             }
             inner.count
         };
-        tracing::info!(target: "db", num_instances, "closed a rocksdb instance");
+        tracing::info!(num_instances, "closed a rocksdb instance");
     }
 
     /// Blocks until all RocksDB instances (usually 0 or 1) shut down.
     fn block_until_all_instances_are_closed(&self) {
         let mut inner = self.inner.lock();
         while inner.count != 0 {
-            tracing::info!(target: "db", num_instances=inner.count,
-                  "waiting for remaining rocksdb instances to close");
+            tracing::info!(
+                num_instances = inner.count,
+                "waiting for remaining rocksdb instances to close"
+            );
             self.zero_cvar.wait(&mut inner);
         }
-        tracing::info!(target: "db", "all rocksdb instances closed");
+        tracing::info!("all rocksdb instances closed");
     }
 }
 

--- a/core/store/src/db/rocksdb/snapshot.rs
+++ b/core/store/src/db/rocksdb/snapshot.rs
@@ -91,7 +91,7 @@ impl Snapshot {
             None => return Ok(Self::none()),
         };
 
-        tracing::info!(target: "db", snapshot_path = %snapshot_path.display(), "creating database snapshot");
+        tracing::info!(snapshot_path = %snapshot_path.display(), "creating database snapshot");
         if snapshot_path.exists() {
             return Err(SnapshotError::AlreadyExists(snapshot_path));
         }
@@ -108,7 +108,7 @@ impl Snapshot {
     /// Does nothing if the object has been created via [`Self::none`].
     pub fn remove(mut self) -> Result<(), SnapshotRemoveError> {
         if let Some(path) = self.0.take() {
-            tracing::info!(target: "db", snapshot_path = %path.display(), "deleting the database snapshot");
+            tracing::info!(snapshot_path = %path.display(), "deleting the database snapshot");
             std::fs::remove_dir_all(&path).map_err(|error| SnapshotRemoveError { path, error })
         } else {
             Ok(())
@@ -124,8 +124,8 @@ impl std::ops::Drop for Snapshot {
     /// system and how to recover data from it.
     fn drop(&mut self) {
         if let Some(path) = &self.0 {
-            tracing::info!(target: "db", snapshot_path = %path.display(), "in case of issues, the database can be recovered from the database snapshot");
-            tracing::info!(target: "db", snapshot_path = %path.display(), "to recover from the snapshot, delete files in the database directory and replace them with contents of the snapshot directory");
+            tracing::info!(snapshot_path = %path.display(), "in case of issues, the database can be recovered from the database snapshot");
+            tracing::info!(snapshot_path = %path.display(), "to recover from the snapshot, delete files in the database directory and replace them with contents of the snapshot directory");
         }
     }
 }

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -127,7 +127,6 @@ impl FlatStorageInner {
         );
         if blocks.len() >= Self::HOPS_LIMIT {
             tracing::warn!(
-                target: "chain",
                 shard_id = %self.shard_uid.shard_id(),
                 flat_head_height = flat_head.height,
                 cached_deltas = self.deltas.len(),
@@ -157,7 +156,6 @@ impl FlatStorageInner {
         let cached_changes_size_bytes = bytesize::ByteSize(cached_changes_size);
         if cached_changes_size_bytes >= Self::CACHED_CHANGES_SIZE_LIMIT {
             tracing::warn!(
-                target: "chain",
                 shard_id = %self.shard_uid.shard_id(),
                 flat_head_height = self.flat_head.height,
                 cached_deltas,
@@ -373,14 +371,14 @@ impl FlatStorage {
 
         let new_head = guard.get_new_flat_head(*block_hash, strict)?;
         if new_head == guard.flat_head.hash {
-            tracing::debug!(target: "store", shard_id = %guard.shard_uid.shard_id(), height = %guard.flat_head.height, "update_flat_head, flat head already at block");
+            tracing::debug!(shard_id = %guard.shard_uid.shard_id(), height = %guard.flat_head.height, "update_flat_head, flat head already at block");
             return Ok(());
         }
 
         let shard_uid = guard.shard_uid;
         let shard_id = shard_uid.shard_id();
 
-        tracing::debug!(target: "store", flat_head = ?guard.flat_head.hash, ?new_head, %shard_id, "moving flat head");
+        tracing::debug!(flat_head = ?guard.flat_head.hash, ?new_head, %shard_id, "moving flat head");
         let blocks = guard.get_blocks_to_head(&new_head)?;
 
         for block_hash in blocks.into_iter().rev() {
@@ -426,7 +424,7 @@ impl FlatStorage {
             }
 
             store_update.commit().unwrap();
-            tracing::debug!(target: "store", %shard_id, %block_hash, %block_height, "moved flat storage head");
+            tracing::debug!(%shard_id, %block_hash, %block_height, "moved flat storage head");
         }
         guard.update_delta_metrics();
 
@@ -455,7 +453,7 @@ impl FlatStorage {
         let block = &delta.metadata.block;
         let block_hash = block.hash;
         let block_height = block.height;
-        tracing::debug!(target: "store", %shard_uid, %block_hash, %block_height, "adding block to flat storage");
+        tracing::debug!(%shard_uid, %block_hash, %block_height, "adding block to flat storage");
         if block.prev_hash != guard.flat_head.hash && !guard.deltas.contains_key(&block.prev_hash) {
             return Err(guard.create_block_not_supported_error(&block_hash));
         }

--- a/core/store/src/genesis/initialization.rs
+++ b/core/store/src/genesis/initialization.rs
@@ -55,7 +55,9 @@ pub fn initialize_sharded_genesis_state(
         let has_dump = home_dir.is_some_and(|dir| dir.join(STATE_DUMP_FILE).exists());
         let state_roots = if has_dump {
             if let GenesisContents::Records { .. } = &genesis.contents {
-                tracing::warn!(target: "store", "found both records in genesis config and the state dump file, will ignore the records");
+                tracing::warn!(
+                    "found both records in genesis config and the state dump file, will ignore the records"
+                );
             }
             genesis_state_from_dump(store.clone(), home_dir.unwrap())
         } else {
@@ -89,7 +91,9 @@ pub fn initialize_genesis_state(store: Store, genesis: &Genesis, home_dir: Optio
 }
 
 fn genesis_state_from_dump(store: Store, home_dir: &Path) -> Vec<StateRoot> {
-    tracing::error!(target: "near", "loading genesis from a state dump file, do not use this outside of genesis-tools");
+    tracing::error!(
+        "loading genesis from a state dump file, do not use this outside of genesis-tools"
+    );
     let mut state_file = home_dir.to_path_buf();
     state_file.push(STATE_DUMP_FILE);
     store.load_state_from_file(state_file.as_path()).expect("Failed to read state dump");
@@ -109,14 +113,12 @@ fn genesis_state_from_genesis(
     match &genesis.contents {
         GenesisContents::Records { records } => {
             tracing::info!(
-                target: "runtime",
                 num_records = records.0.len(),
                 "genesis state has records, computing state roots"
             )
         }
         GenesisContents::RecordsFile { records_file } => {
             tracing::info!(
-                target: "runtime",
                 path=%records_file.display(),
                 message="computing state roots from records",
             )
@@ -134,7 +136,7 @@ fn genesis_state_from_genesis(
     let mut shard_account_ids: BTreeMap<ShardId, HashSet<AccountId>> =
         shard_ids.iter().map(|&shard_id| (shard_id, HashSet::new())).collect();
     let mut has_protocol_account = false;
-    tracing::info!(target: "store","distributing records to shards");
+    tracing::info!("distributing records to shards");
 
     genesis.for_each_record(|record: &StateRecord| {
         let account_id = state_record_to_account_id(record).clone();

--- a/core/store/src/genesis/state_applier.rs
+++ b/core/store/src/genesis/state_applier.rs
@@ -143,7 +143,6 @@ impl<'a> AutoFlushingTrieUpdate<'a> {
     fn flush(&mut self) -> StateRoot {
         let Self { changes, state_root, state_update, .. } = self;
         tracing::info!(
-            target: "runtime",
             shard_uid=?self.shard_uid,
             %state_root,
             %changes,
@@ -185,11 +184,7 @@ impl GenesisStateApplier {
     ) {
         let mut postponed_receipts: Vec<Receipt> = vec![];
         let mut storage_computer = StorageComputer::new(config);
-        tracing::info!(
-            target: "runtime",
-            ?shard_uid,
-            "processing records…"
-        );
+        tracing::info!(?shard_uid, "processing records…");
         genesis.for_each_record(|record: &StateRecord| {
             if !account_ids.contains(state_record_to_account_id(record)) {
                 return;
@@ -224,7 +219,6 @@ impl GenesisStateApplier {
                             );
                         } else {
                             tracing::error!(
-                                target: "runtime",
                                 %account_id,
                                 code_hash = %code.hash(),
                                 message = "code for non-existent account",
@@ -273,11 +267,7 @@ impl GenesisStateApplier {
             }
         });
 
-        tracing::info!(
-            target: "runtime",
-            ?shard_uid,
-            "processing account storage…"
-        );
+        tracing::info!(?shard_uid, "processing account storage…");
         for (account_id, storage_usage) in storage_computer.finalize() {
             storage.modify(|state_update| {
                 let mut account = get_account(state_update, &account_id)
@@ -289,11 +279,7 @@ impl GenesisStateApplier {
         }
 
         // Processing postponed receipts after we stored all received data
-        tracing::info!(
-            target: "runtime",
-            ?shard_uid,
-            "processing postponed receipts…"
-        );
+        tracing::info!(?shard_uid, "processing postponed receipts…");
         for receipt in postponed_receipts {
             let account_id = receipt.receiver_id();
 

--- a/core/store/src/metrics/mod.rs
+++ b/core/store/src/metrics/mod.rs
@@ -609,23 +609,26 @@ pub static ROCKS_CURRENT_ITERATORS: LazyLock<IntGauge> = LazyLock::new(|| {
 
 fn export_store_stats(store: &Store, temperature: Temperature) {
     if let Some(stats) = store.get_store_statistics() {
-        tracing::debug!(target:"metrics", ?temperature, "exporting the db metrics for store");
+        tracing::debug!(?temperature, "exporting the db metrics for store");
         export_stats_as_metrics(stats, temperature);
     } else {
         // TODO Does that happen under normal circumstances?
         // Should this log be a warning or error instead?
-        tracing::debug!(target:"metrics", ?temperature, "exporting the db metrics for store failed, the statistics are missing");
+        tracing::debug!(
+            ?temperature,
+            "exporting the db metrics for store failed, the statistics are missing"
+        );
     }
 }
 
 pub fn spawn_db_metrics_loop(actor_system: ActorSystem, storage: &NodeStorage, period: Duration) {
-    tracing::debug!(target:"metrics", "spawning the db metrics loop");
+    tracing::debug!("spawning the db metrics loop");
 
     let hot_store = storage.get_hot_store();
     let cold_store = storage.get_cold_store();
 
     actor_system.new_future_spawner("db metrics loop").spawn("db metrics loop", async move {
-        tracing::debug!(target:"metrics", "starting the db metrics loop");
+        tracing::debug!("starting the db metrics loop");
         let start = tokio::time::Instant::now();
         let mut interval = tokio::time::interval_at(start, period.unsigned_abs());
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/core/store/src/metrics/rocksdb_metrics.rs
+++ b/core/store/src/metrics/rocksdb_metrics.rs
@@ -13,7 +13,7 @@ pub fn export_stats_as_metrics(stats: StoreStatistics, temperature: Temperature)
     match ROCKSDB_METRICS.lock().export_stats_as_metrics(stats, temperature) {
         Ok(_) => {}
         Err(err) => {
-            tracing::warn!(target:"stats", ?temperature, ?err, "failed to export store statistics");
+            tracing::warn!(?temperature, ?err, "failed to export store statistics");
         }
     }
 }

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -56,7 +56,6 @@ impl Store {
             self.storage.get_raw_bytes(column, &key)
         };
         tracing::trace!(
-            target: "store",
             db_op = "get",
             col = %column,
             key = %StorageKey(key),
@@ -88,7 +87,6 @@ impl Store {
                         Ok(result) => return Ok(Some(result)),
                         Err(_) => {
                             tracing::debug!(
-                                target: "store",
                                 requested = std::any::type_name::<T>(),
                                 "could not downcast an available cached deserialized value"
                             );
@@ -203,7 +201,6 @@ impl Store {
         level = "info",
         // FIXME: start moving things into tighter modules so that its easier to selectively trace
         // specific things.
-        target = "store",
         "Store::load_state_from_file",
         skip_all,
         fields(filename = %filename.display())
@@ -472,7 +469,6 @@ impl StoreUpdate {
 
     #[tracing::instrument(
         level = "trace",
-        target = "store::update",
         // FIXME: start moving things into tighter modules so that its easier to selectively trace
         // specific things.
         "StoreUpdate::commit",
@@ -535,11 +531,10 @@ impl StoreUpdate {
             span.record("delete_range_ops", delete_range_count);
             span.record("total_bytes", total_bytes);
         }
-        if tracing::event_enabled!(target: "store::update::transactions", tracing::Level::TRACE) {
+        if tracing::event_enabled!(tracing::Level::TRACE) {
             for op in &self.transaction.ops {
                 match op {
                     DBOp::Insert { col, key, value } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "insert",
                         %col,
                         key = %StorageKey(key),
@@ -547,7 +542,6 @@ impl StoreUpdate {
                         value = %AbbrBytes(value),
                     ),
                     DBOp::Set { col, key, value } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "set",
                         %col,
                         key = %StorageKey(key),
@@ -555,7 +549,6 @@ impl StoreUpdate {
                         value = %AbbrBytes(value)
                     ),
                     DBOp::UpdateRefcount { col, key, value } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "update_rc",
                         %col,
                         key = %StorageKey(key),
@@ -563,18 +556,15 @@ impl StoreUpdate {
                         value = %AbbrBytes(value)
                     ),
                     DBOp::Delete { col, key } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "delete",
                         %col,
                         key = %StorageKey(key)
                     ),
                     DBOp::DeleteAll { col } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "delete_all",
                         %col
                     ),
                     DBOp::DeleteRange { col, from, to } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "delete_range",
                         %col,
                         from = %StorageKey(from),

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -50,13 +50,13 @@ impl TrieConfig {
         for account in &config.sweat_prefetch_receivers {
             match AccountId::from_str(account) {
                 Ok(account_id) => this.sweat_prefetch_receivers.push(account_id),
-                Err(e) => tracing::error!(target: "config", %account, %e, "invalid account id"),
+                Err(e) => tracing::error!(%account, %e, "invalid account id"),
             }
         }
         for account in &config.sweat_prefetch_senders {
             match AccountId::from_str(account) {
                 Ok(account_id) => this.sweat_prefetch_senders.push(account_id),
-                Err(e) => tracing::error!(target: "config", %account, %e, "invalid account id"),
+                Err(e) => tracing::error!(%account, %e, "invalid account id"),
             }
         }
         this.claim_sweat_prefetch_config.clone_from(&config.claim_sweat_prefetch_config);

--- a/core/store/src/trie/mem/freelist.rs
+++ b/core/store/src/trie/mem/freelist.rs
@@ -66,7 +66,10 @@ impl VecU8Freelist {
                 if cfg!(debug_assertions) {
                     panic!("Too many freelist allocations; expected {}", self.expected_allocs);
                 } else {
-                    tracing::error!(target: "memtrie", expected_allocs = self.expected_allocs, "too many freelist allocations");
+                    tracing::error!(
+                        expected_allocs = self.expected_allocs,
+                        "too many freelist allocations"
+                    );
                 }
             }
             ReusableVecU8 { vec: Vec::new() }

--- a/core/store/src/trie/ops/iter.rs
+++ b/core/store/src/trie/ops/iter.rs
@@ -414,7 +414,7 @@ where
         path_begin: Option<&[u8]>,
         path_end: Option<&[u8]>,
     ) -> Result<Vec<TrieTraversalItem>, StorageError> {
-        let _span = tracing::debug_span!(target: "runtime", "visit_nodes_interval").entered();
+        let _span = tracing::debug_span!("visit_nodes_interval").entered();
         let path_begin = NibbleSlice::new(path_begin.unwrap_or(LAST_STATE_PART_BOUNDARY_NIBBLES));
         let path_end = match path_end {
             Some(p) => NibbleSlice::new(p).iter().collect_vec(),

--- a/core/store/src/trie/prefetching_trie_storage.rs
+++ b/core/store/src/trie/prefetching_trie_storage.rs
@@ -483,7 +483,6 @@ impl PrefetchApi {
                             }
                             Err(e) => {
                                 tracing::debug!(
-                                    target: "store::trie::prefetch",
                                     message = "prefetching failure",
                                     error = %e,
                                     key = ?trie_key

--- a/core/store/src/trie/split.rs
+++ b/core/store/src/trie/split.rs
@@ -257,7 +257,7 @@ impl<NodePtr: Debug + Copy> TrieDescentStage<NodePtr> {
     where
         Getter: Fn(NodePtr) -> Result<GenericTrieNodeWithSize<NodePtr, Value>, StorageError>,
     {
-        tracing::trace!(target = "memtrie", ?self, %nibble, "descending");
+        tracing::trace!(?self, %nibble, "descending");
         match self {
             Self::CutOff => {}
             Self::AtLeaf { .. } => *self = Self::CutOff,
@@ -409,7 +409,7 @@ where
     fn next_step(&self) -> FindSplitResult<Option<(u8, u64, u64)>> {
         // Stop when a leaf is reached in the accounts subtree
         if !self.accounts().can_descend() {
-            tracing::debug!(target = "memtrie", "leaf reached in accounts subtree");
+            tracing::debug!("leaf reached in accounts subtree");
             return Ok(None);
         }
 
@@ -421,14 +421,14 @@ where
         let children_mem_usage = self.aggregate_children_mem_usage()?;
 
         // Find the middle child
-        tracing::debug!(target = "memtrie", ?children_mem_usage, %threshold, "finding middle child");
+        tracing::debug!(?children_mem_usage, %threshold, "finding middle child");
         let Some((middle_child, left_mem_usage)) =
             find_middle_child(&children_mem_usage, threshold)
         else {
             return Ok(None);
         };
         let child_mem_usage = children_mem_usage[middle_child];
-        tracing::debug!(target = "memtrie", %middle_child, %child_mem_usage, %left_mem_usage, "middle child found");
+        tracing::debug!(%middle_child, %child_mem_usage, %left_mem_usage, "middle child found");
 
         // Stop if the further path does not exist in the accounts subtree
         let middle_child = middle_child as u8;
@@ -518,7 +518,7 @@ where
         self.right_memory +=
             self.middle_memory - left_mem_usage - child_mem_usage - parent_mem_usage;
         self.middle_memory = child_mem_usage;
-        tracing::debug!(target = "memtrie", %self.left_memory, %self.right_memory, %self.middle_memory, "remaining memory updated");
+        tracing::debug!(%self.left_memory, %self.right_memory, %self.middle_memory, "remaining memory updated");
 
         // Update descent stages for all subtrees
         let get_node = |ptr| self.trie_storage.get_node_with_size(ptr, AccessOptions::DEFAULT);
@@ -526,7 +526,7 @@ where
             stage.descend(nibble, get_node)?;
         }
         self.nibbles.push(nibble);
-        tracing::debug!(target = "memtrie", ?self.nibbles, nibble_str = String::from_utf8_lossy(&nibbles_to_bytes(&self.nibbles)).to_string(), "nibbles updated");
+        tracing::debug!(?self.nibbles, nibble_str = String::from_utf8_lossy(&nibbles_to_bytes(&self.nibbles)).to_string(), "nibbles updated");
         Ok(())
     }
 }

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -122,7 +122,6 @@ impl Trie {
             .as_ref()
             .map_or_else(ShardId::max, |chunk_view| chunk_view.shard_uid().shard_id());
         let _span = tracing::debug_span!(
-            target: "state-parts",
             "get_state_part_boundaries",
             %shard_id,
             part_id = part_id.idx,
@@ -144,13 +143,7 @@ impl Trie {
         let boundaries_read_duration = boundaries_read_timer.stop_and_record();
         let recorded_trie = recording_trie.recorded_storage().unwrap();
 
-        tracing::debug!(
-            target: "state-parts",
-            idx,
-            total,
-            ?boundaries_read_duration,
-            "found state part boundaries",
-        );
+        tracing::debug!(idx, total, ?boundaries_read_duration, "found state part boundaries",);
         Ok((recorded_trie.nodes, path_begin, path_end))
     }
 
@@ -169,7 +162,6 @@ impl Trie {
             .as_ref()
             .map_or_else(ShardId::max, |chunk_view| chunk_view.shard_uid().shard_id());
         let _span = tracing::debug_span!(
-            target: "state-parts",
             "get_trie_nodes_for_part_with_flat_storage",
             %shard_id,
             part_id = part_id.idx,
@@ -269,7 +261,6 @@ impl Trie {
         let in_memory_created_nodes =
             trie_values.iter().filter(|entry| !disk_read_hashes.contains(&hash(*entry))).count();
         tracing::debug!(
-            target: "state-parts",
             ?part_id,
             values_ref = value_refs.len(),
             %values_inlined,
@@ -315,7 +306,7 @@ impl Trie {
         let mut iterator = self.disk_iter()?;
         let nodes_list =
             iterator.visit_nodes_interval(path_begin.as_deref(), path_end.as_deref())?;
-        tracing::debug!(target: "state-parts", num_nodes = nodes_list.len());
+        tracing::debug!(num_nodes = nodes_list.len());
 
         Ok(())
     }

--- a/core/store/src/trie/trie_storage_update.rs
+++ b/core/store/src/trie/trie_storage_update.rs
@@ -160,7 +160,7 @@ enum FlattenNodesCrumb {
 }
 
 impl TrieStorageUpdate<'_> {
-    #[tracing::instrument(level = "debug", target = "store::trie", "Trie::flatten_nodes", skip_all)]
+    #[tracing::instrument(level = "debug", "Trie::flatten_nodes", skip_all)]
     pub(crate) fn flatten_nodes(
         mut self,
         old_root: &CryptoHash,

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -239,7 +239,6 @@ impl TrieUpdate {
     /// in any other way as desired.
     #[tracing::instrument(
         level = "debug",
-        target = "store::trie",
         "TrieUpdate::finalize",
         skip_all,
         fields(committed.len = self.committed.len(), tag_block_production = true)

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -255,7 +255,7 @@ impl TestEnv {
             for i in 0..network_adapters.len() {
                 let network_adapter = network_adapters.get(i).unwrap();
                 let _span =
-                    tracing::debug_span!(target: "test", "process_partial_encoded_chunks", client=i).entered();
+                    tracing::debug_span!("process_partial_encoded_chunks", client = i).entered();
 
                 keep_going |= network_adapter.handle_filtered(|request| match request {
                     PeerManagerMessageRequest::NetworkRequests(
@@ -381,8 +381,7 @@ impl TestEnv {
     }
 
     pub fn process_shards_manager_responses_and_finish_processing_blocks(&mut self, idx: usize) {
-        let _span =
-            tracing::debug_span!(target: "test", "process_shards_manager", client=idx).entered();
+        let _span = tracing::debug_span!("process_shards_manager", client = idx).entered();
 
         loop {
             self.process_shards_manager_responses(idx);
@@ -439,7 +438,7 @@ impl TestEnv {
                     witness_processing_done_waiters.push(processing_done_tracker.make_waiter());
 
                     if !self.contains_client(&account_id) {
-                        tracing::warn!(target: "test", %account_id, "client not found for account_id");
+                        tracing::warn!(%account_id, "client not found for account_id");
                         continue;
                     }
                     let account_index = self.get_client_index(&account_id);
@@ -483,10 +482,13 @@ impl TestEnv {
                     endorsement,
                 )) => {
                     if !self.contains_client(&account_id) {
-                        tracing::warn!(target: "test", %account_id, "client not found for account_id");
+                        tracing::warn!(%account_id, "client not found for account_id");
                         return None;
                     }
-                    let processing_result = self.client(&account_id).chunk_endorsement_tracker.process_chunk_endorsement(endorsement);
+                    let processing_result = self
+                        .client(&account_id)
+                        .chunk_endorsement_tracker
+                        .process_chunk_endorsement(endorsement);
                     if !allow_errors {
                         processing_result.unwrap();
                     }
@@ -882,7 +884,7 @@ impl TestEnv {
         let genesis_height = client.chain.genesis().height();
         let head_height = client.chain.head().unwrap().height;
 
-        tracing::info!(target: "test", genesis_height, head_height, "printing summary");
+        tracing::info!(genesis_height, head_height, "printing summary");
         for height in genesis_height..head_height + 1 {
             self.print_block_summary(height);
         }
@@ -894,7 +896,7 @@ impl TestEnv {
         let block = match block {
             Ok(block) => block,
             Err(err) => {
-                tracing::info!(target: "test", ?err, %height, "block: missing");
+                tracing::info!(?err, %height, "block: missing");
                 return;
             }
         };
@@ -906,7 +908,14 @@ impl TestEnv {
         let block_hash = block.hash();
         let chunk_mask = block.header().chunk_mask();
 
-        tracing::info!(target: "test", height, ?block_hash, ?chunk_mask, protocol_version, latest_protocol_version, "block");
+        tracing::info!(
+            height,
+            ?block_hash,
+            ?chunk_mask,
+            protocol_version,
+            latest_protocol_version,
+            "block"
+        );
     }
 
     pub fn spice_execute_block(&mut self, id: usize, block_hash: CryptoHash) {

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -735,7 +735,7 @@ fn test_bad_chunk_mask() {
     let first_epoch_id = &EpochId::default();
 
     let shard_layout = env.clients[0].epoch_manager.get_shard_layout(&first_epoch_id).unwrap();
-    tracing::info!(target: "test", ?shard_layout, "shard layout");
+    tracing::info!(?shard_layout, "shard layout");
 
     let [s0, s1] = shard_layout.shard_ids().collect_vec()[..] else { panic!("Expected 2 shards") };
     assert_eq!(s0, shard_layout.account_id_to_shard_id(&account0));
@@ -746,7 +746,7 @@ fn test_bad_chunk_mask() {
 
     let tip = env.clients[0].chain.get_block_by_height(0).unwrap();
     for chunk_header in tip.chunks().iter() {
-        tracing::info!(target: "test", ?chunk_header, "chunk header");
+        tracing::info!(?chunk_header, "chunk header");
     }
 
     for height in 1..5 {
@@ -2539,7 +2539,7 @@ fn test_epoch_multi_protocol_version_change() {
     let protocol_version_override =
         format!("{}={},{}={}", v1_upgrade_time, v1, v2_upgrade_time, v2);
 
-    tracing::debug!(target: "test", ?protocol_version_override, "setting the protocol_version_override");
+    tracing::debug!(?protocol_version_override, "setting the protocol_version_override");
     unsafe { std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", protocol_version_override) };
 
     let epoch_length = 5;
@@ -2575,7 +2575,7 @@ fn test_epoch_multi_protocol_version_change() {
             seen_v2 = true;
         }
 
-        tracing::debug!(target: "test", ?height, ?protocol_version, "loop iter finished");
+        tracing::debug!(?height, ?protocol_version, "loop iter finished");
 
         height += 1;
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -2614,7 +2614,7 @@ fn slow_test_epoch_multi_protocol_version_change_epoch_overlap() {
     let protocol_version_override =
         format!("{}={},{}={}", v1_upgrade_time, v1, v2_upgrade_time, v2);
 
-    tracing::debug!(target: "test", ?protocol_version_override, "setting the protocol_version_override");
+    tracing::debug!(?protocol_version_override, "setting the protocol_version_override");
     unsafe { std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", protocol_version_override) };
 
     let epoch_length = 5;
@@ -2663,7 +2663,7 @@ fn slow_test_epoch_multi_protocol_version_change_epoch_overlap() {
             );
         }
 
-        tracing::debug!(target: "test", ?height, ?protocol_version, "loop iter finished");
+        tracing::debug!(?height, ?protocol_version, "loop iter finished");
 
         height += 1;
         current_epoch_id = epoch_id;

--- a/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
@@ -487,7 +487,7 @@ fn test_processing_chunks_sanity() {
             .iter()
             .map(|chunk| format!("{:?}", chunk.chunk_hash()))
             .collect::<Vec<_>>();
-        tracing::debug!(target: "chunks", block = %i, chunks = %chunks.join(", "));
+        tracing::debug!(block = %i, chunks = %chunks.join(", "));
         blocks.push(block.clone());
         env.process_block(0, block, Provenance::PRODUCED);
     }
@@ -609,7 +609,6 @@ impl ChunkForwardingOptimizationTestData {
                     );
                 }
                 tracing::debug!(
-                    target: "test",
                     %client_id,
                     ?target,
                     chunk_hash_hex = %hex::encode(&request.chunk_hash.as_bytes()[..4]),
@@ -625,7 +624,6 @@ impl ChunkForwardingOptimizationTestData {
             }
             NetworkRequests::PartialEncodedChunkMessage { account_id, partial_encoded_chunk } => {
                 tracing::debug!(
-                    target: "test",
                     %client_id,
                     %account_id,
                     height = %partial_encoded_chunk.header.height_created(),
@@ -652,7 +650,6 @@ impl ChunkForwardingOptimizationTestData {
             }
             NetworkRequests::PartialEncodedChunkForward { account_id, forward } => {
                 tracing::debug!(
-                    target: "test",
                     %client_id,
                     %account_id,
                     hash = %hex::encode(&forward.chunk_hash.as_bytes()[..4]),
@@ -712,7 +709,7 @@ fn test_chunk_forwarding_optimization() {
         if height >= 31 {
             break;
         }
-        tracing::debug!(target: "test", height = %(height + 1), "======= height ======");
+        tracing::debug!(height = %(height + 1), "======= height ======");
         let block = test.env.clients[0].produce_block(height + 1).unwrap().unwrap();
         if block.header().height() > 1 {
             // For any block except the first, the previous block's application at each
@@ -726,7 +723,7 @@ fn test_chunk_forwarding_optimization() {
         }
         // The block producer of course has the complete block so we can process that.
         for i in 0..test.num_validators {
-            tracing::debug!(target: "test", height = %block.header().height(), %i, "processing block as validator");
+            tracing::debug!(height = %block.header().height(), %i, "processing block as validator");
             let _ = test.env.clients[i].start_process_block(
                 block.clone().into(),
                 if i == 0 { Provenance::PRODUCED } else { Provenance::NONE },
@@ -757,7 +754,7 @@ fn test_chunk_forwarding_optimization() {
         test.env.propagate_chunk_state_witnesses_and_endorsements(false);
     }
 
-    tracing::debug!(target: "test",
+    tracing::debug!(
         num_part_ords_requested = %test.num_part_ords_requested,
         num_part_ords_sent_as_partial_encoded_chunk = %test.num_part_ords_sent_as_partial_encoded_chunk,
         num_part_ords_forwarded = %test.num_part_ords_forwarded,

--- a/integration-tests/src/tests/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/features/adversarial_behaviors.rs
@@ -133,7 +133,7 @@ fn slow_test_non_adversarial_case() {
     let mut test = AdversarialBehaviorTestData::new();
     let epoch_manager = test.env.clients[0].epoch_manager.clone();
     for height in 1..=EPOCH_LENGTH * 4 + 5 {
-        tracing::debug!(target: "test", %height, "======= height ======");
+        tracing::debug!(%height, "======= height ======");
         test.process_all_actor_messages();
         let epoch_id = epoch_manager
             .get_epoch_id_from_prev_block(
@@ -162,7 +162,7 @@ fn slow_test_non_adversarial_case() {
         }
 
         for i in 0..test.num_validators {
-            tracing::debug!(target: "test", %height, %i, "processing block as validator");
+            tracing::debug!(%height, %i, "processing block as validator");
             let _ = test.env.clients[i].start_process_block(
                 block.clone().into(),
                 if i == 0 { Provenance::PRODUCED } else { Provenance::NONE },
@@ -215,7 +215,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
     let mut epochs_seen_invalid_chunk: HashSet<EpochId> = HashSet::new();
     let mut last_block_skipped = false;
     for height in 1..=EPOCH_LENGTH * 4 + 5 {
-        tracing::debug!(target: "test", %height, "======= height ======");
+        tracing::debug!(%height, "======= height ======");
         test.process_all_actor_messages();
         let epoch_id = epoch_manager
             .get_epoch_id_from_prev_block(
@@ -265,8 +265,8 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
                 }
             }
         }
-        tracing::debug!(target: "test", ?epoch_id, "epoch id of new block");
-        tracing::debug!(target: "test", %last_block_skipped, "block should be skipped: false, previous block skipped");
+        tracing::debug!(?epoch_id, "epoch id of new block");
+        tracing::debug!(%last_block_skipped, "block should be skipped: false, previous block skipped");
 
         if height > 1 {
             let prev_block =
@@ -295,7 +295,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
 
         // The block producer of course has the complete block so we can process that.
         for i in 0..test.num_validators {
-            tracing::debug!(target: "test", %height, %i, "processing block as validator");
+            tracing::debug!(%height, %i, "processing block as validator");
             let _ = test.env.clients[i].start_process_block(
                 block.clone().into(),
                 if i == 0 { Provenance::PRODUCED } else { Provenance::NONE },

--- a/integration-tests/src/tests/features/orphan_chunk_state_witness.rs
+++ b/integration-tests/src/tests/features/orphan_chunk_state_witness.rs
@@ -69,9 +69,9 @@ fn setup_orphan_witness_test() -> OrphanWitnessTestEnv {
         // Produce the next block
         let tip = env.clients[0].chain.head().unwrap();
         let block_producer = env.get_block_producer_at_offset(&tip, 1);
-        tracing::info!(target: "test", %height, %block_producer, "producing block at height by block producer");
+        tracing::info!(%height, %block_producer, "producing block at height by block producer");
         let block = env.client(&block_producer).produce_block(tip.height + 1).unwrap().unwrap();
-        tracing::info!(target: "test", %height, chunk_hash = ?block.chunks()[0].chunk_hash(), "block produced at height has chunk");
+        tracing::info!(%height, chunk_hash = ?block.chunks()[0].chunk_hash(), "block produced at height has chunk");
 
         // The first block after genesis doesn't have any chunks, but all other blocks should have a new chunk inside.
         if height > 1 {
@@ -129,7 +129,7 @@ fn setup_orphan_witness_test() -> OrphanWitnessTestEnv {
     let clients_without_excluded =
         (0..env.clients.len()).filter(|idx| *idx != excluded_validator_idx);
 
-    tracing::info!(target:"test", height = %(tip.height + 1), "producing block1 at height");
+    tracing::info!(height = %(tip.height + 1), "producing block1 at height");
     let block1 = env.client(&block1_producer).produce_block(tip.height + 1).unwrap().unwrap();
     assert_eq!(
         block1.chunks()[0].height_created(),
@@ -160,7 +160,7 @@ fn setup_orphan_witness_test() -> OrphanWitnessTestEnv {
 
     // Trigger chunk production for block2 by producing the block first
     let block2 = env.client(&block2_producer).produce_block(tip.height + 2).unwrap().unwrap();
-    tracing::info!(target:"test", height = %(tip.height + 2), "producing block2 at height");
+    tracing::info!(height = %(tip.height + 2), "producing block2 at height");
     assert_eq!(
         block2.chunks()[0].height_created(),
         block2.header().height(),

--- a/integration-tests/src/tests/features/stateless_validation.rs
+++ b/integration-tests/src/tests/features/stateless_validation.rs
@@ -174,7 +174,6 @@ fn run_chunk_validation_test(
         let height_offset = height - tip.height;
         let block_producer = env.get_block_producer_at_offset(&tip, height_offset);
         tracing::debug!(
-            target: "client",
             %height, %block_producer, "producing block at height by block producer"
         );
         let block = env.client(&block_producer).produce_block(height).unwrap().unwrap();
@@ -183,7 +182,6 @@ fn run_chunk_validation_test(
         for i in 0..env.clients.len() {
             let validator_id = env.get_client_id(i);
             tracing::debug!(
-                target: "client",
                 height = %block.header().height(), %validator_id, "applying block at height at validator"
             );
             let blocks_processed = if rng.gen_bool(prob_missing_chunk) {
@@ -351,7 +349,7 @@ fn test_chunk_state_witness_bad_shard_id() {
     // Run the client for a few blocks
     let upper_height = 6;
     for height in 1..upper_height {
-        tracing::info!(target: "test", %height, "producing block at height");
+        tracing::info!(%height, "producing block at height");
         let block = env.clients[0].produce_block(height).unwrap().unwrap();
         env.process_block(0, block, Provenance::PRODUCED);
     }
@@ -363,7 +361,7 @@ fn test_chunk_state_witness_bad_shard_id() {
     let witness_size = borsh::object_length(&witness).unwrap();
 
     // Test chunk validation actor rejects witness with invalid shard ID
-    tracing::info!(target: "test", "processing invalid chunk state witness");
+    tracing::info!("processing invalid chunk state witness");
     let witness_message = ChunkStateWitnessMessage {
         witness,
         raw_witness_size: witness_size,
@@ -549,7 +547,6 @@ fn produce_block(env: &mut TestEnv) {
     for i in 0..env.clients.len() {
         let validator_id = env.get_client_id(i);
         tracing::debug!(
-            target: "client",
             height = %block.header().height(), %validator_id, "applying block at height at validator"
         );
         let blocks_processed =

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -304,7 +304,7 @@ impl StateMachine {
         match action {
             Action::AddEdge { from, to, force } => {
                 self.actions.push(Box::new(move |info: &mut RunningInfo| Box::pin(async move {
-                    tracing::debug!(target: "test", num_prev_actions, action = ?action_clone, "runner.rs: action");
+                    tracing::debug!(num_prev_actions, action = ?action_clone, "runner.rs: action");
                     let pm = info.get_node(from)?.actor.clone();
                     let peer_info = info.runner.test_config[to].peer_info();
                     match tcp::Stream::connect(&peer_info, tcp::Tier::T2, &config::SocketOptions::default()).await {
@@ -333,14 +333,14 @@ impl StateMachine {
             }
             Action::Stop(source) => {
                 self.actions.push(Box::new(move |info: &mut RunningInfo| Box::pin(async move {
-                    tracing::debug!(target: "test", num_prev_actions, action = ?action_clone, "runner.rs: action");
+                    tracing::debug!(num_prev_actions, action = ?action_clone, "runner.rs: action");
                     info.stop_node(source);
                     Ok(ControlFlow::Break(()))
                 })));
             }
             Action::Wait(t) => {
                 self.actions.push(Box::new(move |_info: &mut RunningInfo| Box::pin(async move {
-                    tracing::debug!(target: "test", num_prev_actions, action = ?action_clone, "runner.rs: action");
+                    tracing::debug!(num_prev_actions, action = ?action_clone, "runner.rs: action");
                     tokio::time::sleep(t.try_into().unwrap()).await;
                     Ok(ControlFlow::Break(()))
                 })));
@@ -582,7 +582,7 @@ pub(crate) fn start_test(runner: Runner) -> anyhow::Result<()> {
         let step = tokio::time::Duration::from_millis(10);
         let start = tokio::time::Instant::now();
         for (i, a) in actions.into_iter().enumerate() {
-            tracing::debug!(target: "test", %i, "starting action");
+            tracing::debug!(%i, "starting action");
             loop {
                 let done =
                     tokio::time::timeout_at(start + timeout, a(&mut info)).await.with_context(
@@ -653,7 +653,12 @@ pub(crate) fn check_expected_connections(
 ) -> ActionFn {
     Box::new(move |info: &mut RunningInfo| {
         Box::pin(async move {
-            tracing::debug!(target: "test", node_id, expected_connections_lo, ?expected_connections_hi, "runner.rs: check_expected_connections");
+            tracing::debug!(
+                node_id,
+                expected_connections_lo,
+                ?expected_connections_hi,
+                "runner.rs: check_expected_connections"
+            );
             let pm = &info.get_node(node_id)?.actor;
             let res = pm.send_async(GetInfo {}).await?;
             if expected_connections_lo.is_some_and(|l| l > res.num_connected_peers) {
@@ -671,7 +676,7 @@ pub(crate) fn check_expected_connections(
 pub(crate) fn restart(node_id: usize) -> ActionFn {
     Box::new(move |info: &mut RunningInfo| {
         Box::pin(async move {
-            tracing::debug!(target: "test", ?node_id, "runner.rs: restart");
+            tracing::debug!(?node_id, "runner.rs: restart");
             info.start_node(node_id)?;
             Ok(ControlFlow::Break(()))
         })

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -25,7 +25,7 @@ fn read_trie_items(bench: &mut Bencher, shard_index: ShardIndex, shard_id: Shard
     let num_trie_items = 10_000;
 
     bench.iter(move || {
-        tracing::info!(target: "neard", ?home_dir, "home directory");
+        tracing::info!(?home_dir, "home directory");
         let store = near_store::NodeStorage::opener(
             &home_dir,
             &near_config.config.store,
@@ -60,7 +60,7 @@ fn read_trie_items(bench: &mut Bencher, shard_index: ShardIndex, shard_id: Shard
             .enumerate()
             .map(|(i, _)| {
                 if i % 500 == 0 {
-                    tracing::info!(target: "neard", %i, "progress")
+                    tracing::info!(%i, "progress")
                 }
             })
             .take(num_trie_items)

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -542,7 +542,6 @@ impl Config {
             let s = if unrecognized_fields.len() > 1 { "s" } else { "" };
             let fields = unrecognized_fields.join(", ");
             tracing::warn!(
-                target: "neard",
                 path = %path.display(),
                 fields_count = %s,
                 %fields,
@@ -586,7 +585,6 @@ impl Config {
     fn check_for_deprecated_fields(json_str: &str) {
         for (deprecated_key, new_key) in Self::deprecated_fields_in_json(json_str) {
             tracing::warn!(
-                target: "neard",
                 deprecated_key = %deprecated_key,
                 new_key        = %new_key,
                 "deprecated config key detected – please migrate",
@@ -915,7 +913,7 @@ fn generate_or_load_key(
                 ));
             }
         }
-        tracing::info!(target: "near", public_key = %signer.public_key(), account_id = %signer.get_account_id(), "reusing key for account");
+        tracing::info!(public_key = %signer.public_key(), account_id = %signer.get_account_id(), "reusing key for account");
         Ok(Some(signer))
     } else if let Some(account_id) = account_id {
         let signer = if let Some(seed) = test_seed {
@@ -923,7 +921,7 @@ fn generate_or_load_key(
         } else {
             InMemorySigner::from_random(account_id, KeyType::ED25519).into()
         };
-        tracing::info!(target: "near", public_key = %signer.public_key(), account_id = %signer.get_account_id(), "using key for account");
+        tracing::info!(public_key = %signer.public_key(), account_id = %signer.get_account_id(), "using key for account");
         signer
             .write_to_file(&path)
             .with_context(|| anyhow!("Failed saving key to ‘{}’", path.display()))?;
@@ -1082,7 +1080,7 @@ pub fn init_configs(
         near_primitives::chains::MAINNET => {
             let genesis = near_mainnet_res::mainnet_genesis();
             genesis.to_file(dir.join(config.genesis_file));
-            tracing::info!(target: "near", dir = %dir.display(), "generated mainnet genesis file");
+            tracing::info!(dir = %dir.display(), "generated mainnet genesis file");
         }
         near_primitives::chains::TESTNET => {
             if let Some(ref filename) = config.genesis_records_file {
@@ -1139,7 +1137,7 @@ pub fn init_configs(
             genesis.config.chain_id.clone_from(&chain_id);
 
             genesis.to_file(dir.join(config.genesis_file));
-            tracing::info!(target: "near", %chain_id, dir = %dir.display(), "generated network node key and genesis file");
+            tracing::info!(%chain_id, dir = %dir.display(), "generated network node key and genesis file");
         }
         _ => {
             let validator_file = dir.join(&config.validator_key_file);
@@ -1196,7 +1194,7 @@ pub fn init_configs(
             };
             let genesis = Genesis::new(genesis_config, records.into())?;
             genesis.to_file(dir.join(config.genesis_file));
-            tracing::info!(target: "near", dir = %dir.display(), "generated node key, validator key, genesis file");
+            tracing::info!(dir = %dir.display(), "generated node key, validator key, genesis file");
         }
     }
 
@@ -1498,7 +1496,7 @@ pub fn init_localnet_configs(
         log_config
             .write_to_file(&node_dir.join(LOG_CONFIG_FILENAME))
             .expect("Error writing log config");
-        tracing::info!(target: "near", node_dir = %node_dir.display(), "generated node key, validator key, genesis file");
+        tracing::info!(node_dir = %node_dir.display(), "generated node key, validator key, genesis file");
     }
 }
 
@@ -1525,28 +1523,28 @@ pub fn get_config_url(chain_id: &str, config_type: DownloadConfigType) -> String
 }
 
 pub fn download_genesis(url: &str, path: &Path) -> Result<(), FileDownloadError> {
-    tracing::info!(target: "near", %url, "downloading genesis file");
+    tracing::info!(%url, "downloading genesis file");
     let result = run_download_file(url, path);
     if result.is_ok() {
-        tracing::info!(target: "near", path = %path.display(), "saved the genesis file");
+        tracing::info!(path = %path.display(), "saved the genesis file");
     }
     result
 }
 
 pub fn download_records(url: &str, path: &Path) -> Result<(), FileDownloadError> {
-    tracing::info!(target: "near", %url, "downloading records file");
+    tracing::info!(%url, "downloading records file");
     let result = run_download_file(url, path);
     if result.is_ok() {
-        tracing::info!(target: "near", path = %path.display(), "saved the records file");
+        tracing::info!(path = %path.display(), "saved the records file");
     }
     result
 }
 
 pub fn download_config(url: &str, path: &Path) -> Result<(), FileDownloadError> {
-    tracing::info!(target: "near", %url, "downloading config file");
+    tracing::info!(%url, "downloading config file");
     let result = run_download_file(url, path);
     if result.is_ok() {
-        tracing::info!(target: "near", path = %path.display(), "saved the config file");
+        tracing::info!(path = %path.display(), "saved the config file");
     }
     result
 }

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 pub fn validate_config(config: &Config) -> Result<(), ValidationError> {
     let mut validation_errors = ValidationErrors::new();
     let mut config_validator = ConfigValidator::new(config, &mut validation_errors);
-    tracing::info!(target: "config", "validating config, extracted from config.json");
+    tracing::info!("validating config, extracted from config.json");
     config_validator.validate()
 }
 

--- a/nearcore/src/download_file.rs
+++ b/nearcore/src/download_file.rs
@@ -247,7 +247,7 @@ impl<'a> AutoXzDecoder<'a> {
                 xz2::stream::Status::StreamEnd => (),
                 status => {
                     let status = format!("{:?}", status);
-                    tracing::error!(target: "near", %status, ?path, "got unexpected status when decompressing downloaded file");
+                    tracing::error!(%status, ?path, "got unexpected status when decompressing downloaded file");
                     return Err(FileDownloadError::XzStatusError(status));
                 }
             };

--- a/nearcore/src/dyn_config.rs
+++ b/nearcore/src/dyn_config.rs
@@ -53,7 +53,10 @@ pub fn read_updatable_configs(
             validator_signer,
         })
     } else {
-        tracing::warn!(target: "neard", ?errs, "dynamically updatable configs are not valid, please fix this asap otherwise the node will be unable to restart");
+        tracing::warn!(
+            ?errs,
+            "dynamically updatable configs are not valid, please fix this asap otherwise the node will be unable to restart"
+        );
         crate::metrics::CONFIG_CORRECT.set(0);
         Err(UpdatableConfigLoaderError::Errors(errs))
     }
@@ -83,7 +86,7 @@ where
             Ok(config_str_without_comments) => {
                 match serde_json::from_str::<T>(&config_str_without_comments) {
                     Ok(config) => {
-                        tracing::info!(target: "neard", ?config, ?path, "changing the config");
+                        tracing::info!(?config, ?path, "changing the config");
                         Ok(Some(config))
                     }
                     Err(err) => {
@@ -97,7 +100,11 @@ where
         },
         Err(err) => match err.kind() {
             std::io::ErrorKind::NotFound => {
-                tracing::info!(target: "neard", ?err, ?path, "reset the config because the config file doesn't exist");
+                tracing::info!(
+                    ?err,
+                    ?path,
+                    "reset the config because the config file doesn't exist"
+                );
                 Ok(None)
             }
             _ => Err(UpdatableConfigLoaderError::OpenAndRead { file: path.to_path_buf(), err }),
@@ -112,11 +119,11 @@ fn read_validator_key(
     let validator_file: PathBuf = home_dir.join(&config.validator_key_file);
     match crate::config::load_validator_key(&validator_file) {
         Ok(Some(validator_signer)) => {
-            tracing::info!(target: "neard", validator_file = %validator_file.display(), "hot loading validator key");
+            tracing::info!(validator_file = %validator_file.display(), "hot loading validator key");
             Ok(Some(validator_signer))
         }
         Ok(None) => {
-            tracing::info!(target: "neard", validator_file = %validator_file.display(), "no validator key");
+            tracing::info!(validator_file = %validator_file.display(), "no validator key");
             Ok(None)
         }
         Err(err) => {

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -780,7 +780,7 @@ pub async fn start_with_config_and_synchronization_impl(
         );
     }
 
-    tracing::trace!(target: "diagnostic", key = "log", "starting NEAR node with diagnostic activated");
+    tracing::trace!(key = "log", "starting NEAR node with diagnostic activated");
 
     #[cfg(feature = "tx_generator")]
     let tx_generator = near_transactions_generator::actor::start_tx_generator(

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -62,7 +62,7 @@ fn migrate_47_to_48(
     cold_db: Option<&ColdDB>,
     transaction_validity_period: BlockHeightDelta,
 ) -> anyhow::Result<()> {
-    tracing::info!(target: "migrations", "starting migration from DB version 47 to 48");
+    tracing::info!("starting migration from DB version 47 to 48");
 
     if let Some(cold_db) = cold_db {
         copy_block_headers_to_cold_db(hot_store, cold_db)?;
@@ -83,7 +83,7 @@ fn copy_block_headers_to_cold_db(hot_store: &Store, cold_db: &ColdDB) -> anyhow:
     let head_height = hot_store.chain_store().head().unwrap().height;
     let approx_num_blocks = head_height - genesis_height;
 
-    tracing::info!(target: "migrations", ?approx_num_blocks, "copying block headers to cold db");
+    tracing::info!(?approx_num_blocks, "copying block headers to cold db");
 
     let mut count = 0;
     let mut transaction = DBTransaction::new();
@@ -94,11 +94,16 @@ fn copy_block_headers_to_cold_db(hot_store: &Store, cold_db: &ColdDB) -> anyhow:
             cold_db.write(transaction);
             transaction = DBTransaction::new();
             let percent_complete = (count as f64 / approx_num_blocks as f64) * 100.0;
-            tracing::info!(target: "migrations", ?count, ?approx_num_blocks, ?percent_complete, "copied block headers to cold db");
+            tracing::info!(
+                ?count,
+                ?approx_num_blocks,
+                ?percent_complete,
+                "copied block headers to cold db"
+            );
         }
     }
     cold_db.write(transaction);
-    tracing::info!(target: "migrations", ?count, ?approx_num_blocks, "completed copying block headers to cold db");
+    tracing::info!(?count, ?approx_num_blocks, "completed copying block headers to cold db");
 
     Ok(())
 }
@@ -109,7 +114,7 @@ fn update_epoch_sync_proof(
 ) -> anyhow::Result<()> {
     let epoch_store = store.epoch_store();
 
-    tracing::info!(target: "migrations", "updating existing epoch sync proof to compressed format");
+    tracing::info!("updating existing epoch sync proof to compressed format");
 
     // First we move any existing epoch sync proof to the compressed format
     // Note that while accessing the proof, we need to read directly from DBCol::EpochSyncProof
@@ -122,14 +127,14 @@ fn update_epoch_sync_proof(
     }
 
     // Now we generate the epoch sync proof and update it to latest
-    tracing::info!(target: "migrations", "generating latest epoch sync proof");
+    tracing::info!("generating latest epoch sync proof");
     let last_block_hash =
         find_target_epoch_to_produce_proof_for(&store, transaction_validity_period)?;
 
-    tracing::info!(target: "migrations", ?last_block_hash, "deriving epoch sync proof from last final block");
+    tracing::info!(?last_block_hash, "deriving epoch sync proof from last final block");
     let proof = derive_epoch_sync_proof_from_last_block(&epoch_store, &last_block_hash, true)?;
 
-    tracing::info!(target: "migrations", "storing latest epoch sync proof");
+    tracing::info!("storing latest epoch sync proof");
     let mut store_update = epoch_store.store_update();
     store_update.set_epoch_sync_proof(&proof);
     store_update.commit()?;
@@ -145,7 +150,7 @@ fn verify_block_headers(store: &Store) -> anyhow::Result<()> {
     let latest_known_height =
         store.get_ser::<LatestKnown>(DBCol::BlockMisc, LATEST_KNOWN_KEY)?.unwrap().height;
 
-    tracing::info!(target: "migrations", ?tail_height, ?latest_known_height, "verifying block headers before deletion");
+    tracing::info!(?tail_height, ?latest_known_height, "verifying block headers before deletion");
 
     for height in tail_height..(latest_known_height + 1) {
         for block_hash in chain_store.get_all_header_hashes_by_height(height)? {
@@ -166,7 +171,7 @@ fn verify_block_headers(store: &Store) -> anyhow::Result<()> {
 }
 
 fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
-    tracing::info!(target: "migrations", "deleting all block headers from hot store");
+    tracing::info!("deleting all block headers from hot store");
 
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::BlockHeader);
@@ -177,7 +182,11 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
     let latest_known_height =
         store.get_ser::<LatestKnown>(DBCol::BlockMisc, LATEST_KNOWN_KEY)?.unwrap().height;
 
-    tracing::info!(target: "migrations", ?tail_height, ?latest_known_height, "adding required block headers to hot store");
+    tracing::info!(
+        ?tail_height,
+        ?latest_known_height,
+        "adding required block headers to hot store"
+    );
 
     let mut store_update = chain_store.store_update();
     for height in tail_height..(latest_known_height + 1) {
@@ -188,13 +197,17 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
             }
         }
         if height % BATCH_SIZE == 0 {
-            tracing::info!(target: "migrations", ?height, ?latest_known_height, "committing addition of required block headers to hot store");
+            tracing::info!(
+                ?height,
+                ?latest_known_height,
+                "committing addition of required block headers to hot store"
+            );
             store_update.commit()?;
             store_update = chain_store.store_update();
         }
     }
     store_update.commit()?;
-    tracing::info!(target: "migrations", ?latest_known_height, "completed deletion of old block headers from hot store");
+    tracing::info!(?latest_known_height, "completed deletion of old block headers from hot store");
 
     Ok(())
 }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -67,7 +67,6 @@ impl NeardCmd {
         .local();
 
         tracing::info!(
-            target: "neard",
             version = crate::NEARD_VERSION,
             build = crate::NEARD_BUILD,
             commit = crate::NEARD_COMMIT,
@@ -205,7 +204,9 @@ impl NeardOpts {
     // TODO(nikurt): Delete in 1.38 or later.
     pub fn verbose_target(&self) -> Option<&str> {
         self.verbose.as_ref().map(|inner| {
-            tracing::error!(target: "neard", "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead");
+            tracing::error!(
+                "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead"
+            );
             inner.as_ref().map_or("", String::as_str)
         })
     }
@@ -367,18 +368,14 @@ fn check_release_build(chain: &str) {
         && [near_primitives::chains::MAINNET, near_primitives::chains::TESTNET].contains(&chain)
     {
         tracing::warn!(
-            target: "neard",
             %chain,
             "running a neard executable which wasn't built with `make release` command isn't supported"
         );
         tracing::warn!(
-            target: "neard",
             %chain,
             "note that `cargo build --release` builds lack optimizations which may be needed to run properly"
         );
-        tracing::warn!(
-            target: "neard",
-            "consider recompiling the binary using `make release` command");
+        tracing::warn!("consider recompiling the binary using `make release` command");
     }
 }
 
@@ -596,7 +593,7 @@ impl RunCmd {
                     break sig;
                 }
             };
-            tracing::warn!(target: "neard", %sig, "stopping, this may take a few minutes");
+            tracing::warn!(%sig, "stopping, this may take a few minutes");
             if let Some(handle) = cold_store_loop_handle {
                 handle.store(false, std::sync::atomic::Ordering::Relaxed);
             }
@@ -605,7 +602,7 @@ impl RunCmd {
             // Disable the subscriber to properly shutdown the tracer.
             near_o11y::reload(Some("error"), None, Some("off"), None).unwrap();
         });
-        tracing::info!(target: "neard", "waiting for rocksdb to gracefully shutdown");
+        tracing::info!("waiting for rocksdb to gracefully shutdown");
         RocksDB::block_until_all_instances_are_dropped();
     }
 }

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -266,7 +266,6 @@ impl FilesystemContractRuntimeCache {
         let _ = std::fs::rename(&legacy_path, &path);
         if std::fs::exists(legacy_path).ok() == Some(true) {
             tracing::warn!(
-                target: "vm",
                 path = %path.display(),
                 message = "the legacy compiled contract cache path still exists after migration; consider removing it"
             );
@@ -275,7 +274,6 @@ impl FilesystemContractRuntimeCache {
         let dir =
             rustix::fs::open(&path, rustix::fs::OFlags::DIRECTORY, rustix::fs::Mode::empty())?;
         tracing::debug!(
-            target: "vm",
             path = %path.display(),
             message = "opened a contract executable cache directory"
         );
@@ -321,7 +319,6 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
 
     #[tracing::instrument(
         level = "trace",
-        target = "vm",
         "FilesystemContractRuntimeCache::put",
         skip_all,
         fields(key = key.to_string(), value.len = value.compiled.debug_len()),
@@ -381,7 +378,6 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
 
     #[tracing::instrument(
         level = "trace",
-        target = "vm",
         "FilesystemContractRuntimeCache::get",
         skip_all,
         fields(key = key.to_string()),
@@ -425,7 +421,6 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
             // seem to be much reason to possibly crash the node due to this.
             _ => {
                 tracing::debug!(
-                    target: "vm",
                     message = "cached contract executable was found to be malformed",
                     key = %key
                 );
@@ -585,7 +580,7 @@ pub fn precompile_contract(
     config: Arc<Config>,
     cache: Option<&dyn ContractRuntimeCache>,
 ) -> Result<Result<ContractPrecompilatonResult, CompilationError>, CacheError> {
-    let _span = tracing::debug_span!(target: "vm", "precompile_contract").entered();
+    let _span = tracing::debug_span!("precompile_contract").entered();
     let vm_kind = config.vm_kind;
     let runtime = vm_kind
         .runtime(Arc::clone(&config))

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -3827,7 +3827,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
     #[cfg(feature = "sandbox")]
     pub fn sandbox_debug_log(&mut self, len: u64, ptr: u64) -> Result<()> {
         let message = self.sandbox_get_utf8_string(len, ptr)?;
-        tracing::debug!(target: "sandbox", message = &message[..]);
+        tracing::debug!(message = &message[..]);
         Ok(())
     }
 

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -44,7 +44,7 @@ pub fn contract_cached(
 /// module.
 ///
 /// Contract preparation and execution need not to be executed on the same thread.
-#[tracing::instrument(target = "vm", level = "debug", "prepare", skip_all, fields(
+#[tracing::instrument(level = "debug", "prepare", skip_all, fields(
     code.hash = %contract.hash(),
     method_name,
     vm_kind = ?wasm_config.vm_kind,
@@ -81,7 +81,7 @@ pub fn prepare(
 ///
 /// The gas cost for contract preparation will be subtracted by the VM
 /// implementation.
-#[tracing::instrument(target = "vm", level = "debug", "run", skip_all, fields(
+#[tracing::instrument(level = "debug", "run", skip_all, fields(
     method_name,
     burnt_gas = tracing::field::Empty,
     compute_usage = tracing::field::Empty,

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -4256,7 +4256,7 @@ pub fn storage_has_key(caller: &mut Caller<'_, Ctx>, key_len: u64, key_ptr: u64)
 #[cfg(feature = "sandbox")]
 pub fn sandbox_debug_log(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()> {
     let message = sandbox_get_utf8_string(caller, len, ptr)?;
-    tracing::debug!(target: "sandbox", message = &message[..]);
+    tracing::debug!(message = &message[..]);
     Ok(())
 }
 

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -458,7 +458,7 @@ impl WasmtimeVM {
         hasher.finish()
     }
 
-    #[tracing::instrument(target = "vm", level = "debug", "WasmtimeVM::compile_uncached", skip_all)]
+    #[tracing::instrument(level = "debug", "WasmtimeVM::compile_uncached", skip_all)]
     pub(crate) fn compile_uncached(
         &self,
         code: &ContractCode,
@@ -866,7 +866,7 @@ fn link(linker: &mut wasmtime::Linker<Ctx>, config: &Config) {
             fn $name(mut caller: wasmtime::Caller<'_, Ctx>, $( $arg_name: $arg_type ),* ) -> anyhow::Result<($( $returns ),*)> {
                 const TRACE: bool = imports::should_trace_host_function(stringify!($name));
                 let _span = TRACE.then(|| {
-                    tracing::trace_span!(target: "vm::host_function", stringify!($name)).entered()
+                    tracing::trace_span!(stringify!($name)).entered()
                 });
                 match logic::$func(&mut caller, $( $arg_name as $arg_type, )*) {
                     Ok(result) => Ok(result as ($( $returns ),* ) ),

--- a/runtime/near-vm/compiler-singlepass/src/codegen_x64.rs
+++ b/runtime/near-vm/compiler-singlepass/src/codegen_x64.rs
@@ -1670,7 +1670,7 @@ impl<'a> FuncGen<'a> {
         });
     }
 
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn new(
         assembler: &'a mut Assembler,
         module: &'a ModuleInfo,
@@ -1778,7 +1778,7 @@ impl<'a> FuncGen<'a> {
     }
 
     #[allow(clippy::large_stack_frames)]
-    #[tracing::instrument(target = "near_vm", level = "trace", skip(self))]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) fn feed_operator(&mut self, op: Operator) -> Result<(), CodegenError> {
         assert!(self.fp_stack.len() <= self.value_stack.len());
 
@@ -7611,7 +7611,7 @@ impl<'a> FuncGen<'a> {
         Ok(())
     }
 
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn finalize(mut self, data: &FunctionBodyData) -> CompiledFunction {
         debug_assert!(
             self.gas_iter.next().is_none(),
@@ -7724,7 +7724,7 @@ fn sort_call_movs(movs: &mut [(Location, GPR)]) {
 }
 
 // Standard entry trampoline.
-#[tracing::instrument(target = "near_vm", level = "trace")]
+#[tracing::instrument(level = "trace")]
 pub(crate) fn gen_std_trampoline(
     sig: &FunctionType,
     calling_convention: CallingConvention,
@@ -7817,7 +7817,7 @@ pub(crate) fn gen_std_trampoline(
 }
 
 /// Generates dynamic import function call trampoline for a function type.
-#[tracing::instrument(target = "near_vm", level = "trace", skip(vmoffsets))]
+#[tracing::instrument(level = "trace", skip(vmoffsets))]
 pub(crate) fn gen_std_dynamic_import_trampoline(
     vmoffsets: &VMOffsets,
     sig: &FunctionType,
@@ -7935,7 +7935,7 @@ pub(crate) fn gen_std_dynamic_import_trampoline(
 }
 
 // Singlepass calls import functions through a trampoline.
-#[tracing::instrument(target = "near_vm", level = "trace", skip(vmoffsets))]
+#[tracing::instrument(level = "trace", skip(vmoffsets))]
 pub(crate) fn gen_import_call_trampoline(
     vmoffsets: &VMOffsets,
     index: FunctionIndex,

--- a/runtime/near-vm/compiler-singlepass/src/compiler.rs
+++ b/runtime/near-vm/compiler-singlepass/src/compiler.rs
@@ -41,7 +41,7 @@ impl SinglepassCompiler {
 impl Compiler for SinglepassCompiler {
     /// Compile the module using Singlepass, producing a compilation result with
     /// associated relocations.
-    #[tracing::instrument(target = "near_vm", level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn compile_module(
         &self,
         target: &Target,
@@ -87,7 +87,7 @@ impl Compiler for SinglepassCompiler {
         };
         let import_idxs = 0..module.import_counts.functions as usize;
         let import_trampolines: PrimaryMap<SectionIndex, _> =
-            tracing::trace_span!(target: "near_vm", "import_trampolines", n_imports = import_idxs.len()).in_scope(
+            tracing::trace_span!("import_trampolines", n_imports = import_idxs.len()).in_scope(
                 || {
                     import_idxs
                         .into_par_iter()
@@ -111,7 +111,7 @@ impl Compiler for SinglepassCompiler {
             .collect::<Vec<(LocalFunctionIndex, &FunctionBodyData<'_>)>>()
             .into_par_iter()
             .map_init(make_assembler, |assembler, (i, input)| {
-                tracing::trace_span!(target: "near_vm", "function", i = i.index()).in_scope(|| {
+                tracing::trace_span!("function", i = i.index()).in_scope(|| {
                     let reader =
                         near_vm_compiler::FunctionReader::new(input.module_offset, input.data);
                     let stack_init_gas_cost = tunables
@@ -154,9 +154,8 @@ impl Compiler for SinglepassCompiler {
                     let mut operator_reader =
                         reader.get_operators_reader()?.into_iter_with_offsets();
                     while generator.has_control_frames() {
-                        let (op, pos) =
-                            tracing::trace_span!(target: "near_vm", "parsing-next-operator")
-                                .in_scope(|| operator_reader.next().unwrap())?;
+                        let (op, pos) = tracing::trace_span!("parsing-next-operator")
+                            .in_scope(|| operator_reader.next().unwrap())?;
                         generator.set_srcloc(pos as u32);
                         generator.feed_operator(op).map_err(to_compile_error)?;
                     }
@@ -169,7 +168,7 @@ impl Compiler for SinglepassCompiler {
             .collect::<PrimaryMap<LocalFunctionIndex, CompiledFunction>>();
 
         let function_call_trampolines =
-            tracing::trace_span!(target: "near_vm", "function_call_trampolines").in_scope(|| {
+            tracing::trace_span!("function_call_trampolines").in_scope(|| {
                 module
                     .signatures
                     .values()
@@ -183,26 +182,24 @@ impl Compiler for SinglepassCompiler {
                     .collect::<PrimaryMap<_, _>>()
             });
 
-        let dynamic_function_trampolines =
-            tracing::trace_span!(target: "near_vm", "dynamic_function_trampolines").in_scope(
-                || {
-                    module
-                        .imported_function_types()
-                        .collect::<Vec<_>>()
-                        .into_par_iter()
-                        .map_init(make_assembler, |assembler, func_type| {
-                            gen_std_dynamic_import_trampoline(
-                                &vmoffsets,
-                                &func_type,
-                                calling_convention,
-                                assembler,
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .collect::<PrimaryMap<FunctionIndex, FunctionBody>>()
-                },
-            );
+        let dynamic_function_trampolines = tracing::trace_span!("dynamic_function_trampolines")
+            .in_scope(|| {
+                module
+                    .imported_function_types()
+                    .collect::<Vec<_>>()
+                    .into_par_iter()
+                    .map_init(make_assembler, |assembler, func_type| {
+                        gen_std_dynamic_import_trampoline(
+                            &vmoffsets,
+                            &func_type,
+                            calling_convention,
+                            assembler,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .collect::<PrimaryMap<FunctionIndex, FunctionBody>>()
+            });
 
         Ok(Compilation {
             functions,

--- a/runtime/near-vm/compiler/src/translator/environ.rs
+++ b/runtime/near-vm/compiler/src/translator/environ.rs
@@ -59,7 +59,7 @@ impl<'data> ModuleEnvironment<'data> {
 
     /// Translate a wasm module using this environment. This consumes the
     /// `ModuleEnvironment` and produces a `ModuleInfoTranslation`.
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn translate(mut self, data: &'data [u8]) -> WasmResult<Self> {
         assert!(self.module_translation_state.is_none());
         let module_translation_state = translate_module(data, &mut self)?;

--- a/runtime/near-vm/compiler/src/translator/module.rs
+++ b/runtime/near-vm/compiler/src/translator/module.rs
@@ -15,7 +15,7 @@ use wasmparser::{NameSectionReader, Parser, Payload};
 
 /// Translate a sequence of bytes forming a valid Wasm binary into a
 /// parsed ModuleInfo `ModuleTranslationState`.
-#[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn translate_module<'data>(
     data: &'data [u8],
     environ: &mut ModuleEnvironment<'data>,

--- a/runtime/near-vm/compiler/src/translator/state.rs
+++ b/runtime/near-vm/compiler/src/translator/state.rs
@@ -35,7 +35,7 @@ impl ModuleTranslationState {
     }
 
     /// Build map of imported functions names for intrinsification.
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn build_import_map(&mut self, module: &ModuleInfo) {
         for key in module.imports.keys() {
             let value = &module.imports[key];

--- a/runtime/near-vm/engine/src/universal/code_memory.rs
+++ b/runtime/near-vm/engine/src/universal/code_memory.rs
@@ -234,7 +234,6 @@ impl Drop for CodeMemory {
             unsafe {
                 if let Err(e) = mm::munmap(self.map.cast(), self.size) {
                     tracing::error!(
-                        target: "near_vm",
                         message="could not unmap mapping",
                         map=?self.map, size=self.size, error=%e
                     );

--- a/runtime/near-vm/engine/src/universal/engine.rs
+++ b/runtime/near-vm/engine/src/universal/engine.rs
@@ -106,7 +106,7 @@ impl UniversalEngine {
     }
 
     /// Compile a WebAssembly binary
-    #[tracing::instrument(target = "near_vm", level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn compile_universal(
         &self,
         binary: &[u8],
@@ -197,7 +197,7 @@ impl UniversalEngine {
 
     /// Load a [`UniversalExecutable`](crate::UniversalExecutable) with this engine.
     #[cfg(not(windows))]
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn load_universal_executable(
         &self,
         executable: &UniversalExecutable,
@@ -493,7 +493,7 @@ impl UniversalEngine {
     }
 
     /// Validates a WebAssembly module
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn validate(&self, binary: &[u8]) -> Result<(), CompileError> {
         self.inner().validate(binary)
     }

--- a/runtime/near-vm/engine/src/universal/link.rs
+++ b/runtime/near-vm/engine/src/universal/link.rs
@@ -165,7 +165,7 @@ fn apply_relocation(
 
 /// Links a module, patching the allocated functions with the
 /// required relocations and jump tables.
-#[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn link_module(
     allocated_functions: &PrimaryMap<LocalFunctionIndex, VMLocalFunction>,
     jt_offsets: impl Fn(LocalFunctionIndex, JumpTable) -> near_vm_compiler::CodeOffset,

--- a/runtime/near-vm/test-api/src/sys/instance.rs
+++ b/runtime/near-vm/test-api/src/sys/instance.rs
@@ -103,7 +103,7 @@ impl Instance {
     /// Those are, as defined by the spec:
     ///  * Link errors that happen when plugging the imports into the instance
     ///  * Runtime errors that happen when running the module `start` function.
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn new_with_config(
         module: &Module,
         config: InstanceConfig,

--- a/runtime/near-vm/test-api/src/sys/module.rs
+++ b/runtime/near-vm/test-api/src/sys/module.rs
@@ -98,7 +98,7 @@ impl Module {
     /// # }
     /// ```
     #[allow(unreachable_code)]
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn new(store: &Store, bytes: impl AsRef<[u8]>) -> Result<Self, CompileError> {
         #[cfg(feature = "wat")]
         let bytes = wat::parse_bytes(bytes.as_ref()).map_err(|e| {
@@ -113,7 +113,7 @@ impl Module {
     /// Opposed to [`Module::new`], this function is not compatible with
     /// the WebAssembly text format (if the "wat" feature is enabled for
     /// this crate).
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn from_binary(store: &Store, binary: &[u8]) -> Result<Self, CompileError> {
         let engine = store.engine();
         engine.validate(binary)?;

--- a/runtime/near-vm/vm/src/instance/mod.rs
+++ b/runtime/near-vm/vm/src/instance/mod.rs
@@ -1150,7 +1150,7 @@ impl InstanceHandle {
 ///   visible to code in `near_vm_vm`, so it's the caller's responsibility to ensure these
 ///   functions are called with the correct type.
 /// - `instance_ptr` must point to a valid `near_vm_test_api::Instance`.
-#[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub unsafe fn initialize_host_envs<Err: Sized>(
     handle: &parking_lot::Mutex<InstanceHandle>,
     instance_ptr: *const ffi::c_void,

--- a/runtime/near-vm/vm/src/vmoffsets.rs
+++ b/runtime/near-vm/vm/src/vmoffsets.rs
@@ -116,7 +116,7 @@ impl VMOffsets {
     }
 
     /// Add imports and locals from the provided ModuleInfo.
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn with_module_info(mut self, module: &ModuleInfo) -> Self {
         self.num_imported_functions = module.import_counts.functions;
         self.num_imported_tables = module.import_counts.tables;

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -252,7 +252,7 @@ pub(crate) fn action_deploy_contract(
     cache: Option<&dyn ContractRuntimeCache>,
     current_protocol_version: ProtocolVersion,
 ) -> Result<(), StorageError> {
-    let _span = tracing::debug_span!(target: "runtime", "action_deploy_contract").entered();
+    let _span = tracing::debug_span!("action_deploy_contract").entered();
     clear_account_contract_storage_usage(
         state_update,
         account_id,

--- a/runtime/runtime/src/bandwidth_scheduler/mod.rs
+++ b/runtime/runtime/src/bandwidth_scheduler/mod.rs
@@ -51,7 +51,6 @@ pub fn run_bandwidth_scheduler(
 ) -> Result<BandwidthSchedulerOutput, RuntimeError> {
     let start_time = std::time::Instant::now();
     let _span = tracing::debug_span!(
-        target: "runtime",
         "run_bandwidth_scheduler",
         height = apply_state.block_height,
         shard_id = %apply_state.shard_id)
@@ -61,7 +60,7 @@ pub fn run_bandwidth_scheduler(
     let mut scheduler_state = match get_bandwidth_scheduler_state(state_update)? {
         Some(prev_state) => prev_state,
         None => {
-            tracing::debug!(target: "runtime", "bandwidth scheduler state not found - initializing");
+            tracing::debug!("bandwidth scheduler state not found - initializing");
             BandwidthSchedulerState::V1(BandwidthSchedulerStateV1 {
                 link_allowances: Vec::new(),
                 sanity_check_hash: CryptoHash::default(),

--- a/runtime/runtime/src/bandwidth_scheduler/scheduler.rs
+++ b/runtime/runtime/src/bandwidth_scheduler/scheduler.rs
@@ -492,7 +492,7 @@ impl BandwidthScheduler {
     fn grant_more_bandwidth(&mut self, link: &ShardLink, bandwidth: Bandwidth) {
         let current_granted = self.granted_bandwidth.get(link).copied().unwrap_or(0);
         let new_granted = current_granted.checked_add(bandwidth).unwrap_or_else(|| {
-            tracing::warn!(target: "runtime", ?link, "granting bandwidth on link would overflow, this is unexpected, granting max bandwidth instead");
+            tracing::warn!(?link, "granting bandwidth on link would overflow, this is unexpected, granting max bandwidth instead");
             Bandwidth::MAX
         });
         self.granted_bandwidth.insert(*link, new_granted);

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -237,7 +237,7 @@ impl ReceiptSinkV2WithInfo {
         state_update: &mut TrieUpdate,
         apply_state: &ApplyState,
     ) -> Result<(), RuntimeError> {
-        tracing::debug!(target: "runtime", "forwarding receipts from outgoing buffers");
+        tracing::debug!("forwarding receipts from outgoing buffers");
 
         // There mustn't be any shard ids in both the parents and the current
         // shard ids. If this happens the same buffer will be processed twice.
@@ -416,7 +416,6 @@ impl ReceiptSinkV2 {
         let max_receipt_size = apply_state.config.wasm_config.limit_config.max_receipt_size;
         if size > max_receipt_size {
             tracing::debug!(
-                target: "runtime",
                 receipt_id=?receipt.receipt_id(),
                 size,
                 max_receipt_size,
@@ -440,7 +439,7 @@ impl ReceiptSinkV2 {
         let forward_limit = outgoing_limit.entry(shard).or_insert(default_outgoing_limit);
 
         if forward_limit.gas >= gas && forward_limit.size >= size {
-            tracing::trace!(target: "runtime", ?shard, receipt_id=?receipt.receipt_id(), "forwarding buffered receipt");
+            tracing::trace!(?shard, receipt_id=?receipt.receipt_id(), "forwarding buffered receipt");
             outgoing_receipts.push(receipt);
             // underflow impossible: checked forward_limit > gas/size_to_forward above
             forward_limit.gas = forward_limit.gas.checked_sub(gas).unwrap();
@@ -449,7 +448,7 @@ impl ReceiptSinkV2 {
 
             Ok(ReceiptForwarding::Forwarded)
         } else {
-            tracing::trace!(target: "runtime", ?shard, receipt_id=?receipt.receipt_id(), "not forwarding buffered receipt");
+            tracing::trace!(?shard, receipt_id=?receipt.receipt_id(), "not forwarding buffered receipt");
             Ok(ReceiptForwarding::NotForwarded(receipt))
         }
     }

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -170,7 +170,6 @@ impl<'a> External for RuntimeExt<'a> {
             self.trie_access_tracker.state.commit_counts_since(start_ttn, access_tracker)?;
         #[cfg(feature = "io_trace")]
         tracing::trace!(
-            target: "io_tracer",
             storage_op = "write",
             key = base64(&key),
             size = value.len(),
@@ -214,7 +213,6 @@ impl<'a> External for RuntimeExt<'a> {
         #[cfg(feature = "io_trace")]
         if let Ok(read) = &result {
             tracing::trace!(
-                target: "io_tracer",
                 storage_op = "read",
                 key = base64(&key),
                 size = read.as_ref().map(|v| v.len()),
@@ -256,7 +254,6 @@ impl<'a> External for RuntimeExt<'a> {
             self.trie_access_tracker.state.commit_counts_since(start_ttn, access_tracker)?;
         #[cfg(feature = "io_trace")]
         tracing::trace!(
-            target: "io_tracer",
             storage_op = "remove",
             key = base64(&key),
             evicted_len = removed.as_ref().map(Vec::len),
@@ -287,7 +284,6 @@ impl<'a> External for RuntimeExt<'a> {
             self.trie_access_tracker.state.commit_counts_since(start_ttn, access_tracker)?;
         #[cfg(feature = "io_trace")]
         tracing::trace!(
-            target: "io_tracer",
             storage_op = "exists",
             key = base64(&key),
             tn_mem_reads = _delta.mem_reads,

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -256,7 +256,7 @@ pub(crate) fn execute_function_call(
     view_config: Option<ViewConfig>,
 ) -> Result<VMOutcome, RuntimeError> {
     let account_id = runtime_ext.account_id().clone();
-    tracing::debug!(target: "runtime", %account_id, "calling the contract");
+    tracing::debug!(%account_id, "calling the contract");
     // Output data receipts are ignored if the function call is not the last action in the batch.
     let output_data_receivers: Vec<_> = if is_last_action {
         action_receipt.output_data_receivers().iter().map(|r| r.receiver_id.clone()).collect()
@@ -353,7 +353,7 @@ fn apply_recorded_storage_garbage(function_call: &FunctionCallAction, state_upda
         .and_then(|suf| suf.parse::<usize>().ok())
     {
         if state_update.trie.record_storage_garbage(garbage_size_mbs) {
-            tracing::warn!(target: "runtime", %garbage_size_mbs, "generated storage proof garbage");
+            tracing::warn!(%garbage_size_mbs, "generated storage proof garbage");
         }
     }
 }

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -28,7 +28,7 @@ pub(crate) fn action_deploy_global_contract(
     deploy_contract: &DeployGlobalContractAction,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
-    let _span = tracing::debug_span!(target: "runtime", "action_deploy_global_contract").entered();
+    let _span = tracing::debug_span!("action_deploy_global_contract").entered();
 
     let storage_cost = apply_state
         .config
@@ -71,7 +71,7 @@ pub(crate) fn action_use_global_contract(
     current_protocol_version: ProtocolVersion,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
-    let _span = tracing::debug_span!(target: "runtime", "action_use_global_contract").entered();
+    let _span = tracing::debug_span!("action_use_global_contract").entered();
     use_global_contract(
         state_update,
         account_id,
@@ -130,11 +130,7 @@ pub(crate) fn apply_global_contract_distribution_receipt(
     state_update: &mut TrieUpdate,
     receipt_sink: &mut ReceiptSink,
 ) -> Result<(), RuntimeError> {
-    let _span = tracing::debug_span!(
-        target: "runtime",
-        "apply_global_contract_distribution_receipt",
-    )
-    .entered();
+    let _span = tracing::debug_span!("apply_global_contract_distribution_receipt",).entered();
 
     let ReceiptEnum::GlobalContractDistribution(global_contract_data) = receipt.receipt() else {
         unreachable!("given receipt should be an global contract distribution receipt")

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -358,7 +358,7 @@ impl Runtime {
         if log.is_empty() {
             return;
         }
-        tracing::debug!(target: "runtime", logs = %log.join("\n"));
+        tracing::debug!(logs = %log.join("\n"));
     }
 
     fn apply_action(
@@ -1261,13 +1261,13 @@ impl Runtime {
         for (account_id, max_of_stakes) in &validator_accounts_update.stake_info {
             if let Some(mut account) = get_account(state_update, account_id)? {
                 if let Some(reward) = validator_accounts_update.validator_rewards.get(account_id) {
-                    tracing::debug!(target: "runtime", %account_id, %reward, locked = %account.locked(), "account adding reward to stake");
+                    tracing::debug!(%account_id, %reward, locked = %account.locked(), "account adding reward to stake");
                     account.set_locked(account.locked().checked_add(*reward).ok_or_else(|| {
                         RuntimeError::UnexpectedIntegerOverflow("update_validator_accounts".into())
                     })?);
                 }
 
-                tracing::debug!(target: "runtime",
+                tracing::debug!(
                        %account_id, locked = %account.locked(), %max_of_stakes,
                        "account stake and max of stakes"
                 );
@@ -1290,7 +1290,7 @@ impl Runtime {
                             "update_validator_accounts - return stake".into(),
                         )
                     })?;
-                tracing::debug!(target: "runtime", %account_id, %return_stake, "account return stake");
+                tracing::debug!(%account_id, %return_stake, "account return stake");
                 account.set_locked(account.locked().checked_sub(return_stake).ok_or_else(
                     || {
                         RuntimeError::UnexpectedIntegerOverflow(
@@ -1364,7 +1364,7 @@ impl Runtime {
     /// containing invalid transactions does make it to here, these transactions are skipped. This
     /// does pollute the chain with junk data, but it also allows the protocol to make progress, as
     /// the only alternative way to handle these transactions is to make the entire chunk invalid.
-    #[instrument(target = "runtime", level = "debug", "apply", skip_all, fields(
+    #[instrument(level = "debug", "apply", skip_all, fields(
         protocol_version = apply_state.current_protocol_version,
         num_transactions = signed_txs.len(),
         gas_burnt = tracing::field::Empty,
@@ -1530,7 +1530,6 @@ impl Runtime {
     /// Any transactions that fail to validate (e.g. invalid nonces, unknown signing keys,
     /// insufficient NEAR balance, etc.) will be skipped, producing no receipts.
     #[instrument(
-        target = "runtime",
         level = "debug",
         "process_transactions",
         skip_all,
@@ -1923,7 +1922,6 @@ impl Runtime {
                     // This should never happen unless there is a bug in the code.
                     metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
                     tracing::error!(
-                        target: "runtime",
                         tx_hash=?tx.hash(),
                         tx_burnt_amount=?verification_result.burnt_amount,
                         ?err,
@@ -1994,7 +1992,6 @@ impl Runtime {
         mut validator_proposals: &mut Vec<ValidatorStake>,
     ) -> Result<(), RuntimeError> {
         let span = tracing::debug_span!(
-            target: "runtime",
             "process_receipt",
             receipt_id = %receipt.receipt_id(),
             predecessor = %receipt.predecessor_id(),
@@ -2055,7 +2052,7 @@ impl Runtime {
         Ok(())
     }
 
-    #[instrument(target = "runtime", level = "debug", "process_local_receipts", skip_all, fields(
+    #[instrument(level = "debug", "process_local_receipts", skip_all, fields(
         num_receipts = processing_state.local_receipts.len(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
@@ -2134,7 +2131,6 @@ impl Runtime {
     }
 
     #[instrument(
-        target = "runtime",
         level = "debug",
         "process_delayed_receipts",
         skip_all,
@@ -2234,7 +2230,7 @@ impl Runtime {
         Ok(processed_delayed_receipts)
     }
 
-    #[instrument(target = "runtime", level = "debug", "process_incoming_receipts", skip_all, fields(
+    #[instrument(level = "debug", "process_incoming_receipts", skip_all, fields(
         num_receipts = processing_state.incoming_receipts.len(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
@@ -2346,7 +2342,6 @@ impl Runtime {
     /// Processes all receipts (local, delayed and incoming).
     /// Returns a structure containing the result of the processing.
     #[instrument(
-        target = "runtime",
         level = "debug",
         "process_receipts",
         skip_all,
@@ -2415,7 +2410,6 @@ impl Runtime {
     }
 
     #[instrument(
-        target = "runtime",
         level = "debug",
         "validate_apply_state_update",
         skip_all,
@@ -2504,7 +2498,7 @@ impl Runtime {
             // queues: one for data that is going to be required soon, and the other that it would
             // only work when otherwise idle.
             let discarded_prefetch_requests = prefetcher.clear();
-            tracing::debug!(target: "runtime", discarded_prefetch_requests);
+            tracing::debug!(discarded_prefetch_requests);
         }
 
         // Dedup proposals from the same account.
@@ -2587,11 +2581,11 @@ impl ApplyState {
             return Ok(congestion_info.congestion_info);
         }
 
-        tracing::warn!(target: "runtime", "starting to bootstrap congestion info, this might take a while");
+        tracing::warn!("starting to bootstrap congestion info, this might take a while");
         let start = std::time::Instant::now();
         let result = bootstrap_congestion_info(trie, &self.config, self.shard_id);
         let time = start.elapsed();
-        tracing::warn!(target: "runtime", ?time, "bootstrapping congestion info done");
+        tracing::warn!(?time, "bootstrapping congestion info done");
         let computed = result?;
         Ok(computed)
     }

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -868,7 +868,7 @@ fn report_outgoing_buffers(
 pub fn report_recorded_column_sizes(trie: &Trie, apply_state: &ApplyState) {
     // Tracing span to measure time spent on reporting column sizes.
     let _span = tracing::debug_span!(
-            target: "runtime", "report_recorded_column_sizes",
+            "report_recorded_column_sizes",
             shard_id = %apply_state.shard_id,
             block_height = apply_state.block_height)
     .entered();

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -294,7 +294,6 @@ impl ReceiptPreparationPipeline {
             let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
             if !self.block_accounts.contains(account_id) {
                 tracing::debug!(
-                    target: "runtime::pipelining",
                     message="function call task was not submitted for preparation",
                     receipt=%receipt.get_hash(),
                     action_index,
@@ -322,7 +321,6 @@ impl ReceiptPreparationPipeline {
                     drop(status_guard);
                     let start = Instant::now();
                     tracing::trace!(
-                        target: "runtime::pipelining",
                         message="function call preparation on the main thread",
                         receipt=%receipt.get_hash(),
                         action_index

--- a/runtime/runtime/src/prefetch.rs
+++ b/runtime/runtime/src/prefetch.rs
@@ -237,11 +237,13 @@ impl TriePrefetcher {
         match res {
             Err(PrefetchError::QueueFull) => {
                 self.prefetch_queue_full.inc();
-                tracing::debug!(target: "runtime::prefetch", "IO scheduler input queue is full, dropping prefetch request");
+                tracing::debug!("IO scheduler input queue is full, dropping prefetch request");
             }
             Err(PrefetchError::QueueDisconnected) => {
                 // This shouldn't have happened, hence logging warning here
-                tracing::warn!(target: "runtime::prefetch", "IO scheduler input queue is disconnected, dropping prefetch request");
+                tracing::warn!(
+                    "IO scheduler input queue is disconnected, dropping prefetch request"
+                );
             }
             Ok(()) => self.prefetch_enqueued.inc(),
         };

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -345,12 +345,12 @@ impl TrieViewer {
         if let Some(err) = outcome.aborted {
             logs.extend(outcome.logs);
             let message = format!("wasm execution failed with error: {:?}", err);
-            tracing::debug!(target: "runtime", %time_str, %message, "exec time and error message");
+            tracing::debug!(%time_str, %message, "exec time and error message");
             let error: near_primitives::errors::FunctionCallError =
                 crate::conversions::Convert::convert(err);
             Err(errors::CallFunctionError::VMError { error, error_message: message })
         } else {
-            tracing::debug!(target: "runtime", %time_str, ?outcome, "exec time and result of execution");
+            tracing::debug!(%time_str, ?outcome, "exec time and result of execution");
             logs.extend(outcome.logs);
             let result = match outcome.return_data {
                 ReturnData::Value(buf) => buf,

--- a/test-loop-tests/src/tests/bandwidth_scheduler.rs
+++ b/test-loop-tests/src/tests/bandwidth_scheduler.rs
@@ -200,7 +200,7 @@ fn run_bandwidth_scheduler_test(scenario: TestScenario, tx_concurrency: usize) -
         }
         last_height = Some(tip.height);
 
-        tracing::info!(target: "scheduler_test", height = %tip.height);
+        tracing::info!(height = %tip.height);
 
         if tip.height - first_height.unwrap() > workload_blocks {
             return true;
@@ -213,7 +213,7 @@ fn run_bandwidth_scheduler_test(scenario: TestScenario, tx_concurrency: usize) -
     };
     test_loop.run_until(testloop_func, Duration::seconds(300));
 
-    tracing::info!(target: "scheduler_test", txs_done = %workload_generator.txs_done(), "total transactions completed");
+    tracing::info!(txs_done = %workload_generator.txs_done(), "total transactions completed");
 
     let client = &test_loop.data.get(&client_handle).client;
     let bandwidth_stats =
@@ -504,14 +504,14 @@ impl WorkloadGenerator {
                 ));
             }
         }
-        tracing::info!(target: "scheduler_test", workload_senders = %generator.workload_senders.len(), "workload senders");
+        tracing::info!(workload_senders = %generator.workload_senders.len(), "workload senders");
 
         generator
     }
 
     /// Deploy the test contract on all workload accounts
     fn deploy_contracts(&self, test_loop: &mut TestLoopV2, node_datas: &[NodeExecutionData]) {
-        tracing::info!(target: "scheduler_test", "deploying contracts");
+        tracing::info!("deploying contracts");
         let (last_block_hash, nonce) = get_last_block_and_nonce(test_loop, node_datas);
         let deploy_contracts_txs: Vec<SignedTransaction> = self
             .shard_accounts
@@ -527,7 +527,7 @@ impl WorkloadGenerator {
             })
             .collect();
         run_txs_parallel(test_loop, deploy_contracts_txs, &node_datas, Duration::seconds(30));
-        tracing::info!(target: "scheduler_test", "contracts deployed");
+        tracing::info!("contracts deployed");
     }
 
     /// Add `concurrency` many access keys to the workload accounts.
@@ -539,7 +539,7 @@ impl WorkloadGenerator {
         node_datas: &[NodeExecutionData],
         concurrency: usize,
     ) -> BTreeMap<AccountId, Vec<Signer>> {
-        tracing::info!(target: "scheduler_test", "adding access keys");
+        tracing::info!("adding access keys");
 
         // Signers with access keys that were already added to the accounts
         let mut available_signers: BTreeMap<AccountId, Vec<Signer>> = self
@@ -572,7 +572,7 @@ impl WorkloadGenerator {
             let mut new_signers = Vec::new();
 
             let (last_block_hash, nonce) = get_last_block_and_nonce(test_loop, node_datas);
-            tracing::info!(target: "scheduler_test", %nonce, "adding access keys with nonce");
+            tracing::info!(%nonce, "adding access keys with nonce");
 
             for (account, usable_signers) in &available_signers {
                 let Some(to_add) = signers_to_add.get_mut(account) else {
@@ -599,7 +599,7 @@ impl WorkloadGenerator {
 
             run_txs_parallel(test_loop, add_key_txs, node_datas, Duration::seconds(20));
 
-            tracing::info!(target: "scheduler_test", access_keys = %new_signers.len(), "added access keys");
+            tracing::info!(access_keys = %new_signers.len(), "added access keys");
             for (account, new_signer) in new_signers {
                 available_signers.entry(account).or_insert_with(Vec::new).push(new_signer);
             }

--- a/test-loop-tests/src/tests/congestion_control.rs
+++ b/test-loop-tests/src/tests/congestion_control.rs
@@ -191,7 +191,7 @@ fn do_deploy_contract(
     rpc_id: &AccountId,
     contract_id: &AccountId,
 ) {
-    tracing::info!(target: "test", ?rpc_id, ?contract_id, "deploying contract");
+    tracing::info!(?rpc_id, ?contract_id, "deploying contract");
     let code = near_test_contracts::rs_contract().to_vec();
     let tx = deploy_contract(test_loop, node_datas, rpc_id, contract_id, code, 1);
     test_loop.run_for(Duration::seconds(5));
@@ -206,7 +206,7 @@ fn do_call_contract(
     contract_id: &AccountId,
     accounts: &Vec<AccountId>,
 ) {
-    tracing::info!(target: "test", ?rpc_id, ?contract_id, "calling contract");
+    tracing::info!(?rpc_id, ?contract_id, "calling contract");
     let method_name = "burn_gas_raw".to_owned();
     let burn_gas = Gas::from_teragas(250);
     let args = burn_gas.as_gas().to_le_bytes().to_vec();

--- a/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
+++ b/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
@@ -123,7 +123,7 @@ fn deploy_contracts(
     let mut contracts = vec![];
     let mut txs = vec![];
     for (i, contract_id) in contract_ids.into_iter().enumerate() {
-        tracing::info!(target: "test", ?rpc_id, ?contract_id, "deploying contract");
+        tracing::info!(?rpc_id, ?contract_id, "deploying contract");
         let contract =
             ContractCode::new(near_test_contracts::sized_contract((i + 1) * 100).to_vec(), None);
         let tx = deploy_contract(
@@ -155,7 +155,7 @@ fn call_contracts(
     let mut txs = vec![];
     for sender_id in sender_ids {
         for contract_id in contract_ids {
-            tracing::info!(target: "test", ?rpc_id, ?sender_id, ?contract_id, "calling contract");
+            tracing::info!(?rpc_id, ?sender_id, ?contract_id, "calling contract");
             let tx = call_contract(
                 &mut env.test_loop,
                 &env.node_datas,

--- a/test-loop-tests/src/tests/create_delete_account.rs
+++ b/test-loop-tests/src/tests/create_delete_account.rs
@@ -15,7 +15,7 @@ use crate::utils::transactions::{
 
 /// Write block height to contract storage.
 fn do_call_contract(env: &mut TestLoopEnv, rpc_id: &AccountId, contract_id: &AccountId) {
-    tracing::info!(target: "test", "calling contract");
+    tracing::info!("calling contract");
     let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, contract_id);
     let tx = call_contract(
         &mut env.test_loop,

--- a/test-loop-tests/src/tests/increase_max_congestion_missing_chunks.rs
+++ b/test-loop-tests/src/tests/increase_max_congestion_missing_chunks.rs
@@ -137,7 +137,7 @@ fn slow_test_tx_inclusion() {
         if last_observed_height.get() != 0 {
             assert_eq!(last_observed_height.get() + 1, block_header.height());
         }
-        tracing::info!(target: "test", height = %block_header.height(), chunk_mask = ?block_header.chunk_mask(), "observed new block at height");
+        tracing::info!(height = %block_header.height(), chunk_mask = ?block_header.chunk_mask(), "observed new block at height");
         last_observed_height.set(block_header.height());
         true
     };

--- a/test-loop-tests/src/tests/optimistic_block.rs
+++ b/test-loop-tests/src/tests/optimistic_block.rs
@@ -206,7 +206,7 @@ fn test_optimistic_block_after_missing_block() {
     env.test_loop.run_for(Duration::seconds(10));
 
     let (height_to_skip, producer, next_producer) = get_height_to_skip_and_producers(&env);
-    tracing::info!(target: "test", ?height_to_skip, ?producer, "skipping block at height");
+    tracing::info!(?height_to_skip, ?producer, "skipping block at height");
     env = env.drop(DropCondition::BlocksByHeight([height_to_skip].into_iter().collect()));
 
     let client_handle = &env
@@ -305,7 +305,7 @@ fn test_optimistic_block_with_invalidated_outcome() {
 
     let (height_to_skip, producer, next_producer) = get_height_to_skip_and_producers(&env);
 
-    tracing::info!(target: "test", ?height_to_skip, ?producer, "alter optimistic block at height");
+    tracing::info!(?height_to_skip, ?producer, "alter optimistic block at height");
 
     let producer_client_handle = &env
         .get_node_data_by_account_id(producer.account_id())

--- a/test-loop-tests/src/tests/protocol_upgrade.rs
+++ b/test-loop-tests/src/tests/protocol_upgrade.rs
@@ -134,7 +134,7 @@ pub(crate) fn test_protocol_upgrade(
                 // There should be no missing blocks
                 assert_eq!(last_observed_height.get() + 1, block_header.height());
             }
-            tracing::info!(target: "test", height = %block_header.height(), chunk_mask = ?block_header.chunk_mask(), "observed new block at height");
+            tracing::info!(height = %block_header.height(), chunk_mask = ?block_header.chunk_mask(), "observed new block at height");
             last_observed_height.set(block_header.height());
 
             // Record observed missing chunks

--- a/test-loop-tests/src/utils/peer_manager_actor.rs
+++ b/test-loop-tests/src/utils/peer_manager_actor.rs
@@ -541,7 +541,6 @@ fn network_message_to_client_handler(
         NetworkRequests::BanPeer { peer_id, ban_reason } => {
             let my_peer_id = shared_state.account_to_peer_id(&my_account_id);
             tracing::debug!(
-                target: "test_loop",
                 account = %my_account_id,
                 ?peer_id,
                 ?ban_reason,

--- a/test-loop-tests/src/utils/receipts.rs
+++ b/test-loop-tests/src/utils/receipts.rs
@@ -104,7 +104,7 @@ pub fn check_receipts_at_block(
     let num_shards = shard_layout.shard_ids().count();
     let has_delayed = congestion_info.delayed_receipts_gas() != 0;
     let has_buffered = congestion_info.buffered_receipts_gas() != 0;
-    tracing::info!(target: "test", height=tip.height, num_shards, %shard_id, has_delayed, has_buffered, "checking receipts");
+    tracing::info!(height=tip.height, num_shards, %shard_id, has_delayed, has_buffered, "checking receipts");
 
     match kind {
         ReceiptKind::Delayed => {

--- a/test-loop-tests/src/utils/resharding.rs
+++ b/test-loop-tests/src/utils/resharding.rs
@@ -290,7 +290,7 @@ pub(crate) fn call_burn_gas_contract(
                             client_actor.client.chain.get_partial_transaction_result(&tx);
                         let status = tx_outcome.as_ref().map(|o| o.status.clone());
                         let status = status.unwrap();
-                        tracing::debug!(target: "test", ?tx_height, ?tx, ?status, "transaction status");
+                        tracing::debug!(?tx_height, ?tx, ?status, "transaction status");
                         assert_matches!(status, FinalExecutionStatus::SuccessValue(_));
                     }
                     checked_transactions.set(true);
@@ -298,7 +298,7 @@ pub(crate) fn call_burn_gas_contract(
             } else {
                 if next_block_has_new_shard_layout(client_actor.client.epoch_manager.as_ref(), &tip)
                 {
-                    tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                    tracing::debug!(height = tip.height, "resharding height set");
                     resharding_height.set(Some(tip.height));
                 }
             }
@@ -375,7 +375,7 @@ pub(crate) fn send_large_cross_shard_receipts(
             if resharding_height.get().is_none()
                 && next_block_has_new_shard_layout(epoch_manager.as_ref(), &tip)
             {
-                tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                tracing::debug!(height = tip.height, "resharding height set");
                 resharding_height.set(Some(tip.height));
             }
 
@@ -400,7 +400,7 @@ pub(crate) fn send_large_cross_shard_receipts(
                         outgoing_receipt_sizes.insert(target_shard, receipt_sizes);
                     }
                 }
-                tracing::info!(target: "test", shard_id = %shard_uid.shard_id(), ?outgoing_receipt_sizes, "outgoing buffers from shard");
+                tracing::info!(shard_id = %shard_uid.shard_id(), ?outgoing_receipt_sizes, "outgoing buffers from shard");
             }
 
             let is_epoch_before_resharding =
@@ -445,7 +445,6 @@ pub(crate) fn send_large_cross_shard_receipts(
                             tip.last_block_hash,
                         );
                         tracing::info!(
-                            target: "test",
                             %signer_id,
                             %receiver_id,
                             tx_hash = ?tx.get_hash(),
@@ -557,7 +556,7 @@ pub(crate) fn call_promise_yield(
                             client_actor.client.chain.get_partial_transaction_result(&tx);
                         let status = tx_outcome.as_ref().map(|o| o.status.clone());
                         let status = status.unwrap();
-                        tracing::debug!(target: "test", ?tx_height, ?tx, ?status, "transaction status");
+                        tracing::debug!(?tx_height, ?tx, ?status, "transaction status");
                         assert_matches!(status, FinalExecutionStatus::SuccessValue(_));
                     }
                     checked_transactions.set(true);
@@ -568,7 +567,7 @@ pub(crate) fn call_promise_yield(
                     let epoch_manager = client_actor.client.epoch_manager.as_ref();
                     // Check if resharding will happen in this block.
                     if next_block_has_new_shard_layout(epoch_manager, &tip) {
-                        tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                        tracing::debug!(height = tip.height, "resharding height set");
                         resharding_height.set(Some(tip.height));
                         return;
                     }
@@ -814,7 +813,7 @@ pub(crate) fn check_resharding_skipped_when_no_children_tracked(
             if resharding_height.get().is_none() {
                 if next_block_has_new_shard_layout(client.epoch_manager.as_ref(), &tip) {
                     resharding_height.set(Some(tip.height));
-                    tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                    tracing::debug!(height = tip.height, "resharding height set");
                 }
             }
 
@@ -969,7 +968,12 @@ pub(crate) fn promise_yield_repro_missing_trie_value(
                         tx,
                     );
                     sent_flag.map(|flag| flag.set(true));
-                    tracing::debug!(target: "test", height=tip.height, ?signer_account, ?receiver_account, "sent promise yield tx");
+                    tracing::debug!(
+                        height = tip.height,
+                        ?signer_account,
+                        ?receiver_account,
+                        "sent promise yield tx"
+                    );
                 };
 
             // Run this action only once at every block height.
@@ -991,7 +995,7 @@ pub(crate) fn promise_yield_repro_missing_trie_value(
             let indices_left_child_shard = get_promise_yield_indices(left_child_shard_uid);
             let indices_right_child_shard = get_promise_yield_indices(right_child_shard_uid);
 
-            tracing::debug!(target: "test", height=tip.height, epoch=?tip.epoch_id, 
+            tracing::debug!(height=tip.height, epoch=?tip.epoch_id,
                     ?indices_parent_shard, ?indices_left_child_shard, ?indices_right_child_shard, "promise yield indices");
 
             // At any height, if the shard exists and it is tracked, the promise yield indices trie
@@ -1056,7 +1060,7 @@ pub(crate) fn promise_yield_repro_missing_trie_value(
                         let tx_outcome =
                             client_actor.client.chain.get_partial_transaction_result(&tx);
                         let status = tx_outcome.as_ref().map(|o| o.status.clone());
-                        tracing::debug!(target: "test", ?tx_height, ?tx, ?status, "transaction status");
+                        tracing::debug!(?tx_height, ?tx, ?status, "transaction status");
                         // First two txs should have been GC'd, so these cannot be found.
                         if index <= 1 {
                             assert_matches!(status, Err(_));
@@ -1073,7 +1077,7 @@ pub(crate) fn promise_yield_repro_missing_trie_value(
                     let epoch_manager = client_actor.client.epoch_manager.as_ref();
                     // Check if resharding will happen in this block.
                     if next_block_has_new_shard_layout(epoch_manager, &tip) {
-                        tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                        tracing::debug!(height = tip.height, "resharding height set");
                         resharding_height.set(Some(tip.height));
                         return;
                     }
@@ -1178,7 +1182,12 @@ pub(crate) fn delayed_receipts_repro_missing_trie_value(
                     );
                 }
                 sent_flag.map(|flag| flag.set(true));
-                tracing::debug!(target: "test", height=tip.height, ?signer_account, ?receiver_account, "sent burn gas txs");
+                tracing::debug!(
+                    height = tip.height,
+                    ?signer_account,
+                    ?receiver_account,
+                    "sent burn gas txs"
+                );
             };
 
             let get_delayed_receipts_indices = |shard_uid| {
@@ -1194,7 +1203,7 @@ pub(crate) fn delayed_receipts_repro_missing_trie_value(
             let indices_left_child_shard = get_delayed_receipts_indices(left_child_shard_uid);
             let indices_right_child_shard = get_delayed_receipts_indices(right_child_shard_uid);
 
-            tracing::debug!(target: "test", height=tip.height, epoch=?tip.epoch_id, 
+            tracing::debug!(height=tip.height, epoch=?tip.epoch_id,
                     ?indices_parent_shard, ?indices_left_child_shard, ?indices_right_child_shard, "delayed receipts indices");
 
             // At any height, if the shard exists and it is tracked, the delayed receipts indices
@@ -1220,7 +1229,7 @@ pub(crate) fn delayed_receipts_repro_missing_trie_value(
                         let tx_outcome =
                             client_actor.client.chain.get_partial_transaction_result(&tx);
                         let status = tx_outcome.as_ref().map(|o| o.status.clone());
-                        tracing::debug!(target: "test", ?tx_height, ?tx, ?status, "transaction status");
+                        tracing::debug!(?tx_height, ?tx, ?status, "transaction status");
                         assert_matches!(status, Ok(FinalExecutionStatus::SuccessValue(_)));
                     }
                 }
@@ -1237,7 +1246,7 @@ pub(crate) fn delayed_receipts_repro_missing_trie_value(
                     let epoch_manager = client_actor.client.epoch_manager.as_ref();
                     // Check if resharding will happen in this block.
                     if next_block_has_new_shard_layout(epoch_manager, &tip) {
-                        tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                        tracing::debug!(height = tip.height, "resharding height set");
                         resharding_height.set(Some(tip.height));
                         return;
                     }

--- a/test-loop-tests/src/utils/setups.rs
+++ b/test-loop-tests/src/utils/setups.rs
@@ -63,7 +63,7 @@ pub fn derive_new_epoch_config_from_boundary(
     let base_shard_layout = &base_epoch_config.static_shard_layout();
     let new_shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, boundary_account.clone());
-    tracing::info!(target: "test", ?base_shard_layout, ?new_shard_layout, "shard layout");
+    tracing::info!(?base_shard_layout, ?new_shard_layout, "shard layout");
     let epoch_config = base_epoch_config.clone().with_shard_layout(new_shard_layout.clone());
     (epoch_config, new_shard_layout)
 }

--- a/test-loop-tests/src/utils/transactions.rs
+++ b/test-loop-tests/src/utils/transactions.rs
@@ -182,7 +182,7 @@ pub fn do_create_account(
     new_account_id: &AccountId,
     amount: Balance,
 ) {
-    tracing::info!(target: "test", "creating account");
+    tracing::info!("creating account");
     let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, originator);
     let tx = create_account(env, rpc_id, originator, new_account_id, amount, nonce);
     env.test_loop.run_for(Duration::seconds(5));
@@ -195,7 +195,7 @@ pub fn do_delete_account(
     account_id: &AccountId,
     beneficiary_id: &AccountId,
 ) {
-    tracing::info!(target: "test", "deleting account");
+    tracing::info!("deleting account");
     let tx =
         delete_account(&env.test_loop.data, &env.node_datas, rpc_id, account_id, beneficiary_id);
     env.test_loop.run_for(Duration::seconds(5));
@@ -208,7 +208,7 @@ pub fn do_deploy_contract(
     contract_id: &AccountId,
     code: Vec<u8>,
 ) {
-    tracing::info!(target: "test", "deploying contract");
+    tracing::info!("deploying contract");
     let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, contract_id);
     let tx = deploy_contract(&mut env.test_loop, &env.node_datas, rpc_id, contract_id, code, nonce);
     env.test_loop.run_for(Duration::seconds(3));
@@ -223,7 +223,7 @@ pub fn do_call_contract(
     method_name: String,
     args: Vec<u8>,
 ) {
-    tracing::info!(target: "test", "calling contract");
+    tracing::info!("calling contract");
     let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, contract_id);
     let tx = call_contract(
         &mut env.test_loop,
@@ -263,7 +263,7 @@ pub fn create_account(
 
     let tx_hash = tx.get_hash();
     submit_tx(&env.node_datas, rpc_id, tx);
-    tracing::debug!(target: "test", ?originator, ?new_account_id, ?tx_hash, "created account");
+    tracing::debug!(?originator, ?new_account_id, ?tx_hash, "created account");
     tx_hash
 }
 
@@ -289,7 +289,7 @@ pub fn delete_account(
 
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
-    tracing::debug!(target: "test", ?account_id, ?beneficiary_id, ?tx_hash, "deleted account");
+    tracing::debug!(?account_id, ?beneficiary_id, ?tx_hash, "deleted account");
     tx_hash
 }
 
@@ -314,7 +314,7 @@ pub fn deploy_contract(
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
 
-    tracing::debug!(target: "test", ?contract_id, ?tx_hash, "deployed contract");
+    tracing::debug!(?contract_id, ?tx_hash, "deployed contract");
     tx_hash
 }
 
@@ -345,7 +345,7 @@ pub fn deploy_global_contract(
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
 
-    tracing::debug!(target: "test", ?deployer_id, ?tx_hash, ?deploy_mode, "deployed global contract");
+    tracing::debug!(?deployer_id, ?tx_hash, ?deploy_mode, "deployed global contract");
     tx_hash
 }
 
@@ -375,7 +375,7 @@ pub fn use_global_contract(
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
 
-    tracing::debug!(target: "test", ?user_id, ?tx_hash, ?identifier, "use global contract");
+    tracing::debug!(?user_id, ?tx_hash, ?identifier, "use global contract");
     tx_hash
 }
 
@@ -411,7 +411,7 @@ pub fn call_contract(
 
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
-    tracing::debug!(target: "test", ?sender_id, ?contract_id, ?tx_hash, "called contract");
+    tracing::debug!(?sender_id, ?contract_id, ?tx_hash, "called contract");
     tx_hash
 }
 
@@ -462,7 +462,7 @@ pub fn check_txs(
         let tx_outcome = rpc.chain.get_partial_transaction_result(&tx);
         let status = tx_outcome.as_ref().map(|o| o.status.clone());
         let status = status.unwrap();
-        tracing::info!(target: "test", ?tx, ?status, "transaction status");
+        tracing::info!(?tx, ?status, "transaction status");
         assert_matches!(status, FinalExecutionStatus::SuccessValue(_));
     }
 }
@@ -769,7 +769,7 @@ pub fn store_and_submit_tx(
     tx: SignedTransaction,
 ) {
     let mut txs_vec = txs.take();
-    tracing::debug!(target: "test", height, tx_hash=?tx.get_hash(), ?signer_id, ?receiver_id, "submitting transaction");
+    tracing::debug!(height, tx_hash=?tx.get_hash(), ?signer_id, ?receiver_id, "submitting transaction");
     txs_vec.push((tx.get_hash(), height));
     txs.set(txs_vec);
     submit_tx(&node_datas, &rpc_id, tx);
@@ -782,7 +782,7 @@ pub fn check_txs_remove_successful(txs: &Cell<Vec<(CryptoHash, BlockHeight)>>, c
     for (tx_hash, tx_height) in txs.take() {
         let tx_outcome = client.chain.get_final_transaction_result(&tx_hash);
         let status = tx_outcome.as_ref().map(|o| o.status.clone());
-        tracing::debug!(target: "test", ?tx_height, ?tx_hash, ?status, "transaction status");
+        tracing::debug!(?tx_height, ?tx_hash, ?status, "transaction status");
         match status {
             Ok(FinalExecutionStatus::SuccessValue(_)) => continue, // Transaction finished successfully, remove it.
             Ok(FinalExecutionStatus::NotStarted)

--- a/test-loop-tests/src/utils/trie_sanity.rs
+++ b/test-loop-tests/src/utils/trie_sanity.rs
@@ -267,10 +267,10 @@ fn assert_state_sanity(
             flat_storage_manager.get_flat_storage_status(shard_uid)
         {
             if status.flat_head.hash != final_head.prev_block_hash {
-                tracing::warn!(target: "test", "skipping flat storage - memtrie state check");
+                tracing::warn!("skipping flat storage - memtrie state check");
                 continue;
             } else {
-                tracing::debug!(target: "test", "checking flat storage - memtrie state");
+                tracing::debug!("checking flat storage - memtrie state");
             }
         } else {
             continue;
@@ -315,7 +315,7 @@ fn assert_state_equal(
     let mut has_diff = false;
     for (key, value) in diff {
         has_diff = true;
-        tracing::error!(target: "test", ?shard_uid, key=?key, ?value, %cmp_msg, "difference in state between");
+        tracing::error!(?shard_uid, key=?key, ?value, %cmp_msg, "difference in state between");
     }
     assert!(!has_diff, "{} state mismatch!", cmp_msg);
 }

--- a/tools/congestion-model/src/strategy/nep.rs
+++ b/tools/congestion-model/src/strategy/nep.rs
@@ -221,7 +221,6 @@ impl NepStrategy {
         let outgoing_congestion = self.get_outgoing_congestion(ctx);
 
         tracing::debug!(
-            target: "model",
             shard_id=%self.shard_id(),
             incoming_congestion=format!("{incoming_congestion:.2}"),
             outgoing_congestion=format!("{outgoing_congestion:.2}"),

--- a/tools/flat-storage/src/resume_resharding.rs
+++ b/tools/flat-storage/src/resume_resharding.rs
@@ -40,7 +40,7 @@ pub(crate) fn resume_resharding(
 
     flat_storage_resharder.resume(shard_uid)?;
 
-    tracing::info!(target: "resharding", "flat storage resharder completed");
+    tracing::info!("flat storage resharder completed");
 
     let trie_state_resharder = TrieStateResharder::new(
         runtime_adapter,
@@ -50,7 +50,7 @@ pub(crate) fn resume_resharding(
     );
     trie_state_resharder.resume(shard_uid)?;
 
-    tracing::info!(target: "resharding", "trie state resharder completed");
+    tracing::info!("trie state resharder completed");
 
     Ok(())
 }

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -933,7 +933,7 @@ impl ForkNetworkCommand {
             None,
             &epoch_config_dir,
         );
-        tracing::info!(target: "near", epoch_config_dir = %epoch_config_dir.display(), "generated epoch configs files");
+        tracing::info!(epoch_config_dir = %epoch_config_dir.display(), "generated epoch configs files");
         Ok(first_config)
     }
 

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -241,7 +241,6 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::StreamerMessage>
         //     ],
         // }
         tracing::info!(
-            target: "indexer_example",
             height = %streamer_message.block.header.height,
             hash = ?streamer_message.block.header.hash,
             num_shards = %streamer_message.shards.len(),

--- a/tools/mirror/src/cli.rs
+++ b/tools/mirror/src/cli.rs
@@ -271,7 +271,9 @@ fn run_async<F: std::future::Future + 'static>(f: F) -> F::Output {
 
 impl MirrorCommand {
     pub fn run(self) -> anyhow::Result<()> {
-        tracing::warn!(target: "mirror", "the mirror command is not stable, and may be removed or changed arbitrarily at any time");
+        tracing::warn!(
+            "the mirror command is not stable, and may be removed or changed arbitrarily at any time"
+        );
 
         match self.subcmd {
             SubCommand::Prepare(r) => r.run(),

--- a/tools/mirror/src/genesis.rs
+++ b/tools/mirror/src/genesis.rs
@@ -43,7 +43,10 @@ fn map_action(
                 map_delegate_action(delegate, secret, default_key)
             } else {
                 // This should not happen, but we handle the case here defensively
-                tracing::warn!(target: "mirror", ?delegate, "a delegate action was contained inside another delegate action");
+                tracing::warn!(
+                    ?delegate,
+                    "a delegate action was contained inside another delegate action"
+                );
                 None
             }
         }

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -64,7 +64,10 @@ fn secp256k1_from_slice(buf: &mut [u8], public: &Secp256K1PublicKey) -> secp256k
     match secp256k1::SecretKey::from_slice(buf) {
         Ok(s) => s,
         Err(_) => {
-            tracing::warn!(target: "mirror", ?public, "something super unlikely occurred, secp256k1 key mapped from is too large, flipping most significant bit");
+            tracing::warn!(
+                ?public,
+                "something super unlikely occurred, secp256k1 key mapped from is too large, flipping most significant bit"
+            );
             // If we got an error, it means that either `buf` is all zeros, or that when interpreted as a 256-bit
             // int, it is larger than the order of the secp256k1 curve. Since the order of the curve starts with 0xFF,
             // in either case flipping the first bit should work, and we can unwrap() below.

--- a/tools/ping/src/cli.rs
+++ b/tools/ping/src/cli.rs
@@ -134,21 +134,23 @@ fn parse_account_filter<P: AsRef<Path>>(filename: P) -> std::io::Result<HashSet<
                 filter.insert(a);
             }
             Err(e) => {
-                tracing::warn!(target: "ping", %line, %line_num, ?e, "could not parse account on line");
+                tracing::warn!(%line, %line_num, ?e, "could not parse account on line");
             }
         }
         line.clear();
         line_num += 1;
     }
     if filter.is_empty() {
-        tracing::warn!(target: "ping", filename = ?filename.as_ref(), "no accounts parsed, only sending direct pings");
+        tracing::warn!(filename = ?filename.as_ref(), "no accounts parsed, only sending direct pings");
     }
     Ok(filter)
 }
 
 impl PingCommand {
     pub fn run(&self) -> anyhow::Result<()> {
-        tracing::warn!(target: "ping", "the ping command is not stable, and may be removed or changed arbitrarily at any time");
+        tracing::warn!(
+            "the ping command is not stable, and may be removed or changed arbitrarily at any time"
+        );
 
         let mut chain_info = None;
         for info in CHAIN_INFO {

--- a/tools/ping/src/lib.rs
+++ b/tools/ping/src/lib.rs
@@ -178,7 +178,7 @@ impl AppInfo {
                 match pending_pings.entry(nonce) {
                     Entry::Occupied(_) => {
                         tracing::warn!(
-                            target: "ping", %nonce, ?peer_id, "internal error, sent two pings with same nonce, \
+                            %nonce, ?peer_id, "internal error, sent two pings with same nonce, \
                             latency stats will probably be wrong"
                         );
                     }
@@ -234,7 +234,6 @@ impl AppInfo {
                     }
                     None => {
                         tracing::warn!(
-                            target: "ping",
                             %nonce, peer = %peer_str(&peer_id, state.account_id.as_ref()),
                             "received pong after probably treating it as timed out previously"
                         );
@@ -243,7 +242,7 @@ impl AppInfo {
                 }
             }
             None => {
-                tracing::warn!(target: "ping", ?peer_id, "received pong but don't know of this peer");
+                tracing::warn!(?peer_id, "received pong but don't know of this peer");
                 None
             }
         }
@@ -269,7 +268,7 @@ impl AppInfo {
         if let Some(filter) = self.account_filter.as_ref() {
             if let Some(account_id) = account_id.as_ref() {
                 if !filter.contains(account_id) {
-                    tracing::debug!(target: "ping", %account_id, "skipping announce account");
+                    tracing::debug!(%account_id, "skipping announce account");
                     return;
                 }
             }
@@ -285,7 +284,7 @@ impl AppInfo {
                             // We only use the accounts in the account filter and when displaying
                             // ping targets, so theres no reason we cant keep track of all of them
                             tracing::warn!(
-                                target: "ping", ?peer_id, %account_id, old_account_id = %old,
+                                ?peer_id, %account_id, old_account_id = %old,
                                 "received announce account mapping but already knew of account id, keeping old value"
                             );
                         }

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -185,13 +185,13 @@ impl ReplayController {
         let mut total_gas_burnt: Option<Gas> = None;
         match self.replay_block(self.next_height)? {
             ReplayBlockOutput::Genesis(block) => {
-                tracing::debug!(target: "replay-archive", height = %block.header().height(), "skipping genesis block at height");
+                tracing::debug!(height = %block.header().height(), "skipping genesis block at height");
             }
             ReplayBlockOutput::Missing(height) => {
-                tracing::debug!(target: "replay-archive", %height, "skipping missing block at height");
+                tracing::debug!(%height, "skipping missing block at height");
             }
             ReplayBlockOutput::Replayed(block, gas_burnt) => {
-                tracing::debug!(target: "replay-archive", height = %block.header().height(), "replayed block at height");
+                tracing::debug!(height = %block.header().height(), "replayed block at height");
                 total_gas_burnt = Some(gas_burnt);
             }
         }
@@ -202,7 +202,7 @@ impl ReplayController {
     }
 
     fn replay_block(&mut self, height: BlockHeight) -> Result<ReplayBlockOutput> {
-        tracing::info!(target: "replay-archive", height = %self.next_height, "replaying block at height");
+        tracing::info!(height = %self.next_height, "replaying block at height");
 
         let Ok(block_hash) = self.chain_store.get_block_hash_by_height(height) else {
             return Ok(ReplayBlockOutput::Missing(height));
@@ -267,7 +267,7 @@ impl ReplayController {
         chunk_header: &ShardChunkHeader,
         prev_chunk_header: &ShardChunkHeader,
     ) -> Result<ReplayChunkOutput> {
-        let span = tracing::debug_span!(target: "replay-archive", "replay_chunk").entered();
+        let span = tracing::debug_span!("replay_chunk").entered();
 
         // Collect receipts and transactions.
         let chunk_hash = chunk_header.chunk_hash();

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -121,14 +121,13 @@ fn main() {
             // Already kicked out or getting kicked out.
             let amount = if stake_amount.is_zero() { last_stake_amount } else { stake_amount };
             tracing::info!(
-                target: "restaked",
                 account_id = %key_file.account_id, %amount,
                 "sending staking transaction"
             );
             if let Err(err) =
                 user.stake(key_file.account_id.clone(), key_file.public_key.clone(), amount)
             {
-                tracing::error!(target: "restaked", ?err, "failed to send staking transaction");
+                tracing::error!(?err, "failed to send staking transaction");
             }
         }
         std::thread::sleep(Duration::from_secs(wait_period));

--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -249,14 +249,14 @@ fn validate_state_part(state_root: &StateRoot, part_id: PartId, part: &[u8]) -> 
                 Ok(_) => true,
                 // Storage error should not happen
                 Err(err) => {
-                    tracing::error!(target: "state-parts", ?err, "state part storage error");
+                    tracing::error!(?err, "state part storage error");
                     false
                 }
             }
         }
         // Deserialization error means we've got the data from malicious peer
         Err(err) => {
-            tracing::error!(target: "state-parts", ?err, "state part deserialization error");
+            tracing::error!(?err, "state part deserialization error");
             false
         }
     }
@@ -270,7 +270,7 @@ fn validate_state_header(header: &[u8]) -> bool {
         }
         // Deserialization error means we've got invalid data stored in the external folder.
         Err(err) => {
-            tracing::error!(target: "state-parts", ?err, "header deserialization error");
+            tracing::error!(?err, "header deserialization error");
             false
         }
     }

--- a/tools/state-parts/src/cli.rs
+++ b/tools/state-parts/src/cli.rs
@@ -61,7 +61,9 @@ pub struct StatePartsCommand {
 
 impl StatePartsCommand {
     pub fn run(&self) -> anyhow::Result<()> {
-        tracing::warn!(target: "state-parts", "the state-parts command is not stable, and may be removed or changed arbitrarily at any time");
+        tracing::warn!(
+            "the state-parts command is not stable, and may be removed or changed arbitrarily at any time"
+        );
 
         let mut chain_info = None;
         for info in CHAIN_INFO {
@@ -95,7 +97,7 @@ impl StatePartsCommand {
         if peer.addr.is_none() {
             anyhow::bail!("--peer should be in the form [public key]@[socket addr]");
         }
-        tracing::info!(target: "state-parts", ?genesis_hash, ?peer);
+        tracing::info!(?genesis_hash, ?peer);
         let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async move {
             crate::state_parts_from_node(

--- a/tools/state-parts/src/lib.rs
+++ b/tools/state-parts/src/lib.rs
@@ -130,7 +130,7 @@ async fn state_parts_from_node(
             anyhow::bail!("Error connecting to {:?}: {}", peer_addr, e);
         }
     };
-    tracing::info!(target: "state-parts", ?peer_addr, ?peer_id, "connected to peer");
+    tracing::info!(?peer_addr, ?peer_id, "connected to peer");
 
     let next_request = tokio::time::sleep(std::time::Duration::ZERO);
     tokio::pin!(next_request);
@@ -143,10 +143,10 @@ async fn state_parts_from_node(
             _ = &mut next_request => {
                 let target = &peer_id;
                 let msg = DirectMessage::StateRequestPart(shard_id, block_hash, part_id);
-                tracing::info!(target: "state-parts", ?target, %shard_id, ?block_hash, part_id, ttl, "sending a request");
+                tracing::info!(?target, %shard_id, ?block_hash, part_id, ttl, "sending a request");
                 result = peer.send_message(msg).await.with_context(|| format!("Failed sending State Part Request to {:?}", target));
                 app_info.requests_sent.insert(part_id, near_time::Instant::now());
-                tracing::info!(target: "state-parts", ?result);
+                tracing::info!(?result);
                 if result.is_err() {
                     break;
                 }

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -594,7 +594,6 @@ pub fn apply_chain_range(
     storage: StorageSource,
 ) {
     let parent_span = tracing::debug_span!(
-        target: "state_viewer",
         "apply_chain_range",
         ?mode,
         ?start_height,
@@ -713,7 +712,6 @@ pub fn apply_chain_range(
         ApplyRangeMode::Sequential { .. } => {
             range.clone().into_iter().for_each(|height| {
                 let _span = tracing::debug_span!(
-                    target: "state_viewer",
                     parent: &parent_span,
                     "process_block",
                     height)
@@ -724,7 +722,6 @@ pub fn apply_chain_range(
         ApplyRangeMode::Parallel => {
             range.clone().into_par_iter().for_each(|height| {
                 let _span = tracing::debug_span!(
-                target: "mock_node",
                 parent: &parent_span,
                 "process_block",
                 height)
@@ -802,7 +799,6 @@ fn benchmark_chunk_application(
         let cur_input = input.clone();
 
         let _span = tracing::debug_span!(
-            target: "state_viewer",
             parent: &parent_span,
             "process_block",
             height)

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -64,7 +64,7 @@ fn get_incoming_receipts(
                 }
             }
         } else {
-            tracing::error!(target: "state-viewer", chunk_hash = ?chunk.chunk_hash(), "failed to get a partial chunk");
+            tracing::error!(chunk_hash = ?chunk.chunk_hash(), "failed to get a partial chunk");
         }
     }
 
@@ -311,7 +311,7 @@ fn apply_tx_in_chunk(
                 let chunk = match chain_store.get_chunk(&chunk_hash) {
                     Ok(c) => c,
                     Err(_) => {
-                        tracing::warn!(target: "state-viewer", chunk_hash = ?&chunk_hash, "chunk hash appears in DBCol::ChunkHashesByHeight but the chunk is not saved");
+                        tracing::warn!(chunk_hash = ?&chunk_hash, "chunk hash appears in DBCol::ChunkHashesByHeight but the chunk is not saved");
                         continue;
                     }
                 };
@@ -446,7 +446,7 @@ fn apply_receipt_in_chunk(
                 let chunk = match chain_store.get_chunk(&chunk_hash) {
                     Ok(c) => c,
                     Err(_) => {
-                        tracing::warn!(target: "state-viewer", chunk_hash = ?&chunk_hash, "chunk hash appears in DBCol::ChunkHashesByHeight but the chunk is not saved");
+                        tracing::warn!(chunk_hash = ?&chunk_hash, "chunk hash appears in DBCol::ChunkHashesByHeight but the chunk is not saved");
                         continue;
                     }
                 };

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -856,7 +856,7 @@ pub(crate) fn view_genesis(
     );
 
     if view_config || compare {
-        tracing::info!(target: "state_viewer", "computing genesis from config");
+        tracing::info!("computing genesis from config");
         let state_roots =
             near_store::get_genesis_state_roots(&chain_store.store()).unwrap().unwrap();
         let (genesis_block, genesis_chunks) = Chain::make_genesis_block(
@@ -891,7 +891,7 @@ pub(crate) fn view_genesis(
     }
 
     if view_store {
-        tracing::info!(target: "state_viewer", genesis_height, "reading genesis from store");
+        tracing::info!(genesis_height, "reading genesis from store");
         match read_genesis_from_store(&chain_store, genesis_height) {
             Ok((genesis_block, genesis_chunks)) => {
                 println!("Genesis block from store: {:#?}", genesis_block);
@@ -1412,8 +1412,8 @@ fn print_state_stats_for_shard_uid(
         current_size = new_size;
     }
 
-    tracing::info!(target: "state_viewer", ?shard_uid);
-    tracing::info!(target: "state_viewer", ?state_stats);
+    tracing::info!(?shard_uid);
+    tracing::info!(?state_stats);
 }
 
 /// Gets the flat state iterator from the chunk view, rearranges it to be sorted

--- a/tools/state-viewer/src/scan_db.rs
+++ b/tools/state-viewer/src/scan_db.rs
@@ -47,7 +47,7 @@ pub(crate) fn scan_db_column(
     store: Store,
 ) {
     let db_col: DBCol = find_db_col(col);
-    tracing::info!(target: "scan", ?db_col);
+    tracing::info!(?db_col);
     for (key, value) in
         store.iter_range(db_col, lower_bound, upper_bound).take(max_keys.unwrap_or(usize::MAX))
     {

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -339,7 +339,7 @@ async fn load_state_parts(
             let sync_hash = match chain.get_sync_hash(&sync_hash).unwrap() {
                 Some(h) => h,
                 None => {
-                    tracing::warn!(target: "state-parts", ?epoch_id, "sync hash not yet known");
+                    tracing::warn!(?epoch_id, "sync hash not yet known");
                     return;
                 }
             };
@@ -365,7 +365,6 @@ async fn load_state_parts(
     assert_eq!(Some(num_parts), get_num_parts_from_filename(&part_file_names[0]));
     let part_ids = get_part_ids(part_id, part_id.map(|x| x + 1), num_parts);
     tracing::info!(
-        target: "state-parts",
         epoch_height,
         %shard_id,
         num_parts,
@@ -401,7 +400,12 @@ async fn load_state_parts(
                         &epoch_id,
                     )
                     .unwrap();
-                tracing::info!(target: "state-parts", part_id, part_length, elapsed_sec = timer.elapsed().as_secs_f64(), "loaded a state part");
+                tracing::info!(
+                    part_id,
+                    part_length,
+                    elapsed_sec = timer.elapsed().as_secs_f64(),
+                    "loaded a state part"
+                );
             }
             LoadAction::Validate => {
                 assert!(matches!(
@@ -413,7 +417,12 @@ async fn load_state_parts(
                     ),
                     near_chain::types::StatePartValidationResult::Valid
                 ));
-                tracing::info!(target: "state-parts", part_id, part_length, elapsed_sec = timer.elapsed().as_secs_f64(), "validated a state part");
+                tracing::info!(
+                    part_id,
+                    part_length,
+                    elapsed_sec = timer.elapsed().as_secs_f64(),
+                    "validated a state part"
+                );
             }
             LoadAction::Print => {
                 let trie_nodes = part.to_partial_state().unwrap();
@@ -421,7 +430,10 @@ async fn load_state_parts(
             }
         }
     }
-    tracing::info!(target: "state-parts", total_elapsed_sec = timer.elapsed().as_secs_f64(), "loaded all requested state parts");
+    tracing::info!(
+        total_elapsed_sec = timer.elapsed().as_secs_f64(),
+        "loaded all requested state parts"
+    );
 }
 
 fn print_state_part(state_root: &StateRoot, _part_id: PartId, trie_nodes: PartialState) {
@@ -456,7 +468,7 @@ async fn dump_state_parts(
     let sync_hash = match chain.get_sync_hash(&sync_hash).unwrap() {
         Some(h) => h,
         None => {
-            tracing::warn!(target: "state-parts", ?epoch_id, "sync hash not yet known");
+            tracing::warn!(?epoch_id, "sync hash not yet known");
             return;
         }
     };
@@ -472,7 +484,6 @@ async fn dump_state_parts(
     let epoch_height = epoch.epoch_height();
 
     tracing::info!(
-        target: "state-parts",
         epoch_height,
         epoch_id = ?epoch_id.0,
         %shard_id,
@@ -497,7 +508,10 @@ async fn dump_state_parts(
             .put_file(file_type, &state_sync_header_buf, shard_id, &location)
             .await
             .expect("Failed to put header into external storage.");
-        tracing::info!(target: "state-parts", elapsed_sec = timer.elapsed().as_secs_f64(), "header saved to external storage");
+        tracing::info!(
+            elapsed_sec = timer.elapsed().as_secs_f64(),
+            "header saved to external storage"
+        );
     }
 
     // dump parts
@@ -529,14 +543,16 @@ async fn dump_state_parts(
         let trie_nodes = state_part.to_partial_state().unwrap();
         let first_state_record = get_first_state_record(&state_root, trie_nodes);
         tracing::info!(
-            target: "state-parts",
             part_id,
             part_length = bytes.len(),
             elapsed_sec,
             first_state_record = ?first_state_record.map(|sr| format!("{}", sr)),
             "wrote a state part");
     }
-    tracing::info!(target: "state-parts", total_elapsed_sec = timer.elapsed().as_secs_f64(), "wrote all requested state parts");
+    tracing::info!(
+        total_elapsed_sec = timer.elapsed().as_secs_f64(),
+        "wrote all requested state parts"
+    );
 }
 
 /// Returns the first `StateRecord` encountered while iterating over a sub-trie in the state part.
@@ -566,13 +582,13 @@ fn read_state_header(
     let sync_hash = match chain.get_sync_hash(&sync_hash).unwrap() {
         Some(h) => h,
         None => {
-            tracing::warn!(target: "state-parts", ?epoch_id, "sync hash not yet known");
+            tracing::warn!(?epoch_id, "sync hash not yet known");
             return;
         }
     };
 
     let state_header = chain.chain_store().get_state_header(shard_id, sync_hash);
-    tracing::info!(target: "state-parts", ?epoch_id, ?sync_hash, ?state_header);
+    tracing::info!(?epoch_id, ?sync_hash, ?state_header);
 }
 
 fn finalize_state_sync(sync_hash: CryptoHash, shard_id: ShardId, chain: &mut Chain) {

--- a/tools/state-viewer/src/trie_iteration_benchmark.rs
+++ b/tools/state-viewer/src/trie_iteration_benchmark.rs
@@ -194,7 +194,6 @@ impl TrieIterationBenchmarkCmd {
                 }
             };
             tracing::trace!(
-                target: "trie-iteration-benchmark",
                 column = &state_record.get_type_string(),
                 account_id = %state_record_to_account_id(&state_record),
                 "visiting column and account id"
@@ -280,7 +279,6 @@ impl TrieIterationBenchmarkCmd {
         match parse_account_id_from_trie_key_with_separator(col, &key, "") {
             Ok(account_id) => {
                 tracing::trace!(
-                    target: "trie-iteration-benchmark",
                     %col_name,
                     ?account_id,
                     "pruning column and account id"
@@ -296,7 +294,6 @@ impl TrieIterationBenchmarkCmd {
         match parse_account_id_from_access_key_key(&key) {
             Ok(account_id) => {
                 tracing::trace!(
-                    target: "trie-iteration-benchmark",
                     %col_name,
                     ?account_id,
                     "pruning column and account id"

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -13,16 +13,16 @@ use std::fs::File;
 async fn main() -> anyhow::Result<()> {
     let env_filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish().unwrap();
     let _subscriber = near_o11y::default_subscriber(env_filter, &Default::default()).global();
-    tracing::debug!(target: "storage-calculator", "reading genesis");
+    tracing::debug!("reading genesis");
 
     let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full)?;
-    tracing::debug!(target: "storage-calculator", "genesis read");
+    tracing::debug!("genesis read");
 
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION);
     let storage_usage_config = &config.fees.storage_usage_config;
     let storage_usage = compute_genesis_storage_usage(&genesis, storage_usage_config);
-    tracing::debug!(target: "storage-calculator", "storage usage calculated");
+    tracing::debug!("storage usage calculated");
 
     let mut result = Vec::new();
     genesis.for_each_record(|record| {

--- a/tools/undo-block/src/lib.rs
+++ b/tools/undo-block/src/lib.rs
@@ -18,7 +18,13 @@ pub fn undo_block(
     let current_head_height = current_head.height;
     let prev_block_height = prev_tip.height;
 
-    tracing::info!(target: "neard", ?prev_block_hash, ?current_head_hash, ?prev_block_height, ?current_head_height, "trying to update head");
+    tracing::info!(
+        ?prev_block_hash,
+        ?current_head_hash,
+        ?prev_block_height,
+        ?current_head_height,
+        "trying to update head"
+    );
 
     // stop if it's already the final block
     if chain_store.final_head()?.height >= current_head.height {
@@ -43,7 +49,7 @@ pub fn undo_block(
     let new_head_height = new_chain_store_head.height;
     let new_header_height = new_chain_store_header_head.height;
 
-    tracing::info!(target: "neard", ?new_head_height, ?new_header_height, "the current chain store shows");
+    tracing::info!(?new_head_height, ?new_header_height, "the current chain store shows");
     Ok(())
 }
 
@@ -60,10 +66,15 @@ pub fn undo_only_block_head(
     let tail_header = chain_store.get_block_header_by_height(tail_height)?;
     let new_head = Tip::from_header(&tail_header);
 
-    tracing::info!(target: "neard", ?tail_height, ?current_head_height, ?current_header_height, "trying to update head");
+    tracing::info!(
+        ?tail_height,
+        ?current_head_height,
+        ?current_header_height,
+        "trying to update head"
+    );
 
     if current_head_height == tail_height {
-        tracing::info!(target: "neard", "body head is already at the oldest block");
+        tracing::info!("body head is already at the oldest block");
         return Ok(());
     }
 
@@ -77,6 +88,6 @@ pub fn undo_only_block_head(
     let new_head_height = new_chain_store_head.height;
     let new_header_height = new_chain_store_header_head.height;
 
-    tracing::info!(target: "neard", ?new_head_height, ?new_header_height, "the current chain store shows");
+    tracing::info!(?new_head_height, ?new_header_height, "the current chain store shows");
     Ok(())
 }

--- a/utils/config/src/lib.rs
+++ b/utils/config/src/lib.rs
@@ -124,7 +124,7 @@ impl ValidationErrors {
     /// should only be used when you finished inserting all errors
     pub fn return_ok_or_error(&self) -> anyhow::Result<()> {
         if self.0.is_empty() {
-            tracing::info!(target: "config", "all validations have passed");
+            tracing::info!("all validations have passed");
             Ok(())
         } else {
             Err(anyhow::Error::msg(format!(

--- a/utils/fmt/src/lib.rs
+++ b/utils/fmt/src/lib.rs
@@ -22,8 +22,7 @@ use std::str::FromStr;
 /// example:
 ///
 /// ```ignore
-/// tracing::trace!(target: "state",
-///                 db_op = "insert",
+/// tracing::trace!(db_op = "insert",
 ///                 key = %near_fmt::Bytes(key),
 ///                 size = value.len())
 /// ```
@@ -141,8 +140,7 @@ impl<'a> std::fmt::Display for AbbrBytes<Option<&'a [u8]>> {
 /// example:
 ///
 /// ```ignore
-/// tracing::info!(target: "store",
-///                op = "set",
+/// tracing::info!(op = "set",
 ///                col = %col,
 ///                key = %near_fmt::StorageKey(key),
 ///                size = value.len())


### PR DESCRIPTION
Remove target: "…" from all tracing event/span macros and target = "…" from all #[instrument] attributes across the codebase (258 files, ~2,400 removals). The tracing default target — the module path — is sufficient for filtering and grouping in all cases.

docs/practices/style.md is updated to codify this: do not set an explicit target unless a custom subscriber layer dispatches on it. The io_trace! macro targets ("io_tracer" / "io_tracer_count") are the one exception and are intentionally preserved — the IoTraceLayer subscriber dispatches on them at runtime.