### PR TITLE
refactor(store): remove Result from write_col_misc and related methods

### DIFF
--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -589,11 +589,10 @@ impl ChainStore {
 
     /// Save the latest known.
     /// TODO(store): What is this doing here? Cleanup
-    pub fn save_latest_known(&mut self, latest_known: LatestKnown) -> Result<(), Error> {
+    pub fn save_latest_known(&mut self, latest_known: LatestKnown) {
         let mut store_update = self.store.store().store_update();
         store_update.set_ser(DBCol::BlockMisc, LATEST_KNOWN_KEY, &latest_known);
         store_update.commit();
-        Ok(())
     }
 
     /// Retrieve the kinds of state changes occurred in a given block.
@@ -792,7 +791,7 @@ impl ChainStore {
         &self,
         shard_id: ShardId,
         value: Option<StateSyncDumpProgress>,
-    ) -> Result<(), Error> {
+    ) {
         let mut store_update = self.store.store().store_update();
         let key = ChainStore::state_sync_dump_progress_key(shard_id);
         match value {
@@ -800,7 +799,6 @@ impl ChainStore {
             Some(value) => store_update.set_ser(DBCol::BlockMisc, &key, &value),
         }
         store_update.commit();
-        Ok(())
     }
 
     pub fn prev_block_is_caught_up(
@@ -1566,7 +1564,7 @@ impl<'a> ChainStoreUpdate<'a> {
         let latest_known = self.chain_store.get_latest_known().ok();
         if latest_known.is_none() || height > latest_known.unwrap().height {
             self.chain_store
-                .save_latest_known(LatestKnown { height, seen: to_timestamp(Utc::now()) })?;
+                .save_latest_known(LatestKnown { height, seen: to_timestamp(Utc::now()) });
         }
         Ok(())
     }
@@ -1575,8 +1573,7 @@ impl<'a> ChainStoreUpdate<'a> {
     pub fn adv_save_latest_known(&mut self, height: BlockHeight) -> Result<(), Error> {
         let header = self.get_block_header_by_height(height)?;
         let tip = Tip::from_header(&header);
-        self.chain_store
-            .save_latest_known(LatestKnown { height, seen: to_timestamp(Utc::now()) })?;
+        self.chain_store.save_latest_known(LatestKnown { height, seen: to_timestamp(Utc::now()) });
         self.save_head(&tip)?;
         Ok(())
     }
@@ -1851,11 +1848,10 @@ impl<'a> ChainStoreUpdate<'a> {
         store_update: &mut StoreUpdate,
         key: &[u8],
         value: &mut Option<T>,
-    ) -> Result<(), Error> {
+    ) {
         if let Some(t) = value.take() {
             store_update.set_ser(DBCol::BlockMisc, key, &t);
         }
-        Ok(())
     }
 
     #[tracing::instrument(level = "debug", target = "store", "ChainUpdate::finalize", skip_all)]
@@ -1863,28 +1859,28 @@ impl<'a> ChainStoreUpdate<'a> {
         let mut store_update = self.store().store_update();
         {
             let _span = tracing::trace_span!(target: "store", "write_col_misc").entered();
-            Self::write_col_misc(&mut store_update, HEAD_KEY, &mut self.head)?;
-            Self::write_col_misc(&mut store_update, TAIL_KEY, &mut self.tail)?;
-            Self::write_col_misc(&mut store_update, CHUNK_TAIL_KEY, &mut self.chunk_tail)?;
-            Self::write_col_misc(&mut store_update, FORK_TAIL_KEY, &mut self.fork_tail)?;
-            Self::write_col_misc(&mut store_update, HEADER_HEAD_KEY, &mut self.header_head)?;
-            Self::write_col_misc(&mut store_update, FINAL_HEAD_KEY, &mut self.final_head)?;
+            Self::write_col_misc(&mut store_update, HEAD_KEY, &mut self.head);
+            Self::write_col_misc(&mut store_update, TAIL_KEY, &mut self.tail);
+            Self::write_col_misc(&mut store_update, CHUNK_TAIL_KEY, &mut self.chunk_tail);
+            Self::write_col_misc(&mut store_update, FORK_TAIL_KEY, &mut self.fork_tail);
+            Self::write_col_misc(&mut store_update, HEADER_HEAD_KEY, &mut self.header_head);
+            Self::write_col_misc(&mut store_update, FINAL_HEAD_KEY, &mut self.final_head);
             Self::write_col_misc(
                 &mut store_update,
                 SPICE_FINAL_EXECUTION_HEAD_KEY,
                 &mut self.spice_final_execution_head,
-            )?;
+            );
             Self::write_col_misc(
                 &mut store_update,
                 SPICE_EXECUTION_HEAD_KEY,
                 &mut self.spice_execution_head,
-            )?;
+            );
             Self::write_col_misc(
                 &mut store_update,
                 LARGEST_TARGET_HEIGHT_KEY,
                 &mut self.largest_target_height,
-            )?;
-            Self::write_col_misc(&mut store_update, GC_STOP_HEIGHT_KEY, &mut self.gc_stop_height)?;
+            );
+            Self::write_col_misc(&mut store_update, GC_STOP_HEIGHT_KEY, &mut self.gc_stop_height);
         }
         {
             let _span = tracing::trace_span!(target: "store", "write_block").entered();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1020,7 +1020,7 @@ impl Client {
         // Update latest known even before returning block out, to prevent race conditions.
         self.chain
             .mut_chain_store()
-            .save_latest_known(LatestKnown { height, seen: block.header().raw_timestamp() })?;
+            .save_latest_known(LatestKnown { height, seen: block.header().raw_timestamp() });
 
         metrics::BLOCK_PRODUCED_TOTAL.inc();
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1104,7 +1104,7 @@ impl ClientActor {
             if let Some(new_latest_known) =
                 self.sandbox_process_fast_forward(latest_known.height)?
             {
-                self.client.chain.mut_chain_store().save_latest_known(new_latest_known)?;
+                self.client.chain.mut_chain_store().save_latest_known(new_latest_known);
                 self.client.sandbox_update_tip(new_latest_known.height)?;
             }
         }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2725,27 +2725,19 @@ fn test_discard_non_finalizable_block() {
     env.process_block(0, first_block.clone(), Provenance::PRODUCED);
     // Produce, but not process test block on top of block (1).
     let non_finalizable_block = env.clients[0].produce_block(6).unwrap().unwrap();
-    env.clients[0]
-        .chain
-        .mut_chain_store()
-        .save_latest_known(LatestKnown {
-            height: first_block.header().height(),
-            seen: first_block.header().raw_timestamp(),
-        })
-        .unwrap();
+    env.clients[0].chain.mut_chain_store().save_latest_known(LatestKnown {
+        height: first_block.header().height(),
+        seen: first_block.header().raw_timestamp(),
+    });
 
     let second_block = env.clients[0].produce_block(2).unwrap().unwrap();
     env.process_block(0, second_block.clone(), Provenance::PRODUCED);
     // Produce, but not process test block on top of block (2).
     let finalizable_block = env.clients[0].produce_block(7).unwrap().unwrap();
-    env.clients[0]
-        .chain
-        .mut_chain_store()
-        .save_latest_known(LatestKnown {
-            height: second_block.header().height(),
-            seen: second_block.header().raw_timestamp(),
-        })
-        .unwrap();
+    env.clients[0].chain.mut_chain_store().save_latest_known(LatestKnown {
+        height: second_block.header().height(),
+        seen: second_block.header().raw_timestamp(),
+    });
 
     // Produce and process two more blocks.
     for i in 3..5 {
@@ -2826,14 +2818,10 @@ fn test_query_final_state() {
         };
 
     let fork1_block = env.clients[0].produce_block(5).unwrap().unwrap();
-    env.clients[0]
-        .chain
-        .mut_chain_store()
-        .save_latest_known(LatestKnown {
-            height: blocks.last().unwrap().header().height(),
-            seen: blocks.last().unwrap().header().raw_timestamp(),
-        })
-        .unwrap();
+    env.clients[0].chain.mut_chain_store().save_latest_known(LatestKnown {
+        height: blocks.last().unwrap().header().height(),
+        seen: blocks.last().unwrap().header().raw_timestamp(),
+    });
     let fork2_block = env.clients[0].produce_block(6).unwrap().unwrap();
     assert_eq!(fork1_block.header().prev_hash(), fork2_block.header().prev_hash());
     env.process_block(0, fork1_block, Provenance::NONE);
@@ -3123,14 +3111,10 @@ fn test_block_ordinal() {
     ordinal += 1;
     assert_eq!(last_block.header().block_ordinal(), ordinal);
     let fork1_block = env.clients[0].produce_block(100).unwrap().unwrap();
-    env.clients[0]
-        .chain
-        .mut_chain_store()
-        .save_latest_known(LatestKnown {
-            height: last_block.header().height(),
-            seen: last_block.header().raw_timestamp(),
-        })
-        .unwrap();
+    env.clients[0].chain.mut_chain_store().save_latest_known(LatestKnown {
+        height: last_block.header().height(),
+        seen: last_block.header().raw_timestamp(),
+    });
     let fork2_block = env.clients[0].produce_block(101).unwrap().unwrap();
     assert_eq!(fork1_block.header().prev_hash(), fork2_block.header().prev_hash());
     env.process_block(0, fork1_block.clone(), Provenance::NONE);

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -87,7 +87,7 @@ impl StateSyncDumper {
         .unwrap();
         if let Some(shards) = dump_config.restart_dump_for_shards.as_ref() {
             for shard_id in shards {
-                chain.chain_store().set_state_sync_dump_progress(*shard_id, None).unwrap();
+                chain.chain_store().set_state_sync_dump_progress(*shard_id, None);
                 tracing::debug!(target: "state_sync_dump", %shard_id, "dropped existing progress");
             }
         }
@@ -603,10 +603,7 @@ impl StateDumper {
             let (shard_id, (dumped_epoch_id, done)) =
                 res.context("failed iterating over stored dump progress")?;
             if &dumped_epoch_id != epoch_id {
-                self.chain
-                    .chain_store()
-                    .set_state_sync_dump_progress(shard_id, None)
-                    .context("failed setting state dump progress")?;
+                self.chain.chain_store().set_state_sync_dump_progress(shard_id, None);
             } else if done {
                 dump.dump_state.remove(&shard_id);
                 senders.remove(&shard_id);
@@ -801,17 +798,14 @@ impl StateDumper {
     /// with the info and progress represented in `dump`.
     fn new_dump(&mut self, dump: DumpState, sync_hash: CryptoHash) -> anyhow::Result<()> {
         for (shard_id, _) in &dump.dump_state {
-            self.chain
-                .chain_store()
-                .set_state_sync_dump_progress(
-                    *shard_id,
-                    Some(StateSyncDumpProgress::InProgress {
-                        epoch_id: dump.epoch_id,
-                        epoch_height: dump.epoch_height,
-                        sync_hash,
-                    }),
-                )
-                .context("failed setting state dump progress")?;
+            self.chain.chain_store().set_state_sync_dump_progress(
+                *shard_id,
+                Some(StateSyncDumpProgress::InProgress {
+                    epoch_id: dump.epoch_id,
+                    epoch_height: dump.epoch_height,
+                    sync_hash,
+                }),
+            );
         }
         self.current_dump = CurrentDump::InProgress(dump);
         Ok(())
@@ -864,16 +858,13 @@ impl StateDumper {
             }
         }
 
-        self.chain
-            .chain_store()
-            .set_state_sync_dump_progress(
-                shard_id,
-                Some(StateSyncDumpProgress::AllDumped {
-                    epoch_id: dump.epoch_id,
-                    epoch_height: dump.epoch_height,
-                }),
-            )
-            .context("failed setting state dump progress")?;
+        self.chain.chain_store().set_state_sync_dump_progress(
+            shard_id,
+            Some(StateSyncDumpProgress::AllDumped {
+                epoch_id: dump.epoch_id,
+                epoch_height: dump.epoch_height,
+            }),
+        );
 
         if dump.dump_state.is_empty() {
             self.current_dump = CurrentDump::Done(dump.epoch_id);

--- a/tools/undo-block/src/lib.rs
+++ b/tools/undo-block/src/lib.rs
@@ -33,10 +33,8 @@ pub fn undo_block(
 
     chain_store_update.commit()?;
 
-    chain_store.save_latest_known(LatestKnown {
-        height: prev_tip.height,
-        seen: to_timestamp(Utc::now()),
-    })?;
+    chain_store
+        .save_latest_known(LatestKnown { height: prev_tip.height, seen: to_timestamp(Utc::now()) });
 
     let new_chain_store_head = chain_store.head()?;
     let new_chain_store_header_head = chain_store.header_head()?;


### PR DESCRIPTION
- Make `write_col_misc()` return `()`, removing **10 `?` operators** from `finalize()`
- Make `save_latest_known()` return `()` instead of `Result<(), Error>`
- Make `set_state_sync_dump_progress()` return `()` instead of `Result<(), Error>`
- Make `on_new_epoch()` return `()` instead of `Result<(), Error>`
- `write_col_misc()` was the dominant error source in `finalize()`, which is called
  by `ChainStoreUpdate::commit()` — this is the highest-value single change for
  unblocking the `finalize() → commit()` chain
- After this change, `finalize()` has only 1 remaining `?` (`update_sync_hashes()`)
  plus 3 explicit `return Err()` in catchup blocks

Part of the ongoing store Result cleanup effort.