### PR TITLE
refactor(store): remove Result from EpochStoreUpdateAdapter::commit()

### DIFF
--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -197,8 +197,7 @@ impl TestEnv {
                 [0; 32].as_ref().try_into().unwrap(),
             )
             .unwrap()
-            .commit()
-            .unwrap();
+            .commit();
         Self {
             epoch_manager,
             runtime,
@@ -369,8 +368,7 @@ impl TestEnv {
                 [0; 32].as_ref().try_into().unwrap(),
             )
             .unwrap()
-            .commit()
-            .unwrap();
+            .commit();
         let shard_layout = self.epoch_manager.get_shard_layout_from_prev_block(&new_hash).unwrap();
         let mut new_receipts = HashMap::<_, Vec<Receipt>>::new();
         for receipt in all_receipts {
@@ -888,8 +886,7 @@ fn test_state_sync() {
                 [0; 32].as_ref().try_into().unwrap(),
             )
             .unwrap()
-            .commit()
-            .unwrap();
+            .commit();
         new_env.head.height = i;
         new_env.head.last_block_hash = cur_hash;
         new_env.head.prev_block_hash = prev_hash;

--- a/chain/epoch-manager/src/genesis.rs
+++ b/chain/epoch-manager/src/genesis.rs
@@ -33,7 +33,7 @@ impl EpochManager {
         let mut store_update = self.store.store_update();
         self.save_epoch_info(&mut store_update, &EpochId::default(), Arc::new(genesis_epoch_info))?;
         self.save_block_info(&mut store_update, block_info)?;
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -649,8 +649,7 @@ mod tests {
                 [0; 32],
             )
             .unwrap()
-            .commit()
-            .unwrap();
+            .commit();
     }
 
     // Simulates block production over the given height range using the specified protocol version and block hashes.

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -355,8 +355,7 @@ pub fn record_block_with_final_block_hash(
             [0; 32],
         )
         .unwrap()
-        .commit()
-        .unwrap();
+        .commit();
 }
 
 pub fn record_block(
@@ -410,8 +409,7 @@ pub fn record_block_with_version(
             [0; 32],
         )
         .unwrap()
-        .commit()
-        .unwrap();
+        .commit();
 }
 
 pub fn record_blocks<F>(
@@ -468,5 +466,5 @@ pub fn block_info(
 }
 
 pub fn record_with_block_info(epoch_manager: &mut EpochManager, block_info: BlockInfo) {
-    epoch_manager.record_block_info(block_info, [0; 32]).unwrap().commit().unwrap();
+    epoch_manager.record_block_info(block_info, [0; 32]).unwrap().commit();
 }

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -914,8 +914,7 @@ fn test_expected_chunks() {
                 rng_seed,
             )
             .unwrap()
-            .commit()
-            .unwrap();
+            .commit();
         prev_block = *curr_block;
 
         if epoch_id != initial_epoch_id {
@@ -996,8 +995,7 @@ fn test_expected_chunks_prev_block_not_produced() {
                     rng_seed,
                 )
                 .unwrap()
-                .commit()
-                .unwrap();
+                .commit();
             prev_block = *curr_block;
         }
         if epoch_id != initial_epoch_id {
@@ -2323,8 +2321,7 @@ fn test_final_block_consistency() {
             [0; 32],
         )
         .unwrap()
-        .commit()
-        .unwrap();
+        .commit();
     let new_epoch_aggregator_final_hash = epoch_manager.epoch_info_aggregator.last_block_hash;
     assert_eq!(epoch_aggregator_final_hash, new_epoch_aggregator_final_hash);
 }
@@ -3411,7 +3408,7 @@ fn test_possible_epochs_of_height_around_tip() {
             vec![],
             DEFAULT_TOTAL_SUPPLY,
         );
-        epoch_manager.write().record_block_info(block_info, [0; 32]).unwrap().commit().unwrap();
+        epoch_manager.write().record_block_info(block_info, [0; 32]).unwrap().commit();
         let tip = Tip {
             height,
             last_block_hash: h[i],
@@ -3474,7 +3471,7 @@ fn test_possible_epochs_of_height_around_tip() {
             vec![],
             DEFAULT_TOTAL_SUPPLY,
         );
-        epoch_manager.write().record_block_info(block_info, [0; 32]).unwrap().commit().unwrap();
+        epoch_manager.write().record_block_info(block_info, [0; 32]).unwrap().commit();
         let tip = Tip {
             height,
             last_block_hash: h[i],

--- a/core/store/src/adapter/epoch_store.rs
+++ b/core/store/src/adapter/epoch_store.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_info::EpochInfo;
@@ -128,10 +126,9 @@ impl Into<StoreUpdate> for EpochStoreUpdateAdapter<'static> {
 }
 
 impl EpochStoreUpdateAdapter<'static> {
-    pub fn commit(self) -> io::Result<()> {
+    pub fn commit(self) {
         let store_update: StoreUpdate = self.into();
         store_update.commit();
-        Ok(())
     }
 }
 

--- a/core/store/src/adapter/mod.rs
+++ b/core/store/src/adapter/mod.rs
@@ -17,7 +17,7 @@ use crate::{Store, StoreUpdate};
 /// store_update.set_foo("bar");
 /// some_large_update_function(&mut store_update);
 ///
-/// store_update.commit()?;
+/// store_update.commit();
 /// ```
 /// Now with StoreAdapters, store could be of any of the type of the adapters, example `FlatStoreAdapter`.
 /// In that case, we expect the above pattern to look similar, however we would expect calls to
@@ -33,7 +33,7 @@ use crate::{Store, StoreUpdate};
 /// // Pattern 1: reference to store_update
 /// let store_update: StoreUpdate = store.store_update();
 /// update_flat_store(&mut store_update.flat_store_update());
-/// store_update.commit()?;
+/// store_update.commit();
 ///
 /// // Pattern 2: owned store_update
 /// let flat_store: FlatStoreAdapter = store.flat_store();

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -118,7 +118,7 @@ fn update_epoch_sync_proof(
     if let Some(proof) = store.get_ser::<EpochSyncProof>(DBCol::EpochSyncProof, &[]).unwrap() {
         let mut store_update = epoch_store.store_update();
         store_update.set_epoch_sync_proof(&proof);
-        store_update.commit()?;
+        store_update.commit();
     }
 
     // Now we generate the epoch sync proof and update it to latest
@@ -132,7 +132,7 @@ fn update_epoch_sync_proof(
     tracing::info!(target: "migrations", "storing latest epoch sync proof");
     let mut store_update = epoch_store.store_update();
     store_update.set_epoch_sync_proof(&proof);
-    store_update.commit()?;
+    store_update.commit();
 
     Ok(())
 }

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -432,7 +432,7 @@ impl ReplayController {
             BlockInfo::from_header(block.header(), last_finalized_height, current_protocol_version),
             *block.header().random_value(),
         )?;
-        let _ = store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 

--- a/tools/state-viewer/src/replay_headers.rs
+++ b/tools/state-viewer/src/replay_headers.rs
@@ -51,8 +51,7 @@ pub(crate) fn replay_headers(
             epoch_manager_replay
                 .add_validator_proposals(block_info, *header.random_value())
                 .unwrap()
-                .commit()
-                .unwrap();
+                .commit();
 
             if epoch_manager
                 .is_last_block_in_finished_epoch(&block_hash)


### PR DESCRIPTION
## Summary
- `EpochStoreUpdateAdapter::commit()` delegates to `StoreUpdate::commit()` which is already infallible after #15040. Remove the redundant `io::Result<()>` wrapper and update all 16 call sites across 10 files.
- Part of the ongoing store Result cleanup effort (see #15038, #15040).

### Changes
- **Signature**: `EpochStoreUpdateAdapter::commit(self) -> io::Result<()>` → `commit(self)`
- **Production call sites** (4): `genesis.rs`, `migrations.rs` (×2), `replay-archive/cli.rs`
- **Test call sites** (12): `test_utils.rs` (×3), `shard_tracker.rs`, `tests/mod.rs` (×5), `runtime/tests.rs` (×3)
- **Doc comments** (2): Updated examples in `adapter/mod.rs`

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy --all-features --all-targets` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)