### PR TITLE
chore: clarify protocol schema check instructions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Protocol Schema Check
 - Do NOT run the protocol schema check unless explicitly asked. It is expensive.
-- When asked to update the schema, follow the instructions in `tools/protocol-schema-check/README.md` exactly.
+- When asked to update the schema, first read `tools/protocol-schema-check/README.md`, then follow its instructions exactly. Do NOT guess the command.
 
 ## Testing
 - When running tests, use `--features test_features`.


### PR DESCRIPTION
- Make it explicit that the README must be read first before running the protocol schema check command
- An AI agent attempted to run `cargo run -p protocol-schema-check` instead of the correct `RUSTFLAGS="--cfg enable_const_type_id" cargo +nightly run -p protocol-schema-check` from the README, because the previous wording didn't enforce reading the README before executing