### PR TITLE
 feat(spice): handle uncertified validator proposals at epoch boundary

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1872,7 +1872,7 @@ impl Chain {
         self.update_optimistic_blocks_pool(&block)?;
 
         let epoch_id = block.header().epoch_id();
-        let mut memtrie_retained_shards = vec![];
+        let mut shards_cares_this_or_next_epoch = vec![];
         for shard_id in self.epoch_manager.shard_ids(epoch_id)? {
             let cares_about_shard =
                 self.shard_tracker.cares_about_shard(block.header().prev_hash(), shard_id);
@@ -1881,7 +1881,7 @@ impl Chain {
             let cares_about_shard_this_or_next_epoch = cares_about_shard || will_care_about_shard;
             let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, epoch_id)?;
             if cares_about_shard_this_or_next_epoch {
-                memtrie_retained_shards.push(shard_uid);
+                shards_cares_this_or_next_epoch.push(shard_uid);
             }
 
             let need_storage_update = if is_caught_up {
@@ -1916,7 +1916,7 @@ impl Chain {
 
         if self.epoch_manager.is_next_block_epoch_start(block.header().prev_hash())? {
             // Keep in memory only these tries that we care about this or next epoch.
-            self.runtime_adapter.get_tries().retain_memtries(&memtrie_retained_shards);
+            self.runtime_adapter.get_tries().retain_memtries(&shards_cares_this_or_next_epoch);
         }
 
         if let Some(tip) = &new_head {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1916,27 +1916,6 @@ impl Chain {
 
         if self.epoch_manager.is_next_block_epoch_start(block.header().prev_hash())? {
             // Keep in memory only these tries that we care about this or next epoch.
-            // TODO(spice): For spice, we also retain memtries for shards that
-            // we used to care about in the prior epoch but not anymore. This
-            // allows the node to continue executing uncertified blocks of the
-            // prior epoch. We should change this to wait only for certification
-            // of the last block of the prior instead of retaining memtrie for
-            // an additional epoch.
-            if block.is_spice_block() {
-                let prev_hash = block.header().prev_hash();
-                for shard_id in self.epoch_manager.shard_ids(epoch_id)? {
-                    if self
-                        .shard_tracker
-                        .cared_about_shard_in_prev_epoch_from_prev_hash(prev_hash, shard_id)
-                    {
-                        let shard_uid =
-                            shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, epoch_id)?;
-                        if !memtrie_retained_shards.contains(&shard_uid) {
-                            memtrie_retained_shards.push(shard_uid);
-                        }
-                    }
-                }
-            }
             self.runtime_adapter.get_tries().retain_memtries(&memtrie_retained_shards);
         }
 

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -6,12 +6,14 @@ use near_primitives::block_body::{SpiceCoreStatement, SpiceCoreStatements};
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::stateless_validation::spice_chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
 };
+use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, ShardId,
-    SpiceChunkId, SpiceUncertifiedChunkInfo,
+    AccountId, BlockExecutionResults, BlockHeight, ChunkExecutionResult, ChunkExecutionResultHash,
+    ShardId, SpiceChunkId, SpiceUncertifiedChunkInfo,
 };
 use near_primitives::utils::{get_endorsements_key, get_execution_results_key};
 use near_store::adapter::StoreAdapter as _;
@@ -107,6 +109,49 @@ impl SpiceCoreReader {
         block_hash: &CryptoHash,
     ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {
         get_uncertified_chunks(&self.chain_store, block_hash)
+    }
+
+    /// Returns the most recent validator proposals from uncertified chunks for a
+    /// given shard. These are proposals that have not yet made it to consensus
+    /// and need to be accounted for in `last_proposals` at epoch boundaries.
+    ///
+    /// Proposals are sorted ascending by block height. If multiple uncertified
+    /// chunks contain proposals for the same account, the most recent one (last
+    /// in iteration order) should be kept by the caller's fold/insert logic.
+    pub fn get_uncertified_validator_proposals(
+        &self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+    ) -> Result<Vec<ValidatorStake>, Error> {
+        let uncertified_chunks = self.get_uncertified_chunks(block_hash)?;
+        let matching: Vec<_> = uncertified_chunks
+            .into_iter()
+            .filter(|info| info.chunk_id.shard_id == shard_id)
+            .collect();
+        if matching.is_empty() {
+            return Ok(vec![]);
+        }
+        // Collect (height, proposals) for each uncertified chunk.
+        let chunk_store = self.chain_store.chunk_store();
+        let mut height_proposals: Vec<(BlockHeight, Vec<ValidatorStake>)> = Vec::new();
+        for info in &matching {
+            let height = self.chain_store.get_block_height(&info.chunk_id.block_hash)?;
+            let epoch_id = self.epoch_manager.get_epoch_id(&info.chunk_id.block_hash)?;
+            let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+            let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+            let chunk_extra = chunk_store.get_chunk_extra(&info.chunk_id.block_hash, &shard_uid)?;
+            let proposals: Vec<ValidatorStake> = chunk_extra.validator_proposals().collect();
+            if !proposals.is_empty() {
+                height_proposals.push((height, proposals));
+            }
+        }
+
+        height_proposals.sort_by_key(|(h, _)| *h);
+        debug_assert!(
+            height_proposals.windows(2).all(|w| w[0].0 != w[1].0),
+            "multiple uncertified chunks at the same height for shard {shard_id}"
+        );
+        Ok(height_proposals.into_iter().flat_map(|(_, proposals)| proposals).collect())
     }
 
     pub fn get_execution_results_by_shard_id(

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -112,9 +112,10 @@ impl SpiceCoreReader {
         get_uncertified_chunks(&self.chain_store, block_hash)
     }
 
-    /// Returns the most recent validator proposals from uncertified chunks for a
-    /// given shard. These are proposals that have not yet made it to consensus
-    /// and need to be accounted for in `last_proposals` at epoch boundaries.
+    /// Returns the most recent validator proposals from uncertified chunks for
+    /// a given shard. These are proposals that are not yet certified on-chain
+    /// at the given block hash, and need to be accounted for in
+    /// `last_proposals` at epoch boundaries.
     ///
     /// Proposals are sorted ascending by block height. If multiple uncertified
     /// chunks contain proposals for the same account, the most recent one (last

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -108,10 +108,7 @@ impl SpiceCoreReader {
     /// Returns ChunkExtra for a chunk from whichever trusted source is available:
     /// ChunkExtra column (written by the chunk executor on tracking nodes) or
     /// execution_results column (available on all nodes once the chunk is certified).
-    fn get_trusted_chunk_extra(
-        &self,
-        chunk_id: &SpiceChunkId,
-    ) -> Result<Arc<ChunkExtra>, Error> {
+    fn get_trusted_chunk_extra(&self, chunk_id: &SpiceChunkId) -> Result<Arc<ChunkExtra>, Error> {
         let epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         let shard_uid = ShardUId::from_shard_id_and_layout(chunk_id.shard_id, &shard_layout);

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -154,6 +154,21 @@ impl SpiceCoreReader {
         Ok(height_proposals.into_iter().flat_map(|(_, proposals)| proposals).collect())
     }
 
+    /// Returns validator proposals to use as `prev_validator_proposals` when
+    /// constructing `NewChunkData`. At epoch boundaries, returns proposals from
+    /// uncertified chunks; otherwise returns an empty vec.
+    pub fn prev_validator_proposals(
+        &self,
+        prev_block_hash: &CryptoHash,
+        shard_id: ShardId,
+    ) -> Result<Vec<ValidatorStake>, Error> {
+        if self.epoch_manager.is_next_block_epoch_start(prev_block_hash)? {
+            self.get_uncertified_validator_proposals(prev_block_hash, shard_id)
+        } else {
+            Ok(vec![])
+        }
+    }
+
     pub fn get_execution_results_by_shard_id(
         &self,
         block_header: &BlockHeader,

--- a/chain/chain/src/tests/spice_core.rs
+++ b/chain/chain/src/tests/spice_core.rs
@@ -1439,7 +1439,7 @@ fn test_uncertified_validator_proposals_single_chunk() {
         &mut chain,
         &block,
         shard_id,
-        make_chunk_extra_with_proposals(proposals.clone()),
+        make_chunk_extra_with_proposals(proposals),
     );
 
     let result = core_reader.get_uncertified_validator_proposals(block.hash(), shard_id).unwrap();

--- a/chain/chain/src/tests/spice_core.rs
+++ b/chain/chain/src/tests/spice_core.rs
@@ -26,6 +26,8 @@ use near_primitives::types::{
     Balance, BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, ShardId,
     SpiceChunkId,
 };
+use near_primitives::utils::get_execution_results_key;
+use near_store::DBCol;
 use near_store::adapter::StoreAdapter as _;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -1420,6 +1422,18 @@ fn save_chunk_extra_for_block(
     store_update.commit().unwrap();
 }
 
+fn save_execution_result_for_block(
+    chain: &Chain,
+    block: &Block,
+    shard_id: ShardId,
+    execution_result: ChunkExecutionResult,
+) {
+    let key = get_execution_results_key(block.hash(), shard_id);
+    let mut store_update = chain.chain_store.store().store_update();
+    store_update.insert_ser(DBCol::execution_results(), &key, &execution_result).unwrap();
+    store_update.commit().unwrap();
+}
+
 fn test_proposal(account: &str, stake: u128) -> ValidatorStake {
     let signer = create_test_signer(account);
     ValidatorStake::new(account.parse().unwrap(), signer.public_key(), Balance::from_near(stake))
@@ -1517,4 +1531,26 @@ fn test_uncertified_validator_proposals_multiple_heights_same_account() {
     assert_eq!(result[0].stake(), Balance::from_near(100));
     assert_eq!(result[1].account_id().as_str(), "test0");
     assert_eq!(result[1].stake(), Balance::from_near(200));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_uncertified_validator_proposals_execution_results_fallback() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let block = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, block.clone());
+
+    let shard_id = ShardId::new(0);
+    let proposals = vec![test_proposal("test0", 100)];
+    let execution_result = ChunkExecutionResult {
+        chunk_extra: make_chunk_extra_with_proposals(proposals),
+        outgoing_receipts_root: CryptoHash::default(),
+    };
+    save_execution_result_for_block(&chain, &block, shard_id, execution_result);
+
+    let result = core_reader.get_uncertified_validator_proposals(block.hash(), shard_id).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].account_id().as_str(), "test0");
+    assert_eq!(result[0].stake(), Balance::from_near(100));
 }

--- a/chain/chain/src/tests/spice_core.rs
+++ b/chain/chain/src/tests/spice_core.rs
@@ -26,6 +26,8 @@ use near_primitives::types::{
     Balance, BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, ShardId,
     SpiceChunkId,
 };
+use near_primitives::utils::get_execution_results_key;
+use near_store::DBCol;
 use near_store::adapter::StoreAdapter as _;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -1420,6 +1422,18 @@ fn save_chunk_extra_for_block(
     store_update.commit().unwrap();
 }
 
+fn save_execution_result_for_block(
+    chain: &Chain,
+    block: &Block,
+    shard_id: ShardId,
+    execution_result: ChunkExecutionResult,
+) {
+    let key = get_execution_results_key(block.hash(), shard_id);
+    let mut store_update = chain.chain_store.store().store_update();
+    store_update.insert_ser(DBCol::execution_results(), &key, &execution_result).unwrap();
+    store_update.commit().unwrap();
+}
+
 fn test_proposal(account: &str, stake: u128) -> ValidatorStake {
     let signer = create_test_signer(account);
     ValidatorStake::new(account.parse().unwrap(), signer.public_key(), Balance::from_near(stake))
@@ -1521,114 +1535,21 @@ fn test_uncertified_validator_proposals_multiple_heights_same_account() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_uncertified_validator_proposals_from_on_chain_execution_results() {
-    let (mut chain, _) = setup();
+fn test_uncertified_validator_proposals_execution_results_fallback() {
+    let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();
-
-    // block1 has an uncertified chunk with a proposal but no ChunkExtra saved
-    // (simulating a non-tracking node).
-    let block1 = build_block(&mut chain, &genesis, vec![]);
-    process_block(&mut chain, block1.clone());
+    let block = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, block.clone());
 
     let shard_id = ShardId::new(0);
-    let chunk_id = SpiceChunkId { block_hash: *block1.hash(), shard_id };
+    let proposals = vec![test_proposal("test0", 100)];
     let execution_result = ChunkExecutionResult {
-        chunk_extra: make_chunk_extra_with_proposals(vec![test_proposal("test0", 100)]),
+        chunk_extra: make_chunk_extra_with_proposals(proposals),
         outgoing_receipts_root: CryptoHash::default(),
     };
+    save_execution_result_for_block(&chain, &block, shard_id, execution_result);
 
-    // Build endorsements from all validators, then include the execution result.
-    let mut core_statements: Vec<_> = test_validators()
-        .iter()
-        .map(|v| {
-            let endorsement = SpiceChunkEndorsement::new(
-                chunk_id.clone(),
-                execution_result.clone(),
-                &create_test_signer(v),
-            );
-            endorsement_into_core_statement(endorsement)
-        })
-        .collect();
-    core_statements.push(SpiceCoreStatement::ChunkExecutionResult { chunk_id, execution_result });
-
-    let block2 = build_block(&mut chain, &block1, core_statements);
-    process_block(&mut chain, block2);
-
-    let core_reader = core_reader(&chain);
-    let result = core_reader.get_uncertified_validator_proposals(block1.hash(), shard_id).unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].account_id().as_str(), "test0");
-    assert_eq!(result[0].stake(), Balance::from_near(100));
-}
-
-/// Verifies that execution results for other shards don't interfere with
-/// resolving the target shard's uncertified proposals. The other shard's
-/// result is in a later block (closer to head) so the backward walk
-/// encounters it first.
-#[test]
-#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_uncertified_validator_proposals_ignores_other_shards() {
-    let (mut chain, _) = setup();
-    let genesis = chain.genesis_block();
-
-    let block1 = build_block(&mut chain, &genesis, vec![]);
-    process_block(&mut chain, block1.clone());
-
-    let target_shard = ShardId::new(0);
-    let other_shard = ShardId::new(1);
-
-    let target_result = ChunkExecutionResult {
-        chunk_extra: make_chunk_extra_with_proposals(vec![test_proposal("test0", 100)]),
-        outgoing_receipts_root: CryptoHash::default(),
-    };
-    let other_result = ChunkExecutionResult {
-        chunk_extra: make_chunk_extra_with_proposals(vec![]),
-        outgoing_receipts_root: CryptoHash::default(),
-    };
-    let target_chunk_id = SpiceChunkId { block_hash: *block1.hash(), shard_id: target_shard };
-    let other_chunk_id = SpiceChunkId { block_hash: *block1.hash(), shard_id: other_shard };
-
-    // block2: endorsements + execution result for the target shard.
-    let mut target_statements: Vec<_> = test_validators()
-        .iter()
-        .map(|v| {
-            endorsement_into_core_statement(SpiceChunkEndorsement::new(
-                target_chunk_id.clone(),
-                target_result.clone(),
-                &create_test_signer(v),
-            ))
-        })
-        .collect();
-    target_statements.push(SpiceCoreStatement::ChunkExecutionResult {
-        chunk_id: target_chunk_id,
-        execution_result: target_result,
-    });
-    let block2 = build_block(&mut chain, &block1, target_statements);
-    process_block(&mut chain, block2.clone());
-
-    // block3 (head): endorsements + execution result for the other shard.  The
-    // backward walk hits block3 first, but it shouldn't interfere with finding
-    // the target shard's result in block2.
-    let mut other_statements: Vec<_> = test_validators()
-        .iter()
-        .map(|v| {
-            endorsement_into_core_statement(SpiceChunkEndorsement::new(
-                other_chunk_id.clone(),
-                other_result.clone(),
-                &create_test_signer(v),
-            ))
-        })
-        .collect();
-    other_statements.push(SpiceCoreStatement::ChunkExecutionResult {
-        chunk_id: other_chunk_id,
-        execution_result: other_result,
-    });
-    let block3 = build_block(&mut chain, &block2, other_statements);
-    process_block(&mut chain, block3);
-
-    let core_reader = core_reader(&chain);
-    let result =
-        core_reader.get_uncertified_validator_proposals(block1.hash(), target_shard).unwrap();
+    let result = core_reader.get_uncertified_validator_proposals(block.hash(), shard_id).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].account_id().as_str(), "test0");
     assert_eq!(result[0].stake(), Balance::from_near(100));

--- a/chain/chain/src/tests/spice_core.rs
+++ b/chain/chain/src/tests/spice_core.rs
@@ -5,12 +5,15 @@ use near_async::time::Clock;
 use near_chain_configs::test_genesis::{TestGenesisBuilder, ValidatorsSpec};
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::bandwidth_scheduler::BandwidthRequests;
 use near_primitives::block::Block;
 use near_primitives::block_body::{SpiceCoreStatement, SpiceCoreStatements};
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::stateless_validation::spice_chunk_endorsement::testonly_create_endorsement_core_statement;
 use near_primitives::stateless_validation::spice_chunk_endorsement::{
@@ -18,8 +21,10 @@ use near_primitives::stateless_validation::spice_chunk_endorsement::{
 };
 use near_primitives::test_utils::{TestBlockBuilder, create_test_signer};
 use near_primitives::types::chunk_extra::ChunkExtra;
+use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, SpiceChunkId,
+    Balance, BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, ShardId,
+    SpiceChunkId,
 };
 use near_store::adapter::StoreAdapter as _;
 use std::collections::HashMap;
@@ -1385,4 +1390,131 @@ fn endorsement_into_core_statement(endorsement: SpiceChunkEndorsement) -> SpiceC
     verified
         .to_stored()
         .into_core_statement(verified.chunk_id().clone(), verified.account_id().clone())
+}
+
+fn make_chunk_extra_with_proposals(proposals: Vec<ValidatorStake>) -> ChunkExtra {
+    ChunkExtra::new(
+        &CryptoHash::default(),
+        CryptoHash::default(),
+        proposals,
+        Gas::ZERO,
+        Gas::ZERO,
+        Balance::ZERO,
+        Some(CongestionInfo::default()),
+        BandwidthRequests::empty(),
+        None,
+    )
+}
+
+fn save_chunk_extra_for_block(
+    chain: &mut Chain,
+    block: &Block,
+    shard_id: ShardId,
+    chunk_extra: ChunkExtra,
+) {
+    let epoch_id = chain.epoch_manager.get_epoch_id(block.hash()).unwrap();
+    let shard_layout = chain.epoch_manager.get_shard_layout(&epoch_id).unwrap();
+    let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+    let mut store_update = chain.chain_store.store_update();
+    store_update.save_chunk_extra(block.hash(), &shard_uid, Arc::new(chunk_extra));
+    store_update.commit().unwrap();
+}
+
+fn test_proposal(account: &str, stake: u128) -> ValidatorStake {
+    let signer = create_test_signer(account);
+    ValidatorStake::new(account.parse().unwrap(), signer.public_key(), Balance::from_near(stake))
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_uncertified_validator_proposals_single_chunk() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let block = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, block.clone());
+
+    let shard_id = ShardId::new(0);
+    let proposals = vec![test_proposal("test0", 100)];
+    save_chunk_extra_for_block(
+        &mut chain,
+        &block,
+        shard_id,
+        make_chunk_extra_with_proposals(proposals.clone()),
+    );
+
+    let result = core_reader.get_uncertified_validator_proposals(block.hash(), shard_id).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].account_id().as_str(), "test0");
+    assert_eq!(result[0].stake(), Balance::from_near(100));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_uncertified_validator_proposals_multiple_heights_different_accounts() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    let block1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, block1.clone());
+
+    let block2 = build_block(&mut chain, &block1, vec![]);
+    process_block(&mut chain, block2.clone());
+
+    let shard_id = ShardId::new(0);
+    save_chunk_extra_for_block(
+        &mut chain,
+        &block1,
+        shard_id,
+        make_chunk_extra_with_proposals(vec![test_proposal("test0", 100)]),
+    );
+    save_chunk_extra_for_block(
+        &mut chain,
+        &block2,
+        shard_id,
+        make_chunk_extra_with_proposals(vec![test_proposal("test1", 200)]),
+    );
+
+    let result = core_reader.get_uncertified_validator_proposals(block2.hash(), shard_id).unwrap();
+    assert_eq!(result.len(), 2);
+    // Sorted by height ascending: block1 proposals first, then block2.
+    assert_eq!(result[0].account_id().as_str(), "test0");
+    assert_eq!(result[0].stake(), Balance::from_near(100));
+    assert_eq!(result[1].account_id().as_str(), "test1");
+    assert_eq!(result[1].stake(), Balance::from_near(200));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_uncertified_validator_proposals_multiple_heights_same_account() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    let block1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, block1.clone());
+
+    let block2 = build_block(&mut chain, &block1, vec![]);
+    process_block(&mut chain, block2.clone());
+
+    let shard_id = ShardId::new(0);
+    save_chunk_extra_for_block(
+        &mut chain,
+        &block1,
+        shard_id,
+        make_chunk_extra_with_proposals(vec![test_proposal("test0", 100)]),
+    );
+    save_chunk_extra_for_block(
+        &mut chain,
+        &block2,
+        shard_id,
+        make_chunk_extra_with_proposals(vec![test_proposal("test0", 200)]),
+    );
+
+    let result = core_reader.get_uncertified_validator_proposals(block2.hash(), shard_id).unwrap();
+    // Both proposals returned in height order. The caller's fold/insert keeps
+    // the last one (height of block2, stake=200) for "test0".
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].account_id().as_str(), "test0");
+    assert_eq!(result[0].stake(), Balance::from_near(100));
+    assert_eq!(result[1].account_id().as_str(), "test0");
+    assert_eq!(result[1].stake(), Balance::from_near(200));
 }

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -804,18 +804,10 @@ impl ChunkExecutorActor {
         };
 
         let prev_chunk_chunk_extra = chunk_context.prev_chunk_chunk_extra;
-        // In SPICE, uncertified chunks at epoch boundary may contain staking
-        // proposals that haven't been processed by EpochManager. Append them
-        // so the runtime's last_proposals fold picks the most recent per account.
-        let is_epoch_start =
-            self.epoch_manager.is_next_block_epoch_start(&block_context.prev_block_hash)?;
-        let prev_validator_proposals = if is_epoch_start {
-            let shard_id = chunk_context.shard_uid.shard_id();
-            self.core_reader
-                .get_uncertified_validator_proposals(&block_context.prev_block_hash, shard_id)?
-        } else {
-            vec![]
-        };
+        let prev_validator_proposals = self.core_reader.prev_validator_proposals(
+            &block_context.prev_block_hash,
+            chunk_context.shard_uid.shard_id(),
+        )?;
         let shard_update_reason = ShardUpdateReason::NewChunk(NewChunkData {
             gas_limit: prev_chunk_chunk_extra.gas_limit(),
             prev_state_root: *prev_chunk_chunk_extra.state_root(),

--- a/chain/client/src/spice_chunk_validator_actor.rs
+++ b/chain/client/src/spice_chunk_validator_actor.rs
@@ -269,6 +269,7 @@ impl SpiceChunkValidatorActor {
             &prev_block_execution_results,
             self.epoch_manager.as_ref(),
             &self.chain_store,
+            &self.core_reader,
         )?;
 
         let epoch_manager = self.epoch_manager.clone();

--- a/chain/client/src/tests/spice_chunk_executor_actor.rs
+++ b/chain/client/src/tests/spice_chunk_executor_actor.rs
@@ -1044,6 +1044,7 @@ fn test_witness_is_valid() {
             &prev_block_execution_results,
             actor.actor.epoch_manager.as_ref(),
             &actor.actor.chain_store,
+            &actor.actor.core_reader,
         )
         .unwrap();
 

--- a/cspell.json
+++ b/cspell.json
@@ -422,6 +422,7 @@
         "unrequested",
         "unstake",
         "unstaked",
+        "unstaker",
         "unstakes",
         "unstaking",
         "unsync",

--- a/test-loop-tests/src/tests/stake_nodes.rs
+++ b/test-loop-tests/src/tests/stake_nodes.rs
@@ -5,7 +5,7 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::num_rational::Rational32;
 use near_primitives::test_utils::{create_test_signer, create_user_test_signer};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountInfo, Balance};
+use near_primitives::types::{AccountInfo, Balance, ShardId};
 use primitive_types::U256;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -304,6 +304,104 @@ fn test_validator_join_impl(epoch_length: u64, execution_delay: u64) {
         },
         Duration::seconds(120),
     );
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Verifies that a validator who unstakes and then re-stakes in an uncertified chunk
+/// near the epoch boundary does NOT have their stake returned. The re-stake proposal
+/// from the uncertified chunk should be picked up by get_uncertified_validator_proposals.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_uncertified_restake_prevents_stake_return() {
+    init_test_logger();
+
+    let epoch_length: u64 = 10;
+    let endorsement_delay: u64 = 4;
+    let validators_spec = create_validators_spec(4, 0);
+    let accounts = validators_spec_clients(&validators_spec);
+    let unstaker = accounts[0].clone();
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, TESTING_INIT_BALANCE)
+        .max_inflation_rate(Rational32::new(0, 1))
+        .build();
+    let genesis_height = genesis.config.genesis_height;
+
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(accounts.clone())
+        .track_all_shards()
+        .build();
+    delay_endorsements_propagation(&mut env, endorsement_delay);
+    let mut env = env.warmup();
+
+    let node = TestLoopNode::from(&env.node_datas[0]);
+    let initial_stake =
+        query_view_account(node.view_client_actor(&mut env.test_loop.data), unstaker.clone())
+            .locked;
+
+    // Submit unstake (stake = 0) in the first epoch.
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    let unstake_tx = SignedTransaction::stake(
+        1,
+        unstaker.clone(),
+        &create_user_test_signer(&unstaker),
+        Balance::ZERO,
+        create_test_signer(unstaker.as_str()).public_key(),
+        block_hash,
+    );
+    run_tx(&mut env.test_loop, &accounts[0], unstake_tx, &env.node_datas, Duration::seconds(30));
+
+    // Advance to a few blocks before the E4->E5 boundary where stake return would
+    // happen. Unstake in E0 -> active in E0,E1 -> inactive from E2 -> 3-epoch window
+    // covers E2,E3,E4 with 0 stake -> return at E4->E5 boundary.
+    let epoch_boundary = genesis_height + 5 * epoch_length;
+    let restake_submit_height = epoch_boundary - 3;
+    // The restake must land within endorsement_delay of the epoch boundary
+    // to make sure the premise of the test holds.
+    assert!(restake_submit_height + endorsement_delay > epoch_boundary);
+    node.run_until_head_height(&mut env.test_loop, restake_submit_height);
+
+    // Submit re-stake near the end of E4. With endorsement delay, this tx will
+    // land in an uncertified chunk, and its stake proposal should be picked up
+    // by get_uncertified_validator_proposals at the epoch boundary.
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    let restake_tx = SignedTransaction::stake(
+        2,
+        unstaker.clone(),
+        &create_user_test_signer(&unstaker),
+        initial_stake,
+        create_test_signer(unstaker.as_str()).public_key(),
+        block_hash,
+    );
+    node.submit_tx(restake_tx);
+
+    // Run past the epoch boundary, plus extra blocks for execution to certify.
+    node.run_until_head_height(&mut env.test_loop, epoch_boundary + endorsement_delay + 2);
+
+    // Verify the re-stake proposal landed in an uncertified chunk at the epoch boundary.
+    let client = node.client(&env.test_loop.data);
+    let last_block_hash =
+        client.chain.chain_store.get_block_hash_by_height(epoch_boundary - 1).unwrap();
+    let uncertified_proposals = client
+        .chain
+        .spice_core_reader
+        .get_uncertified_validator_proposals(&last_block_hash, ShardId::new(0))
+        .unwrap();
+    assert!(
+        uncertified_proposals.iter().any(|p| p.account_id() == &unstaker),
+        "re-stake proposal should be in uncertified chunks, got: {:?}",
+        uncertified_proposals
+    );
+
+    // Verify that the unstaker's locked balance was NOT returned.
+    let view_client = node.view_client_actor(&mut env.test_loop.data);
+    let account = query_view_account(view_client, unstaker);
+    assert_eq!(account.locked, initial_stake, "stake should NOT have been returned");
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }

--- a/test-loop-tests/src/tests/stake_nodes.rs
+++ b/test-loop-tests/src/tests/stake_nodes.rs
@@ -319,7 +319,7 @@ fn test_spice_uncertified_restake_prevents_stake_return() {
 
     let epoch_length: u64 = 10;
     let endorsement_delay: u64 = 4;
-    let validators_spec = create_validators_spec(4, 0);
+    let validators_spec = create_validators_spec(4, 1);
     let accounts = validators_spec_clients(&validators_spec);
     let clients = validators_spec_clients_with_rpc(&validators_spec);
     let unstaker = accounts[0].clone();


### PR DESCRIPTION
- At epoch boundaries in SPICE, staking proposals from uncertified chunks (chunks whose execution results haven't been endorsed yet) were being ignored. This could cause incorrect stake returns - e.g., a validator who re-stakes in an uncertified chunk near the epoch boundary would have their full stake returned as if they hadn't re-staked.
- Add `get_uncertified_validator_proposals` to `SpiceCoreReader` which collects validator proposals from uncertified chunks, sorted by block height.
- In `ChunkExecutorActor`, at epoch start, append uncertified proposals to prev_validator_proposals` so the runtime's `last_proposals` fold picks up the most recent proposal per account.

Added UTs and test-loop for new behavior.