### PR TITLE
fix(epoch_sync): use prev_hash for epoch boundary detection in proof updates

### DIFF
--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -298,7 +298,8 @@ impl<'a> ChainUpdate<'a> {
             // prev_hash of the first block in epoch T is always the last block of epoch T-1.
             //
             // The downside of using prev_hash is that due to forks we may end up hitting the
-            // epoch boundary multiple times.
+            // epoch boundary multiple times, but that's alright as update_epoch_sync_proof
+            // is idempotent.
             if self.epoch_manager.is_next_block_epoch_start(prev_hash)? {
                 tracing::debug!(block_hash = ?block.hash(), "updating epoch sync proof");
                 let epoch_store = self.chain_store_update.store().epoch_store();


### PR DESCRIPTION
Fixes a bug in epoch sync proof updates where using `last_final_block` for epoch boundary detection could cause proof updates to be missed. When heights are skipped (e.g., during a dead validator's turn), `last_final_block` can jump over epoch boundaries entirely. This change uses `prev_hash` instead, which reliably points to the last block of the previous epoch when processing the first block of a new epoch.