### PR TITLE
chore: update keccak to silence cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,9 +3491,12 @@ checksum = "41ee439ee368ba4a77ac70d04f14015415af8600d6c894dc1f11bd79758c57d5"
 
 [[package]]
 name = "keccak"
-version = "0.1.0"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "keypair-generator"


### PR DESCRIPTION
[RUSTSEC-2026-0012](https://rustsec.org/advisories/RUSTSEC-2026-0012)