### PR TITLE
refactor(store): make FlatStoreAdapter iter/iter_range infallible

### DIFF
--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -26,9 +26,9 @@ use near_primitives::types::{AccountId, BlockHeight};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::flat_store::{FlatStoreAdapter, FlatStoreUpdateAdapter};
 use near_store::flat::{
-    BlockInfo, FlatStateChanges, FlatStorageError, FlatStorageReadyStatus,
-    FlatStorageReshardingShardCatchUpMetrics, FlatStorageReshardingShardSplitMetrics,
-    FlatStorageReshardingStatus, FlatStorageStatus, ParentSplitParameters,
+    BlockInfo, FlatStateChanges, FlatStorageReadyStatus, FlatStorageReshardingShardCatchUpMetrics,
+    FlatStorageReshardingShardSplitMetrics, FlatStorageReshardingStatus, FlatStorageStatus,
+    ParentSplitParameters,
 };
 use near_store::{ShardUId, StorageError};
 
@@ -342,7 +342,7 @@ impl FlatStorageResharder {
                 match iter.next() {
                     // Stop iterating and commit the batch.
                     Some(FlatStorageAndDeltaIterItem::CommitPoint) => break,
-                    Some(FlatStorageAndDeltaIterItem::Entry(Ok((key, value)))) => {
+                    Some(FlatStorageAndDeltaIterItem::Entry((key, value))) => {
                         processed_size += key.len() + value.as_ref().map_or(0, |v| v.size());
                         if let Err(err) = shard_split_handle_key_value(
                             key,
@@ -353,10 +353,6 @@ impl FlatStorageResharder {
                             tracing::error!(target: "resharding", ?err, "failed to handle flat storage key");
                             return FlatStorageReshardingTaskResult::Failed;
                         }
-                    }
-                    Some(FlatStorageAndDeltaIterItem::Entry(Err(err))) => {
-                        tracing::error!(target: "resharding", ?err, "failed to read flat storage value from parent shard");
-                        return FlatStorageReshardingTaskResult::Failed;
                     }
                     None => {
                         iter_exhausted = true;
@@ -475,9 +471,7 @@ impl FlatStorageResharder {
                 .iter(*shard_uid)
                 // Get the flat storage iter and wrap the value in Optional::Some to
                 // match the delta iterator so that they can be chained.
-                .map_ok(|(key, value)| (key, Some(value)))
-                // Wrap the iterator's item into an Entry.
-                .map(|entry| FlatStorageAndDeltaIterItem::Entry(entry)),
+                .map(|(key, value)| FlatStorageAndDeltaIterItem::Entry((key, Some(value)))),
         );
 
         // Get all the blocks from flat head to the wanted block hash.
@@ -513,7 +507,7 @@ impl FlatStorageResharder {
             // Before doing so insert a commit point to separate changes to the same key in different transactions.
             iter = Box::new(iter.chain(iter::once(FlatStorageAndDeltaIterItem::CommitPoint)));
             let deltas_iter = deltas.0.into_iter();
-            let deltas_iter = deltas_iter.map(|item| FlatStorageAndDeltaIterItem::Entry(Ok(item)));
+            let deltas_iter = deltas_iter.map(|item| FlatStorageAndDeltaIterItem::Entry(item));
             iter = Box::new(iter.chain(deltas_iter));
         }
 
@@ -785,7 +779,7 @@ impl FlatStorageResharder {
 /// necessary because otherwise deltas might set again the value of a flat storage entry inside the
 /// same transaction.
 enum FlatStorageAndDeltaIterItem {
-    Entry(Result<(Vec<u8>, Option<FlatStateValue>), FlatStorageError>),
+    Entry((Vec<u8>, Option<FlatStateValue>)),
     CommitPoint,
 }
 

--- a/core/store/src/adapter/flat_store.rs
+++ b/core/store/src/adapter/flat_store.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use borsh::BorshDeserialize;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
@@ -150,20 +148,10 @@ impl FlatStoreAdapter {
             .store
             .iter_range(DBCol::FlatState, Some(&db_key_from), Some(&db_key_to))
             .map(|(key, value)| {
-                Ok((
-                    decode_flat_state_db_key(&key)
-                        .map_err(|err| {
-                            FlatStorageError::StorageInternalError(format!(
-                                "invalid FlatState key format: {err}"
-                            ))
-                        })?
-                        .1,
-                    FlatStateValue::try_from_slice(&value).map_err(|err| {
-                        FlatStorageError::StorageInternalError(format!(
-                            "invalid FlatState value format: {err}"
-                        ))
-                    })?,
-                ))
+                let (_, trie_key) = decode_flat_state_db_key(&key);
+                let value =
+                    FlatStateValue::try_from_slice(&value).expect("invalid FlatState value format");
+                (trie_key, value)
             });
         Box::new(iter)
     }
@@ -258,14 +246,12 @@ pub fn encode_flat_state_db_key(shard_uid: ShardUId, key: &[u8]) -> Vec<u8> {
     buffer
 }
 
-pub fn decode_flat_state_db_key(key: &[u8]) -> io::Result<(ShardUId, Vec<u8>)> {
-    let (shard_uid_bytes, trie_key) = key.split_at_checked(8).ok_or_else(|| {
-        io::Error::other(format!("expected FlatState key length to be at least 8: {key:?}"))
-    })?;
-    let shard_uid = shard_uid_bytes.try_into().map_err(|err| {
-        io::Error::other(format!("failed to decode shard_uid as part of FlatState key: {err}"))
-    })?;
-    Ok((shard_uid, trie_key.to_vec()))
+pub fn decode_flat_state_db_key(key: &[u8]) -> (ShardUId, Vec<u8>) {
+    let (shard_uid_bytes, trie_key) =
+        key.split_at_checked(8).expect("expected FlatState key length to be at least 8");
+    let shard_uid =
+        shard_uid_bytes.try_into().expect("failed to decode shard_uid as part of FlatState key");
+    (shard_uid, trie_key.to_vec())
 }
 
 #[cfg(test)]
@@ -303,7 +289,7 @@ mod tests {
             let key: Vec<u8> = vec![0, 1, i as u8];
             let val: Vec<u8> = vec![0, 1, 2, i as u8];
 
-            assert_eq!(entries, vec![Ok((key, FlatStateValue::inlined(&val)))]);
+            assert_eq!(entries, vec![(key, FlatStateValue::inlined(&val))]);
         }
     }
 }

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -58,8 +58,6 @@ impl From<FlatStorageError> for StorageError {
     }
 }
 
-pub type FlatStorageResult<T> = Result<T, FlatStorageError>;
-
 #[derive(
     BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq, serde::Serialize, ProtocolSchema, Clone,
 )]
@@ -213,5 +211,4 @@ pub struct ParentSplitParameters {
     pub flat_head: BlockInfo,
 }
 
-pub type FlatStateIterator<'a> =
-    Box<dyn Iterator<Item = FlatStorageResult<(Vec<u8>, FlatStateValue)>> + 'a>;
+pub type FlatStateIterator<'a> = Box<dyn Iterator<Item = (Vec<u8>, FlatStateValue)> + 'a>;

--- a/core/store/src/trie/from_flat.rs
+++ b/core/store/src/trie/from_flat.rs
@@ -1,5 +1,5 @@
 use crate::adapter::StoreAdapter;
-use crate::flat::{FlatStorageError, FlatStorageManager};
+use crate::flat::FlatStorageManager;
 use crate::trie::AccessOptions;
 use crate::{ShardTries, StateSnapshotConfig, Store, Trie, TrieConfig, TrieDBStorage, TrieStorage};
 use near_primitives::{shard_layout::ShardUId, state::FlatStateValue};
@@ -14,17 +14,15 @@ use std::time::Instant;
 // flat state can contain deltas after flat_head and can be different from tip of the blockchain.
 pub fn construct_trie_from_flat(store: Store, write_store: Store, shard_uid: ShardUId) {
     let trie_storage = TrieDBStorage::new(store.trie_store(), shard_uid);
-    let flat_state_to_trie_kv =
-        |entry: Result<(Vec<u8>, FlatStateValue), FlatStorageError>| -> (Vec<u8>, Vec<u8>) {
-            let (key, value) = entry.unwrap();
-            let value = match value {
-                FlatStateValue::Ref(ref_value) => {
-                    trie_storage.retrieve_raw_bytes(&ref_value.hash).unwrap().to_vec()
-                }
-                FlatStateValue::Inlined(inline_value) => inline_value,
-            };
-            (key, value)
+    let flat_state_to_trie_kv = |(key, value): (Vec<u8>, FlatStateValue)| -> (Vec<u8>, Vec<u8>) {
+        let value = match value {
+            FlatStateValue::Ref(ref_value) => {
+                trie_storage.retrieve_raw_bytes(&ref_value.hash).unwrap().to_vec()
+            }
+            FlatStateValue::Inlined(inline_value) => inline_value,
         };
+        (key, value)
+    };
 
     let store = store.flat_store();
     let mut iter = store.iter(shard_uid).map(flat_state_to_trie_kv);

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -68,8 +68,7 @@ fn load_memtrie_single_thread(
     let mut arena = STArena::new(shard_uid.to_string());
     let mut recon = TrieConstructor::new(&mut arena);
     let mut num_keys_loaded = 0;
-    for item in store.flat_store().iter(shard_uid) {
-        let (key, value) = item?;
+    for (key, value) in store.flat_store().iter(shard_uid) {
         recon.add_leaf(NibbleSlice::new(&key), value);
         num_keys_loaded += 1;
         if num_keys_loaded % 1000000 == 0 {

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -193,17 +193,14 @@ impl Trie {
         let mut value_refs = vec![];
         let mut values_inlined = 0;
         let mut all_state_part_items: Vec<_> = flat_state_iter
-            .filter_map(|result| {
-                let (k, v) = result.expect("failed to read FlatState entry");
-                match v {
-                    FlatStateValue::Ref(value_ref) => {
-                        value_refs.push((k, value_ref.hash));
-                        None
-                    }
-                    FlatStateValue::Inlined(value) => {
-                        values_inlined += 1;
-                        Some((k, Some(value)))
-                    }
+            .filter_map(|(k, v)| match v {
+                FlatStateValue::Ref(value_ref) => {
+                    value_refs.push((k, value_ref.hash));
+                    None
+                }
+                FlatStateValue::Inlined(value) => {
+                    values_inlined += 1;
+                    Some((k, Some(value)))
                 }
             })
             .collect::<Vec<_>>();

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -68,7 +68,7 @@ fn test_flat_storage_iter() {
             assert_eq!(expected, items.len());
             assert_eq!(
                 TrieKey::Account { account_id: "near".parse().unwrap() }.to_vec(),
-                items[0].as_ref().unwrap().0.to_vec()
+                items[0].0.to_vec()
             );
         }
         if shard_id == s1 {
@@ -78,7 +78,7 @@ fn test_flat_storage_iter() {
             assert_eq!(expected, items.len());
             assert_eq!(
                 TrieKey::Account { account_id: "test0".parse().unwrap() }.to_vec(),
-                items[0].as_ref().unwrap().0.to_vec()
+                items[0].0.to_vec()
             );
         }
         if shard_id == s2 {

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -450,15 +450,14 @@ fn slow_test_state_sync_with_dumped_parts_4_final() {
 fn count_flat_state_value_kinds(store: &Store) -> (u64, u64) {
     let mut num_inlined_values = 0;
     let mut num_ref_values = 0;
-    for item in store.flat_store().iter(ShardUId::single_shard()) {
-        match item {
-            Ok((_, FlatStateValue::Ref(_))) => {
+    for (_, value) in store.flat_store().iter(ShardUId::single_shard()) {
+        match value {
+            FlatStateValue::Ref(_) => {
                 num_ref_values += 1;
             }
-            Ok((_, FlatStateValue::Inlined(_))) => {
+            FlatStateValue::Inlined(_) => {
                 num_inlined_values += 1;
             }
-            _ => {}
         }
     }
     (num_inlined_values, num_ref_values)

--- a/test-loop-tests/src/utils/trie_sanity.rs
+++ b/test-loop-tests/src/utils/trie_sanity.rs
@@ -3,7 +3,6 @@ use crate::utils::sharding::{
     get_memtrie_for_shard, get_tracked_shards, get_tracked_shards_from_prev_block,
 };
 use borsh::BorshDeserialize;
-use itertools::Itertools;
 use near_chain::ChainStoreAccess;
 use near_chain::types::Tip;
 use near_client::Client;
@@ -282,7 +281,7 @@ fn assert_state_sanity(
         };
         let flat_store_state = flat_store_chunk_view
             .iter_range(None, None)
-            .map_ok(|(key, value)| {
+            .map(|(key, value)| {
                 let value = match value {
                     FlatStateValue::Ref(value) => client
                         .chain
@@ -296,8 +295,7 @@ fn assert_state_sanity(
                 };
                 (key, value)
             })
-            .collect::<Result<HashSet<_>, _>>()
-            .unwrap();
+            .collect::<HashSet<_>>();
 
         assert_state_equal(&memtrie_state, &flat_store_state, shard_uid, "memtrie and flat store");
         checked_shards.push(shard_uid);

--- a/tools/database/src/state_perf.rs
+++ b/tools/database/src/state_perf.rs
@@ -179,9 +179,7 @@ fn generate_state_requests(store: FlatStoreAdapter, samples: usize) -> Vec<(Shar
     for shard_uid in shard_uids {
         let shard_samples = samples / num_shards;
         let mut keys_read = std::collections::HashSet::new();
-        for value_ref in
-            store.iter(shard_uid).flat_map(|res| res.map(|(_, value)| value.to_value_ref()))
-        {
+        for value_ref in store.iter(shard_uid).map(|(_, value)| value.to_value_ref()) {
             if value_ref.length > 4096 || !keys_read.insert(value_ref.hash) {
                 continue;
             }

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -309,7 +309,6 @@ impl FlatStorageCommand {
         let mut verified = 0;
         let mut success = true;
         for (item_trie, item_flat) in tqdm(std::iter::zip(trie_iter, flat_state_entries_iter)) {
-            let item_flat = item_flat?;
             let value_ref = item_flat.1.to_value_ref();
             verified += 1;
 

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -966,14 +966,13 @@ impl ForkNetworkCommand {
         let mut records_not_parsed = 0;
         let mut records_parsed = 0;
 
-        for item in store.flat_store().iter(shard_uid) {
-            let (key, value) = match item {
-                Ok((key, FlatStateValue::Ref(ref_value))) => {
+        for (key, flat_value) in store.flat_store().iter(shard_uid) {
+            let (key, value) = match flat_value {
+                FlatStateValue::Ref(ref_value) => {
                     ref_keys_retrieved += 1;
                     (key, trie_storage.retrieve_raw_bytes(&ref_value.hash)?.to_vec())
                 }
-                Ok((key, FlatStateValue::Inlined(value))) => (key, value),
-                otherwise => panic!("Unexpected flat state value: {otherwise:?}"),
+                FlatStateValue::Inlined(value) => (key, value),
             };
             if let Some(sr) = StateRecord::from_raw_key_value(&key, value.clone()) {
                 match sr {
@@ -1094,47 +1093,45 @@ impl ForkNetworkCommand {
         // TODO: Just remember what accounts we saw in the above iteration
         let mut num_added = 0;
         let mut num_accounts = 0;
-        for item in store.flat_store().iter(shard_uid) {
-            if let Ok((key, _)) = item {
-                if key[0] == col::ACCOUNT {
-                    num_accounts += 1;
-                    let account_id = match parse_account_id_from_account_key(&key) {
-                        Ok(account_id) => account_id,
-                        Err(err) => {
-                            tracing::error!(
-                                ?err,
-                                key = %hex::encode(&key),
-                                "failed to parse account id"
-                            );
-                            continue;
-                        }
-                    };
-                    if account_id.get_account_type() == AccountType::NearImplicitAccount
-                        || has_full_key.contains(&account_id)
-                    {
+        for (key, _) in store.flat_store().iter(shard_uid) {
+            if key[0] == col::ACCOUNT {
+                num_accounts += 1;
+                let account_id = match parse_account_id_from_account_key(&key) {
+                    Ok(account_id) => account_id,
+                    Err(err) => {
+                        tracing::error!(
+                            ?err,
+                            key = %hex::encode(&key),
+                            "failed to parse account id"
+                        );
                         continue;
                     }
-                    let shard_id = source_shard_layout.account_id_to_shard_id(&account_id);
-                    if shard_id != shard_uid.shard_id() {
-                        tracing::warn!(
-                            %account_id,
-                            %shard_id,
-                            found_in_shard = %shard_uid.shard_id(),
-                            "account belongs to shard but was found in flat storage for different shard"
-                        );
-                    }
-                    let shard_idx = source_shard_layout.get_shard_index(shard_id).unwrap();
-                    storage_mutator.set_access_key(
-                        shard_idx,
-                        account_id,
-                        default_key.clone(),
-                        AccessKey::full_access(),
-                    )?;
-                    num_added += 1;
-                    if storage_mutator.should_commit(batch_size) {
-                        storage_mutator.commit()?;
-                        storage_mutator = make_storage_mutator(update_state.clone())?;
-                    }
+                };
+                if account_id.get_account_type() == AccountType::NearImplicitAccount
+                    || has_full_key.contains(&account_id)
+                {
+                    continue;
+                }
+                let shard_id = source_shard_layout.account_id_to_shard_id(&account_id);
+                if shard_id != shard_uid.shard_id() {
+                    tracing::warn!(
+                        %account_id,
+                        %shard_id,
+                        found_in_shard = %shard_uid.shard_id(),
+                        "account belongs to shard but was found in flat storage for different shard"
+                    );
+                }
+                let shard_idx = source_shard_layout.get_shard_index(shard_id).unwrap();
+                storage_mutator.set_access_key(
+                    shard_idx,
+                    account_id,
+                    default_key.clone(),
+                    AccessKey::full_access(),
+                )?;
+                num_added += 1;
+                if storage_mutator.should_commit(batch_size) {
+                    storage_mutator.commit()?;
+                    storage_mutator = make_storage_mutator(update_state.clone())?;
                 }
             }
         }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -1440,9 +1440,6 @@ fn get_state_stats_group_by<'a>(
         .map(|(type_byte, _)| chunk_view.iter_range(Some(&[*type_byte]), Some(&[*type_byte + 1])))
         .into_iter();
 
-    // Filter out any errors.
-    let type_iters = type_iters.map(|type_iter| type_iter.filter_map(|item| item.ok())).into_iter();
-
     // Read the values from and convert items to StateStatsStateRecord.
     let type_iters = type_iters
         .map(move |type_iter| {

--- a/tools/state-viewer/src/scan_db.rs
+++ b/tools/state-viewer/src/scan_db.rs
@@ -133,7 +133,7 @@ fn format_key_and_value<'a>(
             Box::new(BlockHeight::try_from_slice(value).unwrap()),
         ),
         DBCol::FlatState => {
-            let (shard_uid, key) = decode_flat_state_db_key(key).unwrap();
+            let (shard_uid, key) = decode_flat_state_db_key(key);
             (Box::new((shard_uid, key)), Box::new(FlatStateValue::try_from_slice(value).unwrap()))
         }
         DBCol::FlatStateChanges => (


### PR DESCRIPTION
Next step in the store Result cleanup series (Phase 2: Adapter Layer).

The underlying store methods (`iter_range`, `get_ser`) are now infallible, so the Result wrapping in the flat state iterator was unnecessary. This PR:
- Makes `decode_flat_state_db_key` panic on corruption instead of returning `io::Result`
- Makes `iter_range()` / `iter()` return items directly instead of `Result<(Vec<u8>, FlatStateValue), FlatStorageError>`
- Updates `FlatStateIterator` type alias accordingly
- Removes the now-unused `FlatStorageResult` type alias
- Removes `Result` from `FlatStorageAndDeltaIterItem::Entry` in the resharding code, since both the flat storage iter and deltas iter are now infallible
- Updates all ~14 call sites across the codebase