### PR TITLE
Add gas key cost estimators

### DIFF
--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -11,7 +11,9 @@ use crate::gas_cost::{GasCost, NonNegativeTolerance};
 use crate::transaction_builder::AccountRequirement;
 use crate::utils::{average_cost, percentiles};
 use near_crypto::{KeyType, PublicKey};
-use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
+use near_primitives::account::{
+    AccessKey, AccessKeyPermission, FunctionCallPermission, GasKeyInfo,
+};
 use near_primitives::action::{DeterministicStateInitAction, GlobalContractIdentifier};
 use near_primitives::deterministic_account_id::{
     DeterministicAccountStateInit, DeterministicAccountStateInitV1,
@@ -916,6 +918,111 @@ pub(crate) fn det_state_init_action(
     }));
 
     (receiver, action)
+}
+
+// --- Gas key estimators ---
+
+fn add_gas_key_full_access_action(num_nonces: u16) -> Action {
+    Action::AddKey(Box::new(near_primitives::transaction::AddKeyAction {
+        public_key: PublicKey::from_seed(KeyType::ED25519, "gas-key-seed"),
+        access_key: AccessKey::gas_key_full_access(num_nonces),
+    }))
+}
+
+fn transfer_to_gas_key_action() -> Action {
+    Action::TransferToGasKey(Box::new(near_primitives::action::TransferToGasKeyAction {
+        public_key: PublicKey::from_seed(KeyType::ED25519, "gas-key-seed"),
+        deposit: Balance::from_millinear(1),
+    }))
+}
+
+pub(crate) fn gas_key_transfer_base_send_sir(ctx: &mut EstimatorContext) -> GasCost {
+    ActionEstimation::new_sir(ctx)
+        .add_action(transfer_to_gas_key_action())
+        .verify_cost(&mut ctx.testbed())
+}
+
+pub(crate) fn gas_key_transfer_base_send_not_sir(ctx: &mut EstimatorContext) -> GasCost {
+    ActionEstimation::new(ctx)
+        .add_action(transfer_to_gas_key_action())
+        .verify_cost(&mut ctx.testbed())
+}
+
+pub(crate) fn gas_key_transfer_base_exec(ctx: &mut EstimatorContext) -> GasCost {
+    // TransferToGasKey exec requires the key to already exist.
+    // Measure [AddGasKey + TransferToGasKey x N] and subtract [AddGasKey] baseline.
+    let manual_inner_iters = 100u64;
+    let mut builder =
+        ActionEstimation::new_sir(ctx).inner_iters(1).add_action(add_gas_key_full_access_action(1));
+    for _ in 0..manual_inner_iters {
+        builder = builder.add_action(transfer_to_gas_key_action());
+    }
+    let total = builder.apply_cost(&mut ctx.testbed());
+    let base = ActionEstimation::new_sir(ctx)
+        .inner_iters(1)
+        .add_action(add_gas_key_full_access_action(1))
+        .apply_cost(&mut ctx.testbed());
+    (total - base) / manual_inner_iters
+}
+
+pub(crate) fn gas_key_key_byte_send_sir(ctx: &mut EstimatorContext) -> GasCost {
+    let send_cost = gas_key_transfer_base_send_sir(ctx);
+    let pk = PublicKey::from_seed(KeyType::ED25519, "gas-key-seed");
+    let key_bytes = pk.len() as u64;
+    send_cost.min_gas(GAS_100_PICOSECONDS) / key_bytes
+}
+
+pub(crate) fn gas_key_key_byte_send_not_sir(ctx: &mut EstimatorContext) -> GasCost {
+    let send_cost = gas_key_transfer_base_send_not_sir(ctx);
+    let pk = PublicKey::from_seed(KeyType::ED25519, "gas-key-seed");
+    let key_bytes = pk.len() as u64;
+    send_cost.min_gas(GAS_100_PICOSECONDS) / key_bytes
+}
+
+pub(crate) fn gas_key_key_byte_exec(ctx: &mut EstimatorContext) -> GasCost {
+    let exec_cost = gas_key_transfer_base_exec(ctx);
+    let pk = PublicKey::from_seed(KeyType::ED25519, "gas-key-seed");
+    // Use the full trie key length: col prefix (2 bytes) + account_id + pk
+    // Approximate with a typical account_id length + pk.len()
+    let key_bytes = pk.len() as u64;
+    exec_cost.min_gas(GAS_100_PICOSECONDS) / key_bytes
+}
+
+pub(crate) fn gas_key_value_byte_send_sir(_ctx: &mut EstimatorContext) -> GasCost {
+    GasCost::zero()
+}
+
+pub(crate) fn gas_key_value_byte_send_not_sir(_ctx: &mut EstimatorContext) -> GasCost {
+    GasCost::zero()
+}
+
+pub(crate) fn gas_key_value_byte_exec(ctx: &mut EstimatorContext) -> GasCost {
+    let exec_cost = gas_key_transfer_base_exec(ctx);
+    let value_bytes = GasKeyInfo::borsh_len() as u64;
+    exec_cost.min_gas(GAS_100_PICOSECONDS) / value_bytes
+}
+
+pub(crate) fn gas_key_nonce_send_sir(_ctx: &mut EstimatorContext) -> GasCost {
+    GasCost::zero()
+}
+
+pub(crate) fn gas_key_nonce_send_not_sir(_ctx: &mut EstimatorContext) -> GasCost {
+    GasCost::zero()
+}
+
+pub(crate) fn gas_key_nonce_exec(ctx: &mut EstimatorContext) -> GasCost {
+    // Measure AddKey with many nonces minus AddKey with 1 nonce.
+    let many_nonces = 100u16;
+    let with_nonces = ActionEstimation::new_sir(ctx)
+        .inner_iters(1)
+        .add_action(add_gas_key_full_access_action(many_nonces))
+        .apply_cost(&mut ctx.testbed());
+    let without_nonces = ActionEstimation::new_sir(ctx)
+        .inner_iters(1)
+        .add_action(add_gas_key_full_access_action(1))
+        .apply_cost(&mut ctx.testbed());
+    let diff = with_nonces.saturating_sub(&without_nonces, &NonNegativeTolerance::PER_MILLE);
+    diff / (many_nonces - 1) as u64
 }
 
 /// Helper enum to select how large an action should be generated.

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -238,6 +238,23 @@ pub enum Cost {
     ActionDeterministicStateInitPerEntrySendNotSir,
     ActionDeterministicStateInitPerEntrySendSir,
     ActionDeterministicStateInitPerEntryExec,
+    // Gas key costs
+    ActionGasKeyTransferBase,
+    ActionGasKeyTransferBaseSendNotSir,
+    ActionGasKeyTransferBaseSendSir,
+    ActionGasKeyTransferBaseExec,
+    ActionGasKeyKeyByte,
+    ActionGasKeyKeyByteSendNotSir,
+    ActionGasKeyKeyByteSendSir,
+    ActionGasKeyKeyByteExec,
+    ActionGasKeyValueByte,
+    ActionGasKeyValueByteSendNotSir,
+    ActionGasKeyValueByteSendSir,
+    ActionGasKeyValueByteExec,
+    ActionGasKeyNonce,
+    ActionGasKeyNonceSendNotSir,
+    ActionGasKeyNonceSendSir,
+    ActionGasKeyNonceExec,
 
     /// Estimates `wasm_config.ext_costs.base` which is intended to be charged
     /// once on every host function call. However, this is currently

--- a/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
+++ b/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
@@ -58,6 +58,16 @@ fn runtime_fees_config(cost_table: &CostTable) -> anyhow::Result<RuntimeFeesConf
         })
     };
 
+    let asymmetric_fee = |sir: Cost, not_sir: Cost, exec: Cost| -> anyhow::Result<Fee> {
+        Ok(Fee {
+            send_sir: cost_table.get(sir).with_context(|| format!("undefined cost: {}", sir))?,
+            send_not_sir: cost_table
+                .get(not_sir)
+                .with_context(|| format!("undefined cost: {}", not_sir))?,
+            execution: cost_table.get(exec).with_context(|| format!("undefined cost: {}", exec))?,
+        })
+    };
+
     let config_store = RuntimeConfigStore::new(None);
     let actual_fees_config = &config_store.get_config(PROTOCOL_VERSION).fees;
     let res = RuntimeFeesConfig {
@@ -85,11 +95,26 @@ fn runtime_fees_config(cost_table: &CostTable) -> anyhow::Result<RuntimeFeesConf
             ActionCosts::deterministic_state_init_base => fee(Cost::ActionDeterministicStateInitBase)?,
             ActionCosts::deterministic_state_init_byte => fee(Cost::ActionDeterministicStateInitPerByte)?,
             ActionCosts::deterministic_state_init_entry => fee(Cost::ActionDeterministicStateInitPerEntry)?,
-            // No estimator for gas key costs; use values from the config store.
-            ActionCosts::gas_key_transfer_base => actual_fees_config.fee(ActionCosts::gas_key_transfer_base).clone(),
-            ActionCosts::gas_key_key_byte => actual_fees_config.fee(ActionCosts::gas_key_key_byte).clone(),
-            ActionCosts::gas_key_value_byte => actual_fees_config.fee(ActionCosts::gas_key_value_byte).clone(),
-            ActionCosts::gas_key_nonce => actual_fees_config.fee(ActionCosts::gas_key_nonce).clone(),
+            ActionCosts::gas_key_transfer_base => asymmetric_fee(
+                Cost::ActionGasKeyTransferBaseSendSir,
+                Cost::ActionGasKeyTransferBaseSendNotSir,
+                Cost::ActionGasKeyTransferBaseExec,
+            )?,
+            ActionCosts::gas_key_key_byte => asymmetric_fee(
+                Cost::ActionGasKeyKeyByteSendSir,
+                Cost::ActionGasKeyKeyByteSendNotSir,
+                Cost::ActionGasKeyKeyByteExec,
+            )?,
+            ActionCosts::gas_key_value_byte => asymmetric_fee(
+                Cost::ActionGasKeyValueByteSendSir,
+                Cost::ActionGasKeyValueByteSendNotSir,
+                Cost::ActionGasKeyValueByteExec,
+            )?,
+            ActionCosts::gas_key_nonce => asymmetric_fee(
+                Cost::ActionGasKeyNonceSendSir,
+                Cost::ActionGasKeyNonceSendNotSir,
+                Cost::ActionGasKeyNonceExec,
+            )?,
         },
         ..RuntimeFeesConfig::clone(&actual_fees_config)
     };


### PR DESCRIPTION
- Add 16 `Cost` enum variants for the 4 gas key `ActionCosts` (transfer_base, key_byte, value_byte, nonce), each with SendSir/SendNotSir/Exec split
- Add estimator functions in `action_costs.rs` using `ActionEstimation` builder pattern
- Add composite whole-transaction estimators in `lib.rs` and register all 16 in `ALL_COSTS`
- Replace hardcoded config-store fallback in `costs_to_runtime_config.rs` with `asymmetric_fee` closure that constructs `Fee` from separate send/exec estimates

Estimator results on dev machine (release mode, default iterations):

| Cost | Component | Estimated | Hardcoded |
|---|---|---|---|
| **transfer_base** | send_sir | ~0 (UNCERTAIN) | 115.1 Ggas |
| | send_not_sir | 83 Mgas (UNCERTAIN) | 115.1 Ggas |
| | exec | 609 Mgas (UNCERTAIN) | 235.7 Ggas |
| | composite | 5.0 Ggas (UNCERTAIN) | - |
| **key_byte** | send_sir | 1.8 Mgas | 59.4 Mgas |
| | send_not_sir | 3.3 Mgas | 59.4 Mgas |
| | exec | 19.8 Mgas | 101.4 Mgas |
| **value_byte** | send_sir | 0 | 0 |
| | send_not_sir | 0 | 0 |
| | exec | 31.1 Mgas | 36.6 Mgas |
| **nonce** | send_sir | 0 | 0 |
| | send_not_sir | 0 | 0 |
| | exec | 189 Mgas | 64.2 Ggas |
| | composite | 1.8 Ggas (UNCERTAIN) | - |

Zero-cost components (value_byte send, nonce send) match correctly. Many results are UNCERTAIN/HIGH-VARIANCE which is expected on a dev machine. Should be re-run on dedicated estimation hardware.