### PR TITLE
refactor(store): remove Result from genesis utils

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -402,7 +402,7 @@ impl Chain {
             epoch_manager.clone(),
             runtime_adapter.clone(),
         );
-        let state_roots = get_genesis_state_roots(runtime_adapter.store())?
+        let state_roots = get_genesis_state_roots(runtime_adapter.store())
             .expect("genesis should be initialized.");
         let (genesis, _genesis_chunks) = Self::make_genesis_block(
             epoch_manager.as_ref(),
@@ -474,7 +474,7 @@ impl Chain {
         resharding_sender: ReshardingSender,
         on_post_state_ready_sender: Option<PostStateReadySender>,
     ) -> Result<Chain, Error> {
-        let state_roots = get_genesis_state_roots(runtime_adapter.store())?
+        let state_roots = get_genesis_state_roots(runtime_adapter.store())
             .expect("genesis should be initialized.");
         let (genesis, genesis_chunks) = Self::make_genesis_block(
             epoch_manager.as_ref(),

--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -226,13 +226,13 @@ impl Chain {
         gas_limit: Gas,
     ) -> Result<ChunkExtra, Error> {
         let shard_index = shard_layout.get_shard_index(shard_id)?;
-        let state_root = *get_genesis_state_roots(store)?
+        let state_root = *get_genesis_state_roots(store)
             .ok_or_else(|| Error::Other("genesis state roots do not exist in the db".to_owned()))?
             .get(shard_index)
             .ok_or_else(|| {
                 Error::Other(format!("genesis state root does not exist for shard id {shard_id} shard index {shard_index}"))
             })?;
-        let congestion_info = *near_store::get_genesis_congestion_infos(store)?
+        let congestion_info = *near_store::get_genesis_congestion_infos(store)
             .ok_or_else(|| Error::Other("genesis congestion infos do not exist in the db".to_owned()))?
             .get(shard_index)
             .ok_or_else(|| {
@@ -301,7 +301,7 @@ fn get_genesis_congestion_infos_impl(
     let genesis_shard_layout = epoch_manager.get_shard_layout(&genesis_epoch_id)?;
 
     // Check we had already computed the congestion infos from the genesis state roots.
-    if let Some(saved_infos) = near_store::get_genesis_congestion_infos(runtime.store())? {
+    if let Some(saved_infos) = near_store::get_genesis_congestion_infos(runtime.store()) {
         tracing::debug!(target: "chain", "reading genesis congestion infos from database");
         return Ok(saved_infos);
     }

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -145,7 +145,7 @@ impl TestEnv {
             DEFAULT_STATE_PARTS_COMPRESSION_LEVEL,
             false,
         );
-        let state_roots = get_genesis_state_roots(&store).unwrap().unwrap();
+        let state_roots = get_genesis_state_roots(&store).unwrap();
         let genesis_hash = hash(&[0]);
 
         let shard_layout = epoch_manager.get_shard_layout(&EpochId::default()).unwrap();
@@ -1507,7 +1507,7 @@ fn test_genesis_hash() {
     );
 
     let state_roots =
-        get_genesis_state_roots(runtime.store()).unwrap().expect("genesis should be initialized.");
+        get_genesis_state_roots(runtime.store()).expect("genesis should be initialized.");
     let (block, _chunks) = Chain::make_genesis_block(
         epoch_manager.as_ref(),
         runtime.as_ref(),

--- a/chain/chain/src/stateless_validation/spice_chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/spice_chunk_validation.rs
@@ -996,7 +996,7 @@ mod tests {
             let shard_layout = self.shard_layout();
             let mut prev_execution_results = BlockExecutionResults(HashMap::new());
             let genesis_state_root =
-                get_genesis_state_roots(&self.chain.chain_store.store()).unwrap().unwrap()[0];
+                get_genesis_state_roots(&self.chain.chain_store.store()).unwrap()[0];
             for shard_id in shard_layout.shard_ids() {
                 let receipts = self.receipts_for_shard(shard_id);
                 let (root, _proofs) = Chain::create_receipts_proofs_from_outgoing_receipts(

--- a/chain/client/src/prepare_transactions.rs
+++ b/chain/client/src/prepare_transactions.rs
@@ -310,9 +310,7 @@ mod tests {
         let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime =
             NightshadeRuntime::test(tempdir.path(), store.clone(), &genesis.config, epoch_manager);
-        let roots = get_genesis_state_roots(&store)
-            .expect("Error getting genesis state roots")
-            .expect("Genesis state roots must exist");
+        let roots = get_genesis_state_roots(&store).expect("Genesis state roots must exist");
         let root = roots.iter().next().expect("Genesis state root for shard must exist");
         let tries = TestTriesBuilder::new().with_store(store).build();
         (runtime, tries.new_trie_update(ShardUId::single_shard(), *root))

--- a/chain/client/src/tests/spice_chunk_validator_actor.rs
+++ b/chain/client/src/tests/spice_chunk_validator_actor.rs
@@ -457,7 +457,7 @@ fn record_execution_results(actor: &TestActor, block: &Block, state_root: Crypto
 }
 
 fn test_starting_state_root(actor: &TestActor) -> CryptoHash {
-    get_genesis_state_roots(&actor.chain_store.store()).unwrap().unwrap()[0]
+    get_genesis_state_roots(&actor.chain_store.store()).unwrap()[0]
 }
 
 fn simulate_chunk_application(

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -46,9 +46,7 @@ impl ChainStoreAdapter {
     /// Helper method to lazily initialize and retrieve the genesis height.
     fn get_or_init_genesis_height(&self) -> BlockHeight {
         *self.genesis_height.get_or_init(|| {
-            get_genesis_height(&self.store)
-                .expect("Store failed on fetching genesis height")
-                .expect("Genesis height not found in storage")
+            get_genesis_height(&self.store).expect("Genesis height not found in storage")
         })
     }
 

--- a/core/store/src/genesis/initialization.rs
+++ b/core/store/src/genesis/initialization.rs
@@ -35,17 +35,14 @@ pub fn initialize_sharded_genesis_state(
     home_dir: Option<&Path>,
 ) {
     let shard_layout = genesis_epoch_config.static_shard_layout();
-    let state_roots = if let Some(state_roots) =
-        get_genesis_state_roots(&store).expect("Store failed on genesis initialization")
-    {
+    let state_roots = if let Some(state_roots) = get_genesis_state_roots(&store) {
         // TODO: with 2.6 release, remove storing genesis height
         let mut store_update: crate::StoreUpdate = store.store_update();
         set_genesis_height(&mut store_update, &genesis.config.genesis_height);
         store_update.commit();
 
-        let genesis_height = get_genesis_height(&store)
-            .expect("Store failed on genesis initialization")
-            .expect("Genesis height not found in storage");
+        let genesis_height =
+            get_genesis_height(&store).expect("Genesis height not found in storage");
         assert_eq!(
             genesis_height, genesis.config.genesis_height,
             "Genesis height in store is different from the one in genesis config"

--- a/core/store/src/utils/mod.rs
+++ b/core/store/src/utils/mod.rs
@@ -19,7 +19,6 @@ use near_primitives::trie_key::{TrieKey, trie_key_parsers};
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, Nonce, NonceIndex, PromiseYieldStatus, StateRoot,
 };
-use std::io;
 
 /// Reads an object from Trie.
 /// # Errors
@@ -456,12 +455,12 @@ pub fn remove_account(
     Ok(())
 }
 
-pub fn get_genesis_state_roots(store: &Store) -> io::Result<Option<Vec<StateRoot>>> {
-    Ok(store.get_ser::<Vec<StateRoot>>(DBCol::BlockMisc, GENESIS_STATE_ROOTS_KEY))
+pub fn get_genesis_state_roots(store: &Store) -> Option<Vec<StateRoot>> {
+    store.get_ser::<Vec<StateRoot>>(DBCol::BlockMisc, GENESIS_STATE_ROOTS_KEY)
 }
 
-pub fn get_genesis_congestion_infos(store: &Store) -> io::Result<Option<Vec<CongestionInfo>>> {
-    Ok(store.get_ser::<Vec<CongestionInfo>>(DBCol::BlockMisc, GENESIS_CONGESTION_INFO_KEY))
+pub fn get_genesis_congestion_infos(store: &Store) -> Option<Vec<CongestionInfo>> {
+    store.get_ser::<Vec<CongestionInfo>>(DBCol::BlockMisc, GENESIS_CONGESTION_INFO_KEY)
 }
 
 pub fn set_genesis_state_roots(store_update: &mut StoreUpdate, genesis_roots: &[StateRoot]) {
@@ -475,8 +474,8 @@ pub fn set_genesis_congestion_infos(
     store_update.set_ser(DBCol::BlockMisc, GENESIS_CONGESTION_INFO_KEY, &congestion_infos);
 }
 
-pub fn get_genesis_height(store: &Store) -> io::Result<Option<BlockHeight>> {
-    Ok(store.get_ser::<BlockHeight>(DBCol::BlockMisc, GENESIS_HEIGHT_KEY))
+pub fn get_genesis_height(store: &Store) -> Option<BlockHeight> {
+    store.get_ser::<BlockHeight>(DBCol::BlockMisc, GENESIS_HEIGHT_KEY)
 }
 
 pub fn set_genesis_height(store_update: &mut StoreUpdate, genesis_height: &BlockHeight) {

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -148,7 +148,7 @@ impl GenesisBuilder {
 
     pub fn build(mut self) -> Result<Self> {
         // First, apply whatever is defined by the genesis config.
-        let roots = get_genesis_state_roots(self.runtime.store())?
+        let roots = get_genesis_state_roots(self.runtime.store())
             .expect("genesis state roots not initialized.");
         let shard_layout = &self.genesis.config.shard_layout;
         let genesis_shard_version = shard_layout.version();

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -92,7 +92,6 @@ fn setup_network_node(
     });
     client_config.ttl_account_id_router = config.ttl_account_id_router.try_into().unwrap();
     let state_roots = near_store::get_genesis_state_roots(runtime.store())
-        .unwrap()
         .expect("genesis should be initialized.");
     let (genesis_block, _genesis_chunks) = Chain::make_genesis_block(
         epoch_manager.as_ref(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -493,7 +493,7 @@ pub async fn start_with_config_and_synchronization_impl(
     let telemetry =
         TelemetryActor::spawn_tokio_actor(actor_system.clone(), config.telemetry_config.clone());
     let chain_genesis = ChainGenesis::new(&config.genesis.config);
-    let state_roots = near_store::get_genesis_state_roots(runtime.store())?
+    let state_roots = near_store::get_genesis_state_roots(runtime.store())
         .expect("genesis should be initialized.");
     let (genesis_block, _genesis_chunks) = Chain::make_genesis_block(
         epoch_manager.as_ref(),

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -179,7 +179,7 @@ fn migrate_48_to_49(
 // Typically this is NOT recommended as ColdDB has specific ways for storing data, example RC columns.
 // But in our case this is fine as the block headers are stored as-is in both hot and cold DBs.
 fn copy_block_headers_to_cold_db(hot_store: &Store, cold_db: &ColdDB) -> anyhow::Result<()> {
-    let genesis_height = get_genesis_height(hot_store)?.unwrap();
+    let genesis_height = get_genesis_height(hot_store).unwrap();
     let head_height = hot_store.chain_store().head().unwrap().height;
     let approx_num_blocks = head_height - genesis_height;
 

--- a/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
+++ b/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
@@ -84,7 +84,7 @@ fn test_missing_genesis_congestion_infos_bootstrap() {
     // Step 1: Initialize genesis to get state roots
     let store1 = create_test_store();
     initialize_genesis_state(store1.clone(), &genesis, None);
-    let genesis_state_roots = near_store::get_genesis_state_roots(&store1).unwrap().unwrap();
+    let genesis_state_roots = near_store::get_genesis_state_roots(&store1).unwrap();
 
     // Step 2: Create a new fresh store (equivalent to a deleted data folder)
     let store2 = create_test_store();
@@ -123,9 +123,8 @@ fn test_missing_genesis_congestion_infos_bootstrap() {
 fn check_genesis_congestion_info_in_store(client: &mut Client) {
     client.chain.clear_data(&client.config.gc).unwrap();
 
-    let infos = near_store::get_genesis_congestion_infos(&client.chain.chain_store().store())
-        .unwrap()
-        .unwrap();
+    let infos =
+        near_store::get_genesis_congestion_infos(&client.chain.chain_store().store()).unwrap();
     assert_eq!(infos.len(), NUM_SHARDS);
     for i in 0..NUM_SHARDS {
         assert_eq!(infos[i].buffered_receipts_gas(), 0);

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -720,7 +720,7 @@ impl ForkNetworkCommand {
 
         // 2. Initialize chain and state storage so we can add benchmark
         // accounts there.
-        let prev_state_roots = get_genesis_state_roots(&store)?.unwrap();
+        let prev_state_roots = get_genesis_state_roots(&store).unwrap();
         let shard_uids: Vec<_> = target_shard_layout.shard_uids().collect();
 
         let base_epoch_config_store = EpochConfigStore::test(BTreeMap::from([(

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -479,7 +479,7 @@ impl ReplayController {
     /// Note that there are no chunks in the genesis block, so we directly generate the ChunkExtras
     /// from the information in the genesis block without applying any transactions or receipts.
     fn save_genesis_chunk_extras(&mut self, genesis_block: &Block) -> Result<()> {
-        let state_roots = get_genesis_state_roots(&self.chain_store.store())?
+        let state_roots = get_genesis_state_roots(&self.chain_store.store())
             .ok_or_else(|| anyhow!("genesis state roots do not exist in the db".to_owned()))?;
         let mut store_update = self.chain_store.store_update();
         Chain::save_genesis_chunk_extras(

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -857,8 +857,7 @@ pub(crate) fn view_genesis(
 
     if view_config || compare {
         tracing::info!(target: "state_viewer", "computing genesis from config");
-        let state_roots =
-            near_store::get_genesis_state_roots(&chain_store.store()).unwrap().unwrap();
+        let state_roots = near_store::get_genesis_state_roots(&chain_store.store()).unwrap();
         let (genesis_block, genesis_chunks) = Chain::make_genesis_block(
             epoch_manager.as_ref(),
             runtime_adapter.as_ref(),


### PR DESCRIPTION
- Make `get_genesis_state_roots()` return `Option<Vec<StateRoot>>` directly instead of `io::Result<Option<...>>`
- Make `get_genesis_congestion_infos()` return `Option<Vec<CongestionInfo>>` directly
- Make `get_genesis_height()` return `Option<BlockHeight>` directly
- Update 17 call site files to remove `.unwrap()` / `?` chains
- Remove unused `use std::io` import from `utils/mod.rs`
- These methods only wrapped infallible `store.get_ser()` in `Ok()`

Part of the ongoing store Result cleanup effort.