### PR TITLE
refactor(store): remove Result from ChainStoreAdapter height/tail methods

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -578,9 +578,9 @@ impl Chain {
         metrics::HEADER_HEAD_HEIGHT.set(header_head.height as i64);
         metrics::BOOT_TIME_SECONDS.set(clock.now_utc().unix_timestamp());
 
-        metrics::TAIL_HEIGHT.set(chain_store.tail()? as i64);
-        metrics::CHUNK_TAIL_HEIGHT.set(chain_store.chunk_tail()? as i64);
-        metrics::FORK_TAIL_HEIGHT.set(chain_store.fork_tail()? as i64);
+        metrics::TAIL_HEIGHT.set(chain_store.tail() as i64);
+        metrics::CHUNK_TAIL_HEIGHT.set(chain_store.chunk_tail() as i64);
+        metrics::FORK_TAIL_HEIGHT.set(chain_store.fork_tail() as i64);
 
         // Even though the channel is unbounded, the channel size is practically bounded by the size
         // of blocks_in_processing, which is set to 5 now.
@@ -1599,7 +1599,7 @@ impl Chain {
         // Reset final head to genesis since at this point we don't have the last final block.
         chain_store_update.save_final_head(&final_head)?;
         // New Tail can not be earlier than `prev_block.header.inner_lite.height`
-        chain_store_update.update_tail(new_tail)?;
+        chain_store_update.update_tail(new_tail);
         // New Chunk Tail can not be earlier than minimum of height_created in Block `prev_block`
         chain_store_update.update_chunk_tail(new_chunk_tail);
         chain_store_update.commit()?;
@@ -1664,7 +1664,7 @@ impl Chain {
                 preprocess_timer.stop_and_discard();
                 match &e {
                     Error::Orphan => {
-                        let tail_height = self.chain_store.tail()?;
+                        let tail_height = self.chain_store.tail();
                         // we only add blocks that couldn't have been gc'ed to the orphan pool.
                         if block_height >= tail_height {
                             let requested_missing_chunks = if let Some(orphan_missing_chunks) =
@@ -3608,7 +3608,7 @@ impl Chain {
 
     /// Gets chain tail height
     #[inline]
-    pub fn tail(&self) -> Result<BlockHeight, Error> {
+    pub fn tail(&self) -> BlockHeight {
         self.chain_store.tail()
     }
 

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -185,18 +185,18 @@ impl ChainStore {
             // Nothing to do if head is at genesis. Return early because some of the later queries would fail.
             return Ok(());
         }
-        let tail = self.tail()?;
+        let tail = self.tail();
         let gc_stop_height = runtime_adapter.get_gc_stop_height(&head.last_block_hash);
         if gc_stop_height > head.height {
             return Err(Error::GCError("gc_stop_height cannot be larger than head.height".into()));
         }
-        let mut fork_tail = self.fork_tail()?;
-        let chunk_tail = self.chain_store().chunk_tail()?;
+        let mut fork_tail = self.fork_tail();
+        let chunk_tail = self.chain_store().chunk_tail();
         metrics::TAIL_HEIGHT.set(tail as i64);
         metrics::FORK_TAIL_HEIGHT.set(fork_tail as i64);
         metrics::CHUNK_TAIL_HEIGHT.set(chunk_tail as i64);
         metrics::GC_STOP_HEIGHT.set(gc_stop_height as i64);
-        let last_known_gc_heigh = self.gc_stop_height()?;
+        let last_known_gc_heigh = self.gc_stop_height();
         if last_known_gc_heigh != gc_stop_height {
             tracing::debug!(
                 target: "garbage_collection",
@@ -310,7 +310,7 @@ impl ChainStore {
 
                 gc_blocks_remaining -= 1;
             }
-            chain_store_update.update_tail(height)?;
+            chain_store_update.update_tail(height);
             chain_store_update.commit()?;
         }
 
@@ -459,7 +459,7 @@ impl ChainStore {
 
         let mut chain_store_update = self.store_update();
         chain_store_update.clear_redundant_chunk_data(gc_stop_height, gc_height_limit)?;
-        metrics::CHUNK_TAIL_HEIGHT.set(chain_store_update.chunk_tail()? as i64);
+        metrics::CHUNK_TAIL_HEIGHT.set(chain_store_update.chunk_tail() as i64);
         metrics::GC_STOP_HEIGHT.set(gc_stop_height as i64);
         chain_store_update.commit()
     }
@@ -548,7 +548,7 @@ impl ChainStore {
 
         // GC all the data from current tail up to `gc_height`. In case tail points to a height where
         // there is no block, we need to make sure that the last block before tail is cleaned.
-        let tail = self.chain_store().tail()?;
+        let tail = self.chain_store().tail();
         let mut tail_prev_block_cleaned = false;
         for height in tail..gc_height {
             let blocks_current_height = self
@@ -625,7 +625,7 @@ impl<'a> ChainStoreUpdate<'a> {
     }
 
     fn clear_chunk_data_and_headers(&mut self, min_chunk_height: BlockHeight) -> Result<(), Error> {
-        let chunk_tail = self.chunk_tail()?;
+        let chunk_tail = self.chunk_tail();
         for height in chunk_tail..min_chunk_height {
             let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height)?;
             for chunk_hash in chunk_hashes {
@@ -688,7 +688,7 @@ impl<'a> ChainStoreUpdate<'a> {
         gc_stop_height: BlockHeight,
         gc_height_limit: BlockHeightDelta,
     ) -> Result<(), Error> {
-        let mut height = self.chunk_tail()?;
+        let mut height = self.chunk_tail();
         let mut remaining = gc_height_limit;
         while height < gc_stop_height && remaining > 0 {
             let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height)?;
@@ -838,7 +838,7 @@ impl<'a> ChainStoreUpdate<'a> {
             GCMode::Canonical(_) => {
                 // 6. Canonical Chain only clearing
                 // Delete chunks, chunk-indexed data and block headers
-                let mut min_chunk_height = self.tail()?;
+                let mut min_chunk_height = self.tail();
                 for chunk_header in block.chunks().iter() {
                     if min_chunk_height > chunk_header.height_created() {
                         min_chunk_height = chunk_header.height_created();

--- a/chain/chain/src/tests/garbage_collection.rs
+++ b/chain/chain/src/tests/garbage_collection.rs
@@ -847,20 +847,20 @@ fn test_fork_chunk_tail_updates() {
             i,
         );
     }
-    assert_eq!(chain.tail().unwrap(), 0);
+    assert_eq!(chain.tail(), 0);
 
     {
         let mut store_update = chain.mut_chain_store().store_update();
-        assert_eq!(store_update.tail().unwrap(), 0);
-        store_update.update_tail(1).unwrap();
+        assert_eq!(store_update.tail(), 0);
+        store_update.update_tail(1);
         store_update.commit().unwrap();
     }
     // Chunk tail should be auto updated to genesis (if not set) and fork_tail to the tail.
     {
         let store_update = chain.mut_chain_store().store_update();
-        assert_eq!(store_update.tail().unwrap(), 1);
-        assert_eq!(store_update.fork_tail().unwrap(), 1);
-        assert_eq!(store_update.chunk_tail().unwrap(), 0);
+        assert_eq!(store_update.tail(), 1);
+        assert_eq!(store_update.fork_tail(), 1);
+        assert_eq!(store_update.chunk_tail(), 0);
     }
     {
         let mut store_update = chain.mut_chain_store().store_update();
@@ -869,13 +869,13 @@ fn test_fork_chunk_tail_updates() {
     }
     {
         let mut store_update = chain.mut_chain_store().store_update();
-        store_update.update_tail(2).unwrap();
+        store_update.update_tail(2);
         store_update.commit().unwrap();
     }
     {
         let store_update = chain.mut_chain_store().store_update();
-        assert_eq!(store_update.tail().unwrap(), 2);
-        assert_eq!(store_update.fork_tail().unwrap(), 3);
-        assert_eq!(store_update.chunk_tail().unwrap(), 0);
+        assert_eq!(store_update.tail(), 2);
+        assert_eq!(store_update.fork_tail(), 3);
+        assert_eq!(store_update.chunk_tail(), 0);
     }
 }

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -381,7 +381,7 @@ impl CloudArchivalWriter {
     ) -> Result<(), CloudArchivalInitializationError> {
         let block_hash = self.hot_store.chain_store().get_block_hash_by_height(cloud_head)?;
         let gc_stop_height = runtime_adapter.get_gc_stop_height(&block_hash);
-        let gc_tail = self.hot_store.chain_store().tail()?;
+        let gc_tail = self.hot_store.chain_store().tail();
         if gc_tail > gc_stop_height {
             return Err(CloudArchivalInitializationError::CloudHeadTooOld {
                 cloud_head,

--- a/chain/client/src/archive/cold_store_actor.rs
+++ b/chain/client/src/archive/cold_store_actor.rs
@@ -427,7 +427,7 @@ pub fn create_cold_store_actor(
     let cold_head_height = cold_store.head().map(|tip| tip.height).unwrap_or(genesis_height);
     let hot_final_head_height =
         hot_store.chain_store().final_head().map(|tip| tip.height).unwrap_or(genesis_height);
-    let hot_tail_height = hot_store.chain_store().tail().unwrap_or(genesis_height);
+    let hot_tail_height = hot_store.chain_store().tail();
 
     sanity_check(cold_head_height, hot_final_head_height, hot_tail_height)?;
     debug_assert!(shard_tracker.is_valid_for_cold_store());

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -359,7 +359,7 @@ impl Client {
 
         let doomslug = Doomslug::new(
             clock.clone(),
-            chain.chain_store().largest_target_height()?,
+            chain.chain_store().largest_target_height(),
             config.min_block_production_delay,
             config.max_block_production_delay,
             config.max_block_production_delay / 10,
@@ -1177,7 +1177,7 @@ impl Client {
             tracing::debug!(target: "client", head_height = head.height, "dropping a block that is too far ahead");
             return Ok(false);
         }
-        let tail = self.chain.tail()?;
+        let tail = self.chain.tail();
         if block_height < tail {
             tracing::debug!(target: "client", tail_height = tail, "dropping a block that is too far behind");
             return Ok(false);

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -58,27 +58,24 @@ impl ChainStoreAdapter {
     }
 
     /// The chain Blocks Tail height.
-    pub fn tail(&self) -> Result<BlockHeight, Error> {
-        Ok(self
-            .store
+    pub fn tail(&self) -> BlockHeight {
+        self.store
             .get_ser(DBCol::BlockMisc, TAIL_KEY)
-            .unwrap_or_else(|| self.get_or_init_genesis_height()))
+            .unwrap_or_else(|| self.get_or_init_genesis_height())
     }
 
     /// The chain Chunks Tail height.
-    pub fn chunk_tail(&self) -> Result<BlockHeight, Error> {
-        Ok(self
-            .store
+    pub fn chunk_tail(&self) -> BlockHeight {
+        self.store
             .get_ser(DBCol::BlockMisc, CHUNK_TAIL_KEY)
-            .unwrap_or_else(|| self.get_or_init_genesis_height()))
+            .unwrap_or_else(|| self.get_or_init_genesis_height())
     }
 
     /// Tail height of the fork cleaning process.
-    pub fn fork_tail(&self) -> Result<BlockHeight, Error> {
-        Ok(self
-            .store
+    pub fn fork_tail(&self) -> BlockHeight {
+        self.store
             .get_ser(DBCol::BlockMisc, FORK_TAIL_KEY)
-            .unwrap_or_else(|| self.get_or_init_genesis_height()))
+            .unwrap_or_else(|| self.get_or_init_genesis_height())
     }
 
     /// Head of the header chain (not the same thing as head_header).
@@ -121,15 +118,14 @@ impl ChainStoreAdapter {
     }
 
     /// Largest approval target height sent by us
-    pub fn largest_target_height(&self) -> Result<BlockHeight, Error> {
-        Ok(self.store.get_ser(DBCol::BlockMisc, LARGEST_TARGET_HEIGHT_KEY).unwrap_or(0))
+    pub fn largest_target_height(&self) -> BlockHeight {
+        self.store.get_ser(DBCol::BlockMisc, LARGEST_TARGET_HEIGHT_KEY).unwrap_or(0)
     }
 
-    pub fn gc_stop_height(&self) -> Result<BlockHeight, Error> {
-        Ok(self
-            .store
+    pub fn gc_stop_height(&self) -> BlockHeight {
+        self.store
             .get_ser(DBCol::BlockMisc, GC_STOP_HEIGHT_KEY)
-            .unwrap_or_else(|| self.get_or_init_genesis_height()))
+            .unwrap_or_else(|| self.get_or_init_genesis_height())
     }
 
     /// Get full block.

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -867,7 +867,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
             );
         }
     }
-    assert_eq!(env.clients[0].chain.chain_store().chunk_tail().unwrap(), epoch_length - 1);
+    assert_eq!(env.clients[0].chain.chain_store().chunk_tail(), epoch_length - 1);
 }
 
 #[test]
@@ -1119,7 +1119,7 @@ fn test_gc_chunk_tail() {
     let mut chunk_tail = 0;
     for i in (1..10).chain(101..epoch_length * 6) {
         env.produce_block(0, i);
-        let cur_chunk_tail = env.clients[0].chain.chain_store().chunk_tail().unwrap();
+        let cur_chunk_tail = env.clients[0].chain.chain_store().chunk_tail();
         assert!(cur_chunk_tail >= chunk_tail);
         chunk_tail = cur_chunk_tail;
     }
@@ -1296,8 +1296,8 @@ fn test_gc_fork_tail() {
     assert!(
         env.clients[1].runtime_adapter.get_gc_stop_height(&head.last_block_hash) > epoch_length
     );
-    let tail = env.clients[1].chain.chain_store().tail().unwrap();
-    let fork_tail = env.clients[1].chain.chain_store().fork_tail().unwrap();
+    let tail = env.clients[1].chain.chain_store().tail();
+    let fork_tail = env.clients[1].chain.chain_store().fork_tail();
     assert!(tail <= fork_tail && fork_tail < second_epoch_start.unwrap());
 }
 
@@ -1521,7 +1521,7 @@ fn test_gc_tail_update() {
         )
         .unwrap();
     env.process_block(1, blocks.pop().unwrap(), Provenance::NONE);
-    assert_eq!(env.clients[1].chain.chain_store().tail().unwrap(), prev_sync_height);
+    assert_eq!(env.clients[1].chain.chain_store().tail(), prev_sync_height);
 }
 
 /// Test that transaction does not become invalid when there is some gas price change.

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -141,7 +141,7 @@ fn update_epoch_sync_proof(
 // as the headers that are stored in DBCol::BlockHeader
 fn verify_block_headers(store: &Store) -> anyhow::Result<()> {
     let chain_store = store.chain_store();
-    let tail_height = chain_store.tail().unwrap();
+    let tail_height = chain_store.tail();
     let latest_known_height =
         store.get_ser::<LatestKnown>(DBCol::BlockMisc, LATEST_KNOWN_KEY).unwrap().height;
 
@@ -172,7 +172,7 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
     store_update.delete_all(DBCol::BlockHeader);
     store_update.commit();
     let chain_store = store.chain_store();
-    let tail_height = chain_store.tail().unwrap();
+    let tail_height = chain_store.tail();
     let latest_known_height =
         store.get_ser::<LatestKnown>(DBCol::BlockMisc, LATEST_KNOWN_KEY).unwrap().height;
 

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -46,7 +46,7 @@ pub fn gc_and_heads_sanity_checks(
     let cloud_head_block_info = epoch_store.get_block_info(&cloud_head_hash).unwrap();
     epoch_store.get_block_info(cloud_head_block_info.epoch_first_block()).unwrap();
 
-    let gc_tail = chain_store.tail().unwrap();
+    let gc_tail = chain_store.tail();
     if split_store_enabled {
         let cold_head = chain_store.store().get_ser::<Tip>(DBCol::BlockMisc, COLD_HEAD_KEY);
         let cold_head_height = cold_head.unwrap().height;

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -96,7 +96,7 @@ impl<'a> TestLoopNode<'a> {
     }
 
     pub fn tail(&self, test_loop_data: &TestLoopData) -> BlockHeight {
-        self.client(test_loop_data).chain.tail().unwrap()
+        self.client(test_loop_data).chain.tail()
     }
 
     pub fn head(&self, test_loop_data: &TestLoopData) -> Arc<Tip> {

--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -111,7 +111,7 @@ fn retrieve_starting_chunk_hash(
     head_height: BlockHeight,
 ) -> anyhow::Result<ChunkHash> {
     let mut last_err = None;
-    for height in (chain.tail().context("failed fetching chain tail")? + 1..=head_height).rev() {
+    for height in (chain.tail() + 1..=head_height).rev() {
         match chain
             .get_block_hash_by_height(height)
             .and_then(|hash| chain.get_block(&hash))
@@ -139,7 +139,7 @@ fn get_head_block(
     chain: &ChainStoreAdapter,
     max_height: BlockHeight,
 ) -> anyhow::Result<Arc<Block>> {
-    let tail = chain.tail().context("failed fetching chain tail")?;
+    let tail = chain.tail();
     for height in (tail + 1..=max_height).rev() {
         let hash = match chain.get_block_hash_by_height(height) {
             Ok(h) => h,

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -653,7 +653,7 @@ pub fn apply_chain_range(
             (ready.flat_head.height + 1, 0)
         }
         (_, StorageSource::Trie | StorageSource::TrieFree) => (
-            start_height.unwrap_or_else(|| chain_store.tail().unwrap()),
+            start_height.unwrap_or_else(|| chain_store.tail()),
             end_height.unwrap_or_else(|| chain_store.head().unwrap().height),
         ),
         (_, StorageSource::FlatStorage | StorageSource::Memtrie) => {

--- a/tools/undo-block/src/lib.rs
+++ b/tools/undo-block/src/lib.rs
@@ -56,7 +56,7 @@ pub fn undo_only_block_head(
     let current_header_head = chain_store.header_head()?;
     let current_header_height = current_header_head.height;
 
-    let tail_height = chain_store.tail()?;
+    let tail_height = chain_store.tail();
     let tail_header = chain_store.get_block_header_by_height(tail_height)?;
     let new_head = Tip::from_header(&tail_header);
 


### PR DESCRIPTION
- Make `tail()`, `chunk_tail()`, `fork_tail()`, `largest_target_height()`, and `gc_stop_height()` infallible on `ChainStoreAdapter` and `ChainStoreAccess` trait
- These methods wrap `get_ser()` with `unwrap_or`/`unwrap_or_else` and never use the `?` operator — the `Result` wrapper was unnecessary
- Update ~50 call sites across 15 files to remove `.unwrap()`, `?`, `.context()`, and `.unwrap_or()` on the return values
- `ChainStoreUpdate::update_tail()` also becomes infallible since its only `?` sources were `fork_tail()` and `chunk_tail()`
- Part of the ongoing store `Result` cleanup effort (#15066)