### PR TITLE
refactor(store): make transaction/receipt/outcome ChainStoreAdapter methods infallible

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2929,7 +2929,7 @@ impl Chain {
         self.get_recursive_transaction_results(&mut outcomes, transaction_hash, true)?;
         let status = self.get_execution_status(&outcomes, transaction_hash);
         let receipts_outcome = outcomes.split_off(1);
-        let transaction = self.chain_store.get_transaction(transaction_hash)?.ok_or_else(|| {
+        let transaction = self.chain_store.get_transaction(transaction_hash).ok_or_else(|| {
             Error::DBNotFoundErr(format!("Transaction {} is not found", transaction_hash))
         })?;
         let transaction = SignedTransactionView::from(Arc::unwrap_or_clone(transaction));
@@ -2943,7 +2943,7 @@ impl Chain {
         &self,
         transaction_hash: &CryptoHash,
     ) -> Result<FinalExecutionOutcomeView, Error> {
-        let transaction = self.chain_store.get_transaction(transaction_hash)?.ok_or_else(|| {
+        let transaction = self.chain_store.get_transaction(transaction_hash).ok_or_else(|| {
             Error::DBNotFoundErr(format!("Transaction {} is not found", transaction_hash))
         })?;
         let transaction = SignedTransactionView::from(Arc::unwrap_or_clone(transaction));
@@ -2982,11 +2982,14 @@ impl Chain {
                 if Some(outcome.id) == receipt_id_from_transaction && is_local_receipt {
                     None
                 } else {
-                    Some(self.chain_store.get_receipt(&outcome.id).and_then(|r| {
-                        r.map(|r| Receipt::clone(&r).into()).ok_or_else(|| {
-                            Error::DBNotFoundErr(format!("Receipt {} is not found", outcome.id))
-                        })
-                    }))
+                    Some(
+                        self.chain_store
+                            .get_receipt(&outcome.id)
+                            .map(|r| Receipt::clone(&r).into())
+                            .ok_or_else(|| {
+                                Error::DBNotFoundErr(format!("Receipt {} is not found", outcome.id))
+                            }),
+                    )
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -1118,7 +1118,7 @@ impl<'a> ChainStoreUpdate<'a> {
             // chunk. An old chunk may have the shard id from the parent shard.
             let shard_id = chunk_header.shard_id();
             let outcome_ids =
-                self.chain_store().get_outcomes_by_block_hash_and_shard_id(block_hash, shard_id)?;
+                self.chain_store().get_outcomes_by_block_hash_and_shard_id(block_hash, shard_id);
             for outcome_id in outcome_ids {
                 self.gc_col(
                     DBCol::TransactionResultForBlock,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -650,8 +650,7 @@ impl ViewClientActor {
                     Ok(TxStatusView { execution_outcome: Some(res), status })
                 }
                 Err(near_chain::Error::DBNotFoundErr(_)) => {
-                    if let Ok(Some(transaction)) = self.chain.chain_store.get_transaction(&tx_hash)
-                    {
+                    if let Some(transaction) = self.chain.chain_store.get_transaction(&tx_hash) {
                         let transaction =
                             SignedTransactionView::from(Arc::unwrap_or_clone(transaction));
                         if let Ok(tx_outcome) = self.chain.get_execution_outcome(&tx_hash) {
@@ -1209,7 +1208,7 @@ impl Handler<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>> for ViewC
         Ok(self
             .chain
             .chain_store()
-            .get_receipt(&msg.receipt_id)?
+            .get_receipt(&msg.receipt_id)
             .map(|receipt| Receipt::clone(&receipt).into()))
     }
 }

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -258,11 +258,8 @@ impl ChainStoreAdapter {
         Ok(self.store.get_ser(DBCol::BlocksToCatchup, prev_hash.as_ref()).unwrap_or_default())
     }
 
-    pub fn get_transaction(
-        &self,
-        tx_hash: &CryptoHash,
-    ) -> Result<Option<Arc<SignedTransaction>>, Error> {
-        Ok(self.store.get_ser(DBCol::Transactions, tx_hash.as_ref()))
+    pub fn get_transaction(&self, tx_hash: &CryptoHash) -> Option<Arc<SignedTransaction>> {
+        self.store.get_ser(DBCol::Transactions, tx_hash.as_ref())
     }
 
     /// Fetch a receipt by id, if it is stored in the store.
@@ -270,8 +267,8 @@ impl ChainStoreAdapter {
     /// Note that not _all_ receipts are persisted. Some receipts are ephemeral,
     /// get processed immediately after creation and don't even get to the
     /// database.
-    pub fn get_receipt(&self, receipt_id: &CryptoHash) -> Result<Option<Arc<Receipt>>, Error> {
-        Ok(self.store.get_ser(DBCol::Receipts, receipt_id.as_ref()))
+    pub fn get_receipt(&self, receipt_id: &CryptoHash) -> Option<Arc<Receipt>> {
+        self.store.get_ser(DBCol::Receipts, receipt_id.as_ref())
     }
 
     pub fn get_block_merkle_tree(
@@ -320,10 +317,9 @@ impl ChainStoreAdapter {
         &self,
         id: &CryptoHash,
         block_hash: &CryptoHash,
-    ) -> Result<Option<ExecutionOutcomeWithProof>, Error> {
-        Ok(self
-            .store
-            .get_ser(DBCol::TransactionResultForBlock, &get_outcome_id_block_hash(id, block_hash)))
+    ) -> Option<ExecutionOutcomeWithProof> {
+        self.store
+            .get_ser(DBCol::TransactionResultForBlock, &get_outcome_id_block_hash(id, block_hash))
     }
 
     /// Returns a vector of Outcome ids for given block and shard id
@@ -331,11 +327,10 @@ impl ChainStoreAdapter {
         &self,
         block_hash: &CryptoHash,
         shard_id: ShardId,
-    ) -> Result<Vec<CryptoHash>, Error> {
-        Ok(self
-            .store
+    ) -> Vec<CryptoHash> {
+        self.store
             .get_ser(DBCol::OutcomeIds, &get_block_shard_id(block_hash, shard_id))
-            .unwrap_or_default())
+            .unwrap_or_default()
     }
 
     /// Returns a vector of all known processed next block hashes.

--- a/core/store/src/archive/cloud_storage/shard_data.rs
+++ b/core/store/src/archive/cloud_storage/shard_data.rs
@@ -75,7 +75,7 @@ pub fn build_shard_data(
     let transactions = chunk.to_transactions().iter().cloned().collect();
     let receipts = chunk.prev_outgoing_receipts().iter().cloned().collect();
 
-    let outcome_ids = chain_store.get_outcomes_by_block_hash_and_shard_id(&block_hash, shard_id)?;
+    let outcome_ids = chain_store.get_outcomes_by_block_hash_and_shard_id(&block_hash, shard_id);
     // TODO(cloud_archival): Check why this `if` is required and whether there's a cleaner approach.
     let incoming_receipts = if block_height > genesis_height + 1 {
         chain_store.get_incoming_receipts(&block_hash, shard_id)?.to_vec()

--- a/tools/database/src/analyze_gas_usage.rs
+++ b/tools/database/src/analyze_gas_usage.rs
@@ -230,11 +230,10 @@ fn get_gas_usage_in_block(
         // The outcome of each transaction and receipt executed in this chunk is saved in the database as an ExecutionOutcome.
         // Go through all ExecutionOutcomes from this chunk and record the gas usage.
         let outcome_ids =
-            chain_store.get_outcomes_by_block_hash_and_shard_id(block.hash(), shard_id).unwrap();
+            chain_store.get_outcomes_by_block_hash_and_shard_id(block.hash(), shard_id);
         for outcome_id in outcome_ids {
             let outcome = chain_store
                 .get_outcome_by_id_and_block_hash(&outcome_id, block.hash())
-                .unwrap()
                 .unwrap()
                 .outcome;
 

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -176,7 +176,7 @@ impl crate::ChainAccess for ChainAccess {
     }
 
     async fn get_receipt(&self, id: &CryptoHash) -> Result<Arc<Receipt>, ChainError> {
-        self.chain.get_receipt(id)?.ok_or(ChainError::Unknown)
+        self.chain.get_receipt(id).ok_or(ChainError::Unknown)
     }
 
     async fn get_full_access_keys(

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -295,7 +295,7 @@ fn apply_tx_in_chunk(
     tx_hash: &CryptoHash,
     storage: StorageSource,
 ) -> anyhow::Result<Vec<ApplyChunkResult>> {
-    if chain_store.get_transaction(tx_hash)?.is_none() {
+    if chain_store.get_transaction(tx_hash).is_none() {
         return Err(anyhow!("tx with hash {} not known", tx_hash));
     }
 


### PR DESCRIPTION
Remove the `Result` wrapper from `get_transaction()`, `get_receipt()`, `get_outcome_by_id_and_block_hash()`, and `get_outcomes_by_block_hash_and_shard_id()` in `ChainStoreAdapter`. These methods cannot fail — they perform simple key lookups that return `Option` or a default value.

Updates the `ChainStoreAccess` trait signatures and both impls (`ChainStore`, `ChainStoreUpdate`), and simplifies all call sites across chain, client, tools, and archive code.