### PR TITLE
doc: expand clippy instructions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@
 
 ## Clippy
 - Only run clippy prior to making a commit. It is somewhat expensive.
+- Run with `RUSTFLAGS="-D warnings"` env variable and `--all-features --all-targets` args.
+  ```
+  RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets
+  ```
 
 ## OpenAPI Spec
 - Do NOT update the OpenAPI spec unless explicitly asked.


### PR DESCRIPTION
Add `RUSTFLAGS="-D warnings"` env variable and `--all-features --all-targets` args to the Clippy section in AGENTS.md. This mirrors how we run it as part of CI.