### PR TITLE
refactor(store): remove Result from db version/kind methods

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -393,7 +393,7 @@ impl NightshadeRuntime {
         // is finished we can check the store kind. It's only set to hot after the
         // migration is finished. If the migration has not finished yet, we expect
         // the GC not to run regardless of what we return here.
-        let kind = self.store.get_db_kind()?;
+        let kind = self.store.get_db_kind();
         if let Some(DbKind::Hot) = kind {
             let Some(cold_head_epoch_start_height) = get_epoch_start_height_from_archival_head(
                 &self.store,

--- a/chain/client/src/archive/cold_store_actor.rs
+++ b/chain/client/src/archive/cold_store_actor.rs
@@ -174,7 +174,7 @@ impl ColdStoreActor {
         }
 
         tracing::info!(target: "cold_store", "starting population of cold store");
-        let new_cold_height = match self.hot_store.get_db_kind()? {
+        let new_cold_height = match self.hot_store.get_db_kind() {
             None => {
                 tracing::error!(target: "cold_store", "hot store kind is unknown");
                 return Err(anyhow::anyhow!("Hot store DBKind is not set"));

--- a/chain/client/src/gc_actor.rs
+++ b/chain/client/src/gc_actor.rs
@@ -64,7 +64,7 @@ impl GCActor {
         // *and* that the migration to split storage is finished we can check
         // the store kind. It's only set to hot after the migration is finished.
         let store = self.store.store();
-        let kind = store.get_db_kind()?;
+        let kind = store.get_db_kind();
         if kind == Some(DbKind::Hot) {
             return self.store.clear_data(
                 &self.gc_config,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -1456,7 +1456,7 @@ impl Handler<GetSplitStorageInfo, Result<SplitStorageInfoView, GetSplitStorageIn
         let final_head = store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?;
         let cold_head = store.get_ser::<Tip>(DBCol::BlockMisc, COLD_HEAD_KEY)?;
 
-        let hot_db_kind = store.get_db_kind()?.map(|kind| kind.to_string());
+        let hot_db_kind = store.get_db_kind().map(|kind| kind.to_string());
 
         Ok(SplitStorageInfoView {
             head_height: head.map(|tip| tip.height),

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -741,7 +741,7 @@ impl RocksDB {
         // out if there are any necessary migrations to perform.
         let cols = [DBCol::DbVersion];
         let db = Self::open_with_columns(path, config, Mode::ReadOnly, Temperature::Hot, &cols)?;
-        Some(metadata::DbMetadata::read(&db)).transpose()
+        Ok(Some(metadata::DbMetadata::read(&db)))
     }
 
     /// Gets every int property in CF_PROPERTY_NAMES for every column in DBCol.

--- a/core/store/src/node_storage/mod.rs
+++ b/core/store/src/node_storage/mod.rs
@@ -203,7 +203,7 @@ impl NodeStorage {
         if self.cold_storage.is_some() {
             return Ok(true);
         }
-        Ok(match metadata::DbMetadata::read(self.hot_storage.as_ref())?.kind.unwrap() {
+        Ok(match metadata::DbMetadata::read(self.hot_storage.as_ref()).kind.unwrap() {
             metadata::DbKind::RPC => false,
             metadata::DbKind::Archive => true,
             metadata::DbKind::Hot | metadata::DbKind::Cold => true,

--- a/core/store/src/node_storage/opener.rs
+++ b/core/store/src/node_storage/opener.rs
@@ -425,7 +425,7 @@ impl<'a> StoreOpener<'a> {
 
                 let db = opener.create()?;
                 let store = Store::new(Arc::new(db));
-                store.set_db_version(DB_VERSION)?;
+                store.set_db_version(DB_VERSION);
                 return Ok(());
             }
             None => {
@@ -446,7 +446,7 @@ impl<'a> StoreOpener<'a> {
         tracing::debug!(target: "db_opener", path = %opener.path.display(), archive, which, "ensure db kind is correct and set");
         let store = Self::open_store_unsafe(mode, opener)?;
 
-        let current_kind = store.get_db_kind()?;
+        let current_kind = store.get_db_kind();
         let default_kind = get_default_kind(archive, temp);
         let err =
             Err(StoreOpenerError::DbKindMismatch { which, got: current_kind, want: default_kind });
@@ -466,7 +466,7 @@ impl<'a> StoreOpener<'a> {
         if mode.read_write() {
             tracing::info!(target: "db_opener", archive, which, ?default_kind, "setting the db kind");
 
-            store.set_db_kind(default_kind)?;
+            store.set_db_kind(default_kind);
             return Ok(());
         }
 
@@ -574,9 +574,9 @@ impl<'a> StoreOpener<'a> {
                 .map_err(StoreOpenerError::MigrationError)?;
 
             // Update versions in both stores
-            hot_store.set_db_version(version + 1)?;
+            hot_store.set_db_version(version + 1);
             if let Some(ref cold) = cold_db {
-                cold.as_store().set_db_version(version + 1)?;
+                cold.as_store().set_db_version(version + 1);
             }
         }
 
@@ -586,11 +586,11 @@ impl<'a> StoreOpener<'a> {
             tracing::info!(target: "db_opener", %version, "setting the database version for nightly");
 
             let hot_store = Self::open_store(mode, hot_opener, DB_VERSION)?;
-            hot_store.set_db_version(version)?;
+            hot_store.set_db_version(version);
 
             if let Some(cold_opener) = cold_opener {
                 let cold_store = Self::open_store(mode, cold_opener, DB_VERSION)?;
-                cold_store.set_db_version(version)?;
+                cold_store.set_db_version(version);
             }
         }
 
@@ -656,7 +656,7 @@ impl<'a> DBOpener<'a> {
     /// Use [`Self::create`] to create a new database.
     fn open(&self, mode: Mode, want_version: DbVersion) -> std::io::Result<(RocksDB, DbMetadata)> {
         let db = RocksDB::open(&self.path, &self.config, mode, self.temp)?;
-        let metadata = DbMetadata::read(&db)?;
+        let metadata = DbMetadata::read(&db);
         if want_version != metadata.version {
             let msg = format!("unexpected DbVersion {}; expected {want_version}", metadata.version);
             Err(std::io::Error::other(msg))
@@ -813,7 +813,7 @@ mod tests {
         let (home_dir, opener) = NodeStorage::test_opener();
         let node_storage = opener.open().unwrap();
         let hot_store = Store::new(node_storage.hot_storage.clone());
-        assert_eq!(hot_store.get_db_kind().unwrap(), Some(DbKind::RPC));
+        assert_eq!(hot_store.get_db_kind(), Some(DbKind::RPC));
 
         let keys = vec![vec![0], vec![1], vec![2], vec![3]];
         let columns = vec![DBCol::Block, DBCol::Chunks, DBCol::BlockHeader];

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -284,26 +284,24 @@ impl Store {
 }
 
 impl Store {
-    pub fn get_db_version(&self) -> io::Result<Option<DbVersion>> {
+    pub fn get_db_version(&self) -> Option<DbVersion> {
         DbMetadata::maybe_read_version(self.storage.as_ref())
     }
 
-    pub fn set_db_version(&self, version: DbVersion) -> io::Result<()> {
+    pub fn set_db_version(&self, version: DbVersion) {
         let mut store_update = self.store_update();
         store_update.set(DBCol::DbVersion, VERSION_KEY, version.to_string().as_bytes());
         store_update.commit();
-        Ok(())
     }
 
-    pub fn get_db_kind(&self) -> io::Result<Option<DbKind>> {
+    pub fn get_db_kind(&self) -> Option<DbKind> {
         DbMetadata::maybe_read_kind(self.storage.as_ref())
     }
 
-    pub fn set_db_kind(&self, kind: DbKind) -> io::Result<()> {
+    pub fn set_db_kind(&self, kind: DbKind) {
         let mut store_update = self.store_update();
         store_update.set(DBCol::DbVersion, KIND_KEY, <&str>::from(kind).as_bytes());
         store_update.commit();
-        Ok(())
     }
 }
 

--- a/core/store/src/utils/test_utils.rs
+++ b/core/store/src/utils/test_utils.rs
@@ -27,8 +27,8 @@ use std::sync::Arc;
 
 fn create_in_memory_node_storage(version: DbVersion, hot_kind: DbKind) -> NodeStorage {
     let storage = NodeStorage::new(TestDB::new());
-    storage.get_hot_store().set_db_version(version).unwrap();
-    storage.get_hot_store().set_db_kind(hot_kind).unwrap();
+    storage.get_hot_store().set_db_version(version);
+    storage.get_hot_store().set_db_kind(hot_kind);
     storage
 }
 
@@ -67,11 +67,11 @@ fn create_test_node_storage_archive(
     let storage = NodeStorage::new_archive(hot.clone(), cold_db, cloud);
 
     let hot_store = storage.get_hot_store();
-    hot_store.set_db_version(version).unwrap();
-    hot_store.set_db_kind(hot_kind).unwrap();
+    hot_store.set_db_version(version);
+    hot_store.set_db_kind(hot_kind);
     if let Some(cold_store) = storage.get_cold_store() {
-        cold_store.set_db_version(version).unwrap();
-        cold_store.set_db_kind(DbKind::Cold).unwrap();
+        cold_store.set_db_version(version);
+        cold_store.set_db_kind(DbKind::Cold);
     }
     (storage, hot, cold)
 }

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -136,7 +136,7 @@ impl TestEnv {
             // *and* that the migration to split storage is finished we can check
             // the store kind. It's only set to hot after the migration is finished.
             let store = self.clients[0].chain.chain_store().store();
-            let kind = store.get_db_kind().unwrap();
+            let kind = store.get_db_kind();
             if kind == Some(DbKind::Hot) {
                 self.clients[id]
                     .chain

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -899,7 +899,7 @@ fn test_archival_save_trie_changes() {
         .save_trie_changes(true)
         .build();
 
-    env.clients[0].chain.chain_store().store().set_db_kind(DbKind::Archive).unwrap();
+    env.clients[0].chain.chain_store().store().set_db_kind(DbKind::Archive);
 
     let mut blocks = vec![];
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -217,7 +217,7 @@ fn get_split_store(config: &NearConfig, storage: &NodeStorage) -> anyhow::Result
     // SplitStore should only be used if the migration is finished. The
     // migration to cold store is finished when the db kind of the hot store is
     // changed from Archive to Hot.
-    if storage.get_hot_store().get_db_kind()? != Some(DbKind::Hot) {
+    if storage.get_hot_store().get_db_kind() != Some(DbKind::Hot) {
         return Ok(None);
     }
 

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -174,7 +174,7 @@ fn print_heads(store: &NodeStorage) -> anyhow::Result<()> {
 
     // hot store
     {
-        let kind = hot_store.get_db_kind()?;
+        let kind = hot_store.get_db_kind();
         let head = hot_store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
         let final_head = hot_store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?;
         let cold_head = hot_store.get_ser::<Tip>(DBCol::BlockMisc, COLD_HEAD_KEY)?;
@@ -186,7 +186,7 @@ fn print_heads(store: &NodeStorage) -> anyhow::Result<()> {
 
     // cold store
     if let Some(cold_store) = cold_store {
-        let kind = cold_store.get_db_kind()?;
+        let kind = cold_store.get_db_kind();
         let head_in_cold = cold_store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
         println!("COLD STORE KIND is {:#?}", kind);
         println!("COLD STORE HEAD is at {:#?}", head_in_cold);
@@ -375,7 +375,7 @@ impl PrepareHotCmd {
 
         tracing::info!(target: "prepare-hot", "the hot, cold and RPC stores are suitable for cold storage migration");
         tracing::info!(target: "prepare-hot", "changing the db kind of the rpc store to hot");
-        rpc_store.set_db_kind(DbKind::Hot)?;
+        rpc_store.set_db_kind(DbKind::Hot);
 
         tracing::info!(target: "prepare-hot", ?path, "successfully prepared the hot store for migration, you can now set the `config.store.path` in neard config");
 
@@ -388,7 +388,7 @@ impl PrepareHotCmd {
         cold_store: &Store,
         rpc_store: &Store,
     ) -> anyhow::Result<()> {
-        let hot_db_kind = hot_store.get_db_kind()?;
+        let hot_db_kind = hot_store.get_db_kind();
         if hot_db_kind != Some(DbKind::Hot) && hot_db_kind != Some(DbKind::Archive) {
             return Err(anyhow::anyhow!(
                 "Unexpected hot_store DbKind, expected: DbKind::Hot or DbKind::Archive, got: {:?}",
@@ -396,7 +396,7 @@ impl PrepareHotCmd {
             ));
         }
 
-        let cold_db_kind = cold_store.get_db_kind()?;
+        let cold_db_kind = cold_store.get_db_kind();
         if cold_db_kind != Some(DbKind::Cold) {
             return Err(anyhow::anyhow!(
                 "Unexpected cold_store DbKind, expected: DbKind::Cold, got: {:?}",
@@ -404,7 +404,7 @@ impl PrepareHotCmd {
             ));
         }
 
-        let rpc_db_kind = rpc_store.get_db_kind()?;
+        let rpc_db_kind = rpc_store.get_db_kind();
         if rpc_db_kind != Some(DbKind::RPC) {
             return Err(anyhow::anyhow!(
                 "Unexpected rpc_store DbKind, expected: DbKind::RPC, got: {:?}",

--- a/tools/database/src/adjust_database.rs
+++ b/tools/database/src/adjust_database.rs
@@ -45,6 +45,7 @@ impl ChangeDbKindCommand {
                 storage.get_cold_store().ok_or_else(|| anyhow::anyhow!("No cold store"))?
             }
         };
-        Ok(store.set_db_kind(self.new_kind)?)
+        store.set_db_kind(self.new_kind);
+        Ok(())
     }
 }

--- a/tools/database/src/set_version.rs
+++ b/tools/database/src/set_version.rs
@@ -29,9 +29,9 @@ impl SetVersionCommand {
         let storage = opener.open_unsafe()?;
         let store = storage.get_hot_store();
 
-        println!("Current hot db version is: {:?}", store.get_db_version()?);
+        println!("Current hot db version is: {:?}", store.get_db_version());
         if let Some(cold_store) = storage.get_cold_store() {
-            println!("Current cold db version is: {:?}", cold_store.get_db_version()?);
+            println!("Current cold db version is: {:?}", cold_store.get_db_version());
         }
 
         if !get_user_confirmation(&format!(
@@ -44,10 +44,10 @@ impl SetVersionCommand {
         }
 
         println!("Setting hot db version to {}... ", self.version);
-        store.set_db_version(self.version)?;
+        store.set_db_version(self.version);
         if let Some(cold_store) = storage.get_cold_store() {
             println!("Setting cold db version to {}... ", self.version);
-            cold_store.set_db_version(self.version)?;
+            cold_store.set_db_version(self.version);
         }
 
         println!("Database version set to {}", self.version);

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -197,7 +197,7 @@ impl FlatStorageCommand {
     ) -> anyhow::Result<()> {
         let (.., hot_store) =
             Self::get_db(&opener, home_dir, &near_config, near_store::Mode::ReadOnly);
-        println!("DB version: {:?}", hot_store.get_db_version()?);
+        println!("DB version: {:?}", hot_store.get_db_version());
         for (bytes_shard_uid, status) in hot_store.iter(DBCol::FlatStorageStatus) {
             let shard_uid = ShardUId::try_from(bytes_shard_uid.as_ref()).unwrap();
             let status = FlatStorageStatus::try_from_slice(&status)?;
@@ -231,7 +231,7 @@ impl FlatStorageCommand {
         let rw_storage = opener.open_in_mode(near_store::Mode::ReadWriteExisting)?;
         let rw_store = rw_storage.get_hot_store();
         println!("Setting storage DB version to: {:?}", cmd.version);
-        rw_store.set_db_version(cmd.version)?;
+        rw_store.set_db_version(cmd.version);
         Ok(())
     }
 


### PR DESCRIPTION
Remove `Result` wrappers from `Store::get_db_version()`, `Store::set_db_version()`, `Store::get_db_kind()`, `Store::set_db_kind()`, and the underlying `DbMetadata` helpers (`read()`, `maybe_read()`, `maybe_read_version()`, `maybe_read_kind()`).

The set methods were already trivially wrapping `Ok(())`. The get/read methods only failed on corrupt database metadata (invalid UTF-8, unparseable values, or missing required entries), which now panics immediately since a corrupted database is not a recoverable condition. This is consistent with the convention established in prior store cleanup PRs.