### PR TITLE
feat(runtime): add claude.md with runtime overview

### DIFF
--- a/runtime/runtime/AGENTS.md
+++ b/runtime/runtime/AGENTS.md
@@ -10,7 +10,6 @@ fn apply() contains the following steps:
 - Read buffered outgoing receipts and send out as many as possible within the outgoing limits
 - Process transactions in the chunk and convert them to the receipts
 - Process receipts, executing them and producing new outgoing receipts
-- Finalize the post-state
 
 `process_transactions` takes all transactions in a chunk, validates them, charges gas, and converts them to local receipts.
 


### PR DESCRIPTION
Add a CLAUDE.md with a summary of how things work in the runtime.

Hopefully this can serve as a sort of "long-term memory", so that claude doesn't have to relearn everything each time it goes to the runtime.

AFAIU claude should read it whenever it goes into the runtime directory.

It's 100% human-generated

Claude is actually a good motivation to write docs :)