### PR TITLE
feat(spice): gas price, total supply from newly certified blocks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2443,23 +2443,25 @@ impl Chain {
 
         let protocol_version =
             self.epoch_manager.get_epoch_protocol_version(block.header().epoch_id())?;
-        let last_certified_block_execution_results =
-            if ProtocolFeature::Spice.enabled(protocol_version) {
-                // We cannot get last certified block until block is fully processed.
-                Some(self.spice_core_reader.get_last_certified_execution_results_for_next_block(
+        let newly_certified_block_execution_results = if ProtocolFeature::Spice
+            .enabled(protocol_version)
+        {
+            Some(
+                self.spice_core_reader.get_newly_certified_block_execution_results_for_next_block(
                     &prev,
                     block.spice_core_statements(),
-                )?)
-            } else {
-                None
-            };
+                )?,
+            )
+        } else {
+            None
+        };
 
         match block.verify_gas_price_checked(
             gas_price,
             self.block_economics_config.min_gas_price(),
             self.block_economics_config.max_gas_price(),
             self.block_economics_config.gas_price_adjustment_rate(),
-            last_certified_block_execution_results.as_ref(),
+            newly_certified_block_execution_results.as_deref(),
         ) {
             Some(true) => {}
             Some(false) => {
@@ -2476,7 +2478,13 @@ impl Chain {
             None
         };
 
-        match block.verify_total_supply_checked(prev.total_supply(), minted_amount) {
+        let total_supply_check =
+            if let Some(results) = newly_certified_block_execution_results.as_deref() {
+                block.verify_total_supply_checked_spice(prev.total_supply(), minted_amount, results)
+            } else {
+                block.verify_total_supply_checked(prev.total_supply(), minted_amount)
+            };
+        match total_supply_check {
             Some(true) => {}
             Some(false) => {
                 byzantine_assert!(false);

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -445,70 +445,118 @@ impl SpiceCoreReader {
         Ok(())
     }
 
-    pub fn get_last_certified_execution_results_for_next_block(
+    /// Returns execution results for all blocks that become newly certified when
+    /// `core_statements_for_next_block` is applied to the current chain state.
+    /// The results are ordered oldest-first. When no new certification frontier
+    /// advancement occurs but the last certified block is genesis, returns genesis
+    /// execution results to bootstrap gas price computation.
+    pub fn get_newly_certified_block_execution_results_for_next_block(
         &self,
         block_header: &BlockHeader,
         core_statements_for_next_block: &SpiceCoreStatements,
-    ) -> Result<BlockExecutionResults, Error> {
+    ) -> Result<Vec<BlockExecutionResults>, Error> {
+        // Find old last certified (before applying new core statements).
+        let old_last_certified =
+            get_last_certified_block_header(&self.chain_store, block_header.hash())?;
+
+        // Find new last certified (after applying new core statements).
         let newly_certified_chunks: HashSet<&SpiceChunkId> =
             core_statements_for_next_block.iter_execution_results().map(|(id, _)| id).collect();
-
         let mut uncertified_chunks =
             get_uncertified_chunks(&self.chain_store, block_header.hash())?;
         uncertified_chunks
             .retain(|chunk_info| !newly_certified_chunks.contains(&chunk_info.chunk_id));
         let oldest_uncertified_block_header =
             find_oldest_uncertified_block_header(&self.chain_store, uncertified_chunks)?;
-        let last_certified_block_header =
+        let new_last_certified =
             if let Some(oldest_uncertified_block_header) = oldest_uncertified_block_header {
-                &self.chain_store.get_block_header(oldest_uncertified_block_header.prev_hash())?
+                self.chain_store.get_block_header(oldest_uncertified_block_header.prev_hash())?
             } else {
-                // If there are no uncertified blocks it means block with block_header is last certified.
-                block_header
+                // After applying new core statements, all blocks up to block_header are certified.
+                Arc::new(block_header.clone())
             };
 
-        if last_certified_block_header.is_genesis() {
-            return Ok(BlockExecutionResults(
-                self.get_execution_results_by_shard_id(last_certified_block_header)?,
-            ));
+        if new_last_certified.hash() == old_last_certified.hash() {
+            if old_last_certified.is_genesis() {
+                // Genesis is certified by definition. Return its execution results so gas price
+                // is computed from genesis gas_limit until the first real certification.
+                return Ok(vec![BlockExecutionResults(
+                    self.get_execution_results_by_shard_id(&old_last_certified)?,
+                )]);
+            }
+            return Ok(vec![]);
         }
+        assert!(
+            old_last_certified.height() < new_last_certified.height(),
+            "old last certified should be a strict ancestor of new"
+        );
 
-        let last_certified_hash = *last_certified_block_header.hash();
-        let num_shards =
-            self.epoch_manager.shard_ids(last_certified_block_header.epoch_id())?.len();
-        let mut execution_results: HashMap<ShardId, Arc<ChunkExecutionResult>> = HashMap::new();
+        // Enumerate newly certified blocks by walking backwards from new_last_certified
+        // to old_last_certified (exclusive), then reverse for oldest-first order.
+        let mut newly_certified_hashes = Vec::new();
+        let mut current = new_last_certified;
+        while current.hash() != old_last_certified.hash()
+            && current.height() > old_last_certified.height()
+        {
+            newly_certified_hashes.push(*current.hash());
+            current = self.chain_store.get_block_header(current.prev_hash())?;
+        }
+        newly_certified_hashes.reverse();
+
+        // Collect execution results from core_statements_for_next_block and block ancestry,
+        // grouped by block_hash.
+        let newly_certified_set: HashSet<CryptoHash> =
+            newly_certified_hashes.iter().copied().collect();
+        let mut results_by_block: HashMap<CryptoHash, HashMap<ShardId, Arc<ChunkExecutionResult>>> =
+            HashMap::new();
         for (chunk_id, result) in core_statements_for_next_block.iter_execution_results() {
-            if chunk_id.block_hash != last_certified_hash {
+            if !newly_certified_set.contains(&chunk_id.block_hash) {
                 continue;
             }
-            execution_results.entry(chunk_id.shard_id).or_insert_with(|| Arc::new(result.clone()));
+            results_by_block
+                .entry(chunk_id.block_hash)
+                .or_default()
+                .entry(chunk_id.shard_id)
+                .or_insert_with(|| Arc::new(result.clone()));
         }
 
-        // Walk backwards from block_header, collecting execution results from
-        // each block's core statements. We can't depend on reading from
-        // DBCol::execution_results, which SpiceCoreWriterActor writes
-        // asynchronously. So, during orphan processing, the results we need
-        // here may not be persisted to that column yet.
+        // Walk backwards from block_header through ancestry, collecting execution results
+        // from each block's core statements. We can't depend on DBCol::execution_results
+        // which SpiceCoreWriterActor writes asynchronously.
         let mut current_hash = *block_header.hash();
-        while execution_results.len() < num_shards && current_hash != last_certified_hash {
+        while current_hash != *old_last_certified.hash() {
             let block = self.chain_store.get_block(&current_hash)?;
+            if block.header().height() <= old_last_certified.height() {
+                break;
+            }
             for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
-                if chunk_id.block_hash != last_certified_hash {
+                if !newly_certified_set.contains(&chunk_id.block_hash) {
                     continue;
                 }
-                execution_results
+                results_by_block
+                    .entry(chunk_id.block_hash)
+                    .or_default()
                     .entry(chunk_id.shard_id)
                     .or_insert_with(|| Arc::new(result.clone()));
             }
             current_hash = *block.header().prev_hash();
         }
 
-        assert_eq!(
-            execution_results.len(),
-            num_shards,
-            "should have found all shard's execution results for last certified block"
-        );
-        Ok(BlockExecutionResults(execution_results))
+        // Build result for each newly certified block, oldest-first.
+        let mut result = Vec::with_capacity(newly_certified_hashes.len());
+        for block_hash in &newly_certified_hashes {
+            let block_header = self.chain_store.get_block_header(block_hash)?;
+            let num_shards = self.epoch_manager.shard_ids(block_header.epoch_id())?.len();
+            let execution_results = results_by_block.remove(block_hash).unwrap_or_default();
+            assert_eq!(
+                execution_results.len(),
+                num_shards,
+                "should have found all shard's execution results for newly certified block {}",
+                block_hash,
+            );
+            result.push(BlockExecutionResults(execution_results));
+        }
+        Ok(result)
     }
 }
 

--- a/chain/chain/src/tests/spice_core.rs
+++ b/chain/chain/src/tests/spice_core.rs
@@ -1077,27 +1077,28 @@ fn test_validate_core_statements_in_block_valid_execution_result_with_ancestral_
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_get_last_certified_execution_results_for_next_block_with_no_certifications() {
+fn test_get_newly_certified_block_execution_results_for_next_block_with_no_certifications() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();
     let block = build_block(&mut chain, &genesis, vec![]);
     process_block(&mut chain, block.clone());
 
     let execution_results = core_reader
-        .get_last_certified_execution_results_for_next_block(
+        .get_newly_certified_block_execution_results_for_next_block(
             block.header(),
             SpiceCoreStatements::empty(),
         )
         .unwrap();
+    // Genesis certifies itself, so genesis execution results are returned.
     let genesis_execution_results =
-        core_reader.get_block_execution_results(genesis.header()).unwrap();
-    assert!(!execution_results.0.is_empty());
-    assert_eq!(execution_results, genesis_execution_results.unwrap());
+        core_reader.get_block_execution_results(genesis.header()).unwrap().unwrap();
+    assert_eq!(execution_results.len(), 1);
+    assert_eq!(genesis_execution_results, execution_results[0]);
 }
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_get_last_certified_execution_results_for_next_block_with_execution_result_in_core() {
+fn test_get_newly_certified_block_execution_results_for_next_block_with_execution_result_in_core() {
     let (mut chain, core_reader) = setup();
     let mut core_writer_actor = core_writer_actor(&chain);
     let genesis = chain.genesis_block();
@@ -1109,19 +1110,19 @@ fn test_get_last_certified_execution_results_for_next_block_with_execution_resul
     process_block(&mut chain, next_block.clone());
     core_writer_actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
 
+    // B1 was already certified in next_block's ancestry, so no newly certified blocks.
     let execution_results = core_reader
-        .get_last_certified_execution_results_for_next_block(
+        .get_newly_certified_block_execution_results_for_next_block(
             next_block.header(),
             SpiceCoreStatements::empty(),
         )
         .unwrap();
-    let block_execution_results = block_execution_results(&block);
-    assert_eq!(block_execution_results, execution_results);
+    assert!(execution_results.is_empty());
 }
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_get_last_certified_execution_results_for_next_block_with_last_block_certified() {
+fn test_get_newly_certified_block_execution_results_for_next_block_with_last_block_certified() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();
     let block = build_block(&mut chain, &genesis, vec![]);
@@ -1129,15 +1130,18 @@ fn test_get_last_certified_execution_results_for_next_block_with_last_block_cert
 
     let core_statements = SpiceCoreStatements::new(block_certification_core_statements(&block));
     let execution_results = core_reader
-        .get_last_certified_execution_results_for_next_block(block.header(), &core_statements)
+        .get_newly_certified_block_execution_results_for_next_block(
+            block.header(),
+            &core_statements,
+        )
         .unwrap();
-    let block_execution_results = block_execution_results(&block);
-    assert_eq!(block_execution_results, execution_results);
+    assert_eq!(execution_results.len(), 1);
+    assert_eq!(block_execution_results(&block), execution_results[0]);
 }
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_get_last_certified_execution_results_for_next_block_with_old_block_certified() {
+fn test_get_newly_certified_block_execution_results_for_next_block_with_old_block_certified() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();
     let block = build_block(&mut chain, &genesis, vec![]);
@@ -1155,19 +1159,19 @@ fn test_get_last_certified_execution_results_for_next_block_with_old_block_certi
         last_block = new_block;
     }
 
+    // B1 was already certified in the ancestry, so no newly certified blocks.
     let execution_results = core_reader
-        .get_last_certified_execution_results_for_next_block(
+        .get_newly_certified_block_execution_results_for_next_block(
             last_block.header(),
             SpiceCoreStatements::empty(),
         )
         .unwrap();
-    let block_execution_results = block_execution_results(&block);
-    assert_eq!(block_execution_results, execution_results);
+    assert!(execution_results.is_empty());
 }
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_get_last_certified_execution_results_for_next_block_with_certification_split_between_core_and_core_statements()
+fn test_get_newly_certified_block_execution_results_for_next_block_with_certification_split_between_core_and_core_statements()
  {
     let (mut chain, core_reader) = setup();
     let mut core_writer_actor = core_writer_actor(&chain);
@@ -1188,22 +1192,22 @@ fn test_get_last_certified_execution_results_for_next_block_with_certification_s
 
     let last_shard_core_statements = SpiceCoreStatements::new(last_shard_core_statements);
     let execution_results = core_reader
-        .get_last_certified_execution_results_for_next_block(
+        .get_newly_certified_block_execution_results_for_next_block(
             next_block.header(),
             &last_shard_core_statements,
         )
         .unwrap();
-    let block_execution_results = block_execution_results(&block);
-    assert_eq!(block_execution_results, execution_results);
+    assert_eq!(execution_results.len(), 1);
+    assert_eq!(block_execution_results(&block), execution_results[0]);
 }
 
-// This test verifies `get_last_certified_execution_results_for_next_block` works without
+// This test verifies `get_newly_certified_block_execution_results_for_next_block` works without
 // `SpiceCoreWriterActor` having processed the blocks. This matters during orphan processing,
 // when multiple blocks can be processed in quick succession and the core writer (which
 // runs asynchronously) may not have caught up yet.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_get_last_certified_execution_results_without_core_writer_execution_result_in_core() {
+fn test_get_newly_certified_block_execution_results_without_core_writer_execution_result_in_core() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();
     let block = build_block(&mut chain, &genesis, vec![]);
@@ -1213,20 +1217,20 @@ fn test_get_last_certified_execution_results_without_core_writer_execution_resul
     let next_block = build_block(&mut chain, &block, core_statements);
     process_block(&mut chain, next_block.clone());
 
+    // B1 was already certified in next_block's ancestry, so no newly certified blocks.
     assert!(core_reader.get_execution_results_by_shard_id(block.header()).unwrap().is_empty());
     let execution_results = core_reader
-        .get_last_certified_execution_results_for_next_block(
+        .get_newly_certified_block_execution_results_for_next_block(
             next_block.header(),
             SpiceCoreStatements::empty(),
         )
         .unwrap();
-    let block_execution_results = block_execution_results(&block);
-    assert_eq!(block_execution_results, execution_results);
+    assert!(execution_results.is_empty());
 }
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_get_last_certified_execution_results_without_core_writer_old_block_certified() {
+fn test_get_newly_certified_block_execution_results_without_core_writer_old_block_certified() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();
     let block = build_block(&mut chain, &genesis, vec![]);
@@ -1242,15 +1246,67 @@ fn test_get_last_certified_execution_results_without_core_writer_old_block_certi
         last_block = new_block;
     }
 
+    // B1 was already certified in the ancestry, so no newly certified blocks.
     assert!(core_reader.get_execution_results_by_shard_id(block.header()).unwrap().is_empty());
     let execution_results = core_reader
-        .get_last_certified_execution_results_for_next_block(
+        .get_newly_certified_block_execution_results_for_next_block(
             last_block.header(),
             SpiceCoreStatements::empty(),
         )
         .unwrap();
-    let block_execution_results = block_execution_results(&block);
-    assert_eq!(block_execution_results, execution_results);
+    assert!(execution_results.is_empty());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_get_newly_certified_block_execution_results_multi_block_single_step() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    // genesis -> B1 -> B2
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let b2 = build_block(&mut chain, &b1, vec![]);
+    process_block(&mut chain, b2.clone());
+
+    // Certify both B1 and B2 at once via core_statements for B3.
+    let mut core_statements = block_certification_core_statements(&b1);
+    core_statements.extend(block_certification_core_statements(&b2));
+    let core_statements = SpiceCoreStatements::new(core_statements);
+    let execution_results = core_reader
+        .get_newly_certified_block_execution_results_for_next_block(b2.header(), &core_statements)
+        .unwrap();
+    assert_eq!(execution_results.len(), 2);
+    assert_eq!(block_execution_results(&b1), execution_results[0]);
+    assert_eq!(block_execution_results(&b2), execution_results[1]);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_get_newly_certified_block_execution_results_multi_block_incremental() {
+    let (mut chain, core_reader) = setup();
+    let mut core_writer_actor = core_writer_actor(&chain);
+    let genesis = chain.genesis_block();
+
+    // genesis -> B1 -> B2 -> B3
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let b2 = build_block(&mut chain, &b1, vec![]);
+    process_block(&mut chain, b2.clone());
+
+    // B3 certifies B1.
+    let b1_cert = block_certification_core_statements(&b1);
+    let b3 = build_block(&mut chain, &b2, b1_cert);
+    process_block(&mut chain, b3.clone());
+    core_writer_actor.handle(ProcessedBlock { block_hash: *b3.hash() });
+
+    // For B4: certify B2. Should return vec![B2_results] only, since B1 was already certified.
+    let b2_cert = SpiceCoreStatements::new(block_certification_core_statements(&b2));
+    let execution_results = core_reader
+        .get_newly_certified_block_execution_results_for_next_block(b3.header(), &b2_cert)
+        .unwrap();
+    assert_eq!(execution_results.len(), 1);
+    assert_eq!(block_execution_results(&b2), execution_results[0]);
 }
 
 fn block_execution_results(block: &Block) -> BlockExecutionResults {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1144,14 +1144,16 @@ impl Client {
             let core_statements = SpiceCoreStatements::new(
                 self.chain.spice_core_reader.core_statements_for_next_block(&prev_header)?,
             );
-            let last_certified_block_execution_results =
-                self.chain.spice_core_reader.get_last_certified_execution_results_for_next_block(
+            let newly_certified_block_execution_results = self
+                .chain
+                .spice_core_reader
+                .get_newly_certified_block_execution_results_for_next_block(
                     prev_header,
                     &core_statements,
                 )?;
             Some(SpiceNewBlockProductionInfo {
                 core_statements,
-                last_certified_block_execution_results,
+                newly_certified_block_execution_results,
             })
         } else {
             None

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -143,12 +143,12 @@ impl Block {
         let mut gas_limit = Gas::ZERO;
         for chunk in &chunks {
             if chunk.height_included() == height {
-                gas_used = gas_used.checked_add(chunk.prev_gas_used()).unwrap();
                 if spice_info.is_none() {
+                    gas_used = gas_used.checked_add(chunk.prev_gas_used()).unwrap();
                     prev_validator_proposals.extend(chunk.prev_validator_proposals());
                     gas_limit = gas_limit.checked_add(chunk.gas_limit()).unwrap();
+                    balance_burnt = balance_burnt.checked_add(chunk.prev_balance_burnt()).unwrap();
                 }
-                balance_burnt = balance_burnt.checked_add(chunk.prev_balance_burnt()).unwrap();
                 chunk_mask.push(true);
             } else {
                 chunk_mask.push(false);
@@ -162,27 +162,30 @@ impl Block {
                     },
                 ),
             );
+            balance_burnt = Self::compute_balance_burnt_from_certified_results_checked(
+                &spice_info.newly_certified_block_execution_results,
+            )
+            .unwrap();
         }
 
-        // TODO(spice): Use gas_used and other relevant fields from spice_info last
-        // certified block execution results.
-        if let Some(ref spice_info) = spice_info {
-            for (_shard_id, execution_result) in
-                &spice_info.last_certified_block_execution_results.0
-            {
-                gas_limit =
-                    gas_limit.checked_add(execution_result.chunk_extra.gas_limit()).unwrap();
-            }
+        let next_gas_price = if let Some(ref spice_info) = spice_info {
+            Self::compute_gas_price_from_certified_results_checked(
+                &spice_info.newly_certified_block_execution_results,
+                prev.next_gas_price(),
+                gas_price_adjustment_rate,
+                min_gas_price,
+                max_gas_price,
+            )
+        } else {
+            Self::compute_next_gas_price_checked(
+                prev.next_gas_price(),
+                gas_used,
+                gas_limit,
+                gas_price_adjustment_rate,
+                min_gas_price,
+                max_gas_price,
+            )
         }
-
-        let next_gas_price = Self::compute_next_gas_price_checked(
-            prev.next_gas_price(),
-            gas_used,
-            gas_limit,
-            gas_price_adjustment_rate,
-            min_gas_price,
-            max_gas_price,
-        )
         .unwrap();
 
         let new_total_supply = prev
@@ -327,6 +330,29 @@ impl Block {
         Some(self.header().total_supply() == new_total_supply)
     }
 
+    // TODO(spice): once spice v1 is released, deprecate `verify_total_supply_checked` in favor
+    // of this method (or fold this back in by making `newly_certified` mandatory).
+    pub fn verify_total_supply_checked_spice(
+        &self,
+        prev_total_supply: Balance,
+        minted_amount: Option<Balance>,
+        newly_certified_block_execution_results: &[BlockExecutionResults],
+    ) -> Option<bool> {
+        let balance_burnt = Self::compute_balance_burnt_from_certified_results_checked(
+            newly_certified_block_execution_results,
+        )?;
+
+        let Some(new_total_supply) = prev_total_supply
+            .checked_add(minted_amount.unwrap_or(Balance::ZERO))?
+            .checked_sub(balance_burnt)
+        else {
+            // This corresponds to balance_burnt > prev_total_supply + minted_amount
+            // which indicates invalid balance burnt, not arithmetic overflow
+            return Some(false);
+        };
+        Some(self.header().total_supply() == new_total_supply)
+    }
+
     #[deprecated(note = "use `verify_gas_price_checked` to avoid overflow panic")]
     pub fn verify_gas_price(
         &self,
@@ -335,14 +361,14 @@ impl Block {
         max_gas_price: Balance,
         gas_price_adjustment_rate: Rational32,
         // TODO(spice): Once spice v1 is released remove Option.
-        last_certified_block_execution_results: Option<&BlockExecutionResults>,
+        newly_certified_block_execution_results: Option<&[BlockExecutionResults]>,
     ) -> bool {
         self.verify_gas_price_checked(
             gas_price,
             min_gas_price,
             max_gas_price,
             gas_price_adjustment_rate,
-            last_certified_block_execution_results,
+            newly_certified_block_execution_results,
         )
         .unwrap()
     }
@@ -354,24 +380,28 @@ impl Block {
         max_gas_price: Balance,
         gas_price_adjustment_rate: Rational32,
         // TODO(spice): Once spice v1 is released remove Option.
-        last_certified_block_execution_results: Option<&BlockExecutionResults>,
+        newly_certified_block_execution_results: Option<&[BlockExecutionResults]>,
     ) -> Option<bool> {
-        let gas_used = self.chunks().compute_gas_used_checked()?;
-        let gas_limit = if let Some(last_certified_block_execution_results) =
-            last_certified_block_execution_results
-        {
-            last_certified_block_execution_results.compute_gas_limit_checked()?
+        let expected_price = if let Some(results) = newly_certified_block_execution_results {
+            Self::compute_gas_price_from_certified_results_checked(
+                results,
+                gas_price,
+                gas_price_adjustment_rate,
+                min_gas_price,
+                max_gas_price,
+            )?
         } else {
-            self.chunks().compute_gas_limit_checked()?
+            let gas_used = self.chunks().compute_gas_used_checked()?;
+            let gas_limit = self.chunks().compute_gas_limit_checked()?;
+            Self::compute_next_gas_price_checked(
+                gas_price,
+                gas_used,
+                gas_limit,
+                gas_price_adjustment_rate,
+                min_gas_price,
+                max_gas_price,
+            )?
         };
-        let expected_price = Self::compute_next_gas_price_checked(
-            gas_price,
-            gas_used,
-            gas_limit,
-            gas_price_adjustment_rate,
-            min_gas_price,
-            max_gas_price,
-        )?;
         Some(self.header().next_gas_price() == expected_price)
     }
 
@@ -435,6 +465,35 @@ impl Block {
                 )
                 .as_u128(),
         ))
+    }
+
+    fn compute_gas_price_from_certified_results_checked(
+        results: &[BlockExecutionResults],
+        initial_gas_price: Balance,
+        gas_price_adjustment_rate: Rational32,
+        min_gas_price: Balance,
+        max_gas_price: Balance,
+    ) -> Option<Balance> {
+        let mut gas_price = initial_gas_price;
+        for block_results in results {
+            gas_price = Self::compute_next_gas_price_checked(
+                gas_price,
+                block_results.compute_gas_used_checked()?,
+                block_results.compute_gas_limit_checked()?,
+                gas_price_adjustment_rate,
+                min_gas_price,
+                max_gas_price,
+            )?;
+        }
+        Some(gas_price)
+    }
+
+    fn compute_balance_burnt_from_certified_results_checked(
+        results: &[BlockExecutionResults],
+    ) -> Option<Balance> {
+        results.iter().try_fold(Balance::ZERO, |acc, block_results| {
+            acc.checked_add(block_results.compute_balance_burnt_checked()?)
+        })
     }
 
     pub fn validate_chunk_header_proof(
@@ -579,7 +638,7 @@ impl Block {
 
 pub struct SpiceNewBlockProductionInfo {
     pub core_statements: SpiceCoreStatements,
-    pub last_certified_block_execution_results: BlockExecutionResults,
+    pub newly_certified_block_execution_results: Vec<BlockExecutionResults>,
 }
 
 /// Distinguishes between new and old chunks.

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -16,12 +16,8 @@ use crate::transaction::{
     DeployContractAction, FunctionCallAction, NonceMode, SignedTransaction, StakeAction,
     Transaction, TransactionNonce, TransactionV0, TransactionV1, TransferAction,
 };
-#[cfg(feature = "clock")]
-use crate::types::chunk_extra::ChunkExtra;
 use crate::types::validator_stake::ValidatorStake;
 use crate::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas, Nonce, ShardId};
-#[cfg(feature = "clock")]
-use crate::types::{BlockExecutionResults, ChunkExecutionResult, StateRoot};
 use crate::validator_signer::ValidatorSigner;
 use crate::views::{ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionStatus};
 use itertools::Itertools;
@@ -874,6 +870,7 @@ pub struct TestBlockBuilder {
     // TODO(spice): Once spice is released remove Option.
     /// Iff `Some` spice block will be created.
     spice_core_statements: Option<crate::block_body::SpiceCoreStatements>,
+    newly_certified_block_execution_results: Vec<crate::types::BlockExecutionResults>,
 }
 
 #[cfg(feature = "clock")]
@@ -910,6 +907,7 @@ impl TestBlockBuilder {
             } else {
                 None
             },
+            newly_certified_block_execution_results: vec![],
         }
     }
 
@@ -994,6 +992,14 @@ impl TestBlockBuilder {
         self
     }
 
+    pub fn newly_certified_block_execution_results(
+        mut self,
+        results: Vec<crate::types::BlockExecutionResults>,
+    ) -> Self {
+        self.newly_certified_block_execution_results = results;
+        self
+    }
+
     pub fn chunk_endorsements(
         mut self,
         chunk_endorsements: Vec<ChunkEndorsementSignatures>,
@@ -1004,20 +1010,6 @@ impl TestBlockBuilder {
 
     pub fn build(self) -> Arc<Block> {
         tracing::debug!(target: "test", height=self.height, ?self.epoch_id, "produce block");
-        let last_certified_block_execution_results = BlockExecutionResults(
-            self.chunks
-                .iter()
-                .map(|chunk| {
-                    (
-                        chunk.shard_id(),
-                        Arc::new(ChunkExecutionResult {
-                            chunk_extra: ChunkExtra::new_with_only_state_root(&StateRoot::new()),
-                            outgoing_receipts_root: CryptoHash::default(),
-                        }),
-                    )
-                })
-                .collect(),
-        );
         Arc::new(Block::produce(
             PROTOCOL_VERSION,
             PROTOCOL_VERSION,
@@ -1044,7 +1036,8 @@ impl TestBlockBuilder {
             self.spice_core_statements.map(|core_statements| {
                 crate::block::SpiceNewBlockProductionInfo {
                     core_statements,
-                    last_certified_block_execution_results,
+                    newly_certified_block_execution_results: self
+                        .newly_certified_block_execution_results,
                 }
             }),
         ))

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1318,6 +1318,18 @@ impl BlockExecutionResults {
             acc.checked_add(execution_result.chunk_extra.gas_limit())
         })
     }
+
+    pub fn compute_gas_used_checked(&self) -> Option<Gas> {
+        self.0.iter().try_fold(Gas::ZERO, |acc, (_shard_id, execution_result)| {
+            acc.checked_add(execution_result.chunk_extra.gas_used())
+        })
+    }
+
+    pub fn compute_balance_burnt_checked(&self) -> Option<Balance> {
+        self.0.iter().try_fold(Balance::ZERO, |acc, (_shard_id, execution_result)| {
+            acc.checked_add(execution_result.chunk_extra.balance_burnt())
+        })
+    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq, Hash)]

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -932,3 +932,32 @@ fn schedule_send_money_txs(
     }
     (sent_txs, balance_changes)
 }
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_total_supply_decreases_with_gas_burn() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+
+    let gas_price = Balance::from_yoctonear(100_000_000);
+    let mut env = TestLoopBuilder::new()
+        .validators(2, 0)
+        .gas_prices(gas_price, gas_price)
+        .add_user_accounts([&sender, &receiver], Balance::from_near(10))
+        .build();
+
+    let initial_total_supply = env.validator().head_block().header().total_supply();
+
+    let tx = env.validator().tx_send_money(&sender, &receiver, Balance::from_near(1));
+    env.validator_runner().run_tx(tx, Duration::seconds(10));
+
+    let block = env.validator().last_executed_block();
+    assert!(
+        block.header().total_supply() < initial_total_supply,
+        "total_supply should decrease after gas is burned: {} >= {}",
+        block.header().total_supply(),
+        initial_total_supply,
+    );
+}

--- a/test-utils/testlib/src/process_blocks.rs
+++ b/test-utils/testlib/src/process_blocks.rs
@@ -77,12 +77,12 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
                 header.inner_lite.prev_state_root = *prev_block.header().prev_state_root();
             } else {
                 header.inner_lite.prev_state_root = chunks.compute_state_root();
+                header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
+                header.inner_rest.total_supply =
+                    header.inner_rest.total_supply.checked_add(balance_burnt).unwrap();
             }
             header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
             header.inner_rest.chunk_mask = vec![false];
-            header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
-            header.inner_rest.total_supply =
-                header.inner_rest.total_supply.checked_add(balance_burnt).unwrap();
             header.inner_rest.block_body_hash = block_body_hash.unwrap();
             header.inner_rest.chunk_endorsements =
                 ChunkEndorsementsBitmap::new(chunk_headers.len());
@@ -97,12 +97,12 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
                 header.inner_lite.prev_state_root = *prev_block.header().prev_state_root();
             } else {
                 header.inner_lite.prev_state_root = chunks.compute_state_root();
+                header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
+                header.inner_rest.total_supply =
+                    header.inner_rest.total_supply.checked_add(balance_burnt).unwrap();
             }
             header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
             header.inner_rest.chunk_mask = vec![false];
-            header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
-            header.inner_rest.total_supply =
-                header.inner_rest.total_supply.checked_add(balance_burnt).unwrap();
             header.inner_rest.block_body_hash = block_body_hash.unwrap();
             header.inner_rest.chunk_endorsements =
                 ChunkEndorsementsBitmap::new(chunk_headers.len());


### PR DESCRIPTION
I propose that when multiple blocks become certified at once, gas price should adjust iteratively for each and balance_burnt (for total_supply) should come from execution results. Previously only the last certified block's results were used.

Some additional benefits:
- By aligning on block boundaries, we can re-use the existing formula (summation of chunks in a block). Otherwise we have to deal with multiple chunks from one shard becoming "executed" at once.
- This is conceptually similar to the "shadow execution" chain (with non-spice behavior) which now follows the main (consensus) chain.

-----
### Changes

- Rename `get_last_certified_execution_results_for_next_block` to `get_newly_certified_block_execution_results_for_next_block`, returning `Vec<BlockExecutionResults>` ordered oldest-first.
- In SPICE, skip gas_used/gas_limit/balance_burnt from chunk headers in `Block::produce`; use certified execution results instead
- Genesis self-certifies: return genesis execution results when no certification frontier advancement occurs, bootstrapping gas price computation
- Add 2 multi-block certification unit tests and 1 test-loop integration test for total_supply