### PR TITLE
refactor(store): remove Result from GC methods and prev_block_is_caught_up

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2465,9 +2465,9 @@ impl Chain {
         prev_prev_hash: &CryptoHash,
     ) -> Result<(bool, Option<StateSyncInfo>), Error> {
         if !self.epoch_manager.is_next_block_epoch_start(prev_hash)? {
-            return Ok((self.prev_block_is_caught_up(prev_prev_hash, prev_hash)?, None));
+            return Ok((self.prev_block_is_caught_up(prev_prev_hash, prev_hash), None));
         }
-        if !self.prev_block_is_caught_up(prev_prev_hash, prev_hash)? {
+        if !self.prev_block_is_caught_up(prev_prev_hash, prev_hash) {
             // The previous block is not caught up for the next epoch relative to the previous
             // block, which is the current epoch for this block, so this block cannot be applied
             // at all yet, needs to be orphaned
@@ -2492,8 +2492,8 @@ impl Chain {
         &self,
         prev_prev_hash: &CryptoHash,
         prev_hash: &CryptoHash,
-    ) -> Result<bool, Error> {
-        Ok(ChainStore::prev_block_is_caught_up(&self.chain_store, prev_prev_hash, prev_hash)?)
+    ) -> bool {
+        ChainStore::prev_block_is_caught_up(&self.chain_store, prev_prev_hash, prev_hash)
     }
 
     /// Check if any block with missing chunk is ready to be processed and start processing these blocks

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -746,7 +746,7 @@ impl<'a> ChainStoreUpdate<'a> {
         tracing::debug!(target: "garbage_collection", ?gc_mode, ?block_hash, "GC block_hash");
 
         // 1. Garbage collect TrieChanges.
-        self.gc_trie_changes(epoch_manager, block_hash, &gc_mode, &mut store_update)?;
+        self.gc_trie_changes(epoch_manager, block_hash, &gc_mode, &mut store_update);
 
         if matches!(gc_mode, GCMode::Canonical(_)) {
             // If you know why do we do this in case of canonical chain please add a comment here.
@@ -818,14 +818,14 @@ impl<'a> ChainStoreUpdate<'a> {
             self.gc_col(DBCol::StateChanges, &key);
         }
         self.gc_col(DBCol::BlockRefCount, block_hash.as_bytes());
-        self.gc_outcomes(&block)?;
+        self.gc_outcomes(&block);
         match gc_mode {
             GCMode::StateSync { clear_block_info: false } => {}
             _ => self.gc_col(DBCol::BlockInfo, block_hash.as_bytes()),
         }
         self.gc_col(DBCol::StateDlInfos, block_hash.as_bytes());
 
-        self.gc_spice_core_data(&block_hash, &shard_layout)?;
+        self.gc_spice_core_data(&block_hash, &shard_layout);
 
         // 4. Update or delete block_hash_per_height
         self.gc_col_block_per_height(&block_hash, height, block.header().epoch_id())?;
@@ -855,13 +855,9 @@ impl<'a> ChainStoreUpdate<'a> {
         Ok(())
     }
 
-    fn gc_spice_core_data(
-        &mut self,
-        block_hash: &CryptoHash,
-        shard_layout: &ShardLayout,
-    ) -> Result<(), Error> {
+    fn gc_spice_core_data(&mut self, block_hash: &CryptoHash, shard_layout: &ShardLayout) {
         if !cfg!(feature = "protocol_feature_spice") {
-            return Ok(());
+            return;
         }
 
         for shard_id in shard_layout.shard_ids() {
@@ -894,7 +890,6 @@ impl<'a> ChainStoreUpdate<'a> {
             );
         }
         self.gc_col(DBCol::uncertified_chunks(), block_hash.as_ref());
-        Ok(())
     }
 
     fn gc_trie_changes(
@@ -903,7 +898,7 @@ impl<'a> ChainStoreUpdate<'a> {
         block_hash: CryptoHash,
         gc_mode: &GCMode,
         store_update: &mut near_store::adapter::trie_store::TrieStoreUpdateAdapter<'_>,
-    ) -> Result<(), Error> {
+    ) {
         let shard_uids_to_gc = self.get_shard_uids_to_gc(epoch_manager, &block_hash);
         for shard_uid in shard_uids_to_gc {
             let trie_changes_key = get_block_shard_uid(&block_hash, &shard_uid);
@@ -928,7 +923,6 @@ impl<'a> ChainStoreUpdate<'a> {
 
             self.gc_col(DBCol::TrieChanges, &trie_changes_key);
         }
-        Ok(())
     }
 
     // Delete all data in rocksdb that are partially or wholly indexed and can be looked up by hash of the current head of the chain
@@ -1001,7 +995,7 @@ impl<'a> ChainStoreUpdate<'a> {
             self.gc_col(DBCol::StateChanges, &key);
         }
         self.gc_col(DBCol::BlockRefCount, block_hash.as_bytes());
-        self.gc_outcomes(&block)?;
+        self.gc_outcomes(&block);
         self.gc_col(DBCol::BlockInfo, block_hash.as_bytes());
         self.gc_col(DBCol::StateDlInfos, block_hash.as_bytes());
         self.gc_col(DBCol::StateSyncNewChunks, block_hash.as_bytes());
@@ -1111,7 +1105,7 @@ impl<'a> ChainStoreUpdate<'a> {
         self.gc_col(DBCol::ProcessedReceiptIds, &get_block_shard_id(block_hash, shard_id));
     }
 
-    fn gc_outcomes(&mut self, block: &Block) -> Result<(), Error> {
+    fn gc_outcomes(&mut self, block: &Block) {
         let block_hash = block.hash();
         let store_update = self.store().store_update();
         for chunk_header in block.chunks().iter_new() {
@@ -1129,7 +1123,6 @@ impl<'a> ChainStoreUpdate<'a> {
             self.gc_col(DBCol::OutcomeIds, &get_block_shard_id(block_hash, shard_id));
         }
         self.merge(store_update);
-        Ok(())
     }
 
     fn gc_col(&mut self, col: DBCol, key: &[u8]) {

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -807,14 +807,14 @@ impl ChainStore {
         chain_store: &ChainStoreAdapter,
         prev_prev_hash: &CryptoHash,
         prev_hash: &CryptoHash,
-    ) -> Result<bool, Error> {
+    ) -> bool {
         // Needs to be used with care: for the first block of each epoch the semantic is slightly
         // different, since the prev_block is in a different epoch. So for all the blocks but the
         // first one in each epoch this method returns true if the block is ready to have state
         // applied for the next epoch, while for the first block in a particular epoch this method
         // returns true if the block is ready to have state applied for the current epoch (and
         // otherwise should be orphaned)
-        Ok(!chain_store.get_blocks_to_catchup(prev_prev_hash).contains(prev_hash))
+        !chain_store.get_blocks_to_catchup(prev_prev_hash).contains(prev_hash)
     }
 }
 

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -265,7 +265,7 @@ impl ChunkProducer {
             // If we are to start new epoch, check if the previous block is
             // caught up. If it is not the case, we wouldn't be able to
             // apply block with the new chunk, so we also skip chunk production.
-            if !ChainStore::prev_block_is_caught_up(&self.chain, &prev_prev_hash, &prev_block_hash)?
+            if !ChainStore::prev_block_is_caught_up(&self.chain, &prev_prev_hash, &prev_block_hash)
             {
                 tracing::debug!(target: "client", "prev block is not caught up");
                 return Err(Error::ChunkProducer(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -572,7 +572,7 @@ impl Client {
         let prev_hash = prev_header.hash();
         if self.epoch_manager.is_next_block_epoch_start(prev_hash)? {
             let prev_prev_hash = prev_header.prev_hash();
-            if !self.chain.prev_block_is_caught_up(prev_prev_hash, prev_hash)? {
+            if !self.chain.prev_block_is_caught_up(prev_prev_hash, prev_hash) {
                 tracing::debug!(target: "client", height, "skipping block production, prev block is not caught up");
                 return Ok(false);
             }


### PR DESCRIPTION
- Make `gc_trie_changes()` return `()` instead of `Result<(), Error>`
- Make `gc_spice_core_data()` return `()` instead of `Result<(), Error>`
- Make `gc_outcomes()` return `()` instead of `Result<(), Error>`
- Make `ChainStore::prev_block_is_caught_up()` return `bool` directly instead of `Result<bool, Error>`
- Make `Chain::prev_block_is_caught_up()` wrapper infallible accordingly
- These methods had no remaining `?` operators after store core methods became infallible
- Reduces error sources in `clear_block_data()` by 3

Part of the ongoing store Result cleanup effort.