### PR TITLE
refactor(tracing): 2/7 remove explicit target from core tracing

### DIFF
--- a/core/async/src/multithread/sender.rs
+++ b/core/async/src/multithread/sender.rs
@@ -15,7 +15,7 @@ where
     fn send(&self, message: M) {
         let seq = next_message_sequence_num();
         let message_type = pretty_type_name::<M>();
-        tracing::trace!(target: "multithread_runtime", seq, message_type, "sending sync message");
+        tracing::trace!(seq, message_type, "sending sync message");
 
         let function = |actor: &mut A| {
             actor.handle(message);
@@ -28,7 +28,7 @@ where
             function: Box::new(function),
         };
         if let Err(_) = self.send_message(message) {
-            tracing::info!(target: "multithread_runtime", seq, "ignoring sync message, receiving actor is being shut down");
+            tracing::info!(seq, "ignoring sync message, receiving actor is being shut down");
         }
     }
 }
@@ -42,7 +42,7 @@ where
     fn send_async(&self, message: M) -> BoxFuture<'static, Result<R, AsyncSendError>> {
         let seq = next_message_sequence_num();
         let message_type = pretty_type_name::<M>();
-        tracing::trace!(target: "multithread_runtime", seq, message_type, ?message, "sending async message");
+        tracing::trace!(seq, message_type, ?message, "sending async message");
 
         let (sender, receiver) = tokio::sync::oneshot::channel();
         let future = async move { receiver.await.map_err(|_| AsyncSendError::Dropped) };

--- a/core/async/src/test_loop/mod.rs
+++ b/core/async/src/test_loop/mod.rs
@@ -203,7 +203,7 @@ impl TestLoopV2 {
         });
         let shutting_down = Arc::new(AtomicBool::new(false));
         // Needed for the log visualizer to know when the test loop starts.
-        tracing::info!(target: "test_loop", "TEST_LOOP_INIT");
+        tracing::info!("TEST_LOOP_INIT");
         Self {
             data: TestLoopData::new(raw_pending_events_sender.clone(), shutting_down.clone()),
             events: BinaryHeap::new(),
@@ -363,7 +363,7 @@ impl TestLoopV2 {
         })
         .unwrap();
         // TODO(logging): testloop visualizer may have a dependency on seeing the trace in this specific format
-        tracing::info!(target: "test_loop", "TEST_LOOP_EVENT_START {}", start_json);
+        tracing::info!("TEST_LOOP_EVENT_START {}", start_json);
         assert_eq!(self.current_time, event.due);
 
         if !event_ignored {
@@ -382,7 +382,7 @@ impl TestLoopV2 {
             serde_json::to_string(&EventEndLogOutput { total_events: self.next_event_index })
                 .unwrap();
         // TODO(logging): testloop visualizer may have a dependency on seeing the trace in this specific format
-        tracing::info!(target: "test_loop", "TEST_LOOP_EVENT_END {}", end_json);
+        tracing::info!("TEST_LOOP_EVENT_END {}", end_json);
     }
 
     /// Runs the test loop for the given duration. This function may be called
@@ -456,7 +456,7 @@ impl Drop for TestLoopV2 {
             }
         }
         // Needed for the log visualizer to know when the test loop ends.
-        tracing::info!(target: "test_loop", "TEST_LOOP_SHUTDOWN");
+        tracing::info!("TEST_LOOP_SHUTDOWN");
     }
 }
 

--- a/core/async/src/tokio/futures.rs
+++ b/core/async/src/tokio/futures.rs
@@ -31,7 +31,7 @@ impl CancellableFutureSpawner {
 
 impl FutureSpawner for CancellableFutureSpawner {
     fn spawn_boxed(&self, description: &'static str, f: crate::futures::BoxFuture<'static, ()>) {
-        tracing::trace!(target: "cancellable_tokio_runtime", description, "spawning future");
+        tracing::trace!(description, "spawning future");
         self.runtime_handle.spawn(f);
     }
 }

--- a/core/async/src/tokio/runtime_handle.rs
+++ b/core/async/src/tokio/runtime_handle.rs
@@ -173,21 +173,21 @@ impl<A: Actor + Send + 'static> TokioRuntimeBuilder<A> {
             loop {
                 tokio::select! {
                     _ = self.system_cancellation_signal.cancelled() => {
-                        tracing::debug!(target: "tokio_runtime", actor_name, "shutting down tokio runtime due to actor system shutdown");
+                        tracing::debug!(actor_name, "shutting down tokio runtime due to actor system shutdown");
                         break;
                     }
                     _ = runtime_handle.cancel.cancelled() => {
-                        tracing::debug!(target: "tokio_runtime", actor_name, "shutting down tokio runtime due to targeted cancellation");
+                        tracing::debug!(actor_name, "shutting down tokio runtime due to targeted cancellation");
                         break;
                     }
                     _ = window_update_timer.tick() => {
-                        tracing::trace!(target: "tokio_runtime", "advancing instrumentation window");
+                        tracing::trace!("advancing instrumentation window");
                         shared_instrumentation.with_thread_local_writer(|writer| writer.advance_window_if_needed());
                     }
                     Some(message) = receiver.recv() => {
                         let seq = message.seq;
                         shared_instrumentation.queue().dequeue(message.name);
-                        tracing::trace!(target: "tokio_runtime", seq, actor_name, "executing message");
+                        tracing::trace!(seq, actor_name, "executing message");
                         let dequeue_time_ns = shared_instrumentation.current_time().saturating_sub(message.enqueued_time_ns);
                         shared_instrumentation.with_thread_local_writer(|writer| writer.start_event(message.name, dequeue_time_ns));
                         (message.function)(&mut actor.actor, &mut runtime_handle);

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -678,7 +678,7 @@ impl Genesis {
         match genesis_validation {
             GenesisValidationMode::Full => validate_genesis(self),
             GenesisValidationMode::UnsafeFast => {
-                tracing::warn!(target: "genesis", "skipped genesis validation");
+                tracing::warn!("skipped genesis validation");
                 Ok(())
             }
         }

--- a/core/chain-configs/src/genesis_validate.rs
+++ b/core/chain-configs/src/genesis_validate.rs
@@ -16,7 +16,7 @@ pub fn validate_genesis(genesis: &Genesis) -> Result<(), ValidationError> {
     }
     let mut validation_errors = ValidationErrors::new();
     let mut genesis_validator = GenesisValidator::new(&genesis.config, &mut validation_errors);
-    tracing::info!(target: "config", "validating genesis config and records, this could take a few minutes");
+    tracing::info!("validating genesis config and records, this could take a few minutes");
     genesis.for_each_record(|record: &StateRecord| {
         genesis_validator.process_record(record);
     });

--- a/core/chain-configs/src/updatable_config.rs
+++ b/core/chain-configs/src/updatable_config.rs
@@ -75,13 +75,13 @@ impl<T: Clone + PartialEq + Debug> MutableConfigValue<T> {
     pub fn update(&self, val: T) -> bool {
         let mut lock = self.value.lock();
         if *lock != val {
-            tracing::info!(target: "config", field_name = self.field_name, old_value = ?*lock, new_value = ?val, "updated config field");
+            tracing::info!(field_name = self.field_name, old_value = ?*lock, new_value = ?val, "updated config field");
             self.set_metric_value(lock.clone(), 0);
             *lock = val.clone();
             self.set_metric_value(val, 1);
             true
         } else {
-            tracing::info!(target: "config", field_name = self.field_name, value = ?val, "mutable config field remains the same");
+            tracing::info!(field_name = self.field_name, value = ?val, "mutable config field remains the same");
             false
         }
     }

--- a/core/external-storage/src/lib.rs
+++ b/core/external-storage/src/lib.rs
@@ -73,14 +73,17 @@ impl ExternalConnection {
             ExternalStorageLocation::GCS { bucket, .. } => {
                 if let Some(credentials_file) = credentials_file {
                     if let Ok(var) = std::env::var("SERVICE_ACCOUNT") {
-                        tracing::warn!(target: "external", %var, ?credentials_file, "environment variable `SERVICE_ACCOUNT` is set, but `credentials_file` in config.json overrides it");
+                        tracing::warn!(%var, ?credentials_file, "environment variable `SERVICE_ACCOUNT` is set, but `credentials_file` in config.json overrides it");
                         println!(
                             "Environment variable 'SERVICE_ACCOUNT' is set to {var}, but 'credentials_file' in config.json overrides it to '{credentials_file:?}'"
                         );
                     }
                     // SAFE: no threads *yet*.
                     unsafe { std::env::set_var("SERVICE_ACCOUNT", &credentials_file) };
-                    tracing::info!(target: "external", ?credentials_file, "set the environment variable `SERVICE_ACCOUNT`");
+                    tracing::info!(
+                        ?credentials_file,
+                        "set the environment variable `SERVICE_ACCOUNT`"
+                    );
                 }
                 ExternalConnection::GCS {
                     gcs_client: Arc::new(
@@ -100,7 +103,7 @@ impl ExternalConnection {
     pub async fn get(&self, path: &str) -> Result<Vec<u8>, anyhow::Error> {
         match self {
             ExternalConnection::S3 { bucket } => {
-                tracing::debug!(target: "external", path, "reading from S3");
+                tracing::debug!(path, "reading from S3");
                 let response = bucket.get_object(path).await?;
                 if response.status_code() == 200 {
                     Ok(response.bytes().to_vec())
@@ -110,7 +113,7 @@ impl ExternalConnection {
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(path);
-                tracing::debug!(target: "external", ?path, "reading a file");
+                tracing::debug!(?path, "reading a file");
                 let data = std::fs::read(&path)?;
                 Ok(data)
             }
@@ -122,7 +125,7 @@ impl ExternalConnection {
                     percent_encoding::percent_encode(bucket.as_bytes(), GCS_ENCODE_SET),
                     percent_encoding::percent_encode(path.as_bytes(), GCS_ENCODE_SET),
                 );
-                tracing::debug!(target: "external", url, "reading from GCS");
+                tracing::debug!(url, "reading from GCS");
                 let response = reqwest_client.get(&url).send().await?.error_for_status();
                 match response {
                     Err(e) => Err(e.into()),
@@ -139,13 +142,13 @@ impl ExternalConnection {
     pub async fn put(&self, path: &str, value: &[u8]) -> Result<(), anyhow::Error> {
         match self {
             ExternalConnection::S3 { bucket } => {
-                tracing::debug!(target: "external", path, "writing to S3");
+                tracing::debug!(path, "writing to S3");
                 bucket.put_object(path, value).await?;
                 Ok(())
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(path);
-                tracing::debug!(target: "external", ?path, "writing to a file");
+                tracing::debug!(?path, "writing to a file");
                 if let Some(parent_dir) = path.parent() {
                     std::fs::create_dir_all(parent_dir)?;
                 }
@@ -160,7 +163,7 @@ impl ExternalConnection {
             ExternalConnection::GCS { gcs_client, .. } => {
                 let path = object_store::path::Path::parse(path)
                     .with_context(|| format!("{path} isn't a valid path for GCP"))?;
-                tracing::debug!(target: "external", ?path, "writing to GCS");
+                tracing::debug!(?path, "writing to GCS");
                 gcs_client.put(&path, PutPayload::from_bytes(value.to_vec().into())).await?;
                 Ok(())
             }
@@ -176,7 +179,7 @@ impl ExternalConnection {
             ExternalConnection::S3 { bucket } => {
                 let prefix = format!("{}/", directory_path);
                 let list_results = bucket.list(prefix.clone(), Some("/".to_string())).await?;
-                tracing::debug!(target: "external", directory_path, "list directory in S3");
+                tracing::debug!(directory_path, "list directory in S3");
                 let mut file_names = vec![];
                 for res in list_results {
                     for obj in res.contents {
@@ -187,7 +190,7 @@ impl ExternalConnection {
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(directory_path);
-                tracing::debug!(target: "external", ?path, "list files in local directory");
+                tracing::debug!(?path, "list files in local directory");
                 std::fs::create_dir_all(&path)?;
                 let mut file_names = vec![];
                 let files = std::fs::read_dir(&path)?;
@@ -199,7 +202,7 @@ impl ExternalConnection {
             }
             ExternalConnection::GCS { gcs_client, .. } => {
                 let prefix = format!("{}/", directory_path);
-                tracing::debug!(target: "external", directory_path, "list directory in GCS");
+                tracing::debug!(directory_path, "list directory in GCS");
                 Ok(gcs_client
                     .list(Some(
                         &object_store::path::Path::parse(&prefix)

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -27,8 +27,8 @@ pub mod testonly;
 #[macro_export]
 #[cfg(feature = "io_trace")]
 macro_rules! io_trace {
-    (count: $name:expr) => { tracing::trace!( target: "io_tracer_count", counter = $name) };
-    ($($fields:tt)*) => { tracing::trace!( target: "io_tracer", $($fields)*) };
+    (count: $name:expr) => { tracing::trace!(target: "io_tracer_count", counter = $name) };
+    ($($fields:tt)*) => { tracing::trace!(target: "io_tracer", $($fields)*) };
 }
 
 #[macro_export]

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -184,7 +184,7 @@ impl Block {
         let (time, vrf_value, vrf_proof, random_value) = optimistic_block
             .as_ref()
             .map(|ob| {
-                tracing::debug!(target: "client", "taking metadata from optimistic block");
+                tracing::debug!("taking metadata from optimistic block");
                 (
                     ob.inner.block_timestamp,
                     ob.inner.vrf_value,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1387,7 +1387,6 @@ impl EncodedShardChunk {
 
     pub fn decode_chunk(&self) -> Result<ShardChunk, std::io::Error> {
         let _span = debug_span!(
-            target: "sharding",
             "decode_chunk",
             height_included = self.cloned_header().height_included(),
             shard_id = %self.cloned_header().shard_id(),

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -967,7 +967,7 @@ impl TestBlockBuilder {
     }
 
     pub fn build(self) -> Arc<Block> {
-        tracing::debug!(target: "test", height=self.height, ?self.epoch_id, "produce block");
+        tracing::debug!(height=self.height, ?self.epoch_id, "produce block");
         let last_certified_block_execution_results = BlockExecutionResults(
             self.chunks
                 .iter()

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -83,7 +83,6 @@ impl ProtocolUpgradeVotingSchedule {
                 client_protocol_version,
             )?;
             tracing::warn!(
-                target: "protocol_upgrade",
                 ?schedule,
                 "setting protocol upgrade override, this is fine in tests but should be avoided otherwise"
             );
@@ -119,7 +118,7 @@ impl ProtocolUpgradeVotingSchedule {
             }
         }
 
-        tracing::debug!(target: "protocol_upgrade", ?schedule, "created protocol upgrade schedule");
+        tracing::debug!(?schedule, "created protocol upgrade schedule");
 
         Ok(Self { client_protocol_version, schedule })
     }

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -373,7 +373,7 @@ macro_rules! unwrap_or_return {
         match $obj {
             Ok(value) => value,
             Err(err) => {
-                tracing::error!(target: "near", ?err, "unwrap error");
+                tracing::error!(?err, "unwrap error");
                 return $ret;
             }
         }
@@ -382,7 +382,7 @@ macro_rules! unwrap_or_return {
         match $obj {
             Ok(value) => value,
             Err(err) => {
-                tracing::error!(target: "near", ?err, "unwrap error");
+                tracing::error!(?err, "unwrap error");
                 return;
             }
         }
@@ -445,7 +445,7 @@ where
 /// it shows its json representation. It is used to display complex
 /// objects using tracing.
 ///
-/// tracing::debug!(target: "diagnostic", value=%ser(&object));
+/// tracing::debug!(value=%ser(&object));
 pub fn ser<T>(object: &T) -> Serializable<'_, T>
 where
     T: serde::Serialize,

--- a/core/store/src/adapter/flat_store.rs
+++ b/core/store/src/adapter/flat_store.rs
@@ -118,7 +118,7 @@ impl FlatStoreAdapter {
                         if flat_head.hash == prev_hash {
                             Some(BlockWithChangesInfo { hash: prev_hash, height: flat_head.height })
                         } else {
-                            tracing::error!(target: "store", ?block_hash, ?prev_hash, "missing delta metadata");
+                            tracing::error!(?block_hash, ?prev_hash, "missing delta metadata");
                             None
                         }
                     }

--- a/core/store/src/db/rocksdb/instance_tracker.rs
+++ b/core/store/src/db/rocksdb/instance_tracker.rs
@@ -58,7 +58,7 @@ impl State {
             inner.count += 1;
             inner.count
         };
-        tracing::info!(target: "db", num_instances, "opened a new rocksdb instance");
+        tracing::info!(num_instances, "opened a new rocksdb instance");
         Ok(())
     }
 
@@ -72,18 +72,20 @@ impl State {
             }
             inner.count
         };
-        tracing::info!(target: "db", num_instances, "closed a rocksdb instance");
+        tracing::info!(num_instances, "closed a rocksdb instance");
     }
 
     /// Blocks until all RocksDB instances (usually 0 or 1) shut down.
     fn block_until_all_instances_are_closed(&self) {
         let mut inner = self.inner.lock();
         while inner.count != 0 {
-            tracing::info!(target: "db", num_instances=inner.count,
-                  "waiting for remaining rocksdb instances to close");
+            tracing::info!(
+                num_instances = inner.count,
+                "waiting for remaining rocksdb instances to close"
+            );
             self.zero_cvar.wait(&mut inner);
         }
-        tracing::info!(target: "db", "all rocksdb instances closed");
+        tracing::info!("all rocksdb instances closed");
     }
 }
 

--- a/core/store/src/db/rocksdb/snapshot.rs
+++ b/core/store/src/db/rocksdb/snapshot.rs
@@ -91,7 +91,7 @@ impl Snapshot {
             None => return Ok(Self::none()),
         };
 
-        tracing::info!(target: "db", snapshot_path = %snapshot_path.display(), "creating database snapshot");
+        tracing::info!(snapshot_path = %snapshot_path.display(), "creating database snapshot");
         if snapshot_path.exists() {
             return Err(SnapshotError::AlreadyExists(snapshot_path));
         }
@@ -108,7 +108,7 @@ impl Snapshot {
     /// Does nothing if the object has been created via [`Self::none`].
     pub fn remove(mut self) -> Result<(), SnapshotRemoveError> {
         if let Some(path) = self.0.take() {
-            tracing::info!(target: "db", snapshot_path = %path.display(), "deleting the database snapshot");
+            tracing::info!(snapshot_path = %path.display(), "deleting the database snapshot");
             std::fs::remove_dir_all(&path).map_err(|error| SnapshotRemoveError { path, error })
         } else {
             Ok(())
@@ -124,8 +124,8 @@ impl std::ops::Drop for Snapshot {
     /// system and how to recover data from it.
     fn drop(&mut self) {
         if let Some(path) = &self.0 {
-            tracing::info!(target: "db", snapshot_path = %path.display(), "in case of issues, the database can be recovered from the database snapshot");
-            tracing::info!(target: "db", snapshot_path = %path.display(), "to recover from the snapshot, delete files in the database directory and replace them with contents of the snapshot directory");
+            tracing::info!(snapshot_path = %path.display(), "in case of issues, the database can be recovered from the database snapshot");
+            tracing::info!(snapshot_path = %path.display(), "to recover from the snapshot, delete files in the database directory and replace them with contents of the snapshot directory");
         }
     }
 }

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -127,7 +127,6 @@ impl FlatStorageInner {
         );
         if blocks.len() >= Self::HOPS_LIMIT {
             tracing::warn!(
-                target: "chain",
                 shard_id = %self.shard_uid.shard_id(),
                 flat_head_height = flat_head.height,
                 cached_deltas = self.deltas.len(),
@@ -157,7 +156,6 @@ impl FlatStorageInner {
         let cached_changes_size_bytes = bytesize::ByteSize(cached_changes_size);
         if cached_changes_size_bytes >= Self::CACHED_CHANGES_SIZE_LIMIT {
             tracing::warn!(
-                target: "chain",
                 shard_id = %self.shard_uid.shard_id(),
                 flat_head_height = self.flat_head.height,
                 cached_deltas,
@@ -373,14 +371,14 @@ impl FlatStorage {
 
         let new_head = guard.get_new_flat_head(*block_hash, strict)?;
         if new_head == guard.flat_head.hash {
-            tracing::debug!(target: "store", shard_id = %guard.shard_uid.shard_id(), height = %guard.flat_head.height, "update_flat_head, flat head already at block");
+            tracing::debug!(shard_id = %guard.shard_uid.shard_id(), height = %guard.flat_head.height, "update_flat_head, flat head already at block");
             return Ok(());
         }
 
         let shard_uid = guard.shard_uid;
         let shard_id = shard_uid.shard_id();
 
-        tracing::debug!(target: "store", flat_head = ?guard.flat_head.hash, ?new_head, %shard_id, "moving flat head");
+        tracing::debug!(flat_head = ?guard.flat_head.hash, ?new_head, %shard_id, "moving flat head");
         let blocks = guard.get_blocks_to_head(&new_head)?;
 
         for block_hash in blocks.into_iter().rev() {
@@ -426,7 +424,7 @@ impl FlatStorage {
             }
 
             store_update.commit().unwrap();
-            tracing::debug!(target: "store", %shard_id, %block_hash, %block_height, "moved flat storage head");
+            tracing::debug!(%shard_id, %block_hash, %block_height, "moved flat storage head");
         }
         guard.update_delta_metrics();
 
@@ -455,7 +453,7 @@ impl FlatStorage {
         let block = &delta.metadata.block;
         let block_hash = block.hash;
         let block_height = block.height;
-        tracing::debug!(target: "store", %shard_uid, %block_hash, %block_height, "adding block to flat storage");
+        tracing::debug!(%shard_uid, %block_hash, %block_height, "adding block to flat storage");
         if block.prev_hash != guard.flat_head.hash && !guard.deltas.contains_key(&block.prev_hash) {
             return Err(guard.create_block_not_supported_error(&block_hash));
         }

--- a/core/store/src/genesis/initialization.rs
+++ b/core/store/src/genesis/initialization.rs
@@ -55,7 +55,9 @@ pub fn initialize_sharded_genesis_state(
         let has_dump = home_dir.is_some_and(|dir| dir.join(STATE_DUMP_FILE).exists());
         let state_roots = if has_dump {
             if let GenesisContents::Records { .. } = &genesis.contents {
-                tracing::warn!(target: "store", "found both records in genesis config and the state dump file, will ignore the records");
+                tracing::warn!(
+                    "found both records in genesis config and the state dump file, will ignore the records"
+                );
             }
             genesis_state_from_dump(store.clone(), home_dir.unwrap())
         } else {
@@ -89,7 +91,9 @@ pub fn initialize_genesis_state(store: Store, genesis: &Genesis, home_dir: Optio
 }
 
 fn genesis_state_from_dump(store: Store, home_dir: &Path) -> Vec<StateRoot> {
-    tracing::error!(target: "near", "loading genesis from a state dump file, do not use this outside of genesis-tools");
+    tracing::error!(
+        "loading genesis from a state dump file, do not use this outside of genesis-tools"
+    );
     let mut state_file = home_dir.to_path_buf();
     state_file.push(STATE_DUMP_FILE);
     store.load_state_from_file(state_file.as_path()).expect("Failed to read state dump");
@@ -109,14 +113,12 @@ fn genesis_state_from_genesis(
     match &genesis.contents {
         GenesisContents::Records { records } => {
             tracing::info!(
-                target: "runtime",
                 num_records = records.0.len(),
                 "genesis state has records, computing state roots"
             )
         }
         GenesisContents::RecordsFile { records_file } => {
             tracing::info!(
-                target: "runtime",
                 path=%records_file.display(),
                 message="computing state roots from records",
             )
@@ -134,7 +136,7 @@ fn genesis_state_from_genesis(
     let mut shard_account_ids: BTreeMap<ShardId, HashSet<AccountId>> =
         shard_ids.iter().map(|&shard_id| (shard_id, HashSet::new())).collect();
     let mut has_protocol_account = false;
-    tracing::info!(target: "store","distributing records to shards");
+    tracing::info!("distributing records to shards");
 
     genesis.for_each_record(|record: &StateRecord| {
         let account_id = state_record_to_account_id(record).clone();

--- a/core/store/src/genesis/state_applier.rs
+++ b/core/store/src/genesis/state_applier.rs
@@ -143,7 +143,6 @@ impl<'a> AutoFlushingTrieUpdate<'a> {
     fn flush(&mut self) -> StateRoot {
         let Self { changes, state_root, state_update, .. } = self;
         tracing::info!(
-            target: "runtime",
             shard_uid=?self.shard_uid,
             %state_root,
             %changes,
@@ -185,11 +184,7 @@ impl GenesisStateApplier {
     ) {
         let mut postponed_receipts: Vec<Receipt> = vec![];
         let mut storage_computer = StorageComputer::new(config);
-        tracing::info!(
-            target: "runtime",
-            ?shard_uid,
-            "processing records…"
-        );
+        tracing::info!(?shard_uid, "processing records…");
         genesis.for_each_record(|record: &StateRecord| {
             if !account_ids.contains(state_record_to_account_id(record)) {
                 return;
@@ -224,7 +219,6 @@ impl GenesisStateApplier {
                             );
                         } else {
                             tracing::error!(
-                                target: "runtime",
                                 %account_id,
                                 code_hash = %code.hash(),
                                 message = "code for non-existent account",
@@ -273,11 +267,7 @@ impl GenesisStateApplier {
             }
         });
 
-        tracing::info!(
-            target: "runtime",
-            ?shard_uid,
-            "processing account storage…"
-        );
+        tracing::info!(?shard_uid, "processing account storage…");
         for (account_id, storage_usage) in storage_computer.finalize() {
             storage.modify(|state_update| {
                 let mut account = get_account(state_update, &account_id)
@@ -289,11 +279,7 @@ impl GenesisStateApplier {
         }
 
         // Processing postponed receipts after we stored all received data
-        tracing::info!(
-            target: "runtime",
-            ?shard_uid,
-            "processing postponed receipts…"
-        );
+        tracing::info!(?shard_uid, "processing postponed receipts…");
         for receipt in postponed_receipts {
             let account_id = receipt.receiver_id();
 

--- a/core/store/src/metrics/mod.rs
+++ b/core/store/src/metrics/mod.rs
@@ -609,23 +609,26 @@ pub static ROCKS_CURRENT_ITERATORS: LazyLock<IntGauge> = LazyLock::new(|| {
 
 fn export_store_stats(store: &Store, temperature: Temperature) {
     if let Some(stats) = store.get_store_statistics() {
-        tracing::debug!(target:"metrics", ?temperature, "exporting the db metrics for store");
+        tracing::debug!(?temperature, "exporting the db metrics for store");
         export_stats_as_metrics(stats, temperature);
     } else {
         // TODO Does that happen under normal circumstances?
         // Should this log be a warning or error instead?
-        tracing::debug!(target:"metrics", ?temperature, "exporting the db metrics for store failed, the statistics are missing");
+        tracing::debug!(
+            ?temperature,
+            "exporting the db metrics for store failed, the statistics are missing"
+        );
     }
 }
 
 pub fn spawn_db_metrics_loop(actor_system: ActorSystem, storage: &NodeStorage, period: Duration) {
-    tracing::debug!(target:"metrics", "spawning the db metrics loop");
+    tracing::debug!("spawning the db metrics loop");
 
     let hot_store = storage.get_hot_store();
     let cold_store = storage.get_cold_store();
 
     actor_system.new_future_spawner("db metrics loop").spawn("db metrics loop", async move {
-        tracing::debug!(target:"metrics", "starting the db metrics loop");
+        tracing::debug!("starting the db metrics loop");
         let start = tokio::time::Instant::now();
         let mut interval = tokio::time::interval_at(start, period.unsigned_abs());
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/core/store/src/metrics/rocksdb_metrics.rs
+++ b/core/store/src/metrics/rocksdb_metrics.rs
@@ -13,7 +13,7 @@ pub fn export_stats_as_metrics(stats: StoreStatistics, temperature: Temperature)
     match ROCKSDB_METRICS.lock().export_stats_as_metrics(stats, temperature) {
         Ok(_) => {}
         Err(err) => {
-            tracing::warn!(target:"stats", ?temperature, ?err, "failed to export store statistics");
+            tracing::warn!(?temperature, ?err, "failed to export store statistics");
         }
     }
 }

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -56,7 +56,6 @@ impl Store {
             self.storage.get_raw_bytes(column, &key)
         };
         tracing::trace!(
-            target: "store",
             db_op = "get",
             col = %column,
             key = %StorageKey(key),
@@ -88,7 +87,6 @@ impl Store {
                         Ok(result) => return Ok(Some(result)),
                         Err(_) => {
                             tracing::debug!(
-                                target: "store",
                                 requested = std::any::type_name::<T>(),
                                 "could not downcast an available cached deserialized value"
                             );
@@ -203,7 +201,6 @@ impl Store {
         level = "info",
         // FIXME: start moving things into tighter modules so that its easier to selectively trace
         // specific things.
-        target = "store",
         "Store::load_state_from_file",
         skip_all,
         fields(filename = %filename.display())
@@ -472,7 +469,6 @@ impl StoreUpdate {
 
     #[tracing::instrument(
         level = "trace",
-        target = "store::update",
         // FIXME: start moving things into tighter modules so that its easier to selectively trace
         // specific things.
         "StoreUpdate::commit",
@@ -535,11 +531,10 @@ impl StoreUpdate {
             span.record("delete_range_ops", delete_range_count);
             span.record("total_bytes", total_bytes);
         }
-        if tracing::event_enabled!(target: "store::update::transactions", tracing::Level::TRACE) {
+        if tracing::event_enabled!(tracing::Level::TRACE) {
             for op in &self.transaction.ops {
                 match op {
                     DBOp::Insert { col, key, value } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "insert",
                         %col,
                         key = %StorageKey(key),
@@ -547,7 +542,6 @@ impl StoreUpdate {
                         value = %AbbrBytes(value),
                     ),
                     DBOp::Set { col, key, value } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "set",
                         %col,
                         key = %StorageKey(key),
@@ -555,7 +549,6 @@ impl StoreUpdate {
                         value = %AbbrBytes(value)
                     ),
                     DBOp::UpdateRefcount { col, key, value } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "update_rc",
                         %col,
                         key = %StorageKey(key),
@@ -563,18 +556,15 @@ impl StoreUpdate {
                         value = %AbbrBytes(value)
                     ),
                     DBOp::Delete { col, key } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "delete",
                         %col,
                         key = %StorageKey(key)
                     ),
                     DBOp::DeleteAll { col } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "delete_all",
                         %col
                     ),
                     DBOp::DeleteRange { col, from, to } => tracing::trace!(
-                        target: "store::update::transactions",
                         db_op = "delete_range",
                         %col,
                         from = %StorageKey(from),

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -50,13 +50,13 @@ impl TrieConfig {
         for account in &config.sweat_prefetch_receivers {
             match AccountId::from_str(account) {
                 Ok(account_id) => this.sweat_prefetch_receivers.push(account_id),
-                Err(e) => tracing::error!(target: "config", %account, %e, "invalid account id"),
+                Err(e) => tracing::error!(%account, %e, "invalid account id"),
             }
         }
         for account in &config.sweat_prefetch_senders {
             match AccountId::from_str(account) {
                 Ok(account_id) => this.sweat_prefetch_senders.push(account_id),
-                Err(e) => tracing::error!(target: "config", %account, %e, "invalid account id"),
+                Err(e) => tracing::error!(%account, %e, "invalid account id"),
             }
         }
         this.claim_sweat_prefetch_config.clone_from(&config.claim_sweat_prefetch_config);

--- a/core/store/src/trie/mem/freelist.rs
+++ b/core/store/src/trie/mem/freelist.rs
@@ -66,7 +66,10 @@ impl VecU8Freelist {
                 if cfg!(debug_assertions) {
                     panic!("Too many freelist allocations; expected {}", self.expected_allocs);
                 } else {
-                    tracing::error!(target: "memtrie", expected_allocs = self.expected_allocs, "too many freelist allocations");
+                    tracing::error!(
+                        expected_allocs = self.expected_allocs,
+                        "too many freelist allocations"
+                    );
                 }
             }
             ReusableVecU8 { vec: Vec::new() }

--- a/core/store/src/trie/ops/iter.rs
+++ b/core/store/src/trie/ops/iter.rs
@@ -414,7 +414,7 @@ where
         path_begin: Option<&[u8]>,
         path_end: Option<&[u8]>,
     ) -> Result<Vec<TrieTraversalItem>, StorageError> {
-        let _span = tracing::debug_span!(target: "runtime", "visit_nodes_interval").entered();
+        let _span = tracing::debug_span!("visit_nodes_interval").entered();
         let path_begin = NibbleSlice::new(path_begin.unwrap_or(LAST_STATE_PART_BOUNDARY_NIBBLES));
         let path_end = match path_end {
             Some(p) => NibbleSlice::new(p).iter().collect_vec(),

--- a/core/store/src/trie/prefetching_trie_storage.rs
+++ b/core/store/src/trie/prefetching_trie_storage.rs
@@ -483,7 +483,6 @@ impl PrefetchApi {
                             }
                             Err(e) => {
                                 tracing::debug!(
-                                    target: "store::trie::prefetch",
                                     message = "prefetching failure",
                                     error = %e,
                                     key = ?trie_key

--- a/core/store/src/trie/split.rs
+++ b/core/store/src/trie/split.rs
@@ -257,7 +257,7 @@ impl<NodePtr: Debug + Copy> TrieDescentStage<NodePtr> {
     where
         Getter: Fn(NodePtr) -> Result<GenericTrieNodeWithSize<NodePtr, Value>, StorageError>,
     {
-        tracing::trace!(target = "memtrie", ?self, %nibble, "descending");
+        tracing::trace!(?self, %nibble, "descending");
         match self {
             Self::CutOff => {}
             Self::AtLeaf { .. } => *self = Self::CutOff,
@@ -409,7 +409,7 @@ where
     fn next_step(&self) -> FindSplitResult<Option<(u8, u64, u64)>> {
         // Stop when a leaf is reached in the accounts subtree
         if !self.accounts().can_descend() {
-            tracing::debug!(target = "memtrie", "leaf reached in accounts subtree");
+            tracing::debug!("leaf reached in accounts subtree");
             return Ok(None);
         }
 
@@ -421,14 +421,14 @@ where
         let children_mem_usage = self.aggregate_children_mem_usage()?;
 
         // Find the middle child
-        tracing::debug!(target = "memtrie", ?children_mem_usage, %threshold, "finding middle child");
+        tracing::debug!(?children_mem_usage, %threshold, "finding middle child");
         let Some((middle_child, left_mem_usage)) =
             find_middle_child(&children_mem_usage, threshold)
         else {
             return Ok(None);
         };
         let child_mem_usage = children_mem_usage[middle_child];
-        tracing::debug!(target = "memtrie", %middle_child, %child_mem_usage, %left_mem_usage, "middle child found");
+        tracing::debug!(%middle_child, %child_mem_usage, %left_mem_usage, "middle child found");
 
         // Stop if the further path does not exist in the accounts subtree
         let middle_child = middle_child as u8;
@@ -518,7 +518,7 @@ where
         self.right_memory +=
             self.middle_memory - left_mem_usage - child_mem_usage - parent_mem_usage;
         self.middle_memory = child_mem_usage;
-        tracing::debug!(target = "memtrie", %self.left_memory, %self.right_memory, %self.middle_memory, "remaining memory updated");
+        tracing::debug!(%self.left_memory, %self.right_memory, %self.middle_memory, "remaining memory updated");
 
         // Update descent stages for all subtrees
         let get_node = |ptr| self.trie_storage.get_node_with_size(ptr, AccessOptions::DEFAULT);
@@ -526,7 +526,7 @@ where
             stage.descend(nibble, get_node)?;
         }
         self.nibbles.push(nibble);
-        tracing::debug!(target = "memtrie", ?self.nibbles, nibble_str = String::from_utf8_lossy(&nibbles_to_bytes(&self.nibbles)).to_string(), "nibbles updated");
+        tracing::debug!(?self.nibbles, nibble_str = String::from_utf8_lossy(&nibbles_to_bytes(&self.nibbles)).to_string(), "nibbles updated");
         Ok(())
     }
 }

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -122,7 +122,6 @@ impl Trie {
             .as_ref()
             .map_or_else(ShardId::max, |chunk_view| chunk_view.shard_uid().shard_id());
         let _span = tracing::debug_span!(
-            target: "state-parts",
             "get_state_part_boundaries",
             %shard_id,
             part_id = part_id.idx,
@@ -144,13 +143,7 @@ impl Trie {
         let boundaries_read_duration = boundaries_read_timer.stop_and_record();
         let recorded_trie = recording_trie.recorded_storage().unwrap();
 
-        tracing::debug!(
-            target: "state-parts",
-            idx,
-            total,
-            ?boundaries_read_duration,
-            "found state part boundaries",
-        );
+        tracing::debug!(idx, total, ?boundaries_read_duration, "found state part boundaries",);
         Ok((recorded_trie.nodes, path_begin, path_end))
     }
 
@@ -169,7 +162,6 @@ impl Trie {
             .as_ref()
             .map_or_else(ShardId::max, |chunk_view| chunk_view.shard_uid().shard_id());
         let _span = tracing::debug_span!(
-            target: "state-parts",
             "get_trie_nodes_for_part_with_flat_storage",
             %shard_id,
             part_id = part_id.idx,
@@ -269,7 +261,6 @@ impl Trie {
         let in_memory_created_nodes =
             trie_values.iter().filter(|entry| !disk_read_hashes.contains(&hash(*entry))).count();
         tracing::debug!(
-            target: "state-parts",
             ?part_id,
             values_ref = value_refs.len(),
             %values_inlined,
@@ -315,7 +306,7 @@ impl Trie {
         let mut iterator = self.disk_iter()?;
         let nodes_list =
             iterator.visit_nodes_interval(path_begin.as_deref(), path_end.as_deref())?;
-        tracing::debug!(target: "state-parts", num_nodes = nodes_list.len());
+        tracing::debug!(num_nodes = nodes_list.len());
 
         Ok(())
     }

--- a/core/store/src/trie/trie_storage_update.rs
+++ b/core/store/src/trie/trie_storage_update.rs
@@ -160,7 +160,7 @@ enum FlattenNodesCrumb {
 }
 
 impl TrieStorageUpdate<'_> {
-    #[tracing::instrument(level = "debug", target = "store::trie", "Trie::flatten_nodes", skip_all)]
+    #[tracing::instrument(level = "debug", "Trie::flatten_nodes", skip_all)]
     pub(crate) fn flatten_nodes(
         mut self,
         old_root: &CryptoHash,

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -239,7 +239,6 @@ impl TrieUpdate {
     /// in any other way as desired.
     #[tracing::instrument(
         level = "debug",
-        target = "store::trie",
         "TrieUpdate::finalize",
         skip_all,
         fields(committed.len = self.committed.len(), tag_block_production = true)

--- a/utils/config/src/lib.rs
+++ b/utils/config/src/lib.rs
@@ -124,7 +124,7 @@ impl ValidationErrors {
     /// should only be used when you finished inserting all errors
     pub fn return_ok_or_error(&self) -> anyhow::Result<()> {
         if self.0.is_empty() {
-            tracing::info!(target: "config", "all validations have passed");
+            tracing::info!("all validations have passed");
             Ok(())
         } else {
             Err(anyhow::Error::msg(format!(

--- a/utils/fmt/src/lib.rs
+++ b/utils/fmt/src/lib.rs
@@ -22,8 +22,7 @@ use std::str::FromStr;
 /// example:
 ///
 /// ```ignore
-/// tracing::trace!(target: "state",
-///                 db_op = "insert",
+/// tracing::trace!(db_op = "insert",
 ///                 key = %near_fmt::Bytes(key),
 ///                 size = value.len())
 /// ```
@@ -141,8 +140,7 @@ impl<'a> std::fmt::Display for AbbrBytes<Option<&'a [u8]>> {
 /// example:
 ///
 /// ```ignore
-/// tracing::info!(target: "store",
-///                op = "set",
+/// tracing::info!(op = "set",
 ///                col = %col,
 ///                key = %near_fmt::StorageKey(key),
 ///                size = value.len())


### PR DESCRIPTION
Removes `target: "…"` from all tracing event/span macros and `target = "…"` from all `#[instrument]` attributes in `core/` (`near-store`, `near-primitives`, `near-async`, `near-chain-configs`, `near-external-storage`, `near-o11y`) and `utils/`. The tracing default target — the module path — is sufficient for filtering and grouping in all cases.

See `docs/practices/style.md` (PR 1/7) for the rationale and convention.

Part 2 of 7.