### PR TITLE
refactor(test-loop): return Result from TestLoopNode query methods

### DIFF
--- a/test-loop-tests/src/examples/multinode.rs
+++ b/test-loop-tests/src/examples/multinode.rs
@@ -55,11 +55,11 @@ fn test_cross_shard_token_transfer() {
     rpc_node.run_for_number_of_blocks(&mut env.test_loop, 1);
 
     assert_eq!(
-        rpc_node.view_account_query(env.test_loop_data(), &sender_account).amount,
+        rpc_node.view_account_query(env.test_loop_data(), &sender_account).unwrap().amount,
         initial_balance.checked_sub(transfer_amount).unwrap()
     );
     assert_eq!(
-        rpc_node.view_account_query(env.test_loop_data(), &receiver_account).amount,
+        rpc_node.view_account_query(env.test_loop_data(), &receiver_account).unwrap().amount,
         initial_balance.checked_add(transfer_amount).unwrap()
     );
 

--- a/test-loop-tests/src/tests/deterministic_account_id.rs
+++ b/test-loop-tests/src/tests/deterministic_account_id.rs
@@ -1039,7 +1039,9 @@ impl TestEnv {
     }
 
     fn runtime_query(&self, query: QueryRequest) -> QueryResponse {
-        TestLoopNode::rpc(&self.env.node_datas).runtime_query(self.env.test_loop_data(), query)
+        TestLoopNode::rpc(&self.env.node_datas)
+            .runtime_query(self.env.test_loop_data(), query)
+            .unwrap()
     }
 
     fn get_account_state(&mut self, account: AccountId) -> AccountView {

--- a/test-loop-tests/src/tests/global_contracts.rs
+++ b/test-loop-tests/src/tests/global_contracts.rs
@@ -547,7 +547,9 @@ impl GlobalContractsTestEnv {
     }
 
     fn runtime_query(&self, query: QueryRequest) -> QueryResponse {
-        TestLoopNode::rpc(&self.env.node_datas).runtime_query(self.env.test_loop_data(), query)
+        TestLoopNode::rpc(&self.env.node_datas)
+            .runtime_query(self.env.test_loop_data(), query)
+            .unwrap()
     }
 
     fn shutdown(self) {

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -96,7 +96,7 @@ fn test_spice_chain() {
         let cp =
             &epoch_manager.get_epoch_chunk_producers_for_shard(&epoch_id, shard_id).unwrap()[0];
         let node = TestLoopNode::from(get_node_data(&node_datas, cp));
-        node.view_account_query(test_loop_data, account).amount
+        node.view_account_query(test_loop_data, account).unwrap().amount
     };
 
     let epoch_id = client.chain.head().unwrap().epoch_id;
@@ -201,7 +201,7 @@ fn test_spice_chain_with_delayed_execution() {
     );
     node.run_tx(&mut env.test_loop, tx, Duration::seconds(10));
 
-    let view_account_result = node.view_account_query(&env.test_loop.data, &receiver);
+    let view_account_result = node.view_account_query(&env.test_loop.data, &receiver).unwrap();
     assert_eq!(view_account_result.amount, Balance::from_near(1));
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
@@ -495,7 +495,7 @@ fn test_restart_rpc_node() {
 
     rpc.run_for_number_of_blocks(&mut env.test_loop, 5);
 
-    let view_account_result = rpc.view_account_query(&env.test_loop.data, &receiver);
+    let view_account_result = rpc.view_account_query(&env.test_loop.data, &receiver).unwrap();
     assert_eq!(view_account_result.amount, Balance::from_near(1));
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
@@ -576,7 +576,8 @@ fn test_restart_producer_node() {
 
     restart_node.run_for_number_of_blocks(&mut env.test_loop, 10);
 
-    let view_account_result = restart_node.view_account_query(&env.test_loop.data, &receiver);
+    let view_account_result =
+        restart_node.view_account_query(&env.test_loop.data, &receiver).unwrap();
     assert_eq!(view_account_result.amount, Balance::from_near(1));
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
@@ -678,12 +679,14 @@ fn test_restart_validator_node() {
         validator_node.head(env.test_loop_data()).height
     );
 
-    let view_account_result = producer_node.view_account_query(&env.test_loop.data, &receiver);
+    let view_account_result =
+        producer_node.view_account_query(&env.test_loop.data, &receiver).unwrap();
     assert_eq!(view_account_result.amount, Balance::from_near(0));
 
     producer_node.run_for_number_of_blocks(&mut env.test_loop, 10);
 
-    let view_account_result = producer_node.view_account_query(&env.test_loop.data, &receiver);
+    let view_account_result =
+        producer_node.view_account_query(&env.test_loop.data, &receiver).unwrap();
     assert_eq!(view_account_result.amount, Balance::from_near(1));
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
@@ -741,7 +744,7 @@ fn test_spice_chain_with_missing_chunks() {
     );
 
     for account in &accounts {
-        let got_balance = rpc_node.view_account_query(&env.test_loop.data, account).amount;
+        let got_balance = rpc_node.view_account_query(&env.test_loop.data, account).unwrap().amount;
         assert_eq!(got_balance, INITIAL_BALANCE);
     }
 
@@ -812,7 +815,7 @@ fn test_spice_chain_with_missing_chunks() {
 
     assert!(!balance_changes.is_empty());
     for (account, balance_change) in &balance_changes {
-        let got_balance = rpc_node.view_account_query(&env.test_loop.data, account).amount;
+        let got_balance = rpc_node.view_account_query(&env.test_loop.data, account).unwrap().amount;
         let want_balance = Balance::from_yoctonear(
             (INITIAL_BALANCE.as_yoctonear() as i128 + balance_change).try_into().unwrap(),
         );

--- a/test-loop-tests/src/tests/stake_nodes.rs
+++ b/test-loop-tests/src/tests/stake_nodes.rs
@@ -176,7 +176,7 @@ fn test_validator_kickout_impl(epoch_length: u64, execution_delay: u64) {
             }
             // Also wait for kicked nodes' locked amounts to return to zero
             for i in 0..2 {
-                let view = node.view_account_query(test_loop_data, &accounts[i]);
+                let view = node.view_account_query(test_loop_data, &accounts[i]).unwrap();
                 if !view.locked.is_zero() {
                     return false;
                 }
@@ -189,7 +189,7 @@ fn test_validator_kickout_impl(epoch_length: u64, execution_delay: u64) {
     // Verify kicked nodes have locked == 0 and stake returned to balance
     let expected_balance = TESTING_INIT_BALANCE.checked_add(TESTING_INIT_STAKE).unwrap();
     for i in 0..2 {
-        let view = node.view_account_query(&env.test_loop.data, &accounts[i]);
+        let view = node.view_account_query(&env.test_loop.data, &accounts[i]).unwrap();
         assert!(view.locked.is_zero(), "kicked node {i}");
         assert_eq!(view.amount, expected_balance, "kicked node {i}");
     }
@@ -197,7 +197,7 @@ fn test_validator_kickout_impl(epoch_length: u64, execution_delay: u64) {
     // Verify remaining validators have locked == TESTING_INIT_STAKE
     // Note: Genesis builder sets amount separately from validator stake (not deducted)
     for i in 2..4 {
-        let view = node.view_account_query(&env.test_loop.data, &accounts[i]);
+        let view = node.view_account_query(&env.test_loop.data, &accounts[i]).unwrap();
         assert_eq!(view.locked, TESTING_INIT_STAKE, "remaining validator {i}");
         assert_eq!(view.amount, TESTING_INIT_BALANCE, "remaining validator {i}");
     }
@@ -289,12 +289,12 @@ fn test_validator_join_impl(epoch_length: u64, execution_delay: u64) {
                 return false;
             }
             // Wait for node1's locked amount to return to zero
-            let view = node.view_account_query(test_loop_data, &accounts[1]);
+            let view = node.view_account_query(test_loop_data, &accounts[1]).unwrap();
             if !view.locked.is_zero() {
                 return false;
             }
             // Wait for node2's locked amount to equal TESTING_INIT_STAKE
-            let view = node.view_account_query(test_loop_data, &accounts[2]);
+            let view = node.view_account_query(test_loop_data, &accounts[2]).unwrap();
             view.locked == TESTING_INIT_STAKE
         },
         Duration::seconds(120),

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -9,7 +9,7 @@ use near_async::time::Duration;
 use near_chain::types::Tip;
 use near_chain::{Block, BlockHeader};
 use near_client::client_actor::ClientActor;
-use near_client::{Client, ProcessTxRequest, Query, ViewClientActor};
+use near_client::{Client, ProcessTxRequest, Query, QueryError, ViewClientActor};
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ShardChunk;
@@ -333,32 +333,30 @@ impl<'a> TestLoopNode<'a> {
         &self,
         test_loop_data: &TestLoopData,
         query: QueryRequest,
-    ) -> QueryResponse {
+    ) -> Result<QueryResponse, QueryError> {
         let handle = self.data().view_client_sender.actor_handle();
         let view_client: &ViewClientActor = test_loop_data.get(&handle);
-        view_client
-            .handle_query(Query::new(
-                near_primitives::types::BlockReference::Finality(
-                    near_primitives::types::Finality::None,
-                ),
-                query,
-            ))
-            .unwrap()
+        view_client.handle_query(Query::new(
+            near_primitives::types::BlockReference::Finality(
+                near_primitives::types::Finality::None,
+            ),
+            query,
+        ))
     }
 
     pub fn view_account_query(
         &self,
         test_loop_data: &TestLoopData,
         account_id: &AccountId,
-    ) -> AccountView {
+    ) -> Result<AccountView, QueryError> {
         let response = self.runtime_query(
             test_loop_data,
             QueryRequest::ViewAccount { account_id: account_id.clone() },
-        );
+        )?;
         let QueryResponseKind::ViewAccount(account_view) = response.kind else {
-            panic!("Unexpected query response type")
+            panic!("unexpected query response type")
         };
-        account_view
+        Ok(account_view)
     }
 
     #[cfg(feature = "test_features")]


### PR DESCRIPTION
- Change `runtime_query` and `view_account_query` on `TestLoopNode` to return `Result` instead of unwrapping internally, letting callers decide how to handle errors. This allows tests to check for specific `QueryError`s.
- Add `.unwrap()` at all existing call sites to preserve current behavior