### PR TITLE
refactor(store): remove Result from chain store and state sync methods

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -458,7 +458,7 @@ impl ChainStore {
         }
 
         let mut chain_store_update = self.store_update();
-        chain_store_update.clear_redundant_chunk_data(gc_stop_height, gc_height_limit)?;
+        chain_store_update.clear_redundant_chunk_data(gc_stop_height, gc_height_limit);
         metrics::CHUNK_TAIL_HEIGHT.set(chain_store_update.chunk_tail() as i64);
         metrics::GC_STOP_HEIGHT.set(gc_stop_height as i64);
         chain_store_update.commit()
@@ -687,7 +687,7 @@ impl<'a> ChainStoreUpdate<'a> {
         &mut self,
         gc_stop_height: BlockHeight,
         gc_height_limit: BlockHeightDelta,
-    ) -> Result<(), Error> {
+    ) {
         let mut height = self.chunk_tail();
         let mut remaining = gc_height_limit;
         while height < gc_stop_height && remaining > 0 {
@@ -706,7 +706,6 @@ impl<'a> ChainStoreUpdate<'a> {
             }
         }
         self.update_chunk_tail(height);
-        Ok(())
     }
 
     fn get_shard_uids_to_gc(

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -25,17 +25,17 @@ fn save_epoch_new_chunks<T: ChainStoreAccess>(
     chain_store: &T,
     store_update: &mut StoreUpdate,
     header: &BlockHeader,
-) -> Result<bool, Error> {
+) -> bool {
     let Some(mut num_new_chunks) =
         get_state_sync_new_chunks(&chain_store.store(), header.prev_hash())
     else {
         // This might happen in the case of epoch sync where we save individual headers without having all
         // headers that belong to the epoch.
-        return Ok(false);
+        return false;
     };
 
     // This shouldn't happen because block headers in the same epoch should have chunks masks
-    // of the same length, but we log it here in case it happens for some reason. We return Ok because if this
+    // of the same length, but we log it here in case it happens for some reason. We return false because if this
     // happens, it's some bug in this state sync logic, because the chunk mask length of headers are checked when
     // they're verified. So in this case we shouldn't fail to commit this store update and store this block header
     if num_new_chunks.len() != header.chunk_mask().len() {
@@ -43,7 +43,7 @@ fn save_epoch_new_chunks<T: ChainStoreAccess>(
             block_hash=%header.hash(), chunk_mask_len=%header.chunk_mask().len(), stored_len=%num_new_chunks.len(),
             "block header's chunk mask not of the same length as stored value in DBCol::StateSyncNewChunks",
         );
-        return Ok(false);
+        return false;
     }
 
     let done = num_new_chunks.iter().all(|num_chunks| *num_chunks >= 2);
@@ -56,7 +56,7 @@ fn save_epoch_new_chunks<T: ChainStoreAccess>(
     }
 
     store_update.set_ser(DBCol::StateSyncNewChunks, header.hash().as_ref(), &num_new_chunks);
-    Ok(done)
+    done
 }
 
 fn on_new_epoch(store_update: &mut StoreUpdate, header: &BlockHeader) {
@@ -94,13 +94,13 @@ fn maybe_get_block_header<T: ChainStoreAccess>(
     }
 }
 
-fn has_enough_new_chunks(store: &Store, block_hash: &CryptoHash) -> Result<Option<bool>, Error> {
+fn has_enough_new_chunks(store: &Store, block_hash: &CryptoHash) -> Option<bool> {
     let Some(num_new_chunks) = get_state_sync_new_chunks(store, block_hash) else {
         // This might happen in the case of epoch sync where we save individual headers without having all
         // headers that belong to the epoch.
-        return Ok(None);
+        return None;
     };
-    Ok(Some(num_new_chunks.iter().all(|num_chunks| *num_chunks >= 2)))
+    Some(num_new_chunks.iter().all(|num_chunks| *num_chunks >= 2))
 }
 
 /// Save num new chunks info and store the state sync hash if it has been found. We store it only
@@ -113,7 +113,7 @@ fn on_new_header<T: ChainStoreAccess>(
     store_update: &mut StoreUpdate,
     header: &BlockHeader,
 ) -> Result<(), Error> {
-    let done = save_epoch_new_chunks(chain_store, store_update, header)?;
+    let done = save_epoch_new_chunks(chain_store, store_update, header);
     if !done {
         return Ok(());
     }
@@ -139,7 +139,7 @@ fn on_new_header<T: ChainStoreAccess>(
         {
             return Ok(());
         }
-        if has_enough_new_chunks(&chain_store.store(), sync_prev.hash())? != Some(true) {
+        if has_enough_new_chunks(&chain_store.store(), sync_prev.hash()) != Some(true) {
             return Ok(());
         }
 
@@ -148,7 +148,7 @@ fn on_new_header<T: ChainStoreAccess>(
             return Ok(());
         };
         let Some(prev_prev_done) =
-            has_enough_new_chunks(&chain_store.store(), sync_prev_prev.hash())?
+            has_enough_new_chunks(&chain_store.store(), sync_prev_prev.hash())
         else {
             return Ok(());
         };

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -947,7 +947,7 @@ impl Handler<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChang
         Ok(self
             .chain
             .chain_store()
-            .get_state_changes_in_block(&msg.block_hash)?
+            .get_state_changes_in_block(&msg.block_hash)
             .into_iter()
             .map(Into::into)
             .collect())
@@ -963,7 +963,7 @@ impl Handler<GetStateChanges, Result<StateChangesView, GetStateChangesError>> fo
         Ok(self
             .chain
             .chain_store()
-            .get_state_changes(&msg.block_hash, &msg.state_changes_request.into())?
+            .get_state_changes(&msg.block_hash, &msg.state_changes_request.into())
             .into_iter()
             .map(Into::into)
             .collect())
@@ -985,7 +985,7 @@ impl Handler<GetStateChangesWithCauseInBlock, Result<StateChangesView, GetStateC
         Ok(self
             .chain
             .chain_store()
-            .get_state_changes_with_cause_in_block(&msg.block_hash)?
+            .get_state_changes_with_cause_in_block(&msg.block_hash)
             .into_iter()
             .map(Into::into)
             .collect())
@@ -1009,7 +1009,7 @@ impl
             .with_label_values(&["GetStateChangesWithCauseInBlockForTrackedShards"])
             .start_timer();
         let state_changes_with_cause_in_block =
-            self.chain.chain_store().get_state_changes_with_cause_in_block(&msg.block_hash)?;
+            self.chain.chain_store().get_state_changes_with_cause_in_block(&msg.block_hash);
 
         let mut state_changes_with_cause_split_by_shard_id: HashMap<ShardId, StateChangesView> =
             HashMap::new();


### PR DESCRIPTION
- Remove redundant `Result` wrappers from 8 functions where errors are irrecoverable (borsh deserialization of DB-stored types cannot fail):
  - `ChainStore::get_state_changes_in_block()` — `Result<StateChangesKinds, Error>` → `StateChangesKinds`
  - `ChainStore::get_state_changes_with_cause_in_block()` — `Result<StateChanges, Error>` → `StateChanges`
  - `ChainStore::get_state_changes()` — `Result<StateChanges, Error>` → `StateChanges`
  - `save_epoch_new_chunks()` — `Result<bool, Error>` → `bool`
  - `has_enough_new_chunks()` — `Result<Option<bool>, Error>` → `Option<bool>`
  - `StateSnapshotActor::should_wait_for_resharding_split()` — `anyhow::Result<bool>` → `bool`
  - `ChainStoreUpdate::try_save_latest_known()` — `Result<(), Error>` → `()`
  - `ChainStoreUpdate::clear_redundant_chunk_data()` — `Result<(), Error>` → `()`
- Update all call sites to remove `?`, `.unwrap()`, and match-on-Result patterns
- Cascading from #15117, #15119, #15120, #15114
- Part of the ongoing store `Result` cleanup effort