### PR TITLE
fix(state-sync): fall back to previous epoch sync hash in get_sync_hash

### DIFF
--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -256,7 +256,8 @@ impl Chain {
         // The current epoch may not have a sync hash yet (e.g. if we just crossed
         // an epoch boundary during header sync and there aren't enough blocks with
         // new chunks in the new epoch). Fall back to the previous epoch's sync hash.
-        let prev_epoch_id = self.epoch_manager.get_prev_epoch_id_from_prev_block(header.prev_hash())?;
+        let prev_epoch_id =
+            self.epoch_manager.get_prev_epoch_id_from_prev_block(header.prev_hash())?;
         self.chain_store.get_current_epoch_sync_hash(&prev_epoch_id)
     }
 


### PR DESCRIPTION
## Summary

- `get_sync_hash` resolves the block hash used as a reference point for state sync. It
  looks up `DBCol::StateSyncHashes` for the epoch that `header_head` belongs to.
- The sync hash for an epoch is only written to StateSyncHashes (by update_sync_hashes →
   on_new_header) once enough blocks have been processed such that every shard has at
  least 2 new chunks and the candidate block is finalized. **This happens some blocks into
  the epoch, not immediately at the boundary.**
- When `header_head` crosses into epoch N+1 before that threshold is met, `get_sync_hash`
  finds no entry for epoch N+1 and returns None. This prevents state sync from starting. This is the bug.
- Technically in this case we should be using previous epoch sync hash. The previous epoch's sync hash is still available — remove_old_epochs explicitly
  retains entries for both the current and previous epoch. This fix falls back to the
  previous epoch's sync hash when the current one isn't available yet.

## Test plan

- Verified by existing `test_epoch_sync_catchup_restart_node` and `test_epoch_sync_catchup_fresh_node` tests, which assert the full sync pipeline including `StateSync` → `StateSyncDone`. Without this fix, those tests get stuck at `HeaderSync`.

Both those tests are part of PR https://github.com/near/nearcore/pull/15035