### PR TITLE
chore(ci): add "revert" as a valid PR title type

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -16,7 +16,7 @@ jobs:
           # PR title must match: <type>: <title> or <type>(<project>): <title>
           # See CONTRIBUTING.md for details.
 
-          VALID_TYPES="fix|feat|refactor|doc|test|chore|perf"
+          VALID_TYPES="fix|feat|refactor|doc|test|chore|perf|revert"
           PATTERN="^(${VALID_TYPES})(\([a-z][a-z0-9-]*\))?: [a-z]"
 
           if [[ ! "$PR_TITLE" =~ $PATTERN ]]; then
@@ -26,7 +26,7 @@ jobs:
             echo "Got:      $PR_TITLE"
             echo ""
             echo "Rules:"
-            echo "  - type must be one of: fix, feat, refactor, doc, test, chore, perf"
+            echo "  - type must be one of: fix, feat, refactor, doc, test, chore, perf, revert"
             echo "  - project (if provided) must be lowercase (e.g. spice, resharding, state-sync)"
             echo "  - title must not be capitalized"
             echo ""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ following steps when creating a PR:
       - `test` for changes that introduce new tests.
       - `chore` for grunt tasks like updating dependencies.
       - `perf` for performance-related changes and benchmarks.
+      - `revert` for reverting existing PRs.
    - `project` is a short non-capitalized project or area name such as `spice`, `resharding`, `state-sync`, `ci`, etc.
    - `title` should not be capitalized.
    - examples:


### PR DESCRIPTION
- Adds `revert` to the list of valid PR title types in the `pr_title.yml` CI workflow and `CONTRIBUTING.md`
- This allows PRs that revert existing changes to use the `revert: <title>` or `revert(<project>): <title>` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)