### PR TITLE
fix(ci): run PR title check workflow on merge group

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -14,6 +14,12 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          # Skip validation for merge_group events since PR title was already validated
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "Skipping PR title validation for merge_group event"
+            exit 0
+          fi
+
           # PR title must match: <type>: <title> or <type>(<project>): <title>
           # See CONTRIBUTING.md for details.
 


### PR DESCRIPTION
Currently we cannot merge PRs because PR Title check workflow is required but doesn't get triggered as part of merge queue.