### PR TITLE
feat(epoch-sync): support epoch sync for nodes with existing state

### DIFF
--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -634,6 +634,13 @@ impl Doomslug {
         }
     }
 
+    /// Resets the doomslug tip to height 0. Used after epoch sync resets the
+    /// chain head back to genesis, so that the next `set_tip` call won't fail
+    /// the assertion that height must increase.
+    pub fn reset_tip(&mut self) {
+        self.tip = DoomslugTip { block_hash: CryptoHash::default(), height: 0 };
+    }
+
     /// Updates the current tip of the chain. Restarts the timer accordingly.
     ///
     /// # Arguments

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -275,6 +275,18 @@ impl FlatStorageManager {
         }
     }
 
+    pub fn remove_all_flat_storages(
+        &self,
+        store_update: &mut FlatStoreUpdateAdapter,
+    ) -> Result<(), StorageError> {
+        let mut flat_storages = self.0.flat_storages.lock();
+        for (shard_uid, flat_storage) in flat_storages.drain() {
+            flat_storage.clear_state(store_update)?;
+            tracing::info!(target: "store", ?shard_uid, "remove_all_flat_storages removed this shard's flat storage");
+        }
+        Ok(())
+    }
+
     /// Returns None if there's no resharding flat storage split in progress
     /// If there is, returns Some(None) if there's at least one child shard that hasn't been split and had its
     /// status set to `CatchingUp`. If they've all been split already and are in the catchup phase,

--- a/test-loop-tests/src/tests/continuous_epoch_sync.rs
+++ b/test-loop-tests/src/tests/continuous_epoch_sync.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use near_async::time::Duration;
 use near_epoch_manager::epoch_sync::derive_epoch_sync_proof_from_last_block;
 use near_o11y::testonly::init_test_logger;
@@ -6,7 +9,7 @@ use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::epoch_store::EpochStoreAdapter;
 
-use crate::setup::builder::TestLoopBuilder;
+use crate::setup::builder::{NodeStateBuilder, TestLoopBuilder};
 use crate::utils::account::{create_validators_spec, validators_spec_clients};
 use crate::utils::node::TestLoopNode;
 
@@ -140,4 +143,215 @@ fn validate_epoch_sync_proof(epoch_store: &EpochStoreAdapter, first_block_hash: 
     .unwrap();
 
     assert_eq!(proof, expected_proof.into_v1());
+}
+
+/// Test that a node killed and restarted after peers have advanced beyond GC
+/// can catch up via epoch sync when ContinuousEpochSync is enabled.
+///
+/// Verifies the node walks through the complete sync pipeline:
+/// AwaitingPeers → NoSync → EpochSync → EpochSyncDone → HeaderSync → StateSync → StateSyncDone → BlockSync → NoSync
+#[test]
+fn test_epoch_sync_catchup_restart_node() {
+    if !ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+
+    init_test_logger();
+
+    let epoch_length = 10;
+    let gc_num_epochs_to_keep = 3;
+
+    let validators_spec = create_validators_spec(4, 0);
+    let clients = validators_spec_clients(&validators_spec);
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .validators_spec(validators_spec)
+        .build();
+
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(clients)
+        .gc_num_epochs_to_keep(gc_num_epochs_to_keep)
+        .config_modifier(|config, _idx| {
+            config.epoch_sync.epoch_sync_horizon = 30;
+        })
+        .build()
+        .warmup();
+
+    let restart_node = TestLoopNode::from(env.node_datas[0].clone());
+    let stable_node = TestLoopNode::from(env.node_datas[1].clone());
+
+    // Progress all nodes for 3 epochs, then kill node 0.
+    let kill_height = 3 * epoch_length;
+    restart_node.run_until_head_height(&mut env.test_loop, kill_height);
+    let killed_node_state = env.kill_node(&restart_node.data().identifier);
+
+    // Progress remaining nodes beyond the GC period.
+    let target_height = kill_height + (gc_num_epochs_to_keep + 5) * epoch_length + 7;
+    stable_node.run_until_head_height(&mut env.test_loop, target_height);
+
+    // Restart the killed node.
+    let restart_account_id = restart_node.data().account_id.clone();
+    let restart_identifier = format!("{}-restart", restart_node.data().identifier);
+    env.restart_node(&restart_identifier, killed_node_state);
+
+    let restart_node = TestLoopNode::for_account(&env.node_datas, &restart_account_id);
+
+    // Track sync status transitions on the restarted node.
+    let restart_handle = restart_node.data().client_sender.actor_handle();
+    let stable_handle = stable_node.data().client_sender.actor_handle();
+    let sync_status_history = Rc::new(RefCell::new(Vec::<String>::new()));
+    {
+        let sync_status_history = sync_status_history.clone();
+        env.test_loop.set_every_event_callback(move |test_loop_data| {
+            let client = &test_loop_data.get(&restart_handle).client;
+            let sync_status = client.sync_handler.sync_status.as_variant_name();
+            let mut history = sync_status_history.borrow_mut();
+            if history.last().map(|s| s as &str) != Some(sync_status) {
+                history.push(sync_status.to_string());
+            }
+        });
+    }
+
+    // Run until the restarted node catches up to the stable node.
+    let restart_handle = restart_node.data().client_sender.actor_handle();
+    env.test_loop.run_until(
+        |test_loop_data| {
+            let stable_height =
+                test_loop_data.get(&stable_handle).client.chain.head().unwrap().height;
+            let restart_height =
+                test_loop_data.get(&restart_handle).client.chain.head().unwrap().height;
+            restart_height == stable_height
+        },
+        Duration::seconds(60),
+    );
+
+    assert_eq!(
+        sync_status_history.borrow().as_slice(),
+        &[
+            "AwaitingPeers",
+            "NoSync",
+            "EpochSync",
+            "EpochSyncDone",
+            "HeaderSync",
+            "StateSync",
+            "StateSyncDone",
+            "BlockSync",
+            "NoSync",
+        ]
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>()
+    );
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Test that a brand-new node joining after the network has advanced beyond GC
+/// can catch up via epoch sync when ContinuousEpochSync is enabled.
+///
+/// Verifies the node walks through the complete sync pipeline:
+/// AwaitingPeers → NoSync → EpochSync → EpochSyncDone → HeaderSync → StateSync → StateSyncDone → BlockSync → NoSync
+#[test]
+fn test_epoch_sync_catchup_fresh_node() {
+    if !ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+
+    init_test_logger();
+
+    let epoch_length = 10;
+    let gc_num_epochs_to_keep = 3;
+
+    let validators_spec = create_validators_spec(4, 0);
+    let clients = validators_spec_clients(&validators_spec);
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .validators_spec(validators_spec)
+        .build();
+
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(clients)
+        .gc_num_epochs_to_keep(gc_num_epochs_to_keep)
+        .config_modifier(|config, _idx| {
+            config.epoch_sync.epoch_sync_horizon = 30;
+        })
+        .build()
+        .warmup();
+
+    let stable_node = TestLoopNode::from(env.node_datas[0].clone());
+
+    // Progress all validators beyond the GC period.
+    let target_height = (gc_num_epochs_to_keep + 8) * epoch_length;
+    stable_node.run_until_head_height(&mut env.test_loop, target_height);
+
+    // Add a brand-new node with only genesis state.
+    let fresh_identifier = "fresh_node0";
+    let fresh_account_id: near_primitives::types::AccountId = fresh_identifier.parse().unwrap();
+    let node_state = NodeStateBuilder::new(
+        env.shared_state.genesis.clone(),
+        env.shared_state.tempdir.path().to_path_buf(),
+    )
+    .account_id(fresh_account_id.clone())
+    .config_modifier(|config| {
+        config.epoch_sync.epoch_sync_horizon = 30;
+    })
+    .build();
+    env.add_node(fresh_identifier, node_state);
+
+    let fresh_node = TestLoopNode::for_account(&env.node_datas, &fresh_account_id);
+
+    // Track sync status transitions on the fresh node.
+    let fresh_handle = fresh_node.data().client_sender.actor_handle();
+    let stable_handle = stable_node.data().client_sender.actor_handle();
+    let sync_status_history = Rc::new(RefCell::new(Vec::<String>::new()));
+    {
+        let sync_status_history = sync_status_history.clone();
+        env.test_loop.set_every_event_callback(move |test_loop_data| {
+            let client = &test_loop_data.get(&fresh_handle).client;
+            let sync_status = client.sync_handler.sync_status.as_variant_name();
+            let mut history = sync_status_history.borrow_mut();
+            if history.last().map(|s| s as &str) != Some(sync_status) {
+                history.push(sync_status.to_string());
+            }
+        });
+    }
+
+    // Run until the fresh node catches up to the stable node.
+    let fresh_handle = fresh_node.data().client_sender.actor_handle();
+    env.test_loop.run_until(
+        |test_loop_data| {
+            let stable_height =
+                test_loop_data.get(&stable_handle).client.chain.head().unwrap().height;
+            let fresh_height =
+                test_loop_data.get(&fresh_handle).client.chain.head().unwrap().height;
+            fresh_height == stable_height
+        },
+        Duration::seconds(60),
+    );
+
+    assert_eq!(
+        sync_status_history.borrow().as_slice(),
+        &[
+            "AwaitingPeers",
+            "NoSync",
+            "EpochSync",
+            "EpochSyncDone",
+            "HeaderSync",
+            "StateSync",
+            "StateSyncDone",
+            "BlockSync",
+            "NoSync",
+        ]
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>()
+    );
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }


### PR DESCRIPTION
Enable epoch sync for non-genesis nodes when ContinuousEpochSync is enabled. Previously, epoch sync was restricted to nodes bootstrapping from genesis. This change allows nodes that have been offline beyond the GC period to catch up by clearing their existing store data and re-applying from a clean genesis state before the epoch sync proof is applied.

Adds `reset_data_pre_epoch_sync` which wipes all store columns (except DbVersion), re-saves genesis data, and resets flat storage. Also resets the doomslug tip after epoch sync and initializes StateSyncNewChunks for the epoch boundary header so that header sync can correctly build the sync hash chain.

The existing `test_epoch_sync_catchup` test is split into two focused tests (`test_epoch_sync_catchup_restart_node` and `test_epoch_sync_catchup_fresh_node`) that assert the full sync status pipeline: AwaitingPeers → NoSync → EpochSync → EpochSyncDone → HeaderSync → StateSync → StateSyncDone → BlockSync → NoSync.