### PR TITLE
chore(runtime): make wasmtime_vm a default feature for near-vm-runner

### DIFF
--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -84,6 +84,7 @@ wasm-smith.workspace = true
 wat.workspace = true
 
 [features]
+default = ["wasmtime_vm"]
 wasmtime_vm = ["wasmtime", "anyhow", "prepare"]
 near_vm = [
     "near-vm-compiler",


### PR DESCRIPTION
- When running tests locally with `cargo test -p near-vm-runner --features test_features`, many tests are silently skipped because `wasmtime_vm` is not enabled — the test output shows `Skipping Wasmtime` but it is easy to miss
- Figuring out the right incantation (`--features test_features,wasmtime_vm`) requires investigating the CI config, Justfile, and feature unification across the workspace
- In workspace builds (including CI) `wasmtime_vm` is already always enabled via feature unification from `node-runtime` which depends on `near-vm-runner` with `features = ["near_vm", "wasmtime_vm"]`, so this change has no effect on CI or production builds
- No crate in the workspace uses `default-features = false` for `near-vm-runner`