### PR TITLE
refactor(store): remove Result from Store::iter_ser() and iter_prefix_ser()

### DIFF
--- a/chain/chain/src/store/latest_witnesses.rs
+++ b/chain/chain/src/store/latest_witnesses.rs
@@ -267,9 +267,9 @@ impl ChainStore {
 
         let mut result: Vec<ChunkStateWitness> = Vec::new();
 
-        for read_result in self.store().iter_prefix_ser::<ChunkStateWitness>(db_col, &key_prefix) {
-            let (key_bytes, witness) = read_result?;
-
+        for (key_bytes, witness) in
+            self.store().iter_prefix_ser::<ChunkStateWitness>(db_col, &key_prefix)
+        {
             let key = StoredWitnessesKey::deserialize(&key_bytes)?;
             if let Some(h) = height {
                 if key.height_created != h {

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -532,8 +532,7 @@ impl ChainStore {
                 DBCol::TransactionResultForBlock,
                 id.as_ref(),
             )
-            .map(|item| {
-                let (key, outcome_with_proof) = item?;
+            .map(|(key, outcome_with_proof)| {
                 let (_, block_hash) = get_outcome_id_block_hash_rev(key.as_ref())?;
                 Ok(ExecutionOutcomeWithIdAndProof {
                     proof: outcome_with_proof.proof,
@@ -768,27 +767,25 @@ impl ChainStore {
         self.store
             .store_ref()
             .iter_prefix_ser::<StateSyncDumpProgress>(DBCol::BlockMisc, STATE_SYNC_DUMP_KEY)
-            .map(|item| {
-                item.and_then(|(key, progress)| {
-                    // + 1 for the ':'
-                    let prefix_len = STATE_SYNC_DUMP_KEY.len() + 1;
-                    let int_part = &key[prefix_len..];
-                    let int_part = int_part.try_into().map_err(|_| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("Bad StateSyncDump column key length: {}", key.len()),
-                        )
-                    })?;
-                    let shard_id = ShardId::from_le_bytes(int_part);
-                    Ok((
-                        shard_id,
-                        match progress {
-                            StateSyncDumpProgress::AllDumped { epoch_id, .. } => (epoch_id, true),
-                            StateSyncDumpProgress::InProgress { epoch_id, .. } => (epoch_id, false),
-                            StateSyncDumpProgress::Skipped { epoch_id, .. } => (epoch_id, true),
-                        },
-                    ))
-                })
+            .map(|(key, progress)| {
+                // + 1 for the ':'
+                let prefix_len = STATE_SYNC_DUMP_KEY.len() + 1;
+                let int_part = &key[prefix_len..];
+                let int_part = int_part.try_into().map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Bad StateSyncDump column key length: {}", key.len()),
+                    )
+                })?;
+                let shard_id = ShardId::from_le_bytes(int_part);
+                Ok((
+                    shard_id,
+                    match progress {
+                        StateSyncDumpProgress::AllDumped { epoch_id, .. } => (epoch_id, true),
+                        StateSyncDumpProgress::InProgress { epoch_id, .. } => (epoch_id, false),
+                        StateSyncDumpProgress::Skipped { epoch_id, .. } => (epoch_id, true),
+                    },
+                ))
             })
     }
 

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -1046,10 +1046,10 @@ fn get_receipt_proofs_for_shard(
     to_shard_id: ShardId,
 ) -> Result<Vec<ReceiptProof>, std::io::Error> {
     let prefix = get_receipt_proof_target_shard_prefix(block_hash, to_shard_id);
-    store
+    Ok(store
         .iter_prefix_ser::<ReceiptProof>(DBCol::receipt_proofs(), &prefix)
-        .map(|res| res.map(|kv| kv.1))
-        .collect()
+        .map(|kv| kv.1)
+        .collect())
 }
 
 pub fn get_witness(

--- a/core/store/src/adapter/flat_store.rs
+++ b/core/store/src/adapter/flat_store.rs
@@ -71,16 +71,11 @@ impl FlatStoreAdapter {
         &self,
         shard_uid: ShardUId,
     ) -> Result<Vec<FlatStateDeltaMetadata>, FlatStorageError> {
-        self.store
+        Ok(self
+            .store
             .iter_prefix_ser(DBCol::FlatStateDeltaMetadata, &shard_uid.to_bytes())
-            .map(|res| {
-                res.map(|(_, value)| value).map_err(|err| {
-                    FlatStorageError::StorageInternalError(format!(
-                        "failed to read delta metadata: {err}"
-                    ))
-                })
-            })
-            .collect()
+            .map(|(_, value)| value)
+            .collect())
     }
 
     pub fn get_prev_block_with_changes(

--- a/core/store/src/archive/cloud_storage/shard_data.rs
+++ b/core/store/src/archive/cloud_storage/shard_data.rs
@@ -126,10 +126,9 @@ fn get_state_changes(
 ) -> Result<Vec<RawStateChangesWithTrieKey>, Error> {
     let storage_key = KeyForStateChanges::for_block(&block_hash);
     let mut state_changes = vec![];
-    for item in store
+    for (key, changes) in store
         .iter_prefix_ser::<RawStateChangesWithTrieKey>(DBCol::StateChanges, storage_key.as_ref())
     {
-        let (key, changes) = item?;
         let decoded_shard_uid = if let Some(account_id) = changes.trie_key.get_account_id() {
             shard_layout.account_id_to_shard_uid(&account_id)
         } else {

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -815,9 +815,8 @@ impl KeyForStateChanges {
             self.0
         );
         store.iter_prefix_ser::<RawStateChangesWithTrieKey>(DBCol::StateChanges, &self.0).map(
-            move |change| {
+            move |(key, state_changes)| {
                 // Split off the irrelevant part of the key, so only the original trie_key is left.
-                let (key, state_changes) = change?;
                 debug_assert!(key.starts_with(&self.0), "Key: {:?}, row key: {:?}", self.0, key);
                 Ok((key, state_changes))
             },

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -248,7 +248,7 @@ impl EntityDebugHandlerImpl {
                         &borsh::to_vec(&outcome_id).unwrap(),
                     )
                     .next()
-                    .ok_or_else(|| anyhow!("Outcome not found"))??;
+                    .ok_or_else(|| anyhow!("Outcome not found"))?;
                 Ok(serialize_entity(&ExecutionOutcomeView::from(outcome.outcome)))
             }
             EntityQuery::OutcomeByTransactionHashAndBlockHash {

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -53,7 +53,6 @@ fn old_outcomes(
                 )
                 .next()
                 .unwrap()
-                .unwrap()
                 .1
                 .outcome;
             ExecutionOutcomeWithId { id: outcome.id, outcome: old_outcome }

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -115,8 +115,6 @@ pub(crate) enum ContractAccountError {
     MissingOutgoingReceipt(CryptoHash),
     #[error("failed loading contract code for account {1}")]
     NoCode(#[source] StorageError, AccountId),
-    #[error("failed parsing a value in col {1}")]
-    UnparsableValue(#[source] std::io::Error, DBCol),
 }
 
 /// List of supported actions to filter for.
@@ -313,13 +311,10 @@ fn try_find_actions_spawned_by_receipt(
             *entry.receipts_in.get_or_insert(0) += 1;
         }
         // next, check the execution results (one for each block in case of forks)
-        for pair in store.iter_prefix_ser::<ExecutionOutcomeWithProof>(
+        for (_key, outcome) in store.iter_prefix_ser::<ExecutionOutcomeWithProof>(
             DBCol::TransactionResultForBlock,
             &raw_key,
         ) {
-            let (_key, outcome) = pair.map_err(|e| {
-                ContractAccountError::UnparsableValue(e, DBCol::TransactionResultForBlock)
-            })?;
             if filter.receipts_out {
                 *entry.receipts_out.get_or_insert(0) += outcome.outcome.receipt_ids.len();
             }


### PR DESCRIPTION
`iter_ser` and `iter_prefix_ser` previously returned `impl Iterator<Item = io::Result<(Box<[u8]>, T)>>`. The only error source was borsh deserialization, which should never fail for well-formed DB values — if it does, it's a bug and panicking is appropriate.

Change both to return `impl Iterator<Item = (Box<[u8]>, T)>` and update all 10 call sites. Also removes the now-dead `ContractAccountError::UnparsableValue` variant in `contract_accounts.rs`.