### PR TITLE
refactor(store): remove Result from ChainStoreAdapter hash/collection methods

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2638,7 +2638,7 @@ impl Chain {
                     Ok(_) => {
                         let mut saw_one = false;
                         for next_block_hash in
-                            self.chain_store.get_blocks_to_catchup(&queued_block)?.clone()
+                            self.chain_store.get_blocks_to_catchup(&queued_block).clone()
                         {
                             saw_one = true;
                             blocks_catch_up_state.pending_blocks.push(next_block_hash);

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -264,7 +264,7 @@ impl ChainStore {
             }
             let blocks_current_height = self
                 .chain_store()
-                .get_all_block_hashes_by_height(height)?
+                .get_all_block_hashes_by_height(height)
                 .values()
                 .flatten()
                 .cloned()
@@ -473,7 +473,7 @@ impl ChainStore {
     ) -> Result<(), Error> {
         let blocks_current_height = self
             .chain_store()
-            .get_all_block_hashes_by_height(height)?
+            .get_all_block_hashes_by_height(height)
             .values()
             .flatten()
             .cloned()
@@ -553,7 +553,7 @@ impl ChainStore {
         for height in tail..gc_height {
             let blocks_current_height = self
                 .chain_store()
-                .get_all_block_hashes_by_height(height)?
+                .get_all_block_hashes_by_height(height)
                 .values()
                 .flatten()
                 .cloned()
@@ -610,7 +610,7 @@ impl<'a> ChainStoreUpdate<'a> {
         end: BlockHeight,
     ) -> Result<(), Error> {
         for height in start..=end {
-            let header_hashes = self.chain_store().get_all_header_hashes_by_height(height)?;
+            let header_hashes = self.chain_store().get_all_header_hashes_by_height(height);
             for header_hash in header_hashes {
                 // Delete header_hash-indexed data: block header
                 let mut store_update = self.store().store_update();
@@ -652,7 +652,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 self.gc_col(DBCol::InvalidChunks, chunk_hash);
             }
 
-            let header_hashes = self.chain_store().get_all_header_hashes_by_height(height)?;
+            let header_hashes = self.chain_store().get_all_header_hashes_by_height(height);
             for _header_hash in header_hashes {
                 // 3. Delete header_hash-indexed data
                 // TODO #3488: enable
@@ -1060,7 +1060,7 @@ impl<'a> ChainStoreUpdate<'a> {
     ) -> Result<(), Error> {
         let mut store_update = self.store().store_update();
         let mut epoch_to_hashes =
-            HashMap::clone(self.chain_store().get_all_block_hashes_by_height(height)?.as_ref());
+            HashMap::clone(self.chain_store().get_all_block_hashes_by_height(height).as_ref());
         let hashes = epoch_to_hashes.get_mut(epoch_id).ok_or_else(|| {
             near_chain_primitives::Error::Other("current epoch id should exist".into())
         })?;

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -175,7 +175,7 @@ pub(crate) fn update_sync_hashes<T: ChainStoreAccess>(
     store_update: &mut StoreUpdate,
     header: &BlockHeader,
 ) -> Result<(), Error> {
-    let sync_hash = chain_store.get_current_epoch_sync_hash(header.epoch_id())?;
+    let sync_hash = chain_store.get_current_epoch_sync_hash(header.epoch_id());
     if sync_hash.is_some() || header.height() == chain_store.get_genesis_height() {
         return Ok(());
     }
@@ -219,7 +219,7 @@ pub(crate) fn is_sync_prev_hash(chain_store: &ChainStoreAdapter, tip: &Tip) -> R
     // found yet. But we still need to check this because it's possible that the sync hash was found
     // during header sync, in which case the contents of the StateSyncNewChunks column will have been cleared,
     // and the conditions below can't be checked.
-    if let Some(sync_hash) = chain_store.get_current_epoch_sync_hash(&tip.epoch_id)? {
+    if let Some(sync_hash) = chain_store.get_current_epoch_sync_hash(&tip.epoch_id) {
         let sync_header = chain_store.get_block_header(&sync_hash)?;
         return Ok(sync_header.prev_hash() == &tip.last_block_hash);
     }
@@ -250,7 +250,7 @@ impl Chain {
             return Ok(None);
         }
         let header = self.get_block_header(block_hash)?;
-        self.chain_store.get_current_epoch_sync_hash(header.epoch_id())
+        Ok(self.chain_store.get_current_epoch_sync_hash(header.epoch_id()))
     }
 
     /// Select the block hash we are using to sync state. It will sync with the state before applying the

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -183,7 +183,7 @@ pub trait ChainStoreAccess {
         shard_id: ShardId,
     ) -> Result<Arc<Vec<ReceiptProof>>, Error>;
 
-    fn get_blocks_to_catchup(&self, prev_hash: &CryptoHash) -> Result<Vec<CryptoHash>, Error>;
+    fn get_blocks_to_catchup(&self, prev_hash: &CryptoHash) -> Vec<CryptoHash>;
 
     /// Returns encoded chunk if it's invalid otherwise None.
     fn is_invalid_chunk(
@@ -247,7 +247,7 @@ pub trait ChainStoreAccess {
         }
     }
 
-    fn get_current_epoch_sync_hash(&self, epoch_id: &EpochId) -> Result<Option<CryptoHash>, Error>;
+    fn get_current_epoch_sync_hash(&self, epoch_id: &EpochId) -> Option<CryptoHash>;
 }
 
 /// Given a vector of receipts return only the receipts that should be assigned
@@ -817,7 +817,7 @@ impl ChainStore {
         // applied for the next epoch, while for the first block in a particular epoch this method
         // returns true if the block is ready to have state applied for the current epoch (and
         // otherwise should be orphaned)
-        Ok(!chain_store.get_blocks_to_catchup(prev_prev_hash)?.contains(prev_hash))
+        Ok(!chain_store.get_blocks_to_catchup(prev_prev_hash).contains(prev_hash))
     }
 }
 
@@ -983,7 +983,7 @@ impl ChainStoreAccess for ChainStore {
         ChainStoreAdapter::get_incoming_receipts(self, block_hash, shard_id)
     }
 
-    fn get_blocks_to_catchup(&self, hash: &CryptoHash) -> Result<Vec<CryptoHash>, Error> {
+    fn get_blocks_to_catchup(&self, hash: &CryptoHash) -> Vec<CryptoHash> {
         ChainStoreAdapter::get_blocks_to_catchup(self, hash)
     }
 
@@ -1024,7 +1024,7 @@ impl ChainStoreAccess for ChainStore {
         ChainStoreAdapter::is_height_processed(self, height)
     }
 
-    fn get_current_epoch_sync_hash(&self, epoch_id: &EpochId) -> Result<Option<CryptoHash>, Error> {
+    fn get_current_epoch_sync_hash(&self, epoch_id: &EpochId) -> Option<CryptoHash> {
         ChainStoreAdapter::get_current_epoch_sync_hash(self, epoch_id)
     }
 }
@@ -1390,7 +1390,7 @@ impl<'a> ChainStoreAccess for ChainStoreUpdate<'a> {
         }
     }
 
-    fn get_blocks_to_catchup(&self, prev_hash: &CryptoHash) -> Result<Vec<CryptoHash>, Error> {
+    fn get_blocks_to_catchup(&self, prev_hash: &CryptoHash) -> Vec<CryptoHash> {
         // Make sure we never request a block to catchup after altering the data structure
         assert_eq!(self.add_blocks_to_catchup.len(), 0);
         assert_eq!(self.remove_blocks_to_catchup.len(), 0);
@@ -1462,7 +1462,7 @@ impl<'a> ChainStoreAccess for ChainStoreUpdate<'a> {
         }
     }
 
-    fn get_current_epoch_sync_hash(&self, epoch_id: &EpochId) -> Result<Option<CryptoHash>, Error> {
+    fn get_current_epoch_sync_hash(&self, epoch_id: &EpochId) -> Option<CryptoHash> {
         self.chain_store.get_current_epoch_sync_hash(epoch_id)
     }
 }
@@ -1901,7 +1901,7 @@ impl<'a> ChainStoreUpdate<'a> {
             if let Some(block) = &self.chain_store_cache_update.block {
                 let mut map = HashMap::clone(
                     self.chain_store
-                        .get_all_block_hashes_by_height(block.header().height())?
+                        .get_all_block_hashes_by_height(block.header().height())
                         .as_ref(),
                 );
                 map.entry(*block.header().epoch_id())
@@ -1916,7 +1916,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 if cfg!(feature = "protocol_feature_spice") {
                     let prev_hash = block.header().prev_hash();
                     let mut prev_next_hashes =
-                        self.chain_store.get_all_next_block_hashes(prev_hash)?;
+                        self.chain_store.get_all_next_block_hashes(prev_hash);
                     prev_next_hashes.push(*block.hash());
                     store_update.set_ser(
                         DBCol::all_next_block_hashes(),
@@ -1936,11 +1936,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 store_update.insert_ser(DBCol::BlockHeader, hash.as_ref(), header);
             }
             for (height, headers) in headers_by_height {
-                let mut hash_set = match self.chain_store.get_all_header_hashes_by_height(height) {
-                    Ok(hashes) => hashes,
-                    Err(Error::DBNotFoundErr(_)) => HashSet::with_capacity(headers.len()),
-                    Err(e) => return Err(e),
-                };
+                let mut hash_set = self.chain_store.get_all_header_hashes_by_height(height);
                 hash_set.extend(headers.iter().map(|header| *header.hash()));
                 store_update.set_ser(
                     DBCol::HeaderHashesByHeight,
@@ -2151,8 +2147,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 }
                 affected_catchup_blocks.insert(prev_hash);
 
-                let mut prev_table =
-                    self.chain_store.get_blocks_to_catchup(&prev_hash).unwrap_or_else(|_| vec![]);
+                let mut prev_table = self.chain_store.get_blocks_to_catchup(&prev_hash);
 
                 let mut remove_idx = prev_table.len();
                 for (i, val) in prev_table.iter().enumerate() {
@@ -2190,8 +2185,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 }
                 affected_catchup_blocks.insert(prev_hash);
 
-                let mut prev_table =
-                    self.chain_store.get_blocks_to_catchup(&prev_hash).unwrap_or_else(|_| vec![]);
+                let mut prev_table = self.chain_store.get_blocks_to_catchup(&prev_hash);
                 prev_table.push(new_hash);
                 store_update.set_ser(DBCol::BlocksToCatchup, prev_hash.as_ref(), &prev_table);
             }

--- a/chain/chain/src/tests/garbage_collection.rs
+++ b/chain/chain/src/tests/garbage_collection.rs
@@ -713,7 +713,7 @@ fn test_clear_old_data() {
         let expected_removed = i < max_height - DEFAULT_GC_NUM_EPOCHS_TO_KEEP as usize;
         let get_block_result = chain.get_block(blocks[i].hash());
         let blocks_by_heigh =
-            chain.mut_chain_store().get_all_block_hashes_by_height(i as BlockHeight).unwrap();
+            chain.mut_chain_store().get_all_block_hashes_by_height(i as BlockHeight);
         assert_eq!(get_block_result.is_err(), expected_removed);
         assert_eq!(blocks_by_heigh.is_empty(), expected_removed);
     }
@@ -797,7 +797,6 @@ fn test_clear_old_data_fixed_height() {
         chain
             .mut_chain_store()
             .get_all_block_hashes_by_height(5)
-            .unwrap()
             .values()
             .flatten()
             .collect::<Vec<_>>(),
@@ -821,9 +820,9 @@ fn test_clear_old_data_fixed_height() {
     assert!(chain.get_block_header(blocks[4].hash()).is_ok());
     assert!(chain.get_block_header(blocks[5].hash()).is_ok());
     assert!(chain.get_block_header(blocks[6].hash()).is_ok());
-    assert!(chain.mut_chain_store().get_all_block_hashes_by_height(4).unwrap().is_empty());
-    assert!(!chain.mut_chain_store().get_all_block_hashes_by_height(5).unwrap().is_empty());
-    assert!(!chain.mut_chain_store().get_all_block_hashes_by_height(6).unwrap().is_empty());
+    assert!(chain.mut_chain_store().get_all_block_hashes_by_height(4).is_empty());
+    assert!(!chain.mut_chain_store().get_all_block_hashes_by_height(5).is_empty());
+    assert!(!chain.mut_chain_store().get_all_block_hashes_by_height(6).is_empty());
     assert!(chain.mut_chain_store().get_next_block_hash(blocks[4].hash()).is_err());
     assert!(chain.mut_chain_store().get_next_block_hash(blocks[5].hash()).is_ok());
     assert!(chain.mut_chain_store().get_next_block_hash(blocks[6].hash()).is_ok());

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -504,7 +504,7 @@ impl ChunkExecutorActor {
     }
 
     fn try_process_next_blocks(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
-        let next_block_hashes = self.chain_store.get_all_next_block_hashes(block_hash)?;
+        let next_block_hashes = self.chain_store.get_all_next_block_hashes(block_hash);
         if next_block_hashes.is_empty() {
             // Next block wasn't received yet.
             tracing::debug!(target: "chunk_executor", %block_hash, "no next block hash is available");
@@ -983,7 +983,7 @@ impl ChunkExecutorActor {
         };
 
         let mut next_block_hashes: VecDeque<_> =
-            self.chain_store.get_all_next_block_hashes(&start_block)?.into();
+            self.chain_store.get_all_next_block_hashes(&start_block).into();
         while let Some(block_hash) = next_block_hashes.pop_front() {
             if !matches!(
                 self.try_apply_chunks(&block_hash)?,
@@ -991,7 +991,7 @@ impl ChunkExecutorActor {
             ) {
                 continue;
             }
-            next_block_hashes.extend(&self.chain_store.get_all_next_block_hashes(&block_hash)?);
+            next_block_hashes.extend(&self.chain_store.get_all_next_block_hashes(&block_hash));
         }
 
         Ok(())

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2080,30 +2080,26 @@ impl Client {
         let parent_hash = match inner {
             ApprovalInner::Endorsement(parent_hash) => *parent_hash,
             ApprovalInner::Skip(parent_height) => {
-                match self.chain.chain_store().get_all_block_hashes_by_height(*parent_height) {
-                    Ok(hashes) => {
-                        // If there is more than one block at the height, all of them will be
-                        // eligible to build the next block on, so we just pick one.
-                        let hash = hashes.values().flatten().next();
-                        match hash {
-                            Some(hash) => *hash,
-                            None => {
-                                self.handle_process_approval_error(
-                                    approval,
-                                    approval_type,
-                                    true,
-                                    near_chain::Error::DBNotFoundErr(format!(
-                                        "Cannot find any block on height {}",
-                                        parent_height
-                                    )),
-                                );
-                                return;
-                            }
+                {
+                    let hashes =
+                        self.chain.chain_store().get_all_block_hashes_by_height(*parent_height);
+                    // If there is more than one block at the height, all of them will be
+                    // eligible to build the next block on, so we just pick one.
+                    let hash = hashes.values().flatten().next();
+                    match hash {
+                        Some(hash) => *hash,
+                        None => {
+                            self.handle_process_approval_error(
+                                approval,
+                                approval_type,
+                                true,
+                                near_chain::Error::DBNotFoundErr(format!(
+                                    "Cannot find any block on height {}",
+                                    parent_height
+                                )),
+                            );
+                            return;
                         }
-                    }
-                    Err(e) => {
-                        self.handle_process_approval_error(approval, approval_type, true, e);
-                        return;
                     }
                 }
             }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -603,10 +603,7 @@ impl Handler<SpanWrapped<BlockResponse>> for ClientActor {
         tracing::debug!(target: "client", block_height = block.header().height(), block_hash = ?block.header().hash(), "received block response");
         let blocks_at_height =
             self.client.chain.chain_store().get_all_block_hashes_by_height(block.header().height());
-        if was_requested
-            || blocks_at_height.is_err()
-            || blocks_at_height.as_ref().unwrap().is_empty()
-        {
+        if was_requested || blocks_at_height.is_empty() {
             // This is a very sneaky piece of logic.
             if self.maybe_receive_state_sync_blocks(Arc::clone(&block)) {
                 // A node is syncing its state. Don't consider receiving
@@ -623,7 +620,7 @@ impl Handler<SpanWrapped<BlockResponse>> for ClientActor {
             match self.client.epoch_manager.get_epoch_id_from_prev_block(block.header().prev_hash())
             {
                 Ok(epoch_id) => {
-                    if let Some(hashes) = blocks_at_height.unwrap().get(&epoch_id) {
+                    if let Some(hashes) = blocks_at_height.get(&epoch_id) {
                         if !hashes.contains(block.header().hash()) {
                             tracing::warn!(target: "client", block_hash = ?block.header().hash(), block_height = block.header().height(), "rejecting un-requested block");
                         }

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -207,11 +207,7 @@ fn get_block_hashes_to_fetch(
     final_height: BlockHeight,
 ) -> Vec<CryptoHash> {
     if height_to_fetch >= final_height {
-        chain_store
-            .get_all_header_hashes_by_height(height_to_fetch)
-            .unwrap_or_default()
-            .into_iter()
-            .collect()
+        chain_store.get_all_header_hashes_by_height(height_to_fetch).into_iter().collect()
     } else {
         chain_store.get_block_hash_by_height(height_to_fetch).ok().into_iter().collect()
     }

--- a/chain/client/src/spice_chunk_validator_actor.rs
+++ b/chain/client/src/spice_chunk_validator_actor.rs
@@ -104,8 +104,7 @@ impl Handler<ProcessedBlock> for SpiceChunkValidatorActor {
 impl Handler<ExecutionResultEndorsed> for SpiceChunkValidatorActor {
     fn handle(&mut self, ExecutionResultEndorsed { block_hash }: ExecutionResultEndorsed) {
         if let Some(signer) = self.validator_signer.get() {
-            let next_block_hashes =
-                self.chain_store.get_all_next_block_hashes(&block_hash).unwrap();
+            let next_block_hashes = self.chain_store.get_all_next_block_hashes(&block_hash);
             for next_block_hash in next_block_hashes {
                 let next_block = self.chain_store.get_block(&next_block_hash).expect(
                     "block added to next blocks only after it's processed so it should be in store",

--- a/chain/client/src/spice_data_distributor_actor.rs
+++ b/chain/client/src/spice_data_distributor_actor.rs
@@ -990,10 +990,10 @@ impl SpiceDataDistributorActor {
         };
 
         let mut next_block_hashes: VecDeque<_> =
-            self.chain_store.get_all_next_block_hashes(&start_block)?.into();
+            self.chain_store.get_all_next_block_hashes(&start_block).into();
         while let Some(block_hash) = next_block_hashes.pop_front() {
             self.start_waiting_on_data(&block_hash)?;
-            next_block_hashes.extend(&self.chain_store.get_all_next_block_hashes(&block_hash)?);
+            next_block_hashes.extend(&self.chain_store.get_all_next_block_hashes(&block_hash));
         }
         Ok(())
     }

--- a/chain/client/src/state_request_actor.rs
+++ b/chain/client/src/state_request_actor.rs
@@ -103,7 +103,7 @@ impl StateRequestActor {
             return Ok(None);
         }
         let header = self.chain_store.get_block_header(block_hash)?;
-        self.chain_store.get_current_epoch_sync_hash(header.epoch_id())
+        Ok(self.chain_store.get_current_epoch_sync_hash(header.epoch_id()))
     }
 
     // TODO(darioush): Remove the code duplication with Chain.

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -188,19 +188,13 @@ impl ChainStoreAdapter {
     pub fn get_all_block_hashes_by_height(
         &self,
         height: BlockHeight,
-    ) -> Result<Arc<HashMap<EpochId, HashSet<CryptoHash>>>, Error> {
-        Ok(self.store.get_ser(DBCol::BlockPerHeight, &index_to_bytes(height)).unwrap_or_default())
+    ) -> Arc<HashMap<EpochId, HashSet<CryptoHash>>> {
+        self.store.get_ser(DBCol::BlockPerHeight, &index_to_bytes(height)).unwrap_or_default()
     }
 
     /// Returns a HashSet of Header Hashes for current Height
-    pub fn get_all_header_hashes_by_height(
-        &self,
-        height: BlockHeight,
-    ) -> Result<HashSet<CryptoHash>, Error> {
-        Ok(self
-            .store
-            .get_ser(DBCol::HeaderHashesByHeight, &index_to_bytes(height))
-            .unwrap_or_default())
+    pub fn get_all_header_hashes_by_height(&self, height: BlockHeight) -> HashSet<CryptoHash> {
+        self.store.get_ser(DBCol::HeaderHashesByHeight, &index_to_bytes(height)).unwrap_or_default()
     }
 
     /// Returns block header from the current chain for given height if present.
@@ -254,8 +248,8 @@ impl ChainStoreAdapter {
         )
     }
 
-    pub fn get_blocks_to_catchup(&self, prev_hash: &CryptoHash) -> Result<Vec<CryptoHash>, Error> {
-        Ok(self.store.get_ser(DBCol::BlocksToCatchup, prev_hash.as_ref()).unwrap_or_default())
+    pub fn get_blocks_to_catchup(&self, prev_hash: &CryptoHash) -> Vec<CryptoHash> {
+        self.store.get_ser(DBCol::BlocksToCatchup, prev_hash.as_ref()).unwrap_or_default()
     }
 
     pub fn get_transaction(
@@ -339,14 +333,8 @@ impl ChainStoreAdapter {
     }
 
     /// Returns a vector of all known processed next block hashes.
-    pub fn get_all_next_block_hashes(
-        &self,
-        block_hash: &CryptoHash,
-    ) -> Result<Vec<CryptoHash>, Error> {
-        Ok(self
-            .store
-            .get_ser(DBCol::all_next_block_hashes(), block_hash.as_ref())
-            .unwrap_or_default())
+    pub fn get_all_next_block_hashes(&self, block_hash: &CryptoHash) -> Vec<CryptoHash> {
+        self.store.get_ser(DBCol::all_next_block_hashes(), block_hash.as_ref()).unwrap_or_default()
     }
 
     pub fn get_state_header(
@@ -360,11 +348,8 @@ impl ChainStoreAdapter {
             .ok_or_else(|| Error::Other("Cannot get shard_state_header".into()))
     }
 
-    pub fn get_current_epoch_sync_hash(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<Option<CryptoHash>, Error> {
-        Ok(self.store.get_ser(DBCol::StateSyncHashes, epoch_id.as_ref()))
+    pub fn get_current_epoch_sync_hash(&self, epoch_id: &EpochId) -> Option<CryptoHash> {
+        self.store.get_ser(DBCol::StateSyncHashes, epoch_id.as_ref())
     }
 
     /// Get height of genesis
@@ -451,7 +436,7 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
     pub fn update_block_header_hashes_by_height(&mut self, header: &BlockHeader) {
         let height = header.height();
         let mut hash_set =
-            self.store_update.store.chain_store().get_all_header_hashes_by_height(height).unwrap();
+            self.store_update.store.chain_store().get_all_header_hashes_by_height(height);
         hash_set.insert(*header.hash());
         self.set_block_header_hashes_by_height(height, &hash_set);
     }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -851,7 +851,6 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
                     .chain
                     .mut_chain_store()
                     .get_all_block_hashes_by_height(i as BlockHeight)
-                    .unwrap()
                     .is_empty()
             );
         } else {
@@ -862,7 +861,6 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
                     .chain
                     .mut_chain_store()
                     .get_all_block_hashes_by_height(i as BlockHeight)
-                    .unwrap()
                     .is_empty()
             );
         }
@@ -921,13 +919,7 @@ fn test_archival_save_trie_changes() {
 
         assert!(chain.get_block(block.hash()).is_ok());
         assert!(chain.get_block_by_height(i).is_ok());
-        assert!(
-            !chain
-                .chain_store()
-                .get_all_block_hashes_by_height(i as BlockHeight)
-                .unwrap()
-                .is_empty()
-        );
+        assert!(!chain.chain_store().get_all_block_hashes_by_height(i as BlockHeight).is_empty());
 
         // The genesis block does not contain trie changes.
         if i == 0 {
@@ -1028,11 +1020,7 @@ fn test_archival_gc_common(
             assert!(chain.get_block(block.hash()).is_ok());
             assert!(chain.get_block_by_height(i).is_ok());
             assert!(
-                !chain
-                    .chain_store()
-                    .get_all_block_hashes_by_height(i as BlockHeight)
-                    .unwrap()
-                    .is_empty()
+                !chain.chain_store().get_all_block_hashes_by_height(i as BlockHeight).is_empty()
             );
         }
     }
@@ -3276,11 +3264,7 @@ fn test_catchup_no_sharding_change() {
             env.clients[0].process_block_test(block.clone().into(), Provenance::PRODUCED).unwrap();
         assert_eq!(env.clients[0].chain.chain_store().iterate_state_sync_infos().unwrap(), vec![]);
         assert_eq!(
-            env.clients[0]
-                .chain
-                .chain_store()
-                .get_blocks_to_catchup(block.header().prev_hash())
-                .unwrap(),
+            env.clients[0].chain.chain_store().get_blocks_to_catchup(block.header().prev_hash()),
             vec![]
         );
     }

--- a/integration-tests/src/tests/tools/apply_chunk.rs
+++ b/integration-tests/src/tests/tools/apply_chunk.rs
@@ -243,7 +243,7 @@ fn test_apply_tx_apply_receipt() {
     // there was no corresponding env.clients[0].produce_block() after
 
     let chunks = store.chunk_store().get_all_chunk_hashes_by_height(5).unwrap();
-    let blocks = chain_store.get_all_header_hashes_by_height(5).unwrap();
+    let blocks = chain_store.get_all_header_hashes_by_height(5);
     assert_ne!(chunks.len(), 0);
     assert_eq!(blocks.len(), 0);
 

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -148,7 +148,7 @@ fn verify_block_headers(store: &Store) -> anyhow::Result<()> {
     tracing::info!(target: "migrations", ?tail_height, ?latest_known_height, "verifying block headers before deletion");
 
     for height in tail_height..(latest_known_height + 1) {
-        for block_hash in chain_store.get_all_header_hashes_by_height(height)? {
+        for block_hash in chain_store.get_all_header_hashes_by_height(height) {
             let block = match chain_store.get_block(&block_hash) {
                 Ok(block) => block,
                 // It's possible that some blocks are missing in the DB when we have forks etc.
@@ -180,7 +180,7 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
 
     let mut store_update = chain_store.store_update();
     for height in tail_height..(latest_known_height + 1) {
-        for block_hash in chain_store.get_all_header_hashes_by_height(height)? {
+        for block_hash in chain_store.get_all_header_hashes_by_height(height) {
             // We've already checked for errors and missing blocks in the verify_block_headers function
             if let Ok(block) = chain_store.get_block(&block_hash) {
                 store_update.set_block_header_only(block.header());

--- a/test-loop-tests/src/tests/state_sync.rs
+++ b/test-loop-tests/src/tests/state_sync.rs
@@ -265,8 +265,7 @@ fn assert_fork_happened(env: &TestLoopEnv, skip_block_height: BlockHeight) {
 
     // The way it's implemented currently, only one client will be aware of the fork
     for client in clients {
-        let hashes =
-            client.chain.chain_store.get_all_block_hashes_by_height(skip_block_height).unwrap();
+        let hashes = client.chain.chain_store.get_all_block_hashes_by_height(skip_block_height);
         if !hashes.is_empty() {
             return;
         }


### PR DESCRIPTION
- Make `get_all_block_hashes_by_height()`, `get_all_header_hashes_by_height()`, `get_blocks_to_catchup()`, `get_all_next_block_hashes()`, and `get_current_epoch_sync_hash()` infallible on `ChainStoreAdapter` and `ChainStoreAccess` trait
- These methods wrap `get_ser()` with `unwrap_or_default()` or return the `Option` directly — the `Result` wrapper was unnecessary
- Update ~35 call sites across 17 files to remove `.unwrap()`, `?`, `.unwrap_or_default()`, `.unwrap_or_else()`, and `match Ok/Err` patterns
- Simplifies `finalize()` by removing two `?` error sources (`get_all_block_hashes_by_height` and `get_all_next_block_hashes`)
- Simplifies `get_all_header_hashes_by_height` match in `finalize()` to a direct call (the function already returns an empty set when no data exists)
- Part of the ongoing store `Result` cleanup effort (#15066)