### PR TITLE
feat(cloud-archive): extend epoch data for reader bootstrap

### DIFF
--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -254,15 +254,16 @@ impl CloudArchivalWriter {
     async fn archive_data(&self, height: BlockHeight) -> Result<(), CloudArchivingError> {
         let block_hash = self.hot_store.chain_store().get_block_hash_by_height(height)?;
         let epoch_id = self.epoch_manager.get_epoch_id(&block_hash)?;
-        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         let tracked_shards =
             self.shard_tracker.get_tracked_shards_for_non_validator_in_epoch(&epoch_id)?;
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
 
         if self.epoch_manager.is_next_block_epoch_start(&block_hash)? {
             self.cloud_storage.archive_epoch_data(&self.hot_store, &shard_layout, epoch_id).await?;
         }
 
         self.cloud_storage.archive_block_data(&self.hot_store, height).await?;
+
         for shard_uid in tracked_shards {
             self.cloud_storage
                 .archive_shard_data(

--- a/core/store/src/archive/cloud_storage/archive.rs
+++ b/core/store/src/archive/cloud_storage/archive.rs
@@ -50,7 +50,7 @@ impl CloudStorage {
     ) -> Result<(), CloudArchivingError> {
         let epoch_data = build_epoch_data(hot_store, shard_layout.clone(), epoch_id)?;
         let file_id = CloudStorageFileID::Epoch(epoch_id);
-        let blob = borsh::to_vec(&epoch_data).unwrap();
+        let blob = borsh::to_vec(&epoch_data)?;
         self.upload(file_id, blob).await
     }
 

--- a/core/store/src/archive/cloud_storage/block_data.rs
+++ b/core/store/src/archive/cloud_storage/block_data.rs
@@ -50,4 +50,10 @@ impl BlockData {
             BlockData::V1(data) => &data.block,
         }
     }
+
+    pub fn block_info(&self) -> &BlockInfo {
+        match self {
+            BlockData::V1(data) => &data.block_info,
+        }
+    }
 }

--- a/core/store/src/archive/cloud_storage/epoch_data.rs
+++ b/core/store/src/archive/cloud_storage/epoch_data.rs
@@ -1,6 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_chain_primitives::Error;
 use near_primitives::epoch_info::EpochInfo;
+use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{BlockHeight, EpochId};
 use near_schema_checker_lib::ProtocolSchema;
@@ -18,10 +19,15 @@ pub enum EpochData {
 pub struct EpochDataV1 {
     /// Read from `DBCol::EpochInfo`.
     epoch_info: EpochInfo,
-    /// Read from `DBCol::EpochStart`.
-    epoch_start: BlockHeight,
     /// Provided by the caller of `build_epoch_data`.
+    /// From `EpochInfoV5`, this data is already part of `EpochInfo`.
     shard_layout: ShardLayout,
+    /// Read from `DBCol::EpochStart` and `DBCol::BlockHeight`.
+    epoch_start_height: BlockHeight,
+    /// Read from `DBCol::BlockMerkleTree`.
+    epoch_start_prev_block_merkle_tree: PartialMerkleTree,
+    /// Read from `DBCol::StateSyncHashes` and `DBCol::BlockHeight`.
+    sync_block_height: BlockHeight,
 }
 
 /// Builds an `EpochData` object for the given epoch ID by reading data from the store.
@@ -32,21 +38,56 @@ pub fn build_epoch_data(
 ) -> Result<EpochData, Error> {
     let store = store.epoch_store();
     let epoch_info = store.get_epoch_info(&epoch_id)?;
-    let epoch_start = store.get_epoch_start(&epoch_id)?;
-    let epoch_data = EpochDataV1 { epoch_info, epoch_start, shard_layout };
+    let epoch_start_height = store.get_epoch_start(&epoch_id)?;
+
+    let store = store.chain_store();
+    let epoch_start_block_hash = store.get_block_hash_by_height(epoch_start_height)?;
+    let epoch_start_block = store.get_block(&epoch_start_block_hash)?;
+    let sync_block_hash = store
+        .chain_store()
+        .get_current_epoch_sync_hash(&epoch_id)
+        .ok_or_else(|| Error::DBNotFoundErr(format!("StateSyncHashes, epoch ID: {epoch_id:?}")))?;
+    let sync_block_height = store.get_block_height(&sync_block_hash)?;
+    let epoch_start_prev_block_merkle_tree =
+        store.get_block_merkle_tree(epoch_start_block.header().prev_hash())?;
+    let epoch_data = EpochDataV1 {
+        epoch_info,
+        shard_layout,
+        epoch_start_height,
+        epoch_start_prev_block_merkle_tree,
+        sync_block_height,
+    };
     Ok(EpochData::V1(epoch_data))
 }
 
 impl EpochData {
-    pub fn epoch_start(&self) -> &BlockHeight {
+    pub fn epoch_info(&self) -> &EpochInfo {
         match self {
-            EpochData::V1(data) => &data.epoch_start,
+            EpochData::V1(data) => &data.epoch_info,
+        }
+    }
+
+    pub fn epoch_start_height(&self) -> &BlockHeight {
+        match self {
+            EpochData::V1(data) => &data.epoch_start_height,
         }
     }
 
     pub fn shard_layout(&self) -> &ShardLayout {
         match self {
             EpochData::V1(data) => &data.shard_layout,
+        }
+    }
+
+    pub fn sync_block_height(&self) -> &BlockHeight {
+        match self {
+            EpochData::V1(data) => &data.sync_block_height,
+        }
+    }
+
+    pub fn epoch_start_prev_block_merkle_tree(&self) -> &PartialMerkleTree {
+        match self {
+            EpochData::V1(data) => &data.epoch_start_prev_block_merkle_tree,
         }
     }
 }

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -1,9 +1,10 @@
 use std::io::{Error, Result};
 
 use near_external_storage::ExternalConnection;
-use near_primitives::types::{BlockHeight, EpochId, ShardId};
+use near_primitives::state_sync::ShardStateSyncResponseHeader;
+use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 
-use crate::archive::cloud_storage::block_data::BlockData;
+pub use crate::archive::cloud_storage::block_data::BlockData;
 use crate::archive::cloud_storage::epoch_data::EpochData;
 use crate::archive::cloud_storage::shard_data::ShardData;
 
@@ -26,6 +27,25 @@ pub struct CloudStorage {
 }
 
 impl CloudStorage {
+    pub fn connection(&self) -> &ExternalConnection {
+        &self.external
+    }
+
+    pub fn chain_id(&self) -> &str {
+        &self.chain_id
+    }
+
+    pub fn get_state_header(
+        &self,
+        epoch_height: EpochHeight,
+        epoch_id: EpochId,
+        shard_id: ShardId,
+    ) -> Result<ShardStateSyncResponseHeader> {
+        let fut = self.retrieve_state_header(epoch_height, epoch_id, shard_id);
+        let state_header = block_on_future(fut).map_err(Error::other)?;
+        Ok(state_header)
+    }
+
     pub fn get_epoch_data(&self, epoch_id: EpochId) -> Result<EpochData> {
         let epoch_data =
             block_on_future(self.retrieve_epoch_data(epoch_id)).map_err(Error::other)?;

--- a/core/store/src/archive/cloud_storage/shard_data.rs
+++ b/core/store/src/archive/cloud_storage/shard_data.rs
@@ -153,4 +153,16 @@ impl ShardData {
             ShardData::V1(data) => &data.chunk,
         }
     }
+
+    pub fn state_changes(&self) -> &[RawStateChangesWithTrieKey] {
+        match self {
+            ShardData::V1(data) => &data.state_changes,
+        }
+    }
+
+    pub fn chunk_extra(&self) -> &ChunkExtra {
+        match self {
+            ShardData::V1(data) => &data.chunk_extra,
+        }
+    }
 }


### PR DESCRIPTION
Extend EpochDataV1 with fields needed to bootstrap a reader node from cloud storage.