### PR TITLE
refactor(store): remove Result from StoreUpdate::commit()

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2607,7 +2607,7 @@ impl Chain {
         let mut store_update = self.chain_store.store().store_update();
         store_update.delete_all(DBCol::StateParts);
         store_update.delete_all(DBCol::StateHeaders);
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -383,7 +383,7 @@ impl ChainStore {
         }
 
         metrics::STATE_TRANSITION_DATA_GC_TOTAL_ENTRIES.set(total_entries);
-        store_update.commit()?;
+        store_update.commit();
         metrics::STATE_TRANSITION_DATA_GC_CLEARED_ENTRIES.inc_by(entries_cleared);
         Ok(())
     }
@@ -429,7 +429,7 @@ impl ChainStore {
         }
 
         metrics::WITNESSES_GC_TOTAL_ENTRIES.set(total_entries);
-        store_update.commit()?;
+        store_update.commit();
         metrics::WITNESSES_GC_CLEARED_ENTRIES.inc_by(entries_cleared);
         Ok(())
     }

--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -331,7 +331,7 @@ fn get_genesis_congestion_infos_impl(
     tracing::debug!(target: "chain", "saving genesis congestion infos to database");
     let mut store_update = runtime.store().store_update();
     near_store::set_genesis_congestion_infos(&mut store_update, &new_infos);
-    store_update.commit()?;
+    store_update.commit();
 
     Ok(new_infos)
 }

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -183,7 +183,7 @@ impl TrieStateResharder {
                 &borsh::to_vec(status)?,
             );
         }
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 
@@ -311,7 +311,7 @@ impl TrieStateResharder {
 
         let mut store_update = self.runtime.store().store_update();
         store_update.set(DBCol::Misc, TRIE_STATE_RESHARDING_STATUS_KEY, &borsh::to_vec(&status)?);
-        store_update.commit()?;
+        store_update.commit();
 
         Ok(())
     }
@@ -681,7 +681,7 @@ mod tests {
             chain_store_update
                 .set_ser(near_store::DBCol::ChunkExtra, &block_shard_uid, &chunk_extra)
                 .unwrap();
-            chain_store_update.commit().unwrap();
+            chain_store_update.commit();
 
             // Now unload the parent memtrie, so the test can verify
             // it will get loaded correctly during resume.

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -161,7 +161,7 @@ impl TestEnv {
                     &genesis_hash,
                     0,
                 );
-                store_update.commit().unwrap();
+                store_update.commit();
                 assert!(matches!(
                     flat_storage_manager.get_flat_storage_status(shard_uid),
                     near_store::flat::FlatStorageStatus::Ready(_)
@@ -310,7 +310,7 @@ impl TestEnv {
             let new_store_update = flat_storage.add_delta(delta).unwrap();
             store_update.merge(new_store_update.into());
         }
-        store_update.commit().unwrap();
+        store_update.commit();
 
         (apply_result.new_root, apply_result.validator_proposals, apply_result.outgoing_receipts)
     }

--- a/chain/chain/src/spice_core_writer_actor.rs
+++ b/chain/chain/src/spice_core_writer_actor.rs
@@ -417,7 +417,7 @@ impl SpiceCoreWriterActor {
         let store_update = self
             .record_chunk_endorsements_with_block(&block, vec![endorsement])
             .map_err(ProcessChunkError::RecordWithBlock)?;
-        store_update.commit()?;
+        store_update.commit();
         // We record endorsement even when execution result is known to allow it being included on
         // chain when execution result isn't endorsed on chain yet.
         // However since we already know about execution result for this endorsement there should
@@ -531,7 +531,7 @@ impl SpiceCoreWriterActor {
         let block = self.chain_store.get_block(&block_hash).unwrap();
         // Since block was already processed we know it's valid so can record it in core state.
         let store_update = self.record_block_core_statements(&block)?;
-        store_update.commit()?;
+        store_update.commit();
         self.send_execution_result_endorsements(&block);
         Ok(())
     }

--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -269,7 +269,7 @@ impl ChainStateSyncAdapter {
         // Saving the header data
         let mut store_update = self.chain_store.store().store_update();
         store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header)?;
-        store_update.commit()?;
+        store_update.commit();
 
         Ok(shard_state_header)
     }
@@ -346,7 +346,7 @@ impl ChainStateSyncAdapter {
         let mut store_update = self.chain_store.store().store_update();
         let bytes = state_part.to_bytes(protocol_version);
         store_update.set(DBCol::StateParts, &key, &bytes);
-        store_update.commit()?;
+        store_update.commit();
 
         Ok(state_part)
     }
@@ -520,7 +520,7 @@ impl ChainStateSyncAdapter {
         let mut store_update = self.chain_store.store().store_update();
         let key = borsh::to_vec(&StateHeaderKey(shard_id, sync_hash))?;
         store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header)?;
-        store_update.commit()?;
+        store_update.commit();
 
         Ok(())
     }
@@ -553,7 +553,7 @@ impl ChainStateSyncAdapter {
         let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id.idx))?;
         let bytes = part.to_bytes(protocol_version);
         store_update.set(DBCol::StateParts, &key, &bytes);
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 

--- a/chain/chain/src/store/latest_witnesses.rs
+++ b/chain/chain/src/store/latest_witnesses.rs
@@ -222,7 +222,7 @@ impl ChainStore {
         let store_update_time = start_time.elapsed();
 
         // Commit the transaction
-        store_update.commit()?;
+        store_update.commit();
 
         let store_commit_time = start_time.elapsed().saturating_sub(store_update_time);
 
@@ -413,7 +413,7 @@ pub fn save_invalid_chunk_state_witness(
         let store_update_time = start_time.elapsed();
 
         // Commit the transaction
-        store_update.commit()?;
+        store_update.commit();
 
         let store_commit_time = start_time.elapsed().saturating_sub(store_update_time);
 

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -600,7 +600,8 @@ impl ChainStore {
     pub fn save_latest_known(&mut self, latest_known: LatestKnown) -> Result<(), Error> {
         let mut store_update = self.store.store().store_update();
         store_update.set_ser(DBCol::BlockMisc, LATEST_KNOWN_KEY, &latest_known)?;
-        store_update.commit().map_err(|err| err.into())
+        store_update.commit();
+        Ok(())
     }
 
     /// Retrieve the kinds of state changes occurred in a given block.
@@ -810,7 +811,8 @@ impl ChainStore {
             None => store_update.delete(DBCol::BlockMisc, &key),
             Some(value) => store_update.set_ser(DBCol::BlockMisc, &key, &value)?,
         }
-        store_update.commit().map_err(|err| err.into())
+        store_update.commit();
+        Ok(())
     }
 
     pub fn prev_block_is_caught_up(
@@ -2207,7 +2209,7 @@ impl<'a> ChainStoreUpdate<'a> {
     #[tracing::instrument(level = "debug", target = "store", "ChainStoreUpdate::commit", skip_all)]
     pub fn commit(mut self) -> Result<(), Error> {
         let store_update = self.finalize()?;
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 }

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -468,7 +468,7 @@ mod tests {
             chain.get_block_by_height(0).unwrap().hash().as_ref(),
             &[123],
         );
-        store_update.commit().unwrap();
+        store_update.commit();
         match sv.validate_col(DBCol::Block) {
             Err(StoreValidatorError::IOError(_)) => {}
             _ => assert!(false),
@@ -481,7 +481,7 @@ mod tests {
         let mut store_update = chain.chain_store().store().store_update();
         assert!(sv.validate_col(DBCol::TrieChanges).is_ok());
         store_update.set_ser::<[u8]>(DBCol::TrieChanges, "567".as_ref(), &[123]).unwrap();
-        store_update.commit().unwrap();
+        store_update.commit();
         match sv.validate_col(DBCol::TrieChanges) {
             Err(StoreValidatorError::DBCorruption(_)) => {}
             _ => assert!(false),

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -73,7 +73,7 @@ impl ChunkTestFixture {
         let store = create_test_store();
         let mut store_update = store.store_update();
         set_genesis_height(&mut store_update, &0);
-        store_update.commit().unwrap();
+        store_update.commit();
 
         let epoch_manager = setup_epoch_manager_with_block_and_chunk_producers(
             store.clone(),

--- a/chain/client/src/archive/cold_store_actor.rs
+++ b/chain/client/src/archive/cold_store_actor.rs
@@ -418,7 +418,7 @@ pub fn create_cold_store_actor(
     // Save the genesis height to cold storage
     let mut store_update = cold_db.as_store().store_update();
     set_genesis_height(&mut store_update, &genesis_height);
-    store_update.commit()?;
+    store_update.commit();
 
     // Perform the sanity check before spawning the actor.
     // If the check fails when the node is starting it's better to just fail

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -873,7 +873,7 @@ impl ChunkExecutorActor {
         for proof in receipt_proofs {
             save_receipt_proof(&mut store_update, &block_hash, &proof)?
         }
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 
@@ -882,7 +882,7 @@ impl ChunkExecutorActor {
         let mut store_update = store.store_update();
         let VerifiedReceipts { receipt_proof, block_hash } = verified_receipts;
         save_receipt_proof(&mut store_update, &block_hash, &receipt_proof)?;
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 
@@ -1036,7 +1036,7 @@ pub(crate) fn save_witness(
     let key = get_witnesses_key(block_hash, shard_id);
     let value = borsh::to_vec(&witness)?;
     store_update.set(DBCol::witnesses(), &key, &value);
-    store_update.commit()?;
+    store_update.commit();
     Ok(())
 }
 

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -298,7 +298,7 @@ impl EpochSync {
             &proof.current_epoch.partial_merkle_tree_for_first_block,
         );
 
-        store_update.commit()?;
+        store_update.commit();
 
         *status = SyncStatus::EpochSyncDone;
         tracing::info!(epoch_id=?last_header.epoch_id(), "bootstrapped from epoch sync");

--- a/chain/client/src/sync/state/downloader.rs
+++ b/chain/client/src/sync/state/downloader.rs
@@ -201,9 +201,7 @@ impl StateSyncDownloader {
                     let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id)).unwrap();
                     let bytes = part.to_bytes(protocol_version);
                     store_update.set(DBCol::StateParts, &key, &bytes);
-                    store_update.commit().map_err(|e| {
-                        near_chain::Error::Other(format!("Failed to store part: {}", e))
-                    })?;
+                    store_update.commit();
                 } else {
                     return Err(near_chain::Error::Other("Part data failed validation".to_owned()));
                 }

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -160,7 +160,7 @@ pub(super) async fn run_state_sync_for_shard(
         runtime
             .get_flat_storage_manager()
             .remove_flat_storage_for_shard(shard_uid, &mut store_update.flat_store_update())?;
-        store_update.commit()?;
+        store_update.commit();
     }
 
     return_if_cancelled!(cancel);
@@ -327,7 +327,7 @@ async fn apply_state_part(
     // Mark part as applied.
     let mut store_update = store.store_update();
     store_update.set_ser(DBCol::StatePartsApplied, &key_bytes, &true)?;
-    store_update.commit()?;
+    store_update.commit();
 
     Ok(StatePartApplyResult::Applied)
 }
@@ -393,7 +393,7 @@ mod tests {
 
         let mut store_update = store.store_update();
         store_update.set(DBCol::StateParts, &key_bytes, &part_bytes);
-        store_update.commit().unwrap();
+        store_update.commit();
 
         // Apply the state part for the first time
         let result = apply_state_part(

--- a/chain/client/src/tests/spice_data_distributor_actor.rs
+++ b/chain/client/src/tests/spice_data_distributor_actor.rs
@@ -922,7 +922,7 @@ fn test_incoming_partial_data_for_already_known_receipts() {
     let receipt_proof = new_test_receipt_proof(&block);
     let mut store_update = chain.chain_store.store().store_update();
     save_receipt_proof(&mut store_update, block.hash(), &receipt_proof).unwrap();
-    store_update.commit().unwrap();
+    store_update.commit();
     let (incoming_data, recipient) = receipt_proof_incoming_data(&chain, &block);
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
@@ -1573,7 +1573,7 @@ fn test_not_requesting_receipts_we_already_have_on_start() {
         &ReceiptProof(vec![], ShardProof { from_shard_id, to_shard_id, proof: vec![] }),
     )
     .unwrap();
-    store_update.commit().unwrap();
+    store_update.commit();
 
     save_final_execution_head(&mut chain, &block);
 
@@ -1941,7 +1941,7 @@ fn test_handling_partial_data_request_with_receipts_in_store() {
     let receipt_proof = new_test_receipt_proof(&block);
     let mut store_update = chain.chain_store.store().store_update();
     save_receipt_proof(&mut store_update, block.hash(), &receipt_proof).unwrap();
-    store_update.commit().unwrap();
+    store_update.commit();
     let producer = producers_of_receipt_proof(&chain, &block, &receipt_proof).swap_remove(0);
     let (_incoming_data, recipient) = receipt_proof_incoming_data(&chain, &block);
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
@@ -2053,7 +2053,7 @@ fn test_requesting_receipts_when_not_validator() {
     let receipt_proof = new_test_receipt_proof(&block);
     let mut store_update = chain.chain_store.store().store_update();
     save_receipt_proof(&mut store_update, block.hash(), &receipt_proof).unwrap();
-    store_update.commit().unwrap();
+    store_update.commit();
 
     let producer = producers_of_receipt_proof(&chain, &block, &receipt_proof).swap_remove(0);
     let data_id = SpiceDataIdentifier::ReceiptProof {

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -76,7 +76,7 @@ fn write_to_db(store: &Store, keys: &[Vec<u8>], max_value_size: usize, col: DBCo
         // NOTE:  this
         store_update.set(col, &key, &val);
     }
-    store_update.commit().unwrap();
+    store_update.commit();
 }
 
 fn benchmark_write_then_read_successful_10m(bench: &mut Bencher) {

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -381,7 +381,8 @@ impl Into<StoreUpdate> for ChainStoreUpdateAdapter<'static> {
 impl ChainStoreUpdateAdapter<'static> {
     pub fn commit(self) -> io::Result<()> {
         let store_update: StoreUpdate = self.into();
-        store_update.commit()
+        store_update.commit();
+        Ok(())
     }
 }
 

--- a/core/store/src/adapter/epoch_store.rs
+++ b/core/store/src/adapter/epoch_store.rs
@@ -130,7 +130,8 @@ impl Into<StoreUpdate> for EpochStoreUpdateAdapter<'static> {
 impl EpochStoreUpdateAdapter<'static> {
     pub fn commit(self) -> io::Result<()> {
         let store_update: StoreUpdate = self.into();
-        store_update.commit()
+        store_update.commit();
+        Ok(())
     }
 }
 

--- a/core/store/src/adapter/flat_store.rs
+++ b/core/store/src/adapter/flat_store.rs
@@ -203,7 +203,8 @@ impl Into<StoreUpdate> for FlatStoreUpdateAdapter<'static> {
 impl FlatStoreUpdateAdapter<'static> {
     pub fn commit(self) -> io::Result<()> {
         let store_update: StoreUpdate = self.into();
-        store_update.commit()
+        store_update.commit();
+        Ok(())
     }
 }
 

--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -107,7 +107,8 @@ impl Into<StoreUpdate> for TrieStoreUpdateAdapter<'static> {
 impl TrieStoreUpdateAdapter<'static> {
     pub fn commit(self) -> io::Result<()> {
         let store_update: StoreUpdate = self.into();
-        store_update.commit()
+        store_update.commit();
+        Ok(())
     }
 }
 

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -190,7 +190,8 @@ fn update_state_shard_uid_mapping(cold_db: &ColdDB, shard_layout: &ShardLayout) 
             update.trie_store_update().set_shard_uid_mapping(child_shard_uid, mapped_shard_uid);
         }
     }
-    update.commit()
+    update.commit();
+    Ok(())
 }
 
 // A specialized version of copy_from_store for the State column. Finds all the

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -908,12 +908,12 @@ mod tests {
         {
             let mut store_update = store.store_update();
             store_update.increment_refcount(DBCol::State, &[1; 8], &[1]);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
         {
             let mut store_update = store.store_update();
             store_update.increment_refcount(DBCol::State, &[1; 8], &[1]);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
         assert_eq!(store.get(DBCol::State, &[1; 8]).as_deref(), Some(&[1][..]));
         assert_eq!(
@@ -923,7 +923,7 @@ mod tests {
         {
             let mut store_update = store.store_update();
             store_update.decrement_refcount(DBCol::State, &[1; 8]);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
         assert_eq!(store.get(DBCol::State, &[1; 8]).as_deref(), Some(&[1][..]));
         assert_eq!(
@@ -933,7 +933,7 @@ mod tests {
         {
             let mut store_update = store.store_update();
             store_update.decrement_refcount(DBCol::State, &[1; 8]);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
         // Refcount goes to 0 -> get() returns None
         assert_eq!(store.get(DBCol::State, &[1; 8]), None);
@@ -998,11 +998,11 @@ mod tests {
         for key in &keys {
             store_update.insert(column, key.clone(), vec![42]);
         }
-        store_update.commit().unwrap();
+        store_update.commit();
 
         let mut store_update = store.store_update();
         store_update.delete_range(column, &keys[1], &keys[3]);
-        store_update.commit().unwrap();
+        store_update.commit();
 
         assert_matches!(store.exists(column, &keys[0]), true);
         assert_matches!(store.exists(column, &keys[1]), false);

--- a/core/store/src/db/rocksdb/snapshot.rs
+++ b/core/store/src/db/rocksdb/snapshot.rs
@@ -173,7 +173,7 @@ fn test_snapshot_recovery() {
         let store = opener.open().unwrap().get_hot_store();
         let mut update = store.store_update();
         update.set_raw_bytes(COL, KEY, b"value");
-        update.commit().unwrap();
+        update.commit();
     }
 
     // Create snapshot
@@ -185,7 +185,7 @@ fn test_snapshot_recovery() {
         let store = opener.open().unwrap().get_hot_store();
         let mut update = store.store_update();
         update.delete(COL, KEY);
-        update.commit().unwrap();
+        update.commit();
 
         assert_eq!(None, store.get(COL, KEY));
     }

--- a/core/store/src/genesis/initialization.rs
+++ b/core/store/src/genesis/initialization.rs
@@ -41,7 +41,7 @@ pub fn initialize_sharded_genesis_state(
         // TODO: with 2.6 release, remove storing genesis height
         let mut store_update: crate::StoreUpdate = store.store_update();
         set_genesis_height(&mut store_update, &genesis.config.genesis_height);
-        store_update.commit().expect("Store failed on genesis initialization");
+        store_update.commit();
 
         let genesis_height = get_genesis_height(&store)
             .expect("Store failed on genesis initialization")
@@ -64,7 +64,7 @@ pub fn initialize_sharded_genesis_state(
         let mut store_update = store.store_update();
         set_genesis_state_roots(&mut store_update, &state_roots);
         set_genesis_height(&mut store_update, &genesis.config.genesis_height);
-        store_update.commit().expect("Store failed on genesis initialization");
+        store_update.commit();
         state_roots
     };
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -53,13 +53,13 @@ mod tests {
             store_update.increment_refcount(DBCol::State, &[1; 8], &[1]);
             store_update.increment_refcount(DBCol::State, &[2; 8], &[2]);
             store_update.increment_refcount(DBCol::State, &[3; 8], &[3]);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
         assert_eq!(store.get(DBCol::State, &[1; 8]).as_deref(), Some(&[1][..]));
         {
             let mut store_update = store.store_update();
             store_update.delete_all(DBCol::State);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
         assert_eq!(store.get(DBCol::State, &[1; 8]), None);
     }
@@ -111,7 +111,7 @@ mod tests {
                 update.set(COLUMN, &buf, &buf);
             }
         }
-        update.commit().unwrap();
+        update.commit();
 
         fn collect<'a>(iter: crate::db::DBIterator<'a>) -> Vec<Box<[u8]>> {
             iter.map(|(key, _)| key).collect()
@@ -158,7 +158,7 @@ mod tests {
             store_update.increment_refcount(DBCol::State, &[1; 8], &[1]);
             store_update.increment_refcount(DBCol::State, &[2; 8], &[2]);
             store_update.increment_refcount(DBCol::State, &[2; 8], &[2]);
-            store_update.commit().unwrap();
+            store_update.commit();
             store.save_state_to_file(tmp.path()).unwrap();
         }
 
@@ -192,7 +192,7 @@ mod tests {
             let mut store_update = store.store_update();
             store_update.decrement_refcount(DBCol::State, &[1; 8]);
             store_update.decrement_refcount(DBCol::State, &[2; 8]);
-            store_update.commit().unwrap();
+            store_update.commit();
             assert_eq!(None, store.get(DBCol::State, &[1; 8]));
             assert_eq!(Some(&[2u8][..]), store.get(DBCol::State, &[2; 8]).as_deref());
         }

--- a/core/store/src/node_storage/opener.rs
+++ b/core/store/src/node_storage/opener.rs
@@ -824,7 +824,7 @@ mod tests {
                 store_update.insert(column, key.clone(), vec![42]);
             }
         }
-        store_update.commit().unwrap();
+        store_update.commit();
 
         let store = checkpoint_hot_storage_and_cleanup_columns(
             &hot_store,

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -293,7 +293,8 @@ impl Store {
     pub fn set_db_version(&self, version: DbVersion) -> io::Result<()> {
         let mut store_update = self.store_update();
         store_update.set(DBCol::DbVersion, VERSION_KEY, version.to_string().as_bytes());
-        store_update.commit()
+        store_update.commit();
+        Ok(())
     }
 
     pub fn get_db_kind(&self) -> io::Result<Option<DbKind>> {
@@ -303,7 +304,8 @@ impl Store {
     pub fn set_db_kind(&self, kind: DbKind) -> io::Result<()> {
         let mut store_update = self.store_update();
         store_update.set(DBCol::DbVersion, KIND_KEY, <&str>::from(kind).as_bytes());
-        store_update.commit()
+        store_update.commit();
+        Ok(())
     }
 }
 
@@ -495,7 +497,7 @@ impl StoreUpdate {
             delete_range_ops
         )
     )]
-    pub fn commit(self) -> io::Result<()> {
+    pub fn commit(self) {
         debug_assert!(
             {
                 let non_refcount_keys = self
@@ -590,7 +592,7 @@ impl StoreUpdate {
                 }
             }
         }
-        self.store.write(self.transaction)
+        self.store.write(self.transaction).expect("Store::write failed");
     }
 }
 

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -542,6 +542,6 @@ mod tests {
         store_update
             .set_ser(DBCol::ChunkExtra, &get_block_shard_uid(&block_hash, &shard_uid), &chunk_extra)
             .unwrap();
-        store_update.commit().unwrap();
+        store_update.commit();
     }
 }

--- a/core/store/src/utils/test_utils.rs
+++ b/core/store/src/utils/test_utils.rs
@@ -214,7 +214,7 @@ impl TestTriesBuilder {
                     )
                     .unwrap();
             }
-            update_for_chunk_extra.commit().unwrap();
+            update_for_chunk_extra.commit();
 
             tries.load_memtries_for_enabled_shards(&shard_uids, &[].into(), false).unwrap();
         }
@@ -272,7 +272,7 @@ pub fn test_populate_store(store: &Store, data: impl Iterator<Item = (DBCol, Vec
     for (column, key, value) in data {
         update.insert(column, key, value);
     }
-    update.commit().expect("db commit failed");
+    update.commit();
 }
 
 /// Insert values to reference-counted columns in the store.
@@ -281,7 +281,7 @@ pub fn test_populate_store_rc(store: &Store, data: &[(DBCol, Vec<u8>, Vec<u8>)])
     for (column, key, value) in data {
         update.increment_refcount(*column, key, value);
     }
-    update.commit().expect("db commit failed");
+    update.commit();
 }
 
 fn gen_alphabet() -> Vec<u8> {

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -516,7 +516,7 @@ fn test_cold_loop_on_gc_boundary() {
     let cold_db = storage.cold_db().unwrap();
     let mut store_update = cold_db.as_store().store_update();
     set_genesis_height(&mut store_update, &0);
-    store_update.commit().unwrap();
+    store_update.commit();
 
     copy_all_data_to_cold(cold_db.clone(), &hot_store, 1000000, &keep_going).unwrap();
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2130,7 +2130,7 @@ fn slow_test_catchup_gas_price_change() {
                 )
                 .unwrap()
         );
-        store_update.commit().unwrap();
+        store_update.commit();
         let protocol_version =
             env.clients[1].epoch_manager.get_epoch_protocol_version(&epoch_id).unwrap();
         for part_id in 0..num_parts {

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -320,7 +320,7 @@ fn run_state_sync_with_dumped_parts(
             )
             .unwrap()
     );
-    store_update.commit().unwrap();
+    store_update.commit();
     let shard_id = ShardId::new(0);
     let protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id).unwrap();
     for part_id in 0..num_parts {

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -170,8 +170,7 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
 
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::BlockHeader);
-    store_update.commit()?;
-
+    store_update.commit();
     let chain_store = store.chain_store();
     let tail_height = chain_store.tail().unwrap();
     let latest_known_height =

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -759,7 +759,7 @@ impl ResetColdCmd {
         let mut store_update = cold_store.store_update();
         store_update.delete(DBCol::BlockMisc, HEAD_KEY);
         store_update.delete(DBCol::BlockMisc, COLD_HEAD_KEY);
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 }

--- a/tools/database/src/make_snapshot.rs
+++ b/tools/database/src/make_snapshot.rs
@@ -56,7 +56,7 @@ mod tests {
             for key in &keys {
                 store_update.insert(DBCol::Block, key.clone(), vec![42]);
             }
-            store_update.commit().unwrap();
+            store_update.commit();
             println!("Populated");
             // Drops node_storage, which unlocks the DB.
         }
@@ -71,7 +71,7 @@ mod tests {
             let node_storage = opener.open().unwrap();
             let mut store_update = node_storage.get_hot_store().store_update();
             store_update.delete_all(DBCol::Block);
-            store_update.commit().unwrap();
+            store_update.commit();
             println!("Deleted");
         }
 

--- a/tools/database/src/write_to_db.rs
+++ b/tools/database/src/write_to_db.rs
@@ -53,6 +53,7 @@ impl WriteCryptoHashCommand {
             },
         }
 
-        Ok(store_update.commit()?)
+        store_update.commit();
+        Ok(())
     }
 }

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -415,7 +415,7 @@ impl ForkNetworkCommand {
         for (shard_uid, state_root) in &state_roots {
             store_update.set_ser(DBCol::Misc, &make_state_roots_key(*shard_uid), state_root)?;
         }
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 
@@ -677,7 +677,7 @@ impl ForkNetworkCommand {
                 genesis_block.header().height(),
             );
         }
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -295,7 +295,7 @@ fn load_snapshot(load_cmd: LoadCmd) {
     let aggregator =
         EpochInfoAggregator::new(snapshot.prev_epoch.id, *snapshot.final_block.header.hash());
     store_update.set_ser(DBCol::EpochInfo, AGGREGATOR_KEY, &aggregator).unwrap();
-    store_update.commit().unwrap();
+    store_update.commit();
 }
 
 fn main() {

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -550,7 +550,7 @@ fn apply_block_from_range(
                     &state_transition_data,
                 )
                 .unwrap();
-            store_update.commit().unwrap();
+            store_update.commit();
         }
         (_, StorageSource::FlatStorage) => {
             // Apply trie changes to trie node caches.

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -1309,7 +1309,7 @@ pub(crate) fn contract_accounts(
 pub(crate) fn clear_cache(store: Store) {
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::CachedContractCode);
-    store_update.commit().unwrap();
+    store_update.commit();
 }
 
 /// Prints the state statistics for all shards. Please note that it relies on


### PR DESCRIPTION
## Summary

- `StoreUpdate::commit()` now returns `()` instead of `io::Result<()>`, panicking on RocksDB I/O errors via `.expect()` since these are irrecoverable
- Adapter `commit()` methods (`FlatStoreUpdateAdapter`, `ChainStoreUpdateAdapter`, `TrieStoreUpdateAdapter`, `EpochStoreUpdateAdapter`) temporarily bridge with `; Ok(())` — they will be simplified in individual follow-up PRs
- Updated all ~42 call sites across the codebase (`?` → removed, `.unwrap()` → removed, `.map_err(...)` → removed)

Part of the store layer simplification effort (#14816, #14817, #14819, #14821, #15038).

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-features --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)