### PR TITLE
refactor(runtime): replace implicit max_gas_burnt override with explicit builder method

### DIFF
--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -1077,6 +1077,7 @@ fn test_memory_copy_full_memory_out_of_gas() {
             )"#,
         )
         .gas(Gas::from_teragas(300))
+        .max_gas_burnt(Gas::from_teragas(300))
         .skip_near_vm()
         .protocol_features(&[ProtocolFeature::Wasmtime])
         .expects(&[expect![[r#"

--- a/runtime/near-vm-runner/src/tests/regression_tests.rs
+++ b/runtime/near-vm-runner/src/tests/regression_tests.rs
@@ -1,5 +1,6 @@
 use crate::tests::test_builder::test_builder;
 use expect_test::expect;
+use near_primitives_core::types::Gas;
 
 #[test]
 fn memory_size_alignment_issue() {
@@ -67,6 +68,7 @@ fn gas_intrinsic_did_not_multiply_by_opcode_cost() {
             "#,
         )
         .method("foo")
+        .max_gas_burnt(Gas::from_teragas(300))
         .expects(&[
             expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100000000000000 used gas 100000000000000


### PR DESCRIPTION
- Add `max_gas_burnt()` method to `TestBuilder` for explicit gas limit override instead of blanket 300 TGas override applied to all vm-runner tests
- Only two tests actually need the 300 TGas limit: `test_memory_copy_full_memory_out_of_gas` and `gas_intrinsic_did_not_multiply_by_opcode_cost`
- Follow-up to #15147 which introduced the implicit override