### PR TITLE
refactor(store): remove Result from ChunkStoreAdapter methods

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1090,7 +1090,7 @@ impl Chain {
             let shard_id = shard_layout.get_shard_id(shard_index)?;
             let chunk_hash = chunk_header.chunk_hash();
             // Check if any chunks are invalid in this block.
-            if let Some(encoded_chunk) = self.chain_store.is_invalid_chunk(chunk_hash)? {
+            if let Some(encoded_chunk) = self.chain_store.is_invalid_chunk(chunk_hash) {
                 let merkle_paths = block.chunks().compute_chunk_headers_root().1;
                 let merkle_proof =
                     merkle_paths.get(shard_index).ok_or(Error::InvalidShardId(shard_id))?;

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -627,7 +627,7 @@ impl<'a> ChainStoreUpdate<'a> {
     fn clear_chunk_data_and_headers(&mut self, min_chunk_height: BlockHeight) -> Result<(), Error> {
         let chunk_tail = self.chunk_tail();
         for height in chunk_tail..min_chunk_height {
-            let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height)?;
+            let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height);
             for chunk_hash in chunk_hashes {
                 // 1. Delete chunk-related data
                 let chunk = self.get_chunk(&chunk_hash)?;
@@ -691,7 +691,7 @@ impl<'a> ChainStoreUpdate<'a> {
         let mut height = self.chunk_tail();
         let mut remaining = gc_height_limit;
         while height < gc_stop_height && remaining > 0 {
-            let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height)?;
+            let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height);
             height += 1;
             if !chunk_hashes.is_empty() {
                 remaining -= 1;
@@ -1021,7 +1021,7 @@ impl<'a> ChainStoreUpdate<'a> {
     }
 
     fn clear_chunk_data_at_height(&mut self, height: BlockHeight) -> Result<(), Error> {
-        let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height)?;
+        let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height);
         for chunk_hash in chunk_hashes {
             // 1. Delete chunk-related data
             let chunk = self.get_chunk(&chunk_hash)?;

--- a/core/store/src/adapter/chunk_store.rs
+++ b/core/store/src/adapter/chunk_store.rs
@@ -57,22 +57,13 @@ impl ChunkStoreAdapter {
     }
 
     /// Returns a HashSet of Chunk Hashes for current Height
-    pub fn get_all_chunk_hashes_by_height(
-        &self,
-        height: BlockHeight,
-    ) -> Result<HashSet<ChunkHash>, Error> {
-        Ok(self
-            .store
-            .get_ser(DBCol::ChunkHashesByHeight, &index_to_bytes(height))
-            .unwrap_or_default())
+    pub fn get_all_chunk_hashes_by_height(&self, height: BlockHeight) -> HashSet<ChunkHash> {
+        self.store.get_ser(DBCol::ChunkHashesByHeight, &index_to_bytes(height)).unwrap_or_default()
     }
 
     /// Returns encoded chunk if it's invalid otherwise None.
-    pub fn is_invalid_chunk(
-        &self,
-        chunk_hash: &ChunkHash,
-    ) -> Result<Option<Arc<EncodedShardChunk>>, Error> {
-        Ok(self.store.get_ser(DBCol::InvalidChunks, chunk_hash.as_ref()))
+    pub fn is_invalid_chunk(&self, chunk_hash: &ChunkHash) -> Option<Arc<EncodedShardChunk>> {
+        self.store.get_ser(DBCol::InvalidChunks, chunk_hash.as_ref())
     }
 
     /// Information from applying chunk.
@@ -92,8 +83,8 @@ impl ChunkStoreAdapter {
         &self,
         block_hash: &CryptoHash,
         shard_id: &ShardId,
-    ) -> Result<Option<ChunkApplyStats>, Error> {
-        Ok(self.store.get_ser(DBCol::ChunkApplyStats, &get_block_shard_id(block_hash, *shard_id)))
+    ) -> Option<ChunkApplyStats> {
+        self.store.get_ser(DBCol::ChunkApplyStats, &get_block_shard_id(block_hash, *shard_id))
     }
 }
 

--- a/core/store/src/archive/cloud_storage/shard_data.rs
+++ b/core/store/src/archive/cloud_storage/shard_data.rs
@@ -92,7 +92,7 @@ pub fn build_shard_data(
     let chunk_extra = (*chunk_store.get_chunk_extra(&block_hash, &shard_uid)?).clone();
     let state_changes = get_state_changes(store, shard_layout, &block_hash, shard_uid)?;
     let chunk_apply_stats =
-        chunk_store.get_chunk_apply_stats(&block_hash, &shard_id)?.ok_or_else(|| {
+        chunk_store.get_chunk_apply_stats(&block_hash, &shard_id).ok_or_else(|| {
             Error::DBNotFoundErr(format!(
                 "CHUNK APPLY STATS, block height: {}, shard ID: {:?}",
                 block_height, shard_id

--- a/integration-tests/src/tests/tools/apply_chunk.rs
+++ b/integration-tests/src/tests/tools/apply_chunk.rs
@@ -242,7 +242,7 @@ fn test_apply_tx_apply_receipt() {
     // in the loop above are produced by env.process_block() but
     // there was no corresponding env.clients[0].produce_block() after
 
-    let chunks = store.chunk_store().get_all_chunk_hashes_by_height(5).unwrap();
+    let chunks = store.chunk_store().get_all_chunk_hashes_by_height(5);
     let blocks = chain_store.get_all_header_hashes_by_height(5);
     assert_ne!(chunks.len(), 0);
     assert_eq!(blocks.len(), 0);

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -43,7 +43,7 @@ fn get_incoming_receipts(
 ) -> anyhow::Result<Vec<Receipt>> {
     let mut receipt_proofs = vec![];
 
-    let chunk_hashes = chain_store.chunk_store().get_all_chunk_hashes_by_height(target_height)?;
+    let chunk_hashes = chain_store.chunk_store().get_all_chunk_hashes_by_height(target_height);
     if !chunk_hashes.contains(chunk_hash) {
         return Err(anyhow!(
             "given chunk hash is not listed in DBCol::ChunkHashesByHeight[{}]",

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -582,11 +582,10 @@ pub(crate) fn print_chunk_apply_stats(
         near_config.genesis.config.transaction_validity_period,
     );
     match chain_store.get_chunk_apply_stats(block_hash, &ShardId::new(shard_id)) {
-        Ok(Some(stats)) => println!("{:#?}", stats),
-        Ok(None) => {
+        Some(stats) => println!("{:#?}", stats),
+        None => {
             println!("\nNo stats found for block hash {} and shard {}\n", block_hash, shard_id)
         }
-        Err(e) => eprintln!("Error: {:#?}", e),
     }
 }
 


### PR DESCRIPTION
- Make `get_all_chunk_hashes_by_height()` return `HashSet<ChunkHash>` directly instead of `Result<HashSet<ChunkHash>, Error>`
- Make `is_invalid_chunk()` return `Option<Arc<EncodedShardChunk>>` directly instead of `Result<Option<...>, Error>`
- Make `get_chunk_apply_stats()` return `Option<ChunkApplyStats>` directly instead of `Result<Option<...>, Error>`
- Update `ChainStoreAccess` trait definitions and impls (`ChainStore`, `ChainStoreUpdate`)
- Simplify all call sites: remove `?`, `.unwrap()`, and `match Ok/Err` patterns
- These methods only wrapped infallible `get_ser()` in `Ok()`, so the `Result` was redundant

Part of the ongoing store Result cleanup effort.