### PR TITLE
fix(ci): install system OpenSSL for protocol schema check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
           echo "SCCACHE_GCS_RW_MODE=READ_WRITE" >> $GITHUB_ENV
           echo "SCCACHE_GCS_KEY_PREFIX=nearcore/ci" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e
         with:
           tool: just


### PR DESCRIPTION
The `protocol_schema_check` CI job was failing because the `openssl-sys` crate  was trying to build OpenSSL from source, which hit an assembler error on the runner. Install `libssl-dev` and `pkg-config` via apt so the crate links against the system OpenSSL.