### PR TITLE
refactor(store): remove Result from client and cold storage methods

### DIFF
--- a/chain/client/src/archive/cold_store_actor.rs
+++ b/chain/client/src/archive/cold_store_actor.rs
@@ -201,7 +201,7 @@ impl ColdStoreActor {
             &self.hot_store,
             batch_size,
             &self.keep_going,
-        )? {
+        ) {
             CopyAllDataToColdStatus::EverythingCopied => {
                 tracing::info!(target: "cold_store", new_cold_height, "cold storage population was successful, writing cold head");
                 update_cold_head(self.cold_db.as_ref(), &self.hot_store, &new_cold_height)?;

--- a/chain/client/src/spice_data_distributor_actor.rs
+++ b/chain/client/src/spice_data_distributor_actor.rs
@@ -913,7 +913,7 @@ impl SpiceDataDistributorActor {
         &mut self,
         data_id: &SpiceDataIdentifier,
         producers_count: usize,
-    ) -> Result<Option<DistributionData>, Error> {
+    ) -> Option<DistributionData> {
         let data = match data_id {
             SpiceDataIdentifier::ReceiptProof { block_hash, from_shard_id, to_shard_id } => {
                 get_receipt_proof(
@@ -931,7 +931,7 @@ impl SpiceDataDistributorActor {
             }
         };
 
-        Ok(data.map(|data| self.encode_distribution_data(&data, producers_count)))
+        data.map(|data| self.encode_distribution_data(&data, producers_count))
     }
 
     fn handle_partial_data_request(
@@ -950,7 +950,7 @@ impl SpiceDataDistributorActor {
             return Err(Error::Other("we do not produce requested data"));
         }
 
-        let Some(data) = self.get_distribution_data(&data_id, producers.len())? else {
+        let Some(data) = self.get_distribution_data(&data_id, producers.len()) else {
             // TODO(spice): Make sure we send requests for data only after we know it may be
             // available and make this into error.
             tracing::debug!(target:"spice_data_distribution", ?data_id, ?requester, "received request for unknown data");

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -422,7 +422,7 @@ pub fn copy_all_data_to_cold(
     hot_store: &Store,
     batch_size: usize,
     keep_going: &Arc<std::sync::atomic::AtomicBool>,
-) -> io::Result<CopyAllDataToColdStatus> {
+) -> CopyAllDataToColdStatus {
     for col in DBCol::iter() {
         if col.is_cold() {
             tracing::info!(target: "cold_store", ?col, "started column migration");
@@ -430,7 +430,7 @@ pub fn copy_all_data_to_cold(
             for (key, value) in hot_store.iter(col) {
                 if !keep_going.load(std::sync::atomic::Ordering::Relaxed) {
                     tracing::debug!(target: "cold_store", "stopping copy_all_data_to_cold");
-                    return Ok(CopyAllDataToColdStatus::Interrupted);
+                    return CopyAllDataToColdStatus::Interrupted;
                 }
                 transaction.set_and_write_if_full(col, key.to_vec(), value.to_vec());
             }
@@ -438,7 +438,7 @@ pub fn copy_all_data_to_cold(
             tracing::info!(target: "cold_store", ?col, "finished column migration");
         }
     }
-    Ok(CopyAllDataToColdStatus::EverythingCopied)
+    CopyAllDataToColdStatus::EverythingCopied
 }
 
 // The copy_state_from_store function depends on the state nodes to be present

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -417,7 +417,7 @@ fn test_initial_copy_to_cold(batch_size: usize) {
     let cold_db = storage.cold_db().unwrap();
     let cold_store = storage.get_cold_store().unwrap();
     let client_store = env.clients[0].runtime_adapter.store();
-    copy_all_data_to_cold(cold_db.clone(), &client_store, batch_size, &keep_going).unwrap();
+    copy_all_data_to_cold(cold_db.clone(), &client_store, batch_size, &keep_going);
 
     for col in DBCol::iter() {
         if !col.is_cold() {
@@ -517,7 +517,7 @@ fn test_cold_loop_on_gc_boundary() {
     set_genesis_height(&mut store_update, &0);
     store_update.commit();
 
-    copy_all_data_to_cold(cold_db.clone(), &hot_store, 1000000, &keep_going).unwrap();
+    copy_all_data_to_cold(cold_db.clone(), &hot_store, 1000000, &keep_going);
 
     update_cold_head(cold_db, &hot_store, &(height_delta - 1)).unwrap();
 

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -76,7 +76,7 @@ fn slow_test_state_dump() {
         validator,
         future_spawner: Arc::new(TokioRuntimeFutureSpawner(tokio_runtime)),
     };
-    state_sync_dumper.start().unwrap();
+    state_sync_dumper.start();
 
     const MAX_HEIGHT: BlockHeight = 37;
     for i in 1..=MAX_HEIGHT {
@@ -186,7 +186,7 @@ fn run_state_sync_with_dumped_parts(
         validator,
         future_spawner: Arc::new(TokioRuntimeFutureSpawner(tokio_runtime)),
     };
-    state_sync_dumper.start().unwrap();
+    state_sync_dumper.start();
 
     let account_creation_at_height = (account_creation_at_epoch_height - 1) * epoch_length + 2;
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -709,7 +709,7 @@ pub async fn start_with_config_and_synchronization_impl(
         validator: config.validator_signer.clone(),
         future_spawner: state_sync_spawner,
     };
-    state_sync_dumper.start()?;
+    state_sync_dumper.start();
 
     let hot_store = storage.get_hot_store();
     let cold_store = storage.get_cold_store();

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -488,7 +488,7 @@ pub fn setup_client(
         validator: validator_signer,
         future_spawner: Arc::new(test_loop.future_spawner(identifier)),
     };
-    let state_sync_dumper_handle = state_sync_dumper.start().unwrap();
+    let state_sync_dumper_handle = state_sync_dumper.start();
     let state_sync_dumper_handle = test_loop.data.register_data(state_sync_dumper_handle);
 
     let client_sender =

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -279,8 +279,7 @@ fn copy_all_blocks(storage: &NodeStorage, batch_size: usize, check: bool) {
         &storage.get_hot_store(),
         batch_size,
         &keep_going,
-    )
-    .expect("Failed to do migration to cold db");
+    );
 
     // Setting cold head to hot_final_head captured BEFORE the start of initial migration.
     // Doesn't really matter here, but very important in case of migration during `neard run`.


### PR DESCRIPTION
- Remove redundant `Result` wrappers from 5 functions where errors are irrecoverable:
  - `SpiceDataDistributorActor::get_distribution_data()` — `Result<Option<DistributionData>, Error>` → `Option<DistributionData>`
  - `StateDumper::new_dump()` — `anyhow::Result<()>` → `()`
  - `StateDumper::check_parts_upload()` — `anyhow::Result<()>` → `()`
  - `StateSyncDumper::start()` — `anyhow::Result<Arc<StateSyncDumpHandle>>` → `Arc<StateSyncDumpHandle>`
  - `copy_all_data_to_cold()` — `io::Result<CopyAllDataToColdStatus>` → `CopyAllDataToColdStatus`
- Update all call sites to remove `?`, `.unwrap()`, `.expect()`, and match-on-Result patterns
- Cascading from #15117, #15118, #15119
- Part of the ongoing store `Result` cleanup effort