### PR TITLE
refactor(store): remove Result from Store::caching_get_ser()

### DIFF
--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -89,7 +89,7 @@ impl SpiceCoreReader {
                 outgoing_receipts_root: CryptoHash::default(),
             })))
         } else {
-            Ok(self.get_execution_result_from_store(block_header.hash(), shard_id)?)
+            Ok(self.get_execution_result_from_store(block_header.hash(), shard_id))
         }
     }
 
@@ -97,7 +97,7 @@ impl SpiceCoreReader {
         &self,
         block_hash: &CryptoHash,
         shard_id: ShardId,
-    ) -> Result<Option<Arc<ChunkExecutionResult>>, std::io::Error> {
+    ) -> Option<Arc<ChunkExecutionResult>> {
         let key = get_execution_results_key(block_hash, shard_id);
         self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key)
     }
@@ -175,8 +175,7 @@ impl SpiceCoreReader {
             let Some(execution_result) = self.get_execution_result_from_store(
                 &chunk_info.chunk_id.block_hash,
                 chunk_info.chunk_id.shard_id,
-            )?
-            else {
+            ) else {
                 continue;
             };
             // Execution results are stored only for endorsed chunks.
@@ -200,7 +199,6 @@ impl SpiceCoreReader {
         ) -> Result<Arc<Block>, InvalidSpiceCoreStatementsError> {
             store
                 .caching_get_ser(DBCol::Block, block_hash.as_ref())
-                .map_err(|error| IoError { error })?
                 .ok_or(UnknownBlock { block_hash: *block_hash })
         }
 

--- a/chain/chain/src/spice_core_writer_actor.rs
+++ b/chain/chain/src/spice_core_writer_actor.rs
@@ -237,7 +237,7 @@ impl SpiceCoreWriterActor {
         shard_id: ShardId,
     ) -> Result<Option<Arc<ChunkExecutionResult>>, std::io::Error> {
         let key = get_execution_results_key(block_hash, shard_id);
-        self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key)
+        Ok(self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key))
     }
 
     fn get_uncertified_execution_result(
@@ -245,7 +245,7 @@ impl SpiceCoreWriterActor {
         execution_result_hash: &ChunkExecutionResultHash,
     ) -> Result<Option<Arc<ChunkExecutionResult>>, std::io::Error> {
         let key = get_uncertified_execution_results_key(execution_result_hash);
-        self.chain_store.store().caching_get_ser(DBCol::uncertified_execution_results(), &key)
+        Ok(self.chain_store.store().caching_get_ser(DBCol::uncertified_execution_results(), &key))
     }
 
     fn validate_verified_endorsement_with_block(

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -585,7 +585,7 @@ impl ChainStore {
         let latest_known: LatestKnown = self
             .store
             .store()
-            .caching_get_ser(DBCol::BlockMisc, LATEST_KNOWN_KEY)?
+            .caching_get_ser(DBCol::BlockMisc, LATEST_KNOWN_KEY)
             .ok_or_else(|| Error::DBNotFoundErr("LATEST_KNOWN_KEY".to_string()))
             .map(|v| *v)?;
         Ok(latest_known)

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -54,7 +54,7 @@ impl ChainStoreAdapter {
 
     /// The chain head.
     pub fn head(&self) -> Result<Arc<Tip>, Error> {
-        option_to_not_found(self.store.caching_get_ser(DBCol::BlockMisc, HEAD_KEY)?, "HEAD")
+        option_to_not_found(self.store.caching_get_ser(DBCol::BlockMisc, HEAD_KEY), "HEAD")
     }
 
     /// The chain Blocks Tail height.
@@ -84,7 +84,7 @@ impl ChainStoreAdapter {
     /// Head of the header chain (not the same thing as head_header).
     pub fn header_head(&self) -> Result<Arc<Tip>, Error> {
         option_to_not_found(
-            self.store.caching_get_ser(DBCol::BlockMisc, HEADER_HEAD_KEY)?,
+            self.store.caching_get_ser(DBCol::BlockMisc, HEADER_HEAD_KEY),
             "HEADER_HEAD",
         )
     }
@@ -93,7 +93,7 @@ impl ChainStoreAdapter {
     pub fn head_header(&self) -> Result<Arc<BlockHeader>, Error> {
         let last_block_hash = self.head()?.last_block_hash;
         option_to_not_found(
-            self.store.caching_get_ser(DBCol::BlockHeader, last_block_hash.as_ref())?,
+            self.store.caching_get_ser(DBCol::BlockHeader, last_block_hash.as_ref()),
             format_args!("BLOCK HEADER: {}", last_block_hash),
         )
     }
@@ -101,21 +101,21 @@ impl ChainStoreAdapter {
     /// The chain final head. It is guaranteed to be monotonically increasing.
     pub fn final_head(&self) -> Result<Arc<Tip>, Error> {
         option_to_not_found(
-            self.store.caching_get_ser(DBCol::BlockMisc, FINAL_HEAD_KEY)?,
+            self.store.caching_get_ser(DBCol::BlockMisc, FINAL_HEAD_KEY),
             "FINAL HEAD",
         )
     }
 
     pub fn spice_final_execution_head(&self) -> Result<Arc<Tip>, Error> {
         option_to_not_found(
-            self.store.caching_get_ser(DBCol::BlockMisc, SPICE_FINAL_EXECUTION_HEAD_KEY)?,
+            self.store.caching_get_ser(DBCol::BlockMisc, SPICE_FINAL_EXECUTION_HEAD_KEY),
             "SPICE FINAL EXECUTION HEAD",
         )
     }
 
     pub fn spice_execution_head(&self) -> Result<Arc<Tip>, Error> {
         option_to_not_found(
-            self.store.caching_get_ser(DBCol::BlockMisc, SPICE_EXECUTION_HEAD_KEY)?,
+            self.store.caching_get_ser(DBCol::BlockMisc, SPICE_EXECUTION_HEAD_KEY),
             "SPICE EXECUTION HEAD",
         )
     }
@@ -135,7 +135,7 @@ impl ChainStoreAdapter {
     /// Get full block.
     pub fn get_block(&self, block_hash: &CryptoHash) -> Result<Arc<Block>, Error> {
         option_to_not_found(
-            self.store.caching_get_ser(DBCol::Block, block_hash.as_ref())?,
+            self.store.caching_get_ser(DBCol::Block, block_hash.as_ref()),
             format_args!("BLOCK: {}", block_hash),
         )
     }
@@ -156,7 +156,7 @@ impl ChainStoreAdapter {
     /// Get block header.
     pub fn get_block_header(&self, h: &CryptoHash) -> Result<Arc<BlockHeader>, Error> {
         option_to_not_found(
-            self.store.caching_get_ser(DBCol::BlockHeader, h.as_ref())?,
+            self.store.caching_get_ser(DBCol::BlockHeader, h.as_ref()),
             format_args!("BLOCK HEADER: {}", h),
         )
     }
@@ -178,7 +178,7 @@ impl ChainStoreAdapter {
     /// Returns hash of the block on the main chain for given height.
     pub fn get_block_hash_by_height(&self, height: BlockHeight) -> Result<CryptoHash, Error> {
         option_to_not_found(
-            self.store.caching_get_ser(DBCol::BlockHeight, &index_to_bytes(height))?,
+            self.store.caching_get_ser(DBCol::BlockHeight, &index_to_bytes(height)),
             format_args!("BLOCK HEIGHT: {}", height),
         )
         .map(|v| *v)

--- a/core/store/src/adapter/chunk_store.rs
+++ b/core/store/src/adapter/chunk_store.rs
@@ -37,7 +37,6 @@ impl ChunkStoreAdapter {
     ) -> Result<Arc<PartialEncodedChunk>, ChunkAccessError> {
         self.store
             .caching_get_ser(DBCol::PartialChunks, chunk_hash.as_ref())
-            .expect("Borsh should not have failed here")
             .ok_or_else(|| ChunkAccessError::ChunkMissing(chunk_hash.clone()))
     }
 
@@ -84,7 +83,7 @@ impl ChunkStoreAdapter {
     ) -> Result<Arc<ChunkExtra>, Error> {
         option_to_not_found(
             self.store
-                .caching_get_ser(DBCol::ChunkExtra, &get_block_shard_uid(block_hash, shard_uid))?,
+                .caching_get_ser(DBCol::ChunkExtra, &get_block_shard_uid(block_hash, shard_uid)),
             format_args!("CHUNK EXTRA: {}:{:?}", block_hash, shard_uid),
         )
     }

--- a/core/store/src/adapter/epoch_store.rs
+++ b/core/store/src/adapter/epoch_store.rs
@@ -90,7 +90,7 @@ impl EpochStoreAdapter {
         let proof = self.store.caching_get_ser::<CompressedEpochSyncProof>(
             DBCol::EpochSyncProof,
             COMPRESSED_EPOCH_SYNC_PROOF_KEY,
-        )?;
+        );
         Ok(proof.as_deref().cloned())
     }
 

--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -226,9 +226,6 @@ pub fn get_shard_uid_mapping(store: &Store, child_shard_uid: ShardUId) -> ShardU
 fn maybe_get_shard_uid_mapping(store: &Store, child_shard_uid: ShardUId) -> Option<ShardUId> {
     store
         .caching_get_ser::<ShardUId>(DBCol::StateShardUIdMapping, &child_shard_uid.to_bytes())
-        .unwrap_or_else(|_| {
-            panic!("get_shard_uid_mapping() failed for child_shard_uid = {}", child_shard_uid)
-        })
         .map(|v| *v)
 }
 

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -68,7 +68,7 @@ impl EntityDebugHandlerImpl {
             }
             EntityQuery::BlockByHash { block_hash } => {
                 let block = store
-                    .caching_get_ser::<Block>(DBCol::Block, &borsh::to_vec(&block_hash).unwrap())?
+                    .caching_get_ser::<Block>(DBCol::Block, &borsh::to_vec(&block_hash).unwrap())
                     .ok_or_else(|| anyhow!("Block not found"))?;
                 let author = self
                     .epoch_manager
@@ -267,7 +267,7 @@ impl EntityDebugHandlerImpl {
             EntityQuery::OutcomeIdsByBlockHash { block_hash } => {
                 // Get all shard IDs for the epoch of this block
                 let block = store
-                    .caching_get_ser::<Block>(DBCol::Block, &borsh::to_vec(&block_hash).unwrap())?
+                    .caching_get_ser::<Block>(DBCol::Block, &borsh::to_vec(&block_hash).unwrap())
                     .ok_or_else(|| anyhow!("Block not found"))?;
                 let epoch_id = block.header().epoch_id();
                 let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
@@ -358,7 +358,7 @@ impl EntityDebugHandlerImpl {
             }
             EntityQuery::StateTransitionData { block_hash } => {
                 let block = store
-                    .caching_get_ser::<Block>(DBCol::Block, &borsh::to_vec(&block_hash).unwrap())?
+                    .caching_get_ser::<Block>(DBCol::Block, &borsh::to_vec(&block_hash).unwrap())
                     .ok_or_else(|| anyhow!("Block not found"))?;
                 let epoch_id = block.header().epoch_id();
                 let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;


### PR DESCRIPTION
`caching_get_ser` internally calls the now-infallible `get_ser`, making its `io::Result` wrapper redundant. Change the return type from `io::Result<Option<Arc<T>>>` to `Option<Arc<T>>` and update all ~20 call sites — removing `?` operators, `.expect()` calls, and panic-on-error wrappers.