### PR TITLE
fix: reorder gas key nonce parsing in state record deserialization

### DIFF
--- a/core/primitives/src/state_record.rs
+++ b/core/primitives/src/state_record.rs
@@ -235,3 +235,30 @@ pub fn is_contract_code_key(key: &[u8]) -> bool {
     debug_assert!(!key.is_empty());
     key[0] == col::CONTRACT_CODE
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gas_key_nonce_from_raw_key_value() {
+        let account_id: AccountId = "alice.near".parse().unwrap();
+        let public_key = PublicKey::from_seed(near_crypto::KeyType::ED25519, "test");
+        let nonce_index: NonceIndex = 42;
+        let nonce: Nonce = 123;
+
+        let trie_key = TrieKey::GasKeyNonce {
+            account_id: account_id.clone(),
+            public_key: public_key.clone(),
+            index: nonce_index,
+        };
+        let raw_key = trie_key.to_vec();
+        let raw_value = borsh::to_vec(&nonce).unwrap();
+
+        let record = StateRecord::from_raw_key_value(&raw_key, raw_value);
+        assert_eq!(
+            record,
+            Some(StateRecord::GasKeyNonce { account_id, public_key, index: nonce_index, nonce })
+        );
+    }
+}


### PR DESCRIPTION
`from_raw_key_value_impl` tried to parse the value as `AccessKey` before checking whether the trie key was a gas key nonce entry. Since gas key nonce entries share the `ACCESS_KEY` column prefix but store a `u64` value (not an `AccessKey`), the parse failed and the entry was silently skipped via `unwrap_or(None)`. This caused `fork-network amend-access-keys` to drop gas key nonce trie entries, leaving forked state with gas key access keys but no corresponding nonce storage.

- Parse the key structure first to determine if it's a gas key nonce
- Only call `AccessKey::try_from_slice` when there is no nonce index suffix