### PR TITLE
chore: add consensus section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,7 @@
 ## OpenAPI Spec
 - Do NOT update the OpenAPI spec unless explicitly asked.
 - When asked, follow the `openapi-spec` recipe in the `Justfile`.
+
+## Consensus
+- For high-level documentation on the consensus protocol, see `docs/ChainSpec/Consensus.md`.
+- Doomslug is implemented in `chain/chain/src/doomslug.rs`.


### PR DESCRIPTION
- Add a Consensus section to AGENTS.md
- Reference `docs/ChainSpec/Consensus.md` for high-level protocol documentation
- Note Doomslug implementation location in `chain/chain/src/doomslug.rs`