### PR TITLE
feat(jsonrpc): add Clock::timeout() and use Clock-based timing in RPC

### DIFF
--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -203,6 +203,7 @@ pub fn create_test_setup_with_accounts_and_validity(
     };
 
     let app = create_jsonrpc_app(
+        Clock::real(),
         rpc_config,
         genesis.config,
         client_result.client_actor.into_multi_sender(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -7,7 +7,7 @@ use crate::metrics::spawn_trie_metrics_loop;
 use crate::state_sync::StateSyncDumper;
 use anyhow::Context;
 use near_async::messaging::{IntoMultiSender, IntoSender, LateBoundSender, noop};
-use near_async::time::{self, Clock};
+use near_async::time::Clock;
 use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::resharding::resharding_actor::ReshardingActor;
 pub use near_chain::runtime::NightshadeRuntime;
@@ -715,7 +715,7 @@ pub async fn start_with_config_and_synchronization_impl(
     let cold_store = storage.get_cold_store();
 
     let network_actor = PeerManagerActor::spawn(
-        time::Clock::real(),
+        Clock::real(),
         actor_system.clone(),
         storage.into_inner(near_store::Temperature::Hot),
         config.network_config,
@@ -752,6 +752,7 @@ pub async fn start_with_config_and_synchronization_impl(
             cold_store,
         };
         near_jsonrpc::start_http(
+            Clock::real(),
             rpc_config,
             config.genesis.config.clone(),
             client_actor.clone().into_multi_sender(),


### PR DESCRIPTION
- Add `Clock::timeout()` to `near-time` using `std::future::poll_fn` — works with both real and fake clocks for testloop compatibility, no new dependencies
- Pass `Clock` into `JsonRpcHandler` and replace `tokio::time::timeout`/`tokio::time::sleep` with `Clock::timeout()`/`Clock::sleep()` in RPC polling methods
- Switch `RpcPollingConfig` fields from `std::time::Duration` to `near_time::Duration` (with `serde_duration_as_std` for config compatibility), removing `.try_into().unwrap()` at all call sites

This is required to make jsonrpc compatible with fake clock and eventually testloop. The RPC polling methods (`tx_exists`, `tx_status_fetch`, `sandbox_patch_state`, `sandbox_fast_forward`) previously used `tokio::time::timeout`/`sleep` directly, which only work with real time and cannot be controlled in testloop tests.