### PR TITLE
fix(runtime): adjust method name for ProhibitedInView error

### DIFF
--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -3171,7 +3171,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         self.result_state.gas_counter.pay_base(base)?;
         if self.context.is_view() {
             return Err(HostError::ProhibitedInView {
-                method_name: "promise_submit_data".to_string(),
+                method_name: "promise_yield_resume".to_string(),
             }
             .into());
         }

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -3507,9 +3507,10 @@ pub fn promise_yield_resume(
     let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
-        return Err(
-            HostError::ProhibitedInView { method_name: "promise_submit_data".to_string() }.into()
-        );
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_yield_resume".to_string(),
+        }
+        .into());
     }
     ctx.result_state.gas_counter.pay_base(yield_resume_base)?;
     ctx.result_state.gas_counter.pay_per(yield_resume_byte, payload_len)?;


### PR DESCRIPTION
The method name is "promise_yield_resume", but the error says "promise_submit_data". Let's correct the method name in the error.