### PR TITLE
refactor(test-loop): make TestLoopNode read-only

### DIFF
--- a/test-loop-tests/README.md
+++ b/test-loop-tests/README.md
@@ -73,7 +73,7 @@ env.validator_runner().run_until_head_height(10);
 ```
 
 `NodeRunner::run_until` can be used to progress the blockchain until a
-condition is met. The condition closure receives a `&mut TestLoopNode` for
+condition is met. The condition closure receives a `&TestLoopNode` for
 the associated node:
 
 ```rust

--- a/test-loop-tests/src/tests/continuous_epoch_sync.rs
+++ b/test-loop-tests/src/tests/continuous_epoch_sync.rs
@@ -97,7 +97,7 @@ fn test_epoch_sync_proof_update_with_forks() {
     let height_selection = AdvProduceBlockHeightSelection::NextHeightOnSelectedBlock {
         base_block_height: head.height - 1,
     };
-    env.validator().client_actor().adv_produce_blocks_on(3, true, height_selection);
+    env.client_actor(0).adv_produce_blocks_on(3, true, height_selection);
 
     // verify proof after processing fork
     {

--- a/test-loop-tests/src/tests/processed_receipts_gc.rs
+++ b/test-loop-tests/src/tests/processed_receipts_gc.rs
@@ -120,7 +120,7 @@ fn test_processed_receipt_ids_gc() {
     );
 
     #[cfg(feature = "test_features")]
-    env.validator().validate_store();
+    env.validate_store(0);
 
     // Run enough epochs for GC to clean up the receipts.
     let num_blocks = EPOCH_LENGTH * GC_NUM_EPOCHS_TO_KEEP + 1;

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -91,7 +91,7 @@ fn test_spice_chain() {
     let client = &test_loop.data.get(&client_handles[0]).client;
     let epoch_manager = client.epoch_manager.clone();
 
-    let get_balance = |test_loop_data: &mut TestLoopData, account: &AccountId, epoch_id| {
+    let get_balance = |test_loop_data: &TestLoopData, account: &AccountId, epoch_id| {
         let shard_id = shard_layout.account_id_to_shard_id(account);
         let cp =
             &epoch_manager.get_epoch_chunk_producers_for_shard(&epoch_id, shard_id).unwrap()[0];
@@ -102,7 +102,7 @@ fn test_spice_chain() {
 
     let epoch_id = client.chain.head().unwrap().epoch_id;
     for account in &accounts {
-        let got_balance = get_balance(&mut test_loop.data, account, epoch_id);
+        let got_balance = get_balance(&test_loop.data, account, epoch_id);
         assert_eq!(got_balance, INITIAL_BALANCE);
     }
 
@@ -147,7 +147,7 @@ fn test_spice_chain() {
 
     assert!(!balance_changes.is_empty());
     for (account, balance_change) in &balance_changes {
-        let got_balance = get_balance(&mut test_loop.data, account, epoch_id);
+        let got_balance = get_balance(&test_loop.data, account, epoch_id);
         let want_balance = Balance::from_yoctonear(
             (INITIAL_BALANCE.as_yoctonear() as i128 + balance_change).try_into().unwrap(),
         );

--- a/test-loop-tests/src/tests/view_requests.rs
+++ b/test-loop-tests/src/tests/view_requests.rs
@@ -61,8 +61,8 @@ fn test_access_key_changes_includes_gas_key_nonces() {
     let tx_block_hash = outcome.transaction_outcome.block_hash;
     let tx_block_header = env.rpc_node().client().chain.get_block_header(&tx_block_hash).unwrap();
     env.rpc_runner().run_until_block_executed(&tx_block_header, Duration::seconds(10));
-    let mut rpc = env.rpc_node();
-    let view_client = rpc.view_client_actor();
+    let rpc_idx = env.rpc_data_idx();
+    let view_client = env.view_client_actor(rpc_idx);
 
     // Test AllAccessKey changes request
     let state_changes = view_client

--- a/test-loop-tests/src/tests/yield_timeouts.rs
+++ b/test-loop-tests/src/tests/yield_timeouts.rs
@@ -588,7 +588,7 @@ fn test_skip_timeout_height() {
     // We still expect the timeout to be processed and produce a YieldResume receipt.
     assert_eq!(env.validator().head().height, YIELD_TIMEOUT_HEIGHT - 1);
     // Produce block at YIELD_TIMEOUT_HEIGHT+1 using the one at YIELD_TIMEOUT_HEIGHT-1 as the previous block.
-    env.validator().client_actor().adv_produce_blocks_on(
+    env.client_actor(0).adv_produce_blocks_on(
         1,
         true,
         near_client::client_actor::AdvProduceBlockHeightSelection::SelectedHeightOnLatestKnown {


### PR DESCRIPTION
- Change `TestLoopNode` to hold `&TestLoopData` instead of `&mut TestLoopData`, making it a genuinely read-only view
- Move `client_actor()`, `view_client_actor()`, and `validate_store()` to `TestLoopEnv` since they are the only methods requiring mutable access (4 call sites total)
- `env.validator()` / `env.rpc_node()` / `env.node()` now take `&self` instead of `&mut self`
- `run_until` closures receive `&TestLoopNode` instead of `&mut TestLoopNode`