### PR TITLE
feat: handle the large compiled contracts

### DIFF
--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -56,6 +56,19 @@ pub enum FunctionCallError {
     HostError(HostError),
 }
 
+impl FunctionCallError {
+    pub fn size_bytes_approximate(&self) -> usize {
+        const BASE_SIZE: usize = 4; // to roughly accommodate for static parts of the enum
+        match self {
+            FunctionCallError::CompilationError(e) => e.size_bytes_approximate(),
+            FunctionCallError::LinkError { msg } => BASE_SIZE + msg.len(),
+            FunctionCallError::MethodResolveError(_)
+            | FunctionCallError::WasmTrap(_)
+            | FunctionCallError::HostError(_) => BASE_SIZE,
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 pub enum CacheError {
     #[error("cache read error: {0}")]
@@ -118,6 +131,22 @@ pub enum CompilationError {
     WasmtimeCompileError {
         msg: String,
     } = 3,
+}
+
+impl CompilationError {
+    /// Calculate the approximate memory footprint of given CompilationError.
+    pub fn size_bytes_approximate(&self) -> usize {
+        const BASE_SIZE: usize = 4; // to accommodate for String/Box/Box<str> etc
+
+        let dynamic_size = match self {
+            CompilationError::CodeDoesNotExist { account_id } => account_id.len(),
+            CompilationError::WasmerCompileError { msg }
+            | CompilationError::WasmtimeCompileError { msg } => msg.len(),
+            CompilationError::PrepareError(_) => 0,
+        };
+
+        BASE_SIZE + dynamic_size
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -474,6 +474,12 @@ impl WasmtimeVM {
         serialized
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        target = "vm",
+        name = "Wasmtime::compile_and_cache",
+        skip_all
+    )]
     fn compile_and_cache(
         &self,
         code: &ContractCode,
@@ -492,6 +498,12 @@ impl WasmtimeVM {
         Ok(serialized_or_error)
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        target = "vm",
+        name = "Wasmtime::with_compiled_and_loaded",
+        skip_all
+    )]
     fn with_compiled_and_loaded(
         &self,
         cache: &dyn ContractRuntimeCache,
@@ -515,7 +527,10 @@ impl WasmtimeVM {
                     if let Some(CompiledContractInfo { wasm_bytes, compiled }) = cache_record {
                         match compiled {
                             CompiledContract::CompileModuleError(err) => {
-                                return Ok(to_any((wasm_bytes, Err(err))));
+                                return Ok((
+                                    err.size_bytes_approximate() as u64,
+                                    to_any((wasm_bytes, Err(err))),
+                                ));
                             }
                             CompiledContract::Code(module) => (wasm_bytes, module),
                         }
@@ -525,7 +540,12 @@ impl WasmtimeVM {
                         };
                         let wasm_bytes = code.code().len() as u64;
                         match self.compile_and_cache(&code, cache)? {
-                            Err(err) => return Ok(to_any((wasm_bytes, Err(err)))),
+                            Err(err) => {
+                                return Ok((
+                                    err.size_bytes_approximate() as u64,
+                                    to_any((wasm_bytes, Err(err))),
+                                ));
+                            }
                             Ok(module) => (wasm_bytes, module),
                         }
                     };
@@ -539,15 +559,15 @@ impl WasmtimeVM {
                 //
                 // There should definitely be some validation in near_vm to ensure
                 // we load what we think we load.
+                let compiled_size = module.len();
                 let module = unsafe { Module::deserialize(&self.engine, &module) }
                     .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
                 let Some(memory) = module.get_export_index(MEMORY_EXPORT) else {
-                    return Ok(to_any((
-                        wasm_bytes,
-                        Ok(Err(FunctionCallError::LinkError {
-                            msg: "memory export missing".into(),
-                        })),
-                    )));
+                    let err = FunctionCallError::LinkError { msg: "memory export missing".into() };
+                    return Ok((
+                        err.size_bytes_approximate() as u64,
+                        to_any((wasm_bytes, Ok(Err(err)))),
+                    ));
                 };
                 let remaining_gas = module.get_export_index(REMAINING_GAS_EXPORT);
                 let start = module.get_export_index(START_EXPORT);
@@ -556,20 +576,29 @@ impl WasmtimeVM {
                 match linker.instantiate_pre(&module) {
                     Err(err) => {
                         let err = err.into_vm_error()?;
-                        Ok(to_any((wasm_bytes, Ok(Err(err)))))
+                        Ok((
+                            err.size_bytes_approximate() as u64,
+                            to_any((wasm_bytes, Ok(Err(err)))),
+                        ))
                     }
                     Ok(pre) => {
                         let ResourcesRequired { num_tables, .. } = module.resources_required();
-                        Ok(to_any((
-                            wasm_bytes,
-                            Ok(Ok(PreparedModule {
-                                pre,
-                                memory,
-                                remaining_gas,
-                                start,
-                                num_tables,
-                            })),
-                        )))
+                        // The module `weight` is estimated as its serialized size. This is a
+                        // rough approximation as the runtime metadata size is not included.
+                        // Should be sufficient for our purposes.
+                        Ok((
+                            compiled_size as u64,
+                            to_any((
+                                wasm_bytes,
+                                Ok(Ok(PreparedModule {
+                                    pre,
+                                    memory,
+                                    remaining_gas,
+                                    start,
+                                    num_tables,
+                                })),
+                            )),
+                        ))
                     }
                 }
             },


### PR DESCRIPTION
The underlying LRU cache is made weight-aware dropping the number of lru items until we have room for the new item. The weight corresponds (roughly) to the compiled contract size. The total size of the cached items is chosen to roughly correspond to the current cache memory footprint under normal conditions (~4GB). I avoided adding new config parameters, so the memory cap is estimated from the previously used number of cache elements cap.

The follow-up adding explicit limits on the size of the instrumented wasm and compiled contract sizes is needed but not urgent and I still do not have all the data to get the right numbers for those.

Some additional logging added.