### PR TITLE
feat(crypto): verification of `Secp256K1PublicKey` on string parsing

### DIFF
--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -72,33 +72,29 @@ fn split_key_type_data(value: &str) -> Result<(KeyType, &str), crate::errors::Pa
 #[as_ref(forward)]
 pub struct Secp256K1PublicKey([u8; 64]);
 
-impl Secp256K1PublicKey {
-    /// Validates that the point lies on the secp256k1 curve.
-    pub fn verify(&self) -> Result<(), crate::errors::ParseKeyError> {
-        let mut uncompressed = [0x04; 65];
-        uncompressed[1..].copy_from_slice(&self.0);
-
-        // This checks if PublicKey lies on the curve
-        secp256k1::PublicKey::from_slice(&uncompressed).map_err(|e| {
-            crate::errors::ParseKeyError::InvalidData { error_message: e.to_string() }
-        })?;
-
-        Ok(())
-    }
-}
-
 impl TryFrom<&[u8]> for Secp256K1PublicKey {
     type Error = crate::errors::ParseKeyError;
 
     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-        let pk: Self = data.try_into().map_err(|_| Self::Error::InvalidLength {
+        let data: [u8; 64] = data.try_into().map_err(|_| Self::Error::InvalidLength {
             expected_length: 64,
             received_length: data.len(),
         })?;
 
-        pk.verify()?;
+        let mut uncompressed = [0x04; 65];
+        uncompressed[1..].copy_from_slice(&data);
 
-        Ok(pk)
+        // This checks if PublicKey lies on the curve
+        // We add 0x04 header byte to show that this is "uncompressed" public key, as
+        // internal `secp256k1_ec_pubkey_parse` expects it to be 65 bytes
+        //
+        // P.S. newer version of secp256k1 crate also accept 64 byte-sized PublicKey, but on older
+        // versions it just passes it to internal `secp256k1_ec_pubkey_parse` C library binding
+        secp256k1::PublicKey::from_slice(&uncompressed).map_err(|e| {
+            crate::errors::ParseKeyError::InvalidData { error_message: e.to_string() }
+        })?;
+
+        Ok(Self(data))
     }
 }
 
@@ -250,9 +246,10 @@ impl BorshDeserialize for PublicKey {
                 Ok(PublicKey::ED25519(ED25519PublicKey(BorshDeserialize::deserialize_reader(rd)?)))
             }
             KeyType::SECP256K1 => {
-                let pk = Secp256K1PublicKey(BorshDeserialize::deserialize_reader(rd)?);
-                pk.verify().map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
-                Ok(PublicKey::SECP256K1(pk))
+                let data: [u8; 64] = BorshDeserialize::deserialize_reader(rd)?;
+                let pk = Secp256K1PublicKey::try_from(data.as_slice())
+                    .map_err(|err| Error::new(ErrorKind::InvalidData, err.to_string()))?;
+                Ok(Self::SECP256K1(pk))
             }
         }
     }
@@ -289,8 +286,8 @@ impl FromStr for PublicKey {
         Ok(match key_type {
             KeyType::ED25519 => Self::ED25519(ED25519PublicKey(decode_bs58(key_data)?)),
             KeyType::SECP256K1 => {
-                let pk = Secp256K1PublicKey(decode_bs58(key_data)?);
-                pk.verify()?;
+                let data = decode_bs58::<64>(key_data)?;
+                let pk = Secp256K1PublicKey::try_from(data.as_slice())?;
                 Self::SECP256K1(pk)
             }
         })
@@ -823,6 +820,8 @@ impl std::convert::From<DecodeBs58Error> for crate::errors::ParseSignatureError 
 
 #[cfg(test)]
 mod tests {
+    use borsh::BorshDeserialize;
+
     use super::{KeyType, PublicKey, SecretKey, Signature};
 
     #[cfg(feature = "rand")]
@@ -946,5 +945,12 @@ mod tests {
         assert!(serde_json::from_str::<PublicKey>(invalid).is_err());
         assert!(serde_json::from_str::<SecretKey>(invalid).is_err());
         assert!(serde_json::from_str::<Signature>(invalid).is_err());
+
+        let invalid_pk_secp = "\"secp256k1:qMoRgcoXai4mBPsdbHi1wfyxF9TdbPCF4qSDQTRP3TfescSRoUdSx6nmeQoN3aiwGzwMyGXAb1gUjBTv5AY8DXjL\"";
+        assert!(serde_json::from_str::<PublicKey>(invalid_pk_secp).is_err());
+
+        let mut invalid_borsh = vec![1u8];
+        invalid_borsh.extend_from_slice(&[0xFF; 64]);
+        assert!(PublicKey::try_from_slice(&invalid_borsh).is_err())
     }
 }

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -817,8 +817,6 @@ impl std::convert::From<DecodeBs58Error> for crate::errors::ParseSignatureError 
 
 #[cfg(test)]
 mod tests {
-    use borsh::BorshDeserialize;
-
     use super::{KeyType, PublicKey, SecretKey, Signature};
 
     #[cfg(feature = "rand")]
@@ -945,9 +943,5 @@ mod tests {
 
         let invalid_pk_secp = "\"secp256k1:qMoRgcoXai4mBPsdbHi1wfyxF9TdbPCF4qSDQTRP3TfescSRoUdSx6nmeQoN3aiwGzwMyGXAb1gUjBTv5AY8DXjL\"";
         assert!(serde_json::from_str::<PublicKey>(invalid_pk_secp).is_err());
-
-        let mut invalid_borsh = vec![1u8];
-        invalid_borsh.extend_from_slice(&[0xFF; 64]);
-        assert!(PublicKey::try_from_slice(&invalid_borsh).is_err())
     }
 }

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -72,14 +72,33 @@ fn split_key_type_data(value: &str) -> Result<(KeyType, &str), crate::errors::Pa
 #[as_ref(forward)]
 pub struct Secp256K1PublicKey([u8; 64]);
 
+impl Secp256K1PublicKey {
+    /// Validates that the point lies on the secp256k1 curve.
+    pub fn verify(&self) -> Result<(), crate::errors::ParseKeyError> {
+        let mut uncompressed = [0x04; 65];
+        uncompressed[1..].copy_from_slice(&self.0);
+
+        // This checks if PublicKey lies on the curve
+        secp256k1::PublicKey::from_slice(&uncompressed).map_err(|e| {
+            crate::errors::ParseKeyError::InvalidData { error_message: e.to_string() }
+        })?;
+
+        Ok(())
+    }
+}
+
 impl TryFrom<&[u8]> for Secp256K1PublicKey {
     type Error = crate::errors::ParseKeyError;
 
     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-        data.try_into().map(Self).map_err(|_| Self::Error::InvalidLength {
+        let pk: Self = data.try_into().map_err(|_| Self::Error::InvalidLength {
             expected_length: 64,
             received_length: data.len(),
-        })
+        })?;
+
+        pk.verify()?;
+
+        Ok(pk)
     }
 }
 
@@ -230,9 +249,11 @@ impl BorshDeserialize for PublicKey {
             KeyType::ED25519 => {
                 Ok(PublicKey::ED25519(ED25519PublicKey(BorshDeserialize::deserialize_reader(rd)?)))
             }
-            KeyType::SECP256K1 => Ok(PublicKey::SECP256K1(Secp256K1PublicKey(
-                BorshDeserialize::deserialize_reader(rd)?,
-            ))),
+            KeyType::SECP256K1 => {
+                let pk = Secp256K1PublicKey(BorshDeserialize::deserialize_reader(rd)?);
+                pk.verify().map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+                Ok(PublicKey::SECP256K1(pk))
+            }
         }
     }
 }
@@ -267,7 +288,11 @@ impl FromStr for PublicKey {
         let (key_type, key_data) = split_key_type_data(value)?;
         Ok(match key_type {
             KeyType::ED25519 => Self::ED25519(ED25519PublicKey(decode_bs58(key_data)?)),
-            KeyType::SECP256K1 => Self::SECP256K1(Secp256K1PublicKey(decode_bs58(key_data)?)),
+            KeyType::SECP256K1 => {
+                let pk = Secp256K1PublicKey(decode_bs58(key_data)?);
+                pk.verify()?;
+                Self::SECP256K1(pk)
+            }
         })
     }
 }

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -245,12 +245,9 @@ impl BorshDeserialize for PublicKey {
             KeyType::ED25519 => {
                 Ok(PublicKey::ED25519(ED25519PublicKey(BorshDeserialize::deserialize_reader(rd)?)))
             }
-            KeyType::SECP256K1 => {
-                let data: [u8; 64] = BorshDeserialize::deserialize_reader(rd)?;
-                let pk = Secp256K1PublicKey::try_from(data.as_slice())
-                    .map_err(|err| Error::new(ErrorKind::InvalidData, err.to_string()))?;
-                Ok(Self::SECP256K1(pk))
-            }
+            KeyType::SECP256K1 => Ok(PublicKey::SECP256K1(Secp256K1PublicKey(
+                BorshDeserialize::deserialize_reader(rd)?,
+            ))),
         }
     }
 }

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -81,15 +81,15 @@ impl TryFrom<&[u8]> for Secp256K1PublicKey {
             received_length: data.len(),
         })?;
 
-        let mut uncompressed = [0x04; 65];
-        uncompressed[1..].copy_from_slice(&data);
-
-        // This checks if PublicKey lies on the curve
         // We add 0x04 header byte to show that this is "uncompressed" public key, as
         // internal `secp256k1_ec_pubkey_parse` expects it to be 65 bytes
         //
         // P.S. newer version of secp256k1 crate also accept 64 byte-sized PublicKey, but on older
         // versions it just passes it to internal `secp256k1_ec_pubkey_parse` C library binding
+        let mut uncompressed = [0x04; 65];
+        uncompressed[1..].copy_from_slice(&data);
+
+        // This checks if PublicKey lies on the curve
         secp256k1::PublicKey::from_slice(&uncompressed).map_err(|e| {
             crate::errors::ParseKeyError::InvalidData { error_message: e.to_string() }
         })?;
@@ -941,7 +941,7 @@ mod tests {
         assert!(serde_json::from_str::<SecretKey>(invalid).is_err());
         assert!(serde_json::from_str::<Signature>(invalid).is_err());
 
-        let invalid_pk_secp = "\"secp256k1:qMoRgcoXai4mBPsdbHi1wfyxF9TdbPCF4qSDQTRP3TfescSRoUdSx6nmeQoN3aiwGzwMyGXAb1gUjBTv5AY8DXjL\"";
+        let invalid_pk_secp = "\"secp256k1:qMoRgcoXai4mBPsdbHi1wfyxF9TdbPCF4qSDQTRP3TfescSRoUdSx6nmeQoN3aiwGzwMyGXAb1gUjBTv5AY8DXj\"";
         assert!(serde_json::from_str::<PublicKey>(invalid_pk_secp).is_err());
     }
 }


### PR DESCRIPTION
This is a continuation to the [discussion regarding parsing of `Secp256K1PublicKey` in Zulip](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/Questions.20regarding.20parsing.20of.20.60Secp256k1PublicKey.60/with/570963179)
                                                                                                                                                                                                                    
`Secp256K1PublicKey` parsing previously only checked that the input was 64 bytes, without validating that the point actually lies on the secp256k1 curve. This deferred validation to signature verification time, where the error is more confusing. Meanwhile, SecretKey parsing already validated via `secp256k1::SecretKey::from_slice()`.

This PR adds curve validation via `secp256k1::PublicKey::from_slice()` directly in `TryFrom<&[u8]>`, making it the single validation gatekeeper. Only `FromStr` delegates to it, as adding it to `BorshDeserialize` might bring issues for malformed PubKeys that are already inside storage and might throw.

Internal code that constructs `Secp256K1PublicKey` from trusted sources (aka from an already-verified signature recovery) still uses `Secp256K1PublicKey([..])` directly to avoid redundant validation.

Note: `From<[u8; 64]>` (via `derive_more::From`) is intentionally kept for backward compatibility and does not validate.