### PR TITLE
chore(ci): add PR title validation workflow

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,0 +1,42 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-title:
+    name: "PR Title"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # PR title must match: <type>: <title> or <type>(<project>): <title>
+          # See CONTRIBUTING.md for details.
+
+          VALID_TYPES="fix|feat|refactor|doc|test|chore|perf"
+          PATTERN="^(${VALID_TYPES})(\([a-z][a-z0-9-]*\))?: [a-z]"
+
+          if [[ ! "$PR_TITLE" =~ $PATTERN ]]; then
+            echo "::error::PR title does not follow the required format."
+            echo ""
+            echo "Expected: <type>: <title> or <type>(<project>): <title>"
+            echo "Got:      $PR_TITLE"
+            echo ""
+            echo "Rules:"
+            echo "  - type must be one of: fix, feat, refactor, doc, test, chore, perf"
+            echo "  - project (if provided) must be lowercase (e.g. spice, resharding, state-sync)"
+            echo "  - title must not be capitalized"
+            echo ""
+            echo "Examples:"
+            echo "  test: add delayed receipt example"
+            echo "  feat(spice): add catchup logic"
+            echo "  fix(state-sync): properly validate header"
+            echo ""
+            echo "See CONTRIBUTING.md for full guidelines."
+            exit 1
+          fi
+
+          echo "PR title is valid: $PR_TITLE"


### PR DESCRIPTION
- Adds a GitHub Actions workflow that validates PR titles against the conventions in CONTRIBUTING.md
- Enforces the `<type>: <title>` or `<type>(<project>): <title>` format
- Checks that type is one of: fix, feat, refactor, doc, test, chore, perf
- Checks that project name (if present) and title are lowercase

Separately this will be added to the list of required checks for merging PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)