### PR TITLE
doc: add Rust coding conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # nearcore
 
+## Rust
+- Prefer `use` declarations over fully qualified paths.
+- Don't capitalize string literal messages in logs, errors, `Option::expect`, `panic!`, etc.
+
 ## Pull Requests
 - Always follow the Pull Requests instructions from `CONTRIBUTING.md`.
 - Use bullet-point description for PRs that highlight key changes, motivations, testing, and important context.


### PR DESCRIPTION
Add Rust section with two conventions:
  - Prefer `use` declarations over fully qualified paths
  - Do not capitalize string literal messages in logs, errors, expects, panics, etc.

Examples of `use` declaration convention:

```rust
// Preferred: use declaration + short path
use near_crypto::Signer;

let signer = Signer::new(key);

// Avoided: fully qualified path inline
let signer = near_crypto::Signer::new(key);
```

Examples of lowercase message convention:

```rust
// Correct
tracing::info!("starting block processing");
panic!("unexpected state");
option.expect("value must be present");
anyhow::bail!("failed to connect");

// Incorrect
tracing::info!("Starting block processing");
panic!("Unexpected state");
option.expect("Value must be present");
anyhow::bail!("Failed to connect");
```