### PR TITLE
refactor(store): remove Result from StoreUpdate::set_ser()

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -1072,7 +1072,7 @@ impl<'a> ChainStoreUpdate<'a> {
         if epoch_to_hashes.is_empty() {
             store_update.delete(DBCol::BlockPerHeight, key);
         } else {
-            store_update.set_ser(DBCol::BlockPerHeight, key, &epoch_to_hashes)?;
+            store_update.set_ser(DBCol::BlockPerHeight, key, &epoch_to_hashes);
         }
         if self.is_height_processed(height) {
             self.gc_col(DBCol::ProcessedBlockHeights, key);

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -678,9 +678,11 @@ mod tests {
             let mut chain_store_update = runtime.store().store_update();
             let chunk_extra = ChunkExtra::new_with_only_state_root(&parent_root);
             let block_shard_uid = get_block_shard_uid(&parent_root, &parent_shard);
-            chain_store_update
-                .set_ser(near_store::DBCol::ChunkExtra, &block_shard_uid, &chunk_extra)
-                .unwrap();
+            chain_store_update.set_ser(
+                near_store::DBCol::ChunkExtra,
+                &block_shard_uid,
+                &chunk_extra,
+            );
             chain_store_update.commit();
 
             // Now unload the parent memtrie, so the test can verify

--- a/chain/chain/src/spice_core_writer_actor.rs
+++ b/chain/chain/src/spice_core_writer_actor.rs
@@ -99,7 +99,7 @@ impl SpiceCoreWriterActor {
     ) -> Result<StoreUpdate, std::io::Error> {
         let key = get_endorsements_key(block_hash, shard_id, account_id);
         let mut store_update = self.chain_store.store().store_update();
-        store_update.set_ser(DBCol::endorsements(), &key, endorsement)?;
+        store_update.set_ser(DBCol::endorsements(), &key, endorsement);
         Ok(store_update)
     }
 

--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -268,7 +268,7 @@ impl ChainStateSyncAdapter {
 
         // Saving the header data
         let mut store_update = self.chain_store.store().store_update();
-        store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header)?;
+        store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header);
         store_update.commit();
 
         Ok(shard_state_header)
@@ -519,7 +519,7 @@ impl ChainStateSyncAdapter {
         // Saving the header data.
         let mut store_update = self.chain_store.store().store_update();
         let key = borsh::to_vec(&StateHeaderKey(shard_id, sync_hash))?;
-        store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header)?;
+        store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header);
         store_update.commit();
 
         Ok(())

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -58,13 +58,13 @@ fn save_epoch_new_chunks<T: ChainStoreAccess>(
         }
     }
 
-    store_update.set_ser(DBCol::StateSyncNewChunks, header.hash().as_ref(), &num_new_chunks)?;
+    store_update.set_ser(DBCol::StateSyncNewChunks, header.hash().as_ref(), &num_new_chunks);
     Ok(done)
 }
 
 fn on_new_epoch(store_update: &mut StoreUpdate, header: &BlockHeader) -> Result<(), Error> {
     let num_new_chunks = vec![0u8; header.chunk_mask().len()];
-    store_update.set_ser(DBCol::StateSyncNewChunks, header.hash().as_ref(), &num_new_chunks)?;
+    store_update.set_ser(DBCol::StateSyncNewChunks, header.hash().as_ref(), &num_new_chunks);
     Ok(())
 }
 
@@ -160,7 +160,7 @@ fn on_new_header<T: ChainStoreAccess>(
         if !prev_prev_done {
             // `sync_prev_prev` doesn't have enough new chunks, and `sync_prev` does, meaning `sync` is the first final
             // valid sync block
-            store_update.set_ser(DBCol::StateSyncHashes, epoch_id.as_ref(), sync.hash())?;
+            store_update.set_ser(DBCol::StateSyncHashes, epoch_id.as_ref(), sync.hash());
             store_update.delete_all(DBCol::StateSyncNewChunks);
             return Ok(());
         }

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -605,7 +605,7 @@ impl ChainStore {
     /// TODO(store): What is this doing here? Cleanup
     pub fn save_latest_known(&mut self, latest_known: LatestKnown) -> Result<(), Error> {
         let mut store_update = self.store.store().store_update();
-        store_update.set_ser(DBCol::BlockMisc, LATEST_KNOWN_KEY, &latest_known)?;
+        store_update.set_ser(DBCol::BlockMisc, LATEST_KNOWN_KEY, &latest_known);
         store_update.commit();
         Ok(())
     }
@@ -815,7 +815,7 @@ impl ChainStore {
         let key = ChainStore::state_sync_dump_progress_key(shard_id);
         match value {
             None => store_update.delete(DBCol::BlockMisc, &key),
-            Some(value) => store_update.set_ser(DBCol::BlockMisc, &key, &value)?,
+            Some(value) => store_update.set_ser(DBCol::BlockMisc, &key, &value),
         }
         store_update.commit();
         Ok(())
@@ -1878,7 +1878,7 @@ impl<'a> ChainStoreUpdate<'a> {
         value: &mut Option<T>,
     ) -> Result<(), Error> {
         if let Some(t) = value.take() {
-            store_update.set_ser(DBCol::BlockMisc, key, &t)?;
+            store_update.set_ser(DBCol::BlockMisc, key, &t);
         }
         Ok(())
     }
@@ -1926,7 +1926,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::BlockPerHeight,
                     &index_to_bytes(block.header().height()),
                     &map,
-                )?;
+                );
                 store_update.insert_ser(DBCol::Block, block.hash().as_ref(), block)?;
                 if cfg!(feature = "protocol_feature_spice") {
                     let prev_hash = block.header().prev_hash();
@@ -1937,7 +1937,7 @@ impl<'a> ChainStoreUpdate<'a> {
                         DBCol::all_next_block_hashes(),
                         prev_hash.as_ref(),
                         &prev_next_hashes,
-                    )?;
+                    );
                 }
             }
             // This is a BTreeMap because the update_sync_hashes() calls below must be done in order of height
@@ -1961,7 +1961,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::HeaderHashesByHeight,
                     &index_to_bytes(height),
                     &hash_set,
-                )?;
+                );
                 for header in headers {
                     crate::state_sync::update_sync_hashes(self, &mut store_update, header)?;
                 }
@@ -1973,7 +1973,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::ChunkExtra,
                     &get_block_shard_uid(block_hash, shard_uid),
                     chunk_extra,
-                )?;
+                );
             }
         }
 
@@ -2022,7 +2022,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::ChunkHashesByHeight,
                     &index_to_bytes(height),
                     &hash_set,
-                )?;
+                );
             }
             for (chunk_hash, partial_chunk) in &self.chain_store_cache_update.partial_chunks {
                 store_update.insert_ser(
@@ -2041,13 +2041,13 @@ impl<'a> ChainStoreUpdate<'a> {
 
         for (height, hash) in &self.chain_store_cache_update.height_to_hashes {
             if let Some(hash) = hash {
-                store_update.set_ser(DBCol::BlockHeight, &index_to_bytes(*height), hash)?;
+                store_update.set_ser(DBCol::BlockHeight, &index_to_bytes(*height), hash);
             } else {
                 store_update.delete(DBCol::BlockHeight, &index_to_bytes(*height));
             }
         }
         for (block_hash, next_hash) in &self.chain_store_cache_update.next_block_hashes {
-            store_update.set_ser(DBCol::NextBlockHashes, block_hash.as_ref(), next_hash)?;
+            store_update.set_ser(DBCol::NextBlockHashes, block_hash.as_ref(), next_hash);
         }
         for (epoch_hash, light_client_block) in
             &self.chain_store_cache_update.epoch_light_client_blocks
@@ -2056,7 +2056,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 DBCol::EpochLightClientBlocks,
                 epoch_hash.as_ref(),
                 light_client_block,
-            )?;
+            );
         }
         {
             let _span = tracing::trace_span!(target: "store", "write receipts").entered();
@@ -2068,7 +2068,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::OutgoingReceipts,
                     &get_block_shard_id(block_hash, *shard_id),
                     receipt,
-                )?;
+                );
             }
             for ((block_hash, shard_id), receipt) in
                 &self.chain_store_cache_update.incoming_receipts
@@ -2077,7 +2077,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::IncomingReceipts,
                     &get_block_shard_id(block_hash, *shard_id),
                     receipt,
-                )?;
+                );
             }
 
             for ((block_hash, shard_id), metadata) in
@@ -2087,7 +2087,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::ProcessedReceiptIds,
                     &get_block_shard_id(block_hash, *shard_id),
                     metadata,
-                )?;
+                );
             }
             for receipt in &self.chain_store_cache_update.processed_receipts_to_save {
                 save_receipt(&mut store_update, receipt);
@@ -2111,22 +2111,18 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::OutcomeIds,
                     &get_block_shard_id(block_hash, *shard_id),
                     &ids,
-                )?;
+                );
             }
         }
 
         for (block_hash, refcount) in &self.chain_store_cache_update.block_refcounts {
-            store_update.set_ser(DBCol::BlockRefCount, block_hash.as_ref(), refcount)?;
+            store_update.set_ser(DBCol::BlockRefCount, block_hash.as_ref(), refcount);
         }
         for (block_hash, block_merkle_tree) in &self.chain_store_cache_update.block_merkle_tree {
-            store_update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree)?;
+            store_update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree);
         }
         for (block_ordinal, block_hash) in &self.chain_store_cache_update.block_ordinal_to_hash {
-            store_update.set_ser(
-                DBCol::BlockOrdinal,
-                &index_to_bytes(*block_ordinal),
-                block_hash,
-            )?;
+            store_update.set_ser(DBCol::BlockOrdinal, &index_to_bytes(*block_ordinal), block_hash);
         }
 
         // Convert trie changes to database ops for trie nodes.
@@ -2158,7 +2154,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::StateTransitionData,
                     &get_block_shard_id(&block_hash, shard_id),
                     &state_transition_data,
-                )?;
+                );
             }
         }
         {
@@ -2188,11 +2184,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 prev_table.swap_remove(remove_idx);
 
                 if !prev_table.is_empty() {
-                    store_update.set_ser(
-                        DBCol::BlocksToCatchup,
-                        prev_hash.as_ref(),
-                        &prev_table,
-                    )?;
+                    store_update.set_ser(DBCol::BlocksToCatchup, prev_hash.as_ref(), &prev_table);
                 } else {
                     store_update.delete(DBCol::BlocksToCatchup, prev_hash.as_ref());
                 }
@@ -2220,7 +2212,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 let mut prev_table =
                     self.chain_store.get_blocks_to_catchup(&prev_hash).unwrap_or_else(|_| vec![]);
                 prev_table.push(new_hash);
-                store_update.set_ser(DBCol::BlocksToCatchup, prev_hash.as_ref(), &prev_table)?;
+                store_update.set_ser(DBCol::BlocksToCatchup, prev_hash.as_ref(), &prev_table);
             }
         }
 
@@ -2229,7 +2221,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 DBCol::StateDlInfos,
                 state_sync_info.epoch_first_block().as_ref(),
                 &state_sync_info,
-            )?;
+            );
         }
         for hash in self.remove_state_sync_infos.drain(..) {
             store_update.delete(DBCol::StateDlInfos, hash.as_ref());
@@ -2238,18 +2230,14 @@ impl<'a> ChainStoreUpdate<'a> {
             store_update.insert_ser(DBCol::InvalidChunks, chunk_hash.as_ref(), chunk)?;
         }
         for block_height in &self.chain_store_cache_update.processed_block_heights {
-            store_update.set_ser(
-                DBCol::ProcessedBlockHeights,
-                &index_to_bytes(*block_height),
-                &(),
-            )?;
+            store_update.set_ser(DBCol::ProcessedBlockHeights, &index_to_bytes(*block_height), &());
         }
         for ((block_hash, shard_id), stats) in &self.chunk_apply_stats {
             store_update.set_ser(
                 DBCol::ChunkApplyStats,
                 &get_block_shard_id(block_hash, *shard_id),
                 stats,
-            )?;
+            );
         }
         for other in self.store_updates.drain(..) {
             store_update.merge(other);

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -500,7 +500,7 @@ mod tests {
         let (chain, mut sv) = init();
         let mut store_update = chain.chain_store().store().store_update();
         assert!(sv.validate_col(DBCol::TrieChanges).is_ok());
-        store_update.set_ser::<[u8]>(DBCol::TrieChanges, "567".as_ref(), &[123]).unwrap();
+        store_update.set_ser::<[u8]>(DBCol::TrieChanges, "567".as_ref(), &[123]);
         store_update.commit();
         match sv.validate_col(DBCol::TrieChanges) {
             Err(StoreValidatorError::DBCorruption(_)) => {}

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -326,7 +326,7 @@ async fn apply_state_part(
 
     // Mark part as applied.
     let mut store_update = store.store_update();
-    store_update.set_ser(DBCol::StatePartsApplied, &key_bytes, &true)?;
+    store_update.set_ser(DBCol::StatePartsApplied, &key_bytes, &true);
     store_update.commit();
 
     Ok(StatePartApplyResult::Applied)

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -424,9 +424,7 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
         height: BlockHeight,
         hash_set: &HashSet<CryptoHash>,
     ) {
-        self.store_update
-            .set_ser(DBCol::HeaderHashesByHeight, &index_to_bytes(height), hash_set)
-            .unwrap();
+        self.store_update.set_ser(DBCol::HeaderHashesByHeight, &index_to_bytes(height), hash_set);
     }
 
     /// Note: Typically block_merkle_tree is saved while saving the block header
@@ -436,29 +434,23 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
         block_hash: &CryptoHash,
         block_merkle_tree: &PartialMerkleTree,
     ) {
-        self.store_update
-            .set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree)
-            .unwrap();
+        self.store_update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree);
     }
 
     pub fn set_block_ordinal(&mut self, block_ordinal: NumBlocks, block_hash: &CryptoHash) {
-        self.store_update
-            .set_ser(DBCol::BlockOrdinal, &index_to_bytes(block_ordinal), block_hash)
-            .unwrap();
+        self.store_update.set_ser(DBCol::BlockOrdinal, &index_to_bytes(block_ordinal), block_hash);
     }
 
     pub fn set_block_height(&mut self, hash: &CryptoHash, height: BlockHeight) {
-        self.store_update
-            .set_ser(DBCol::BlockHeight, &borsh::to_vec(&height).unwrap(), hash)
-            .unwrap();
+        self.store_update.set_ser(DBCol::BlockHeight, &borsh::to_vec(&height).unwrap(), hash);
     }
 
     pub fn set_header_head(&mut self, header_head: &Tip) {
-        self.store_update.set_ser(DBCol::BlockMisc, HEADER_HEAD_KEY, header_head).unwrap();
+        self.store_update.set_ser(DBCol::BlockMisc, HEADER_HEAD_KEY, header_head);
     }
 
     pub fn set_final_head(&mut self, final_head: &Tip) {
-        self.store_update.set_ser(DBCol::BlockMisc, FINAL_HEAD_KEY, final_head).unwrap();
+        self.store_update.set_ser(DBCol::BlockMisc, FINAL_HEAD_KEY, final_head);
     }
 
     /// This function is normally clubbed with set_block_header_only

--- a/core/store/src/adapter/epoch_store.rs
+++ b/core/store/src/adapter/epoch_store.rs
@@ -144,7 +144,7 @@ impl<'a> EpochStoreUpdateAdapter<'a> {
     }
 
     pub fn set_epoch_start(&mut self, epoch_id: &EpochId, start: BlockHeight) {
-        self.store_update.set_ser(DBCol::EpochStart, epoch_id.as_ref(), &start).unwrap();
+        self.store_update.set_ser(DBCol::EpochStart, epoch_id.as_ref(), &start);
     }
 
     pub fn set_block_info(&mut self, block_info: &BlockInfo) {
@@ -154,20 +154,18 @@ impl<'a> EpochStoreUpdateAdapter<'a> {
     }
 
     pub fn set_epoch_info(&mut self, epoch_id: &EpochId, epoch_info: &EpochInfo) {
-        self.store_update.set_ser(DBCol::EpochInfo, epoch_id.as_ref(), epoch_info).unwrap();
+        self.store_update.set_ser(DBCol::EpochInfo, epoch_id.as_ref(), epoch_info);
     }
 
     pub fn set_epoch_info_aggregator<T: BorshSerialize + ?Sized>(
         &mut self,
         epoch_info_aggregator: &T,
     ) {
-        self.store_update.set_ser(DBCol::EpochInfo, AGGREGATOR_KEY, epoch_info_aggregator).unwrap();
+        self.store_update.set_ser(DBCol::EpochInfo, AGGREGATOR_KEY, epoch_info_aggregator);
     }
 
     pub fn set_epoch_validator_info(&mut self, epoch_id: &EpochId, epoch_summary: &EpochSummary) {
-        self.store_update
-            .set_ser(DBCol::EpochValidatorInfo, epoch_id.as_ref(), epoch_summary)
-            .unwrap();
+        self.store_update.set_ser(DBCol::EpochValidatorInfo, epoch_id.as_ref(), epoch_summary);
     }
 
     pub fn set_epoch_sync_proof(&mut self, proof: &EpochSyncProof) {
@@ -175,13 +173,15 @@ impl<'a> EpochStoreUpdateAdapter<'a> {
         // Enabling ContinuousEpochSync performs a migration to store the compressed proof.
         if ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) {
             let (compressed_proof, _) = CompressedEpochSyncProof::encode(proof).unwrap();
-            self.store_update
-                .set_ser(DBCol::EpochSyncProof, COMPRESSED_EPOCH_SYNC_PROOF_KEY, &compressed_proof)
-                .unwrap();
+            self.store_update.set_ser(
+                DBCol::EpochSyncProof,
+                COMPRESSED_EPOCH_SYNC_PROOF_KEY,
+                &compressed_proof,
+            );
             let compressed_proof_size = compressed_proof.size_bytes() as i64;
             metrics::EPOCH_SYNC_LAST_GENERATED_COMPRESSED_PROOF_SIZE.set(compressed_proof_size);
         } else {
-            self.store_update.set_ser(DBCol::EpochSyncProof, &[], &proof).unwrap();
+            self.store_update.set_ser(DBCol::EpochSyncProof, &[], &proof);
         }
     }
 }

--- a/core/store/src/adapter/flat_store.rs
+++ b/core/store/src/adapter/flat_store.rs
@@ -221,10 +221,7 @@ impl<'a> FlatStoreUpdateAdapter<'a> {
     pub fn set(&mut self, shard_uid: ShardUId, key: Vec<u8>, value: Option<FlatStateValue>) {
         let db_key = encode_flat_state_db_key(shard_uid, &key);
         match value {
-            Some(value) => self
-                .store_update
-                .set_ser(DBCol::FlatState, &db_key, &value)
-                .expect("Borsh should not have failed here"),
+            Some(value) => self.store_update.set_ser(DBCol::FlatState, &db_key, &value),
             None => self.store_update.delete(DBCol::FlatState, &db_key),
         }
     }
@@ -234,9 +231,7 @@ impl<'a> FlatStoreUpdateAdapter<'a> {
     }
 
     pub fn set_flat_storage_status(&mut self, shard_uid: ShardUId, status: FlatStorageStatus) {
-        self.store_update
-            .set_ser(DBCol::FlatStorageStatus, &shard_uid.to_bytes(), &status)
-            .expect("Borsh should not have failed here")
+        self.store_update.set_ser(DBCol::FlatStorageStatus, &shard_uid.to_bytes(), &status);
     }
 
     pub fn remove_status(&mut self, shard_uid: ShardUId) {
@@ -246,12 +241,8 @@ impl<'a> FlatStoreUpdateAdapter<'a> {
     pub fn set_delta(&mut self, shard_uid: ShardUId, delta: &FlatStateDelta) {
         let key =
             KeyForFlatStateDelta { shard_uid, block_hash: delta.metadata.block.hash }.to_bytes();
-        self.store_update
-            .set_ser(DBCol::FlatStateChanges, &key, &delta.changes)
-            .expect("Borsh should not have failed here");
-        self.store_update
-            .set_ser(DBCol::FlatStateDeltaMetadata, &key, &delta.metadata)
-            .expect("Borsh should not have failed here");
+        self.store_update.set_ser(DBCol::FlatStateChanges, &key, &delta.changes);
+        self.store_update.set_ser(DBCol::FlatStateDeltaMetadata, &key, &delta.metadata);
     }
 
     pub fn remove_delta(&mut self, shard_uid: ShardUId, block_hash: CryptoHash) {

--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -159,7 +159,7 @@ impl<'a> TrieStoreUpdateAdapter<'a> {
     pub fn set_state_snapshot_hash(&mut self, hash: Option<CryptoHash>) {
         let key = STATE_SNAPSHOT_KEY;
         match hash {
-            Some(hash) => self.store_update.set_ser(DBCol::BlockMisc, key, &hash).unwrap(),
+            Some(hash) => self.store_update.set_ser(DBCol::BlockMisc, key, &hash),
             None => self.store_update.delete(DBCol::BlockMisc, key),
         }
     }
@@ -171,7 +171,7 @@ impl<'a> TrieStoreUpdateAdapter<'a> {
         trie_changes: &TrieChanges,
     ) {
         let key = get_block_shard_uid(block_hash, &shard_uid);
-        self.store_update.set_ser(DBCol::TrieChanges, &key, trie_changes).unwrap();
+        self.store_update.set_ser(DBCol::TrieChanges, &key, trie_changes);
     }
 
     pub fn set_state_changes(

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -420,16 +420,10 @@ impl StoreUpdate {
     ///
     /// Must not be used for reference-counted columns; use
     /// ['Self::increment_refcount'] or [`Self::decrement_refcount`] instead.
-    pub fn set_ser<T: BorshSerialize + ?Sized>(
-        &mut self,
-        column: DBCol,
-        key: &[u8],
-        value: &T,
-    ) -> io::Result<()> {
+    pub fn set_ser<T: BorshSerialize + ?Sized>(&mut self, column: DBCol, key: &[u8], value: &T) {
         assert!(!(column.is_rc() || column.is_insert_only()), "can't set_ser: {column}");
-        let data = borsh::to_vec(&value)?;
+        let data = borsh::to_vec(&value).expect("borsh serialization should not fail");
         self.set(column, key, &data);
-        Ok(())
     }
 
     /// Modify raw value stored in the database, without doing any sanity checks
@@ -692,7 +686,7 @@ mod tests {
 
     fn set_and_write(store: &Store, key: &[u8], val: u64) {
         let mut su = store.store_update();
-        su.set_ser(COL, key, &val).unwrap();
+        su.set_ser(COL, key, &val);
         store.write(su.transaction);
     }
 

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -539,9 +539,11 @@ mod tests {
     ) {
         let chunk_extra = ChunkExtra::new_with_only_state_root(&state_root);
         let mut store_update = store.store_update();
-        store_update
-            .set_ser(DBCol::ChunkExtra, &get_block_shard_uid(&block_hash, &shard_uid), &chunk_extra)
-            .unwrap();
+        store_update.set_ser(
+            DBCol::ChunkExtra,
+            &get_block_shard_uid(&block_hash, &shard_uid),
+            &chunk_extra,
+        );
         store_update.commit();
     }
 }

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -458,14 +458,11 @@ mod trie_recording_tests {
         // ChunkExtra is needed for in-memory trie loading code to query state roots.
         let chunk_extra = ChunkExtra::new_with_only_state_root(&state_root);
         let mut update_for_chunk_extra = tries_for_building.store_update();
-        update_for_chunk_extra
-            .store_update()
-            .set_ser(
-                DBCol::ChunkExtra,
-                &get_block_shard_uid(&CryptoHash::default(), &shard_uid),
-                &chunk_extra,
-            )
-            .unwrap();
+        update_for_chunk_extra.store_update().set_ser(
+            DBCol::ChunkExtra,
+            &get_block_shard_uid(&CryptoHash::default(), &shard_uid),
+            &chunk_extra,
+        );
         update_for_chunk_extra.commit();
 
         let data_in_trie = trie_changes

--- a/core/store/src/utils/mod.rs
+++ b/core/store/src/utils/mod.rs
@@ -397,18 +397,14 @@ pub fn get_genesis_congestion_infos(store: &Store) -> io::Result<Option<Vec<Cong
 }
 
 pub fn set_genesis_state_roots(store_update: &mut StoreUpdate, genesis_roots: &[StateRoot]) {
-    store_update
-        .set_ser(DBCol::BlockMisc, GENESIS_STATE_ROOTS_KEY, genesis_roots)
-        .expect("Borsh cannot fail");
+    store_update.set_ser(DBCol::BlockMisc, GENESIS_STATE_ROOTS_KEY, genesis_roots);
 }
 
 pub fn set_genesis_congestion_infos(
     store_update: &mut StoreUpdate,
     congestion_infos: &[CongestionInfo],
 ) {
-    store_update
-        .set_ser(DBCol::BlockMisc, GENESIS_CONGESTION_INFO_KEY, &congestion_infos)
-        .expect("Borsh cannot fail");
+    store_update.set_ser(DBCol::BlockMisc, GENESIS_CONGESTION_INFO_KEY, &congestion_infos);
 }
 
 pub fn get_genesis_height(store: &Store) -> io::Result<Option<BlockHeight>> {
@@ -416,7 +412,5 @@ pub fn get_genesis_height(store: &Store) -> io::Result<Option<BlockHeight>> {
 }
 
 pub fn set_genesis_height(store_update: &mut StoreUpdate, genesis_height: &BlockHeight) {
-    store_update
-        .set_ser::<BlockHeight>(DBCol::BlockMisc, GENESIS_HEIGHT_KEY, genesis_height)
-        .expect("Borsh cannot fail");
+    store_update.set_ser::<BlockHeight>(DBCol::BlockMisc, GENESIS_HEIGHT_KEY, genesis_height);
 }

--- a/core/store/src/utils/test_utils.rs
+++ b/core/store/src/utils/test_utils.rs
@@ -206,13 +206,11 @@ impl TestTriesBuilder {
             let chunk_extra = ChunkExtra::new_with_only_state_root(&Trie::EMPTY_ROOT);
             let mut update_for_chunk_extra = store.store_update();
             for shard_uid in &shard_uids {
-                update_for_chunk_extra
-                    .set_ser(
-                        DBCol::ChunkExtra,
-                        &get_block_shard_uid(&CryptoHash::default(), shard_uid),
-                        &chunk_extra,
-                    )
-                    .unwrap();
+                update_for_chunk_extra.set_ser(
+                    DBCol::ChunkExtra,
+                    &get_block_shard_uid(&CryptoHash::default(), shard_uid),
+                    &chunk_extra,
+                );
             }
             update_for_chunk_extra.commit();
 

--- a/tools/database/src/write_to_db.rs
+++ b/tools/database/src/write_to_db.rs
@@ -48,7 +48,7 @@ impl WriteCryptoHashCommand {
                         DBCol::BlockMisc,
                         near_store::STATE_SNAPSHOT_KEY,
                         &self.hash,
-                    )?;
+                    );
                 }
             },
         }

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -409,11 +409,11 @@ impl ForkNetworkCommand {
         );
 
         let mut store_update = store.store_update();
-        store_update.set_ser(DBCol::Misc, EPOCH_ID_KEY, epoch_id)?;
-        store_update.set_ser(DBCol::Misc, FLAT_HEAD_KEY, &desired_flat_head)?;
-        store_update.set_ser(DBCol::Misc, SHARD_LAYOUT_KEY, &target_shard_layout)?;
+        store_update.set_ser(DBCol::Misc, EPOCH_ID_KEY, epoch_id);
+        store_update.set_ser(DBCol::Misc, FLAT_HEAD_KEY, &desired_flat_head);
+        store_update.set_ser(DBCol::Misc, SHARD_LAYOUT_KEY, &target_shard_layout);
         for (shard_uid, state_root) in &state_roots {
-            store_update.set_ser(DBCol::Misc, &make_state_roots_key(*shard_uid), state_root)?;
+            store_update.set_ser(DBCol::Misc, &make_state_roots_key(*shard_uid), state_root);
         }
         store_update.commit();
         Ok(())

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -450,7 +450,7 @@ fn commit_to_existing_state(
 
     tracing::info!(?shard_uid, num_updates, "committing");
     let key = crate::cli::make_state_roots_key(shard_uid);
-    update.store_update().set_ser(DBCol::Misc, &key, &state_root)?;
+    update.store_update().set_ser(DBCol::Misc, &key, &state_root);
 
     update.commit();
     tracing::info!(?shard_uid, ?state_root, "commit is done");
@@ -482,7 +482,7 @@ fn commit_to_new_state(
     FlatStateChanges::from_state_changes(&state_changes)
         .apply_to_flat_state(&mut store_update.flat_store_update(), shard_uid);
     let key = crate::cli::make_state_roots_key(shard_uid);
-    store_update.store_update().set_ser(DBCol::Misc, &key, &state_root)?;
+    store_update.store_update().set_ser(DBCol::Misc, &key, &state_root);
     tracing::info!(?shard_uid, "committing initial state to new shard");
     store_update.commit();
 
@@ -615,13 +615,11 @@ pub(crate) fn finalize_state(
 
         let mut trie_update = shard_tries.store_update();
         let store_update = trie_update.store_update();
-        store_update
-            .set_ser(
-                DBCol::FlatStorageStatus,
-                &shard_uid.to_bytes(),
-                &FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head }),
-            )
-            .unwrap();
+        store_update.set_ser(
+            DBCol::FlatStorageStatus,
+            &shard_uid.to_bytes(),
+            &FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head }),
+        );
         trie_update.commit();
         tracing::info!(?shard_uid, "wrote flat storage status for new shard");
     }

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -99,30 +99,22 @@ fn read_block_checkpoint(store: &Store, block_hash: &CryptoHash) -> BlockCheckpo
 
 fn write_block_checkpoint(store_update: &mut StoreUpdate, block_checkpoint: &BlockCheckpoint) {
     let hash = block_checkpoint.header.hash();
-    store_update
-        .set_ser(DBCol::BlockHeader, hash.as_ref(), &block_checkpoint.header)
-        .expect("Failed writing a header");
+    store_update.set_ser(DBCol::BlockHeader, hash.as_ref(), &block_checkpoint.header);
 
     store_update
         .insert_ser(DBCol::BlockInfo, hash.as_ref(), &block_checkpoint.info)
         .expect("Failed writing a block info");
 
-    store_update
-        .set_ser(DBCol::BlockMerkleTree, hash.as_ref(), &block_checkpoint.merkle_tree)
-        .expect("Failed writing merkle tree");
-    store_update
-        .set_ser(
-            DBCol::BlockHeight,
-            &index_to_bytes(block_checkpoint.header.height()),
-            block_checkpoint.header.hash(),
-        )
-        .unwrap();
+    store_update.set_ser(DBCol::BlockMerkleTree, hash.as_ref(), &block_checkpoint.merkle_tree);
+    store_update.set_ser(
+        DBCol::BlockHeight,
+        &index_to_bytes(block_checkpoint.header.height()),
+        block_checkpoint.header.hash(),
+    );
 }
 
 fn write_epoch_checkpoint(store_update: &mut StoreUpdate, epoch_checkpoint: &EpochCheckpoint) {
-    store_update
-        .set_ser(DBCol::EpochInfo, epoch_checkpoint.id.as_ref(), &epoch_checkpoint.info)
-        .expect("Failed to write epoch info");
+    store_update.set_ser(DBCol::EpochInfo, epoch_checkpoint.id.as_ref(), &epoch_checkpoint.info);
 }
 
 fn create_snapshot(create_cmd: CreateCmd) {
@@ -286,15 +278,17 @@ fn load_snapshot(load_cmd: LoadCmd) {
     write_block_checkpoint(&mut store_update, &snapshot.first_block);
 
     // Store the HEADER_KEY (used in header sync).
-    store_update
-        .set_ser(DBCol::BlockMisc, HEADER_HEAD_KEY, &Tip::from_header(&snapshot.block.header))
-        .unwrap();
+    store_update.set_ser(
+        DBCol::BlockMisc,
+        HEADER_HEAD_KEY,
+        &Tip::from_header(&snapshot.block.header),
+    );
 
     // TODO: confirm if this aggregator can be empty.
     // If not - we'll have to compute one and put it in the checkpoint.
     let aggregator =
         EpochInfoAggregator::new(snapshot.prev_epoch.id, *snapshot.final_block.header.hash());
-    store_update.set_ser(DBCol::EpochInfo, AGGREGATOR_KEY, &aggregator).unwrap();
+    store_update.set_ser(DBCol::EpochInfo, AGGREGATOR_KEY, &aggregator);
     store_update.commit();
 }
 

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -543,13 +543,11 @@ fn apply_block_from_range(
                         .map(|c| c.into())
                         .collect(),
                 });
-            store_update
-                .set_ser(
-                    DBCol::StateTransitionData,
-                    &get_block_shard_id(&block_hash, shard_id),
-                    &state_transition_data,
-                )
-                .unwrap();
+            store_update.set_ser(
+                DBCol::StateTransitionData,
+                &get_block_shard_id(&block_hash, shard_id),
+                &state_transition_data,
+            );
             store_update.commit();
         }
         (_, StorageSource::FlatStorage) => {


### PR DESCRIPTION
`StoreUpdate::set_ser()` returned `io::Result<()>` solely because `borsh::to_vec()` can theoretically fail. In practice, borsh serialization of in-memory Rust types never fails — if it does, it's a bug and panicking is appropriate (per the established project convention for irrecoverable store errors).

Change the return type from `io::Result<()>` to `()`, replacing the `?` on `borsh::to_vec()` with `.expect()`. Update all call sites across 22 files to drop the now-unnecessary `?` or `.unwrap()`.