### PR TITLE
refactor(tracing): 5/7 remove explicit target from network tracing

### DIFF
--- a/chain/jsonrpc/src/api/blocks.rs
+++ b/chain/jsonrpc/src/api/blocks.rs
@@ -30,7 +30,7 @@ impl RpcFrom<GetBlockError> for RpcBlockError {
             GetBlockError::NotSyncedYet => Self::NotSyncedYet,
             GetBlockError::IOError { error_message } => Self::InternalError { error_message },
             GetBlockError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcBlockError"])
                     .inc();

--- a/chain/jsonrpc/src/api/changes.rs
+++ b/chain/jsonrpc/src/api/changes.rs
@@ -34,7 +34,7 @@ impl RpcFrom<GetBlockError> for RpcStateChangesError {
             GetBlockError::NotSyncedYet => Self::NotSyncedYet,
             GetBlockError::IOError { error_message } => Self::InternalError { error_message },
             GetBlockError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcStateChangesError"])
                     .inc();
@@ -55,7 +55,7 @@ impl RpcFrom<GetStateChangesError> for RpcStateChangesError {
             }
             GetStateChangesError::NotSyncedYet => Self::NotSyncedYet,
             GetStateChangesError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcStateChangesError"])
                     .inc();

--- a/chain/jsonrpc/src/api/chunks.rs
+++ b/chain/jsonrpc/src/api/chunks.rs
@@ -62,7 +62,7 @@ impl RpcFrom<GetChunkError> for RpcChunkError {
             }
             GetChunkError::UnknownChunk { chunk_hash } => Self::UnknownChunk { chunk_hash },
             GetChunkError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcChunkError"])
                     .inc();

--- a/chain/jsonrpc/src/api/client_config.rs
+++ b/chain/jsonrpc/src/api/client_config.rs
@@ -15,7 +15,7 @@ impl RpcFrom<GetClientConfigError> for RpcClientConfigError {
         match error {
             GetClientConfigError::IOError(error_message) => Self::InternalError { error_message },
             GetClientConfigError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcClientConfigError"])
                     .inc();

--- a/chain/jsonrpc/src/api/config.rs
+++ b/chain/jsonrpc/src/api/config.rs
@@ -26,7 +26,7 @@ impl RpcFrom<GetProtocolConfigError> for RpcProtocolConfigError {
             }
             GetProtocolConfigError::IOError(error_message) => Self::InternalError { error_message },
             GetProtocolConfigError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcProtocolConfigError"])
                     .inc();

--- a/chain/jsonrpc/src/api/gas_price.rs
+++ b/chain/jsonrpc/src/api/gas_price.rs
@@ -29,7 +29,7 @@ impl RpcFrom<GetGasPriceError> for RpcGasPriceError {
                 Self::InternalError { error_message }
             }
             GetGasPriceError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcGasPriceError"])
                     .inc();

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -65,7 +65,7 @@ impl RpcFrom<GetExecutionOutcomeError> for RpcLightClientProofError {
                 Self::InternalError { error_message }
             }
             GetExecutionOutcomeError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcLightClientProofError"])
                     .inc();
@@ -91,7 +91,7 @@ impl RpcFrom<GetBlockProofError> for RpcLightClientProofError {
                 Self::InternalError { error_message }
             }
             GetBlockProofError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcLightClientProofError"])
                     .inc();
@@ -120,7 +120,7 @@ impl RpcFrom<GetNextLightClientBlockError> for RpcLightClientNextBlockError {
                 Self::EpochOutOfBounds { epoch_id }
             }
             GetNextLightClientBlockError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcLightClientNextBlockError"])
                     .inc();

--- a/chain/jsonrpc/src/api/maintenance.rs
+++ b/chain/jsonrpc/src/api/maintenance.rs
@@ -28,7 +28,7 @@ impl RpcFrom<GetMaintenanceWindowsError> for RpcMaintenanceWindowsError {
                 Self::InternalError { error_message }
             }
             GetMaintenanceWindowsError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 Self::InternalError { error_message: error.to_string() }
             }
         }

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -122,7 +122,7 @@ impl RpcFrom<QueryError> for RpcQueryError {
                 Self::ContractExecutionError { vm_error, error, block_height, block_hash }
             }
             QueryError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcQueryError"])
                     .inc();

--- a/chain/jsonrpc/src/api/receipts.rs
+++ b/chain/jsonrpc/src/api/receipts.rs
@@ -31,7 +31,7 @@ impl RpcFrom<GetReceiptError> for RpcReceiptError {
             GetReceiptError::IOError(error_message) => Self::InternalError { error_message },
             GetReceiptError::UnknownReceipt(hash) => Self::UnknownReceipt { receipt_id: hash },
             GetReceiptError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcReceiptError"])
                     .inc();

--- a/chain/jsonrpc/src/api/split_storage.rs
+++ b/chain/jsonrpc/src/api/split_storage.rs
@@ -27,7 +27,7 @@ impl RpcFrom<GetSplitStorageInfoError> for RpcSplitStorageInfoError {
                 Self::InternalError { error_message }
             }
             GetSplitStorageInfoError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcSplitStorageInfoError"])
                     .inc();

--- a/chain/jsonrpc/src/api/status.rs
+++ b/chain/jsonrpc/src/api/status.rs
@@ -92,7 +92,7 @@ impl RpcFrom<StatusError> for RpcStatusError {
             StatusError::NoNewBlocks { elapsed } => Self::NoNewBlocks { elapsed },
             StatusError::EpochOutOfBounds { epoch_id } => Self::EpochOutOfBounds { epoch_id },
             StatusError::Unreachable { ref error_message } => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcStatusError"])
                     .inc();

--- a/chain/jsonrpc/src/api/validator.rs
+++ b/chain/jsonrpc/src/api/validator.rs
@@ -41,7 +41,7 @@ impl RpcFrom<GetValidatorInfoError> for RpcValidatorError {
             GetValidatorInfoError::ValidatorInfoUnavailable => Self::ValidatorInfoUnavailable,
             GetValidatorInfoError::IOError(error_message) => Self::InternalError { error_message },
             GetValidatorInfoError::Unreachable(ref error_message) => {
-                tracing::warn!(target: "jsonrpc", %error_message, "unreachable error occurred");
+                tracing::warn!(%error_message, "unreachable error occurred");
                 crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
                     .with_label_values(&["RpcValidatorError"])
                     .inc();

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -651,7 +651,6 @@ impl JsonRpcHandler {
         .map_err(|_| {
             metrics::RPC_TIMEOUT_TOTAL.inc();
             tracing::warn!(
-                target: "jsonrpc",
                 ?tx_hash,
                 ?signer_account_id,
                 "timeout: tx_exists method"
@@ -721,7 +720,6 @@ impl JsonRpcHandler {
         .map_err(|_| {
             metrics::RPC_TIMEOUT_TOTAL.inc();
             tracing::warn!(
-                target: "jsonrpc",
                 ?tx_info,
                 ?fetch_receipt,
                 ?tx_status_result,
@@ -2035,7 +2033,7 @@ pub async fn start_http(
     let addr = config.addr;
     let prometheus_addr = config.prometheus_addr.clone().filter(|it| it != &addr.to_string());
     let cors_allowed_origins = config.cors_allowed_origins.clone();
-    tracing::info!(target: "network", %addr, "starting http server");
+    tracing::info!(%addr, "starting http server");
 
     // Create the axum app using the extracted function
     let app = create_jsonrpc_app(
@@ -2059,12 +2057,12 @@ pub async fn start_http(
     // Start main server
     future_spawner.spawn("JSON RPC", async move {
         if let Err(e) = axum::serve(listener, app).await {
-            tracing::error!(target: "network", ?e, "HTTP server error");
+            tracing::error!(?e, "HTTP server error");
         }
     });
 
     if let Some(prometheus_addr) = prometheus_addr {
-        tracing::info!(target: "network", %prometheus_addr, "starting http monitoring server");
+        tracing::info!(%prometheus_addr, "starting http monitoring server");
         // Export only the /metrics service. It's a read-only service and can have very relaxed
         // access restrictions.
         let prometheus_app = Router::new()
@@ -2079,7 +2077,7 @@ pub async fn start_http(
         // Start Prometheus server
         future_spawner.spawn("Prometheus Metrics", async move {
             if let Err(e) = axum::serve(listener, prometheus_app).await {
-                tracing::error!(target: "network", ?e, "prometheus server error");
+                tracing::error!(?e, "prometheus server error");
             }
         });
     }

--- a/chain/network/src/announce_accounts/mod.rs
+++ b/chain/network/src/announce_accounts/mod.rs
@@ -32,7 +32,7 @@ impl Inner {
 
         match self.store.get_account_announcement(&account_id) {
             Err(err) => {
-                tracing::warn!(target: "network", ?err, "error loading announce account from store");
+                tracing::warn!(?err, "error loading announce account from store");
                 None
             }
             Ok(None) => None,

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -481,7 +481,7 @@ impl PeerMessage {
     }
 
     pub(crate) fn deserialize(data: &[u8]) -> Result<PeerMessage, ParsePeerMessageError> {
-        let span = tracing::trace_span!(target: "network", "deserialize").entered();
+        let span = tracing::trace_span!("deserialize").entered();
         Ok({
             let proto_msg: proto::PeerMessage = proto::PeerMessage::parse_from_bytes(data)
                 .map_err(ParsePeerMessageError::ProtoDecode)?;
@@ -1139,10 +1139,7 @@ impl RoutedMessage {
                 ttl: msg.ttl,
                 body: msg.body.into(),
                 signature: msg.signature.unwrap_or_else(|| {
-                    tracing::error!(
-                        target: "network",
-                        "signature is missing, this should not yet happen"
-                    );
+                    tracing::error!("signature is missing, this should not yet happen");
                     Signature::default()
                 }),
             },

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -50,7 +50,7 @@ async fn test_peer_communication() -> anyhow::Result<()> {
         }
     };
 
-    tracing::info!(target:"test", "request update nonce");
+    tracing::info!("request update nonce");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::RequestUpdateNonce(PartialEdgeInfo::new(
         &outbound.cfg.network.node_id(),
@@ -61,13 +61,13 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "peers request");
+    tracing::info!("peers request");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::PeersRequest(PeersRequest { max_peers: None, max_direct_peers: None });
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "peers response");
+    tracing::info!("peers response");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::PeersResponse(PeersResponse {
         peers: (0..5).map(|_| data::make_peer_info(&mut rng)).collect(),
@@ -76,37 +76,37 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "block request");
+    tracing::info!("block request");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::BlockRequest(*chain.blocks[5].hash());
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target: "test", "block");
+    tracing::info!("block");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::Block(chain.blocks[5].clone());
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "block headers request");
+    tracing::info!("block headers request");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::BlockHeadersRequest(chain.blocks.iter().map(|b| *b.hash()).collect());
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "block headers");
+    tracing::info!("block headers");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::BlockHeaders(chain.get_block_headers().map(Into::into).collect());
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "sync routing table");
+    tracing::info!("sync routing table");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::SyncRoutingTable(data::make_routing_table(&mut rng));
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "partial encoded chunk request");
+    tracing::info!("partial encoded chunk request");
     let mut events = inbound.events.from_now();
     let want = PeerMessage::Routed(Box::new(
         outbound.routed_message(
@@ -124,7 +124,7 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target:"test", "partial encoded chunk response");
+    tracing::info!("partial encoded chunk response");
     let mut events = inbound.events.from_now();
     let want_hash = chain.blocks[3].chunks()[0].chunk_hash().clone();
     let want_parts = data::make_chunk_parts(chain.chunks[&want_hash].clone());
@@ -144,7 +144,7 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 
-    tracing::info!(target: "test", "transaction");
+    tracing::info!("transaction");
     let mut events = inbound.events.from_now();
     let want = data::make_signed_transaction(&mut rng);
     let want = PeerMessage::Transaction(want);

--- a/chain/network/src/peer/tests/rate_limits.rs
+++ b/chain/network/src/peer/tests/rate_limits.rs
@@ -36,7 +36,7 @@ async fn test_message_rate_limits() -> anyhow::Result<()> {
     // Check how many messages of each type have been received.
     let messages_received =
         wait_for_similar_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
-    tracing::debug!(target:"test", ?messages_received, "received messages");
+    tracing::debug!(?messages_received, "received messages");
     // BlockRequest gets rate limited (7 sent vs 5 bucket_start).
     assert!(messages_received[0] < MESSAGES);
     // PartialEncodedChunkRequest gets rate limited (7 sent vs 5 bucket_start).
@@ -76,7 +76,7 @@ async fn slow_test_message_rate_limits_over_time() -> anyhow::Result<()> {
 
     let messages_received =
         wait_for_similar_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
-    tracing::debug!(target:"test", ?messages_received, "received messages");
+    tracing::debug!(?messages_received, "received messages");
     // BlockRequest and PartialEncodedChunkRequest don't get rate limited
     // 12 sent vs 5 bucket_start + 2.5 refilled * 4s
     assert_eq!(messages_received[0], MESSAGES * 3);
@@ -172,14 +172,14 @@ async fn send_messages(
 ) -> Vec<PeerMessage> {
     let mut messages_samples = Vec::new();
 
-    tracing::info!(target:"test", "send block request");
+    tracing::info!("send block request");
     let message = PeerMessage::BlockRequest(CryptoHash::default());
     for _ in 0..count {
         outbound.send(message.clone()).await;
     }
     messages_samples.push(message);
 
-    tracing::info!(target:"test", "send partial encoded chunk request");
+    tracing::info!("send partial encoded chunk request");
     // Duplicated routed messages are filtered out so we must tweak each message to make it unique.
 
     for i in 0..count {
@@ -202,7 +202,7 @@ async fn send_messages(
         }
     }
 
-    tracing::info!(target: "test", "send transaction");
+    tracing::info!("send transaction");
     let message = PeerMessage::Transaction(data::make_signed_transaction(rng));
     for _ in 0..count {
         outbound.send(message.clone()).await;

--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -165,7 +165,7 @@ impl Connection {
     // so that we can skip the actor queue when sending messages.
     pub fn send_message(&self, msg: Arc<PeerMessage>) {
         let msg_kind = msg.msg_variant().to_string();
-        tracing::trace!(target: "network", ?msg_kind, "sending message");
+        tracing::trace!(?msg_kind, "sending message");
         self.handle.send(SendMessage { message: msg }.span_wrap());
     }
 
@@ -448,7 +448,7 @@ impl Pool {
                     // however conflicting connections with the same account key indicate an
                     // incorrect validator setup, so we log it here as a warn!, rather than just
                     // info!.
-                    tracing::warn!(target:"network", %id, ?err, "pool register failed");
+                    tracing::warn!(%id, ?err, "pool register failed");
                     metrics::ALREADY_CONNECTED_ACCOUNT.inc();
                     return Err(err);
                 }
@@ -509,7 +509,7 @@ impl Pool {
             peer.send_message(msg);
             return true;
         }
-        tracing::debug!(target: "network",
+        tracing::debug!(
            to = ?peer_id,
            num_connected_peers = pool.ready.len(),
            ?msg,

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -48,7 +48,7 @@ impl NetworkState {
         let this = self.clone();
         self.spawn("add_accounts", async move {
             let new_accounts = this.account_announcements.add_accounts(accounts);
-            tracing::debug!(target: "network", account_id = ?this.config.validator.account_id(), ?new_accounts, "received new accounts");
+            tracing::debug!(account_id = ?this.config.validator.account_id(), ?new_accounts, "received new accounts");
             #[cfg(test)]
             this.config.event_sink.send(crate::peer_manager::peer_manager_actor::Event::AccountsAdded(new_accounts.clone()));
             this.broadcast_routing_table_update(RoutingTableUpdate::from_accounts(
@@ -215,7 +215,7 @@ impl NetworkState {
             return;
         }
 
-        tracing::trace!(target: "network", route_back = ?msg.clone(), "received peer message that requires response");
+        tracing::trace!(route_back = ?msg.clone(), "received peer message that requires response");
         let from = &conn.peer_info.id;
 
         match conn.tier {

--- a/chain/network/src/peer_manager/peer_store/mod.rs
+++ b/chain/network/src/peer_manager/peer_store/mod.rs
@@ -232,7 +232,7 @@ impl Inner {
             if peer_status.status != KnownPeerStatus::Connected
                 && now > peer_status.last_seen + self.config.peer_expiration_duration
             {
-                tracing::debug!(target: "network", last_seen = ?peer_status.last_seen, "removing expired peer");
+                tracing::debug!(last_seen = ?peer_status.last_seen, "removing expired peer");
                 to_remove.push(peer_id.clone());
             }
         }
@@ -246,13 +246,13 @@ impl Inner {
                 if now < ban_time + self.config.ban_window {
                     continue;
                 }
-                tracing::info!(target: "network", unbanned = ?peer_id, ?ban_time, "unbanning a peer");
+                tracing::info!(unbanned = ?peer_id, ?ban_time, "unbanning a peer");
                 to_unban.push(peer_id.clone());
             }
         }
         for peer_id in &to_unban {
             if let Err(err) = self.peer_unban(&peer_id) {
-                tracing::error!(target: "network", ?peer_id, ?err, "failed to unban a peer");
+                tracing::error!(?peer_id, ?err, "failed to unban a peer");
             }
         }
     }
@@ -417,7 +417,7 @@ impl PeerStore {
         peer_id: &PeerId,
         ban_reason: ReasonForBan,
     ) -> anyhow::Result<()> {
-        tracing::warn!(target: "network", %peer_id, ?ban_reason, "banning peer");
+        tracing::warn!(%peer_id, ?ban_reason, "banning peer");
         let mut inner = self.0.lock();
         if let Some(peer_state) = inner.peer_states.get_mut(peer_id) {
             let now = clock.now_utc();
@@ -499,7 +499,7 @@ impl PeerStore {
             }
         }
         if blacklisted != 0 {
-            tracing::info!(target: "network", %blacklisted, %total,
+            tracing::info!(%blacklisted, %total,
                   "ignored blacklisted peers out of indirect peers");
         }
     }

--- a/chain/network/src/peer_manager/tests/accounts_data.rs
+++ b/chain/network/src/peer_manager/tests/accounts_data.rs
@@ -54,13 +54,13 @@ async fn broadcast() {
     };
 
     let data = chain.make_tier1_data(rng, clock);
-    tracing::info!(target:"test", "connect peer, expect initial sync to be empty");
+    tracing::info!("connect peer, expect initial sync to be empty");
     let mut peer1 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let got1 = peer1.events.recv_until(take_full_sync).await;
     assert_eq!(got1.accounts_data, vec![]);
 
-    tracing::info!(target:"test", "send some data");
+    tracing::info!("send some data");
     let msg = SyncAccountsData {
         accounts_data: vec![data[0].clone(), data[1].clone()],
         incremental: true,
@@ -70,13 +70,13 @@ async fn broadcast() {
     peer1.send(PeerMessage::SyncAccountsData(msg)).await;
     pm.wait_for_accounts_data(&want).await;
 
-    tracing::info!(target:"test", "connect another peer and perform initial full sync");
+    tracing::info!("connect another peer and perform initial full sync");
     let mut peer2 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let got2 = peer2.events.recv_until(take_full_sync).await;
     assert_eq!(got2.accounts_data.as_set(), want.iter().collect::<HashSet<_>>());
 
-    tracing::info!(target:"test", "send a mix of new and old data, only new data should be broadcasted");
+    tracing::info!("send a mix of new and old data, only new data should be broadcasted");
     let msg = SyncAccountsData {
         accounts_data: vec![data[1].clone(), data[2].clone()],
         incremental: true,
@@ -87,7 +87,7 @@ async fn broadcast() {
     let got2 = peer2.events.recv_until(take_incremental_sync).await;
     assert_eq!(got2.accounts_data.as_set(), want.as_set());
 
-    tracing::info!(target:"test", "send a request for a full sync");
+    tracing::info!("send a request for a full sync");
     let want = vec![data[0].clone(), data[1].clone(), data[2].clone()];
     let mut events = peer1.events.from_now();
     peer1
@@ -134,7 +134,7 @@ async fn gradual_epoch_change() {
 
     // For every order of nodes.
     for ids in (0..pms.len()).permutations(pms.len()) {
-        tracing::info!(target:"test", ?ids, "permutation");
+        tracing::info!(?ids, "permutation");
         clock.advance(time::Duration::hours(1));
         let chain_info = testonly::make_chain_info(
             &chain,
@@ -142,7 +142,7 @@ async fn gradual_epoch_change() {
         );
 
         let mut want = HashSet::new();
-        tracing::info!(target:"test", "advance epoch in the given order");
+        tracing::info!("advance epoch in the given order");
         for id in ids {
             pms[id].set_chain_info(chain_info.clone()).await;
             // In this tests each node is its own proxy, so it can immediately
@@ -153,7 +153,7 @@ async fn gradual_epoch_change() {
             want.extend(pms[id].tier1_advertise_proxies(&clock.clock()).await);
         }
         for pm in &mut pms {
-            tracing::info!(target:"test", node_id = %pm.cfg.node_id(), "wait for data to arrive");
+            tracing::info!(node_id = %pm.cfg.node_id(), "wait for data to arrive");
             pm.wait_for_accounts_data(&want).await;
         }
     }
@@ -198,7 +198,7 @@ async fn slow_test_rate_limiting() {
             .await,
         );
     }
-    tracing::info!(target:"test", "construct a 4-layer bipartite graph");
+    tracing::info!("construct a 4-layer bipartite graph");
 
     let mut connections = 0;
     let mut tasks = vec![];
@@ -225,7 +225,7 @@ async fn slow_test_rate_limiting() {
     // the total number of SyncAccountsData messages exchanged in the process.
     let events: Vec<_> = pms.iter().map(|pm| pm.events.from_now()).collect();
 
-    tracing::info!(target:"test", "advance epoch in random order");
+    tracing::info!("advance epoch in random order");
     pms.shuffle(rng);
     let mut want = HashSet::new();
     for pm in &mut pms {
@@ -233,12 +233,12 @@ async fn slow_test_rate_limiting() {
         want.extend(pm.tier1_advertise_proxies(&clock.clock()).await);
     }
 
-    tracing::info!(target:"test", "wait for data to arrive");
+    tracing::info!("wait for data to arrive");
     for pm in &mut pms {
         pm.wait_for_accounts_data(&want).await;
     }
 
-    tracing::info!(target:"test", "count the sync accounts data messages exchanged");
+    tracing::info!("count the sync accounts data messages exchanged");
     let mut msgs = 0;
     for mut es in events {
         while let Some(ev) = es.try_recv() {
@@ -286,7 +286,7 @@ async fn validator_node_restart() {
         (2, ZERO),
         (2, SEC),
     ] {
-        tracing::info!(target:"test", %n, %downtime, "test case");
+        tracing::info!(%n, %downtime, "test case");
 
         let mut rng = make_rng(921853233);
         let rng = &mut rng;

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -269,7 +269,7 @@ async fn invalid_edge() {
 
     for (name, edge) in &testcases {
         for tier in [tcp::Tier::T1, tcp::Tier::T2, tcp::Tier::T3] {
-            tracing::info!(target:"test", %name, ?tier, "test case");
+            tracing::info!(%name, ?tier, "test case");
             let stream = tcp::Stream::connect(&pm.peer_info(), tier, &SocketOptions::default())
                 .await
                 .unwrap();

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -44,7 +44,7 @@ async fn test_nonces() {
     ];
 
     for test in test_cases {
-        tracing::info!(target: "test", test_name = test.2, "running test");
+        tracing::info!(test_name = test.2, "running test");
         // Start a PeerManager and connect a peer to it.
         let pm = peer_manager::testonly::start(
             clock.clock(),

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -35,24 +35,24 @@ async fn simple() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes");
+    tracing::info!("start two nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
 
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[]).await;
 
-    tracing::info!(target:"test", "connect the nodes");
+    tracing::info!("connect the nodes");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[(id1.clone(), vec![id1.clone()])]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[(id0.clone(), vec![id0.clone()])]).await;
 }
 
@@ -65,7 +65,7 @@ async fn three_nodes_path() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "connect three nodes in a line");
+    tracing::info!("connect three nodes in a line");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -77,19 +77,19 @@ async fn three_nodes_path() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -106,7 +106,7 @@ async fn three_nodes_star() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "connect three nodes in a line");
+    tracing::info!("connect three nodes in a line");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -118,41 +118,41 @@ async fn three_nodes_star() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
     ])
     .await;
 
-    tracing::info!(target:"test", %id0, %id2, "connect nodes");
+    tracing::info!(%id0, %id2, "connect nodes");
     pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -170,7 +170,7 @@ async fn join_components() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "create two connected components having two nodes each");
+    tracing::info!("create two connected components having two nodes each");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -184,42 +184,42 @@ async fn join_components() {
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm2.connect_to(&pm3.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[(id1.clone(), vec![id1.clone()])]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[(id0.clone(), vec![id0.clone()])]).await;
 
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[(id3.clone(), vec![id3.clone()])]).await;
-    tracing::info!(target:"test", %id3, "wait for routing table");
+    tracing::info!(%id3, "wait for routing table");
     pm3.wait_for_routing_table(&[(id2.clone(), vec![id2.clone()])]).await;
 
-    tracing::info!(target:"test", "join the two components into a square");
+    tracing::info!("join the two components into a square");
     pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
     pm3.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id2.clone()]),
         (id3.clone(), vec![id1.clone(), id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id0.clone(), id3.clone()]),
         (id3.clone(), vec![id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id1.clone(), vec![id0.clone(), id3.clone()]),
         (id3.clone(), vec![id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id3, "wait for routing table");
+    tracing::info!(%id3, "wait for routing table");
     pm3.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone(), id2.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -241,7 +241,7 @@ async fn simple_remove() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "connect 3 nodes in a line");
+    tracing::info!("connect 3 nodes in a line");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -253,31 +253,31 @@ async fn simple_remove() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
     ])
     .await;
 
-    tracing::info!(target:"test", %id1, "stop node");
+    tracing::info!(%id1, "stop node");
     drop(pm1);
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[]).await;
 }
 
@@ -332,7 +332,7 @@ async fn ping_simple() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes");
+    tracing::info!("start two nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
 
@@ -341,20 +341,20 @@ async fn ping_simple() {
 
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[(id1.clone(), vec![id1.clone()])]).await;
 
     // capture event streams before pinging
     let mut pm0_ev = pm0.events.from_now();
     let mut pm1_ev = pm1.events.from_now();
 
-    tracing::info!(target:"test", %id0, %id1, "send ping");
+    tracing::info!(%id0, %id1, "send ping");
     pm0.send_ping(&clock.clock(), 0, id1.clone()).await;
 
-    tracing::info!(target:"test", %id1, "await ping");
+    tracing::info!(%id1, "await ping");
     wait_for_ping(&mut pm1_ev, Ping { nonce: 0, source: id0.clone() }).await;
 
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 0, source: id1.clone() }).await;
 
     drop(pm0);
@@ -370,7 +370,7 @@ async fn ping_jump() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes");
+    tracing::info!("start three nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -379,23 +379,23 @@ async fn ping_jump() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", "connect nodes in a line");
+    tracing::info!("connect nodes in a line");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -406,13 +406,13 @@ async fn ping_jump() {
     let mut pm0_ev = pm0.events.from_now();
     let mut pm2_ev = pm2.events.from_now();
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
 
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 0, source: id0.clone() }).await;
 
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 0, source: id2.clone() }).await;
 }
 
@@ -425,7 +425,7 @@ async fn test_dont_drop_after_ttl() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes");
+    tracing::info!("start three nodes");
     let mut cfg0 = chain.make_config(rng);
     cfg0.routed_message_ttl = 2;
     let pm0 = start_pm(clock.clock(), TestDB::new(), cfg0, chain.clone()).await;
@@ -436,23 +436,23 @@ async fn test_dont_drop_after_ttl() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", "connect nodes in a line");
+    tracing::info!("connect nodes in a line");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -463,13 +463,13 @@ async fn test_dont_drop_after_ttl() {
     let mut pm0_ev = pm0.events.from_now();
     let mut pm2_ev = pm2.events.from_now();
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
 
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 0, source: id0.clone() }).await;
 
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 0, source: id2.clone() }).await;
 }
 
@@ -482,7 +482,7 @@ async fn test_drop_after_ttl() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes");
+    tracing::info!("start three nodes");
     let mut cfg0 = chain.make_config(rng);
     cfg0.routed_message_ttl = 1;
     let pm0 = start_pm(clock.clock(), TestDB::new(), cfg0, chain.clone()).await;
@@ -493,23 +493,23 @@ async fn test_drop_after_ttl() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", "connect nodes in a line");
+    tracing::info!("connect nodes in a line");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -519,10 +519,10 @@ async fn test_drop_after_ttl() {
     // capture event stream before pinging
     let mut pm1_ev = pm1.events.from_now();
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
 
-    tracing::info!(target:"test", %id1, "await message dropped");
+    tracing::info!(%id1, "await message dropped");
     wait_for_message_dropped(&mut pm1_ev).await;
 }
 
@@ -535,7 +535,7 @@ async fn test_dropping_duplicate_messages() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes");
+    tracing::info!("start three nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -544,23 +544,23 @@ async fn test_dropping_duplicate_messages() {
     let id1 = pm1.cfg.node_id();
     let id2 = pm2.cfg.node_id();
 
-    tracing::info!(target:"test", "connect nodes in a line");
+    tracing::info!("connect nodes in a line");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id1.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id1.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -573,33 +573,33 @@ async fn test_dropping_duplicate_messages() {
     let mut pm2_ev = pm2.events.from_now();
 
     // Send two identical messages. One will be dropped, because the delay between them was less than 50ms.
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 0, source: id0.clone() }).await;
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 0, source: id2.clone() }).await;
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 0, id2.clone()).await;
-    tracing::info!(target:"test", %id1, "await message dropped");
+    tracing::info!(%id1, "await message dropped");
     wait_for_message_dropped(&mut pm1_ev).await;
 
     // Send two identical messages but with 300ms delay so they don't get dropped.
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 1, id2.clone()).await;
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 1, source: id0.clone() }).await;
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 1, source: id2.clone() }).await;
 
     clock.advance(DROP_DUPLICATED_MESSAGES_PERIOD + time::Duration::milliseconds(1));
 
-    tracing::info!(target:"test", %id0, %id2, "send ping");
+    tracing::info!(%id0, %id2, "send ping");
     pm0.send_ping(&clock.clock(), 1, id2.clone()).await;
-    tracing::info!(target:"test", %id2, "await ping");
+    tracing::info!(%id2, "await ping");
     wait_for_ping(&mut pm2_ev, Ping { nonce: 1, source: id0.clone() }).await;
-    tracing::info!(target:"test", %id0, "await pong");
+    tracing::info!(%id0, "await pong");
     wait_for_pong(&mut pm0_ev, Pong { nonce: 1, source: id2.clone() }).await;
 }
 
@@ -655,7 +655,7 @@ async fn from_boot_nodes() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes");
+    tracing::info!("start two nodes");
     let configs = make_configs(&chain, rng, 2, 1, true);
     let pm0 = start_pm(clock.clock(), TestDB::new(), configs[0].clone(), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), configs[1].clone(), chain.clone()).await;
@@ -663,9 +663,9 @@ async fn from_boot_nodes() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[(id1.clone(), vec![id1.clone()])]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[(id0.clone(), vec![id0.clone()])]).await;
 }
 
@@ -678,7 +678,7 @@ async fn blacklist_01() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes with 0 blacklisting 1");
+    tracing::info!("start two nodes with 0 blacklisting 1");
     let mut configs = make_configs(&chain, rng, 2, 2, true);
     configs[0].peer_store.blacklist =
         [blacklist::Entry::from_addr(**configs[1].node_addr.as_ref().unwrap())]
@@ -691,16 +691,16 @@ async fn blacklist_01() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "wait for the connection to be attempted and rejected");
+    tracing::info!("wait for the connection to be attempted and rejected");
     wait_for_connection_closed(
         &mut pm0.events.clone(),
         ClosingReason::RejectedByPeerManager(RegisterPeerError::Blacklisted),
     )
     .await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[]).await;
 }
 
@@ -713,7 +713,7 @@ async fn blacklist_10() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes with 1 blacklisting 0");
+    tracing::info!("start two nodes with 1 blacklisting 0");
     let mut configs = make_configs(&chain, rng, 2, 2, true);
     configs[1].peer_store.blacklist =
         [blacklist::Entry::from_addr(**configs[0].node_addr.as_ref().unwrap())]
@@ -726,16 +726,16 @@ async fn blacklist_10() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "wait for the connection to be attempted and rejected");
+    tracing::info!("wait for the connection to be attempted and rejected");
     wait_for_connection_closed(
         &mut pm1.events.clone(),
         ClosingReason::RejectedByPeerManager(RegisterPeerError::Blacklisted),
     )
     .await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[]).await;
 }
 
@@ -748,7 +748,7 @@ async fn blacklist_all() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes with 0 blacklisting everything");
+    tracing::info!("start two nodes with 0 blacklisting everything");
     let mut configs = make_configs(&chain, rng, 2, 2, true);
     configs[0].peer_store.blacklist =
         [blacklist::Entry::from_ip(Ipv6Addr::LOCALHOST.into())].into_iter().collect();
@@ -759,16 +759,16 @@ async fn blacklist_all() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "wait for the connection to be attempted and rejected");
+    tracing::info!("wait for the connection to be attempted and rejected");
     wait_for_connection_closed(
         &mut pm0.events.clone(),
         ClosingReason::RejectedByPeerManager(RegisterPeerError::Blacklisted),
     )
     .await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[]).await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[]).await;
 }
 
@@ -782,7 +782,7 @@ async fn max_num_peers_limit() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start three nodes with max_num_peers=2");
+    tracing::info!("start three nodes with max_num_peers=2");
     let mut configs = make_configs(&chain, rng, 4, 4, false);
     for config in &mut configs {
         config.max_num_peers = 2;
@@ -802,19 +802,19 @@ async fn max_num_peers_limit() {
     pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
     pm1.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id1.clone(), vec![id1.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "wait for routing table");
+    tracing::info!(%id1, "wait for routing table");
     pm1.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id2.clone(), vec![id2.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id0.clone(), vec![id0.clone()]),
         (id1.clone(), vec![id1.clone()]),
@@ -825,26 +825,26 @@ async fn max_num_peers_limit() {
     let mut pm1_ev = pm1.events.from_now();
     let mut pm2_ev = pm2.events.from_now();
 
-    tracing::info!(target:"test", "start a fourth node");
+    tracing::info!("start a fourth node");
     let pm3 = start_pm(clock.clock(), TestDB::new(), configs[3].clone(), chain.clone()).await;
 
     let id3 = pm3.cfg.node_id();
 
-    tracing::info!(target:"test", %id0, "wait to reject attempted connection");
+    tracing::info!(%id0, "wait to reject attempted connection");
     pm3.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(
         &mut pm0_ev,
         ClosingReason::RejectedByPeerManager(RegisterPeerError::ConnectionLimitExceeded),
     )
     .await;
-    tracing::info!(target:"test", %id1, "wait to reject attempted connection");
+    tracing::info!(%id1, "wait to reject attempted connection");
     pm3.send_outbound_connect(&pm1.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(
         &mut pm1_ev,
         ClosingReason::RejectedByPeerManager(RegisterPeerError::ConnectionLimitExceeded),
     )
     .await;
-    tracing::info!(target:"test", %id2, "wait to reject attempted connection");
+    tracing::info!(%id2, "wait to reject attempted connection");
     pm3.send_outbound_connect(&pm2.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(
         &mut pm2_ev,
@@ -852,7 +852,7 @@ async fn max_num_peers_limit() {
     )
     .await;
 
-    tracing::info!(target:"test", %id3, "wait for routing table");
+    tracing::info!(%id3, "wait for routing table");
     pm3.wait_for_routing_table(&[]).await;
 
     // These drop() calls fix the place at which we want the values to be dropped,
@@ -959,7 +959,7 @@ async fn repeated_data_in_sync_routing_table() {
 
     // Gradually increment the amount of data in the system and then broadcast it.
     for i in 0..10 {
-        tracing::info!(target: "test", %i, "iteration");
+        tracing::info!(%i, "iteration");
         // Wait for the new data to be broadcasted.
         // Note that in the first iteration we expect just 1 edge, without sending anything before.
         // It is important because the first SyncRoutingTable contains snapshot of all data known to
@@ -1014,7 +1014,7 @@ async fn square() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "connect 4 nodes in a square");
+    tracing::info!("connect 4 nodes in a square");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -1034,21 +1034,21 @@ async fn square() {
         (id2.clone(), vec![id1.clone(), id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id1, "stop node");
+    tracing::info!(%id1, "stop node");
     drop(pm1);
-    tracing::info!(target:"test", %id0, "wait for routing table");
+    tracing::info!(%id0, "wait for routing table");
     pm0.wait_for_routing_table(&[
         (id3.clone(), vec![id3.clone()]),
         (id2.clone(), vec![id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id2, "wait for routing table");
+    tracing::info!(%id2, "wait for routing table");
     pm2.wait_for_routing_table(&[
         (id3.clone(), vec![id3.clone()]),
         (id0.clone(), vec![id3.clone()]),
     ])
     .await;
-    tracing::info!(target:"test", %id3, "wait for routing table");
+    tracing::info!(%id3, "wait for routing table");
     pm3.wait_for_routing_table(&[
         (id2.clone(), vec![id2.clone()]),
         (id0.clone(), vec![id0.clone()]),
@@ -1090,7 +1090,7 @@ async fn fix_local_edges() {
         edge2.clone(),
     ]));
 
-    tracing::info!(target:"test", "waiting for fake edges to be processed");
+    tracing::info!("waiting for fake edges to be processed");
     let mut events = pm.events.from_now();
     conn.send(msg.clone()).await;
     events
@@ -1100,7 +1100,7 @@ async fn fix_local_edges() {
         })
         .await;
 
-    tracing::info!(target:"test", "waiting for fake edges to be fixed");
+    tracing::info!("waiting for fake edges to be fixed");
     let mut events = pm.events.from_now();
     pm.fix_local_edges(&clock.clock(), time::Duration::ZERO).await;
     // TODO(gprusak): make fix_local_edges await closing of the connections, so
@@ -1112,7 +1112,7 @@ async fn fix_local_edges() {
         })
         .await;
 
-    tracing::info!(target:"test", "checking the consistency");
+    tracing::info!("checking the consistency");
     pm.check_consistency().await;
     drop(conn);
 }
@@ -1129,7 +1129,7 @@ async fn do_not_block_announce_account_broadcast() {
     let db1 = TestDB::new();
     let aa = data::make_announce_account(rng);
 
-    tracing::info!(target:"test", "spawn 2 nodes and announce the account");
+    tracing::info!("spawn 2 nodes and announce the account");
     let pm0 = start_pm(clock.clock(), db0.clone(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), db1.clone(), chain.make_config(rng), chain.clone()).await;
     pm1.connect_to(&pm0.peer_info(), tcp::Tier::T2).await;
@@ -1138,7 +1138,7 @@ async fn do_not_block_announce_account_broadcast() {
     drop(pm0);
     drop(pm1);
 
-    tracing::info!(target:"test", "spawn 3 nodes and re-announce the account");
+    tracing::info!("spawn 3 nodes and re-announce the account");
     // Even though the account was previously announced (pm0 and pm1 have it in DB),
     // the nodes should allow to let the broadcast through.
     let pm0 = start_pm(clock.clock(), db0, chain.make_config(rng), chain.clone()).await;
@@ -1174,7 +1174,7 @@ async fn archival_node() {
     configs[0].archive = true;
     configs[1].archive = true;
 
-    tracing::info!(target:"test", "start five nodes, the first two of which are archival nodes");
+    tracing::info!("start five nodes, the first two of which are archival nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), configs[0].clone(), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), configs[1].clone(), chain.clone()).await;
     let pm2 = start_pm(clock.clock(), TestDB::new(), configs[2].clone(), chain.clone()).await;
@@ -1186,24 +1186,24 @@ async fn archival_node() {
     // capture pm0 event stream
     let mut pm0_ev = pm0.events.from_now();
 
-    tracing::info!(target:"test", "connect node 2 to node 0");
+    tracing::info!("connect node 2 to node 0");
     pm2.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
-    tracing::info!(target:"test", "connect node 3 to node 0");
+    tracing::info!("connect node 3 to node 0");
     pm3.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", "connect node 4 to node 0 and wait for pm0 to close a connection");
+    tracing::info!("connect node 4 to node 0 and wait for pm0 to close a connection");
     pm4.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(&mut pm0_ev, ClosingReason::PeerManagerRequest).await;
 
-    tracing::info!(target:"test", "connect node 1 to node 0 and wait for pm0 to close a connection");
+    tracing::info!("connect node 1 to node 0 and wait for pm0 to close a connection");
     pm1.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
     wait_for_connection_closed(&mut pm0_ev, ClosingReason::PeerManagerRequest).await;
 
-    tracing::info!(target:"test", "check that node 0 and node 1 are still connected");
+    tracing::info!("check that node 0 and node 1 are still connected");
     pm0.wait_for_direct_connection(id1.clone()).await;
 
     for _step in 0..10 {
-        tracing::info!(target:"test", %_step, "select a node which node 0 is not connected to");
+        tracing::info!(%_step, "select a node which node 0 is not connected to");
         let pm0_connections: HashSet<PeerId> =
             pm0.with_state(|s| async move { s.tier2.load().ready.keys().cloned().collect() }).await;
 
@@ -1214,14 +1214,14 @@ async fn archival_node() {
             .choose(rng)
             .unwrap();
 
-        tracing::info!(target:"test", %_step, "wait for the chosen node to finish disconnecting from node 0");
+        tracing::info!(%_step, "wait for the chosen node to finish disconnecting from node 0");
         chosen.wait_for_num_connected_peers(0).await;
 
-        tracing::info!(target:"test", %_step, "connect the chosen node to node 0 and wait for pm0 to close a connection");
+        tracing::info!(%_step, "connect the chosen node to node 0 and wait for pm0 to close a connection");
         chosen.send_outbound_connect(&pm0.peer_info(), tcp::Tier::T2).await;
         wait_for_connection_closed(&mut pm0_ev, ClosingReason::PeerManagerRequest).await;
 
-        tracing::info!(target:"test", %_step, "check that node 0 and node 1 are still connected");
+        tracing::info!(%_step, "check that node 0 and node 1 are still connected");
         pm0.wait_for_direct_connection(id1.clone()).await;
     }
 
@@ -1259,10 +1259,10 @@ async fn connect_to_unbanned_peer() {
     let mut pm1 =
         start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
 
-    tracing::info!(target:"test", "pm0 connects to pm1");
+    tracing::info!("pm0 connects to pm1");
     let stream_id = pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", "pm1 bans pm0");
+    tracing::info!("pm1 bans pm0");
     let ban_reason = ReasonForBan::BadBlock;
     pm1.disconnect_and_ban(&clock.clock(), &pm0.cfg.node_id(), ban_reason).await;
     wait_for_stream_closed(&mut pm0.events, stream_id).await;
@@ -1271,7 +1271,7 @@ async fn connect_to_unbanned_peer() {
         wait_for_stream_closed(&mut pm1.events, stream_id).await
     );
 
-    tracing::info!(target:"test", "pm0 fails to reconnect to pm1");
+    tracing::info!("pm0 fails to reconnect to pm1");
     let got_reason = pm1
         .start_inbound(chain.clone(), pm0.cfg.clone())
         .await
@@ -1280,11 +1280,11 @@ async fn connect_to_unbanned_peer() {
     assert_eq!(ClosingReason::RejectedByPeerManager(RegisterPeerError::Banned), got_reason);
 
     // cspell:words unbans
-    tracing::info!(target:"test", "pm1 unbans pm0");
+    tracing::info!("pm1 unbans pm0");
     clock.advance(pm1.cfg.peer_store.ban_window);
     pm1.peer_store_update(&clock.clock()).await;
 
-    tracing::info!(target:"test", "pm0 reconnects to pm1");
+    tracing::info!("pm0 reconnects to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
     drop(pm0);
@@ -1315,7 +1315,7 @@ async fn peer_connect_send_distance_vector() {
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
-    tracing::info!(target:"test", "start two nodes");
+    tracing::info!("start two nodes");
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
     let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
 
@@ -1326,7 +1326,7 @@ async fn peer_connect_send_distance_vector() {
     let mut pm0_ev = pm0.events.from_now();
     let mut pm1_ev = pm1.events.from_now();
 
-    tracing::info!(target:"test", "connect the nodes");
+    tracing::info!("connect the nodes");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
     wait_for_distance_vector(&mut pm0_ev, id1).await;

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -88,14 +88,14 @@ async fn broadcast() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect a peer, expect initial sync to be empty");
+    tracing::info!("connect a peer, expect initial sync to be empty");
     let peer1_config = chain.make_config(rng);
     let mut peer1 =
         pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
     let empty_sync_msg = peer1.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "connect two more peers");
+    tracing::info!("connect two more peers");
     let peer2_config = chain.make_config(rng);
     let mut peer2 =
         pm.start_inbound(chain.clone(), peer2_config.clone()).await.handshake(clock).await;
@@ -107,7 +107,9 @@ async fn broadcast() {
     let empty_sync_msg = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "send a sync snapshot hosts message from peer1, make sure that all peers receive it");
+    tracing::info!(
+        "send a sync snapshot hosts message from peer1, make sure that all peers receive it"
+    );
 
     let info1 = make_snapshot_host_info(&peer1_config.node_id(), &peer1_config.node_key, rng);
 
@@ -124,13 +126,17 @@ async fn broadcast() {
     let got3 = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(got3.hosts, vec![info1.clone()]);
 
-    tracing::info!(target:"test", "connect another peer, make sure that it receives the correct information on joining");
+    tracing::info!(
+        "connect another peer, make sure that it receives the correct information on joining"
+    );
     let mut peer4 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let peer4_sync_msg = peer4.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(peer4_sync_msg.hosts, vec![info1.clone()]);
 
-    tracing::info!(target:"test", "publish another piece of snapshot information, check that it's also broadcasted");
+    tracing::info!(
+        "publish another piece of snapshot information, check that it's also broadcasted"
+    );
     let info2 = make_snapshot_host_info(&peer2_config.node_id(), &peer2_config.node_key, rng);
 
     peer2
@@ -140,7 +146,7 @@ async fn broadcast() {
     let got1 = peer1.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(got1.hosts, vec![info2.clone()]);
 
-    tracing::info!(target:"test", "connect another peer, check that it receives all of the published information");
+    tracing::info!("connect another peer, check that it receives all of the published information");
     let mut peer5 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let peer5_sync_msg = peer5.events.recv_until(take_sync_snapshot_msg).await;
@@ -166,7 +172,7 @@ async fn invalid_signature_not_broadcast() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect peers, expect initial sync to be empty");
+    tracing::info!("connect peers, expect initial sync to be empty");
     let peer1_config = chain.make_config(rng);
     let mut peer1 =
         pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
@@ -184,7 +190,9 @@ async fn invalid_signature_not_broadcast() {
     let empty_sync_msg = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "send an invalid sync snapshot hosts message from peer1, one of the host infos has an invalid signature");
+    tracing::info!(
+        "send an invalid sync snapshot hosts message from peer1, one of the host infos has an invalid signature"
+    );
     let random_secret_key = SecretKey::from_random(near_crypto::KeyType::ED25519);
     let invalid_info = make_snapshot_host_info(&peer1_config.node_id(), &random_secret_key, rng);
 
@@ -196,7 +204,7 @@ async fn invalid_signature_not_broadcast() {
     });
     peer1.send(invalid_message).await;
 
-    tracing::info!(target:"test", "send a valid message from peer2 (as peer1 got banned), it should reach peer3");
+    tracing::info!("send a valid message from peer2 (as peer1 got banned), it should reach peer3");
 
     let info2 = make_snapshot_host_info(&peer2_config.node_id(), &peer2_config.node_key, rng);
 
@@ -204,7 +212,7 @@ async fn invalid_signature_not_broadcast() {
         .send(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts { hosts: vec![info2.clone()] }))
         .await;
 
-    tracing::info!(target:"test", "make sure that only the valid messages are broadcast");
+    tracing::info!("make sure that only the valid messages are broadcast");
 
     // Wait until peer2 receives info2. Ignore ok_info_a and ok_info_b,
     // as the PeerManager could accept and broadcast them despite the neighboring invalid_info.
@@ -230,7 +238,7 @@ async fn too_many_shards_not_broadcast() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect peers, expect initial sync to be empty");
+    tracing::info!("connect peers, expect initial sync to be empty");
     let peer1_config = chain.make_config(rng);
     let mut peer1 =
         pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
@@ -248,7 +256,9 @@ async fn too_many_shards_not_broadcast() {
     let empty_sync_msg = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "send an invalid sync snapshot hosts message from peer1, one of the host infos has more shard ids than allowed");
+    tracing::info!(
+        "send an invalid sync snapshot hosts message from peer1, one of the host infos has more shard ids than allowed"
+    );
     let too_many_shards: Vec<ShardId> =
         (0..(MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64 + 1)).map(Into::into).collect();
     let invalid_info = Arc::new(SnapshotHostInfo::new(
@@ -267,7 +277,7 @@ async fn too_many_shards_not_broadcast() {
     });
     peer1.send(invalid_message).await;
 
-    tracing::info!(target:"test", "send a valid message from peer2 (as peer1 got banned), it should reach peer3");
+    tracing::info!("send a valid message from peer2 (as peer1 got banned), it should reach peer3");
 
     let info2 = make_snapshot_host_info(&peer2_config.node_id(), &peer2_config.node_key, rng);
 
@@ -275,7 +285,7 @@ async fn too_many_shards_not_broadcast() {
         .send(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts { hosts: vec![info2.clone()] }))
         .await;
 
-    tracing::info!(target:"test", "make sure that only valid messages are broadcast");
+    tracing::info!("make sure that only valid messages are broadcast");
 
     // Wait until peer2 receives info2. Ignore ok_info_a and ok_info_b,
     // as the PeerManager could accept and broadcast them despite the neighboring invalid_info.
@@ -303,7 +313,7 @@ async fn propagate() {
         .set(std::cmp::min(limit.1, (1000 + 4 * FDS_PER_PEER * MAX_CONNECTIONS) as u64), limit.1)
         .unwrap();
 
-    tracing::info!(target:"test", "create four peer manager instances");
+    tracing::info!("create four peer manager instances");
     let mut pms = vec![];
     for _ in 0..4 {
         pms.push(
@@ -317,7 +327,7 @@ async fn propagate() {
         );
     }
 
-    tracing::info!(target:"test", "connect the four peer managers into a ring");
+    tracing::info!("connect the four peer managers into a ring");
     // [0] - [1]
     //  |     |
     // [2] - [3]
@@ -326,7 +336,7 @@ async fn propagate() {
     pms[1].connect_to(&pms[3].peer_info(), tcp::Tier::T2).await;
     pms[2].connect_to(&pms[3].peer_info(), tcp::Tier::T2).await;
 
-    tracing::info!(target:"test", "send a snapshot host info message from peer manager #1");
+    tracing::info!("send a snapshot host info message from peer manager #1");
     let info1 = make_snapshot_host_info(&pms[1].peer_info().id, &pms[1].cfg.node_key, rng);
     let new_epoch_event =
         PeerManagerMessageRequest::NetworkRequests(NetworkRequests::SnapshotHostEvent(
@@ -342,7 +352,9 @@ async fn propagate() {
     let _: () = pms[1].actor.send_async(new_epoch_event).await.unwrap();
     let _: () = pms[1].actor.send_async(message).await.unwrap();
 
-    tracing::info!(target:"test", "make sure that the message sent from #1 reaches #2 on the other side of the ring");
+    tracing::info!(
+        "make sure that the message sent from #1 reaches #2 on the other side of the ring"
+    );
     let want: HashSet<Arc<SnapshotHostInfo>> = std::iter::once(info1).collect();
     pms[2].wait_for_snapshot_hosts(&want).await;
 }
@@ -359,7 +371,7 @@ async fn large_shard_id_in_cache() {
     let clock = clock.clock();
     let clock = &clock;
 
-    tracing::info!(target:"test", "create a peer manager");
+    tracing::info!("create a peer manager");
     let pm = peer_manager::testonly::start(
         clock.clone(),
         near_store::db::TestDB::new(),
@@ -368,11 +380,11 @@ async fn large_shard_id_in_cache() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect a peer");
+    tracing::info!("connect a peer");
     let peer1_config = chain.make_config(rng);
     let peer1 = pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
 
-    tracing::info!(target:"test", "send a snapshot host info message with very large shard ids");
+    tracing::info!("send a snapshot host info message with very large shard ids");
     let large_shard_id_1 = ShardId::new(u64::MAX - 1);
     let large_shard_id_2 = ShardId::new(u64::MAX);
     let big_shard_info = Arc::new(SnapshotHostInfo::new(
@@ -391,7 +403,7 @@ async fn large_shard_id_in_cache() {
         }))
         .await;
 
-    tracing::info!(target:"test", "make sure that the message is received and processed without any problems");
+    tracing::info!("make sure that the message is received and processed without any problems");
     let want: HashSet<Arc<SnapshotHostInfo>> = std::iter::once(big_shard_info).collect();
     pm.wait_for_snapshot_hosts(&want).await;
 }
@@ -409,7 +421,7 @@ async fn too_many_shards_truncate() {
     let clock = clock.clock();
     let clock = &clock;
 
-    tracing::info!(target:"test", "create a single peer manager");
+    tracing::info!("create a single peer manager");
     let pm = peer_manager::testonly::start(
         clock.clone(),
         near_store::db::TestDB::new(),
@@ -418,13 +430,15 @@ async fn too_many_shards_truncate() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect a peer, expect initial sync message to be empty");
+    tracing::info!("connect a peer, expect initial sync message to be empty");
     let mut peer1 =
         pm.start_inbound(chain.clone(), chain.make_config(rng)).await.handshake(clock).await;
     let empty_sync_msg = peer1.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "ask peer manager to send out an invalid sync snapshot hosts message, the info has more shard ids than allowed");
+    tracing::info!(
+        "ask peer manager to send out an invalid sync snapshot hosts message, the info has more shard ids than allowed"
+    );
     // Create a list of shards with twice as many shard ids as is allowed
     let too_many_shards: Vec<ShardId> =
         (0..(2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64)).map(Into::into).collect();
@@ -446,7 +460,9 @@ async fn too_many_shards_truncate() {
     let _: () = pm.actor.send_async(new_epoch_event).await.unwrap();
     let _: () = pm.actor.send_async(message).await.unwrap();
 
-    tracing::info!(target:"test", "receive the truncated snapshot host info message on peer1, make sure that the contents are correct");
+    tracing::info!(
+        "receive the truncated snapshot host info message on peer1, make sure that the contents are correct"
+    );
     let msg = peer1.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(msg.hosts.len(), 1);
     let info: &SnapshotHostInfo = &msg.hosts[0];
@@ -488,7 +504,7 @@ async fn no_shards_not_broadcast() {
     )
     .await;
 
-    tracing::info!(target:"test", "connect peers, expect initial sync to be empty");
+    tracing::info!("connect peers, expect initial sync to be empty");
     let peer1_config = chain.make_config(rng);
     let mut peer1 =
         pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
@@ -501,7 +517,9 @@ async fn no_shards_not_broadcast() {
     let empty_sync_msg = peer2.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "send an empty sync snapshot host message from peer1, the host info has no shards");
+    tracing::info!(
+        "send an empty sync snapshot host message from peer1, the host info has no shards"
+    );
     let no_shards_info = Arc::new(SnapshotHostInfo::new(
         peer1_config.node_id(),
         CryptoHash::hash_borsh(rng.r#gen::<u64>()),
@@ -514,7 +532,7 @@ async fn no_shards_not_broadcast() {
         PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts { hosts: vec![no_shards_info.clone()] });
     peer1.send(no_shards_message).await;
 
-    tracing::info!(target:"test", "send a valid message from peer2");
+    tracing::info!("send a valid message from peer2");
 
     let info2 = make_snapshot_host_info(&peer2_config.node_id(), &peer2_config.node_key, rng);
 
@@ -522,7 +540,7 @@ async fn no_shards_not_broadcast() {
         .send(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts { hosts: vec![info2.clone()] }))
         .await;
 
-    tracing::info!(target:"test", "make sure that only valid messages are broadcast");
+    tracing::info!("make sure that only valid messages are broadcast");
 
     // Wait until peer2 receives info2. No other messages should be broadcast.
     wait_for_host_info(&mut peer2, &info2, &[]).await;

--- a/chain/network/src/peer_manager/tests/tier2.rs
+++ b/chain/network/src/peer_manager/tests/tier2.rs
@@ -53,19 +53,19 @@ async fn test_store_outbound_connection() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm2.connect_to(&pm0.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "check that pm1 does not store anything, as it has no outbound connections");
+    tracing::info!("check that pm1 does not store anything, as it has no outbound connections");
     check_recent_outbound_connections(&pm1, vec![]).await;
 
-    tracing::info!(target:"test", "check that pm2 stores the outbound connection to pm0");
+    tracing::info!("check that pm2 stores the outbound connection to pm0");
     pm2.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm2, vec![id0.clone()]).await;
 }
@@ -84,20 +84,20 @@ async fn test_storage_after_disconnect() {
     let id0 = pm0.cfg.node_id();
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "have pm1 disconnect from pm0");
+    tracing::info!("have pm1 disconnect from pm0");
     let mut pm0_ev = pm0.events.from_now();
     pm1.disconnect(&id0).await;
     wait_for_connection_closed(&mut pm0_ev).await;
 
-    tracing::info!(target:"test", "check that pm0 retains the stored outbound connection to pm1 after disconnect");
+    tracing::info!("check that pm0 retains the stored outbound connection to pm1 after disconnect");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 }
@@ -116,19 +116,19 @@ async fn test_reconnect_after_restart_outbound_side() {
 
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "drop pm0 and start it again with the same db");
+    tracing::info!("drop pm0 and start it again with the same db");
     drop(pm0);
     let pm0 = start_pm(clock.clock(), pm0_db, chain.make_config(rng), chain.clone()).await;
 
-    tracing::info!(target:"test", "check that pm0 reconnects to pm1");
+    tracing::info!("check that pm0 reconnects to pm1");
     pm0.wait_for_direct_connection(id1.clone()).await;
 }
 
@@ -149,19 +149,19 @@ async fn test_skip_reconnect_after_restart_outbound_side() {
 
     let id1 = pm1.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "drop pm0 and start it again with the same db");
+    tracing::info!("drop pm0 and start it again with the same db");
     drop(pm0);
     let pm0 = start_pm(clock.clock(), pm0_db.clone(), pm0_cfg.clone(), chain.clone()).await;
 
-    tracing::info!(target:"test", "check that pm0 starts without attempting to reconnect to pm1");
+    tracing::info!("check that pm0 starts without attempting to reconnect to pm1");
     let mut pm0_ev = pm0.events.clone();
     pm0_ev
         .recv_until(|ev| match ev {
@@ -173,7 +173,7 @@ async fn test_skip_reconnect_after_restart_outbound_side() {
         })
         .await;
 
-    tracing::info!(target:"test", "check that pm0 has pm1 as a recent connection");
+    tracing::info!("check that pm0 has pm1 as a recent connection");
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 }
 
@@ -192,20 +192,20 @@ async fn test_reconnect_after_restart_inbound_side() {
 
     let id1 = pm1.cfg.node_id().clone();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "drop pm1");
+    tracing::info!("drop pm1");
     let mut pm0_ev = pm0.events.from_now();
     drop(pm1);
     wait_for_connection_closed(&mut pm0_ev).await;
 
-    tracing::info!(target:"test", "start pm1 again with the same config, check that pm0 reconnects");
+    tracing::info!("start pm1 again with the same config, check that pm0 reconnects");
     let _pm1 = start_pm(clock.clock(), TestDB::new(), pm1_cfg.clone(), chain.clone()).await;
     clock.advance(POLL_CONNECTION_STORE_INTERVAL + RECONNECT_ATTEMPT_INTERVAL);
     pm0.wait_for_direct_connection(id1.clone()).await;
@@ -227,20 +227,20 @@ async fn test_reconnect_after_disconnect_inbound_side() {
     let id0 = pm0.cfg.node_id().clone();
     let id1 = pm1.cfg.node_id().clone();
 
-    tracing::info!(target:"test", "connect pm0 to pm1");
+    tracing::info!("connect pm0 to pm1");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    tracing::info!("check that pm0 stores the outbound connection to pm1");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
 
-    tracing::info!(target:"test", "have pm1 disconnect gracefully from pm0");
+    tracing::info!("have pm1 disconnect gracefully from pm0");
     let mut pm0_ev = pm0.events.from_now();
     pm1.disconnect(&id0).await;
     wait_for_connection_closed(&mut pm0_ev).await;
 
-    tracing::info!(target:"test", "check that pm0 reconnects");
+    tracing::info!("check that pm0 reconnects");
     clock.advance(POLL_CONNECTION_STORE_INTERVAL + RECONNECT_ATTEMPT_INTERVAL);
     pm0.wait_for_direct_connection(id1.clone()).await;
 }
@@ -265,7 +265,7 @@ async fn test_reconnect_after_restart_outbound_side_multi() {
     let id3 = pm3.cfg.node_id();
     let id4 = pm4.cfg.node_id();
 
-    tracing::info!(target:"test", "connect pm0 to other pms");
+    tracing::info!("connect pm0 to other pms");
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
     pm0.wait_for_direct_connection(id1.clone()).await;
     pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
@@ -276,7 +276,7 @@ async fn test_reconnect_after_restart_outbound_side_multi() {
     pm0.wait_for_direct_connection(id4.clone()).await;
     clock.advance(STORED_CONNECTIONS_MIN_DURATION);
 
-    tracing::info!(target:"test", "check that pm0 stores the outbound connections");
+    tracing::info!("check that pm0 stores the outbound connections");
     pm0.update_connection_store(&clock.clock()).await;
     check_recent_outbound_connections(
         &pm0,
@@ -284,11 +284,11 @@ async fn test_reconnect_after_restart_outbound_side_multi() {
     )
     .await;
 
-    tracing::info!(target:"test", "drop pm0 and start it again with the same db");
+    tracing::info!("drop pm0 and start it again with the same db");
     drop(pm0);
     let pm0 = start_pm(clock.clock(), pm0_db, chain.make_config(rng), chain.clone()).await;
 
-    tracing::info!(target:"test", "wait for pm0 to reconnect to the other nodes");
+    tracing::info!("wait for pm0 to reconnect to the other nodes");
     pm0.wait_for_direct_connection(id1.clone()).await;
     pm0.wait_for_direct_connection(id2.clone()).await;
     pm0.wait_for_direct_connection(id3.clone()).await;

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -30,7 +30,7 @@ impl RateLimits {
             ) {
                 Ok(bucket) => buckets[*key] = Some(bucket),
                 Err(err) => {
-                    tracing::warn!(target: "network", ?key, ?err, "ignoring rate limit due to an error")
+                    tracing::warn!(?key, ?err, "ignoring rate limit due to an error")
                 }
             }
         }

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -201,12 +201,7 @@ impl Inner {
     /// 1. Prunes expired edges.
     /// 2. Prunes unreachable graph components.
     /// 3. Recomputes GraphSnapshot.
-    #[tracing::instrument(
-        target = "network::routing::graph",
-        level = "debug",
-        "GraphInner::update",
-        skip_all
-    )]
+    #[tracing::instrument(level = "debug", "GraphInner::update", skip_all)]
     pub fn update(
         &mut self,
         clock: &time::Clock,

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -69,22 +69,22 @@ async fn one_edge() {
     let e1 = data::make_edge(&node_key, &p1, 1);
     let e1v2 = e1.remove_edge(peer_id(&p1), &p1);
 
-    tracing::info!(target:"test", "add an active edge, update rt with pruning");
+    tracing::info!("add an active edge, update rt with pruning");
     // NOOP, since p1 is reachable.
     g.simple_update(vec![e1.clone()]).await;
     g.check(&[e1.clone()]);
 
-    tracing::info!(target:"test", "override with an inactive edge");
+    tracing::info!("override with an inactive edge");
     g.simple_update(vec![e1v2.clone()]).await;
     g.check(&[e1v2.clone()]);
 
-    tracing::info!(target:"test", "after 2s, simple_update rt with pruning unreachable for 3s");
+    tracing::info!("after 2s, simple_update rt with pruning unreachable for 3s");
     // NOOP, since p1 is unreachable for 2s.
     clock.advance(2 * SEC);
     g.simple_update(vec![]).await;
     g.check(&[e1v2.clone()]);
 
-    tracing::info!(target:"test", "update rt with pruning unreachable for 1s");
+    tracing::info!("update rt with pruning unreachable for 1s");
     // p1 should be moved to DB.
     clock.advance(2 * SEC);
     g.simple_update(vec![]).await;
@@ -123,30 +123,30 @@ async fn expired_edges() {
     let still_old_e2 = data::make_edge(&node_key, &p2, to_active_nonce(now - 90 * SEC));
     let fresh_e2 = data::make_edge(&node_key, &p2, to_active_nonce(now));
 
-    tracing::info!(target:"test", "add an active edge");
+    tracing::info!("add an active edge");
     g.simple_update(vec![e1.clone(), old_e2.clone()]).await;
     g.check(&[e1.clone(), old_e2.clone()]);
-    tracing::info!(target:"test", "update rt with pruning");
+    tracing::info!("update rt with pruning");
     // e1 should stay - as it is fresh, but old_e2 should be removed.
     clock.advance(40 * SEC);
     g.simple_update(vec![]).await;
     g.check(&[e1.clone()]);
 
-    tracing::info!(target:"test", "adding 'still old' edge to e2 should fail");
+    tracing::info!("adding 'still old' edge to e2 should fail");
     // (as it is older than the last prune_edges_older_than)
     g.simple_update(vec![still_old_e2.clone()]).await;
     g.check(&[e1.clone()]);
 
-    tracing::info!(target:"test", "but adding the fresh edge should work");
+    tracing::info!("but adding the fresh edge should work");
     g.simple_update(vec![fresh_e2.clone()]).await;
     g.check(&[e1.clone(), fresh_e2.clone()]);
 
-    tracing::info!(target:"test", "advance so that the edge is 'too old' and should be removed");
+    tracing::info!("advance so that the edge is 'too old' and should be removed");
     clock.advance(100 * SEC);
     g.simple_update(vec![]).await;
     g.check(&[]);
 
-    tracing::info!(target:"test", "let's create a removal edge");
+    tracing::info!("let's create a removal edge");
     let e1v2 = data::make_edge(&node_key, &p1, to_active_nonce(clock.now_utc()))
         .remove_edge(peer_id(&p1), &p1);
     g.simple_update(vec![e1v2.clone()]).await;

--- a/chain/network/src/routing/graph_v2/mod.rs
+++ b/chain/network/src/routing/graph_v2/mod.rs
@@ -580,11 +580,11 @@ impl Inner {
         distances: HashMap<PeerId, u32>,
     ) -> Option<network_protocol::DistanceVector> {
         if self.my_distances == distances {
-            tracing::debug!(target: "routing", "no change to routing distances after processing network updates");
+            tracing::debug!("no change to routing distances after processing network updates");
             return None;
         }
 
-        tracing::debug!(target: "routing", "routing distances have changed; reconstructing distance vector");
+        tracing::debug!("routing distances have changed; reconstructing distance vector");
 
         let distance_vector = self.construct_distance_vector_message(&distances)?;
 
@@ -623,7 +623,7 @@ impl Inner {
 
     /// Logs the state of the routing table
     pub(crate) fn log_state(&self) {
-        tracing::debug!(target: "routing", my_distances = ?self.my_distances, peer_labels = ?self.edge_cache.p2id, peer_distances = ?self.peer_distances);
+        tracing::debug!(my_distances = ?self.my_distances, peer_labels = ?self.edge_cache.p2id, peer_distances = ?self.peer_distances);
     }
 }
 
@@ -743,11 +743,7 @@ impl Handler<NetworkChanges, (Option<network_protocol::DistanceVector>, Vec<bool
         &mut self,
         msg: NetworkChanges,
     ) -> (Option<network_protocol::DistanceVector>, Vec<bool>) {
-        tracing::debug!(
-            target: "routing",
-            length = msg.0.len(),
-            "processing a batch of network topology changes",
-        );
+        tracing::debug!(length = msg.0.len(), "processing a batch of network topology changes",);
 
         let mut inner = self.inner.lock();
         let oks: Vec<bool> =
@@ -756,9 +752,9 @@ impl Handler<NetworkChanges, (Option<network_protocol::DistanceVector>, Vec<bool
         // Logs the given batch of updates and the results from processing them.
         for (update, ok) in msg.0.iter().zip(&oks) {
             if *ok {
-                tracing::debug!(target: "routing", ?update, "processed event");
+                tracing::debug!(?update, "processed event");
             } else {
-                tracing::debug!(target: "routing", ?update, "rejected invalid distance vector");
+                tracing::debug!(?update, "rejected invalid distance vector");
             }
         }
 

--- a/chain/network/src/store/mod.rs
+++ b/chain/network/src/store/mod.rs
@@ -28,7 +28,6 @@ pub(crate) struct Store(schema::Store);
 impl Store {
     /// Inserts (account_id,aa) to the AccountAnnouncements column.
     #[tracing::instrument(
-        target = "network::store",
         level = "trace",
         "Store::set_account_announcement",
         skip_all,
@@ -51,12 +50,7 @@ impl Store {
 
 // ConnectionStore storage.
 impl Store {
-    #[tracing::instrument(
-        target = "network::store",
-        level = "trace",
-        "Store::set_recent_outbound_connections",
-        skip_all
-    )]
+    #[tracing::instrument(level = "trace", "Store::set_recent_outbound_connections", skip_all)]
     pub fn set_recent_outbound_connections(
         &self,
         recent_outbound_connections: &Vec<ConnectionInfo>,

--- a/chain/network/src/store/schema/mod.rs
+++ b/chain/network/src/store/schema/mod.rs
@@ -207,12 +207,7 @@ impl Store {
         Default::default()
     }
 
-    #[tracing::instrument(
-        target = "network::store::schema",
-        level = "trace",
-        "Store::commit",
-        skip_all
-    )]
+    #[tracing::instrument(level = "trace", "Store::commit", skip_all)]
     pub fn commit(&self, update: StoreUpdate) {
         self.0.write(update.0);
     }

--- a/chain/network/src/tcp.rs
+++ b/chain/network/src/tcp.rs
@@ -87,7 +87,7 @@ impl Socket {
 impl Stream {
     fn new(stream: tokio::net::TcpStream, type_: StreamType) -> std::io::Result<Self> {
         if let Err(err) = stream.set_nodelay(true) {
-            tracing::warn!(target: "network", ?err, "failed to set TCP_NODELAY");
+            tracing::warn!(?err, "failed to set TCP_NODELAY");
         }
         Ok(Self { peer_addr: stream.peer_addr()?, local_addr: stream.local_addr()?, stream, type_ })
     }
@@ -111,12 +111,12 @@ impl Stream {
             Tier::T2 => {
                 if let Some(so_recv_buffer) = socket_options.recv_buffer_size {
                     socket.set_recv_buffer_size(so_recv_buffer)?;
-                    tracing::debug!(target: "network", wanted_recv_buffer = %so_recv_buffer, actual_recv_buffer = ?socket.recv_buffer_size());
+                    tracing::debug!(wanted_recv_buffer = %so_recv_buffer, actual_recv_buffer = ?socket.recv_buffer_size());
                 }
 
                 if let Some(so_send_buffer) = socket_options.send_buffer_size {
                     socket.set_send_buffer_size(so_send_buffer)?;
-                    tracing::debug!(target: "network", wanted_send_buffer = %so_send_buffer, actual_send_buffer = ?socket.send_buffer_size());
+                    tracing::debug!(wanted_send_buffer = %so_send_buffer, actual_send_buffer = ?socket.send_buffer_size());
                 }
             }
             _ => {}
@@ -238,7 +238,7 @@ impl ListenerAddr {
                 Ok(guard) => guard,
                 Err(named_lock::Error::WouldBlock) => {
                     // this port is already reserved, try another one
-                    tracing::trace!(target: "network", %port, "port is already reserved, trying another one");
+                    tracing::trace!(%port, "port is already reserved, trying another one");
                     continue;
                 }
                 Err(err) => {
@@ -249,7 +249,7 @@ impl ListenerAddr {
             let tcp_socket = std::net::TcpListener::bind(addr);
             if tcp_socket.is_err() {
                 // this port is already in use, try another one
-                tracing::trace!(target: "network", %port, "port is already in use, trying another one");
+                tracing::trace!(%port, "port is already in use, trying another one");
                 continue;
             }
             RESERVED_PORT_LOCKS.lock().push(guard);

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -125,7 +125,7 @@ impl StopSignal {
 
 impl Handler<StopSignal> for PeerManagerActor {
     fn handle(&mut self, msg: StopSignal) {
-        tracing::debug!(target: "network", "received stop signal");
+        tracing::debug!("received stop signal");
 
         if msg.should_panic {
             panic!("Node crashed");

--- a/chain/network/src/testonly/mod.rs
+++ b/chain/network/src/testonly/mod.rs
@@ -53,7 +53,7 @@ pub(crate) fn abort_on_panic() {
     if nextest != "1" || nextest_execution_mode != "process-per-test" {
         return;
     }
-    tracing::info!(target:"test", "[panic=abort] enabled");
+    tracing::info!("[panic=abort] enabled");
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         orig_hook(panic_info);

--- a/chain/telemetry/src/lib.rs
+++ b/chain/telemetry/src/lib.rs
@@ -86,7 +86,7 @@ impl TelemetryActor {
 
 impl Handler<TelemetryEvent> for TelemetryActor {
     fn handle(&mut self, msg: TelemetryEvent) {
-        tracing::debug!(target: "telemetry", ?msg);
+        tracing::debug!(?msg);
         let now = Instant::now();
         if now - self.last_telemetry_update < self.config.reporting_interval {
             // Throttle requests to the telemetry endpoints, to at most one
@@ -106,7 +106,6 @@ impl Handler<TelemetryEvent> for TelemetryActor {
                     .map(move |response| {
                         let result = if let Err(error) = response {
                             tracing::warn!(
-                                target: "telemetry",
                                 err = ?error,
                                 endpoint = ?endpoint,
                                 "failed to send telemetry data");


### PR DESCRIPTION
Removes `target: "…"` from all tracing event/span macros and `target = "…"` from all `#[instrument]` attributes in `chain/network/`, `chain/jsonrpc/`, and `chain/telemetry/`. The tracing default target — the module path — is sufficient for filtering and grouping in all cases.

See `docs/practices/style.md` (PR 1/7) for the rationale and convention.

Part 5 of 7.