### PR TITLE
refactor(tracing): 4/7 remove explicit target from client tracing

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -191,8 +191,7 @@ impl SyncStatus {
 
     pub fn update(&mut self, new_value: Self) {
         let _span =
-            tracing::debug_span!(target: "sync", "update_sync_status", old_value = ?self, ?new_value)
-                .entered();
+            tracing::debug_span!("update_sync_status", old_value = ?self, ?new_value).entered();
         *self = new_value;
     }
 }

--- a/chain/client/src/archive/cold_store_actor.rs
+++ b/chain/client/src/archive/cold_store_actor.rs
@@ -113,7 +113,7 @@ pub struct ColdStoreActor {
 
 impl Actor for ColdStoreActor {
     fn start_actor(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
-        tracing::info!(target: "cold_store", "starting the cold store actor");
+        tracing::info!("starting the cold store actor");
         // Note that we start with the cold store migration loop which later spawns the cold store loop.
         self.cold_store_migration_loop(ctx);
     }
@@ -169,31 +169,31 @@ impl ColdStoreActor {
         // Migration is only needed if cold storage is not properly initialized,
         // i.e. if cold head is not set.
         if self.cold_db.as_store().chain_store().head().is_ok() {
-            tracing::info!(target: "cold_store", "cold store already has a head set, no migration needed");
+            tracing::info!("cold store already has a head set, no migration needed");
             return Ok(ColdStoreMigrationResult::NoNeedForMigration);
         }
 
-        tracing::info!(target: "cold_store", "starting population of cold store");
+        tracing::info!("starting population of cold store");
         let new_cold_height = match self.hot_store.get_db_kind()? {
             None => {
-                tracing::error!(target: "cold_store", "hot store kind is unknown");
+                tracing::error!("hot store kind is unknown");
                 return Err(anyhow::anyhow!("Hot store DBKind is not set"));
             }
             Some(DbKind::Hot) => {
-                tracing::info!(target: "cold_store", "hot store kind is hot");
+                tracing::info!("hot store kind is hot");
                 self.genesis_height
             }
             Some(DbKind::Archive) => {
-                tracing::info!(target: "cold_store", "hot store kind is archive");
+                tracing::info!("hot store kind is archive");
                 self.hot_store.chain_store().final_head()?.height
             }
             Some(kind) => {
-                tracing::error!(target: "cold_store", ?kind, "hot store kind not supported");
+                tracing::error!(?kind, "hot store kind not supported");
                 return Err(anyhow::anyhow!(format!("Hot store DBKind not {kind:?}.")));
             }
         };
 
-        tracing::info!(target: "cold_store", new_cold_height, "determined cold storage head height after migration");
+        tracing::info!(new_cold_height, "determined cold storage head height after migration");
 
         let batch_size = self.split_storage_config.cold_store_initial_migration_batch_size;
         match copy_all_data_to_cold(
@@ -203,12 +203,15 @@ impl ColdStoreActor {
             &self.keep_going,
         )? {
             CopyAllDataToColdStatus::EverythingCopied => {
-                tracing::info!(target: "cold_store", new_cold_height, "cold storage population was successful, writing cold head");
+                tracing::info!(
+                    new_cold_height,
+                    "cold storage population was successful, writing cold head"
+                );
                 update_cold_head(self.cold_db.as_ref(), &self.hot_store, &new_cold_height)?;
                 Ok(ColdStoreMigrationResult::SuccessfulMigration)
             }
             CopyAllDataToColdStatus::Interrupted => {
-                tracing::info!(target: "cold_store", "cold storage population was interrupted");
+                tracing::info!("cold storage population was interrupted");
                 Ok(ColdStoreMigrationResult::MigrationInterrupted)
             }
         }
@@ -219,7 +222,7 @@ impl ColdStoreActor {
     /// If migration returned any successful status (including interruption status) breaks the loop.
     fn cold_store_migration_loop(&self, ctx: &mut dyn DelayedActionRunner<Self>) {
         if !self.keep_going.load(std::sync::atomic::Ordering::Relaxed) {
-            tracing::debug!(target: "cold_store", "stopping the initial migration loop");
+            tracing::debug!("stopping the initial migration loop");
             return;
         }
 
@@ -229,7 +232,7 @@ impl ColdStoreActor {
                 // Here we pick the second option.
                 let duration =
                     self.split_storage_config.cold_store_initial_migration_loop_sleep_duration;
-                tracing::error!(target: "cold_store", ?err, ?duration, "migration failed, sleeping and trying again");
+                tracing::error!(?err, ?duration, "migration failed, sleeping and trying again");
                 ctx.run_later("cold_store_migration_loop", duration, move |actor, ctx| {
                     actor.cold_store_migration_loop(ctx);
                 });
@@ -237,13 +240,13 @@ impl ColdStoreActor {
             Ok(migration_status) => {
                 match migration_status {
                     ColdStoreMigrationResult::MigrationInterrupted => {
-                        tracing::info!(target: "cold_store", "cold storage migration was interrupted");
+                        tracing::info!("cold storage migration was interrupted");
                         return;
                     }
                     ColdStoreMigrationResult::NoNeedForMigration
                     | ColdStoreMigrationResult::SuccessfulMigration => {
                         // Migration was successful, we can start the cold store loop.
-                        tracing::info!(target: "cold_store", "starting the cold store loop");
+                        tracing::info!("starting the cold store loop");
                         self.cold_store_loop(ctx);
                     }
                 }
@@ -257,7 +260,7 @@ impl ColdStoreActor {
     // trying to copy data at the next height.
     fn cold_store_loop(&self, ctx: &mut dyn DelayedActionRunner<Self>) {
         if !self.keep_going.load(std::sync::atomic::Ordering::Relaxed) {
-            tracing::debug!(target: "cold_store", "stopping the cold store loop");
+            tracing::debug!("stopping the cold store loop");
             return;
         }
 
@@ -284,22 +287,22 @@ impl ColdStoreActor {
         let result_string = cold_store_copy_result_to_string(&result);
         metrics::COLD_STORE_COPY_RESULT.with_label_values(&[result_string]).inc();
         if duration > std::time::Duration::from_secs(1) {
-            tracing::debug!(target: "cold_store", ?duration, "cold store copy completed");
+            tracing::debug!(?duration, "cold store copy completed");
         }
 
         match &result {
             Err(err) => {
-                tracing::error!(target: "cold_store", ?err, "cold store copy failed");
+                tracing::error!(?err, "cold store copy failed");
             }
             Ok(copy_result) => match copy_result {
                 ColdStoreCopyResult::NoBlockCopied => {
-                    tracing::trace!(target: "cold_store", "cold head is up to date, no blocks were copied");
+                    tracing::trace!("cold head is up to date, no blocks were copied");
                 }
                 ColdStoreCopyResult::LatestBlockCopied => {
-                    tracing::trace!(target: "cold_store", "latest block was copied");
+                    tracing::trace!("latest block was copied");
                 }
                 ColdStoreCopyResult::OtherBlockCopied => {
-                    tracing::trace!(target: "cold_store", "other block was copied - more copying needed");
+                    tracing::trace!("other block was copied - more copying needed");
                 }
             },
         }
@@ -325,7 +328,13 @@ impl ColdStoreActor {
         let hot_tail = self.hot_store.get_ser::<u64>(DBCol::BlockMisc, TAIL_KEY)?;
         let hot_tail_height = hot_tail.unwrap_or(self.genesis_height);
 
-        let _span = tracing::debug_span!(target: "cold_store", "cold_store_copy", cold_head_height, hot_final_head_height, hot_tail_height).entered();
+        let _span = tracing::debug_span!(
+            "cold_store_copy",
+            cold_head_height,
+            hot_final_head_height,
+            hot_tail_height
+        )
+        .entered();
 
         sanity_check(cold_head_height, hot_final_head_height, hot_tail_height)?;
 
@@ -379,7 +388,7 @@ impl ColdStoreActor {
             Ok(ColdStoreCopyResult::OtherBlockCopied)
         };
 
-        tracing::trace!(target: "cold_store", ?result, "ending");
+        tracing::trace!(?result, "ending");
         result
     }
 
@@ -401,13 +410,15 @@ pub fn create_cold_store_actor(
     shard_tracker: ShardTracker,
 ) -> anyhow::Result<Option<(ColdStoreActor, Arc<AtomicBool>)>> {
     if save_trie_changes != Some(true) {
-        tracing::debug!(target: "cold_store", "not creating cold store actor because trie changes are not saved");
+        tracing::debug!("not creating cold store actor because trie changes are not saved");
         return Ok(None);
     }
     let cold_db = match cold_db {
         Some(cold_db) => cold_db.clone(),
         None => {
-            tracing::debug!(target: "cold_store", "not creating the cold store actor because cold store is not configured");
+            tracing::debug!(
+                "not creating the cold store actor because cold store is not configured"
+            );
             return Ok(None);
         }
     };
@@ -432,7 +443,7 @@ pub fn create_cold_store_actor(
     sanity_check(cold_head_height, hot_final_head_height, hot_tail_height)?;
     debug_assert!(shard_tracker.is_valid_for_cold_store());
 
-    tracing::info!(target: "cold_store", "creating the cold store actor");
+    tracing::info!("creating the cold store actor");
 
     let actor = ColdStoreActor::new(
         split_storage_config.clone(),

--- a/chain/client/src/chunk_distribution_network.rs
+++ b/chain/client/src/chunk_distribution_network.rs
@@ -97,7 +97,7 @@ fn request_missing_chunk<C>(
     C::Error: fmt::Debug,
 {
     let shard_id = header.shard_id();
-    tracing::debug!(target: "client", %shard_id, chunk_hash=?header.chunk_hash(), "request_missing_chunk");
+    tracing::debug!(%shard_id, chunk_hash=?header.chunk_hash(), "request_missing_chunk");
     // TODO(#14005): Use a TokioRuntimeHandle to spawn this future.
     tokio::spawn(async move {
         match client.lookup_chunk(prev_hash, shard_id).await {
@@ -115,7 +115,7 @@ fn request_missing_chunk<C>(
                 });
             }
             Err(err) => {
-                tracing::error!(target: "client", ?err, "failed to find chunk via chunk distribution network");
+                tracing::error!(?err, "failed to find chunk via chunk distribution network");
                 adapter.send(ShardsManagerRequestFromClient::RequestChunks {
                     chunks_to_request: vec![header],
                     prev_hash,
@@ -160,7 +160,7 @@ fn request_orphan_chunk<C>(
                 );
             }
             Err(err) => {
-                tracing::error!(target: "client", ?err, "failed to find chunk via chunk distribution network");
+                tracing::error!(?err, "failed to find chunk via chunk distribution network");
                 thread_local_shards_manager_adapter.send(
                     ShardsManagerRequestFromClient::RequestChunksForOrphan {
                         chunks_to_request: vec![header],

--- a/chain/client/src/chunk_endorsement_handler.rs
+++ b/chain/client/src/chunk_endorsement_handler.rs
@@ -10,7 +10,7 @@ use crate::stateless_validation::chunk_endorsement::ChunkEndorsementTracker;
 impl Handler<ChunkEndorsementMessage> for ChunkEndorsementHandlerActor {
     fn handle(&mut self, msg: ChunkEndorsementMessage) {
         if let Err(err) = self.chunk_endorsement_tracker.process_chunk_endorsement(msg.0) {
-            tracing::error!(target: "client", ?err, "error processing chunk endorsement");
+            tracing::error!(?err, "error processing chunk endorsement");
         }
     }
 }

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -146,7 +146,6 @@ impl ChunkInclusionTracker {
             self.banned_chunk_producers.contains(&(*epoch_id, chunk_info.chunk_producer.clone()));
         if banned {
             tracing::warn!(
-                target: "client",
                 chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
                 chunk_producer = ?chunk_info.chunk_producer,
                 "not including chunk from a banned validator");
@@ -176,7 +175,6 @@ impl ChunkInclusionTracker {
             let is_endorsed = chunk_info.endorsements.is_endorsed;
             if !is_endorsed {
                 tracing::debug!(
-                    target: "client",
                     chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
                     chunk_producer = ?chunk_info.chunk_producer,
                     "not including chunk because of insufficient chunk endorsements"

--- a/chain/client/src/config_updater.rs
+++ b/chain/client/src/config_updater.rs
@@ -42,14 +42,14 @@ impl ConfigUpdater {
                     if let Some(client_config) = updatable_configs.client_config {
                         update_result.client_config_updated |=
                             update_client_config_fn(client_config);
-                        tracing::info!(target: "config", "updated client config");
+                        tracing::info!("updated client config");
                     }
                     if let UpdatableValidatorSigner::MaybeKey(validator_signer) =
                         updatable_configs.validator_signer
                     {
                         update_result.validator_signer_updated |=
                             update_validator_signer_fn(validator_signer);
-                        tracing::info!(target: "config", "updated validator key");
+                        tracing::info!("updated validator key");
                     }
                     self.updatable_configs_error = None;
                 }
@@ -65,7 +65,6 @@ impl ConfigUpdater {
     pub fn report_status(&self) {
         if let Some(updatable_configs_error) = &self.updatable_configs_error {
             tracing::warn!(
-                target: "stats",
                 error = %*updatable_configs_error,
                 "dynamically updated configs are not valid, please fix this ASAP otherwise the node will probably crash after restart"
             );

--- a/chain/client/src/gc_actor.rs
+++ b/chain/client/src/gc_actor.rs
@@ -81,17 +81,17 @@ impl GCActor {
 
     fn gc(&mut self) {
         if self.no_gc {
-            tracing::warn!(target: "garbage collection", "GC is disabled");
+            tracing::warn!("GC is disabled");
             return;
         }
         if self.store.head().is_err() {
-            tracing::warn!(target: "garbage collection", "state not initialized yet, head doesn't exist");
+            tracing::warn!("state not initialized yet, head doesn't exist");
             return;
         }
 
         let timer = metrics::GC_TIME.start_timer();
         if let Err(e) = self.clear_data() {
-            tracing::error!(target: "garbage collection", ?e, "error in gc");
+            tracing::error!(?e, "error in gc");
             debug_assert!(false, "Error in GCActor");
         }
         timer.observe_duration();

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -255,7 +255,7 @@ impl InfoHelper {
                 let chunk_producers_settlement = &epoch_info.chunk_producers_settlement();
                 let chunk_producers = chunk_producers_settlement.get(shard_index);
                 let Some(chunk_producers) = chunk_producers else {
-                    tracing::warn!(target: "stats", %shard_id, ?chunk_producers_settlement, "invalid shard id, not found in the shard settlement");
+                    tracing::warn!(%shard_id, ?chunk_producers_settlement, "invalid shard id, not found in the shard settlement");
                     continue;
                 };
                 for &id in chunk_producers {
@@ -450,7 +450,7 @@ impl InfoHelper {
             blocks_info_log,
             machine_info_log
         );
-        tracing::info!(target: "stats", ?node_status);
+        tracing::info!(?node_status);
         log_catchup_status(catchup_status);
         if let Some(config_updater) = &config_updater {
             config_updater.report_status();
@@ -620,7 +620,6 @@ impl InfoHelper {
         let info = chain.get_chain_processing_info();
         let blocks_info = BlocksInfo { blocks_info: info.blocks_info };
         tracing::debug!(
-            target: "stats",
             "{:?} Orphans: {} With missing chunks: {} In processing {}{}",
             epoch_id,
             info.num_orphans,

--- a/chain/client/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement.rs
@@ -48,7 +48,7 @@ impl ChunkEndorsementTracker {
         {
             let cache = self.chunk_endorsements.lock();
             if cache.peek(&key).is_some_and(|entry| entry.contains_key(account_id)) {
-                tracing::debug!(target: "client", ?endorsement, "already received chunk endorsement");
+                tracing::debug!(?endorsement, "already received chunk endorsement");
                 return Ok(());
             }
         }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -26,7 +26,6 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
     network_sender: &Sender<PeerManagerMessageRequest>,
 ) -> Option<ChunkEndorsement> {
     let _span = tracing::debug_span!(
-        target: "client",
         "send_chunk_endorsement",
         chunk_hash = ?chunk_header.chunk_hash(),
         height = %chunk_header.height_created(),
@@ -52,7 +51,6 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
 
     let chunk_hash = chunk_header.chunk_hash();
     tracing::debug!(
-        target: "client",
         chunk_hash=?chunk_hash,
         shard_id=%chunk_header.shard_id(),
         ?block_producers,

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
@@ -28,7 +28,6 @@ impl OrphanStateWitnessPool {
     pub fn new(cache_capacity: usize) -> Self {
         if cache_capacity > 128 {
             tracing::warn!(
-                target: "client",
                 cache_capacity,
                 "orphan state witness cache capacity is larger than expected, this might lead to performance problems"
             );
@@ -54,7 +53,6 @@ impl OrphanStateWitnessPool {
             // Another witness has been ejected from the cache due to capacity limit
             let header = &ejected_entry.witness.chunk_header();
             tracing::debug!(
-                target: "client",
                 ejected_witness_height = header.height_created(),
                 ejected_witness_shard = ?header.shard_id(),
                 ejected_witness_chunk = ?header.chunk_hash(),
@@ -98,7 +96,6 @@ impl OrphanStateWitnessPool {
                 to_remove.push(cache_key.clone());
                 let header = &cache_entry.witness.chunk_header();
                 tracing::debug!(
-                    target: "client",
                     final_height,
                     ejected_witness_height = witness_height,
                     ejected_witness_shard = ?cache_key.shard_id,

--- a/chain/client/src/stateless_validation/partial_witness/partial_deploys_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_deploys_tracker.rs
@@ -38,7 +38,6 @@ impl CacheEntry {
         let part_ord = part.part_ord;
         if self.parts.encoded_length() != part.encoded_length {
             tracing::warn!(
-                target: "client",
                 expected = self.parts.encoded_length(),
                 actual = part.encoded_length,
                 part_ord,
@@ -50,7 +49,6 @@ impl CacheEntry {
             InsertPartResult::Accepted => None,
             InsertPartResult::PartAlreadyAvailable => {
                 tracing::warn!(
-                    target: "client",
                     ?key,
                     part_ord,
                     "received duplicate or redundant contract deploy part"
@@ -58,12 +56,7 @@ impl CacheEntry {
                 None
             }
             InsertPartResult::InvalidPartOrd => {
-                tracing::warn!(
-                    target: "client",
-                    ?key,
-                    part_ord,
-                    "received invalid contract deploys part ord"
-                );
+                tracing::warn!(?key, part_ord, "received invalid contract deploys part ord");
                 None
             }
             InsertPartResult::Decoded(decode_result) => Some(decode_result),
@@ -97,7 +90,6 @@ impl PartialEncodedContractDeploysTracker {
             .is_some_and(|entry| entry.parts.has_part(partial_deploys.part().part_ord))
         {
             tracing::warn!(
-                target: "client",
                 ?key,
                 part = ?partial_deploys.part(),
                 "received already processed partial deploys part"
@@ -119,7 +111,6 @@ impl PartialEncodedContractDeploysTracker {
                 self.parts_cache.push(key.clone(), new_entry)
             {
                 tracing::warn!(
-                    target: "client",
                     ?evicted_key,
                     data_parts_present = ?evicted_entry.parts.data_parts_present(),
                     data_parts_required = ?evicted_entry.parts.data_parts_required(),
@@ -138,12 +129,7 @@ impl PartialEncodedContractDeploysTracker {
             let deploys = match decode_result {
                 Ok(deploys) => deploys,
                 Err(err) => {
-                    tracing::warn!(
-                        target: "client",
-                        ?err,
-                        ?key,
-                        "failed to reed solomon decode deployed contracts"
-                    );
+                    tracing::warn!(?err, ?key, "failed to reed solomon decode deployed contracts");
                     return Ok(None);
                 }
             };

--- a/chain/client/src/stateless_validation/shadow_validate.rs
+++ b/chain/client/src/stateless_validation/shadow_validate.rs
@@ -14,7 +14,7 @@ impl Client {
             return Ok(());
         }
         let block_hash = block.hash();
-        tracing::debug!(target: "client", ?block_hash, "shadow validation for block chunks");
+        tracing::debug!(?block_hash, "shadow validation for block chunks");
         let prev_block = self.chain.get_block(block.header().prev_hash())?;
         let prev_block_chunks = prev_block.chunks();
         for (shard_index, chunk) in block.chunks().iter_new().enumerate() {
@@ -27,7 +27,6 @@ impl Client {
                 near_chain::stateless_validation::metrics::SHADOW_CHUNK_VALIDATION_FAILED_TOTAL
                     .inc();
                 tracing::error!(
-                    target: "client",
                     ?err,
                     shard_id = %chunk.shard_id(),
                     ?block_hash,

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -28,7 +28,6 @@ impl Client {
         let shard_id = chunk_header.shard_id();
         let height = chunk_header.height_created();
         let _span = tracing::debug_span!(
-            target: "client",
             "send_chunk_state_witness",
             chunk_hash=?chunk_header.chunk_hash(),
             height,
@@ -60,7 +59,7 @@ impl Client {
             .contains(my_signer.validator_id())
         {
             // Bypass state witness validation if we created state witness. Endorse the chunk immediately.
-            tracing::debug!(target: "client", chunk_hash=?chunk_header.chunk_hash(), %shard_id, "send_chunk_endorsement_from_chunk_producer");
+            tracing::debug!(chunk_hash=?chunk_header.chunk_hash(), %shard_id, "send_chunk_endorsement_from_chunk_producer");
             if let Some(endorsement) = send_chunk_endorsement_to_block_producers(
                 &chunk_header,
                 self.epoch_manager.as_ref(),

--- a/chain/client/src/stateless_validation/state_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/state_witness_tracker.rs
@@ -67,7 +67,7 @@ impl ChunkStateWitnessTracker {
         num_validators: usize,
     ) -> () {
         let key = ChunkStateWitnessKey::new(chunk_hash);
-        tracing::trace!(target: "state_witness_tracker", witness_key=?key,
+        tracing::trace!(witness_key=?key,
             size=witness_size_in_bytes, "recording state witness sent");
         self.witnesses.put(
             key,
@@ -83,7 +83,7 @@ impl ChunkStateWitnessTracker {
     /// records it in the corresponding metric.
     pub fn on_witness_ack_received(&mut self, ack: ChunkStateWitnessAck) -> () {
         let key = ChunkStateWitnessKey { chunk_hash: ack.chunk_hash };
-        tracing::trace!(target: "state_witness_tracker", witness_key=?key,
+        tracing::trace!(witness_key=?key,
             "received ack for state witness");
         if let Some(record) = self.witnesses.get_mut(&key) {
             debug_assert!(record.num_validators > 0);

--- a/chain/client/src/stateless_validation/validate.rs
+++ b/chain/client/src/stateless_validation/validate.rs
@@ -69,7 +69,6 @@ pub fn validate_partial_encoded_state_witness(
     let ChunkProductionKey { shard_id, epoch_id, height_created } =
         partial_witness.chunk_production_key();
     let _span = tracing::debug_span!(
-        target: "client",
         "validate_partial_encoded_state_witness",
         height = %height_created,
         shard_id = %shard_id,
@@ -135,7 +134,6 @@ pub fn validate_chunk_endorsement(
     store: &Store,
 ) -> Result<ChunkRelevance, Error> {
     let _span = tracing::debug_span!(
-        target: "stateless_validation",
         "validate_chunk_endorsement",
         height = endorsement.chunk_production_key().height_created,
         shard_id = %endorsement.chunk_production_key().shard_id,
@@ -236,11 +234,7 @@ fn validate_chunk_relevant(
     let height_created = chunk_production_key.height_created;
 
     if !epoch_manager.get_shard_layout(&epoch_id)?.shard_ids().contains(&shard_id) {
-        tracing::error!(
-            target: "stateless_validation",
-            ?chunk_production_key,
-            "shard id is not in the shard layout of the epoch"
-        );
+        tracing::error!(?chunk_production_key, "shard id is not in the shard layout of the epoch");
         return Err(Error::InvalidShardId(shard_id));
     }
 
@@ -257,7 +251,6 @@ fn validate_chunk_relevant(
     if let Some(final_head) = final_head {
         if height_created <= final_head.height {
             tracing::debug!(
-                target: "stateless_validation",
                 ?chunk_production_key,
                 final_head_height = final_head.height,
                 "skipping because height created is not greater than final head height",
@@ -268,7 +261,6 @@ fn validate_chunk_relevant(
     if let Some(head) = head {
         if height_created > head.height + MAX_HEIGHTS_AHEAD {
             tracing::debug!(
-                target: "stateless_validation",
                 ?chunk_production_key,
                 head_height = head.height,
                 %MAX_HEIGHTS_AHEAD,
@@ -286,7 +278,6 @@ fn validate_chunk_relevant(
             epoch_manager.possible_epochs_of_height_around_tip(&head, height_created)?;
         if !possible_epochs.contains(&epoch_id) {
             tracing::debug!(
-                target: "stateless_validation",
                 ?chunk_production_key,
                 ?possible_epochs,
                 "skipping because epoch id is not in the possible list of epochs"

--- a/chain/client/src/sync/block.rs
+++ b/chain/client/src/sync/block.rs
@@ -71,14 +71,13 @@ impl BlockSync {
         highest_height_peers: &[HighestHeightPeerInfo],
         max_block_requests: usize,
     ) -> Result<bool, near_chain::Error> {
-        let _span =
-            tracing::debug_span!(target: "sync", "run_sync", sync_type = "BlockSync").entered();
+        let _span = tracing::debug_span!("run_sync", sync_type = "BlockSync").entered();
         let head = chain.head()?;
         let header_head = chain.header_head()?;
 
         match self.block_sync_due(&head, &header_head) {
             BlockSyncDue::StateSync => {
-                tracing::debug!(target: "sync", "sync: transition to state sync");
+                tracing::debug!("sync: transition to state sync");
                 return Ok(true);
             }
             BlockSyncDue::RequestBlock => {
@@ -116,7 +115,6 @@ impl BlockSync {
             && head.height.saturating_add(self.block_fetch_horizon) < header_head.height;
         if prefer_state_sync {
             tracing::debug!(
-                target: "sync",
                 head_epoch_id = ?head.epoch_id,
                 header_head_epoch_id = ?header_head.epoch_id,
                 head_next_epoch_id = ?head.next_epoch_id,
@@ -173,7 +171,6 @@ impl BlockSync {
     /// Request recent blocks from a randomly chosen peer.
     /// pub for testing
     #[instrument(
-        target = "sync",
         level = "debug",
         skip_all,
         fields(head_last_block_hash, head_height, header_head_height, num_requests)
@@ -215,7 +212,6 @@ impl BlockSync {
                 Err(e) => match e {
                     near_chain::Error::DBNotFoundErr(_) => {
                         tracing::debug!(
-                            target: "sync",
                             block_hash = ?next_hash,
                             "next block hash is not found"
                         );
@@ -226,7 +222,6 @@ impl BlockSync {
             };
             if let BlockKnowledge::Known(err) = chain.check_block_known(&next_hash) {
                 tracing::debug!(
-                    target: "sync",
                     block_hash = ?next_hash,
                     ?err,
                     "block is known"
@@ -249,7 +244,6 @@ impl BlockSync {
 
             if let Some(peer) = peer {
                 tracing::debug!(
-                    target: "sync",
                     block_hash = ?next_hash,
                     block_height = next_height,
                     request_from_archival,
@@ -266,7 +260,6 @@ impl BlockSync {
                 num_requests += 1;
             } else {
                 tracing::warn!(
-                    target: "sync",
                     block_hash = ?next_hash,
                     block_height = next_height,
                     request_from_archival,

--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -70,13 +70,13 @@ impl StateSyncConnection {
         let result = self.connection.get(location).await;
         match &result {
             Ok(bytes) => {
-                tracing::debug!(target: "sync", %shard_id, location, num_bytes = bytes.len(), storage = self.storage_name, "request finished");
+                tracing::debug!(%shard_id, location, num_bytes = bytes.len(), storage = self.storage_name, "request finished");
                 metrics::STATE_SYNC_EXTERNAL_PARTS_SIZE_DOWNLOADED
                     .with_label_values(&[&shard_id.to_string(), &file_type.to_string()])
                     .inc_by(bytes.len() as u64);
             }
             Err(error) => {
-                tracing::debug!(target: "sync", %shard_id, location, ?error, storage = self.storage_name, "request failed");
+                tracing::debug!(%shard_id, location, ?error, storage = self.storage_name, "request failed");
             }
         }
         result
@@ -95,11 +95,11 @@ impl StateSyncConnection {
         let res = self.connection.put(location, data).await;
         let is_ok = match &res {
             Ok(()) => {
-                tracing::debug!(target: "state_sync_dump", %shard_id, part_length = data.len(), ?location, ?file_type, storage = self.storage_name, "wrote a state part");
+                tracing::debug!(%shard_id, part_length = data.len(), ?location, ?file_type, storage = self.storage_name, "wrote a state part");
                 "ok"
             }
             Err(error) => {
-                tracing::error!(target: "state_sync_dump", %shard_id, part_length = data.len(), ?location, ?file_type, storage = self.storage_name, ?error, "failed to write a state part");
+                tracing::error!(%shard_id, part_length = data.len(), ?location, ?file_type, storage = self.storage_name, ?error, "failed to write a state part");
                 "error"
             }
         };
@@ -121,7 +121,7 @@ impl StateSyncConnection {
         let _timer = metrics::STATE_SYNC_DUMP_LIST_OBJECT_ELAPSED
             .with_label_values(&[&shard_id.to_string()])
             .start_timer();
-        tracing::debug!(target: "state_sync_dump", %shard_id, directory_path, "list state parts");
+        tracing::debug!(%shard_id, directory_path, "list state parts");
         self.connection.list(directory_path).await
     }
 
@@ -144,7 +144,6 @@ impl StateSyncConnection {
         let file_names = self.list_objects(shard_id, &directory_path).await?;
         let header_exits = file_names.contains(&file_type.filename());
         tracing::debug!(
-            target: "state_sync_dump",
             ?directory_path,
             "{}",
             match header_exits {

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -104,8 +104,7 @@ impl HeaderSync {
         highest_height: BlockHeight,
         highest_height_peers: &[HighestHeightPeerInfo],
     ) -> Result<(), near_chain::Error> {
-        let _span =
-            tracing::debug_span!(target: "sync", "run_sync", sync_type = "HeaderSync").entered();
+        let _span = tracing::debug_span!("run_sync", sync_type = "HeaderSync").entered();
         let head = chain.head()?;
         let header_head = chain.header_head()?;
 
@@ -127,7 +126,7 @@ impl HeaderSync {
                 true
             }
             SyncStatus::NoSync | SyncStatus::AwaitingPeers => {
-                tracing::debug!(target: "sync", header_head_hash = ?header_head.last_block_hash, header_head_height = header_head.height, "initial transition to header sync");
+                tracing::debug!(header_head_hash = ?header_head.last_block_hash, header_head_height = header_head.height, "initial transition to header sync");
                 true
             }
             SyncStatus::EpochSync { .. } | SyncStatus::StateSync { .. } => false,
@@ -240,7 +239,7 @@ impl HeaderSync {
                                     && *highest_height == peer.highest_block_height
                                 {
                                     // The peer is one of the peers with the highest height, but we consider the peer stalling.
-                                    tracing::warn!(target: "sync", peer_info = %peer.peer_info, peer_height = peer.highest_block_height, "banning a peer for not providing enough headers");
+                                    tracing::warn!(peer_info = %peer.peer_info, peer_height = peer.highest_block_height, "banning a peer for not providing enough headers");
                                     // Ban the peer, which blocks all interactions with the peer for some time.
                                     // TODO: Consider not banning straightaway, but give a node a few attempts before banning it.
                                     // TODO: Prefer not to request the next batch of headers from the same peer.
@@ -313,7 +312,7 @@ impl HeaderSync {
         peer: &HighestHeightPeerInfo,
     ) -> Result<(), near_chain::Error> {
         let locator = self.get_locator(chain)?;
-        tracing::debug!(target: "sync", peer_id = %peer.peer_info.id, ?locator, "requesting headers");
+        tracing::debug!(peer_id = %peer.peer_info.id, ?locator, "requesting headers");
         self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
             NetworkRequests::BlockHeadersRequest {
                 hashes: locator,
@@ -355,11 +354,11 @@ impl HeaderSync {
                     if *ordinal == tip_ordinal {
                         return Err(e);
                     }
-                    tracing::debug!(target: "sync", ordinal, error = ?e, "failed to get block hash from ordinal, this is normal if we just finished epoch sync");
+                    tracing::debug!(ordinal, error = ?e, "failed to get block hash from ordinal, this is normal if we just finished epoch sync");
                 }
             }
         }
-        tracing::debug!(target: "sync", ?locator, ?ordinals);
+        tracing::debug!(?locator, ?ordinals);
         Ok(locator)
     }
 }

--- a/chain/client/src/sync/state/external.rs
+++ b/chain/client/src/sync/state/external.rs
@@ -43,11 +43,11 @@ impl StateSyncDownloadSourceExternal {
             StateFileType::StateHeader => "header",
             StateFileType::StatePart { .. } => "part",
         };
-        tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, "external download starting");
+        tracing::debug!(?shard_id, ?file_type, ?location, "external download starting");
         tokio::select! {
             _ = clock.sleep_until(deadline) => {
                 increment_download_count(shard_id, typ, "external", "timeout");
-                tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, "external download timed out");
+                tracing::debug!(?shard_id, ?file_type, ?location, "external download timed out");
                 Err(near_chain::Error::Other("Timeout".to_owned()))
             }
             _ = cancellation.cancelled() => {
@@ -58,7 +58,7 @@ impl StateSyncDownloadSourceExternal {
                 match result {
                     Err(err) => {
                         increment_download_count(shard_id, typ, "external", "download_error");
-                        tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, %err, "external download error");
+                        tracing::debug!(?shard_id, ?file_type, ?location, %err, "external download error");
                         Err(near_chain::Error::Other(format!("Failed to download: {}", err)))
                     }
                     Ok(res) => Ok(res)

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -205,8 +205,7 @@ impl StateSync {
         sync_status: &mut StateSyncStatus,
         tracking_shards: &[ShardId],
     ) -> Result<StateSyncResult, near_chain::Error> {
-        let _span =
-            tracing::debug_span!(target: "sync", "run_sync", sync_type = "StateSync").entered();
+        let _span = tracing::debug_span!("run_sync", sync_type = "StateSync").entered();
         tracing::debug!(%sync_hash, ?tracking_shards, "syncing state");
 
         let mut all_done = true;

--- a/chain/client/src/sync/state/network.rs
+++ b/chain/client/src/sync/state/network.rs
@@ -86,7 +86,7 @@ impl StateSyncDownloadSourcePeerSharedState {
         let key = PendingPeerRequestKey { shard_id, sync_hash: msg.sync_hash(), part_id_or_header };
 
         let Some(request) = self.pending_requests.get_mut(&key) else {
-            tracing::debug!(target: "sync", ?key, %peer_id, "unexpected state response, request may have timed out");
+            tracing::debug!(?key, %peer_id, "unexpected state response, request may have timed out");
             return Ok(());
         };
 
@@ -211,7 +211,7 @@ impl StateSyncDownloadSourcePeer {
             }
         };
 
-        tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request sent");
+        tracing::debug!(?key, ?request_sent_to_peer, "p2p request sent");
 
         let state_value = PendingPeerRequestValue { peer_id: request_sent_to_peer.clone(), sender };
 
@@ -227,7 +227,7 @@ impl StateSyncDownloadSourcePeer {
         select! {
             _ = clock.sleep_until(deadline) => {
                 increment_download_count(key.shard_id, typ, "network", "timeout");
-                tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request timed out");
+                tracing::debug!(?key, ?request_sent_to_peer, "p2p request timed out");
                 Err(near_chain::Error::Other("Timeout".to_owned()))
             }
             _ = cancel.cancelled() => {
@@ -237,7 +237,7 @@ impl StateSyncDownloadSourcePeer {
             result = receiver => {
                 match result {
                     Ok(result) => {
-                        tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request succeeded");
+                        tracing::debug!(?key, ?request_sent_to_peer, "p2p request succeeded");
                         increment_download_count(key.shard_id, typ, "network", "success");
                         Ok(result)
                     }

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -153,9 +153,13 @@ pub(super) async fn run_state_sync_for_shard(
         store.exists(DBCol::StatePartsApplied, &key_bytes)
     });
     if apply_parts_started {
-        tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "not clearing flat storage before applying state parts because some parts were already applied");
+        tracing::debug!(
+            ?shard_id,
+            ?sync_hash,
+            "not clearing flat storage before applying state parts because some parts were already applied"
+        );
     } else {
-        tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
+        tracing::debug!(?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
         let mut store_update = store.store_update();
         runtime
             .get_flat_storage_manager()
@@ -255,7 +259,12 @@ fn create_flat_storage_for_shard(
     let flat_head_prev_hash = *flat_head_header.prev_hash();
     let flat_head_height = flat_head_header.height();
 
-    tracing::debug!(target: "store", ?shard_uid, ?flat_head_hash, flat_head_height, "set_state_finalize - initialized flat storage");
+    tracing::debug!(
+        ?shard_uid,
+        ?flat_head_hash,
+        flat_head_height,
+        "set_state_finalize - initialized flat storage"
+    );
 
     let mut store_update = store.flat_store().store_update();
     store_update.set_flat_storage_status(
@@ -296,7 +305,7 @@ async fn apply_state_part(
     let key_bytes = borsh::to_vec(&key).unwrap();
     let already_applied = store.exists(DBCol::StatePartsApplied, &key_bytes);
     if already_applied {
-        tracing::debug!(target: "sync", ?key, "state part already applied, skipping");
+        tracing::debug!(?key, "state part already applied, skipping");
         return Ok(StatePartApplyResult::AlreadyApplied);
     }
     return_if_cancelled!(cancel);
@@ -322,7 +331,7 @@ async fn apply_state_part(
         &state_part,
         &epoch_id,
     )?;
-    tracing::debug!(target: "sync", ?key, "applied state part");
+    tracing::debug!(?key, "applied state part");
 
     // Mark part as applied.
     let mut store_update = store.store_update();

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -32,7 +32,7 @@ impl SyncJobsActor {
     }
 
     pub fn handle_block_catch_up_request(&mut self, msg: BlockCatchUpRequest) {
-        tracing::debug!(target: "sync", ?msg);
+        tracing::debug!(?msg);
         let results = do_apply_chunks(
             self.apply_chunks_iteration_mode,
             BlockToApply::Normal(msg.block_hash),

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -678,7 +678,7 @@ impl ViewClientActor {
                     }
                 }
                 Err(err) => {
-                    tracing::warn!(target: "client", ?err, "error trying to get transaction result");
+                    tracing::warn!(?err, "error trying to get transaction result");
                     Err(err.into())
                 }
             }
@@ -734,7 +734,7 @@ impl ViewClientActor {
 
 impl Handler<Query, Result<QueryResponse, QueryError>> for ViewClientActor {
     fn handle(&mut self, msg: Query) -> Result<QueryResponse, QueryError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["Query"]).start_timer();
         self.handle_query(msg)
     }
@@ -743,7 +743,7 @@ impl Handler<Query, Result<QueryResponse, QueryError>> for ViewClientActor {
 /// Handles retrieving block from the chain.
 impl Handler<GetBlock, Result<BlockView, GetBlockError>> for ViewClientActor {
     fn handle(&mut self, msg: GetBlock) -> Result<BlockView, GetBlockError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetBlock"]).start_timer();
         let block = self.get_block_by_reference(&msg.0)?.ok_or(GetBlockError::NotSyncedYet)?;
@@ -762,7 +762,7 @@ impl Handler<GetBlockWithMerkleTree, Result<(BlockView, Arc<PartialMerkleTree>),
         &mut self,
         msg: GetBlockWithMerkleTree,
     ) -> Result<(BlockView, Arc<PartialMerkleTree>), GetBlockError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetBlockWithMerkleTree"])
             .start_timer();
@@ -799,7 +799,7 @@ fn get_chunk_from_block(
 
 impl Handler<GetShardChunk, Result<ShardChunk, GetChunkError>> for ViewClientActor {
     fn handle(&mut self, msg: GetShardChunk) -> Result<ShardChunk, GetChunkError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetShardChunk"]).start_timer();
 
@@ -822,7 +822,7 @@ impl Handler<GetShardChunk, Result<ShardChunk, GetChunkError>> for ViewClientAct
 
 impl Handler<GetChunk, Result<ChunkView, GetChunkError>> for ViewClientActor {
     fn handle(&mut self, msg: GetChunk) -> Result<ChunkView, GetChunkError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetChunk"]).start_timer();
 
@@ -862,7 +862,7 @@ impl Handler<GetChunk, Result<ChunkView, GetChunkError>> for ViewClientActor {
 
 impl Handler<TxStatus, Result<TxStatusView, TxStatusError>> for ViewClientActor {
     fn handle(&mut self, msg: TxStatus) -> Result<TxStatusView, TxStatusError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["TxStatus"]).start_timer();
         self.get_tx_status(msg.tx_hash, msg.signer_account_id, msg.fetch_receipt)
@@ -876,7 +876,7 @@ impl Handler<GetValidatorInfo, Result<EpochValidatorInfo, GetValidatorInfoError>
         &mut self,
         msg: GetValidatorInfo,
     ) -> Result<EpochValidatorInfo, GetValidatorInfoError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetValidatorInfo"])
             .start_timer();
@@ -924,7 +924,7 @@ impl Handler<GetValidatorOrdered, Result<Vec<ValidatorStakeView>, GetValidatorIn
         &mut self,
         msg: GetValidatorOrdered,
     ) -> Result<Vec<ValidatorStakeView>, GetValidatorInfoError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetValidatorOrdered"])
             .start_timer();
@@ -941,7 +941,7 @@ impl Handler<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChang
         &mut self,
         msg: GetStateChangesInBlock,
     ) -> Result<StateChangesKindsView, GetStateChangesError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetStateChangesInBlock"])
             .start_timer();
@@ -958,7 +958,7 @@ impl Handler<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChang
 /// Returns a list of changes in a store for a given block filtering by the state changes request.
 impl Handler<GetStateChanges, Result<StateChangesView, GetStateChangesError>> for ViewClientActor {
     fn handle(&mut self, msg: GetStateChanges) -> Result<StateChangesView, GetStateChangesError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetStateChanges"]).start_timer();
         Ok(self
@@ -979,7 +979,7 @@ impl Handler<GetStateChangesWithCauseInBlock, Result<StateChangesView, GetStateC
         &mut self,
         msg: GetStateChangesWithCauseInBlock,
     ) -> Result<StateChangesView, GetStateChangesError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetStateChangesWithCauseInBlock"])
             .start_timer();
@@ -1005,7 +1005,7 @@ impl
         &mut self,
         msg: GetStateChangesWithCauseInBlockForTrackedShards,
     ) -> Result<HashMap<ShardId, StateChangesView>, GetStateChangesError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetStateChangesWithCauseInBlockForTrackedShards"])
             .start_timer();
@@ -1054,7 +1054,7 @@ impl
         &mut self,
         msg: GetNextLightClientBlock,
     ) -> Result<Option<Arc<LightClientBlockView>>, GetNextLightClientBlockError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetNextLightClientBlock"])
             .start_timer();
@@ -1095,7 +1095,7 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
         &mut self,
         msg: GetExecutionOutcome,
     ) -> Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetExecutionOutcome"])
             .start_timer();
@@ -1186,7 +1186,7 @@ impl
         &mut self,
         msg: GetExecutionOutcomesForBlock,
     ) -> Result<HashMap<ShardId, Vec<ExecutionOutcomeWithIdView>>, String> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetExecutionOutcomesForBlock"])
             .start_timer();
@@ -1203,7 +1203,7 @@ impl
 
 impl Handler<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>> for ViewClientActor {
     fn handle(&mut self, msg: GetReceipt) -> Result<Option<ReceiptView>, GetReceiptError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetReceipt"]).start_timer();
         Ok(self
@@ -1216,7 +1216,7 @@ impl Handler<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>> for ViewC
 
 impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> for ViewClientActor {
     fn handle(&mut self, msg: GetBlockProof) -> Result<GetBlockProofResponse, GetBlockProofError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetBlockProof"]).start_timer();
         let block_header = self.chain.get_block_header(&msg.block_hash)?;
@@ -1240,7 +1240,7 @@ impl Handler<GetProtocolConfig, Result<ProtocolConfigView, GetProtocolConfigErro
         &mut self,
         msg: GetProtocolConfig,
     ) -> Result<ProtocolConfigView, GetProtocolConfigError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["GetProtocolConfig"])
             .start_timer();
@@ -1270,21 +1270,21 @@ impl Handler<NetworkAdversarialMessage> for ViewClientActor {
 #[cfg(feature = "test_features")]
 impl Handler<NetworkAdversarialMessage, Option<u64>> for ViewClientActor {
     fn handle(&mut self, msg: NetworkAdversarialMessage) -> Option<u64> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["NetworkAdversarialMessage"])
             .start_timer();
         match msg {
             NetworkAdversarialMessage::AdvDisableDoomslug => {
-                tracing::info!(target: "adversary", "turning doomslug off");
+                tracing::info!("turning doomslug off");
                 self.adv.set_disable_doomslug(true);
             }
             NetworkAdversarialMessage::AdvDisableHeaderSync => {
-                tracing::info!(target: "adversary", "blocking header sync");
+                tracing::info!("blocking header sync");
                 self.adv.set_disable_header_sync(true);
             }
             NetworkAdversarialMessage::AdvSwitchToHeight(height) => {
-                tracing::info!(target: "adversary", "switching to height");
+                tracing::info!("switching to height");
                 let mut chain_store_update = self.chain.mut_chain_store().store_update();
                 chain_store_update.save_largest_target_height(height);
                 chain_store_update
@@ -1300,7 +1300,7 @@ impl Handler<NetworkAdversarialMessage, Option<u64>> for ViewClientActor {
 
 impl Handler<TxStatusRequest, Option<Box<FinalExecutionOutcomeView>>> for ViewClientActor {
     fn handle(&mut self, msg: TxStatusRequest) -> Option<Box<FinalExecutionOutcomeView>> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["TxStatusRequest"]).start_timer();
         let TxStatusRequest { tx_hash, signer_account_id } = msg;
@@ -1318,7 +1318,6 @@ impl Handler<TxStatusResponse> for ViewClientActor {
     fn handle(&mut self, msg: TxStatusResponse) {
         let TxStatusResponse(tx_result) = msg;
         tracing::debug!(
-            target: "client",
             tx_hash = %tx_result.transaction.hash, status = ?tx_result.status,
             tx_outcome_status = ?tx_result.transaction_outcome.outcome.status,
             num_receipt_outcomes = tx_result.receipts_outcome.len(),
@@ -1337,7 +1336,7 @@ impl Handler<TxStatusResponse> for ViewClientActor {
 
 impl Handler<BlockRequest, Option<Arc<Block>>> for ViewClientActor {
     fn handle(&mut self, msg: BlockRequest) -> Option<Arc<Block>> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["BlockRequest"]).start_timer();
         let BlockRequest(hash) = msg;
@@ -1347,7 +1346,7 @@ impl Handler<BlockRequest, Option<Arc<Block>>> for ViewClientActor {
 
 impl Handler<BlockHeadersRequest, Option<Vec<Arc<BlockHeader>>>> for ViewClientActor {
     fn handle(&mut self, msg: BlockHeadersRequest) -> Option<Vec<Arc<BlockHeader>>> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["BlockHeadersRequest"])
             .start_timer();
@@ -1370,7 +1369,7 @@ impl Handler<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>
         &mut self,
         msg: AnnounceAccountRequest,
     ) -> Result<Vec<AnnounceAccount>, ReasonForBan> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
             .with_label_values(&["AnnounceAccountRequest"])
             .start_timer();
@@ -1411,7 +1410,7 @@ impl Handler<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>
                 // We currently do NOT ban the peer for either.
                 // TODO(gprusak): consider whether we should change that.
                 Err(err) => {
-                    tracing::debug!(target: "view_client", ?err, "failed to validate account announce signature");
+                    tracing::debug!(?err, "failed to validate account announce signature");
                 }
             }
         }
@@ -1421,7 +1420,7 @@ impl Handler<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>
 
 impl Handler<GetGasPrice, Result<GasPriceView, GetGasPriceError>> for ViewClientActor {
     fn handle(&mut self, msg: GetGasPrice) -> Result<GasPriceView, GetGasPriceError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetGasPrice"]).start_timer();
         let header = self.maybe_block_id_to_block_header(msg.block_id);
@@ -1436,7 +1435,7 @@ impl Handler<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanc
         &mut self,
         msg: GetMaintenanceWindows,
     ) -> Result<MaintenanceWindowsView, GetMaintenanceWindowsError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
         Ok(self.get_maintenance_windows(msg.account_id)?)
     }
 }
@@ -1449,7 +1448,7 @@ impl Handler<GetSplitStorageInfo, Result<SplitStorageInfoView, GetSplitStorageIn
         &mut self,
         msg: GetSplitStorageInfo,
     ) -> Result<SplitStorageInfoView, GetSplitStorageInfoError> {
-        tracing::debug!(target: "client", ?msg);
+        tracing::debug!(?msg);
 
         let store = self.chain.chain_store().store();
         let head = store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -92,7 +92,7 @@ pub trait EpochManagerAdapter: Send + Sync {
             Err(err @ EpochError::IOErr(_)) => Err(err),
             Err(EpochError::EpochOutOfBounds(_) | EpochError::MissingBlock(_)) => Ok(false),
             Err(err) => {
-                tracing::warn!(target: "epoch_manager", ?err, "unexpected error in is_last_block_in_finished_epoch");
+                tracing::warn!(?err, "unexpected error in is_last_block_in_finished_epoch");
                 Ok(false)
             }
         }

--- a/chain/epoch-manager/src/epoch_info_aggregator.rs
+++ b/chain/epoch-manager/src/epoch_info_aggregator.rs
@@ -68,8 +68,7 @@ impl EpochInfoAggregator {
         shard_layout: &ShardLayout,
         prev_block_height: BlockHeight,
     ) {
-        let _span = tracing::debug_span!(target: "epoch_tracker", "update_tail", prev_block_height)
-            .entered();
+        let _span = tracing::debug_span!("update_tail", prev_block_height).entered();
 
         // Step 1: update block tracer (block-production stats)
 
@@ -86,7 +85,6 @@ impl EpochInfoAggregator {
                     .or_insert(ValidatorStats { produced: 1, expected: 1 });
             } else {
                 tracing::debug!(
-                    target: "epoch_tracker",
                     block_producer = ?epoch_info.validator_account_id(block_producer_id),
                     block_height = height, "missed block");
                 entry
@@ -113,7 +111,6 @@ impl EpochInfoAggregator {
                         *stats.produced_mut() += 1;
                     } else {
                         tracing::debug!(
-                            target: "epoch_tracker",
                             chunk_validator = ?epoch_info.validator_account_id(chunk_producer_id),
                             %shard_id,
                             block_height = prev_block_height + 1,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -490,7 +490,10 @@ impl EpochManager {
             }
         }
         if all_kicked_out {
-            tracing::info!(target: "epoch_manager", ?max_validator, "we are about to kick out all validators in the next two epochs, so we are going to save one");
+            tracing::info!(
+                ?max_validator,
+                "we are about to kick out all validators in the next two epochs, so we are going to save one"
+            );
             if let Some(validator) = max_validator {
                 validator_kickout.remove(&validator);
             }
@@ -541,7 +544,7 @@ impl EpochManager {
                 / U256::from(total_block_producer_stake.as_yoctonear()))
             .as_u128() as i64;
             PROTOCOL_VERSION_VOTES.with_label_values(&[&version.to_string()]).set(stake_percent);
-            tracing::info!(target: "epoch_manager", ?version, ?stake_percent, "protocol version voting");
+            tracing::info!(?version, ?stake_percent, "protocol version voting");
         }
 
         let protocol_version = next_epoch_info.protocol_version();
@@ -565,7 +568,7 @@ impl EpochManager {
         };
 
         PROTOCOL_VERSION_NEXT.set(next_next_epoch_version as i64);
-        tracing::info!(target: "epoch_manager", ?next_next_epoch_version, "protocol version voting");
+        tracing::info!(?next_next_epoch_version, "protocol version voting");
 
         let mut validator_kickout = HashMap::new();
 
@@ -613,7 +616,6 @@ impl EpochManager {
         );
         validator_kickout.extend(kickout);
         tracing::debug!(
-            target: "epoch_manager",
             ?proposals,
             ?validator_kickout,
             ?block_validator_tracker,
@@ -720,13 +722,13 @@ impl EpochManager {
         ) {
             Ok(next_next_epoch_info) => next_next_epoch_info,
             Err(EpochError::ThresholdError { stake_sum, num_seats }) => {
-                tracing::warn!(target: "epoch_manager", %stake_sum, %num_seats, "not enough stake for required number of seats (all validators tried to unstake?)");
+                tracing::warn!(%stake_sum, %num_seats, "not enough stake for required number of seats (all validators tried to unstake?)");
                 let mut epoch_info = EpochInfo::clone(&next_epoch_info);
                 *epoch_info.epoch_height_mut() += 1;
                 epoch_info
             }
             Err(EpochError::NotEnoughValidators { num_validators, num_shards }) => {
-                tracing::warn!(target: "epoch_manager", %num_validators, %num_shards, "not enough validators for required number of shards (all validators tried to unstake?)");
+                tracing::warn!(%num_validators, %num_shards, "not enough validators for required number of shards (all validators tried to unstake?)");
                 let mut epoch_info = EpochInfo::clone(&next_epoch_info);
                 *epoch_info.epoch_height_mut() += 1;
                 epoch_info
@@ -735,7 +737,6 @@ impl EpochManager {
         };
         let next_next_epoch_id = EpochId(*last_block_hash);
         tracing::debug!(
-            target: "epoch_manager",
             next_next_epoch_height = %next_next_epoch_info.epoch_height(),
             ?next_next_epoch_id,
             next_next_protocol_version = %next_next_epoch_info.protocol_version(),
@@ -1032,7 +1033,7 @@ impl EpochManager {
 
         let next_epoch_id = self.get_next_epoch_id(last_block_hash)?;
         let epoch_id = self.get_epoch_id(last_block_hash)?;
-        tracing::debug!(target: "epoch_manager",
+        tracing::debug!(
             epoch_id = ?next_next_epoch_id,
             prev_epoch_id = ?next_epoch_id,
             prev_prev_epoch_id= ?epoch_id,
@@ -1043,11 +1044,7 @@ impl EpochManager {
         let prev_prev_stake_change = self.get_epoch_info(&epoch_id)?.stake_change().clone();
         let prev_stake_change = self.get_epoch_info(&next_epoch_id)?.stake_change().clone();
         let stake_change = self.get_epoch_info(&next_next_epoch_id)?.stake_change().clone();
-        tracing::debug!(target: "epoch_manager",
-            ?prev_prev_stake_change,
-            ?prev_stake_change,
-            ?stake_change,
-        );
+        tracing::debug!(?prev_prev_stake_change, ?prev_stake_change, ?stake_change,);
         let all_stake_changes =
             prev_prev_stake_change.iter().chain(&prev_stake_change).chain(&stake_change);
         let all_keys: HashSet<&AccountId> = all_stake_changes.map(|(key, _)| key).collect();
@@ -1061,7 +1058,7 @@ impl EpochManager {
                 vec![prev_prev_stake, prev_stake, new_stake].into_iter().max().unwrap();
             stake_info.insert(account_id.clone(), max_of_stakes);
         }
-        tracing::debug!(target: "epoch_manager", ?stake_info, ?validator_reward);
+        tracing::debug!(?stake_info, ?validator_reward);
         Ok((stake_info, validator_reward))
     }
 
@@ -1318,7 +1315,7 @@ impl EpochManager {
         // Check that genesis block doesn't have any proposals.
         let prev_validator_proposals = block_info.proposals_iter().collect::<Vec<_>>();
         assert!(block_info.height() > 0 || prev_validator_proposals.is_empty());
-        tracing::debug!(target: "epoch_manager",
+        tracing::debug!(
             height = block_info.height(),
             proposals = ?prev_validator_proposals,
             "add_validator_proposals");

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -396,7 +396,7 @@ impl ShardTracker {
         if shards_to_state_sync.is_empty() {
             Ok(None)
         } else {
-            tracing::debug!(target: "chain", ?shards_to_state_sync, "downloading state");
+            tracing::debug!(?shards_to_state_sync, "downloading state");
             // Note that this block is the first block in an epoch because this function is only called
             // in get_catchup_and_state_sync_infos() when that is the case.
             let state_sync_info = StateSyncInfo::new(*block_hash, shards_to_state_sync);

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -3302,12 +3302,12 @@ fn test_possible_epochs_of_height_around_tip() {
     );
 
     let epoch1 = EpochId(h[0]);
-    tracing::info!(target: "test", ?epoch1);
+    tracing::info!(?epoch1);
 
     // Add blocks with heights 1..5, a standard epoch with no surprises
     for i in 1..=5 {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         record_block(&mut epoch_manager.write(), h[i - 1], h[i], height, vec![]);
         let tip = Tip {
             height,
@@ -3344,12 +3344,12 @@ fn test_possible_epochs_of_height_around_tip() {
     }
 
     let epoch2 = EpochId(h[5]);
-    tracing::info!(target: "test", ?epoch2);
+    tracing::info!(?epoch2);
 
     // Add blocks with heights 6..10, also a standard epoch with no surprises
     for i in 6..=10 {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         record_block(&mut epoch_manager.write(), h[i - 1], h[i], height, vec![]);
         let tip = Tip {
             height,
@@ -3390,7 +3390,7 @@ fn test_possible_epochs_of_height_around_tip() {
     }
 
     let epoch3 = EpochId(h[10]);
-    tracing::info!(target: "test", ?epoch3);
+    tracing::info!(?epoch3);
 
     // Now there is a very long epoch with no final blocks (all odd blocks are missing)
     // For all the blocks inside this for the last final block will be block #8, as it has #9 and #10
@@ -3399,7 +3399,7 @@ fn test_possible_epochs_of_height_around_tip() {
     let last_finalized_height = genesis_height + 8;
     for i in (12..=24).filter(|i| i % 2 == 0) {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         let block_info = block_info(
             h[i],
             height,
@@ -3462,7 +3462,7 @@ fn test_possible_epochs_of_height_around_tip() {
     // make block 24 final and finalize epoch2.
     for i in [25, 26] {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         let block_info = block_info(
             h[i],
             height,
@@ -3525,7 +3525,7 @@ fn test_possible_epochs_of_height_around_tip() {
     let epoch4 = EpochId(h[12]);
     for i in 27..=31 {
         let height = genesis_height + i as BlockHeight;
-        tracing::info!(target: "test", height);
+        tracing::info!(height);
         record_block(&mut epoch_manager.write(), h[i - 1], h[i], height, vec![]);
         let tip = Tip {
             height,


### PR DESCRIPTION
Removes `target: "…"` from all tracing event/span macros and `target = "…"` from all `#[instrument]` attributes in `chain/client/`, `chain/client-primitives/`, and `chain/epoch-manager/`. The tracing default target — the module path — is sufficient for filtering and grouping in all cases.

See `docs/practices/style.md` (PR 1/7) for the rationale and convention.

Part 4 of 7.