### PR TITLE
feat(gas-keys): charge gas on failed deposit for gas key txs

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1003,7 +1003,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         break;
                     }
                     TxVerdict::DepositFailed { error, .. } | TxVerdict::Failed(error) => {
-                        tracing::trace!(target: "runtime", tx=?validated_tx.get_hash(), ?error, "discarding transaction that failed verification or verification");
+                        tracing::trace!(target: "runtime", tx=?validated_tx.get_hash(), ?error, "discarding transaction that failed validation or verification");
                         rejected_invalid_tx += 1;
                     }
                 }

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -195,10 +195,12 @@ impl std::error::Error for StorageError {}
     serde::Serialize,
     ProtocolSchema,
 )]
+#[borsh(use_discriminant = true)]
+#[repr(u8)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum DepositCostFailureReason {
-    NotEnoughBalance,
-    LackBalanceForState,
+    NotEnoughBalance = 0,
+    LackBalanceForState = 1,
 }
 
 /// An error happened during TX execution

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -610,11 +610,23 @@ pub struct ExecutionOutcomeWithId {
 
 impl ExecutionOutcomeWithId {
     pub fn failed(transaction: &SignedTransaction, error: InvalidTxError) -> Self {
+        Self::failed_with_gas_burnt(transaction, error, Gas::ZERO, Balance::ZERO)
+    }
+
+    pub fn failed_with_gas_burnt(
+        transaction: &SignedTransaction,
+        error: InvalidTxError,
+        gas_burnt: Gas,
+        tokens_burnt: Balance,
+    ) -> Self {
         Self {
             id: transaction.get_hash(),
             outcome: ExecutionOutcome {
                 executor_id: transaction.transaction.signer_id().clone(),
                 status: ExecutionStatus::Failure(TxExecutionError::InvalidTxError(error)),
+                gas_burnt,
+                compute_usage: Some(gas_burnt.as_gas()),
+                tokens_burnt,
                 ..Default::default()
             },
         }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -463,7 +463,7 @@ impl Testbed<'_> {
         let (mut signer, mut access_key) = get_signer_and_access_key(&state_update, &validated_tx)
             .expect("getting signer and access key should not fail in estimator");
 
-        let TxVerdict::Success(vr) = verify_and_charge_tx_ephemeral(
+        let TxVerdict::Success(result) = verify_and_charge_tx_ephemeral(
             &self.apply_state.config,
             &signer,
             &mut access_key,
@@ -474,7 +474,7 @@ impl Testbed<'_> {
         ) else {
             panic!("tx verification should not fail in estimator");
         };
-        vr.apply(&mut signer, &mut access_key);
+        result.apply(&mut signer, &mut access_key);
         set_tx_state_changes(&mut state_update, &validated_tx, &signer, &access_key);
         clock.elapsed()
     }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -28,7 +28,7 @@ use near_vm_runner::FilesystemContractRuntimeCache;
 use near_vm_runner::logic::LimitConfig;
 use node_runtime::config::tx_cost;
 use node_runtime::{
-    ApplyState, Runtime, SignedValidPeriodTransactions, get_signer_and_access_key,
+    ApplyState, Runtime, SignedValidPeriodTransactions, TxVerdict, get_signer_and_access_key,
     set_tx_state_changes, verify_and_charge_tx_ephemeral,
 };
 use std::collections::{HashMap, VecDeque};
@@ -463,16 +463,18 @@ impl Testbed<'_> {
         let (mut signer, mut access_key) = get_signer_and_access_key(&state_update, &validated_tx)
             .expect("getting signer and access key should not fail in estimator");
 
-        verify_and_charge_tx_ephemeral(
+        let TxVerdict::Success(vr) = verify_and_charge_tx_ephemeral(
             &self.apply_state.config,
-            &mut signer,
+            &signer,
             &mut access_key,
             validated_tx.to_tx(),
             &cost,
             block_height,
             PROTOCOL_VERSION,
-        )
-        .expect("tx verification should not fail in estimator");
+        ) else {
+            panic!("tx verification should not fail in estimator");
+        };
+        vr.apply(&mut signer, &mut access_key);
         set_tx_state_changes(&mut state_update, &validated_tx, &signer, &access_key);
         clock.elapsed()
     }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -276,7 +276,7 @@ pub struct VerificationResult {
 /// Describes how to update the access key after a verified transaction.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AccessKeyUpdate {
-    /// Regular tx: set access_key.nonce, optionally update allowance.
+    /// Regular tx: set access_key.nonce, update allowance if specified.
     Regular { nonce: Nonce, new_allowance: Option<Balance> },
     /// Gas key tx: set gas_key_info.balance and persist external nonce.
     GasKey { new_balance: Balance, nonce_index: NonceIndex, nonce: Nonce },

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -257,15 +257,6 @@ impl From<InvalidTxError> for TxVerdict {
     }
 }
 
-/// Describes how to update the access key after a verified transaction.
-#[derive(Debug, Clone, PartialEq)]
-pub enum AccessKeyUpdate {
-    /// Regular tx: set access_key.nonce, optionally update allowance.
-    Regular { nonce: Nonce, new_allowance: Option<Balance> },
-    /// Gas key tx: set gas_key_info.balance and persist external nonce.
-    GasKey { new_balance: Balance, nonce_index: NonceIndex, nonce: Nonce },
-}
-
 #[derive(Debug)]
 pub struct VerificationResult {
     /// The amount gas that was burnt to convert the transaction into a receipt and send it.
@@ -280,6 +271,15 @@ pub struct VerificationResult {
     pub new_account_amount: Balance,
     /// Describes how to update the access key.
     pub access_key_update: AccessKeyUpdate,
+}
+
+/// Describes how to update the access key after a verified transaction.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AccessKeyUpdate {
+    /// Regular tx: set access_key.nonce, optionally update allowance.
+    Regular { nonce: Nonce, new_allowance: Option<Balance> },
+    /// Gas key tx: set gas_key_info.balance and persist external nonce.
+    GasKey { new_balance: Balance, nonce_index: NonceIndex, nonce: Nonce },
 }
 
 impl VerificationResult {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -38,8 +38,8 @@ pub use near_crypto;
 use near_crypto::{PublicKey, Signature};
 use near_parameters::{ActionCosts, RuntimeConfig};
 pub use near_primitives;
-use near_primitives::account::Account;
 use near_primitives::account::id::AccountType;
+use near_primitives::account::{AccessKey, Account};
 use near_primitives::bandwidth_scheduler::{BandwidthRequests, BlockBandwidthRequests};
 use near_primitives::chunk_apply_stats::ChunkApplyStatsV0;
 use near_primitives::congestion_info::{BlockCongestionInfo, CongestionInfo};
@@ -231,6 +231,41 @@ pub struct ValidatorAccountsUpdate {
     pub protocol_treasury_account_id: Option<AccountId>,
 }
 
+/// Outcome of transaction verification and charging.
+///
+/// Returned by both `verify_and_charge_tx_ephemeral` and
+/// `verify_and_charge_gas_key_tx_ephemeral`. Neither function mutates state;
+/// callers apply changes based on the variant:
+/// - `Success`: apply all state changes via `VerificationResult::apply`.
+/// - `DepositFailed`: apply gas-only state changes via `VerificationResult::apply`
+///   (only returned by gas key path).
+/// - `Failed`: no state changes.
+#[derive(Debug)]
+pub enum TxVerdict {
+    /// All checks passed.
+    Success(VerificationResult),
+    /// Gas key valid with sufficient gas balance, but account can't cover deposit.
+    /// Gas key balance is deducted, account balance unchanged.
+    DepositFailed { result: VerificationResult, error: InvalidTxError },
+    /// Hard failure (bad key, bad nonce, insufficient balance). No state changes.
+    Failed(InvalidTxError),
+}
+
+impl From<InvalidTxError> for TxVerdict {
+    fn from(e: InvalidTxError) -> Self {
+        TxVerdict::Failed(e)
+    }
+}
+
+/// Describes how to update the access key after a verified transaction.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AccessKeyUpdate {
+    /// Regular tx: set access_key.nonce, optionally update allowance.
+    Regular { nonce: Nonce, new_allowance: Option<Balance> },
+    /// Gas key tx: set gas_key_info.balance and persist external nonce.
+    GasKey { new_balance: Balance, nonce_index: NonceIndex, nonce: Nonce },
+}
+
 #[derive(Debug)]
 pub struct VerificationResult {
     /// The amount gas that was burnt to convert the transaction into a receipt and send it.
@@ -241,8 +276,37 @@ pub struct VerificationResult {
     pub receipt_gas_price: Balance,
     /// The balance that was burnt to convert the transaction into a receipt and send it.
     pub burnt_amount: Balance,
-    /// For gas key transactions: the nonce index and new nonce value to persist.
-    pub gas_key_nonce_update: Option<(NonceIndex, Nonce)>,
+    /// New account balance after deducting costs.
+    pub new_account_amount: Balance,
+    /// Describes how to update the access key.
+    pub access_key_update: AccessKeyUpdate,
+}
+
+impl VerificationResult {
+    /// Apply the state changes described by this result to the given account and access key.
+    pub fn apply(&self, account: &mut Account, access_key: &mut AccessKey) {
+        account.set_amount(self.new_account_amount);
+        match &self.access_key_update {
+            AccessKeyUpdate::Regular { nonce, new_allowance } => {
+                access_key.nonce = *nonce;
+                if let Some(a) = new_allowance {
+                    access_key.permission.function_call_permission_mut().unwrap().allowance =
+                        Some(*a);
+                }
+            }
+            AccessKeyUpdate::GasKey { new_balance, .. } => {
+                access_key.gas_key_info_mut().unwrap().balance = *new_balance;
+            }
+        }
+    }
+
+    /// Extract the gas key nonce update, if this is a gas key transaction.
+    pub fn gas_key_nonce_update(&self) -> Option<(NonceIndex, Nonce)> {
+        match &self.access_key_update {
+            AccessKeyUpdate::GasKey { nonce_index, nonce, .. } => Some((*nonce_index, *nonce)),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -1814,9 +1878,7 @@ impl Runtime {
                 None => unreachable!("access keys should've been prefetched"),
             };
             // Verify and charge based on transaction type (gas key vs regular access key)
-            let verification_result = if let Some(nonce_index) =
-                tx.transaction.nonce().nonce_index()
-            {
+            let verdict = if let Some(nonce_index) = tx.transaction.nonce().nonce_index() {
                 // Gas key transaction - load nonce from prefetched cache
                 let nonce_entry = gas_key_nonces.get(&(signer_id, pubkey, nonce_index));
                 let current_nonce = match nonce_entry.as_deref() {
@@ -1843,7 +1905,7 @@ impl Runtime {
                     Some(Err(e)) => return Err(e.clone().into()),
                     None => unreachable!("gas key nonces should've been prefetched"),
                 };
-                match verify_and_charge_gas_key_tx_ephemeral(
+                verify_and_charge_gas_key_tx_ephemeral(
                     &processing_state.apply_state.config,
                     account,
                     access_key,
@@ -1851,23 +1913,10 @@ impl Runtime {
                     &tx.transaction,
                     &cost,
                     Some(block_height),
-                ) {
-                    Ok(vr) => vr,
-                    Err(error) => {
-                        metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
-                        tracing::debug!(%tx_hash, error = &error as &dyn std::error::Error, "transaction failed verify/charge");
-                        let outcome = ExecutionOutcomeWithId::failed(tx, error);
-                        Self::register_outcome(
-                            processing_state.protocol_version,
-                            &mut processing_state.outcomes,
-                            outcome,
-                        );
-                        continue;
-                    }
-                }
+                )
             } else {
                 // Regular access key transaction
-                match verify_and_charge_tx_ephemeral(
+                verify_and_charge_tx_ephemeral(
                     &processing_state.apply_state.config,
                     account,
                     access_key,
@@ -1875,59 +1924,79 @@ impl Runtime {
                     &cost,
                     Some(block_height),
                     processing_state.protocol_version,
-                ) {
-                    Ok(vr) => vr,
-                    Err(error) => {
-                        metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
-                        tracing::debug!(%tx_hash, error = &error as &dyn std::error::Error, "transaction failed verify/charge");
-                        let outcome = ExecutionOutcomeWithId::failed(tx, error);
-                        Self::register_outcome(
-                            processing_state.protocol_version,
-                            &mut processing_state.outcomes,
-                            outcome,
-                        );
-                        continue;
+                )
+            };
+
+            // Build the outcome and extract the verification result (if any).
+            let (outcome, result) = match verdict {
+                TxVerdict::DepositFailed { result, error } => {
+                    metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
+                    tracing::debug!(%tx_hash, error = &error as &dyn std::error::Error, "gas key transaction failed deposit check, charging gas");
+                    let outcome = ExecutionOutcomeWithId::failed_with_gas_burnt(
+                        tx,
+                        error,
+                        result.gas_burnt,
+                        result.burnt_amount,
+                    );
+                    (outcome, result)
+                }
+                TxVerdict::Success(result) => {
+                    let receipt_id = create_receipt_id_from_transaction(
+                        tx_hash,
+                        processing_state.apply_state.block_height,
+                    );
+                    let receipt = Receipt::from_tx(
+                        receipt_id,
+                        signer_id.clone(),
+                        tx.transaction.receiver_id().clone(),
+                        pubkey.clone(),
+                        result.receipt_gas_price,
+                        tx.transaction.actions().to_vec(),
+                    );
+                    let outcome = ExecutionOutcomeWithId {
+                        id: tx.get_hash(),
+                        outcome: ExecutionOutcome {
+                            status: ExecutionStatus::SuccessReceiptId(*receipt.receipt_id()),
+                            logs: vec![],
+                            receipt_ids: vec![*receipt.receipt_id()],
+                            gas_burnt: result.gas_burnt,
+                            // TODO(#8806): Support compute costs for actions. For now they match burnt gas.
+                            compute_usage: Some(result.gas_burnt.as_gas()),
+                            tokens_burnt: result.burnt_amount,
+                            executor_id: signer_id.clone(),
+                            // TODO: profile data is only counted in apply_action, which only happened at process_receipt
+                            // VerificationResult needs updates to incorporate profile data to support profile data of txns
+                            metadata: ExecutionMetadata::V1,
+                        },
+                    };
+                    if receipt.receiver_id() == signer_id {
+                        processing_state.local_receipts.push_back(receipt);
+                    } else {
+                        receipt_sink.forward_or_buffer_receipt(
+                            receipt,
+                            &processing_state.apply_state,
+                            &mut processing_state.state_update,
+                        )?;
                     }
+                    metrics::TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL.inc();
+                    (outcome, result)
+                }
+                TxVerdict::Failed(error) => {
+                    metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
+                    tracing::debug!(%tx_hash, error = &error as &dyn std::error::Error, "transaction failed verify/charge");
+                    let outcome = ExecutionOutcomeWithId::failed(tx, error);
+                    Self::register_outcome(
+                        processing_state.protocol_version,
+                        &mut processing_state.outcomes,
+                        outcome,
+                    );
+                    continue;
                 }
             };
-
-            let (receipt, outcome) = {
-                let receipt_id = create_receipt_id_from_transaction(
-                    tx_hash,
-                    processing_state.apply_state.block_height,
-                );
-                let receipt = Receipt::from_tx(
-                    receipt_id,
-                    signer_id.clone(),
-                    tx.transaction.receiver_id().clone(),
-                    pubkey.clone(),
-                    verification_result.receipt_gas_price,
-                    tx.transaction.actions().to_vec(),
-                );
-                let gas_burnt = verification_result.gas_burnt;
-                let compute_usage = gas_burnt.as_gas();
-                let outcome = ExecutionOutcomeWithId {
-                    id: tx.get_hash(),
-                    outcome: ExecutionOutcome {
-                        status: ExecutionStatus::SuccessReceiptId(*receipt.receipt_id()),
-                        logs: vec![],
-                        receipt_ids: vec![*receipt.receipt_id()],
-                        gas_burnt,
-                        // TODO(#8806): Support compute costs for actions. For now they match burnt gas.
-                        compute_usage: Some(compute_usage),
-                        tokens_burnt: verification_result.burnt_amount,
-                        executor_id: signer_id.clone(),
-                        // TODO: profile data is only counted in apply_action, which only happened at process_receipt
-                        // VerificationResult needs updates to incorporate profile data to support profile data of txns
-                        metadata: ExecutionMetadata::V1,
-                    },
-                };
-                (receipt, outcome)
-            };
-
+            // Accumulate burnt gas stats.
             match safe_add_balance(
                 processing_state.stats.balance.tx_burnt_amount,
-                verification_result.burnt_amount,
+                outcome.outcome.tokens_burnt,
             ) {
                 Ok(new_balance) => {
                     processing_state.stats.balance.tx_burnt_amount = new_balance;
@@ -1939,7 +2008,7 @@ impl Runtime {
                     tracing::error!(
                         target: "runtime",
                         tx_hash=?tx.hash(),
-                        tx_burnt_amount=?verification_result.burnt_amount,
+                        tx_burnt_amount=?outcome.outcome.tokens_burnt,
                         ?err,
                         "chunk total burnt gas overflow",
                     );
@@ -1947,23 +2016,17 @@ impl Runtime {
                 }
             }
 
-            if receipt.receiver_id() == signer_id {
-                processing_state.local_receipts.push_back(receipt);
-            } else {
-                receipt_sink.forward_or_buffer_receipt(
-                    receipt,
-                    &processing_state.apply_state,
-                    &mut processing_state.state_update,
-                )?;
-            }
-            let compute = outcome.outcome.compute_usage;
-            let compute = compute.expect("`process_transaction` must populate compute usage");
+            let compute = outcome
+                .outcome
+                .compute_usage
+                .expect("`process_transaction` must populate compute usage");
             processing_state.total.add(outcome.outcome.gas_burnt.as_gas(), compute)?;
             processing_state.outcomes.push(outcome);
-            metrics::TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL.inc();
+
+            result.apply(account, access_key);
             set_account(&mut processing_state.state_update, signer_id.clone(), account);
             // Update gas key nonce if applicable
-            if let Some((nonce_index, new_nonce)) = verification_result.gas_key_nonce_update {
+            if let Some((nonce_index, new_nonce)) = result.gas_key_nonce_update() {
                 set_gas_key_nonce(
                     &mut processing_state.state_update,
                     signer_id.clone(),

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -3638,6 +3638,7 @@ struct GasKeyTestSetup {
     apply_state: ApplyState,
     epoch_info_provider: MockEpochInfoProvider,
     gas_key_signer: Arc<Signer>,
+    shard_uid: ShardUId,
 }
 
 fn setup_gas_key_test(
@@ -3669,7 +3670,6 @@ fn setup_gas_key_test(
     apply_state.current_protocol_version = ProtocolFeature::GasKeys.protocol_version();
     apply_state.block_height = GAS_KEY_BLOCK_HEIGHT;
 
-    let shard_uid = ShardUId::single_shard();
     let mut state_update = tries.new_trie_update(shard_uid, root);
 
     let mut account = get_account(&state_update, &gas_key_owner).unwrap().unwrap();
@@ -3709,7 +3709,15 @@ fn setup_gas_key_test(
     let root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
     store_update.commit().unwrap();
 
-    GasKeyTestSetup { runtime, tries, root, apply_state, epoch_info_provider, gas_key_signer }
+    GasKeyTestSetup {
+        runtime,
+        tries,
+        root,
+        apply_state,
+        epoch_info_provider,
+        gas_key_signer,
+        shard_uid,
+    }
 }
 
 #[test]
@@ -3725,7 +3733,7 @@ fn test_apply_gas_key_transaction() {
         mut apply_state,
         epoch_info_provider,
         gas_key_signer,
-        ..
+        shard_uid,
     } = setup_gas_key_test(
         alice_account(),
         vec![alice_account(), bob_account()],
@@ -3734,7 +3742,6 @@ fn test_apply_gas_key_transaction() {
         gas_key_balance,
     );
 
-    let shard_uid = ShardUId::single_shard();
     let initial_nonce = initial_nonce_value(GAS_KEY_BLOCK_HEIGHT);
     let nonce_index = 1;
 
@@ -3818,7 +3825,7 @@ fn test_gas_refund_to_gas_key() {
         mut apply_state,
         epoch_info_provider,
         gas_key_signer,
-        ..
+        shard_uid,
     } = setup_gas_key_test(
         alice_account(),
         vec![alice_account()],
@@ -3826,8 +3833,6 @@ fn test_gas_refund_to_gas_key() {
         1,
         gas_key_balance,
     );
-
-    let shard_uid = ShardUId::single_shard();
 
     // Create a gas refund receipt targeting alice's gas key
     let refund_amount = Balance::from_millinear(1);
@@ -3913,7 +3918,7 @@ fn test_gas_key_tx_deposit_insufficient_charges_gas() {
         mut apply_state,
         epoch_info_provider,
         gas_key_signer,
-        ..
+        shard_uid,
     } = setup_gas_key_test(
         alice_account(),
         vec![alice_account(), bob_account()],
@@ -3922,7 +3927,6 @@ fn test_gas_key_tx_deposit_insufficient_charges_gas() {
         gas_key_balance,
     );
 
-    let shard_uid = ShardUId::single_shard();
     let initial_nonce = initial_nonce_value(GAS_KEY_BLOCK_HEIGHT);
     let nonce_index: NonceIndex = 0;
 

--- a/test-loop-tests/src/tests/gas_keys.rs
+++ b/test-loop-tests/src/tests/gas_keys.rs
@@ -317,3 +317,5 @@ fn test_gas_key_refund() {
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(5));
 }
+
+// TODO(gas-keys): Add test-loop test for DepositFailed (deposit-insufficient gas key tx).


### PR DESCRIPTION
- When a gas key transaction fails because the account can't cover the deposit, gas is still charged from the gas key balance. This prevents SPICE spam where an attacker drains their account between submission and execution to get free transactions.
- Refactored verifier functions (`verify_and_charge_tx_ephemeral`, `verify_and_charge_gas_key_tx_ephemeral`) to return a `TxVerdict` enum instead of mutating account/access key directly (see #14965). Callers apply state changes via `VerificationResult::apply()`.
- Added `NotEnoughBalanceForDeposit` error variant.
- `test_gas_key_tx_deposit_insufficient_charges_gas` (apply-level), `test_gas_key_tx_deposit_failed_for_{account_balance, storage_stake}` (verifier-level)
- Will fix protocol schema and openapi.json after review.