### PR TITLE
feat(gas-keys): rosetta action encoding for gas key transfers

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -488,9 +488,45 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                 near_primitives::transaction::Action::DeterministicStateInit(_) => {
                     // TODO(#14073): Implement rosetta adapter, probably first requires global contracts, too
                 }
-                near_primitives::transaction::Action::TransferToGasKey(_)
-                | near_primitives::transaction::Action::WithdrawFromGasKey(_) => {
-                    // TODO(gas-keys): Implement rosetta adapter for gas key transfers
+                near_primitives::transaction::Action::TransferToGasKey(action) => {
+                    let initiate_op_id = crate::models::OperationIdentifier::new(&operations);
+                    operations.push(
+                        validated_operations::InitiateTransferToGasKeyOperation {
+                            sender_account: sender_account_identifier.clone(),
+                        }
+                        .into_operation(initiate_op_id.clone()),
+                    );
+                    operations.push(
+                        validated_operations::TransferToGasKeyOperation {
+                            account: receiver_account_identifier.clone(),
+                            amount: action.deposit,
+                            public_key: (&action.public_key).into(),
+                        }
+                        .into_related_operation(
+                            crate::models::OperationIdentifier::new(&operations),
+                            vec![initiate_op_id],
+                        ),
+                    );
+                }
+                near_primitives::transaction::Action::WithdrawFromGasKey(action) => {
+                    let initiate_op_id = crate::models::OperationIdentifier::new(&operations);
+                    operations.push(
+                        validated_operations::InitiateWithdrawFromGasKeyOperation {
+                            sender_account: sender_account_identifier.clone(),
+                        }
+                        .into_operation(initiate_op_id.clone()),
+                    );
+                    operations.push(
+                        validated_operations::WithdrawFromGasKeyOperation {
+                            account: receiver_account_identifier.clone(),
+                            amount: action.amount,
+                            public_key: (&action.public_key).into(),
+                        }
+                        .into_related_operation(
+                            crate::models::OperationIdentifier::new(&operations),
+                            vec![initiate_op_id],
+                        ),
+                    );
                 }
             }
         }
@@ -798,6 +834,53 @@ impl TryFrom<Vec<crate::models::Operation>> for NearActions {
 
                     actions = vec![delegate_action];
                 }
+                crate::models::OperationType::TransferToGasKey => {
+                    let op =
+                        validated_operations::TransferToGasKeyOperation::try_from(tail_operation)?;
+                    receiver_account_id.try_set(&op.account)?;
+                    let initiate_op =
+                        validated_operations::InitiateTransferToGasKeyOperation::try_from_option(
+                            operations.next(),
+                        )?;
+                    sender_account_id.try_set(&initiate_op.sender_account)?;
+                    let public_key = (&op.public_key).try_into().map_err(|_| {
+                        crate::errors::ErrorKind::InvalidInput(format!(
+                            "Invalid public_key: {:?}",
+                            op.public_key
+                        ))
+                    })?;
+                    actions.push(
+                        near_primitives::action::TransferToGasKeyAction {
+                            public_key,
+                            deposit: op.amount,
+                        }
+                        .into(),
+                    )
+                }
+                crate::models::OperationType::WithdrawFromGasKey => {
+                    let op = validated_operations::WithdrawFromGasKeyOperation::try_from(
+                        tail_operation,
+                    )?;
+                    receiver_account_id.try_set(&op.account)?;
+                    let initiate_op =
+                        validated_operations::InitiateWithdrawFromGasKeyOperation::try_from_option(
+                            operations.next(),
+                        )?;
+                    sender_account_id.try_set(&initiate_op.sender_account)?;
+                    let public_key = (&op.public_key).try_into().map_err(|_| {
+                        crate::errors::ErrorKind::InvalidInput(format!(
+                            "Invalid public_key: {:?}",
+                            op.public_key
+                        ))
+                    })?;
+                    actions.push(
+                        near_primitives::action::WithdrawFromGasKeyAction {
+                            public_key,
+                            amount: op.amount,
+                        }
+                        .into(),
+                    )
+                }
                 crate::models::OperationType::InitiateCreateAccount
                 | crate::models::OperationType::InitiateDeleteAccount
                 | crate::models::OperationType::InitiateAddKey
@@ -807,6 +890,8 @@ impl TryFrom<Vec<crate::models::Operation>> for NearActions {
                 | crate::models::OperationType::SignedDelegateAction
                 | crate::models::OperationType::InitiateSignedDelegateAction
                 | crate::models::OperationType::InitiateDelegateAction
+                | crate::models::OperationType::InitiateTransferToGasKey
+                | crate::models::OperationType::InitiateWithdrawFromGasKey
                 | crate::models::OperationType::DeleteAccount => {
                     return Err(crate::errors::ErrorKind::InvalidInput(format!(
                         "Unexpected operation `{:?}`",
@@ -937,6 +1022,23 @@ mod tests {
         ]
         .concat();
 
+        let sk = SecretKey::from_seed(KeyType::ED25519, "gas-key-test");
+        let gas_key_pk = sk.public_key();
+        let transfer_to_gas_key_actions = vec![
+            near_primitives::action::TransferToGasKeyAction {
+                public_key: gas_key_pk.clone(),
+                deposit: Balance::from_millinear(500),
+            }
+            .into(),
+        ];
+        let withdraw_from_gas_key_actions = vec![
+            near_primitives::action::WithdrawFromGasKeyAction {
+                public_key: gas_key_pk,
+                amount: Balance::from_millinear(200),
+            }
+            .into(),
+        ];
+
         let non_sir_compatible_actions = vec![
             create_account_actions,
             delete_account_actions,
@@ -946,6 +1048,7 @@ mod tests {
             deploy_contract_actions,
             function_call_without_balance_actions,
             function_call_with_balance_actions,
+            transfer_to_gas_key_actions,
             wallet_style_create_account_actions,
             create_account_and_stake_immediately_actions,
             deploy_contract_and_call_it_actions,
@@ -972,7 +1075,9 @@ mod tests {
             assert_eq!(near_actions_recreated.actions, near_actions.actions);
         }
 
-        let sir_compatible_actions = [non_sir_compatible_actions, vec![stake_actions]].concat();
+        let sir_compatible_actions =
+            [non_sir_compatible_actions, vec![stake_actions, withdraw_from_gas_key_actions]]
+                .concat();
         for actions in sir_compatible_actions {
             let near_actions = NearActions {
                 sender_account_id: "sender-is-receiver.near".parse().unwrap(),

--- a/chain/rosetta-rpc/src/adapters/validated_operations/initiate_transfer_to_gas_key.rs
+++ b/chain/rosetta-rpc/src/adapters/validated_operations/initiate_transfer_to_gas_key.rs
@@ -1,0 +1,36 @@
+use super::ValidatedOperation;
+
+pub(crate) struct InitiateTransferToGasKeyOperation {
+    pub(crate) sender_account: crate::models::AccountIdentifier,
+}
+
+impl ValidatedOperation for InitiateTransferToGasKeyOperation {
+    const OPERATION_TYPE: crate::models::OperationType =
+        crate::models::OperationType::InitiateTransferToGasKey;
+
+    fn into_operation(
+        self,
+        operation_identifier: crate::models::OperationIdentifier,
+    ) -> crate::models::Operation {
+        crate::models::Operation {
+            operation_identifier,
+
+            account: self.sender_account,
+            amount: None,
+            metadata: None,
+
+            related_operations: None,
+            type_: Self::OPERATION_TYPE,
+            status: None,
+        }
+    }
+}
+
+impl TryFrom<crate::models::Operation> for InitiateTransferToGasKeyOperation {
+    type Error = crate::errors::ErrorKind;
+
+    fn try_from(operation: crate::models::Operation) -> Result<Self, Self::Error> {
+        Self::validate_operation_type(operation.type_)?;
+        Ok(Self { sender_account: operation.account })
+    }
+}

--- a/chain/rosetta-rpc/src/adapters/validated_operations/initiate_withdraw_from_gas_key.rs
+++ b/chain/rosetta-rpc/src/adapters/validated_operations/initiate_withdraw_from_gas_key.rs
@@ -1,0 +1,36 @@
+use super::ValidatedOperation;
+
+pub(crate) struct InitiateWithdrawFromGasKeyOperation {
+    pub(crate) sender_account: crate::models::AccountIdentifier,
+}
+
+impl ValidatedOperation for InitiateWithdrawFromGasKeyOperation {
+    const OPERATION_TYPE: crate::models::OperationType =
+        crate::models::OperationType::InitiateWithdrawFromGasKey;
+
+    fn into_operation(
+        self,
+        operation_identifier: crate::models::OperationIdentifier,
+    ) -> crate::models::Operation {
+        crate::models::Operation {
+            operation_identifier,
+
+            account: self.sender_account,
+            amount: None,
+            metadata: None,
+
+            related_operations: None,
+            type_: Self::OPERATION_TYPE,
+            status: None,
+        }
+    }
+}
+
+impl TryFrom<crate::models::Operation> for InitiateWithdrawFromGasKeyOperation {
+    type Error = crate::errors::ErrorKind;
+
+    fn try_from(operation: crate::models::Operation) -> Result<Self, Self::Error> {
+        Self::validate_operation_type(operation.type_)?;
+        Ok(Self { sender_account: operation.account })
+    }
+}

--- a/chain/rosetta-rpc/src/adapters/validated_operations/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/validated_operations/mod.rs
@@ -12,9 +12,13 @@ pub(crate) use self::initiate_delete_key::InitiateDeleteKeyOperation;
 pub(crate) use self::initiate_deploy_contract::InitiateDeployContractOperation;
 pub(crate) use self::initiate_function_call::InitiateFunctionCallOperation;
 pub(crate) use self::initiate_signed_delegate_action::InitiateSignedDelegateActionOperation;
+pub(crate) use self::initiate_transfer_to_gas_key::InitiateTransferToGasKeyOperation;
+pub(crate) use self::initiate_withdraw_from_gas_key::InitiateWithdrawFromGasKeyOperation;
 pub(crate) use self::refund_delete_account::RefundDeleteAccountOperation;
 pub(crate) use self::stake::StakeOperation;
 pub(crate) use self::transfer::TransferOperation;
+pub(crate) use self::transfer_to_gas_key::TransferToGasKeyOperation;
+pub(crate) use self::withdraw_from_gas_key::WithdrawFromGasKeyOperation;
 
 mod add_key;
 mod create_account;
@@ -31,10 +35,14 @@ mod initiate_delete_key;
 mod initiate_deploy_contract;
 mod initiate_function_call;
 pub mod initiate_signed_delegate_action;
+mod initiate_transfer_to_gas_key;
+mod initiate_withdraw_from_gas_key;
 mod refund_delete_account;
 pub mod signed_delegate_action;
 mod stake;
 mod transfer;
+mod transfer_to_gas_key;
+mod withdraw_from_gas_key;
 
 pub(crate) trait ValidatedOperation:
     TryFrom<crate::models::Operation, Error = crate::errors::ErrorKind>

--- a/chain/rosetta-rpc/src/adapters/validated_operations/withdraw_from_gas_key.rs
+++ b/chain/rosetta-rpc/src/adapters/validated_operations/withdraw_from_gas_key.rs
@@ -1,0 +1,62 @@
+use super::ValidatedOperation;
+use near_primitives::types::Balance;
+
+pub(crate) struct WithdrawFromGasKeyOperation {
+    pub(crate) account: crate::models::AccountIdentifier,
+    pub(crate) amount: Balance,
+    pub(crate) public_key: crate::models::PublicKey,
+}
+
+impl ValidatedOperation for WithdrawFromGasKeyOperation {
+    const OPERATION_TYPE: crate::models::OperationType =
+        crate::models::OperationType::WithdrawFromGasKey;
+
+    fn into_operation(
+        self,
+        operation_identifier: crate::models::OperationIdentifier,
+    ) -> crate::models::Operation {
+        crate::models::Operation {
+            operation_identifier,
+
+            account: self.account,
+            amount: Some(crate::models::Amount::from_balance(self.amount)),
+            metadata: Some(crate::models::OperationMetadata {
+                public_key: Some(self.public_key),
+                ..Default::default()
+            }),
+
+            related_operations: None,
+            type_: Self::OPERATION_TYPE,
+            status: None,
+        }
+    }
+}
+
+fn required_fields_error() -> crate::errors::ErrorKind {
+    crate::errors::ErrorKind::InvalidInput(
+        "WITHDRAW_FROM_GAS_KEY operation requires `public_key` (passed in the metadata) and non-negative `amount`"
+            .into(),
+    )
+}
+
+impl TryFrom<crate::models::Operation> for WithdrawFromGasKeyOperation {
+    type Error = crate::errors::ErrorKind;
+
+    fn try_from(operation: crate::models::Operation) -> Result<Self, Self::Error> {
+        Self::validate_operation_type(operation.type_)?;
+        let amount = operation.amount.ok_or_else(required_fields_error)?;
+        if !amount.currency.is_near() {
+            return Err(crate::errors::ErrorKind::InvalidInput(
+                "WITHDRAW_FROM_GAS_KEY operations must have NEAR currency".to_string(),
+            ));
+        }
+        let amount = if amount.value.is_positive() {
+            Balance::from_yoctonear(amount.value.absolute_difference())
+        } else {
+            return Err(required_fields_error());
+        };
+        let metadata = operation.metadata.ok_or_else(required_fields_error)?;
+        let public_key = metadata.public_key.ok_or_else(required_fields_error)?;
+        Ok(Self { account: operation.account, amount, public_key })
+    }
+}

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -757,6 +757,10 @@ pub(crate) enum OperationType {
     InitiateSignedDelegateAction,
     InitiateDelegateAction,
     FunctionCall,
+    InitiateTransferToGasKey,
+    TransferToGasKey,
+    InitiateWithdrawFromGasKey,
+    WithdrawFromGasKey,
 }
 
 #[derive(


### PR DESCRIPTION
Gas keys ([NEP-611](https://github.com/near/NEPs/pull/611)) allow access keys to carry a NEAR balance dedicated to paying for gas, separate from the account's main balance. This PR implements Rosetta Construction API support for `TransferToGasKey` and `WithdrawFromGasKey` actions, enabling bidirectional conversion between NEAR actions and Rosetta operations.

- New operations: `InitiateTransferToGasKey`, `TransferToGasKey`, `InitiateWithdrawFromGasKey`, `WithdrawFromGasKey`
- Each gas key action maps to a pair of Rosetta operations (initiate + main), following the existing pattern used by `Transfer`, `AddKey`, etc.
- `TransferToGasKey` is non-SIR-compatible (sender != receiver), `WithdrawFromGasKey` is SIR-compatible
- Roundtrip bijection test updated to cover both new action types