### PR TITLE
refactor(store): replace borsh::to_vec()? with .unwrap()

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3223,10 +3223,10 @@ impl Chain {
             size_of::<CryptoHash>() + size_of::<CryptoHash>() + size_of::<u64>();
 
         let mut bytes: Vec<u8> = Vec::with_capacity(BYTES_LEN);
-        bytes.extend_from_slice(&hash(&borsh::to_vec(&block)?).0);
+        bytes.extend_from_slice(&hash(&borsh::to_vec(&block).unwrap()).0);
 
         let chunks_key_source: Vec<_> = chunk_headers.iter_raw().map(|c| c.chunk_hash()).collect();
-        bytes.extend_from_slice(&hash(&borsh::to_vec(&chunks_key_source)?).0);
+        bytes.extend_from_slice(&hash(&borsh::to_vec(&chunks_key_source).unwrap()).0);
         bytes.extend_from_slice(&shard_id.to_le_bytes());
 
         Ok(CachedShardUpdateKey::new(hash(&bytes)))

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -786,7 +786,7 @@ impl<'a> ChainStoreUpdate<'a> {
             {
                 let state_num_parts = shard_state_header.num_state_parts();
                 self.gc_col_state_parts(block_hash, shard_id, state_num_parts)?;
-                let key = borsh::to_vec(&StateHeaderKey(shard_id, block_hash))?;
+                let key = borsh::to_vec(&StateHeaderKey(shard_id, block_hash)).unwrap();
                 self.gc_col(DBCol::StateHeaders, &key);
             }
         }
@@ -975,7 +975,8 @@ impl<'a> ChainStoreUpdate<'a> {
             {
                 let state_num_parts = shard_state_header.num_state_parts();
                 self.gc_col_state_parts(block_hash, shard_id, state_num_parts)?;
-                let state_header_key = borsh::to_vec(&StateHeaderKey(shard_id, block_hash))?;
+                let state_header_key =
+                    borsh::to_vec(&StateHeaderKey(shard_id, block_hash)).unwrap();
                 self.gc_col(DBCol::StateHeaders, &state_header_key);
             }
 
@@ -1088,7 +1089,7 @@ impl<'a> ChainStoreUpdate<'a> {
         num_parts: u64,
     ) -> Result<(), Error> {
         for part_id in 0..num_parts {
-            let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id))?;
+            let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id)).unwrap();
             self.gc_col(DBCol::StateParts, &key);
             self.gc_col(DBCol::StatePartsApplied, &key);
         }

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -180,7 +180,7 @@ impl TrieStateResharder {
             store_update.set(
                 DBCol::Misc,
                 TRIE_STATE_RESHARDING_STATUS_KEY,
-                &borsh::to_vec(status)?,
+                &borsh::to_vec(status).unwrap(),
             );
         }
         store_update.commit();
@@ -310,7 +310,11 @@ impl TrieStateResharder {
         );
 
         let mut store_update = self.runtime.store().store_update();
-        store_update.set(DBCol::Misc, TRIE_STATE_RESHARDING_STATUS_KEY, &borsh::to_vec(&status)?);
+        store_update.set(
+            DBCol::Misc,
+            TRIE_STATE_RESHARDING_STATUS_KEY,
+            &borsh::to_vec(&status).unwrap(),
+        );
         store_update.commit();
 
         Ok(())

--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -259,7 +259,7 @@ impl ChainStateSyncAdapter {
         sync_hash: CryptoHash,
     ) -> Result<ShardStateSyncResponseHeader, Error> {
         // Check cache
-        let key = borsh::to_vec(&StateHeaderKey(shard_id, sync_hash))?;
+        let key = borsh::to_vec(&StateHeaderKey(shard_id, sync_hash)).unwrap();
         if let Some(header) = self.chain_store.store().get_ser(DBCol::StateHeaders, &key) {
             return Ok(header);
         }
@@ -295,7 +295,7 @@ impl ChainStateSyncAdapter {
         let epoch_id = block.header().epoch_id();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         // Check cache
-        let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id))?;
+        let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id)).unwrap();
         if let Some(bytes) = self.chain_store.store_ref().get(DBCol::StateParts, &key) {
             metrics::STATE_PART_CACHE_HIT.inc();
             let state_part = StatePart::from_bytes(bytes.to_vec(), protocol_version)?;
@@ -518,7 +518,7 @@ impl ChainStateSyncAdapter {
 
         // Saving the header data.
         let mut store_update = self.chain_store.store().store_update();
-        let key = borsh::to_vec(&StateHeaderKey(shard_id, sync_hash))?;
+        let key = borsh::to_vec(&StateHeaderKey(shard_id, sync_hash)).unwrap();
         store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header);
         store_update.commit();
 
@@ -550,7 +550,7 @@ impl ChainStateSyncAdapter {
 
         // Saving the part data.
         let mut store_update = self.chain_store.store().store_update();
-        let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id.idx))?;
+        let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id.idx)).unwrap();
         let bytes = part.to_bytes(protocol_version);
         store_update.set(DBCol::StateParts, &key, &bytes);
         store_update.commit();

--- a/chain/chain/src/stateless_validation/metrics.rs
+++ b/chain/chain/src/stateless_validation/metrics.rs
@@ -221,10 +221,10 @@ fn record_witness_size_metrics_fallible(
         .observe(encoded_size as f64);
     CHUNK_STATE_WITNESS_MAIN_STATE_TRANSITION_SIZE
         .with_label_values(&[shard_id.as_str()])
-        .observe(borsh::object_length(&witness.main_state_transition())? as f64);
+        .observe(borsh::object_length(&witness.main_state_transition()).unwrap() as f64);
     CHUNK_STATE_WITNESS_SOURCE_RECEIPT_PROOFS_SIZE
         .with_label_values(&[&shard_id.as_str()])
-        .observe(borsh::object_length(&witness.source_receipt_proofs())? as f64);
+        .observe(borsh::object_length(&witness.source_receipt_proofs()).unwrap() as f64);
     Ok(())
 }
 

--- a/chain/chain/src/store/latest_witnesses.rs
+++ b/chain/chain/src/store/latest_witnesses.rs
@@ -152,7 +152,7 @@ impl ChainStore {
             witness.chunk_production_key();
         let _span = tracing::info_span!(target: "client", "save_latest_chunk_state_witness", ?height_created, %shard_id).entered();
 
-        let serialized_witness = borsh::to_vec(witness)?;
+        let serialized_witness = borsh::to_vec(witness).unwrap();
         let witness_size: u64 =
             serialized_witness.len().try_into().expect("Cannot convert usize to u64");
 
@@ -217,7 +217,7 @@ impl ChainStore {
         );
 
         // Update LatestWitnessesInfo
-        store_update.set(DBCol::Misc, &LATEST_WITNESSES_INFO, &borsh::to_vec(&info)?);
+        store_update.set(DBCol::Misc, &LATEST_WITNESSES_INFO, &borsh::to_vec(&info).unwrap());
 
         let store_update_time = start_time.elapsed();
 
@@ -337,7 +337,7 @@ pub fn save_invalid_chunk_state_witness(
     )
     .entered();
 
-    let serialized_witness = borsh::to_vec(witness)?;
+    let serialized_witness = borsh::to_vec(witness).unwrap();
     let serialized_witness_size: u64 =
         serialized_witness.len().try_into().expect("Cannot convert usize to u64");
 
@@ -408,7 +408,7 @@ pub fn save_invalid_chunk_state_witness(
         );
 
         // Update InvalidWitnessesInfo
-        store_update.set(DBCol::Misc, &INVALID_WITNESSES_INFO, &borsh::to_vec(&info)?);
+        store_update.set(DBCol::Misc, &INVALID_WITNESSES_INFO, &borsh::to_vec(&info).unwrap());
 
         let store_update_time = start_time.elapsed();
 

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -415,7 +415,11 @@ impl CloudArchivalWriter {
             self.hot_store.chain_store().get_block_header_by_height(new_head)?;
         let cloud_head_tip = Tip::from_header(&cloud_head_header);
         let mut transaction = DBTransaction::new();
-        transaction.set(DBCol::BlockMisc, CLOUD_HEAD_KEY.to_vec(), borsh::to_vec(&cloud_head_tip)?);
+        transaction.set(
+            DBCol::BlockMisc,
+            CLOUD_HEAD_KEY.to_vec(),
+            borsh::to_vec(&cloud_head_tip).unwrap(),
+        );
         self.hot_store.database().write(transaction);
         Ok(())
     }

--- a/chain/client/src/chunk_distribution_network.rs
+++ b/chain/client/src/chunk_distribution_network.rs
@@ -197,7 +197,7 @@ impl ChunkDistributionClient for ChunkDistributionNetwork {
         chunk: &PartialEncodedChunk,
     ) -> Result<Self::Response, Self::Error> {
         let prev_hash = chunk.prev_block();
-        let bytes = borsh::to_vec(chunk)?;
+        let bytes = borsh::to_vec(chunk).unwrap();
         let url = &self.config.uris.set;
         let request = self
             .client

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -1021,7 +1021,7 @@ pub(crate) fn save_receipt_proof(
 ) -> Result<(), std::io::Error> {
     let &ReceiptProof(_, ShardProof { from_shard_id, to_shard_id, .. }) = receipt_proof;
     let key = get_receipt_proof_key(block_hash, from_shard_id, to_shard_id);
-    let value = borsh::to_vec(&receipt_proof)?;
+    let value = borsh::to_vec(&receipt_proof).unwrap();
     store_update.set(DBCol::receipt_proofs(), &key, &value);
     Ok(())
 }
@@ -1034,7 +1034,7 @@ pub(crate) fn save_witness(
 ) -> Result<(), Error> {
     let mut store_update = chain_store.store().store_update();
     let key = get_witnesses_key(block_hash, shard_id);
-    let value = borsh::to_vec(&witness)?;
+    let value = borsh::to_vec(&witness).unwrap();
     store_update.set(DBCol::witnesses(), &key, &value);
     store_update.commit();
     Ok(())

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -354,7 +354,7 @@ impl ChainStoreAdapter {
         shard_id: ShardId,
         block_hash: CryptoHash,
     ) -> Result<ShardStateSyncResponseHeader, Error> {
-        let key = borsh::to_vec(&StateHeaderKey(shard_id, block_hash))?;
+        let key = borsh::to_vec(&StateHeaderKey(shard_id, block_hash)).unwrap();
         self.store
             .get_ser(DBCol::StateHeaders, &key)
             .ok_or_else(|| Error::Other("Cannot get shard_state_header".into()))

--- a/core/store/src/archive/cloud_storage/archive.rs
+++ b/core/store/src/archive/cloud_storage/archive.rs
@@ -50,7 +50,7 @@ impl CloudStorage {
     ) -> Result<(), CloudArchivingError> {
         let epoch_data = build_epoch_data(hot_store, shard_layout.clone(), epoch_id)?;
         let file_id = CloudStorageFileID::Epoch(epoch_id);
-        let blob = borsh::to_vec(&epoch_data)?;
+        let blob = borsh::to_vec(&epoch_data).unwrap();
         self.upload(file_id, blob).await
     }
 
@@ -62,7 +62,7 @@ impl CloudStorage {
     ) -> Result<(), CloudArchivingError> {
         let block_data = build_block_data(hot_store, block_height)?;
         let file_id = CloudStorageFileID::Block(block_height);
-        let blob = borsh::to_vec(&block_data)?;
+        let blob = borsh::to_vec(&block_data).unwrap();
         self.upload(file_id, blob).await
     }
 
@@ -78,13 +78,13 @@ impl CloudStorage {
         let shard_data =
             build_shard_data(hot_store, genesis_height, shard_layout, block_height, shard_uid)?;
         let file_id = CloudStorageFileID::Shard(block_height, shard_uid.shard_id());
-        let blob = borsh::to_vec(&shard_data)?;
+        let blob = borsh::to_vec(&shard_data).unwrap();
         self.upload(file_id, blob).await
     }
 
     /// Persists the cloud head to external storage.
     pub async fn update_cloud_head(&self, head: BlockHeight) -> Result<(), CloudArchivingError> {
-        self.upload(CloudStorageFileID::Head, borsh::to_vec(&head)?).await
+        self.upload(CloudStorageFileID::Head, borsh::to_vec(&head).unwrap()).await
     }
 
     /// Uploads the given value to the external cloud storage under the specified

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -379,21 +379,21 @@ pub fn update_cold_head(
     // Write HEAD to the cold db.
     {
         let mut transaction = DBTransaction::new();
-        transaction.set(DBCol::BlockMisc, HEAD_KEY.to_vec(), borsh::to_vec(&tip)?);
+        transaction.set(DBCol::BlockMisc, HEAD_KEY.to_vec(), borsh::to_vec(&tip).unwrap());
         cold_db.write(transaction);
     }
 
     // Write COLD_HEAD_KEY to the cold db.
     {
         let mut transaction = DBTransaction::new();
-        transaction.set(DBCol::BlockMisc, COLD_HEAD_KEY.to_vec(), borsh::to_vec(&tip)?);
+        transaction.set(DBCol::BlockMisc, COLD_HEAD_KEY.to_vec(), borsh::to_vec(&tip).unwrap());
         cold_db.write(transaction);
     }
 
     // Write COLD_HEAD to the hot db.
     {
         let mut transaction = DBTransaction::new();
-        transaction.set(DBCol::BlockMisc, COLD_HEAD_KEY.to_vec(), borsh::to_vec(&tip)?);
+        transaction.set(DBCol::BlockMisc, COLD_HEAD_KEY.to_vec(), borsh::to_vec(&tip).unwrap());
         hot_store.database().write(transaction);
 
         crate::metrics::COLD_HEAD_HEIGHT.set(*height as i64);

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -953,7 +953,7 @@ pub(crate) fn receipt_size(
 /// The calculation is part of protocol and should only be modified with a
 /// protocol upgrade.
 pub(crate) fn compute_receipt_size(receipt: &Receipt) -> Result<u64, IntegerOverflowError> {
-    let size = borsh::object_length(&receipt).map_err(|_| IntegerOverflowError)?;
+    let size = borsh::object_length(&receipt).unwrap();
     size.try_into().map_err(|_| IntegerOverflowError)
 }
 

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -185,7 +185,7 @@ impl StorageMutator {
         account_id: AccountId,
         value: Account,
     ) -> anyhow::Result<()> {
-        self.set(shard_idx, TrieKey::Account { account_id }, borsh::to_vec(&value)?)
+        self.set(shard_idx, TrieKey::Account { account_id }, borsh::to_vec(&value).unwrap())
     }
 
     fn mapped_account_id(
@@ -250,7 +250,7 @@ impl StorageMutator {
         self.set(
             shard_idx,
             TrieKey::AccessKey { account_id, public_key },
-            borsh::to_vec(&access_key)?,
+            borsh::to_vec(&access_key).unwrap(),
         )
     }
 
@@ -280,7 +280,7 @@ impl StorageMutator {
         self.set(
             shard_idx,
             TrieKey::GasKeyNonce { account_id, public_key, index },
-            borsh::to_vec(&nonce)?,
+            borsh::to_vec(&nonce).unwrap(),
         )
     }
 
@@ -303,7 +303,7 @@ impl StorageMutator {
             self.set(
                 mapped.target,
                 TrieKey::ContractData { account_id: mapped.new_account_id, key: data_key.to_vec() },
-                borsh::to_vec(&value)?,
+                borsh::to_vec(&value).unwrap(),
             )?;
         }
         Ok(())
@@ -355,7 +355,7 @@ impl StorageMutator {
                 receiver_id: receipt.receiver_id().clone(),
                 receipt_id: *receipt.receipt_id(),
             },
-            borsh::to_vec(&receipt)?,
+            borsh::to_vec(&receipt).unwrap(),
         )
     }
 
@@ -378,7 +378,7 @@ impl StorageMutator {
             self.set(
                 mapped.target,
                 TrieKey::ReceivedData { receiver_id: mapped.new_account_id, data_id },
-                borsh::to_vec(data)?,
+                borsh::to_vec(data).unwrap(),
             )?;
         }
         Ok(())
@@ -389,7 +389,7 @@ impl StorageMutator {
         shard_idx: ShardIndex,
         state: BandwidthSchedulerState,
     ) -> anyhow::Result<()> {
-        self.set(shard_idx, TrieKey::BandwidthSchedulerState, borsh::to_vec(&state)?)
+        self.set(shard_idx, TrieKey::BandwidthSchedulerState, borsh::to_vec(&state).unwrap())
     }
 
     /// Check if the total number of updates is greater than or equal to the batch size


### PR DESCRIPTION
`borsh::to_vec()` serializes into a `Vec<u8>` whose `io::Write` implementation is infallible, so the `Result` it returns can never be `Err`. About 82% of call sites already use `.unwrap()` or `.expect()`, but ~34 sites were propagating the error with `?`, falsely making their enclosing functions appear fallible due to serialization. Same for 3 `borsh::object_length()` call sites.

This replaces all remaining `?` propagation with `.unwrap()` across 14 files for consistency.