### PR TITLE
refactor(store): remove Result from FlatStoreUpdateAdapter::commit()

### DIFF
--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -235,7 +235,7 @@ impl FlatStorageResharder {
             split_params.right_child_shard,
             FlatStorageStatus::Resharding(FlatStorageReshardingStatus::CreatingChild),
         );
-        store_update.commit().unwrap();
+        store_update.commit();
 
         metrics.update_shards_status(&self.runtime.get_flat_storage_manager());
     }
@@ -255,7 +255,7 @@ impl FlatStorageResharder {
         for child in [left_child_shard, right_child_shard] {
             store_update.remove_all_values(*child);
         }
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 
@@ -365,10 +365,7 @@ impl FlatStorageResharder {
             }
 
             // Make a pause to commit and check if the routine should stop.
-            if let Err(err) = store_update.commit() {
-                tracing::error!(target: "resharding", ?err, "failed to commit store update");
-                return FlatStorageReshardingTaskResult::Failed;
-            }
+            store_update.commit();
 
             num_batches_done += 1;
             metrics.set_split_shard_processed_batches(num_batches_done);
@@ -461,7 +458,7 @@ impl FlatStorageResharder {
                 }
             }
         }
-        store_update.commit().unwrap();
+        store_update.commit();
         metrics.update_shards_status(&self.runtime.get_flat_storage_manager());
     }
 
@@ -712,7 +709,7 @@ impl FlatStorageResharder {
             shard_uid,
             FlatStorageStatus::Resharding(FlatStorageReshardingStatus::CatchingUp(flat_head)),
         );
-        store_update.commit()?;
+        store_update.commit();
 
         // Update metrics with current head height progress.
         metrics.set_head_height(flat_head.height);
@@ -773,7 +770,7 @@ impl FlatStorageResharder {
             },
         });
         store_update.set_flat_storage_status(shard_uid, flat_storage_status.clone());
-        store_update.commit()?;
+        store_update.commit();
         metrics.set_status(&flat_storage_status);
         tracing::info!(target: "resharding", ?shard_uid, %deltas_gc_count, "garbage collected flat storage deltas");
         // Create the flat storage entry for this shard in the manager.
@@ -1102,7 +1099,7 @@ mod tests {
             parent_shard,
             FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: split_params.flat_head }),
         );
-        store_update.commit().unwrap();
+        store_update.commit();
 
         // Check task execution
         let task_result =
@@ -1156,7 +1153,7 @@ mod tests {
                 );
             }
         }
-        store_update.commit().unwrap();
+        store_update.commit();
 
         // Resume resharding
         assert!(flat_storage_resharder.resume(parent_shard).is_ok(), "Resume should succeed");
@@ -1183,7 +1180,7 @@ mod tests {
             parent_shard,
             FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: split_params.flat_head }),
         );
-        store_update.commit().unwrap();
+        store_update.commit();
 
         // Cancel the task before executing it
         flat_storage_resharder.handle.0.stop();
@@ -1224,7 +1221,7 @@ mod tests {
             FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: split_params.flat_head }),
         );
 
-        store_update.commit().unwrap();
+        store_update.commit();
 
         // Set up initial state for shard catchup from split task
         let split_task_result =
@@ -1308,7 +1305,7 @@ mod tests {
         let account_mm_keys = inject("mm".parse().unwrap());
         let account_vv_keys = inject("vv".parse().unwrap());
 
-        store_update.commit().unwrap();
+        store_update.commit();
 
         Box::new(move |left_child_shard: ShardUId, right_child_shard: ShardUId| {
             // Check each child has the correct keys assigned to itself.
@@ -1344,7 +1341,7 @@ mod tests {
         let delayed_receipt_value = Some(FlatStateValue::Inlined(vec![1]));
         store_update.set(parent_shard, delayed_receipt_key.clone(), delayed_receipt_value.clone());
 
-        store_update.commit().unwrap();
+        store_update.commit();
 
         Box::new(move |left_child_shard: ShardUId, right_child_shard: ShardUId| {
             // Check that flat storages of both children contain the delayed receipt.
@@ -1408,7 +1405,7 @@ mod tests {
             promise_yield_receipt_value.clone(),
         );
 
-        store_update.commit().unwrap();
+        store_update.commit();
 
         Box::new(move |left_child_shard: ShardUId, right_child_shard: ShardUId| {
             // Check that flat storages of both children contain the promise yield timeout and indices.
@@ -1462,7 +1459,7 @@ mod tests {
             buffered_receipt_value.clone(),
         );
 
-        store_update.commit().unwrap();
+        store_update.commit();
 
         Box::new(move |left_child_shard: ShardUId, right_child_shard: ShardUId| {
             // Check that only the first child contain the buffered receipt.

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -481,7 +481,7 @@ impl TrieStateResharder {
             store_update.remove_flat_storage(parent_shard_uid);
         }
 
-        store_update.commit().unwrap();
+        store_update.commit();
     }
 }
 
@@ -672,7 +672,7 @@ mod tests {
                     },
                 }),
             );
-            store_update.commit().unwrap();
+            store_update.commit();
 
             // Fourth, create ChunkExtra for the flat storage head so load_memtrie can find the state root.
             let mut chain_store_update = runtime.store().store_update();

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -268,7 +268,7 @@ fn create_flat_storage_for_shard(
             },
         }),
     );
-    store_update.commit()?;
+    store_update.commit();
     flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
     Ok(())
 }

--- a/core/store/src/adapter/flat_store.rs
+++ b/core/store/src/adapter/flat_store.rs
@@ -201,10 +201,9 @@ impl Into<StoreUpdate> for FlatStoreUpdateAdapter<'static> {
 }
 
 impl FlatStoreUpdateAdapter<'static> {
-    pub fn commit(self) -> io::Result<()> {
+    pub fn commit(self) {
         let store_update: StoreUpdate = self.into();
         store_update.commit();
-        Ok(())
     }
 }
 
@@ -325,7 +324,7 @@ mod tests {
                 Some(FlatStateValue::inlined(&val)),
             );
 
-            store_update.commit().unwrap();
+            store_update.commit();
         }
 
         for (i, shard_uid) in shard_uids.iter().enumerate() {

--- a/core/store/src/adapter/mod.rs
+++ b/core/store/src/adapter/mod.rs
@@ -39,7 +39,7 @@ use crate::{Store, StoreUpdate};
 /// let flat_store: FlatStoreAdapter = store.flat_store();
 /// let flat_store_update: FlatStoreUpdateAdapter<'static> = flat_store.store_update();
 /// update_flat_store(&mut flat_store_update);
-/// flat_store_update.commit()?;
+/// flat_store_update.commit();
 /// ```
 ///
 /// To make both these patterns possible, where in pattern 1, flat_store_update holds a reference to store_update

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -120,8 +120,7 @@ impl FlatStorageManager {
             shard_uid,
             FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head }),
         );
-        // TODO: Consider adding a StorageError::IO variant?
-        store_update.commit().map_err(|_| StorageError::StorageInternalError)?;
+        store_update.commit();
         Ok(())
     }
 

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -425,7 +425,7 @@ impl FlatStorage {
                 guard.deltas.remove(&hash);
             }
 
-            store_update.commit().unwrap();
+            store_update.commit();
             tracing::debug!(target: "store", %shard_id, %block_hash, %block_height, "moved flat storage head");
         }
         guard.update_delta_metrics();
@@ -553,7 +553,7 @@ mod tests {
             };
             store_update.set_delta(shard_uid, &delta);
         }
-        store_update.commit().unwrap();
+        store_update.commit();
 
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
@@ -585,7 +585,7 @@ mod tests {
         // Should result in `StorageInternalError` indicating that flat storage is broken.
         let mut store_update = store.store_update();
         store_update.remove_delta(shard_uid, chain.get_block_hash(3));
-        store_update.commit().unwrap();
+        store_update.commit();
         assert_matches!(
             flat_storage.update_flat_head_impl(&chain.get_block_hash(3), true),
             Err(FlatStorageError::StorageInternalError(_))
@@ -631,7 +631,7 @@ mod tests {
             };
             store_update.set_delta(shard_uid, &delta);
         }
-        store_update.commit().unwrap();
+        store_update.commit();
 
         let flat_storage_manager = FlatStorageManager::new(store);
         flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
@@ -673,7 +673,7 @@ mod tests {
             };
             store_update.set_delta(shard_uid, &delta);
         }
-        store_update.commit().unwrap();
+        store_update.commit();
 
         // Check that flat storage state is created correctly for chain which has skipped heights.
         let flat_storage_manager = FlatStorageManager::new(store);
@@ -715,7 +715,7 @@ mod tests {
             };
             store_update.set_delta(shard_uid, &delta);
         }
-        store_update.commit().unwrap();
+        store_update.commit();
 
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
@@ -748,7 +748,7 @@ mod tests {
                 },
             })
             .unwrap();
-        store_update.commit().unwrap();
+        store_update.commit();
 
         // 4. Create a flat_state0 at block 10 and flat_state1 at block 4
         //    Verify that they return the correct values
@@ -806,7 +806,7 @@ mod tests {
             FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: chain.get_block(0) }),
         );
         store_update.set(shard_uid, vec![1], Some(FlatStateValue::value_ref(&[0])));
-        store_update.commit().unwrap();
+        store_update.commit();
 
         for i in 1..num_blocks as BlockHeight {
             let mut store_update = store.store_update();
@@ -839,7 +839,7 @@ mod tests {
             };
             tracing::info!(?i, ?delta);
             store_update.set_delta(shard_uid, &delta);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
 
         let flat_storage_manager = FlatStorageManager::new(store.clone());
@@ -896,7 +896,7 @@ mod tests {
             FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: chain.get_block(0) }),
         );
         store_update.set(shard_uid, vec![1], Some(FlatStateValue::value_ref(&[0])));
-        store_update.commit().unwrap();
+        store_update.commit();
 
         for i in 1..num_blocks as BlockHeight {
             let mut store_update = store.store_update();
@@ -919,7 +919,7 @@ mod tests {
             };
             tracing::info!(?i, ?delta);
             store_update.set_delta(shard_uid, &delta);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
 
         let flat_storage_manager = FlatStorageManager::new(store);
@@ -954,7 +954,7 @@ mod tests {
             FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: chain.get_block(0) }),
         );
         store_update.set(shard_uid, vec![1], Some(FlatStateValue::value_ref(&[0])));
-        store_update.commit().unwrap();
+        store_update.commit();
 
         for i in 1..num_blocks as BlockHeight {
             let mut store_update = store.store_update();
@@ -987,7 +987,7 @@ mod tests {
             };
             tracing::info!(?i, ?delta);
             store_update.set_delta(shard_uid, &delta);
-            store_update.commit().unwrap();
+            store_update.commit();
         }
 
         let flat_storage_manager = FlatStorageManager::new(store.clone());
@@ -1049,7 +1049,7 @@ mod tests {
                 FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: chain.get_block(0) }),
             );
             store_update.set(shard_uid, vec![1], Some(FlatStateValue::value_ref(&[0])));
-            store_update.commit().unwrap();
+            store_update.commit();
 
             for i in 1..num_blocks as BlockHeight {
                 let mut store_update = store.store_update();
@@ -1067,7 +1067,7 @@ mod tests {
                 };
                 tracing::info!(?i, ?delta);
                 store_update.set_delta(shard_uid, &delta);
-                store_update.commit().unwrap();
+                store_update.commit();
             }
 
             let flat_storage_manager = FlatStorageManager::new(store);
@@ -1099,7 +1099,7 @@ mod tests {
                 FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: chain.get_block(0) }),
             );
             store_update.set(shard_uid, vec![1], Some(FlatStateValue::value_ref(&[0])));
-            store_update.commit().unwrap();
+            store_update.commit();
 
             for i in 1..num_blocks as BlockHeight {
                 let mut store_update = store.store_update();
@@ -1132,7 +1132,7 @@ mod tests {
                 };
                 tracing::info!(?i, ?delta);
                 store_update.set_delta(shard_uid, &delta);
-                store_update.commit().unwrap();
+                store_update.commit();
             }
 
             let flat_storage_manager = FlatStorageManager::new(store);
@@ -1184,7 +1184,7 @@ mod tests {
                 FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: chain.get_block(0) }),
             );
             store_update.set(shard_uid, vec![1], Some(FlatStateValue::value_ref(&[0])));
-            store_update.commit().unwrap();
+            store_update.commit();
 
             for i in 1..num_blocks as BlockHeight {
                 let mut store_update = store.store_update();
@@ -1217,7 +1217,7 @@ mod tests {
                 };
                 tracing::info!(?i, ?delta);
                 store_update.set_delta(shard_uid, &delta);
-                store_update.commit().unwrap();
+                store_update.commit();
             }
 
             let flat_storage_manager = FlatStorageManager::new(store);

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -414,7 +414,7 @@ mod tests {
             FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: chain.get_block(0) }),
         );
         store_update.set(shard_uid, test_key.to_vec(), Some(FlatStateValue::inlined(&test_val0)));
-        store_update.commit().unwrap();
+        store_update.commit();
 
         // Populate the initial trie at block 0 too.
         let state_root_0 = test_populate_trie(

--- a/core/store/src/utils/test_utils.rs
+++ b/core/store/src/utils/test_utils.rs
@@ -263,7 +263,7 @@ pub fn test_populate_flat_storage(
             value.as_ref().map(|value| FlatStateValue::on_disk(value)),
         );
     }
-    store_update.commit().unwrap();
+    store_update.commit();
 }
 
 /// Insert values to non-reference-counted columns in the store.

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -94,7 +94,7 @@ impl<'c> EstimatorContext<'c> {
                 flat_head: BlockInfo::genesis(CryptoHash::hash_borsh(0usize), 0),
             }),
         );
-        store_update.commit().unwrap();
+        store_update.commit();
         flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
 
         let flat_storage = flat_storage_manager.get_flat_storage_for_shard(shard_uid).unwrap();

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -252,7 +252,7 @@ impl FlatStorageCommand {
         flat_storage_manager.create_flat_storage_for_shard(shard_uid)?;
         let mut store_update = store.flat_store().store_update();
         flat_storage_manager.remove_flat_storage_for_shard(shard_uid, &mut store_update)?;
-        store_update.commit()?;
+        store_update.commit();
         Ok(())
     }
 
@@ -488,7 +488,7 @@ impl FlatStorageCommand {
                     },
                 }),
             );
-            store_update.commit()?;
+            store_update.commit();
 
             height = prev_height;
             println!("moved to {height} on {shard_uid}");

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -516,7 +516,7 @@ fn apply_block_from_range(
             let flat_storage_manager = runtime_adapter.get_flat_storage_manager();
             let flat_storage = flat_storage_manager.get_flat_storage_for_shard(shard_uid).unwrap();
             let store_update = flat_storage.add_delta(delta).unwrap();
-            store_update.commit().unwrap();
+            store_update.commit();
             flat_storage.update_flat_head(&block_hash).unwrap();
         }
         (_, StorageSource::Recorded) => {


### PR DESCRIPTION
## Summary
- Remove the redundant `io::Result<()>` return type from `FlatStoreUpdateAdapter::commit()`, which delegates to `StoreUpdate::commit()` that already panics on irrecoverable errors
- Simplify ~30 call sites across production and test code by removing `.unwrap()`, `.map_err(...)`, and `?` operators
- Remove dead error-handling branch in `flat_storage_resharder.rs` that could never trigger

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-features --all-targets` passes clean
- [ ] Existing tests continue to pass (no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)