### PR TITLE
doc: add coding agents section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,3 +176,13 @@ testnet.  The process for feature stabilization can be found in [this
 document](docs/practices/protocol_upgrade.md).  After the release candidate has been
 running on testnet for four weeks and no issues are observed, we stabilize and
 publish the release for mainnet.
+
+## Coding Agents
+
+When using AI coding agents (e.g. Claude Code, Cursor, Copilot), general
+instructions for working with this codebase are maintained in the root
+[`AGENTS.md`](AGENTS.md) file following the [agents.md](https://agents.md/)
+convention.
+
+Individual modules or subprojects may provide their own `AGENTS.md` files with
+module-specific instructions. These are referenced from the root `AGENTS.md`.


### PR DESCRIPTION
- Add a "Coding Agents" section to CONTRIBUTING.md pointing to the root `AGENTS.md` for general AI coding agent instructions
- Reference the [agents.md](https://agents.md/) convention
- Note that individual modules/subprojects can maintain their own `AGENTS.md` files, referenced from the root one