### PR TITLE
refactor(store): remove Result from FlatStoreAdapter::get, get_delta, get_all_deltas_metadata

### DIFF
--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -501,12 +501,7 @@ impl FlatStorageResharder {
         // Get all the delta iterators and wrap the items in Result to match the flat
         // storage iter so that they can be chained.
         for block in blocks_to_head {
-            let deltas = flat_store.get_delta(*shard_uid, block).map_err(|err| {
-                StorageError::StorageInconsistentState(format!(
-                    "can't retrieve deltas for flat storage at {block}/{shard_uid:?}({err})"
-                ))
-            })?;
-            let Some(deltas) = deltas else {
+            let Some(deltas) = flat_store.get_delta(*shard_uid, block) else {
                 continue;
             };
             // Chain the iterators effectively adding a block worth of deltas.
@@ -694,10 +689,7 @@ impl FlatStorageResharder {
                 prev_hash: *next_header.prev_hash(),
             };
 
-            if let Some(changes) = store
-                .get_delta(shard_uid, flat_head.hash)
-                .map_err(|err| Into::<StorageError>::into(err))?
-            {
+            if let Some(changes) = store.get_delta(shard_uid, flat_head.hash) {
                 merged_changes.merge(changes);
                 store_update.remove_delta(shard_uid, flat_head.hash);
             }
@@ -751,9 +743,7 @@ impl FlatStorageResharder {
         let store = self.runtime.store().flat_store();
         let mut store_update = store.store_update();
         // Deltas must exist because we applied them previously.
-        let deltas_metadata = store.get_all_deltas_metadata(shard_uid).unwrap_or_else(|_| {
-            panic!("Cannot read flat state deltas metadata for shard {shard_uid} from storage")
-        });
+        let deltas_metadata = store.get_all_deltas_metadata(shard_uid);
         let mut deltas_gc_count = 0;
         for delta_metadata in deltas_metadata {
             if delta_metadata.block.height <= flat_head.height {
@@ -1164,7 +1154,7 @@ mod tests {
         let store = flat_storage_resharder.runtime.store().flat_store();
         for (key, _) in &test_keys {
             for child_shard in [split_params.left_child_shard, split_params.right_child_shard] {
-                assert!(store.get(child_shard, key).unwrap().is_none());
+                assert!(store.get(child_shard, key).is_none());
             }
         }
     }
@@ -1312,12 +1302,12 @@ mod tests {
         Box::new(move |left_child_shard: ShardUId, right_child_shard: ShardUId| {
             // Check each child has the correct keys assigned to itself.
             for key in &account_mm_keys {
-                assert_eq!(flat_store.get(left_child_shard, key), Ok(test_value.clone()));
-                assert_eq!(flat_store.get(right_child_shard, key), Ok(None));
+                assert_eq!(flat_store.get(left_child_shard, key), test_value.clone());
+                assert_eq!(flat_store.get(right_child_shard, key), None);
             }
             for key in &account_vv_keys {
-                assert_eq!(flat_store.get(left_child_shard, key), Ok(None));
-                assert_eq!(flat_store.get(right_child_shard, key), Ok(test_value.clone()));
+                assert_eq!(flat_store.get(left_child_shard, key), None);
+                assert_eq!(flat_store.get(right_child_shard, key), test_value.clone());
             }
         })
     }
@@ -1350,11 +1340,11 @@ mod tests {
             for child_shard in [left_child_shard, right_child_shard] {
                 assert_eq!(
                     flat_store.get(child_shard, &delayed_receipt_indices_key),
-                    Ok(delayed_receipt_indices_value.clone())
+                    delayed_receipt_indices_value.clone()
                 );
                 assert_eq!(
                     flat_store.get(child_shard, &delayed_receipt_key),
-                    Ok(delayed_receipt_value.clone())
+                    delayed_receipt_value.clone()
                 );
             }
         })
@@ -1414,23 +1404,23 @@ mod tests {
             for child_shard in [left_child_shard, right_child_shard] {
                 assert_eq!(
                     flat_store.get(child_shard, &promise_yield_indices_key),
-                    Ok(promise_yield_indices_value.clone())
+                    promise_yield_indices_value.clone()
                 );
                 assert_eq!(
                     flat_store.get(child_shard, &promise_yield_timeout_key),
-                    Ok(promise_yield_timeout_value.clone())
+                    promise_yield_timeout_value.clone()
                 );
             }
             // Receipts work differently: these should be split depending on the account.
             assert_eq!(
                 flat_store.get(left_child_shard, &promise_yield_receipt_mm_key),
-                Ok(promise_yield_receipt_value.clone())
+                promise_yield_receipt_value.clone()
             );
-            assert_eq!(flat_store.get(left_child_shard, &promise_yield_receipt_vv_key), Ok(None));
-            assert_eq!(flat_store.get(right_child_shard, &promise_yield_receipt_mm_key), Ok(None));
+            assert_eq!(flat_store.get(left_child_shard, &promise_yield_receipt_vv_key), None);
+            assert_eq!(flat_store.get(right_child_shard, &promise_yield_receipt_mm_key), None);
             assert_eq!(
                 flat_store.get(right_child_shard, &promise_yield_receipt_vv_key),
-                Ok(promise_yield_receipt_value)
+                promise_yield_receipt_value
             );
         })
     }
@@ -1467,14 +1457,14 @@ mod tests {
             // Check that only the first child contain the buffered receipt.
             assert_eq!(
                 flat_store.get(left_child_shard, &buffered_receipt_indices_key),
-                Ok(buffered_receipt_indices_value)
+                buffered_receipt_indices_value
             );
-            assert_eq!(flat_store.get(right_child_shard, &buffered_receipt_indices_key), Ok(None));
+            assert_eq!(flat_store.get(right_child_shard, &buffered_receipt_indices_key), None);
             assert_eq!(
                 flat_store.get(left_child_shard, &buffered_receipt_key),
-                Ok(buffered_receipt_value)
+                buffered_receipt_value
             );
-            assert_eq!(flat_store.get(right_child_shard, &buffered_receipt_key), Ok(None));
+            assert_eq!(flat_store.get(right_child_shard, &buffered_receipt_key), None);
         })
     }
 

--- a/core/store/src/adapter/flat_store.rs
+++ b/core/store/src/adapter/flat_store.rs
@@ -39,13 +39,9 @@ impl FlatStoreAdapter {
         self.store.exists(DBCol::FlatState, &db_key)
     }
 
-    pub fn get(
-        &self,
-        shard_uid: ShardUId,
-        key: &[u8],
-    ) -> Result<Option<FlatStateValue>, FlatStorageError> {
+    pub fn get(&self, shard_uid: ShardUId, key: &[u8]) -> Option<FlatStateValue> {
         let db_key = encode_flat_state_db_key(shard_uid, key);
-        Ok(self.store.get_ser(DBCol::FlatState, &db_key))
+        self.store.get_ser(DBCol::FlatState, &db_key)
     }
 
     pub fn get_flat_storage_status(
@@ -62,20 +58,16 @@ impl FlatStoreAdapter {
         &self,
         shard_uid: ShardUId,
         block_hash: CryptoHash,
-    ) -> Result<Option<FlatStateChanges>, FlatStorageError> {
+    ) -> Option<FlatStateChanges> {
         let key = KeyForFlatStateDelta { shard_uid, block_hash };
-        Ok(self.store.get_ser::<FlatStateChanges>(DBCol::FlatStateChanges, &key.to_bytes()))
+        self.store.get_ser::<FlatStateChanges>(DBCol::FlatStateChanges, &key.to_bytes())
     }
 
-    pub fn get_all_deltas_metadata(
-        &self,
-        shard_uid: ShardUId,
-    ) -> Result<Vec<FlatStateDeltaMetadata>, FlatStorageError> {
-        Ok(self
-            .store
+    pub fn get_all_deltas_metadata(&self, shard_uid: ShardUId) -> Vec<FlatStateDeltaMetadata> {
+        self.store
             .iter_prefix_ser(DBCol::FlatStateDeltaMetadata, &shard_uid.to_bytes())
             .map(|(_, value)| value)
-            .collect())
+            .collect()
     }
 
     pub fn get_prev_block_with_changes(

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -248,16 +248,13 @@ impl FlatStorage {
         let metrics = FlatStorageMetrics::new(shard_uid);
         metrics.set_flat_head_height(flat_head.height);
 
-        let deltas_metadata = store.get_all_deltas_metadata(shard_uid).unwrap_or_else(|_| {
-            panic!("Cannot read flat state deltas metadata for shard {shard_id} from storage")
-        });
+        let deltas_metadata = store.get_all_deltas_metadata(shard_uid);
         let mut deltas = HashMap::new();
         for delta_metadata in deltas_metadata {
             let block_hash = delta_metadata.block.hash;
             let changes: CachedFlatStateChanges = if delta_metadata.has_changes() {
                 store
                     .get_delta(shard_uid, block_hash)
-                    .expect("failed to read flat state delta changes")
                     .unwrap_or_else(|| {
                         panic!("cannot find block delta for block {block_hash:?} shard {shard_id}")
                     })
@@ -312,7 +309,7 @@ impl FlatStorage {
             };
         }
 
-        let value = guard.store.get(guard.shard_uid, key)?;
+        let value = guard.store.get(guard.shard_uid, key);
         Ok(value)
     }
 
@@ -389,7 +386,7 @@ impl FlatStorage {
             // path from old to new head. Otherwise we return internal error.
             let changes = guard
                 .store
-                .get_delta(shard_uid, block_hash)?
+                .get_delta(shard_uid, block_hash)
                 .ok_or_else(|| missing_delta_error(&block_hash))?;
             changes.apply_to_flat_state(&mut store_update, guard.shard_uid);
             let metadata = guard
@@ -762,13 +759,13 @@ mod tests {
         assert_eq!(chunk_view0.get_value(&[2]).unwrap(), Some(FlatStateValue::value_ref(&[1])));
         assert_eq!(chunk_view1.get_value(&[1]).unwrap(), Some(FlatStateValue::value_ref(&[4])));
         assert_eq!(chunk_view1.get_value(&[2]).unwrap(), None);
-        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(5)).unwrap(), Some(_));
-        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(10)).unwrap(), Some(_));
+        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(5)), Some(_));
+        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(10)), Some(_));
 
         // 5. Move the flat head to block 5, verify that chunk_view0 still returns the same values
         // and chunk_view1 returns an error. Also check that DBCol::FlatState is updated correctly
         flat_storage.update_flat_head_impl(&chain.get_block_hash(5), true).unwrap();
-        assert_eq!(store.get(shard_uid, &[1]).unwrap(), Some(FlatStateValue::value_ref(&[5])));
+        assert_eq!(store.get(shard_uid, &[1]), Some(FlatStateValue::value_ref(&[5])));
         let blocks = flat_storage.get_blocks_to_head(&chain.get_block_hash(10)).unwrap();
         assert_eq!(blocks.len(), 5);
         assert_eq!(chunk_view0.get_value(&[1]).unwrap(), None);
@@ -777,19 +774,19 @@ mod tests {
             chunk_view1.get_value(&[1]),
             Err(StorageError::FlatStorageBlockNotSupported(_))
         );
-        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(5)).unwrap(), None);
-        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(10)).unwrap(), Some(_));
+        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(5)), None);
+        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(10)), Some(_));
 
         // 6. Move the flat head to block 10, verify that chunk_view0 still returns the same values
         //    Also checks that DBCol::FlatState is updated correctly.
         flat_storage.update_flat_head_impl(&chain.get_block_hash(10), true).unwrap();
         let blocks = flat_storage.get_blocks_to_head(&chain.get_block_hash(10)).unwrap();
         assert_eq!(blocks.len(), 0);
-        assert_eq!(store.get(shard_uid, &[1]).unwrap(), None);
-        assert_eq!(store.get(shard_uid, &[2]).unwrap(), Some(FlatStateValue::value_ref(&[1])));
+        assert_eq!(store.get(shard_uid, &[1]), None);
+        assert_eq!(store.get(shard_uid, &[2]), Some(FlatStateValue::value_ref(&[1])));
         assert_eq!(chunk_view0.get_value(&[1]).unwrap(), None);
         assert_eq!(chunk_view0.get_value(&[2]).unwrap(), Some(FlatStateValue::value_ref(&[1])));
-        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(10)).unwrap(), None);
+        assert_matches!(store.get_delta(shard_uid, chain.get_block_hash(10)), None);
     }
 
     #[test]
@@ -858,7 +855,7 @@ mod tests {
             // Don't check the first block because it may be a block with no changes.
             for i in 1..blocks.len() {
                 let block_hash = blocks[i];
-                let delta = store.get_delta(shard_uid, block_hash).unwrap().unwrap();
+                let delta = store.get_delta(shard_uid, block_hash).unwrap();
                 assert!(
                     !delta.0.is_empty(),
                     "i: {i}, block_hash: {block_hash:?}, delta: {delta:?}"
@@ -1012,7 +1009,7 @@ mod tests {
             // Don't check the first block because it may be a block with no changes.
             for i in 1..blocks.len() {
                 let block_hash = blocks[i];
-                let delta = store.get_delta(shard_uid, block_hash).unwrap().unwrap();
+                let delta = store.get_delta(shard_uid, block_hash).unwrap();
                 assert!(
                     !delta.0.is_empty(),
                     "i: {i}, block_hash: {block_hash:?}, delta: {delta:?}"
@@ -1023,7 +1020,7 @@ mod tests {
             let flat_head_height = hashes.get(&flat_head_hash).unwrap();
 
             let flat_head_lag = i - flat_head_height;
-            let delta = store.get_delta(shard_uid, block_hash).unwrap().unwrap();
+            let delta = store.get_delta(shard_uid, block_hash).unwrap();
             let has_changes = !delta.0.is_empty();
             tracing::info!(?i, has_changes, ?flat_head_lag);
             max_lag = max_lag.max(Some(flat_head_lag));

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -145,14 +145,13 @@ pub fn load_trie_from_flat_state_and_delta(
     // We load the deltas in order of height, so that we always have the previous state root
     // already loaded.
     let mut sorted_deltas: BTreeSet<(BlockHeight, CryptoHash, CryptoHash)> = Default::default();
-    for delta in flat_store.get_all_deltas_metadata(shard_uid).unwrap() {
+    for delta in flat_store.get_all_deltas_metadata(shard_uid) {
         sorted_deltas.insert((delta.block.height, delta.block.hash, delta.block.prev_hash));
     }
 
     tracing::debug!(target: "memtrie", %shard_uid, num_deltas = sorted_deltas.len(), "deltas to apply");
     for (height, hash, prev_hash) in sorted_deltas {
-        let delta = flat_store.get_delta(shard_uid, hash).unwrap();
-        if let Some(changes) = delta {
+        if let Some(changes) = flat_store.get_delta(shard_uid, hash) {
             let old_state_root = get_state_root(store, prev_hash, shard_uid)?;
             let new_state_root = get_state_root(store, hash, shard_uid)?;
 

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -136,12 +136,12 @@ pub struct ResumeReshardingCmd {
 }
 
 fn print_delta(store: &FlatStoreAdapter, shard_uid: ShardUId, metadata: FlatStateDeltaMetadata) {
-    let changes = store.get_delta(shard_uid, metadata.block.hash).unwrap().unwrap();
+    let changes = store.get_delta(shard_uid, metadata.block.hash).unwrap();
     println!("{:?}", FlatStateDelta { metadata, changes });
 }
 
 fn print_deltas(store: &FlatStoreAdapter, shard_uid: ShardUId) {
-    let deltas_metadata = store.get_all_deltas_metadata(shard_uid).unwrap();
+    let deltas_metadata = store.get_all_deltas_metadata(shard_uid);
     let num_deltas = deltas_metadata.len();
     println!("Deltas: {}", num_deltas);
 
@@ -448,7 +448,7 @@ impl FlatStorageCommand {
                         )?
                         .map(|value_ref| value_ref.into_value_ref());
                     let value_ref =
-                        flat_store.get(shard_uid, trie_key)?.map(|val| val.to_value_ref());
+                        flat_store.get(shard_uid, trie_key).map(|val| val.to_value_ref());
                     if prev_value_ref == value_ref {
                         // Value didn't change, skip it.
                         continue;

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -49,9 +49,7 @@ impl ShardUpdateState {
         shard_uid: ShardUId,
         state_root: CryptoHash,
     ) -> anyhow::Result<Self> {
-        let deltas = flat_store
-            .get_all_deltas_metadata(shard_uid)
-            .with_context(|| format!("failed getting flat storage deltas for {}", shard_uid))?;
+        let deltas = flat_store.get_all_deltas_metadata(shard_uid);
 
         let max_delta_height = deltas.iter().map(|d| d.block.height).max();
         let max_delta_height = match max_delta_height {


### PR DESCRIPTION
`FlatStoreAdapter::get()`, `get_delta()`, and `get_all_deltas_metadata()` all wrap infallible `Store` calls in `Ok(...)`, making them return `Result` unnecessarily. This removes the `Result` wrapper from all three methods and simplifies call sites across the codebase — removing `.unwrap()`, `?`, `.map_err(...)`, and `.unwrap_or_else(|_| ...)` where the error path was unreachable.

Part of the ongoing store `Result` cleanup series (Phase 2: Adapter Layer).