### PR TITLE
refactor(store): remove Result from scattered ready functions

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1737,7 +1737,7 @@ impl Chain {
 
         if self.epoch_manager.is_next_block_epoch_start(block.header().prev_hash())? {
             // This is the end of the epoch. Next epoch we will generate new state parts. We can drop the old ones.
-            self.clear_all_downloaded_parts()?;
+            self.clear_all_downloaded_parts();
         }
 
         // 2) Start creating snapshot if needed.
@@ -2602,13 +2602,12 @@ impl Chain {
     }
 
     /// Drop all downloaded or generated state parts and headers.
-    pub fn clear_all_downloaded_parts(&mut self) -> Result<(), Error> {
+    pub fn clear_all_downloaded_parts(&mut self) {
         tracing::debug!(target: "state_sync", "clear old state parts");
         let mut store_update = self.chain_store.store().store_update();
         store_update.delete_all(DBCol::StateParts);
         store_update.delete_all(DBCol::StateHeaders);
         store_update.commit();
-        Ok(())
     }
 
     pub fn catchup_blocks_step(

--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -185,7 +185,7 @@ impl FlatStorageResharder {
                     // On resume, flat storage status is already set correctly and read from DB.
                     // Thus, we don't need to care about cancelling other existing resharding events.
                     // Children are not both ready, so we need to clean them and restart resharding.
-                    self.clean_children_shards(&status)?;
+                    self.clean_children_shards(&status);
                     self.start_resharding_blocking_impl(parent_shard_uid, status);
                 }
             }
@@ -248,7 +248,7 @@ impl FlatStorageResharder {
         skip_all,
         fields(left_child_shard = ?status.left_child_shard, right_child_shard = ?status.right_child_shard)
     )]
-    fn clean_children_shards(&self, status: &ParentSplitParameters) -> Result<(), Error> {
+    fn clean_children_shards(&self, status: &ParentSplitParameters) {
         let ParentSplitParameters { left_child_shard, right_child_shard, .. } = status;
         tracing::info!(target: "resharding", ?left_child_shard, ?right_child_shard, "cleaning up children shards flat storage's content");
         let mut store_update = self.runtime.store().flat_store().store_update();
@@ -256,7 +256,6 @@ impl FlatStorageResharder {
             store_update.remove_all_values(*child);
         }
         store_update.commit();
-        Ok(())
     }
 
     /// Task to perform the actual split of a flat storage shard. This may be a long operation

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -118,7 +118,7 @@ impl TrieStateResharder {
         let resharder = Self { runtime, handle, resharding_config };
         if resume_allowed == ResumeAllowed::No {
             // Load the status to check if resharding is in progress
-            if let Some(status) = resharder.load_status().unwrap() {
+            if let Some(status) = resharder.load_status() {
                 panic!(
                     "TrieStateReshardingStatus already exists for shard {}, must run resume_resharding to continue interrupted resharding operation before starting node.",
                     status.parent_shard_uid
@@ -240,11 +240,10 @@ impl TrieStateResharder {
         Ok(next_key)
     }
 
-    fn load_status(&self) -> Result<Option<TrieStateReshardingStatus>, Error> {
-        Ok(self
-            .runtime
+    fn load_status(&self) -> Option<TrieStateReshardingStatus> {
+        self.runtime
             .store()
-            .get_ser::<TrieStateReshardingStatus>(DBCol::Misc, TRIE_STATE_RESHARDING_STATUS_KEY))
+            .get_ser::<TrieStateReshardingStatus>(DBCol::Misc, TRIE_STATE_RESHARDING_STATUS_KEY)
     }
 
     /// Initializes the trie state resharding status for a new resharding operation.
@@ -255,7 +254,7 @@ impl TrieStateResharder {
         &self,
         event: &ReshardingSplitShardParams,
     ) -> Result<(), Error> {
-        if let Some(status) = self.load_status()? {
+        if let Some(status) = self.load_status() {
             panic!(
                 "TrieStateReshardingStatus already exists for shard {}, cannot start a new resharding operation. Run resume_resharding to continue.",
                 status.parent_shard_uid
@@ -326,7 +325,7 @@ impl TrieStateResharder {
         &self,
         event: &ReshardingSplitShardParams,
     ) -> Result<(), Error> {
-        let Some(status) = self.load_status()? else {
+        let Some(status) = self.load_status() else {
             panic!(
                 "TrieStateReshardingStatus not found. Have we called initialize_trie_state_resharding_status?"
             );
@@ -340,7 +339,7 @@ impl TrieStateResharder {
 
     /// Resume an interrupted resharding operation.
     pub fn resume(&self, parent_shard_uid: ShardUId) -> Result<(), Error> {
-        let Some(status) = self.load_status()? else {
+        let Some(status) = self.load_status() else {
             tracing::info!(target: "resharding", "resharding status not found, nothing to resume");
             return Ok(());
         };
@@ -723,7 +722,7 @@ mod tests {
         let mut update_status = test.as_status();
         resharder.resharding_blocking_impl(&mut update_status).unwrap();
         // The resharding status should be None after completion.
-        assert!(resharder.load_status().unwrap().is_none());
+        assert!(resharder.load_status().is_none());
         check_child_tries_contain_all_keys(&test);
         // StateShardUIdMapping should be removed after resharding.
         assert_eq!(0, test.runtime.store().iter(DBCol::StateShardUIdMapping).count());
@@ -765,10 +764,8 @@ mod tests {
 
         resharder.process_batch_and_update_status(&mut update_status, !missing_memtries).unwrap();
 
-        let got_status = resharder
-            .load_status()
-            .unwrap()
-            .expect("status should not be empty after processing one batch");
+        let got_status =
+            resharder.load_status().expect("status should not be empty after processing one batch");
         assert_eq!(update_status, got_status);
         // The persisted status should indicate continuing from the expected next key,
         // which is the first key in the left child.
@@ -813,7 +810,7 @@ mod tests {
         }
 
         // The resharding status should be None after completion.
-        assert!(resharder.load_status().unwrap().is_none());
+        assert!(resharder.load_status().is_none());
         check_child_tries_contain_all_keys(&test);
         // StateShardUIdMapping should be removed after resharding.
         assert_eq!(0, test.runtime.store().iter(DBCol::StateShardUIdMapping).count());

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -83,7 +83,7 @@ impl StateSnapshotActor {
     ) -> anyhow::Result<bool> {
         let shard_uids = shard_indexes_and_uids.iter().map(|(_idx, uid)| *uid);
         let Some(min_height) =
-            self.flat_storage_manager.resharding_catchup_height_reached(shard_uids)?
+            self.flat_storage_manager.resharding_catchup_height_reached(shard_uids)
         else {
             // No flat storage split + catchup is in progress, ok to proceed
             return Ok(false);

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -10,11 +10,8 @@ use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::{DBCol, Store, StoreUpdate};
 use std::sync::Arc;
 
-fn get_state_sync_new_chunks(
-    store: &Store,
-    block_hash: &CryptoHash,
-) -> Result<Option<Vec<u8>>, Error> {
-    Ok(store.get_ser(DBCol::StateSyncNewChunks, block_hash.as_ref()))
+fn get_state_sync_new_chunks(store: &Store, block_hash: &CryptoHash) -> Option<Vec<u8>> {
+    store.get_ser(DBCol::StateSyncNewChunks, block_hash.as_ref())
 }
 
 fn iter_state_sync_hashes_keys<'a>(
@@ -30,7 +27,7 @@ fn save_epoch_new_chunks<T: ChainStoreAccess>(
     header: &BlockHeader,
 ) -> Result<bool, Error> {
     let Some(mut num_new_chunks) =
-        get_state_sync_new_chunks(&chain_store.store(), header.prev_hash())?
+        get_state_sync_new_chunks(&chain_store.store(), header.prev_hash())
     else {
         // This might happen in the case of epoch sync where we save individual headers without having all
         // headers that belong to the epoch.
@@ -99,7 +96,7 @@ fn maybe_get_block_header<T: ChainStoreAccess>(
 }
 
 fn has_enough_new_chunks(store: &Store, block_hash: &CryptoHash) -> Result<Option<bool>, Error> {
-    let Some(num_new_chunks) = get_state_sync_new_chunks(store, block_hash)? else {
+    let Some(num_new_chunks) = get_state_sync_new_chunks(store, block_hash) else {
         // This might happen in the case of epoch sync where we save individual headers without having all
         // headers that belong to the epoch.
         return Ok(None);
@@ -224,14 +221,14 @@ pub(crate) fn is_sync_prev_hash(chain_store: &ChainStoreAdapter, tip: &Tip) -> R
         return Ok(sync_header.prev_hash() == &tip.last_block_hash);
     }
     let store = chain_store.store_ref();
-    let Some(new_chunks) = get_state_sync_new_chunks(store, &tip.last_block_hash)? else {
+    let Some(new_chunks) = get_state_sync_new_chunks(store, &tip.last_block_hash) else {
         return Ok(false);
     };
     let done = new_chunks.iter().all(|num_chunks| *num_chunks >= 2);
     if !done {
         return Ok(false);
     }
-    let Some(prev_new_chunks) = get_state_sync_new_chunks(store, &tip.prev_block_hash)? else {
+    let Some(prev_new_chunks) = get_state_sync_new_chunks(store, &tip.prev_block_hash) else {
         return Ok(false);
     };
     let prev_done = prev_new_chunks.iter().all(|num_chunks| *num_chunks >= 2);

--- a/chain/chain/src/stateless_validation/metrics.rs
+++ b/chain/chain/src/stateless_validation/metrics.rs
@@ -202,16 +202,6 @@ pub fn record_witness_size_metrics(
     encoded_size: usize,
     witness: &ChunkStateWitness,
 ) {
-    if let Err(err) = record_witness_size_metrics_fallible(decoded_size, encoded_size, witness) {
-        tracing::warn!(target: "client", ?err, "failed to record witness size metrics");
-    }
-}
-
-fn record_witness_size_metrics_fallible(
-    decoded_size: usize,
-    encoded_size: usize,
-    witness: &ChunkStateWitness,
-) -> Result<(), std::io::Error> {
     let shard_id = witness.chunk_header().shard_id().to_string();
     CHUNK_STATE_WITNESS_RAW_SIZE
         .with_label_values(&[shard_id.as_str()])
@@ -225,7 +215,6 @@ fn record_witness_size_metrics_fallible(
     CHUNK_STATE_WITNESS_SOURCE_RECEIPT_PROOFS_SIZE
         .with_label_values(&[&shard_id.as_str()])
         .observe(borsh::object_length(&witness.source_receipt_proofs()).unwrap() as f64);
-    Ok(())
 }
 
 /// Buckets from 0 to 10MB

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -278,7 +278,7 @@ impl FlatStorageManager {
     pub fn resharding_catchup_height_reached(
         &self,
         shard_uids: impl Iterator<Item = ShardUId>,
-    ) -> Result<Option<Option<BlockHeight>>, StorageError> {
+    ) -> Option<Option<BlockHeight>> {
         let mut ret = None;
         for shard_uid in shard_uids {
             match self.0.store.get_flat_storage_status(shard_uid) {
@@ -291,11 +291,11 @@ impl FlatStorageManager {
                         ret = Some(Some(flat_head.height));
                     }
                 }
-                FlatStorageStatus::Resharding(_) => return Ok(Some(None)),
+                FlatStorageStatus::Resharding(_) => return Some(None),
                 _ => {}
             };
         }
-        Ok(ret)
+        ret
     }
 
     /// Should be called when we want to take a state snapshot. Disallows flat head updates, and signals to any resharding


### PR DESCRIPTION
- Make `Chain::clear_all_downloaded_parts()` return `()` instead of `Result<(), Error>`
- Make `FlatStorageResharder::clean_children_shards()` return `()` instead of `Result<(), Error>`
- Make `get_state_sync_new_chunks()` return `Option<Vec<u8>>` directly
- Make `TrieStateResharder::load_status()` return `Option<TrieStateReshardingStatus>` directly
- Make `resharding_catchup_height_reached()` return `Option<Option<BlockHeight>>` directly
- Inline `record_witness_size_metrics_fallible()` into `record_witness_size_metrics()` (function removed)
- These are the remaining ready functions across different files

Part of the ongoing store Result cleanup effort.