### PR TITLE
refactor(tracing): 6/7 remove explicit target from runtime tracing

### DIFF
--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -266,7 +266,6 @@ impl FilesystemContractRuntimeCache {
         let _ = std::fs::rename(&legacy_path, &path);
         if std::fs::exists(legacy_path).ok() == Some(true) {
             tracing::warn!(
-                target: "vm",
                 path = %path.display(),
                 message = "the legacy compiled contract cache path still exists after migration; consider removing it"
             );
@@ -275,7 +274,6 @@ impl FilesystemContractRuntimeCache {
         let dir =
             rustix::fs::open(&path, rustix::fs::OFlags::DIRECTORY, rustix::fs::Mode::empty())?;
         tracing::debug!(
-            target: "vm",
             path = %path.display(),
             message = "opened a contract executable cache directory"
         );
@@ -321,7 +319,6 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
 
     #[tracing::instrument(
         level = "trace",
-        target = "vm",
         "FilesystemContractRuntimeCache::put",
         skip_all,
         fields(key = key.to_string(), value.len = value.compiled.debug_len()),
@@ -381,7 +378,6 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
 
     #[tracing::instrument(
         level = "trace",
-        target = "vm",
         "FilesystemContractRuntimeCache::get",
         skip_all,
         fields(key = key.to_string()),
@@ -425,7 +421,6 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
             // seem to be much reason to possibly crash the node due to this.
             _ => {
                 tracing::debug!(
-                    target: "vm",
                     message = "cached contract executable was found to be malformed",
                     key = %key
                 );
@@ -585,7 +580,7 @@ pub fn precompile_contract(
     config: Arc<Config>,
     cache: Option<&dyn ContractRuntimeCache>,
 ) -> Result<Result<ContractPrecompilatonResult, CompilationError>, CacheError> {
-    let _span = tracing::debug_span!(target: "vm", "precompile_contract").entered();
+    let _span = tracing::debug_span!("precompile_contract").entered();
     let vm_kind = config.vm_kind;
     let runtime = vm_kind
         .runtime(Arc::clone(&config))

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -3827,7 +3827,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
     #[cfg(feature = "sandbox")]
     pub fn sandbox_debug_log(&mut self, len: u64, ptr: u64) -> Result<()> {
         let message = self.sandbox_get_utf8_string(len, ptr)?;
-        tracing::debug!(target: "sandbox", message = &message[..]);
+        tracing::debug!(message = &message[..]);
         Ok(())
     }
 

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -44,7 +44,7 @@ pub fn contract_cached(
 /// module.
 ///
 /// Contract preparation and execution need not to be executed on the same thread.
-#[tracing::instrument(target = "vm", level = "debug", "prepare", skip_all, fields(
+#[tracing::instrument(level = "debug", "prepare", skip_all, fields(
     code.hash = %contract.hash(),
     method_name,
     vm_kind = ?wasm_config.vm_kind,
@@ -81,7 +81,7 @@ pub fn prepare(
 ///
 /// The gas cost for contract preparation will be subtracted by the VM
 /// implementation.
-#[tracing::instrument(target = "vm", level = "debug", "run", skip_all, fields(
+#[tracing::instrument(level = "debug", "run", skip_all, fields(
     method_name,
     burnt_gas = tracing::field::Empty,
     compute_usage = tracing::field::Empty,

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -4256,7 +4256,7 @@ pub fn storage_has_key(caller: &mut Caller<'_, Ctx>, key_len: u64, key_ptr: u64)
 #[cfg(feature = "sandbox")]
 pub fn sandbox_debug_log(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()> {
     let message = sandbox_get_utf8_string(caller, len, ptr)?;
-    tracing::debug!(target: "sandbox", message = &message[..]);
+    tracing::debug!(message = &message[..]);
     Ok(())
 }
 

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -458,7 +458,7 @@ impl WasmtimeVM {
         hasher.finish()
     }
 
-    #[tracing::instrument(target = "vm", level = "debug", "WasmtimeVM::compile_uncached", skip_all)]
+    #[tracing::instrument(level = "debug", "WasmtimeVM::compile_uncached", skip_all)]
     pub(crate) fn compile_uncached(
         &self,
         code: &ContractCode,
@@ -866,7 +866,7 @@ fn link(linker: &mut wasmtime::Linker<Ctx>, config: &Config) {
             fn $name(mut caller: wasmtime::Caller<'_, Ctx>, $( $arg_name: $arg_type ),* ) -> anyhow::Result<($( $returns ),*)> {
                 const TRACE: bool = imports::should_trace_host_function(stringify!($name));
                 let _span = TRACE.then(|| {
-                    tracing::trace_span!(target: "vm::host_function", stringify!($name)).entered()
+                    tracing::trace_span!(stringify!($name)).entered()
                 });
                 match logic::$func(&mut caller, $( $arg_name as $arg_type, )*) {
                     Ok(result) => Ok(result as ($( $returns ),* ) ),

--- a/runtime/near-vm/compiler-singlepass/src/codegen_x64.rs
+++ b/runtime/near-vm/compiler-singlepass/src/codegen_x64.rs
@@ -1670,7 +1670,7 @@ impl<'a> FuncGen<'a> {
         });
     }
 
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn new(
         assembler: &'a mut Assembler,
         module: &'a ModuleInfo,
@@ -1778,7 +1778,7 @@ impl<'a> FuncGen<'a> {
     }
 
     #[allow(clippy::large_stack_frames)]
-    #[tracing::instrument(target = "near_vm", level = "trace", skip(self))]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) fn feed_operator(&mut self, op: Operator) -> Result<(), CodegenError> {
         assert!(self.fp_stack.len() <= self.value_stack.len());
 
@@ -7611,7 +7611,7 @@ impl<'a> FuncGen<'a> {
         Ok(())
     }
 
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn finalize(mut self, data: &FunctionBodyData) -> CompiledFunction {
         debug_assert!(
             self.gas_iter.next().is_none(),
@@ -7724,7 +7724,7 @@ fn sort_call_movs(movs: &mut [(Location, GPR)]) {
 }
 
 // Standard entry trampoline.
-#[tracing::instrument(target = "near_vm", level = "trace")]
+#[tracing::instrument(level = "trace")]
 pub(crate) fn gen_std_trampoline(
     sig: &FunctionType,
     calling_convention: CallingConvention,
@@ -7817,7 +7817,7 @@ pub(crate) fn gen_std_trampoline(
 }
 
 /// Generates dynamic import function call trampoline for a function type.
-#[tracing::instrument(target = "near_vm", level = "trace", skip(vmoffsets))]
+#[tracing::instrument(level = "trace", skip(vmoffsets))]
 pub(crate) fn gen_std_dynamic_import_trampoline(
     vmoffsets: &VMOffsets,
     sig: &FunctionType,
@@ -7935,7 +7935,7 @@ pub(crate) fn gen_std_dynamic_import_trampoline(
 }
 
 // Singlepass calls import functions through a trampoline.
-#[tracing::instrument(target = "near_vm", level = "trace", skip(vmoffsets))]
+#[tracing::instrument(level = "trace", skip(vmoffsets))]
 pub(crate) fn gen_import_call_trampoline(
     vmoffsets: &VMOffsets,
     index: FunctionIndex,

--- a/runtime/near-vm/compiler-singlepass/src/compiler.rs
+++ b/runtime/near-vm/compiler-singlepass/src/compiler.rs
@@ -41,7 +41,7 @@ impl SinglepassCompiler {
 impl Compiler for SinglepassCompiler {
     /// Compile the module using Singlepass, producing a compilation result with
     /// associated relocations.
-    #[tracing::instrument(target = "near_vm", level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn compile_module(
         &self,
         target: &Target,
@@ -87,7 +87,7 @@ impl Compiler for SinglepassCompiler {
         };
         let import_idxs = 0..module.import_counts.functions as usize;
         let import_trampolines: PrimaryMap<SectionIndex, _> =
-            tracing::trace_span!(target: "near_vm", "import_trampolines", n_imports = import_idxs.len()).in_scope(
+            tracing::trace_span!("import_trampolines", n_imports = import_idxs.len()).in_scope(
                 || {
                     import_idxs
                         .into_par_iter()
@@ -111,7 +111,7 @@ impl Compiler for SinglepassCompiler {
             .collect::<Vec<(LocalFunctionIndex, &FunctionBodyData<'_>)>>()
             .into_par_iter()
             .map_init(make_assembler, |assembler, (i, input)| {
-                tracing::trace_span!(target: "near_vm", "function", i = i.index()).in_scope(|| {
+                tracing::trace_span!("function", i = i.index()).in_scope(|| {
                     let reader =
                         near_vm_compiler::FunctionReader::new(input.module_offset, input.data);
                     let stack_init_gas_cost = tunables
@@ -154,9 +154,8 @@ impl Compiler for SinglepassCompiler {
                     let mut operator_reader =
                         reader.get_operators_reader()?.into_iter_with_offsets();
                     while generator.has_control_frames() {
-                        let (op, pos) =
-                            tracing::trace_span!(target: "near_vm", "parsing-next-operator")
-                                .in_scope(|| operator_reader.next().unwrap())?;
+                        let (op, pos) = tracing::trace_span!("parsing-next-operator")
+                            .in_scope(|| operator_reader.next().unwrap())?;
                         generator.set_srcloc(pos as u32);
                         generator.feed_operator(op).map_err(to_compile_error)?;
                     }
@@ -169,7 +168,7 @@ impl Compiler for SinglepassCompiler {
             .collect::<PrimaryMap<LocalFunctionIndex, CompiledFunction>>();
 
         let function_call_trampolines =
-            tracing::trace_span!(target: "near_vm", "function_call_trampolines").in_scope(|| {
+            tracing::trace_span!("function_call_trampolines").in_scope(|| {
                 module
                     .signatures
                     .values()
@@ -183,26 +182,24 @@ impl Compiler for SinglepassCompiler {
                     .collect::<PrimaryMap<_, _>>()
             });
 
-        let dynamic_function_trampolines =
-            tracing::trace_span!(target: "near_vm", "dynamic_function_trampolines").in_scope(
-                || {
-                    module
-                        .imported_function_types()
-                        .collect::<Vec<_>>()
-                        .into_par_iter()
-                        .map_init(make_assembler, |assembler, func_type| {
-                            gen_std_dynamic_import_trampoline(
-                                &vmoffsets,
-                                &func_type,
-                                calling_convention,
-                                assembler,
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .collect::<PrimaryMap<FunctionIndex, FunctionBody>>()
-                },
-            );
+        let dynamic_function_trampolines = tracing::trace_span!("dynamic_function_trampolines")
+            .in_scope(|| {
+                module
+                    .imported_function_types()
+                    .collect::<Vec<_>>()
+                    .into_par_iter()
+                    .map_init(make_assembler, |assembler, func_type| {
+                        gen_std_dynamic_import_trampoline(
+                            &vmoffsets,
+                            &func_type,
+                            calling_convention,
+                            assembler,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .collect::<PrimaryMap<FunctionIndex, FunctionBody>>()
+            });
 
         Ok(Compilation {
             functions,

--- a/runtime/near-vm/compiler/src/translator/environ.rs
+++ b/runtime/near-vm/compiler/src/translator/environ.rs
@@ -59,7 +59,7 @@ impl<'data> ModuleEnvironment<'data> {
 
     /// Translate a wasm module using this environment. This consumes the
     /// `ModuleEnvironment` and produces a `ModuleInfoTranslation`.
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn translate(mut self, data: &'data [u8]) -> WasmResult<Self> {
         assert!(self.module_translation_state.is_none());
         let module_translation_state = translate_module(data, &mut self)?;

--- a/runtime/near-vm/compiler/src/translator/module.rs
+++ b/runtime/near-vm/compiler/src/translator/module.rs
@@ -15,7 +15,7 @@ use wasmparser::{NameSectionReader, Parser, Payload};
 
 /// Translate a sequence of bytes forming a valid Wasm binary into a
 /// parsed ModuleInfo `ModuleTranslationState`.
-#[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn translate_module<'data>(
     data: &'data [u8],
     environ: &mut ModuleEnvironment<'data>,

--- a/runtime/near-vm/compiler/src/translator/state.rs
+++ b/runtime/near-vm/compiler/src/translator/state.rs
@@ -35,7 +35,7 @@ impl ModuleTranslationState {
     }
 
     /// Build map of imported functions names for intrinsification.
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn build_import_map(&mut self, module: &ModuleInfo) {
         for key in module.imports.keys() {
             let value = &module.imports[key];

--- a/runtime/near-vm/engine/src/universal/code_memory.rs
+++ b/runtime/near-vm/engine/src/universal/code_memory.rs
@@ -234,7 +234,6 @@ impl Drop for CodeMemory {
             unsafe {
                 if let Err(e) = mm::munmap(self.map.cast(), self.size) {
                     tracing::error!(
-                        target: "near_vm",
                         message="could not unmap mapping",
                         map=?self.map, size=self.size, error=%e
                     );

--- a/runtime/near-vm/engine/src/universal/engine.rs
+++ b/runtime/near-vm/engine/src/universal/engine.rs
@@ -106,7 +106,7 @@ impl UniversalEngine {
     }
 
     /// Compile a WebAssembly binary
-    #[tracing::instrument(target = "near_vm", level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn compile_universal(
         &self,
         binary: &[u8],
@@ -197,7 +197,7 @@ impl UniversalEngine {
 
     /// Load a [`UniversalExecutable`](crate::UniversalExecutable) with this engine.
     #[cfg(not(windows))]
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn load_universal_executable(
         &self,
         executable: &UniversalExecutable,
@@ -493,7 +493,7 @@ impl UniversalEngine {
     }
 
     /// Validates a WebAssembly module
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn validate(&self, binary: &[u8]) -> Result<(), CompileError> {
         self.inner().validate(binary)
     }

--- a/runtime/near-vm/engine/src/universal/link.rs
+++ b/runtime/near-vm/engine/src/universal/link.rs
@@ -165,7 +165,7 @@ fn apply_relocation(
 
 /// Links a module, patching the allocated functions with the
 /// required relocations and jump tables.
-#[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn link_module(
     allocated_functions: &PrimaryMap<LocalFunctionIndex, VMLocalFunction>,
     jt_offsets: impl Fn(LocalFunctionIndex, JumpTable) -> near_vm_compiler::CodeOffset,

--- a/runtime/near-vm/test-api/src/sys/instance.rs
+++ b/runtime/near-vm/test-api/src/sys/instance.rs
@@ -103,7 +103,7 @@ impl Instance {
     /// Those are, as defined by the spec:
     ///  * Link errors that happen when plugging the imports into the instance
     ///  * Runtime errors that happen when running the module `start` function.
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn new_with_config(
         module: &Module,
         config: InstanceConfig,

--- a/runtime/near-vm/test-api/src/sys/module.rs
+++ b/runtime/near-vm/test-api/src/sys/module.rs
@@ -98,7 +98,7 @@ impl Module {
     /// # }
     /// ```
     #[allow(unreachable_code)]
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn new(store: &Store, bytes: impl AsRef<[u8]>) -> Result<Self, CompileError> {
         #[cfg(feature = "wat")]
         let bytes = wat::parse_bytes(bytes.as_ref()).map_err(|e| {
@@ -113,7 +113,7 @@ impl Module {
     /// Opposed to [`Module::new`], this function is not compatible with
     /// the WebAssembly text format (if the "wat" feature is enabled for
     /// this crate).
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn from_binary(store: &Store, binary: &[u8]) -> Result<Self, CompileError> {
         let engine = store.engine();
         engine.validate(binary)?;

--- a/runtime/near-vm/vm/src/instance/mod.rs
+++ b/runtime/near-vm/vm/src/instance/mod.rs
@@ -1150,7 +1150,7 @@ impl InstanceHandle {
 ///   visible to code in `near_vm_vm`, so it's the caller's responsibility to ensure these
 ///   functions are called with the correct type.
 /// - `instance_ptr` must point to a valid `near_vm_test_api::Instance`.
-#[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub unsafe fn initialize_host_envs<Err: Sized>(
     handle: &parking_lot::Mutex<InstanceHandle>,
     instance_ptr: *const ffi::c_void,

--- a/runtime/near-vm/vm/src/vmoffsets.rs
+++ b/runtime/near-vm/vm/src/vmoffsets.rs
@@ -116,7 +116,7 @@ impl VMOffsets {
     }
 
     /// Add imports and locals from the provided ModuleInfo.
-    #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn with_module_info(mut self, module: &ModuleInfo) -> Self {
         self.num_imported_functions = module.import_counts.functions;
         self.num_imported_tables = module.import_counts.tables;

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -252,7 +252,7 @@ pub(crate) fn action_deploy_contract(
     cache: Option<&dyn ContractRuntimeCache>,
     current_protocol_version: ProtocolVersion,
 ) -> Result<(), StorageError> {
-    let _span = tracing::debug_span!(target: "runtime", "action_deploy_contract").entered();
+    let _span = tracing::debug_span!("action_deploy_contract").entered();
     clear_account_contract_storage_usage(
         state_update,
         account_id,

--- a/runtime/runtime/src/bandwidth_scheduler/mod.rs
+++ b/runtime/runtime/src/bandwidth_scheduler/mod.rs
@@ -51,7 +51,6 @@ pub fn run_bandwidth_scheduler(
 ) -> Result<BandwidthSchedulerOutput, RuntimeError> {
     let start_time = std::time::Instant::now();
     let _span = tracing::debug_span!(
-        target: "runtime",
         "run_bandwidth_scheduler",
         height = apply_state.block_height,
         shard_id = %apply_state.shard_id)
@@ -61,7 +60,7 @@ pub fn run_bandwidth_scheduler(
     let mut scheduler_state = match get_bandwidth_scheduler_state(state_update)? {
         Some(prev_state) => prev_state,
         None => {
-            tracing::debug!(target: "runtime", "bandwidth scheduler state not found - initializing");
+            tracing::debug!("bandwidth scheduler state not found - initializing");
             BandwidthSchedulerState::V1(BandwidthSchedulerStateV1 {
                 link_allowances: Vec::new(),
                 sanity_check_hash: CryptoHash::default(),

--- a/runtime/runtime/src/bandwidth_scheduler/scheduler.rs
+++ b/runtime/runtime/src/bandwidth_scheduler/scheduler.rs
@@ -492,7 +492,7 @@ impl BandwidthScheduler {
     fn grant_more_bandwidth(&mut self, link: &ShardLink, bandwidth: Bandwidth) {
         let current_granted = self.granted_bandwidth.get(link).copied().unwrap_or(0);
         let new_granted = current_granted.checked_add(bandwidth).unwrap_or_else(|| {
-            tracing::warn!(target: "runtime", ?link, "granting bandwidth on link would overflow, this is unexpected, granting max bandwidth instead");
+            tracing::warn!(?link, "granting bandwidth on link would overflow, this is unexpected, granting max bandwidth instead");
             Bandwidth::MAX
         });
         self.granted_bandwidth.insert(*link, new_granted);

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -237,7 +237,7 @@ impl ReceiptSinkV2WithInfo {
         state_update: &mut TrieUpdate,
         apply_state: &ApplyState,
     ) -> Result<(), RuntimeError> {
-        tracing::debug!(target: "runtime", "forwarding receipts from outgoing buffers");
+        tracing::debug!("forwarding receipts from outgoing buffers");
 
         // There mustn't be any shard ids in both the parents and the current
         // shard ids. If this happens the same buffer will be processed twice.
@@ -416,7 +416,6 @@ impl ReceiptSinkV2 {
         let max_receipt_size = apply_state.config.wasm_config.limit_config.max_receipt_size;
         if size > max_receipt_size {
             tracing::debug!(
-                target: "runtime",
                 receipt_id=?receipt.receipt_id(),
                 size,
                 max_receipt_size,
@@ -440,7 +439,7 @@ impl ReceiptSinkV2 {
         let forward_limit = outgoing_limit.entry(shard).or_insert(default_outgoing_limit);
 
         if forward_limit.gas >= gas && forward_limit.size >= size {
-            tracing::trace!(target: "runtime", ?shard, receipt_id=?receipt.receipt_id(), "forwarding buffered receipt");
+            tracing::trace!(?shard, receipt_id=?receipt.receipt_id(), "forwarding buffered receipt");
             outgoing_receipts.push(receipt);
             // underflow impossible: checked forward_limit > gas/size_to_forward above
             forward_limit.gas = forward_limit.gas.checked_sub(gas).unwrap();
@@ -449,7 +448,7 @@ impl ReceiptSinkV2 {
 
             Ok(ReceiptForwarding::Forwarded)
         } else {
-            tracing::trace!(target: "runtime", ?shard, receipt_id=?receipt.receipt_id(), "not forwarding buffered receipt");
+            tracing::trace!(?shard, receipt_id=?receipt.receipt_id(), "not forwarding buffered receipt");
             Ok(ReceiptForwarding::NotForwarded(receipt))
         }
     }

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -170,7 +170,6 @@ impl<'a> External for RuntimeExt<'a> {
             self.trie_access_tracker.state.commit_counts_since(start_ttn, access_tracker)?;
         #[cfg(feature = "io_trace")]
         tracing::trace!(
-            target: "io_tracer",
             storage_op = "write",
             key = base64(&key),
             size = value.len(),
@@ -214,7 +213,6 @@ impl<'a> External for RuntimeExt<'a> {
         #[cfg(feature = "io_trace")]
         if let Ok(read) = &result {
             tracing::trace!(
-                target: "io_tracer",
                 storage_op = "read",
                 key = base64(&key),
                 size = read.as_ref().map(|v| v.len()),
@@ -256,7 +254,6 @@ impl<'a> External for RuntimeExt<'a> {
             self.trie_access_tracker.state.commit_counts_since(start_ttn, access_tracker)?;
         #[cfg(feature = "io_trace")]
         tracing::trace!(
-            target: "io_tracer",
             storage_op = "remove",
             key = base64(&key),
             evicted_len = removed.as_ref().map(Vec::len),
@@ -287,7 +284,6 @@ impl<'a> External for RuntimeExt<'a> {
             self.trie_access_tracker.state.commit_counts_since(start_ttn, access_tracker)?;
         #[cfg(feature = "io_trace")]
         tracing::trace!(
-            target: "io_tracer",
             storage_op = "exists",
             key = base64(&key),
             tn_mem_reads = _delta.mem_reads,

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -256,7 +256,7 @@ pub(crate) fn execute_function_call(
     view_config: Option<ViewConfig>,
 ) -> Result<VMOutcome, RuntimeError> {
     let account_id = runtime_ext.account_id().clone();
-    tracing::debug!(target: "runtime", %account_id, "calling the contract");
+    tracing::debug!(%account_id, "calling the contract");
     // Output data receipts are ignored if the function call is not the last action in the batch.
     let output_data_receivers: Vec<_> = if is_last_action {
         action_receipt.output_data_receivers().iter().map(|r| r.receiver_id.clone()).collect()
@@ -353,7 +353,7 @@ fn apply_recorded_storage_garbage(function_call: &FunctionCallAction, state_upda
         .and_then(|suf| suf.parse::<usize>().ok())
     {
         if state_update.trie.record_storage_garbage(garbage_size_mbs) {
-            tracing::warn!(target: "runtime", %garbage_size_mbs, "generated storage proof garbage");
+            tracing::warn!(%garbage_size_mbs, "generated storage proof garbage");
         }
     }
 }

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -28,7 +28,7 @@ pub(crate) fn action_deploy_global_contract(
     deploy_contract: &DeployGlobalContractAction,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
-    let _span = tracing::debug_span!(target: "runtime", "action_deploy_global_contract").entered();
+    let _span = tracing::debug_span!("action_deploy_global_contract").entered();
 
     let storage_cost = apply_state
         .config
@@ -71,7 +71,7 @@ pub(crate) fn action_use_global_contract(
     current_protocol_version: ProtocolVersion,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
-    let _span = tracing::debug_span!(target: "runtime", "action_use_global_contract").entered();
+    let _span = tracing::debug_span!("action_use_global_contract").entered();
     use_global_contract(
         state_update,
         account_id,
@@ -130,11 +130,7 @@ pub(crate) fn apply_global_contract_distribution_receipt(
     state_update: &mut TrieUpdate,
     receipt_sink: &mut ReceiptSink,
 ) -> Result<(), RuntimeError> {
-    let _span = tracing::debug_span!(
-        target: "runtime",
-        "apply_global_contract_distribution_receipt",
-    )
-    .entered();
+    let _span = tracing::debug_span!("apply_global_contract_distribution_receipt",).entered();
 
     let ReceiptEnum::GlobalContractDistribution(global_contract_data) = receipt.receipt() else {
         unreachable!("given receipt should be an global contract distribution receipt")

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -358,7 +358,7 @@ impl Runtime {
         if log.is_empty() {
             return;
         }
-        tracing::debug!(target: "runtime", logs = %log.join("\n"));
+        tracing::debug!(logs = %log.join("\n"));
     }
 
     fn apply_action(
@@ -1261,13 +1261,13 @@ impl Runtime {
         for (account_id, max_of_stakes) in &validator_accounts_update.stake_info {
             if let Some(mut account) = get_account(state_update, account_id)? {
                 if let Some(reward) = validator_accounts_update.validator_rewards.get(account_id) {
-                    tracing::debug!(target: "runtime", %account_id, %reward, locked = %account.locked(), "account adding reward to stake");
+                    tracing::debug!(%account_id, %reward, locked = %account.locked(), "account adding reward to stake");
                     account.set_locked(account.locked().checked_add(*reward).ok_or_else(|| {
                         RuntimeError::UnexpectedIntegerOverflow("update_validator_accounts".into())
                     })?);
                 }
 
-                tracing::debug!(target: "runtime",
+                tracing::debug!(
                        %account_id, locked = %account.locked(), %max_of_stakes,
                        "account stake and max of stakes"
                 );
@@ -1290,7 +1290,7 @@ impl Runtime {
                             "update_validator_accounts - return stake".into(),
                         )
                     })?;
-                tracing::debug!(target: "runtime", %account_id, %return_stake, "account return stake");
+                tracing::debug!(%account_id, %return_stake, "account return stake");
                 account.set_locked(account.locked().checked_sub(return_stake).ok_or_else(
                     || {
                         RuntimeError::UnexpectedIntegerOverflow(
@@ -1364,7 +1364,7 @@ impl Runtime {
     /// containing invalid transactions does make it to here, these transactions are skipped. This
     /// does pollute the chain with junk data, but it also allows the protocol to make progress, as
     /// the only alternative way to handle these transactions is to make the entire chunk invalid.
-    #[instrument(target = "runtime", level = "debug", "apply", skip_all, fields(
+    #[instrument(level = "debug", "apply", skip_all, fields(
         protocol_version = apply_state.current_protocol_version,
         num_transactions = signed_txs.len(),
         gas_burnt = tracing::field::Empty,
@@ -1530,7 +1530,6 @@ impl Runtime {
     /// Any transactions that fail to validate (e.g. invalid nonces, unknown signing keys,
     /// insufficient NEAR balance, etc.) will be skipped, producing no receipts.
     #[instrument(
-        target = "runtime",
         level = "debug",
         "process_transactions",
         skip_all,
@@ -1923,7 +1922,6 @@ impl Runtime {
                     // This should never happen unless there is a bug in the code.
                     metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
                     tracing::error!(
-                        target: "runtime",
                         tx_hash=?tx.hash(),
                         tx_burnt_amount=?verification_result.burnt_amount,
                         ?err,
@@ -1994,7 +1992,6 @@ impl Runtime {
         mut validator_proposals: &mut Vec<ValidatorStake>,
     ) -> Result<(), RuntimeError> {
         let span = tracing::debug_span!(
-            target: "runtime",
             "process_receipt",
             receipt_id = %receipt.receipt_id(),
             predecessor = %receipt.predecessor_id(),
@@ -2055,7 +2052,7 @@ impl Runtime {
         Ok(())
     }
 
-    #[instrument(target = "runtime", level = "debug", "process_local_receipts", skip_all, fields(
+    #[instrument(level = "debug", "process_local_receipts", skip_all, fields(
         num_receipts = processing_state.local_receipts.len(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
@@ -2134,7 +2131,6 @@ impl Runtime {
     }
 
     #[instrument(
-        target = "runtime",
         level = "debug",
         "process_delayed_receipts",
         skip_all,
@@ -2234,7 +2230,7 @@ impl Runtime {
         Ok(processed_delayed_receipts)
     }
 
-    #[instrument(target = "runtime", level = "debug", "process_incoming_receipts", skip_all, fields(
+    #[instrument(level = "debug", "process_incoming_receipts", skip_all, fields(
         num_receipts = processing_state.incoming_receipts.len(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
@@ -2346,7 +2342,6 @@ impl Runtime {
     /// Processes all receipts (local, delayed and incoming).
     /// Returns a structure containing the result of the processing.
     #[instrument(
-        target = "runtime",
         level = "debug",
         "process_receipts",
         skip_all,
@@ -2415,7 +2410,6 @@ impl Runtime {
     }
 
     #[instrument(
-        target = "runtime",
         level = "debug",
         "validate_apply_state_update",
         skip_all,
@@ -2504,7 +2498,7 @@ impl Runtime {
             // queues: one for data that is going to be required soon, and the other that it would
             // only work when otherwise idle.
             let discarded_prefetch_requests = prefetcher.clear();
-            tracing::debug!(target: "runtime", discarded_prefetch_requests);
+            tracing::debug!(discarded_prefetch_requests);
         }
 
         // Dedup proposals from the same account.
@@ -2587,11 +2581,11 @@ impl ApplyState {
             return Ok(congestion_info.congestion_info);
         }
 
-        tracing::warn!(target: "runtime", "starting to bootstrap congestion info, this might take a while");
+        tracing::warn!("starting to bootstrap congestion info, this might take a while");
         let start = std::time::Instant::now();
         let result = bootstrap_congestion_info(trie, &self.config, self.shard_id);
         let time = start.elapsed();
-        tracing::warn!(target: "runtime", ?time, "bootstrapping congestion info done");
+        tracing::warn!(?time, "bootstrapping congestion info done");
         let computed = result?;
         Ok(computed)
     }

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -868,7 +868,7 @@ fn report_outgoing_buffers(
 pub fn report_recorded_column_sizes(trie: &Trie, apply_state: &ApplyState) {
     // Tracing span to measure time spent on reporting column sizes.
     let _span = tracing::debug_span!(
-            target: "runtime", "report_recorded_column_sizes",
+            "report_recorded_column_sizes",
             shard_id = %apply_state.shard_id,
             block_height = apply_state.block_height)
     .entered();

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -294,7 +294,6 @@ impl ReceiptPreparationPipeline {
             let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
             if !self.block_accounts.contains(account_id) {
                 tracing::debug!(
-                    target: "runtime::pipelining",
                     message="function call task was not submitted for preparation",
                     receipt=%receipt.get_hash(),
                     action_index,
@@ -322,7 +321,6 @@ impl ReceiptPreparationPipeline {
                     drop(status_guard);
                     let start = Instant::now();
                     tracing::trace!(
-                        target: "runtime::pipelining",
                         message="function call preparation on the main thread",
                         receipt=%receipt.get_hash(),
                         action_index

--- a/runtime/runtime/src/prefetch.rs
+++ b/runtime/runtime/src/prefetch.rs
@@ -237,11 +237,13 @@ impl TriePrefetcher {
         match res {
             Err(PrefetchError::QueueFull) => {
                 self.prefetch_queue_full.inc();
-                tracing::debug!(target: "runtime::prefetch", "IO scheduler input queue is full, dropping prefetch request");
+                tracing::debug!("IO scheduler input queue is full, dropping prefetch request");
             }
             Err(PrefetchError::QueueDisconnected) => {
                 // This shouldn't have happened, hence logging warning here
-                tracing::warn!(target: "runtime::prefetch", "IO scheduler input queue is disconnected, dropping prefetch request");
+                tracing::warn!(
+                    "IO scheduler input queue is disconnected, dropping prefetch request"
+                );
             }
             Ok(()) => self.prefetch_enqueued.inc(),
         };

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -345,12 +345,12 @@ impl TrieViewer {
         if let Some(err) = outcome.aborted {
             logs.extend(outcome.logs);
             let message = format!("wasm execution failed with error: {:?}", err);
-            tracing::debug!(target: "runtime", %time_str, %message, "exec time and error message");
+            tracing::debug!(%time_str, %message, "exec time and error message");
             let error: near_primitives::errors::FunctionCallError =
                 crate::conversions::Convert::convert(err);
             Err(errors::CallFunctionError::VMError { error, error_message: message })
         } else {
-            tracing::debug!(target: "runtime", %time_str, ?outcome, "exec time and result of execution");
+            tracing::debug!(%time_str, ?outcome, "exec time and result of execution");
             logs.extend(outcome.logs);
             let result = match outcome.return_data {
                 ReturnData::Value(buf) => buf,


### PR DESCRIPTION
Removes `target: "…"` from all tracing event/span macros and `target = "…"` from all `#[instrument]` attributes in `runtime/` (`near-vm`, `near-vm-runner`, `node-runtime`). The tracing default target — the module path — is sufficient for filtering and grouping in all cases.

See `docs/practices/style.md` (PR 1/7) for the rationale and convention.

Part 6 of 7.