### PR TITLE
refactor(tracing): 7/7 remove explicit target from tools and tests tracing

### DIFF
--- a/benchmarks/transactions-generator/src/actor.rs
+++ b/benchmarks/transactions-generator/src/actor.rs
@@ -18,11 +18,10 @@ impl GeneratorActor {
     pub fn start(&mut self, _ctx: &mut dyn DelayedActionRunner<Self>) {
         match self.tx_generator.start() {
             Err(err) => {
-                tracing::error!(target: "transaction-generator", ?err);
+                tracing::error!(?err);
             }
             Ok(_) => {
-                tracing::info!(target: "transaction-generator",
-                    schedule=?self.tx_generator.params.schedule, "started");
+                tracing::info!(schedule=?self.tx_generator.params.schedule, "started");
             }
         };
     }

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -255,7 +255,7 @@ impl TestEnv {
             for i in 0..network_adapters.len() {
                 let network_adapter = network_adapters.get(i).unwrap();
                 let _span =
-                    tracing::debug_span!(target: "test", "process_partial_encoded_chunks", client=i).entered();
+                    tracing::debug_span!("process_partial_encoded_chunks", client = i).entered();
 
                 keep_going |= network_adapter.handle_filtered(|request| match request {
                     PeerManagerMessageRequest::NetworkRequests(
@@ -381,8 +381,7 @@ impl TestEnv {
     }
 
     pub fn process_shards_manager_responses_and_finish_processing_blocks(&mut self, idx: usize) {
-        let _span =
-            tracing::debug_span!(target: "test", "process_shards_manager", client=idx).entered();
+        let _span = tracing::debug_span!("process_shards_manager", client = idx).entered();
 
         loop {
             self.process_shards_manager_responses(idx);
@@ -439,7 +438,7 @@ impl TestEnv {
                     witness_processing_done_waiters.push(processing_done_tracker.make_waiter());
 
                     if !self.contains_client(&account_id) {
-                        tracing::warn!(target: "test", %account_id, "client not found for account_id");
+                        tracing::warn!(%account_id, "client not found for account_id");
                         continue;
                     }
                     let account_index = self.get_client_index(&account_id);
@@ -483,10 +482,13 @@ impl TestEnv {
                     endorsement,
                 )) => {
                     if !self.contains_client(&account_id) {
-                        tracing::warn!(target: "test", %account_id, "client not found for account_id");
+                        tracing::warn!(%account_id, "client not found for account_id");
                         return None;
                     }
-                    let processing_result = self.client(&account_id).chunk_endorsement_tracker.process_chunk_endorsement(endorsement);
+                    let processing_result = self
+                        .client(&account_id)
+                        .chunk_endorsement_tracker
+                        .process_chunk_endorsement(endorsement);
                     if !allow_errors {
                         processing_result.unwrap();
                     }
@@ -882,7 +884,7 @@ impl TestEnv {
         let genesis_height = client.chain.genesis().height();
         let head_height = client.chain.head().unwrap().height;
 
-        tracing::info!(target: "test", genesis_height, head_height, "printing summary");
+        tracing::info!(genesis_height, head_height, "printing summary");
         for height in genesis_height..head_height + 1 {
             self.print_block_summary(height);
         }
@@ -894,7 +896,7 @@ impl TestEnv {
         let block = match block {
             Ok(block) => block,
             Err(err) => {
-                tracing::info!(target: "test", ?err, %height, "block: missing");
+                tracing::info!(?err, %height, "block: missing");
                 return;
             }
         };
@@ -906,7 +908,14 @@ impl TestEnv {
         let block_hash = block.hash();
         let chunk_mask = block.header().chunk_mask();
 
-        tracing::info!(target: "test", height, ?block_hash, ?chunk_mask, protocol_version, latest_protocol_version, "block");
+        tracing::info!(
+            height,
+            ?block_hash,
+            ?chunk_mask,
+            protocol_version,
+            latest_protocol_version,
+            "block"
+        );
     }
 
     pub fn spice_execute_block(&mut self, id: usize, block_hash: CryptoHash) {

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -735,7 +735,7 @@ fn test_bad_chunk_mask() {
     let first_epoch_id = &EpochId::default();
 
     let shard_layout = env.clients[0].epoch_manager.get_shard_layout(&first_epoch_id).unwrap();
-    tracing::info!(target: "test", ?shard_layout, "shard layout");
+    tracing::info!(?shard_layout, "shard layout");
 
     let [s0, s1] = shard_layout.shard_ids().collect_vec()[..] else { panic!("Expected 2 shards") };
     assert_eq!(s0, shard_layout.account_id_to_shard_id(&account0));
@@ -746,7 +746,7 @@ fn test_bad_chunk_mask() {
 
     let tip = env.clients[0].chain.get_block_by_height(0).unwrap();
     for chunk_header in tip.chunks().iter() {
-        tracing::info!(target: "test", ?chunk_header, "chunk header");
+        tracing::info!(?chunk_header, "chunk header");
     }
 
     for height in 1..5 {
@@ -2539,7 +2539,7 @@ fn test_epoch_multi_protocol_version_change() {
     let protocol_version_override =
         format!("{}={},{}={}", v1_upgrade_time, v1, v2_upgrade_time, v2);
 
-    tracing::debug!(target: "test", ?protocol_version_override, "setting the protocol_version_override");
+    tracing::debug!(?protocol_version_override, "setting the protocol_version_override");
     unsafe { std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", protocol_version_override) };
 
     let epoch_length = 5;
@@ -2575,7 +2575,7 @@ fn test_epoch_multi_protocol_version_change() {
             seen_v2 = true;
         }
 
-        tracing::debug!(target: "test", ?height, ?protocol_version, "loop iter finished");
+        tracing::debug!(?height, ?protocol_version, "loop iter finished");
 
         height += 1;
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -2614,7 +2614,7 @@ fn slow_test_epoch_multi_protocol_version_change_epoch_overlap() {
     let protocol_version_override =
         format!("{}={},{}={}", v1_upgrade_time, v1, v2_upgrade_time, v2);
 
-    tracing::debug!(target: "test", ?protocol_version_override, "setting the protocol_version_override");
+    tracing::debug!(?protocol_version_override, "setting the protocol_version_override");
     unsafe { std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", protocol_version_override) };
 
     let epoch_length = 5;
@@ -2663,7 +2663,7 @@ fn slow_test_epoch_multi_protocol_version_change_epoch_overlap() {
             );
         }
 
-        tracing::debug!(target: "test", ?height, ?protocol_version, "loop iter finished");
+        tracing::debug!(?height, ?protocol_version, "loop iter finished");
 
         height += 1;
         current_epoch_id = epoch_id;

--- a/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
@@ -487,7 +487,7 @@ fn test_processing_chunks_sanity() {
             .iter()
             .map(|chunk| format!("{:?}", chunk.chunk_hash()))
             .collect::<Vec<_>>();
-        tracing::debug!(target: "chunks", block = %i, chunks = %chunks.join(", "));
+        tracing::debug!(block = %i, chunks = %chunks.join(", "));
         blocks.push(block.clone());
         env.process_block(0, block, Provenance::PRODUCED);
     }
@@ -609,7 +609,6 @@ impl ChunkForwardingOptimizationTestData {
                     );
                 }
                 tracing::debug!(
-                    target: "test",
                     %client_id,
                     ?target,
                     chunk_hash_hex = %hex::encode(&request.chunk_hash.as_bytes()[..4]),
@@ -625,7 +624,6 @@ impl ChunkForwardingOptimizationTestData {
             }
             NetworkRequests::PartialEncodedChunkMessage { account_id, partial_encoded_chunk } => {
                 tracing::debug!(
-                    target: "test",
                     %client_id,
                     %account_id,
                     height = %partial_encoded_chunk.header.height_created(),
@@ -652,7 +650,6 @@ impl ChunkForwardingOptimizationTestData {
             }
             NetworkRequests::PartialEncodedChunkForward { account_id, forward } => {
                 tracing::debug!(
-                    target: "test",
                     %client_id,
                     %account_id,
                     hash = %hex::encode(&forward.chunk_hash.as_bytes()[..4]),
@@ -712,7 +709,7 @@ fn test_chunk_forwarding_optimization() {
         if height >= 31 {
             break;
         }
-        tracing::debug!(target: "test", height = %(height + 1), "======= height ======");
+        tracing::debug!(height = %(height + 1), "======= height ======");
         let block = test.env.clients[0].produce_block(height + 1).unwrap().unwrap();
         if block.header().height() > 1 {
             // For any block except the first, the previous block's application at each
@@ -726,7 +723,7 @@ fn test_chunk_forwarding_optimization() {
         }
         // The block producer of course has the complete block so we can process that.
         for i in 0..test.num_validators {
-            tracing::debug!(target: "test", height = %block.header().height(), %i, "processing block as validator");
+            tracing::debug!(height = %block.header().height(), %i, "processing block as validator");
             let _ = test.env.clients[i].start_process_block(
                 block.clone().into(),
                 if i == 0 { Provenance::PRODUCED } else { Provenance::NONE },
@@ -757,7 +754,7 @@ fn test_chunk_forwarding_optimization() {
         test.env.propagate_chunk_state_witnesses_and_endorsements(false);
     }
 
-    tracing::debug!(target: "test",
+    tracing::debug!(
         num_part_ords_requested = %test.num_part_ords_requested,
         num_part_ords_sent_as_partial_encoded_chunk = %test.num_part_ords_sent_as_partial_encoded_chunk,
         num_part_ords_forwarded = %test.num_part_ords_forwarded,

--- a/integration-tests/src/tests/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/features/adversarial_behaviors.rs
@@ -133,7 +133,7 @@ fn slow_test_non_adversarial_case() {
     let mut test = AdversarialBehaviorTestData::new();
     let epoch_manager = test.env.clients[0].epoch_manager.clone();
     for height in 1..=EPOCH_LENGTH * 4 + 5 {
-        tracing::debug!(target: "test", %height, "======= height ======");
+        tracing::debug!(%height, "======= height ======");
         test.process_all_actor_messages();
         let epoch_id = epoch_manager
             .get_epoch_id_from_prev_block(
@@ -162,7 +162,7 @@ fn slow_test_non_adversarial_case() {
         }
 
         for i in 0..test.num_validators {
-            tracing::debug!(target: "test", %height, %i, "processing block as validator");
+            tracing::debug!(%height, %i, "processing block as validator");
             let _ = test.env.clients[i].start_process_block(
                 block.clone().into(),
                 if i == 0 { Provenance::PRODUCED } else { Provenance::NONE },
@@ -215,7 +215,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
     let mut epochs_seen_invalid_chunk: HashSet<EpochId> = HashSet::new();
     let mut last_block_skipped = false;
     for height in 1..=EPOCH_LENGTH * 4 + 5 {
-        tracing::debug!(target: "test", %height, "======= height ======");
+        tracing::debug!(%height, "======= height ======");
         test.process_all_actor_messages();
         let epoch_id = epoch_manager
             .get_epoch_id_from_prev_block(
@@ -265,8 +265,8 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
                 }
             }
         }
-        tracing::debug!(target: "test", ?epoch_id, "epoch id of new block");
-        tracing::debug!(target: "test", %last_block_skipped, "block should be skipped: false, previous block skipped");
+        tracing::debug!(?epoch_id, "epoch id of new block");
+        tracing::debug!(%last_block_skipped, "block should be skipped: false, previous block skipped");
 
         if height > 1 {
             let prev_block =
@@ -295,7 +295,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
 
         // The block producer of course has the complete block so we can process that.
         for i in 0..test.num_validators {
-            tracing::debug!(target: "test", %height, %i, "processing block as validator");
+            tracing::debug!(%height, %i, "processing block as validator");
             let _ = test.env.clients[i].start_process_block(
                 block.clone().into(),
                 if i == 0 { Provenance::PRODUCED } else { Provenance::NONE },

--- a/integration-tests/src/tests/features/orphan_chunk_state_witness.rs
+++ b/integration-tests/src/tests/features/orphan_chunk_state_witness.rs
@@ -69,9 +69,9 @@ fn setup_orphan_witness_test() -> OrphanWitnessTestEnv {
         // Produce the next block
         let tip = env.clients[0].chain.head().unwrap();
         let block_producer = env.get_block_producer_at_offset(&tip, 1);
-        tracing::info!(target: "test", %height, %block_producer, "producing block at height by block producer");
+        tracing::info!(%height, %block_producer, "producing block at height by block producer");
         let block = env.client(&block_producer).produce_block(tip.height + 1).unwrap().unwrap();
-        tracing::info!(target: "test", %height, chunk_hash = ?block.chunks()[0].chunk_hash(), "block produced at height has chunk");
+        tracing::info!(%height, chunk_hash = ?block.chunks()[0].chunk_hash(), "block produced at height has chunk");
 
         // The first block after genesis doesn't have any chunks, but all other blocks should have a new chunk inside.
         if height > 1 {
@@ -129,7 +129,7 @@ fn setup_orphan_witness_test() -> OrphanWitnessTestEnv {
     let clients_without_excluded =
         (0..env.clients.len()).filter(|idx| *idx != excluded_validator_idx);
 
-    tracing::info!(target:"test", height = %(tip.height + 1), "producing block1 at height");
+    tracing::info!(height = %(tip.height + 1), "producing block1 at height");
     let block1 = env.client(&block1_producer).produce_block(tip.height + 1).unwrap().unwrap();
     assert_eq!(
         block1.chunks()[0].height_created(),
@@ -160,7 +160,7 @@ fn setup_orphan_witness_test() -> OrphanWitnessTestEnv {
 
     // Trigger chunk production for block2 by producing the block first
     let block2 = env.client(&block2_producer).produce_block(tip.height + 2).unwrap().unwrap();
-    tracing::info!(target:"test", height = %(tip.height + 2), "producing block2 at height");
+    tracing::info!(height = %(tip.height + 2), "producing block2 at height");
     assert_eq!(
         block2.chunks()[0].height_created(),
         block2.header().height(),

--- a/integration-tests/src/tests/features/stateless_validation.rs
+++ b/integration-tests/src/tests/features/stateless_validation.rs
@@ -174,7 +174,6 @@ fn run_chunk_validation_test(
         let height_offset = height - tip.height;
         let block_producer = env.get_block_producer_at_offset(&tip, height_offset);
         tracing::debug!(
-            target: "client",
             %height, %block_producer, "producing block at height by block producer"
         );
         let block = env.client(&block_producer).produce_block(height).unwrap().unwrap();
@@ -183,7 +182,6 @@ fn run_chunk_validation_test(
         for i in 0..env.clients.len() {
             let validator_id = env.get_client_id(i);
             tracing::debug!(
-                target: "client",
                 height = %block.header().height(), %validator_id, "applying block at height at validator"
             );
             let blocks_processed = if rng.gen_bool(prob_missing_chunk) {
@@ -351,7 +349,7 @@ fn test_chunk_state_witness_bad_shard_id() {
     // Run the client for a few blocks
     let upper_height = 6;
     for height in 1..upper_height {
-        tracing::info!(target: "test", %height, "producing block at height");
+        tracing::info!(%height, "producing block at height");
         let block = env.clients[0].produce_block(height).unwrap().unwrap();
         env.process_block(0, block, Provenance::PRODUCED);
     }
@@ -363,7 +361,7 @@ fn test_chunk_state_witness_bad_shard_id() {
     let witness_size = borsh::object_length(&witness).unwrap();
 
     // Test chunk validation actor rejects witness with invalid shard ID
-    tracing::info!(target: "test", "processing invalid chunk state witness");
+    tracing::info!("processing invalid chunk state witness");
     let witness_message = ChunkStateWitnessMessage {
         witness,
         raw_witness_size: witness_size,
@@ -549,7 +547,6 @@ fn produce_block(env: &mut TestEnv) {
     for i in 0..env.clients.len() {
         let validator_id = env.get_client_id(i);
         tracing::debug!(
-            target: "client",
             height = %block.header().height(), %validator_id, "applying block at height at validator"
         );
         let blocks_processed =

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -304,7 +304,7 @@ impl StateMachine {
         match action {
             Action::AddEdge { from, to, force } => {
                 self.actions.push(Box::new(move |info: &mut RunningInfo| Box::pin(async move {
-                    tracing::debug!(target: "test", num_prev_actions, action = ?action_clone, "runner.rs: action");
+                    tracing::debug!(num_prev_actions, action = ?action_clone, "runner.rs: action");
                     let pm = info.get_node(from)?.actor.clone();
                     let peer_info = info.runner.test_config[to].peer_info();
                     match tcp::Stream::connect(&peer_info, tcp::Tier::T2, &config::SocketOptions::default()).await {
@@ -333,14 +333,14 @@ impl StateMachine {
             }
             Action::Stop(source) => {
                 self.actions.push(Box::new(move |info: &mut RunningInfo| Box::pin(async move {
-                    tracing::debug!(target: "test", num_prev_actions, action = ?action_clone, "runner.rs: action");
+                    tracing::debug!(num_prev_actions, action = ?action_clone, "runner.rs: action");
                     info.stop_node(source);
                     Ok(ControlFlow::Break(()))
                 })));
             }
             Action::Wait(t) => {
                 self.actions.push(Box::new(move |_info: &mut RunningInfo| Box::pin(async move {
-                    tracing::debug!(target: "test", num_prev_actions, action = ?action_clone, "runner.rs: action");
+                    tracing::debug!(num_prev_actions, action = ?action_clone, "runner.rs: action");
                     tokio::time::sleep(t.try_into().unwrap()).await;
                     Ok(ControlFlow::Break(()))
                 })));
@@ -582,7 +582,7 @@ pub(crate) fn start_test(runner: Runner) -> anyhow::Result<()> {
         let step = tokio::time::Duration::from_millis(10);
         let start = tokio::time::Instant::now();
         for (i, a) in actions.into_iter().enumerate() {
-            tracing::debug!(target: "test", %i, "starting action");
+            tracing::debug!(%i, "starting action");
             loop {
                 let done =
                     tokio::time::timeout_at(start + timeout, a(&mut info)).await.with_context(
@@ -653,7 +653,12 @@ pub(crate) fn check_expected_connections(
 ) -> ActionFn {
     Box::new(move |info: &mut RunningInfo| {
         Box::pin(async move {
-            tracing::debug!(target: "test", node_id, expected_connections_lo, ?expected_connections_hi, "runner.rs: check_expected_connections");
+            tracing::debug!(
+                node_id,
+                expected_connections_lo,
+                ?expected_connections_hi,
+                "runner.rs: check_expected_connections"
+            );
             let pm = &info.get_node(node_id)?.actor;
             let res = pm.send_async(GetInfo {}).await?;
             if expected_connections_lo.is_some_and(|l| l > res.num_connected_peers) {
@@ -671,7 +676,7 @@ pub(crate) fn check_expected_connections(
 pub(crate) fn restart(node_id: usize) -> ActionFn {
     Box::new(move |info: &mut RunningInfo| {
         Box::pin(async move {
-            tracing::debug!(target: "test", ?node_id, "runner.rs: restart");
+            tracing::debug!(?node_id, "runner.rs: restart");
             info.start_node(node_id)?;
             Ok(ControlFlow::Break(()))
         })

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -25,7 +25,7 @@ fn read_trie_items(bench: &mut Bencher, shard_index: ShardIndex, shard_id: Shard
     let num_trie_items = 10_000;
 
     bench.iter(move || {
-        tracing::info!(target: "neard", ?home_dir, "home directory");
+        tracing::info!(?home_dir, "home directory");
         let store = near_store::NodeStorage::opener(
             &home_dir,
             &near_config.config.store,
@@ -60,7 +60,7 @@ fn read_trie_items(bench: &mut Bencher, shard_index: ShardIndex, shard_id: Shard
             .enumerate()
             .map(|(i, _)| {
                 if i % 500 == 0 {
-                    tracing::info!(target: "neard", %i, "progress")
+                    tracing::info!(%i, "progress")
                 }
             })
             .take(num_trie_items)

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -542,7 +542,6 @@ impl Config {
             let s = if unrecognized_fields.len() > 1 { "s" } else { "" };
             let fields = unrecognized_fields.join(", ");
             tracing::warn!(
-                target: "neard",
                 path = %path.display(),
                 fields_count = %s,
                 %fields,
@@ -586,7 +585,6 @@ impl Config {
     fn check_for_deprecated_fields(json_str: &str) {
         for (deprecated_key, new_key) in Self::deprecated_fields_in_json(json_str) {
             tracing::warn!(
-                target: "neard",
                 deprecated_key = %deprecated_key,
                 new_key        = %new_key,
                 "deprecated config key detected – please migrate",
@@ -915,7 +913,7 @@ fn generate_or_load_key(
                 ));
             }
         }
-        tracing::info!(target: "near", public_key = %signer.public_key(), account_id = %signer.get_account_id(), "reusing key for account");
+        tracing::info!(public_key = %signer.public_key(), account_id = %signer.get_account_id(), "reusing key for account");
         Ok(Some(signer))
     } else if let Some(account_id) = account_id {
         let signer = if let Some(seed) = test_seed {
@@ -923,7 +921,7 @@ fn generate_or_load_key(
         } else {
             InMemorySigner::from_random(account_id, KeyType::ED25519).into()
         };
-        tracing::info!(target: "near", public_key = %signer.public_key(), account_id = %signer.get_account_id(), "using key for account");
+        tracing::info!(public_key = %signer.public_key(), account_id = %signer.get_account_id(), "using key for account");
         signer
             .write_to_file(&path)
             .with_context(|| anyhow!("Failed saving key to ‘{}’", path.display()))?;
@@ -1082,7 +1080,7 @@ pub fn init_configs(
         near_primitives::chains::MAINNET => {
             let genesis = near_mainnet_res::mainnet_genesis();
             genesis.to_file(dir.join(config.genesis_file));
-            tracing::info!(target: "near", dir = %dir.display(), "generated mainnet genesis file");
+            tracing::info!(dir = %dir.display(), "generated mainnet genesis file");
         }
         near_primitives::chains::TESTNET => {
             if let Some(ref filename) = config.genesis_records_file {
@@ -1139,7 +1137,7 @@ pub fn init_configs(
             genesis.config.chain_id.clone_from(&chain_id);
 
             genesis.to_file(dir.join(config.genesis_file));
-            tracing::info!(target: "near", %chain_id, dir = %dir.display(), "generated network node key and genesis file");
+            tracing::info!(%chain_id, dir = %dir.display(), "generated network node key and genesis file");
         }
         _ => {
             let validator_file = dir.join(&config.validator_key_file);
@@ -1196,7 +1194,7 @@ pub fn init_configs(
             };
             let genesis = Genesis::new(genesis_config, records.into())?;
             genesis.to_file(dir.join(config.genesis_file));
-            tracing::info!(target: "near", dir = %dir.display(), "generated node key, validator key, genesis file");
+            tracing::info!(dir = %dir.display(), "generated node key, validator key, genesis file");
         }
     }
 
@@ -1498,7 +1496,7 @@ pub fn init_localnet_configs(
         log_config
             .write_to_file(&node_dir.join(LOG_CONFIG_FILENAME))
             .expect("Error writing log config");
-        tracing::info!(target: "near", node_dir = %node_dir.display(), "generated node key, validator key, genesis file");
+        tracing::info!(node_dir = %node_dir.display(), "generated node key, validator key, genesis file");
     }
 }
 
@@ -1525,28 +1523,28 @@ pub fn get_config_url(chain_id: &str, config_type: DownloadConfigType) -> String
 }
 
 pub fn download_genesis(url: &str, path: &Path) -> Result<(), FileDownloadError> {
-    tracing::info!(target: "near", %url, "downloading genesis file");
+    tracing::info!(%url, "downloading genesis file");
     let result = run_download_file(url, path);
     if result.is_ok() {
-        tracing::info!(target: "near", path = %path.display(), "saved the genesis file");
+        tracing::info!(path = %path.display(), "saved the genesis file");
     }
     result
 }
 
 pub fn download_records(url: &str, path: &Path) -> Result<(), FileDownloadError> {
-    tracing::info!(target: "near", %url, "downloading records file");
+    tracing::info!(%url, "downloading records file");
     let result = run_download_file(url, path);
     if result.is_ok() {
-        tracing::info!(target: "near", path = %path.display(), "saved the records file");
+        tracing::info!(path = %path.display(), "saved the records file");
     }
     result
 }
 
 pub fn download_config(url: &str, path: &Path) -> Result<(), FileDownloadError> {
-    tracing::info!(target: "near", %url, "downloading config file");
+    tracing::info!(%url, "downloading config file");
     let result = run_download_file(url, path);
     if result.is_ok() {
-        tracing::info!(target: "near", path = %path.display(), "saved the config file");
+        tracing::info!(path = %path.display(), "saved the config file");
     }
     result
 }

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 pub fn validate_config(config: &Config) -> Result<(), ValidationError> {
     let mut validation_errors = ValidationErrors::new();
     let mut config_validator = ConfigValidator::new(config, &mut validation_errors);
-    tracing::info!(target: "config", "validating config, extracted from config.json");
+    tracing::info!("validating config, extracted from config.json");
     config_validator.validate()
 }
 

--- a/nearcore/src/download_file.rs
+++ b/nearcore/src/download_file.rs
@@ -247,7 +247,7 @@ impl<'a> AutoXzDecoder<'a> {
                 xz2::stream::Status::StreamEnd => (),
                 status => {
                     let status = format!("{:?}", status);
-                    tracing::error!(target: "near", %status, ?path, "got unexpected status when decompressing downloaded file");
+                    tracing::error!(%status, ?path, "got unexpected status when decompressing downloaded file");
                     return Err(FileDownloadError::XzStatusError(status));
                 }
             };

--- a/nearcore/src/dyn_config.rs
+++ b/nearcore/src/dyn_config.rs
@@ -53,7 +53,10 @@ pub fn read_updatable_configs(
             validator_signer,
         })
     } else {
-        tracing::warn!(target: "neard", ?errs, "dynamically updatable configs are not valid, please fix this asap otherwise the node will be unable to restart");
+        tracing::warn!(
+            ?errs,
+            "dynamically updatable configs are not valid, please fix this asap otherwise the node will be unable to restart"
+        );
         crate::metrics::CONFIG_CORRECT.set(0);
         Err(UpdatableConfigLoaderError::Errors(errs))
     }
@@ -83,7 +86,7 @@ where
             Ok(config_str_without_comments) => {
                 match serde_json::from_str::<T>(&config_str_without_comments) {
                     Ok(config) => {
-                        tracing::info!(target: "neard", ?config, ?path, "changing the config");
+                        tracing::info!(?config, ?path, "changing the config");
                         Ok(Some(config))
                     }
                     Err(err) => {
@@ -97,7 +100,11 @@ where
         },
         Err(err) => match err.kind() {
             std::io::ErrorKind::NotFound => {
-                tracing::info!(target: "neard", ?err, ?path, "reset the config because the config file doesn't exist");
+                tracing::info!(
+                    ?err,
+                    ?path,
+                    "reset the config because the config file doesn't exist"
+                );
                 Ok(None)
             }
             _ => Err(UpdatableConfigLoaderError::OpenAndRead { file: path.to_path_buf(), err }),
@@ -112,11 +119,11 @@ fn read_validator_key(
     let validator_file: PathBuf = home_dir.join(&config.validator_key_file);
     match crate::config::load_validator_key(&validator_file) {
         Ok(Some(validator_signer)) => {
-            tracing::info!(target: "neard", validator_file = %validator_file.display(), "hot loading validator key");
+            tracing::info!(validator_file = %validator_file.display(), "hot loading validator key");
             Ok(Some(validator_signer))
         }
         Ok(None) => {
-            tracing::info!(target: "neard", validator_file = %validator_file.display(), "no validator key");
+            tracing::info!(validator_file = %validator_file.display(), "no validator key");
             Ok(None)
         }
         Err(err) => {

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -780,7 +780,7 @@ pub async fn start_with_config_and_synchronization_impl(
         );
     }
 
-    tracing::trace!(target: "diagnostic", key = "log", "starting NEAR node with diagnostic activated");
+    tracing::trace!(key = "log", "starting NEAR node with diagnostic activated");
 
     #[cfg(feature = "tx_generator")]
     let tx_generator = near_transactions_generator::actor::start_tx_generator(

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -62,7 +62,7 @@ fn migrate_47_to_48(
     cold_db: Option<&ColdDB>,
     transaction_validity_period: BlockHeightDelta,
 ) -> anyhow::Result<()> {
-    tracing::info!(target: "migrations", "starting migration from DB version 47 to 48");
+    tracing::info!("starting migration from DB version 47 to 48");
 
     if let Some(cold_db) = cold_db {
         copy_block_headers_to_cold_db(hot_store, cold_db)?;
@@ -83,7 +83,7 @@ fn copy_block_headers_to_cold_db(hot_store: &Store, cold_db: &ColdDB) -> anyhow:
     let head_height = hot_store.chain_store().head().unwrap().height;
     let approx_num_blocks = head_height - genesis_height;
 
-    tracing::info!(target: "migrations", ?approx_num_blocks, "copying block headers to cold db");
+    tracing::info!(?approx_num_blocks, "copying block headers to cold db");
 
     let mut count = 0;
     let mut transaction = DBTransaction::new();
@@ -94,11 +94,16 @@ fn copy_block_headers_to_cold_db(hot_store: &Store, cold_db: &ColdDB) -> anyhow:
             cold_db.write(transaction);
             transaction = DBTransaction::new();
             let percent_complete = (count as f64 / approx_num_blocks as f64) * 100.0;
-            tracing::info!(target: "migrations", ?count, ?approx_num_blocks, ?percent_complete, "copied block headers to cold db");
+            tracing::info!(
+                ?count,
+                ?approx_num_blocks,
+                ?percent_complete,
+                "copied block headers to cold db"
+            );
         }
     }
     cold_db.write(transaction);
-    tracing::info!(target: "migrations", ?count, ?approx_num_blocks, "completed copying block headers to cold db");
+    tracing::info!(?count, ?approx_num_blocks, "completed copying block headers to cold db");
 
     Ok(())
 }
@@ -109,7 +114,7 @@ fn update_epoch_sync_proof(
 ) -> anyhow::Result<()> {
     let epoch_store = store.epoch_store();
 
-    tracing::info!(target: "migrations", "updating existing epoch sync proof to compressed format");
+    tracing::info!("updating existing epoch sync proof to compressed format");
 
     // First we move any existing epoch sync proof to the compressed format
     // Note that while accessing the proof, we need to read directly from DBCol::EpochSyncProof
@@ -122,14 +127,14 @@ fn update_epoch_sync_proof(
     }
 
     // Now we generate the epoch sync proof and update it to latest
-    tracing::info!(target: "migrations", "generating latest epoch sync proof");
+    tracing::info!("generating latest epoch sync proof");
     let last_block_hash =
         find_target_epoch_to_produce_proof_for(&store, transaction_validity_period)?;
 
-    tracing::info!(target: "migrations", ?last_block_hash, "deriving epoch sync proof from last final block");
+    tracing::info!(?last_block_hash, "deriving epoch sync proof from last final block");
     let proof = derive_epoch_sync_proof_from_last_block(&epoch_store, &last_block_hash, true)?;
 
-    tracing::info!(target: "migrations", "storing latest epoch sync proof");
+    tracing::info!("storing latest epoch sync proof");
     let mut store_update = epoch_store.store_update();
     store_update.set_epoch_sync_proof(&proof);
     store_update.commit()?;
@@ -145,7 +150,7 @@ fn verify_block_headers(store: &Store) -> anyhow::Result<()> {
     let latest_known_height =
         store.get_ser::<LatestKnown>(DBCol::BlockMisc, LATEST_KNOWN_KEY)?.unwrap().height;
 
-    tracing::info!(target: "migrations", ?tail_height, ?latest_known_height, "verifying block headers before deletion");
+    tracing::info!(?tail_height, ?latest_known_height, "verifying block headers before deletion");
 
     for height in tail_height..(latest_known_height + 1) {
         for block_hash in chain_store.get_all_header_hashes_by_height(height)? {
@@ -166,7 +171,7 @@ fn verify_block_headers(store: &Store) -> anyhow::Result<()> {
 }
 
 fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
-    tracing::info!(target: "migrations", "deleting all block headers from hot store");
+    tracing::info!("deleting all block headers from hot store");
 
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::BlockHeader);
@@ -177,7 +182,11 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
     let latest_known_height =
         store.get_ser::<LatestKnown>(DBCol::BlockMisc, LATEST_KNOWN_KEY)?.unwrap().height;
 
-    tracing::info!(target: "migrations", ?tail_height, ?latest_known_height, "adding required block headers to hot store");
+    tracing::info!(
+        ?tail_height,
+        ?latest_known_height,
+        "adding required block headers to hot store"
+    );
 
     let mut store_update = chain_store.store_update();
     for height in tail_height..(latest_known_height + 1) {
@@ -188,13 +197,17 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
             }
         }
         if height % BATCH_SIZE == 0 {
-            tracing::info!(target: "migrations", ?height, ?latest_known_height, "committing addition of required block headers to hot store");
+            tracing::info!(
+                ?height,
+                ?latest_known_height,
+                "committing addition of required block headers to hot store"
+            );
             store_update.commit()?;
             store_update = chain_store.store_update();
         }
     }
     store_update.commit()?;
-    tracing::info!(target: "migrations", ?latest_known_height, "completed deletion of old block headers from hot store");
+    tracing::info!(?latest_known_height, "completed deletion of old block headers from hot store");
 
     Ok(())
 }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -67,7 +67,6 @@ impl NeardCmd {
         .local();
 
         tracing::info!(
-            target: "neard",
             version = crate::NEARD_VERSION,
             build = crate::NEARD_BUILD,
             commit = crate::NEARD_COMMIT,
@@ -205,7 +204,9 @@ impl NeardOpts {
     // TODO(nikurt): Delete in 1.38 or later.
     pub fn verbose_target(&self) -> Option<&str> {
         self.verbose.as_ref().map(|inner| {
-            tracing::error!(target: "neard", "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead");
+            tracing::error!(
+                "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead"
+            );
             inner.as_ref().map_or("", String::as_str)
         })
     }
@@ -367,18 +368,14 @@ fn check_release_build(chain: &str) {
         && [near_primitives::chains::MAINNET, near_primitives::chains::TESTNET].contains(&chain)
     {
         tracing::warn!(
-            target: "neard",
             %chain,
             "running a neard executable which wasn't built with `make release` command isn't supported"
         );
         tracing::warn!(
-            target: "neard",
             %chain,
             "note that `cargo build --release` builds lack optimizations which may be needed to run properly"
         );
-        tracing::warn!(
-            target: "neard",
-            "consider recompiling the binary using `make release` command");
+        tracing::warn!("consider recompiling the binary using `make release` command");
     }
 }
 
@@ -596,7 +593,7 @@ impl RunCmd {
                     break sig;
                 }
             };
-            tracing::warn!(target: "neard", %sig, "stopping, this may take a few minutes");
+            tracing::warn!(%sig, "stopping, this may take a few minutes");
             if let Some(handle) = cold_store_loop_handle {
                 handle.store(false, std::sync::atomic::Ordering::Relaxed);
             }
@@ -605,7 +602,7 @@ impl RunCmd {
             // Disable the subscriber to properly shutdown the tracer.
             near_o11y::reload(Some("error"), None, Some("off"), None).unwrap();
         });
-        tracing::info!(target: "neard", "waiting for rocksdb to gracefully shutdown");
+        tracing::info!("waiting for rocksdb to gracefully shutdown");
         RocksDB::block_until_all_instances_are_dropped();
     }
 }

--- a/test-loop-tests/src/tests/bandwidth_scheduler.rs
+++ b/test-loop-tests/src/tests/bandwidth_scheduler.rs
@@ -200,7 +200,7 @@ fn run_bandwidth_scheduler_test(scenario: TestScenario, tx_concurrency: usize) -
         }
         last_height = Some(tip.height);
 
-        tracing::info!(target: "scheduler_test", height = %tip.height);
+        tracing::info!(height = %tip.height);
 
         if tip.height - first_height.unwrap() > workload_blocks {
             return true;
@@ -213,7 +213,7 @@ fn run_bandwidth_scheduler_test(scenario: TestScenario, tx_concurrency: usize) -
     };
     test_loop.run_until(testloop_func, Duration::seconds(300));
 
-    tracing::info!(target: "scheduler_test", txs_done = %workload_generator.txs_done(), "total transactions completed");
+    tracing::info!(txs_done = %workload_generator.txs_done(), "total transactions completed");
 
     let client = &test_loop.data.get(&client_handle).client;
     let bandwidth_stats =
@@ -504,14 +504,14 @@ impl WorkloadGenerator {
                 ));
             }
         }
-        tracing::info!(target: "scheduler_test", workload_senders = %generator.workload_senders.len(), "workload senders");
+        tracing::info!(workload_senders = %generator.workload_senders.len(), "workload senders");
 
         generator
     }
 
     /// Deploy the test contract on all workload accounts
     fn deploy_contracts(&self, test_loop: &mut TestLoopV2, node_datas: &[NodeExecutionData]) {
-        tracing::info!(target: "scheduler_test", "deploying contracts");
+        tracing::info!("deploying contracts");
         let (last_block_hash, nonce) = get_last_block_and_nonce(test_loop, node_datas);
         let deploy_contracts_txs: Vec<SignedTransaction> = self
             .shard_accounts
@@ -527,7 +527,7 @@ impl WorkloadGenerator {
             })
             .collect();
         run_txs_parallel(test_loop, deploy_contracts_txs, &node_datas, Duration::seconds(30));
-        tracing::info!(target: "scheduler_test", "contracts deployed");
+        tracing::info!("contracts deployed");
     }
 
     /// Add `concurrency` many access keys to the workload accounts.
@@ -539,7 +539,7 @@ impl WorkloadGenerator {
         node_datas: &[NodeExecutionData],
         concurrency: usize,
     ) -> BTreeMap<AccountId, Vec<Signer>> {
-        tracing::info!(target: "scheduler_test", "adding access keys");
+        tracing::info!("adding access keys");
 
         // Signers with access keys that were already added to the accounts
         let mut available_signers: BTreeMap<AccountId, Vec<Signer>> = self
@@ -572,7 +572,7 @@ impl WorkloadGenerator {
             let mut new_signers = Vec::new();
 
             let (last_block_hash, nonce) = get_last_block_and_nonce(test_loop, node_datas);
-            tracing::info!(target: "scheduler_test", %nonce, "adding access keys with nonce");
+            tracing::info!(%nonce, "adding access keys with nonce");
 
             for (account, usable_signers) in &available_signers {
                 let Some(to_add) = signers_to_add.get_mut(account) else {
@@ -599,7 +599,7 @@ impl WorkloadGenerator {
 
             run_txs_parallel(test_loop, add_key_txs, node_datas, Duration::seconds(20));
 
-            tracing::info!(target: "scheduler_test", access_keys = %new_signers.len(), "added access keys");
+            tracing::info!(access_keys = %new_signers.len(), "added access keys");
             for (account, new_signer) in new_signers {
                 available_signers.entry(account).or_insert_with(Vec::new).push(new_signer);
             }

--- a/test-loop-tests/src/tests/congestion_control.rs
+++ b/test-loop-tests/src/tests/congestion_control.rs
@@ -191,7 +191,7 @@ fn do_deploy_contract(
     rpc_id: &AccountId,
     contract_id: &AccountId,
 ) {
-    tracing::info!(target: "test", ?rpc_id, ?contract_id, "deploying contract");
+    tracing::info!(?rpc_id, ?contract_id, "deploying contract");
     let code = near_test_contracts::rs_contract().to_vec();
     let tx = deploy_contract(test_loop, node_datas, rpc_id, contract_id, code, 1);
     test_loop.run_for(Duration::seconds(5));
@@ -206,7 +206,7 @@ fn do_call_contract(
     contract_id: &AccountId,
     accounts: &Vec<AccountId>,
 ) {
-    tracing::info!(target: "test", ?rpc_id, ?contract_id, "calling contract");
+    tracing::info!(?rpc_id, ?contract_id, "calling contract");
     let method_name = "burn_gas_raw".to_owned();
     let burn_gas = Gas::from_teragas(250);
     let args = burn_gas.as_gas().to_le_bytes().to_vec();

--- a/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
+++ b/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
@@ -123,7 +123,7 @@ fn deploy_contracts(
     let mut contracts = vec![];
     let mut txs = vec![];
     for (i, contract_id) in contract_ids.into_iter().enumerate() {
-        tracing::info!(target: "test", ?rpc_id, ?contract_id, "deploying contract");
+        tracing::info!(?rpc_id, ?contract_id, "deploying contract");
         let contract =
             ContractCode::new(near_test_contracts::sized_contract((i + 1) * 100).to_vec(), None);
         let tx = deploy_contract(
@@ -155,7 +155,7 @@ fn call_contracts(
     let mut txs = vec![];
     for sender_id in sender_ids {
         for contract_id in contract_ids {
-            tracing::info!(target: "test", ?rpc_id, ?sender_id, ?contract_id, "calling contract");
+            tracing::info!(?rpc_id, ?sender_id, ?contract_id, "calling contract");
             let tx = call_contract(
                 &mut env.test_loop,
                 &env.node_datas,

--- a/test-loop-tests/src/tests/create_delete_account.rs
+++ b/test-loop-tests/src/tests/create_delete_account.rs
@@ -15,7 +15,7 @@ use crate::utils::transactions::{
 
 /// Write block height to contract storage.
 fn do_call_contract(env: &mut TestLoopEnv, rpc_id: &AccountId, contract_id: &AccountId) {
-    tracing::info!(target: "test", "calling contract");
+    tracing::info!("calling contract");
     let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, contract_id);
     let tx = call_contract(
         &mut env.test_loop,

--- a/test-loop-tests/src/tests/increase_max_congestion_missing_chunks.rs
+++ b/test-loop-tests/src/tests/increase_max_congestion_missing_chunks.rs
@@ -137,7 +137,7 @@ fn slow_test_tx_inclusion() {
         if last_observed_height.get() != 0 {
             assert_eq!(last_observed_height.get() + 1, block_header.height());
         }
-        tracing::info!(target: "test", height = %block_header.height(), chunk_mask = ?block_header.chunk_mask(), "observed new block at height");
+        tracing::info!(height = %block_header.height(), chunk_mask = ?block_header.chunk_mask(), "observed new block at height");
         last_observed_height.set(block_header.height());
         true
     };

--- a/test-loop-tests/src/tests/optimistic_block.rs
+++ b/test-loop-tests/src/tests/optimistic_block.rs
@@ -206,7 +206,7 @@ fn test_optimistic_block_after_missing_block() {
     env.test_loop.run_for(Duration::seconds(10));
 
     let (height_to_skip, producer, next_producer) = get_height_to_skip_and_producers(&env);
-    tracing::info!(target: "test", ?height_to_skip, ?producer, "skipping block at height");
+    tracing::info!(?height_to_skip, ?producer, "skipping block at height");
     env = env.drop(DropCondition::BlocksByHeight([height_to_skip].into_iter().collect()));
 
     let client_handle = &env
@@ -305,7 +305,7 @@ fn test_optimistic_block_with_invalidated_outcome() {
 
     let (height_to_skip, producer, next_producer) = get_height_to_skip_and_producers(&env);
 
-    tracing::info!(target: "test", ?height_to_skip, ?producer, "alter optimistic block at height");
+    tracing::info!(?height_to_skip, ?producer, "alter optimistic block at height");
 
     let producer_client_handle = &env
         .get_node_data_by_account_id(producer.account_id())

--- a/test-loop-tests/src/tests/protocol_upgrade.rs
+++ b/test-loop-tests/src/tests/protocol_upgrade.rs
@@ -134,7 +134,7 @@ pub(crate) fn test_protocol_upgrade(
                 // There should be no missing blocks
                 assert_eq!(last_observed_height.get() + 1, block_header.height());
             }
-            tracing::info!(target: "test", height = %block_header.height(), chunk_mask = ?block_header.chunk_mask(), "observed new block at height");
+            tracing::info!(height = %block_header.height(), chunk_mask = ?block_header.chunk_mask(), "observed new block at height");
             last_observed_height.set(block_header.height());
 
             // Record observed missing chunks

--- a/test-loop-tests/src/utils/peer_manager_actor.rs
+++ b/test-loop-tests/src/utils/peer_manager_actor.rs
@@ -541,7 +541,6 @@ fn network_message_to_client_handler(
         NetworkRequests::BanPeer { peer_id, ban_reason } => {
             let my_peer_id = shared_state.account_to_peer_id(&my_account_id);
             tracing::debug!(
-                target: "test_loop",
                 account = %my_account_id,
                 ?peer_id,
                 ?ban_reason,

--- a/test-loop-tests/src/utils/receipts.rs
+++ b/test-loop-tests/src/utils/receipts.rs
@@ -104,7 +104,7 @@ pub fn check_receipts_at_block(
     let num_shards = shard_layout.shard_ids().count();
     let has_delayed = congestion_info.delayed_receipts_gas() != 0;
     let has_buffered = congestion_info.buffered_receipts_gas() != 0;
-    tracing::info!(target: "test", height=tip.height, num_shards, %shard_id, has_delayed, has_buffered, "checking receipts");
+    tracing::info!(height=tip.height, num_shards, %shard_id, has_delayed, has_buffered, "checking receipts");
 
     match kind {
         ReceiptKind::Delayed => {

--- a/test-loop-tests/src/utils/resharding.rs
+++ b/test-loop-tests/src/utils/resharding.rs
@@ -290,7 +290,7 @@ pub(crate) fn call_burn_gas_contract(
                             client_actor.client.chain.get_partial_transaction_result(&tx);
                         let status = tx_outcome.as_ref().map(|o| o.status.clone());
                         let status = status.unwrap();
-                        tracing::debug!(target: "test", ?tx_height, ?tx, ?status, "transaction status");
+                        tracing::debug!(?tx_height, ?tx, ?status, "transaction status");
                         assert_matches!(status, FinalExecutionStatus::SuccessValue(_));
                     }
                     checked_transactions.set(true);
@@ -298,7 +298,7 @@ pub(crate) fn call_burn_gas_contract(
             } else {
                 if next_block_has_new_shard_layout(client_actor.client.epoch_manager.as_ref(), &tip)
                 {
-                    tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                    tracing::debug!(height = tip.height, "resharding height set");
                     resharding_height.set(Some(tip.height));
                 }
             }
@@ -375,7 +375,7 @@ pub(crate) fn send_large_cross_shard_receipts(
             if resharding_height.get().is_none()
                 && next_block_has_new_shard_layout(epoch_manager.as_ref(), &tip)
             {
-                tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                tracing::debug!(height = tip.height, "resharding height set");
                 resharding_height.set(Some(tip.height));
             }
 
@@ -400,7 +400,7 @@ pub(crate) fn send_large_cross_shard_receipts(
                         outgoing_receipt_sizes.insert(target_shard, receipt_sizes);
                     }
                 }
-                tracing::info!(target: "test", shard_id = %shard_uid.shard_id(), ?outgoing_receipt_sizes, "outgoing buffers from shard");
+                tracing::info!(shard_id = %shard_uid.shard_id(), ?outgoing_receipt_sizes, "outgoing buffers from shard");
             }
 
             let is_epoch_before_resharding =
@@ -445,7 +445,6 @@ pub(crate) fn send_large_cross_shard_receipts(
                             tip.last_block_hash,
                         );
                         tracing::info!(
-                            target: "test",
                             %signer_id,
                             %receiver_id,
                             tx_hash = ?tx.get_hash(),
@@ -557,7 +556,7 @@ pub(crate) fn call_promise_yield(
                             client_actor.client.chain.get_partial_transaction_result(&tx);
                         let status = tx_outcome.as_ref().map(|o| o.status.clone());
                         let status = status.unwrap();
-                        tracing::debug!(target: "test", ?tx_height, ?tx, ?status, "transaction status");
+                        tracing::debug!(?tx_height, ?tx, ?status, "transaction status");
                         assert_matches!(status, FinalExecutionStatus::SuccessValue(_));
                     }
                     checked_transactions.set(true);
@@ -568,7 +567,7 @@ pub(crate) fn call_promise_yield(
                     let epoch_manager = client_actor.client.epoch_manager.as_ref();
                     // Check if resharding will happen in this block.
                     if next_block_has_new_shard_layout(epoch_manager, &tip) {
-                        tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                        tracing::debug!(height = tip.height, "resharding height set");
                         resharding_height.set(Some(tip.height));
                         return;
                     }
@@ -814,7 +813,7 @@ pub(crate) fn check_resharding_skipped_when_no_children_tracked(
             if resharding_height.get().is_none() {
                 if next_block_has_new_shard_layout(client.epoch_manager.as_ref(), &tip) {
                     resharding_height.set(Some(tip.height));
-                    tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                    tracing::debug!(height = tip.height, "resharding height set");
                 }
             }
 
@@ -969,7 +968,12 @@ pub(crate) fn promise_yield_repro_missing_trie_value(
                         tx,
                     );
                     sent_flag.map(|flag| flag.set(true));
-                    tracing::debug!(target: "test", height=tip.height, ?signer_account, ?receiver_account, "sent promise yield tx");
+                    tracing::debug!(
+                        height = tip.height,
+                        ?signer_account,
+                        ?receiver_account,
+                        "sent promise yield tx"
+                    );
                 };
 
             // Run this action only once at every block height.
@@ -991,7 +995,7 @@ pub(crate) fn promise_yield_repro_missing_trie_value(
             let indices_left_child_shard = get_promise_yield_indices(left_child_shard_uid);
             let indices_right_child_shard = get_promise_yield_indices(right_child_shard_uid);
 
-            tracing::debug!(target: "test", height=tip.height, epoch=?tip.epoch_id, 
+            tracing::debug!(height=tip.height, epoch=?tip.epoch_id,
                     ?indices_parent_shard, ?indices_left_child_shard, ?indices_right_child_shard, "promise yield indices");
 
             // At any height, if the shard exists and it is tracked, the promise yield indices trie
@@ -1056,7 +1060,7 @@ pub(crate) fn promise_yield_repro_missing_trie_value(
                         let tx_outcome =
                             client_actor.client.chain.get_partial_transaction_result(&tx);
                         let status = tx_outcome.as_ref().map(|o| o.status.clone());
-                        tracing::debug!(target: "test", ?tx_height, ?tx, ?status, "transaction status");
+                        tracing::debug!(?tx_height, ?tx, ?status, "transaction status");
                         // First two txs should have been GC'd, so these cannot be found.
                         if index <= 1 {
                             assert_matches!(status, Err(_));
@@ -1073,7 +1077,7 @@ pub(crate) fn promise_yield_repro_missing_trie_value(
                     let epoch_manager = client_actor.client.epoch_manager.as_ref();
                     // Check if resharding will happen in this block.
                     if next_block_has_new_shard_layout(epoch_manager, &tip) {
-                        tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                        tracing::debug!(height = tip.height, "resharding height set");
                         resharding_height.set(Some(tip.height));
                         return;
                     }
@@ -1178,7 +1182,12 @@ pub(crate) fn delayed_receipts_repro_missing_trie_value(
                     );
                 }
                 sent_flag.map(|flag| flag.set(true));
-                tracing::debug!(target: "test", height=tip.height, ?signer_account, ?receiver_account, "sent burn gas txs");
+                tracing::debug!(
+                    height = tip.height,
+                    ?signer_account,
+                    ?receiver_account,
+                    "sent burn gas txs"
+                );
             };
 
             let get_delayed_receipts_indices = |shard_uid| {
@@ -1194,7 +1203,7 @@ pub(crate) fn delayed_receipts_repro_missing_trie_value(
             let indices_left_child_shard = get_delayed_receipts_indices(left_child_shard_uid);
             let indices_right_child_shard = get_delayed_receipts_indices(right_child_shard_uid);
 
-            tracing::debug!(target: "test", height=tip.height, epoch=?tip.epoch_id, 
+            tracing::debug!(height=tip.height, epoch=?tip.epoch_id,
                     ?indices_parent_shard, ?indices_left_child_shard, ?indices_right_child_shard, "delayed receipts indices");
 
             // At any height, if the shard exists and it is tracked, the delayed receipts indices
@@ -1220,7 +1229,7 @@ pub(crate) fn delayed_receipts_repro_missing_trie_value(
                         let tx_outcome =
                             client_actor.client.chain.get_partial_transaction_result(&tx);
                         let status = tx_outcome.as_ref().map(|o| o.status.clone());
-                        tracing::debug!(target: "test", ?tx_height, ?tx, ?status, "transaction status");
+                        tracing::debug!(?tx_height, ?tx, ?status, "transaction status");
                         assert_matches!(status, Ok(FinalExecutionStatus::SuccessValue(_)));
                     }
                 }
@@ -1237,7 +1246,7 @@ pub(crate) fn delayed_receipts_repro_missing_trie_value(
                     let epoch_manager = client_actor.client.epoch_manager.as_ref();
                     // Check if resharding will happen in this block.
                     if next_block_has_new_shard_layout(epoch_manager, &tip) {
-                        tracing::debug!(target: "test", height=tip.height, "resharding height set");
+                        tracing::debug!(height = tip.height, "resharding height set");
                         resharding_height.set(Some(tip.height));
                         return;
                     }

--- a/test-loop-tests/src/utils/setups.rs
+++ b/test-loop-tests/src/utils/setups.rs
@@ -63,7 +63,7 @@ pub fn derive_new_epoch_config_from_boundary(
     let base_shard_layout = &base_epoch_config.static_shard_layout();
     let new_shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, boundary_account.clone());
-    tracing::info!(target: "test", ?base_shard_layout, ?new_shard_layout, "shard layout");
+    tracing::info!(?base_shard_layout, ?new_shard_layout, "shard layout");
     let epoch_config = base_epoch_config.clone().with_shard_layout(new_shard_layout.clone());
     (epoch_config, new_shard_layout)
 }

--- a/test-loop-tests/src/utils/transactions.rs
+++ b/test-loop-tests/src/utils/transactions.rs
@@ -182,7 +182,7 @@ pub fn do_create_account(
     new_account_id: &AccountId,
     amount: Balance,
 ) {
-    tracing::info!(target: "test", "creating account");
+    tracing::info!("creating account");
     let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, originator);
     let tx = create_account(env, rpc_id, originator, new_account_id, amount, nonce);
     env.test_loop.run_for(Duration::seconds(5));
@@ -195,7 +195,7 @@ pub fn do_delete_account(
     account_id: &AccountId,
     beneficiary_id: &AccountId,
 ) {
-    tracing::info!(target: "test", "deleting account");
+    tracing::info!("deleting account");
     let tx =
         delete_account(&env.test_loop.data, &env.node_datas, rpc_id, account_id, beneficiary_id);
     env.test_loop.run_for(Duration::seconds(5));
@@ -208,7 +208,7 @@ pub fn do_deploy_contract(
     contract_id: &AccountId,
     code: Vec<u8>,
 ) {
-    tracing::info!(target: "test", "deploying contract");
+    tracing::info!("deploying contract");
     let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, contract_id);
     let tx = deploy_contract(&mut env.test_loop, &env.node_datas, rpc_id, contract_id, code, nonce);
     env.test_loop.run_for(Duration::seconds(3));
@@ -223,7 +223,7 @@ pub fn do_call_contract(
     method_name: String,
     args: Vec<u8>,
 ) {
-    tracing::info!(target: "test", "calling contract");
+    tracing::info!("calling contract");
     let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, contract_id);
     let tx = call_contract(
         &mut env.test_loop,
@@ -263,7 +263,7 @@ pub fn create_account(
 
     let tx_hash = tx.get_hash();
     submit_tx(&env.node_datas, rpc_id, tx);
-    tracing::debug!(target: "test", ?originator, ?new_account_id, ?tx_hash, "created account");
+    tracing::debug!(?originator, ?new_account_id, ?tx_hash, "created account");
     tx_hash
 }
 
@@ -289,7 +289,7 @@ pub fn delete_account(
 
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
-    tracing::debug!(target: "test", ?account_id, ?beneficiary_id, ?tx_hash, "deleted account");
+    tracing::debug!(?account_id, ?beneficiary_id, ?tx_hash, "deleted account");
     tx_hash
 }
 
@@ -314,7 +314,7 @@ pub fn deploy_contract(
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
 
-    tracing::debug!(target: "test", ?contract_id, ?tx_hash, "deployed contract");
+    tracing::debug!(?contract_id, ?tx_hash, "deployed contract");
     tx_hash
 }
 
@@ -345,7 +345,7 @@ pub fn deploy_global_contract(
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
 
-    tracing::debug!(target: "test", ?deployer_id, ?tx_hash, ?deploy_mode, "deployed global contract");
+    tracing::debug!(?deployer_id, ?tx_hash, ?deploy_mode, "deployed global contract");
     tx_hash
 }
 
@@ -375,7 +375,7 @@ pub fn use_global_contract(
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
 
-    tracing::debug!(target: "test", ?user_id, ?tx_hash, ?identifier, "use global contract");
+    tracing::debug!(?user_id, ?tx_hash, ?identifier, "use global contract");
     tx_hash
 }
 
@@ -411,7 +411,7 @@ pub fn call_contract(
 
     let tx_hash = tx.get_hash();
     submit_tx(node_datas, rpc_id, tx);
-    tracing::debug!(target: "test", ?sender_id, ?contract_id, ?tx_hash, "called contract");
+    tracing::debug!(?sender_id, ?contract_id, ?tx_hash, "called contract");
     tx_hash
 }
 
@@ -462,7 +462,7 @@ pub fn check_txs(
         let tx_outcome = rpc.chain.get_partial_transaction_result(&tx);
         let status = tx_outcome.as_ref().map(|o| o.status.clone());
         let status = status.unwrap();
-        tracing::info!(target: "test", ?tx, ?status, "transaction status");
+        tracing::info!(?tx, ?status, "transaction status");
         assert_matches!(status, FinalExecutionStatus::SuccessValue(_));
     }
 }
@@ -769,7 +769,7 @@ pub fn store_and_submit_tx(
     tx: SignedTransaction,
 ) {
     let mut txs_vec = txs.take();
-    tracing::debug!(target: "test", height, tx_hash=?tx.get_hash(), ?signer_id, ?receiver_id, "submitting transaction");
+    tracing::debug!(height, tx_hash=?tx.get_hash(), ?signer_id, ?receiver_id, "submitting transaction");
     txs_vec.push((tx.get_hash(), height));
     txs.set(txs_vec);
     submit_tx(&node_datas, &rpc_id, tx);
@@ -782,7 +782,7 @@ pub fn check_txs_remove_successful(txs: &Cell<Vec<(CryptoHash, BlockHeight)>>, c
     for (tx_hash, tx_height) in txs.take() {
         let tx_outcome = client.chain.get_final_transaction_result(&tx_hash);
         let status = tx_outcome.as_ref().map(|o| o.status.clone());
-        tracing::debug!(target: "test", ?tx_height, ?tx_hash, ?status, "transaction status");
+        tracing::debug!(?tx_height, ?tx_hash, ?status, "transaction status");
         match status {
             Ok(FinalExecutionStatus::SuccessValue(_)) => continue, // Transaction finished successfully, remove it.
             Ok(FinalExecutionStatus::NotStarted)

--- a/test-loop-tests/src/utils/trie_sanity.rs
+++ b/test-loop-tests/src/utils/trie_sanity.rs
@@ -267,10 +267,10 @@ fn assert_state_sanity(
             flat_storage_manager.get_flat_storage_status(shard_uid)
         {
             if status.flat_head.hash != final_head.prev_block_hash {
-                tracing::warn!(target: "test", "skipping flat storage - memtrie state check");
+                tracing::warn!("skipping flat storage - memtrie state check");
                 continue;
             } else {
-                tracing::debug!(target: "test", "checking flat storage - memtrie state");
+                tracing::debug!("checking flat storage - memtrie state");
             }
         } else {
             continue;
@@ -315,7 +315,7 @@ fn assert_state_equal(
     let mut has_diff = false;
     for (key, value) in diff {
         has_diff = true;
-        tracing::error!(target: "test", ?shard_uid, key=?key, ?value, %cmp_msg, "difference in state between");
+        tracing::error!(?shard_uid, key=?key, ?value, %cmp_msg, "difference in state between");
     }
     assert!(!has_diff, "{} state mismatch!", cmp_msg);
 }

--- a/tools/congestion-model/src/strategy/nep.rs
+++ b/tools/congestion-model/src/strategy/nep.rs
@@ -221,7 +221,6 @@ impl NepStrategy {
         let outgoing_congestion = self.get_outgoing_congestion(ctx);
 
         tracing::debug!(
-            target: "model",
             shard_id=%self.shard_id(),
             incoming_congestion=format!("{incoming_congestion:.2}"),
             outgoing_congestion=format!("{outgoing_congestion:.2}"),

--- a/tools/flat-storage/src/resume_resharding.rs
+++ b/tools/flat-storage/src/resume_resharding.rs
@@ -40,7 +40,7 @@ pub(crate) fn resume_resharding(
 
     flat_storage_resharder.resume(shard_uid)?;
 
-    tracing::info!(target: "resharding", "flat storage resharder completed");
+    tracing::info!("flat storage resharder completed");
 
     let trie_state_resharder = TrieStateResharder::new(
         runtime_adapter,
@@ -50,7 +50,7 @@ pub(crate) fn resume_resharding(
     );
     trie_state_resharder.resume(shard_uid)?;
 
-    tracing::info!(target: "resharding", "trie state resharder completed");
+    tracing::info!("trie state resharder completed");
 
     Ok(())
 }

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -933,7 +933,7 @@ impl ForkNetworkCommand {
             None,
             &epoch_config_dir,
         );
-        tracing::info!(target: "near", epoch_config_dir = %epoch_config_dir.display(), "generated epoch configs files");
+        tracing::info!(epoch_config_dir = %epoch_config_dir.display(), "generated epoch configs files");
         Ok(first_config)
     }
 

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -241,7 +241,6 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::StreamerMessage>
         //     ],
         // }
         tracing::info!(
-            target: "indexer_example",
             height = %streamer_message.block.header.height,
             hash = ?streamer_message.block.header.hash,
             num_shards = %streamer_message.shards.len(),

--- a/tools/mirror/src/cli.rs
+++ b/tools/mirror/src/cli.rs
@@ -271,7 +271,9 @@ fn run_async<F: std::future::Future + 'static>(f: F) -> F::Output {
 
 impl MirrorCommand {
     pub fn run(self) -> anyhow::Result<()> {
-        tracing::warn!(target: "mirror", "the mirror command is not stable, and may be removed or changed arbitrarily at any time");
+        tracing::warn!(
+            "the mirror command is not stable, and may be removed or changed arbitrarily at any time"
+        );
 
         match self.subcmd {
             SubCommand::Prepare(r) => r.run(),

--- a/tools/mirror/src/genesis.rs
+++ b/tools/mirror/src/genesis.rs
@@ -43,7 +43,10 @@ fn map_action(
                 map_delegate_action(delegate, secret, default_key)
             } else {
                 // This should not happen, but we handle the case here defensively
-                tracing::warn!(target: "mirror", ?delegate, "a delegate action was contained inside another delegate action");
+                tracing::warn!(
+                    ?delegate,
+                    "a delegate action was contained inside another delegate action"
+                );
                 None
             }
         }

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -64,7 +64,10 @@ fn secp256k1_from_slice(buf: &mut [u8], public: &Secp256K1PublicKey) -> secp256k
     match secp256k1::SecretKey::from_slice(buf) {
         Ok(s) => s,
         Err(_) => {
-            tracing::warn!(target: "mirror", ?public, "something super unlikely occurred, secp256k1 key mapped from is too large, flipping most significant bit");
+            tracing::warn!(
+                ?public,
+                "something super unlikely occurred, secp256k1 key mapped from is too large, flipping most significant bit"
+            );
             // If we got an error, it means that either `buf` is all zeros, or that when interpreted as a 256-bit
             // int, it is larger than the order of the secp256k1 curve. Since the order of the curve starts with 0xFF,
             // in either case flipping the first bit should work, and we can unwrap() below.

--- a/tools/ping/src/cli.rs
+++ b/tools/ping/src/cli.rs
@@ -134,21 +134,23 @@ fn parse_account_filter<P: AsRef<Path>>(filename: P) -> std::io::Result<HashSet<
                 filter.insert(a);
             }
             Err(e) => {
-                tracing::warn!(target: "ping", %line, %line_num, ?e, "could not parse account on line");
+                tracing::warn!(%line, %line_num, ?e, "could not parse account on line");
             }
         }
         line.clear();
         line_num += 1;
     }
     if filter.is_empty() {
-        tracing::warn!(target: "ping", filename = ?filename.as_ref(), "no accounts parsed, only sending direct pings");
+        tracing::warn!(filename = ?filename.as_ref(), "no accounts parsed, only sending direct pings");
     }
     Ok(filter)
 }
 
 impl PingCommand {
     pub fn run(&self) -> anyhow::Result<()> {
-        tracing::warn!(target: "ping", "the ping command is not stable, and may be removed or changed arbitrarily at any time");
+        tracing::warn!(
+            "the ping command is not stable, and may be removed or changed arbitrarily at any time"
+        );
 
         let mut chain_info = None;
         for info in CHAIN_INFO {

--- a/tools/ping/src/lib.rs
+++ b/tools/ping/src/lib.rs
@@ -178,7 +178,7 @@ impl AppInfo {
                 match pending_pings.entry(nonce) {
                     Entry::Occupied(_) => {
                         tracing::warn!(
-                            target: "ping", %nonce, ?peer_id, "internal error, sent two pings with same nonce, \
+                            %nonce, ?peer_id, "internal error, sent two pings with same nonce, \
                             latency stats will probably be wrong"
                         );
                     }
@@ -234,7 +234,6 @@ impl AppInfo {
                     }
                     None => {
                         tracing::warn!(
-                            target: "ping",
                             %nonce, peer = %peer_str(&peer_id, state.account_id.as_ref()),
                             "received pong after probably treating it as timed out previously"
                         );
@@ -243,7 +242,7 @@ impl AppInfo {
                 }
             }
             None => {
-                tracing::warn!(target: "ping", ?peer_id, "received pong but don't know of this peer");
+                tracing::warn!(?peer_id, "received pong but don't know of this peer");
                 None
             }
         }
@@ -269,7 +268,7 @@ impl AppInfo {
         if let Some(filter) = self.account_filter.as_ref() {
             if let Some(account_id) = account_id.as_ref() {
                 if !filter.contains(account_id) {
-                    tracing::debug!(target: "ping", %account_id, "skipping announce account");
+                    tracing::debug!(%account_id, "skipping announce account");
                     return;
                 }
             }
@@ -285,7 +284,7 @@ impl AppInfo {
                             // We only use the accounts in the account filter and when displaying
                             // ping targets, so theres no reason we cant keep track of all of them
                             tracing::warn!(
-                                target: "ping", ?peer_id, %account_id, old_account_id = %old,
+                                ?peer_id, %account_id, old_account_id = %old,
                                 "received announce account mapping but already knew of account id, keeping old value"
                             );
                         }

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -185,13 +185,13 @@ impl ReplayController {
         let mut total_gas_burnt: Option<Gas> = None;
         match self.replay_block(self.next_height)? {
             ReplayBlockOutput::Genesis(block) => {
-                tracing::debug!(target: "replay-archive", height = %block.header().height(), "skipping genesis block at height");
+                tracing::debug!(height = %block.header().height(), "skipping genesis block at height");
             }
             ReplayBlockOutput::Missing(height) => {
-                tracing::debug!(target: "replay-archive", %height, "skipping missing block at height");
+                tracing::debug!(%height, "skipping missing block at height");
             }
             ReplayBlockOutput::Replayed(block, gas_burnt) => {
-                tracing::debug!(target: "replay-archive", height = %block.header().height(), "replayed block at height");
+                tracing::debug!(height = %block.header().height(), "replayed block at height");
                 total_gas_burnt = Some(gas_burnt);
             }
         }
@@ -202,7 +202,7 @@ impl ReplayController {
     }
 
     fn replay_block(&mut self, height: BlockHeight) -> Result<ReplayBlockOutput> {
-        tracing::info!(target: "replay-archive", height = %self.next_height, "replaying block at height");
+        tracing::info!(height = %self.next_height, "replaying block at height");
 
         let Ok(block_hash) = self.chain_store.get_block_hash_by_height(height) else {
             return Ok(ReplayBlockOutput::Missing(height));
@@ -267,7 +267,7 @@ impl ReplayController {
         chunk_header: &ShardChunkHeader,
         prev_chunk_header: &ShardChunkHeader,
     ) -> Result<ReplayChunkOutput> {
-        let span = tracing::debug_span!(target: "replay-archive", "replay_chunk").entered();
+        let span = tracing::debug_span!("replay_chunk").entered();
 
         // Collect receipts and transactions.
         let chunk_hash = chunk_header.chunk_hash();

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -121,14 +121,13 @@ fn main() {
             // Already kicked out or getting kicked out.
             let amount = if stake_amount.is_zero() { last_stake_amount } else { stake_amount };
             tracing::info!(
-                target: "restaked",
                 account_id = %key_file.account_id, %amount,
                 "sending staking transaction"
             );
             if let Err(err) =
                 user.stake(key_file.account_id.clone(), key_file.public_key.clone(), amount)
             {
-                tracing::error!(target: "restaked", ?err, "failed to send staking transaction");
+                tracing::error!(?err, "failed to send staking transaction");
             }
         }
         std::thread::sleep(Duration::from_secs(wait_period));

--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -249,14 +249,14 @@ fn validate_state_part(state_root: &StateRoot, part_id: PartId, part: &[u8]) -> 
                 Ok(_) => true,
                 // Storage error should not happen
                 Err(err) => {
-                    tracing::error!(target: "state-parts", ?err, "state part storage error");
+                    tracing::error!(?err, "state part storage error");
                     false
                 }
             }
         }
         // Deserialization error means we've got the data from malicious peer
         Err(err) => {
-            tracing::error!(target: "state-parts", ?err, "state part deserialization error");
+            tracing::error!(?err, "state part deserialization error");
             false
         }
     }
@@ -270,7 +270,7 @@ fn validate_state_header(header: &[u8]) -> bool {
         }
         // Deserialization error means we've got invalid data stored in the external folder.
         Err(err) => {
-            tracing::error!(target: "state-parts", ?err, "header deserialization error");
+            tracing::error!(?err, "header deserialization error");
             false
         }
     }

--- a/tools/state-parts/src/cli.rs
+++ b/tools/state-parts/src/cli.rs
@@ -61,7 +61,9 @@ pub struct StatePartsCommand {
 
 impl StatePartsCommand {
     pub fn run(&self) -> anyhow::Result<()> {
-        tracing::warn!(target: "state-parts", "the state-parts command is not stable, and may be removed or changed arbitrarily at any time");
+        tracing::warn!(
+            "the state-parts command is not stable, and may be removed or changed arbitrarily at any time"
+        );
 
         let mut chain_info = None;
         for info in CHAIN_INFO {
@@ -95,7 +97,7 @@ impl StatePartsCommand {
         if peer.addr.is_none() {
             anyhow::bail!("--peer should be in the form [public key]@[socket addr]");
         }
-        tracing::info!(target: "state-parts", ?genesis_hash, ?peer);
+        tracing::info!(?genesis_hash, ?peer);
         let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async move {
             crate::state_parts_from_node(

--- a/tools/state-parts/src/lib.rs
+++ b/tools/state-parts/src/lib.rs
@@ -130,7 +130,7 @@ async fn state_parts_from_node(
             anyhow::bail!("Error connecting to {:?}: {}", peer_addr, e);
         }
     };
-    tracing::info!(target: "state-parts", ?peer_addr, ?peer_id, "connected to peer");
+    tracing::info!(?peer_addr, ?peer_id, "connected to peer");
 
     let next_request = tokio::time::sleep(std::time::Duration::ZERO);
     tokio::pin!(next_request);
@@ -143,10 +143,10 @@ async fn state_parts_from_node(
             _ = &mut next_request => {
                 let target = &peer_id;
                 let msg = DirectMessage::StateRequestPart(shard_id, block_hash, part_id);
-                tracing::info!(target: "state-parts", ?target, %shard_id, ?block_hash, part_id, ttl, "sending a request");
+                tracing::info!(?target, %shard_id, ?block_hash, part_id, ttl, "sending a request");
                 result = peer.send_message(msg).await.with_context(|| format!("Failed sending State Part Request to {:?}", target));
                 app_info.requests_sent.insert(part_id, near_time::Instant::now());
-                tracing::info!(target: "state-parts", ?result);
+                tracing::info!(?result);
                 if result.is_err() {
                     break;
                 }

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -594,7 +594,6 @@ pub fn apply_chain_range(
     storage: StorageSource,
 ) {
     let parent_span = tracing::debug_span!(
-        target: "state_viewer",
         "apply_chain_range",
         ?mode,
         ?start_height,
@@ -713,7 +712,6 @@ pub fn apply_chain_range(
         ApplyRangeMode::Sequential { .. } => {
             range.clone().into_iter().for_each(|height| {
                 let _span = tracing::debug_span!(
-                    target: "state_viewer",
                     parent: &parent_span,
                     "process_block",
                     height)
@@ -724,7 +722,6 @@ pub fn apply_chain_range(
         ApplyRangeMode::Parallel => {
             range.clone().into_par_iter().for_each(|height| {
                 let _span = tracing::debug_span!(
-                target: "mock_node",
                 parent: &parent_span,
                 "process_block",
                 height)
@@ -802,7 +799,6 @@ fn benchmark_chunk_application(
         let cur_input = input.clone();
 
         let _span = tracing::debug_span!(
-            target: "state_viewer",
             parent: &parent_span,
             "process_block",
             height)

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -64,7 +64,7 @@ fn get_incoming_receipts(
                 }
             }
         } else {
-            tracing::error!(target: "state-viewer", chunk_hash = ?chunk.chunk_hash(), "failed to get a partial chunk");
+            tracing::error!(chunk_hash = ?chunk.chunk_hash(), "failed to get a partial chunk");
         }
     }
 
@@ -311,7 +311,7 @@ fn apply_tx_in_chunk(
                 let chunk = match chain_store.get_chunk(&chunk_hash) {
                     Ok(c) => c,
                     Err(_) => {
-                        tracing::warn!(target: "state-viewer", chunk_hash = ?&chunk_hash, "chunk hash appears in DBCol::ChunkHashesByHeight but the chunk is not saved");
+                        tracing::warn!(chunk_hash = ?&chunk_hash, "chunk hash appears in DBCol::ChunkHashesByHeight but the chunk is not saved");
                         continue;
                     }
                 };
@@ -446,7 +446,7 @@ fn apply_receipt_in_chunk(
                 let chunk = match chain_store.get_chunk(&chunk_hash) {
                     Ok(c) => c,
                     Err(_) => {
-                        tracing::warn!(target: "state-viewer", chunk_hash = ?&chunk_hash, "chunk hash appears in DBCol::ChunkHashesByHeight but the chunk is not saved");
+                        tracing::warn!(chunk_hash = ?&chunk_hash, "chunk hash appears in DBCol::ChunkHashesByHeight but the chunk is not saved");
                         continue;
                     }
                 };

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -856,7 +856,7 @@ pub(crate) fn view_genesis(
     );
 
     if view_config || compare {
-        tracing::info!(target: "state_viewer", "computing genesis from config");
+        tracing::info!("computing genesis from config");
         let state_roots =
             near_store::get_genesis_state_roots(&chain_store.store()).unwrap().unwrap();
         let (genesis_block, genesis_chunks) = Chain::make_genesis_block(
@@ -891,7 +891,7 @@ pub(crate) fn view_genesis(
     }
 
     if view_store {
-        tracing::info!(target: "state_viewer", genesis_height, "reading genesis from store");
+        tracing::info!(genesis_height, "reading genesis from store");
         match read_genesis_from_store(&chain_store, genesis_height) {
             Ok((genesis_block, genesis_chunks)) => {
                 println!("Genesis block from store: {:#?}", genesis_block);
@@ -1412,8 +1412,8 @@ fn print_state_stats_for_shard_uid(
         current_size = new_size;
     }
 
-    tracing::info!(target: "state_viewer", ?shard_uid);
-    tracing::info!(target: "state_viewer", ?state_stats);
+    tracing::info!(?shard_uid);
+    tracing::info!(?state_stats);
 }
 
 /// Gets the flat state iterator from the chunk view, rearranges it to be sorted

--- a/tools/state-viewer/src/scan_db.rs
+++ b/tools/state-viewer/src/scan_db.rs
@@ -47,7 +47,7 @@ pub(crate) fn scan_db_column(
     store: Store,
 ) {
     let db_col: DBCol = find_db_col(col);
-    tracing::info!(target: "scan", ?db_col);
+    tracing::info!(?db_col);
     for (key, value) in
         store.iter_range(db_col, lower_bound, upper_bound).take(max_keys.unwrap_or(usize::MAX))
     {

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -339,7 +339,7 @@ async fn load_state_parts(
             let sync_hash = match chain.get_sync_hash(&sync_hash).unwrap() {
                 Some(h) => h,
                 None => {
-                    tracing::warn!(target: "state-parts", ?epoch_id, "sync hash not yet known");
+                    tracing::warn!(?epoch_id, "sync hash not yet known");
                     return;
                 }
             };
@@ -365,7 +365,6 @@ async fn load_state_parts(
     assert_eq!(Some(num_parts), get_num_parts_from_filename(&part_file_names[0]));
     let part_ids = get_part_ids(part_id, part_id.map(|x| x + 1), num_parts);
     tracing::info!(
-        target: "state-parts",
         epoch_height,
         %shard_id,
         num_parts,
@@ -401,7 +400,12 @@ async fn load_state_parts(
                         &epoch_id,
                     )
                     .unwrap();
-                tracing::info!(target: "state-parts", part_id, part_length, elapsed_sec = timer.elapsed().as_secs_f64(), "loaded a state part");
+                tracing::info!(
+                    part_id,
+                    part_length,
+                    elapsed_sec = timer.elapsed().as_secs_f64(),
+                    "loaded a state part"
+                );
             }
             LoadAction::Validate => {
                 assert!(matches!(
@@ -413,7 +417,12 @@ async fn load_state_parts(
                     ),
                     near_chain::types::StatePartValidationResult::Valid
                 ));
-                tracing::info!(target: "state-parts", part_id, part_length, elapsed_sec = timer.elapsed().as_secs_f64(), "validated a state part");
+                tracing::info!(
+                    part_id,
+                    part_length,
+                    elapsed_sec = timer.elapsed().as_secs_f64(),
+                    "validated a state part"
+                );
             }
             LoadAction::Print => {
                 let trie_nodes = part.to_partial_state().unwrap();
@@ -421,7 +430,10 @@ async fn load_state_parts(
             }
         }
     }
-    tracing::info!(target: "state-parts", total_elapsed_sec = timer.elapsed().as_secs_f64(), "loaded all requested state parts");
+    tracing::info!(
+        total_elapsed_sec = timer.elapsed().as_secs_f64(),
+        "loaded all requested state parts"
+    );
 }
 
 fn print_state_part(state_root: &StateRoot, _part_id: PartId, trie_nodes: PartialState) {
@@ -456,7 +468,7 @@ async fn dump_state_parts(
     let sync_hash = match chain.get_sync_hash(&sync_hash).unwrap() {
         Some(h) => h,
         None => {
-            tracing::warn!(target: "state-parts", ?epoch_id, "sync hash not yet known");
+            tracing::warn!(?epoch_id, "sync hash not yet known");
             return;
         }
     };
@@ -472,7 +484,6 @@ async fn dump_state_parts(
     let epoch_height = epoch.epoch_height();
 
     tracing::info!(
-        target: "state-parts",
         epoch_height,
         epoch_id = ?epoch_id.0,
         %shard_id,
@@ -497,7 +508,10 @@ async fn dump_state_parts(
             .put_file(file_type, &state_sync_header_buf, shard_id, &location)
             .await
             .expect("Failed to put header into external storage.");
-        tracing::info!(target: "state-parts", elapsed_sec = timer.elapsed().as_secs_f64(), "header saved to external storage");
+        tracing::info!(
+            elapsed_sec = timer.elapsed().as_secs_f64(),
+            "header saved to external storage"
+        );
     }
 
     // dump parts
@@ -529,14 +543,16 @@ async fn dump_state_parts(
         let trie_nodes = state_part.to_partial_state().unwrap();
         let first_state_record = get_first_state_record(&state_root, trie_nodes);
         tracing::info!(
-            target: "state-parts",
             part_id,
             part_length = bytes.len(),
             elapsed_sec,
             first_state_record = ?first_state_record.map(|sr| format!("{}", sr)),
             "wrote a state part");
     }
-    tracing::info!(target: "state-parts", total_elapsed_sec = timer.elapsed().as_secs_f64(), "wrote all requested state parts");
+    tracing::info!(
+        total_elapsed_sec = timer.elapsed().as_secs_f64(),
+        "wrote all requested state parts"
+    );
 }
 
 /// Returns the first `StateRecord` encountered while iterating over a sub-trie in the state part.
@@ -566,13 +582,13 @@ fn read_state_header(
     let sync_hash = match chain.get_sync_hash(&sync_hash).unwrap() {
         Some(h) => h,
         None => {
-            tracing::warn!(target: "state-parts", ?epoch_id, "sync hash not yet known");
+            tracing::warn!(?epoch_id, "sync hash not yet known");
             return;
         }
     };
 
     let state_header = chain.chain_store().get_state_header(shard_id, sync_hash);
-    tracing::info!(target: "state-parts", ?epoch_id, ?sync_hash, ?state_header);
+    tracing::info!(?epoch_id, ?sync_hash, ?state_header);
 }
 
 fn finalize_state_sync(sync_hash: CryptoHash, shard_id: ShardId, chain: &mut Chain) {

--- a/tools/state-viewer/src/trie_iteration_benchmark.rs
+++ b/tools/state-viewer/src/trie_iteration_benchmark.rs
@@ -194,7 +194,6 @@ impl TrieIterationBenchmarkCmd {
                 }
             };
             tracing::trace!(
-                target: "trie-iteration-benchmark",
                 column = &state_record.get_type_string(),
                 account_id = %state_record_to_account_id(&state_record),
                 "visiting column and account id"
@@ -280,7 +279,6 @@ impl TrieIterationBenchmarkCmd {
         match parse_account_id_from_trie_key_with_separator(col, &key, "") {
             Ok(account_id) => {
                 tracing::trace!(
-                    target: "trie-iteration-benchmark",
                     %col_name,
                     ?account_id,
                     "pruning column and account id"
@@ -296,7 +294,6 @@ impl TrieIterationBenchmarkCmd {
         match parse_account_id_from_access_key_key(&key) {
             Ok(account_id) => {
                 tracing::trace!(
-                    target: "trie-iteration-benchmark",
                     %col_name,
                     ?account_id,
                     "pruning column and account id"

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -13,16 +13,16 @@ use std::fs::File;
 async fn main() -> anyhow::Result<()> {
     let env_filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish().unwrap();
     let _subscriber = near_o11y::default_subscriber(env_filter, &Default::default()).global();
-    tracing::debug!(target: "storage-calculator", "reading genesis");
+    tracing::debug!("reading genesis");
 
     let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full)?;
-    tracing::debug!(target: "storage-calculator", "genesis read");
+    tracing::debug!("genesis read");
 
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION);
     let storage_usage_config = &config.fees.storage_usage_config;
     let storage_usage = compute_genesis_storage_usage(&genesis, storage_usage_config);
-    tracing::debug!(target: "storage-calculator", "storage usage calculated");
+    tracing::debug!("storage usage calculated");
 
     let mut result = Vec::new();
     genesis.for_each_record(|record| {

--- a/tools/undo-block/src/lib.rs
+++ b/tools/undo-block/src/lib.rs
@@ -18,7 +18,13 @@ pub fn undo_block(
     let current_head_height = current_head.height;
     let prev_block_height = prev_tip.height;
 
-    tracing::info!(target: "neard", ?prev_block_hash, ?current_head_hash, ?prev_block_height, ?current_head_height, "trying to update head");
+    tracing::info!(
+        ?prev_block_hash,
+        ?current_head_hash,
+        ?prev_block_height,
+        ?current_head_height,
+        "trying to update head"
+    );
 
     // stop if it's already the final block
     if chain_store.final_head()?.height >= current_head.height {
@@ -43,7 +49,7 @@ pub fn undo_block(
     let new_head_height = new_chain_store_head.height;
     let new_header_height = new_chain_store_header_head.height;
 
-    tracing::info!(target: "neard", ?new_head_height, ?new_header_height, "the current chain store shows");
+    tracing::info!(?new_head_height, ?new_header_height, "the current chain store shows");
     Ok(())
 }
 
@@ -60,10 +66,15 @@ pub fn undo_only_block_head(
     let tail_header = chain_store.get_block_header_by_height(tail_height)?;
     let new_head = Tip::from_header(&tail_header);
 
-    tracing::info!(target: "neard", ?tail_height, ?current_head_height, ?current_header_height, "trying to update head");
+    tracing::info!(
+        ?tail_height,
+        ?current_head_height,
+        ?current_header_height,
+        "trying to update head"
+    );
 
     if current_head_height == tail_height {
-        tracing::info!(target: "neard", "body head is already at the oldest block");
+        tracing::info!("body head is already at the oldest block");
         return Ok(());
     }
 
@@ -77,6 +88,6 @@ pub fn undo_only_block_head(
     let new_head_height = new_chain_store_head.height;
     let new_header_height = new_chain_store_header_head.height;
 
-    tracing::info!(target: "neard", ?new_head_height, ?new_header_height, "the current chain store shows");
+    tracing::info!(?new_head_height, ?new_header_height, "the current chain store shows");
     Ok(())
 }


### PR DESCRIPTION
Removes `target: "…"` from all tracing event/span macros and `target = "…"` from all `#[instrument]` attributes in `tools/`, `benchmarks/`, `integration-tests/`, `test-loop-tests/`, `nearcore/`, and `neard/`. The tracing default target — the module path — is sufficient for filtering and grouping in all cases.

See `docs/practices/style.md` (PR 1/7) for the rationale and convention. Final PR in this series — after merge, no explicit tracing targets remain in the codebase (aside from `io_trace!`, intentionally preserved for `IoTraceLayer` dispatch).

Part 7 of 7.