### PR TITLE
refactor(store): remove Result from StoreUpdate::insert_ser()

### DIFF
--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -532,7 +532,7 @@ pub fn record_uncertified_chunks_for_block(
         DBCol::uncertified_chunks(),
         block.header().hash().as_ref(),
         &uncertified_chunks,
-    )?;
+    );
     chain_store_update.merge(store_update);
     Ok(())
 }

--- a/chain/chain/src/spice_core_writer_actor.rs
+++ b/chain/chain/src/spice_core_writer_actor.rs
@@ -111,7 +111,7 @@ impl SpiceCoreWriterActor {
     ) -> Result<StoreUpdate, std::io::Error> {
         let key = get_execution_results_key(block_hash, shard_id);
         let mut store_update = self.chain_store.store().store_update();
-        store_update.insert_ser(DBCol::execution_results(), &key, &execution_result)?;
+        store_update.insert_ser(DBCol::execution_results(), &key, &execution_result);
         Ok(store_update)
     }
 
@@ -121,7 +121,7 @@ impl SpiceCoreWriterActor {
     ) -> Result<StoreUpdate, std::io::Error> {
         let key = get_uncertified_execution_results_key(&execution_result.compute_hash());
         let mut store_update = self.chain_store.store().store_update();
-        store_update.insert_ser(DBCol::uncertified_execution_results(), &key, &execution_result)?;
+        store_update.insert_ser(DBCol::uncertified_execution_results(), &key, &execution_result);
         Ok(store_update)
     }
 

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1927,7 +1927,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     &index_to_bytes(block.header().height()),
                     &map,
                 );
-                store_update.insert_ser(DBCol::Block, block.hash().as_ref(), block)?;
+                store_update.insert_ser(DBCol::Block, block.hash().as_ref(), block);
                 if cfg!(feature = "protocol_feature_spice") {
                     let prev_hash = block.header().prev_hash();
                     let mut prev_next_hashes =
@@ -1948,7 +1948,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     continue;
                 }
                 headers_by_height.entry(header.height()).or_default().push(header);
-                store_update.insert_ser(DBCol::BlockHeader, hash.as_ref(), header)?;
+                store_update.insert_ser(DBCol::BlockHeader, hash.as_ref(), header);
             }
             for (height, headers) in headers_by_height {
                 let mut hash_set = match self.chain_store.get_all_header_hashes_by_height(height) {
@@ -2015,7 +2015,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     );
                 }
 
-                store_update.insert_ser(DBCol::Chunks, chunk_hash.as_ref(), chunk)?;
+                store_update.insert_ser(DBCol::Chunks, chunk_hash.as_ref(), chunk);
             }
             for (height, hash_set) in chunk_hashes_by_height {
                 store_update.set_ser(
@@ -2025,11 +2025,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 );
             }
             for (chunk_hash, partial_chunk) in &self.chain_store_cache_update.partial_chunks {
-                store_update.insert_ser(
-                    DBCol::PartialChunks,
-                    chunk_hash.as_ref(),
-                    partial_chunk,
-                )?;
+                store_update.insert_ser(DBCol::PartialChunks, chunk_hash.as_ref(), partial_chunk);
 
                 for receipts in partial_chunk.prev_outgoing_receipts() {
                     for receipt in &receipts.0 {
@@ -2104,7 +2100,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     DBCol::TransactionResultForBlock,
                     &get_outcome_id_block_hash(outcome_id, block_hash),
                     &outcome_with_proof,
-                )?;
+                );
             }
             for ((block_hash, shard_id), ids) in &self.chain_store_cache_update.outcome_ids {
                 store_update.set_ser(
@@ -2227,7 +2223,7 @@ impl<'a> ChainStoreUpdate<'a> {
             store_update.delete(DBCol::StateDlInfos, hash.as_ref());
         }
         for (chunk_hash, chunk) in &self.chain_store_cache_update.invalid_chunks {
-            store_update.insert_ser(DBCol::InvalidChunks, chunk_hash.as_ref(), chunk)?;
+            store_update.insert_ser(DBCol::InvalidChunks, chunk_hash.as_ref(), chunk);
         }
         for block_height in &self.chain_store_cache_update.processed_block_heights {
             store_update.set_ser(DBCol::ProcessedBlockHeights, &index_to_bytes(*block_height), &());

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -49,9 +49,11 @@ fn benchmark_write_shard_chunk(bench: &mut Bencher) {
     let store = near_store::test_utils::create_test_store();
     bench.iter(|| {
         let mut update = store.store_update();
-        update
-            .insert_ser(DBCol::Chunks, chunk_hash.as_ref(), &chunks.choose(&mut rand::thread_rng()))
-            .unwrap();
+        update.insert_ser(
+            DBCol::Chunks,
+            chunk_hash.as_ref(),
+            &chunks.choose(&mut rand::thread_rng()),
+        );
         black_box(update);
     });
 }
@@ -73,13 +75,11 @@ fn benchmark_write_partial_encoded_chunk(bench: &mut Bencher) {
     let store = near_store::test_utils::create_test_store();
     bench.iter(|| {
         let mut update = store.store_update();
-        update
-            .insert_ser(
-                DBCol::PartialChunks,
-                chunk_hash.as_ref(),
-                &chunks.choose(&mut rand::thread_rng()),
-            )
-            .unwrap();
+        update.insert_ser(
+            DBCol::PartialChunks,
+            chunk_hash.as_ref(),
+            &chunks.choose(&mut rand::thread_rng()),
+        );
         black_box(update);
     });
 }

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -413,7 +413,7 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
     /// block_header_hashes_by_height and update block_merkle_tree
     /// This is a primitive function and changing only the BlockHeader column can lead to inconsistencies
     pub fn set_block_header_only(&mut self, header: &BlockHeader) {
-        self.store_update.insert_ser(DBCol::BlockHeader, header.hash().as_ref(), header).unwrap();
+        self.store_update.insert_ser(DBCol::BlockHeader, header.hash().as_ref(), header);
     }
 
     /// Note: Typically block_header_hashes_by_height is saved while saving the block header

--- a/core/store/src/adapter/epoch_store.rs
+++ b/core/store/src/adapter/epoch_store.rs
@@ -148,9 +148,7 @@ impl<'a> EpochStoreUpdateAdapter<'a> {
     }
 
     pub fn set_block_info(&mut self, block_info: &BlockInfo) {
-        self.store_update
-            .insert_ser(DBCol::BlockInfo, block_info.hash().as_ref(), block_info)
-            .unwrap();
+        self.store_update.insert_ser(DBCol::BlockInfo, block_info.hash().as_ref(), block_info);
     }
 
     pub fn set_epoch_info(&mut self, epoch_id: &EpochId, epoch_info: &EpochInfo) {

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -342,16 +342,10 @@ impl StoreUpdate {
     /// `CryptoHash` as key, which has the data in a small fixed-sized array.
     /// Copying and allocating that is not prohibitively expensive and we have
     /// to do it either way. Thus, we take a slice for the key for the nice API.
-    pub fn insert_ser<T: BorshSerialize>(
-        &mut self,
-        column: DBCol,
-        key: &[u8],
-        value: &T,
-    ) -> io::Result<()> {
+    pub fn insert_ser<T: BorshSerialize>(&mut self, column: DBCol, key: &[u8], value: &T) {
         assert!(column.is_insert_only(), "can't insert_ser: {column}");
-        let data = borsh::to_vec(&value)?;
+        let data = borsh::to_vec(&value).expect("borsh serialization should not fail");
         self.insert(column, key.to_vec(), data);
-        Ok(())
     }
 
     /// Inserts a new reference-counted value or increases its reference count

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -101,9 +101,7 @@ fn write_block_checkpoint(store_update: &mut StoreUpdate, block_checkpoint: &Blo
     let hash = block_checkpoint.header.hash();
     store_update.set_ser(DBCol::BlockHeader, hash.as_ref(), &block_checkpoint.header);
 
-    store_update
-        .insert_ser(DBCol::BlockInfo, hash.as_ref(), &block_checkpoint.info)
-        .expect("Failed writing a block info");
+    store_update.insert_ser(DBCol::BlockInfo, hash.as_ref(), &block_checkpoint.info);
 
     store_update.set_ser(DBCol::BlockMerkleTree, hash.as_ref(), &block_checkpoint.merkle_tree);
     store_update.set_ser(


### PR DESCRIPTION
Change `StoreUpdate::insert_ser()` to return `()` instead of `io::Result<()>`.
Borsh serialization of in-memory types never fails, so the error case is unreachable.
`borsh::to_vec()` is now wrapped with `.expect("borsh serialization should not fail")`.

Updates 14 call sites across 8 files to remove `?` or `.unwrap()` operators:
- `core/store/src/store.rs` — primary change
- `core/store/src/adapter/chain_store.rs`, `epoch_store.rs` — adapter methods
- `chain/chain/src/store/mod.rs` — 6 call sites in finalize logic
- `chain/chain/src/spice_core.rs`, `spice_core_writer_actor.rs` — spice integration
- `tools/speedy_sync/src/main.rs`, `core/store/benches/finalize_bench.rs` — tools & benches