### PR TITLE
refactor(tracing): 3/7 remove explicit target from chain tracing

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -275,7 +275,7 @@ pub trait LogTransientStorageError {
 impl<T> LogTransientStorageError for Result<T, Error> {
     fn log_storage_error(self, message: &str) -> Self {
         if let Err(err) = &self {
-            tracing::error!(target: "chain", %message, ?err, "transient storage error");
+            tracing::error!(%message, ?err, "transient storage error");
         }
         self
     }

--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -244,7 +244,7 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.dropped = Some(reason);
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was dropped but was not marked received");
+            tracing::error!(?block_hash, "block was dropped but was not marked received");
         }
     }
 
@@ -252,7 +252,7 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.error = Some(err);
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was errored but was not marked received");
+            tracing::error!(?block_hash, "block was errored but was not marked received");
         }
     }
 
@@ -260,7 +260,7 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.orphaned_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was orphaned but was not marked received");
+            tracing::error!(?block_hash, "block was orphaned but was not marked received");
         }
     }
 
@@ -268,7 +268,7 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_orphan_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was unorphaned but was not marked received");
+            tracing::error!(?block_hash, "block was unorphaned but was not marked received");
         }
     }
 
@@ -276,7 +276,10 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.missing_chunks_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as having missing chunks but was not marked received");
+            tracing::error!(
+                ?block_hash,
+                "block was marked as having missing chunks but was not marked received"
+            );
         }
     }
 
@@ -284,7 +287,10 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.pending_execution_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as pending execution but was not marked received");
+            tracing::error!(
+                ?block_hash,
+                "block was marked as pending execution but was not marked received"
+            );
         }
     }
 
@@ -292,7 +298,10 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_pending_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as completed pending execution but was not marked received");
+            tracing::error!(
+                ?block_hash,
+                "block was marked as completed pending execution but was not marked received"
+            );
         }
     }
 
@@ -300,7 +309,10 @@ impl BlocksDelayTracker {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_missing_chunks_timestamp = Some(self.clock.now());
         } else {
-            tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as having no missing chunks but was not marked received");
+            tracing::error!(
+                ?block_hash,
+                "block was marked as having no missing chunks but was not marked received"
+            );
         }
     }
 
@@ -360,7 +372,7 @@ impl BlocksDelayTracker {
                     }
                 } else {
                     debug_assert!(false);
-                    tracing::error!(target: "block_delay_tracker", ?block_hash, "block in height map but not in blocks");
+                    tracing::error!(?block_hash, "block in height map but not in blocks");
                 }
             }
 
@@ -395,7 +407,7 @@ impl BlocksDelayTracker {
                 if let Some(chunk_hash) = chunk_hash {
                     if let Some(processed_chunk) = self.chunks.get(&chunk_hash) {
                         let Ok(shard_id) = shard_layout.get_shard_id(shard_index) else {
-                            tracing::error!(target: "block_delay_tracker", ?shard_index, "invalid shard index");
+                            tracing::error!(?shard_index, "invalid shard index");
                             continue;
                         };
                         self.update_chunk_metrics(processed_chunk, shard_id);

--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -726,32 +726,32 @@ impl Doomslug {
         verbose: bool,
     ) -> bool {
         let span = debug_span!(
-            target: "doomslug",
             "ready_to_produce_block",
             target_height,
             enough_chunks_for = field::Empty,
             enough_approvals_for = field::Empty,
             ready_to_produce_block = field::Empty,
-            need_to_wait = field::Empty)
+            need_to_wait = field::Empty
+        )
         .entered();
         let now = self.clock.now();
         let hash_or_height =
             ApprovalInner::new(&self.tip.block_hash, self.tip.height, target_height);
         let Some(approval_trackers_at_height) = self.approval_trackers.get_mut(&target_height)
         else {
-            tracing::debug!(target: "doomslug", target_height, "no approval trackers at height");
+            tracing::debug!(target_height, "no approval trackers at height");
             return false;
         };
         let Some(approval_tracker) =
             approval_trackers_at_height.approval_trackers.get_mut(&hash_or_height)
         else {
-            tracing::debug!(target: "doomslug", target_height, ?hash_or_height, "no approval tracker");
+            tracing::debug!(target_height, ?hash_or_height, "no approval tracker");
             return false;
         };
 
         let when = match approval_tracker.get_block_production_readiness() {
             DoomslugBlockProductionReadiness::NotReady => {
-                tracing::debug!(target: "doomslug", target_height, ?hash_or_height, "not ready to produce block");
+                tracing::debug!(target_height, ?hash_or_height, "not ready to produce block");
                 return false;
             }
             DoomslugBlockProductionReadiness::ReadySince(when) => when,
@@ -766,7 +766,9 @@ impl Doomslug {
             metrics::BLOCK_APPROVAL_DELAY.observe(enough_chunks_for.as_seconds_f64());
             if verbose {
                 tracing::info!(
-                    target: "doomslug", target_height, ?enough_approvals_for, ?enough_chunks_for,
+                    target_height,
+                    ?enough_approvals_for,
+                    ?enough_chunks_for,
                     "ready to produce block, has enough approvals, has enough chunks"
                 );
             }
@@ -783,12 +785,13 @@ impl Doomslug {
         if verbose {
             if ready {
                 tracing::info!(
-                    target: "doomslug", target_height, ?enough_approvals_for,
+                    target_height,
+                    ?enough_approvals_for,
                     "ready to produce block, but does not have enough chunks"
                 );
             } else {
                 tracing::info!(
-                    target: "doomslug", target_height, need_to_wait_for = ?(when + delay - now),
+                    target_height, need_to_wait_for = ?(when + delay - now),
                     ?enough_approvals_for, "not ready to produce block, need to wait"
                 );
             }

--- a/chain/chain/src/flat_storage_init.rs
+++ b/chain/chain/src/flat_storage_init.rs
@@ -38,7 +38,7 @@ fn init_flat_storage_for_current_epoch(
     flat_storage_manager: &FlatStorageManager,
 ) -> Result<(), Error> {
     let epoch_id = &chain_head.epoch_id;
-    tracing::debug!(target: "chain", ?epoch_id, "init flat storage for the current epoch");
+    tracing::debug!(?epoch_id, "init flat storage for the current epoch");
 
     let shard_ids = epoch_manager.shard_ids(epoch_id)?;
     for shard_id in shard_ids {
@@ -70,7 +70,7 @@ fn init_flat_storage_for_next_epoch(
     }
 
     let next_epoch_id = &chain_head.next_epoch_id;
-    tracing::debug!(target: "chain", ?next_epoch_id, "init flat storage for the next epoch");
+    tracing::debug!(?next_epoch_id, "init flat storage for the next epoch");
 
     let shard_ids = epoch_manager.shard_ids(next_epoch_id)?;
     for shard_id in shard_ids {

--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -160,7 +160,7 @@ impl Chain {
         }
         store_update.merge(tmp_store_update);
         store_update.commit()?;
-        tracing::info!(target: "chain", height = %block_head.height, ?block_head.last_block_hash, ?state_roots, "genesis has been saved");
+        tracing::info!(height = %block_head.height, ?block_head.last_block_hash, ?state_roots, "genesis has been saved");
         Ok(())
     }
 
@@ -278,7 +278,7 @@ pub fn get_genesis_congestion_infos(
     state_roots: &Vec<CryptoHash>,
 ) -> Result<Vec<CongestionInfo>, Error> {
     get_genesis_congestion_infos_impl(epoch_manager, runtime, state_roots).map_err(|err| {
-        tracing::error!(target: "chain", ?err, "failed to get the genesis congestion infos");
+        tracing::error!(?err, "failed to get the genesis congestion infos");
         err
     })
 }
@@ -295,7 +295,7 @@ fn get_genesis_congestion_infos_impl(
 
     // Check we had already computed the congestion infos from the genesis state roots.
     if let Some(saved_infos) = near_store::get_genesis_congestion_infos(runtime.store())? {
-        tracing::debug!(target: "chain", "reading genesis congestion infos from database");
+        tracing::debug!("reading genesis congestion infos from database");
         return Ok(saved_infos);
     }
 
@@ -312,7 +312,6 @@ fn get_genesis_congestion_infos_impl(
             Ok(info) => info,
             Err(_) => {
                 tracing::info!(
-                    target: "chain",
                     %shard_id,
                     "genesis state unavailable, using default congestion info"
                 );
@@ -325,7 +324,7 @@ fn get_genesis_congestion_infos_impl(
     // Store it in DB so that we can read it later, instead of recomputing from genesis state roots.
     // Note that this is necessary because genesis state roots will be garbage-collected and will not
     // be available, for example, when the node restarts later.
-    tracing::debug!(target: "chain", "saving genesis congestion infos to database");
+    tracing::debug!("saving genesis congestion infos to database");
     let mut store_update = runtime.store().store_update();
     near_store::set_genesis_congestion_infos(&mut store_update, &new_infos);
     store_update.commit()?;
@@ -345,7 +344,7 @@ fn get_genesis_congestion_info(
     let trie = runtime.get_view_trie_for_shard(shard_id, prev_hash, state_root)?;
     let runtime_config = runtime.get_runtime_config(protocol_version);
     let congestion_info = bootstrap_congestion_info(&trie, runtime_config, shard_id)?;
-    tracing::debug!(target: "chain", %shard_id, ?state_root, ?congestion_info, "computed genesis congestion info");
+    tracing::debug!(%shard_id, ?state_root, ?congestion_info, "computed genesis congestion info");
     Ok(congestion_info)
 }
 

--- a/chain/chain/src/pending.rs
+++ b/chain/chain/src/pending.rs
@@ -25,7 +25,7 @@ impl<Block: BlockLike> PendingBlocksPool<Block> {
     pub fn add_block(&mut self, block: Block) {
         let height = block.height();
         if self.blocks.contains_key(&height) {
-            tracing::debug!(target: "chain", block_hash = ?block.hash(), "block already exists in pending blocks pool");
+            tracing::debug!(block_hash = ?block.hash(), "block already exists in pending blocks pool");
             return;
         }
         self.block_hashes.insert(block.hash());

--- a/chain/chain/src/resharding/event_type.rs
+++ b/chain/chain/src/resharding/event_type.rs
@@ -50,7 +50,7 @@ impl ReshardingEventType {
         resharding_block: BlockInfo,
     ) -> Result<Option<ReshardingEventType>, Error> {
         let log_and_error = |err_msg: &str| {
-            tracing::error!(target: "resharding", ?next_shard_layout, err_msg);
+            tracing::error!(?next_shard_layout, err_msg);
             Err(Error::ReshardingError(err_msg.to_owned()))
         };
 

--- a/chain/chain/src/resharding/migrations.rs
+++ b/chain/chain/src/resharding/migrations.rs
@@ -41,17 +41,17 @@ pub fn migrate_46_to_47(
     store_config: &StoreConfig,
 ) -> anyhow::Result<()> {
     let Some(cold_db) = cold_db else {
-        tracing::info!(target: "migrations", "skipping migration 46->47 for hot store only",);
+        tracing::info!("skipping migration 46->47 for hot store only",);
         return Ok(());
     };
 
     // Current migration is targeted only for mainnet
     if genesis_config.chain_id != MAINNET {
-        tracing::info!(target: "migrations", chain_id = ?genesis_config.chain_id, "skipping migration 46->47",);
+        tracing::info!(chain_id = ?genesis_config.chain_id, "skipping migration 46->47",);
         return Ok(());
     }
 
-    tracing::info!(target: "migrations", "starting migration 46->47 for cold store");
+    tracing::info!("starting migration 46->47 for cold store");
 
     let cold_store = cold_db.as_store();
     let epoch_config_store =
@@ -65,7 +65,7 @@ pub fn migrate_46_to_47(
 
     let mut transaction = DBTransaction::new();
     for (protocol_version, resharding_block_hash) in MAINNET_RESHARDING_BLOCK_HASHES {
-        tracing::info!(target: "migrations", ?resharding_block_hash, "processing resharding block");
+        tracing::info!(?resharding_block_hash, "processing resharding block");
 
         let resharding_block_hash = CryptoHash::from_str(resharding_block_hash).unwrap();
         let shard_layout = &epoch_config_store.get_config(protocol_version).static_shard_layout();
@@ -108,7 +108,7 @@ pub fn migrate_46_to_47(
         }
     }
 
-    tracing::info!(target: "migrations", "Writing changes to the database");
+    tracing::info!("Writing changes to the database");
     cold_db.write(transaction);
 
     Ok(())

--- a/chain/chain/src/resharding/resharding_actor.rs
+++ b/chain/chain/src/resharding/resharding_actor.rs
@@ -89,12 +89,12 @@ impl ReshardingActor {
         split_shard_event: ReshardingSplitShardParams,
         ctx: &mut dyn DelayedActionRunner<Self>,
     ) {
-        tracing::info!(target: "resharding", ?split_shard_event, "handle_schedule_resharding");
+        tracing::info!(?split_shard_event, "handle_schedule_resharding");
 
         let parent_shard = split_shard_event.parent_shard;
         if self.resharding_started.contains(&parent_shard) {
             // The event is already in progress, no need to reschedule.
-            tracing::info!(target: "resharding", "resharding already in progress");
+            tracing::info!("resharding already in progress");
             return;
         }
 
@@ -145,11 +145,11 @@ impl ReshardingActor {
         &self,
         parent_shard_uid: ShardUId,
     ) -> ReshardingSchedulingStatus {
-        tracing::info!(target: "resharding", ?parent_shard_uid, "get_resharding_scheduling_status");
+        tracing::info!(?parent_shard_uid, "get_resharding_scheduling_status");
 
         if self.resharding_started.contains(&parent_shard_uid) {
             // The event is already in progress, no need to reschedule.
-            tracing::info!(target: "resharding", "resharding already in progress");
+            tracing::info!("resharding already in progress");
             return ReshardingSchedulingStatus::AlreadyStarted;
         }
 
@@ -185,7 +185,7 @@ impl ReshardingActor {
             // This behavior is configured through `adv_task_delay_by_blocks`
             #[cfg(feature = "test_features")]
             if event.resharding_block.height + self.adv_task_delay_by_blocks > chain_final_height {
-                tracing::info!(target: "resharding", "resharding has been artificially postponed");
+                tracing::info!("resharding has been artificially postponed");
                 return ReshardingSchedulingStatus::WaitForFinalBlock;
             }
 
@@ -205,19 +205,19 @@ impl ReshardingActor {
         if let Err(err) =
             self.trie_state_resharder.initialize_trie_state_resharding_status(&resharding_event)
         {
-            tracing::error!(target: "resharding", ?err, "failed to initialize trie state resharding status");
+            tracing::error!(?err, "failed to initialize trie state resharding status");
             return;
         }
 
         // This is a long running task and would block the actor
         if let Err(err) = self.flat_storage_resharder.start_resharding_blocking(&resharding_event) {
-            tracing::error!(target: "resharding", ?err, "failed to start flat storage resharding");
+            tracing::error!(?err, "failed to start flat storage resharding");
             return;
         }
 
-        tracing::info!(target: "resharding", "trie state resharder starting");
+        tracing::info!("trie state resharder starting");
         if let Err(err) = self.trie_state_resharder.start_resharding_blocking(&resharding_event) {
-            tracing::error!(target: "resharding", ?err, "failed to start trie state resharding");
+            tracing::error!(?err, "failed to start trie state resharding");
             return;
         }
     }

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -147,7 +147,6 @@ impl TrieStateResharder {
         // regular node operation.
         std::thread::sleep(batch_delay);
         let _span = tracing::debug_span!(
-            target: "resharding",
             "TrieStateResharder::process_batch_and_update_status",
             parent_shard_uid = ?status.parent_shard_uid,
             child_shard_uid = ?child.shard_uid,
@@ -275,7 +274,6 @@ impl TrieStateResharder {
             *store.get_chunk_extra(&block_hash, &event.parent_shard)?.state_root();
 
         tracing::debug!(
-            target: "resharding",
             ?left_state_root,
             ?right_state_root,
             ?parent_state_root,
@@ -328,7 +326,7 @@ impl TrieStateResharder {
             );
         };
 
-        tracing::info!(target: "resharding", ?status, ?event, "start_resharding_blocking");
+        tracing::info!(?status, ?event, "start_resharding_blocking");
 
         let mut status = status.with_metrics();
         self.resharding_blocking_impl(&mut status)
@@ -337,7 +335,7 @@ impl TrieStateResharder {
     /// Resume an interrupted resharding operation.
     pub fn resume(&self, parent_shard_uid: ShardUId) -> Result<(), Error> {
         let Some(status) = self.load_status()? else {
-            tracing::info!(target: "resharding", "resharding status not found, nothing to resume");
+            tracing::info!("resharding status not found, nothing to resume");
             return Ok(());
         };
 
@@ -388,7 +386,6 @@ impl TrieStateResharder {
         // Parent memtrie must be loaded before proceeding.
         if tries.get_memtries(parent_shard_uid).is_none() {
             tracing::info!(
-                target: "resharding",
                 ?parent_shard_uid,
                 parent_state_root = ?status.parent_state_root,
                 "parent memtrie not loaded, loading it now"
@@ -413,7 +410,6 @@ impl TrieStateResharder {
         // Recreate each missing child memtrie.
         for (child_shard_uid, retain_mode) in &missing_children {
             tracing::info!(
-                target: "resharding",
                 ?child_shard_uid,
                 ?parent_shard_uid,
                 ?boundary_account,
@@ -429,7 +425,6 @@ impl TrieStateResharder {
             tries.apply_memtrie_changes(&trie_changes, parent_shard_uid, block_height);
 
             tracing::info!(
-                target: "resharding",
                 ?child_shard_uid,
                 new_root = ?trie_changes.new_root,
                 "successfully recreated child memtrie from parent"
@@ -464,7 +459,6 @@ impl TrieStateResharder {
     /// Cleans up parent flat storage after trie state resharding is complete.
     fn cleanup_parent_flat_storage(&self, parent_shard_uid: ShardUId) {
         tracing::info!(
-            target: "resharding",
             ?parent_shard_uid,
             "trie state resharding complete, cleaning up parent flat storage"
         );

--- a/chain/chain/src/soft_realtime_thread_pool.rs
+++ b/chain/chain/src/soft_realtime_thread_pool.rs
@@ -80,10 +80,11 @@ impl ThreadPool {
             .priority(self.priority)
             .spawn(move |res| {
                 if let Err(err) = res {
-                    tracing::debug!(target: "chain::soft_realtime_thread_pool", name = name, err = %err, "setting scheduler policy failed");
+                    tracing::debug!(name = name, err = %err, "setting scheduler policy failed");
                 };
                 run_worker(job, idle_timeout, idle_queue, counter_guard)
-            }).expect("Failed to spawn thread");
+            })
+            .expect("Failed to spawn thread");
     }
 }
 
@@ -115,7 +116,6 @@ impl WorkerCounter {
         let num_threads = self.num_threads.fetch_add(1, Ordering::SeqCst);
         if num_threads > self.limit {
             tracing::debug!(
-                target: "chain::soft_realtime_thread_pool",
                 name = self.name,
                 limit = self.limit,
                 num_threads = num_threads,

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -207,7 +207,7 @@ impl SpiceCoreReader {
         let prev_uncertified_chunks = self
             .get_uncertified_chunks(block.header().prev_hash())
             .map_err(|err| {
-                tracing::debug!(target: "spice_core", prev_hash=?block.header().prev_hash(), ?err, "failed getting uncertified_chunks");
+                tracing::debug!(prev_hash=?block.header().prev_hash(), ?err, "failed getting uncertified_chunks");
                 NoPrevUncertifiedChunks
             })?;
         let waiting_on_endorsements: HashSet<_> = prev_uncertified_chunks

--- a/chain/chain/src/spice_core_writer_actor.rs
+++ b/chain/chain/src/spice_core_writer_actor.rs
@@ -58,7 +58,7 @@ impl near_async::messaging::Actor for SpiceCoreWriterActor {}
 impl Handler<ProcessedBlock> for SpiceCoreWriterActor {
     fn handle(&mut self, ProcessedBlock { block_hash }: ProcessedBlock) {
         if let Err(err) = self.handle_processed_block(block_hash) {
-            tracing::error!(target: "spice_core_writer", ?err, "error handling processed block");
+            tracing::error!(?err, "error handling processed block");
         }
     }
 }
@@ -66,7 +66,7 @@ impl Handler<ProcessedBlock> for SpiceCoreWriterActor {
 impl Handler<SpiceChunkEndorsementMessage> for SpiceCoreWriterActor {
     fn handle(&mut self, msg: SpiceChunkEndorsementMessage) {
         if let Err(err) = self.process_chunk_endorsement(msg.0) {
-            tracing::error!(target: "spice_core_writer", ?err, "error processing spice chunk endorsement");
+            tracing::error!(?err, "error processing spice chunk endorsement");
         }
     }
 }
@@ -355,7 +355,6 @@ impl SpiceCoreWriterActor {
                     Ok(()) => true,
                     Err(err) => {
                         tracing::info!(
-                            target: "spice_core_writer",
                             chunk_id = ?endorsement.chunk_id(),
                             ?err,
                             "encountered invalid pending endorsement"
@@ -391,7 +390,6 @@ impl SpiceCoreWriterActor {
             Ok(block) => block,
             Err(Error::DBNotFoundErr(_)) => {
                 tracing::debug!(
-                    target: "spice_core_writer",
                     block_hash = ?endorsement.block_hash(),
                     "not processing endorsement immediately since haven't received relevant block yet"
                 );

--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -281,7 +281,6 @@ impl ChainStateSyncAdapter {
         sync_hash: CryptoHash,
     ) -> Result<StatePart, Error> {
         let _span = tracing::debug_span!(
-            target: "sync",
             "get_state_response_part",
             %shard_id,
             part_id,

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -263,12 +263,7 @@ impl Chain {
         };
 
         let genesis_hash = self.genesis().hash();
-        tracing::debug!(
-            target: "sync",
-            ?header_head,
-            ?sync_hash,
-            ?genesis_hash,
-            "find_sync_hash");
+        tracing::debug!(?header_head, ?sync_hash, ?genesis_hash, "find_sync_hash");
         assert_ne!(&sync_hash, genesis_hash);
         Ok(Some(sync_hash))
     }
@@ -289,7 +284,7 @@ impl Chain {
         };
 
         let Some(min_height_included) = sync_prev_block.chunks().min_height_included() else {
-            tracing::warn!(target: "sync", ?sync_prev_hash, "cannot find the min block height to sync from");
+            tracing::warn!(?sync_prev_hash, "cannot find the min block height to sync from");
             return vec![];
         };
 
@@ -298,7 +293,7 @@ impl Chain {
         loop {
             let next_header = self.get_block_header(&next_hash);
             let Ok(next_header) = next_header else {
-                tracing::error!(target: "sync", hash=?next_hash, "cannot get block header to sync");
+                tracing::error!(hash=?next_hash, "cannot get block header to sync");
                 break;
             };
 

--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -24,7 +24,6 @@ pub fn validate_chunk_endorsements_in_block(
     // Number of chunks and chunk endorsements must match and must be equal to number of shards
     if block.chunks().len() != block.chunk_endorsements().len() {
         tracing::error!(
-            target: "chain",
             num_chunks = block.chunks().len(),
             num_chunk_endorsement_shards = block.chunk_endorsements().len(),
             "number of chunks and chunk endorsements does not match",
@@ -51,7 +50,6 @@ pub fn validate_chunk_endorsements_in_block(
         if chunk_header.height_included() != block.header().height() {
             if !signatures.is_empty() {
                 tracing::error!(
-                    target: "chain",
                     chunk_header_height_included = chunk_header.height_included(),
                     block_header_height = block.header().height(),
                     "expected chunk endorsements to be empty for old chunks in current block",
@@ -74,7 +72,6 @@ pub fn validate_chunk_endorsements_in_block(
         let ordered_chunk_validators = chunk_validator_assignments.ordered_chunk_validators();
         if ordered_chunk_validators.len() != signatures.len() {
             tracing::error!(
-                target: "chain",
                 num_ordered_chunk_validators = ordered_chunk_validators.len(),
                 num_chunk_endorsement_signatures = signatures.len(),
                 "number of ordered chunk validators and chunk endorsement signatures does not match",
@@ -97,7 +94,6 @@ pub fn validate_chunk_endorsements_in_block(
                 validator.public_key(),
             ) {
                 tracing::error!(
-                    target: "chain",
                     chunk_hash = ?chunk_header.chunk_hash(),
                     validator = ?validator.account_id(),
                     "invalid chunk endorsement signature"
@@ -112,7 +108,7 @@ pub fn validate_chunk_endorsements_in_block(
         let endorsement_state =
             chunk_validator_assignments.compute_endorsement_state(endorsed_chunk_validators);
         if !endorsement_state.is_endorsed {
-            tracing::error!(target: "chain", ?endorsement_state, "chunk does not have enough stake to be endorsed");
+            tracing::error!(?endorsement_state, "chunk does not have enough stake to be endorsed");
             return Err(Error::InvalidChunkEndorsement);
         }
 

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -551,7 +551,6 @@ pub fn validate_chunk_state_witness_impl(
         .with_label_values(&[&witness_chunk_shard_id.to_string()])
         .start_timer();
     let span = tracing::debug_span!(
-        target: "client",
         "validate_chunk_state_witness",
         height = height_created,
         shard_id = %witness_chunk_shard_id,
@@ -782,11 +781,7 @@ pub fn validate_chunk_state_witness(
     );
     if result.is_err() {
         if let Err(storage_err) = save_invalid_chunk_state_witness(store, &state_witness) {
-            tracing::error!(
-                target: "stateless_validation",
-                ?storage_err,
-                "failed to store invalid state witness"
-            );
+            tracing::error!(?storage_err, "failed to store invalid state witness");
         }
     }
     result
@@ -804,7 +799,7 @@ impl Chain {
         let height_created = witness.chunk_header().height_created();
         let chunk_hash = witness.chunk_header().chunk_hash().clone();
         let parent_span = tracing::debug_span!(
-            target: "chain", "shadow_validate", %shard_id, height_created);
+            "shadow_validate", %shard_id, height_created);
         let (encoded_witness, raw_witness_size) = {
             let shard_id_label = shard_id.to_string();
             let encode_timer =

--- a/chain/chain/src/stateless_validation/metrics.rs
+++ b/chain/chain/src/stateless_validation/metrics.rs
@@ -203,7 +203,7 @@ pub fn record_witness_size_metrics(
     witness: &ChunkStateWitness,
 ) {
     if let Err(err) = record_witness_size_metrics_fallible(decoded_size, encoded_size, witness) {
-        tracing::warn!(target: "client", ?err, "failed to record witness size metrics");
+        tracing::warn!(?err, "failed to record witness size metrics");
     }
 }
 

--- a/chain/chain/src/stateless_validation/spice_chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/spice_chunk_validation.rs
@@ -165,7 +165,6 @@ pub fn spice_pre_validate_chunk_state_witness(
 #[tracing::instrument(
     level = tracing::Level::DEBUG,
     skip_all,
-    target = "spice_chunk_validator",
     fields(
         chunk_id = ?state_witness.chunk_id(),
     )

--- a/chain/chain/src/stateless_validation/state_witness.rs
+++ b/chain/chain/src/stateless_validation/state_witness.rs
@@ -51,7 +51,6 @@ impl ChainStore {
     ) -> Result<CreateWitnessResult, Error> {
         let chunk_header = chunk.cloned_header();
         let _span = tracing::debug_span!(
-            target: "client",
             "create_state_witness",
             chunk_hash = ?chunk_header.chunk_hash(),
             height = chunk_header.height_created(),

--- a/chain/chain/src/store/latest_witnesses.rs
+++ b/chain/chain/src/store/latest_witnesses.rs
@@ -150,7 +150,9 @@ impl ChainStore {
         let start_time = std::time::Instant::now();
         let ChunkProductionKey { shard_id, epoch_id, height_created } =
             witness.chunk_production_key();
-        let _span = tracing::info_span!(target: "client", "save_latest_chunk_state_witness", ?height_created, %shard_id).entered();
+        let _span =
+            tracing::info_span!("save_latest_chunk_state_witness", ?height_created, %shard_id)
+                .entered();
 
         let serialized_witness = borsh::to_vec(witness)?;
         let witness_size: u64 =
@@ -330,7 +332,6 @@ pub fn save_invalid_chunk_state_witness(
 ) -> Result<(), std::io::Error> {
     let start_time = std::time::Instant::now();
     let _span = tracing::info_span!(
-        target: "client",
         "save_invalid_chunk_state_witness",
         witness_height = witness.chunk_header().height_created(),
         witness_shard = ?witness.chunk_header().shard_id(),

--- a/chain/chain/src/store/utils.rs
+++ b/chain/chain/src/store/utils.rs
@@ -169,8 +169,13 @@ pub fn get_incoming_receipts_for_shard(
     last_chunk_height_included: BlockHeight,
     receipts_filter: ReceiptFilter,
 ) -> Result<Vec<ReceiptProofResponse>, Error> {
-    let _span =
-            tracing::debug_span!(target: "chain", "get_incoming_receipts_for_shard", ?target_shard_id, ?block_hash, last_chunk_height_included).entered();
+    let _span = tracing::debug_span!(
+        "get_incoming_receipts_for_shard",
+        ?target_shard_id,
+        ?block_hash,
+        last_chunk_height_included
+    )
+    .entered();
 
     let mut ret = vec![];
 
@@ -195,7 +200,6 @@ pub fn get_incoming_receipts_for_shard(
         if prev_shard_layout != current_shard_layout {
             let parent_shard_id = current_shard_layout.get_parent_shard_id(current_shard_id)?;
             tracing::info!(
-                target: "chain",
                 version = current_shard_layout.version(),
                 prev_version = prev_shard_layout.version(),
                 ?current_shard_id,
@@ -210,18 +214,11 @@ pub fn get_incoming_receipts_for_shard(
             chain_store.get_incoming_receipts(&current_block_hash, current_shard_id);
         let receipts_proofs = match maybe_receipts_proofs {
             Ok(receipts_proofs) => {
-                tracing::debug!(
-                    target: "chain",
-                    "found receipts from block with missing chunks",
-                );
+                tracing::debug!("found receipts from block with missing chunks",);
                 receipts_proofs
             }
             Err(err) => {
-                tracing::debug!(
-                    target: "chain",
-                    ?err,
-                    "could not find receipts from block with missing chunks"
-                );
+                tracing::debug!(?err, "could not find receipts from block with missing chunks");
 
                 // This can happen when all chunks are missing in a block
                 // and then we can safely assume that there aren't any

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -349,7 +349,7 @@ impl StoreValidator {
             }
             if let Some(timeout) = self.timeout {
                 if self.start_time.elapsed() > Duration::milliseconds(timeout) {
-                    tracing::warn!(target: "adversary", %col, col_index = %col.into_usize(), col_length = %DBCol::LENGTH, "store validator hit timeout");
+                    tracing::warn!(%col, col_index = %col.into_usize(), col_length = %DBCol::LENGTH, "store validator hit timeout");
                     return;
                 }
             }
@@ -357,7 +357,7 @@ impl StoreValidator {
         if let Some(timeout) = self.timeout {
             // We didn't complete all Column checks and cannot do final checks, returning here
             if self.start_time.elapsed() > Duration::milliseconds(timeout) {
-                tracing::warn!(target: "adversary", "store validator hit timeout before final checks");
+                tracing::warn!("store validator hit timeout before final checks");
                 return;
             }
         }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -142,7 +142,7 @@ pub struct ApplyChunkResult {
 
 impl ApplyChunkResult {
     /// Returns root and paths for all the outcomes in the result.
-    #[instrument(target = "runtime", level = "debug", "compute_outcomes_proof", skip_all, fields(
+    #[instrument(level = "debug", "compute_outcomes_proof", skip_all, fields(
         num_outcomes = outcomes.len()
     ))]
     pub fn compute_outcomes_proof(

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -137,7 +137,6 @@ pub fn apply_new_chunk(
     } = data;
     let shard_id = shard_context.shard_uid.shard_id();
     let _span = tracing::debug_span!(
-        target: "chain",
         parent: parent_span,
         "apply_new_chunk",
         height = block.height,
@@ -191,7 +190,6 @@ pub fn apply_old_chunk(
     let OldChunkData { prev_chunk_extra, block, storage_context } = data;
     let shard_id = shard_context.shard_uid.shard_id();
     let _span = tracing::debug_span!(
-        target: "chain",
         parent: parent_span,
         "apply_old_chunk",
         height = block.height,

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -145,7 +145,7 @@ impl EncodedChunksCache {
             let previous_block_hash = &entry.header.prev_block_hash().clone();
             self.remove_chunk_from_incomplete_chunks(previous_block_hash, chunk_hash);
         } else {
-            tracing::warn!(target: "chunks", ?chunk_hash, "cannot mark non-existent entry as complete");
+            tracing::warn!(?chunk_hash, "cannot mark non-existent entry as complete");
         }
     }
 

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -124,7 +124,6 @@ impl ShardedTransactionPool {
     /// transactions back to the pool with the new shard uids.
     pub fn reshard(&mut self, old_shard_layout: &ShardLayout, new_shard_layout: &ShardLayout) {
         tracing::debug!(
-            target: "resharding",
             old_shard_layout_version = old_shard_layout.version(),
             new_shard_layout_version = new_shard_layout.version(),
             "resharding the transaction pool"

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -124,7 +124,7 @@ pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts(
     }
 }
 
-#[instrument(target = "chunks", level = "debug", "create_partial_chunk", skip_all, fields(
+#[instrument(level = "debug", "create_partial_chunk", skip_all, fields(
     height = chunk.to_shard_chunk().height_created(),
     shard_id = %chunk.to_shard_chunk().shard_id(),
     chunk_hash = ?chunk.to_shard_chunk().chunk_hash(),
@@ -180,7 +180,7 @@ pub fn create_partial_chunk(
     ))
 }
 
-#[instrument(target = "client", level = "debug", "persist_chunk", skip_all, fields(
+#[instrument(level = "debug", "persist_chunk", skip_all, fields(
     height = partial_chunk.height_created(),
     shard_id = %partial_chunk.shard_id(),
     chunk_hash = ?partial_chunk.chunk_hash(),


### PR DESCRIPTION
Removes `target: "…"` from all tracing event/span macros and `target = "…"` from all `#[instrument]` attributes in `chain/chain/`, `chain/chunks/`, and `chain/chain-primitives/`. The tracing default target — the module path — is sufficient for filtering and grouping in all cases.

See `docs/practices/style.md` (PR 1/7) for the rationale and convention.

Part 3 of 7.