### PR TITLE
feat(epoch-sync): trigger data reset and shutdown for stale nodes entering epoch sync

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1819,6 +1819,10 @@ impl ClientActor {
             SyncHandlerRequest::NeedProcessBlockArtifact(block_processing_artifacts) => {
                 self.client.process_block_processing_artifact(block_processing_artifacts);
             }
+            SyncHandlerRequest::NeedsDataReset => {
+                tracing::info!(target: "client", "epoch sync data reset marker written, shutting down for restart");
+                self.shutdown_signal.fire();
+            }
         }
     }
 

--- a/chain/client/src/sync/handler.rs
+++ b/chain/client/src/sync/handler.rs
@@ -1,5 +1,5 @@
 use super::block::BlockSync;
-use super::epoch::EpochSync;
+use super::epoch::{EpochSync, EpochSyncRunResult};
 use super::header::HeaderSync;
 use super::state::StateSync;
 use crate::sync::state::StateSyncResult;
@@ -52,6 +52,8 @@ pub enum SyncHandlerRequest {
     NeedRequestBlocks(Vec<(CryptoHash, PeerId)>),
     /// Need to process block artifact unlocked by state sync.
     NeedProcessBlockArtifact(BlockProcessingArtifact),
+    /// Epoch sync determined node data needs reset; caller should fire shutdown.
+    NeedsDataReset,
 }
 
 impl SyncHandler {
@@ -96,7 +98,14 @@ impl SyncHandler {
             highest_height,
             &highest_height_peers,
         );
-        unwrap_and_report_state_sync_result!(epoch_sync_result);
+        let epoch_sync_result = unwrap_and_report_state_sync_result!(epoch_sync_result);
+
+        match epoch_sync_result {
+            EpochSyncRunResult::Ok => {}
+            EpochSyncRunResult::NeedsDataReset => {
+                return Some(SyncHandlerRequest::NeedsDataReset);
+            }
+        }
 
         // Run header sync as long as there are headers to catch up.
         let header_sync_result = self.header_sync.run(

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -15,6 +15,7 @@ use near_chain::validate::validate_chunk_with_chunk_extra;
 use near_chain::{BlockProcessingArtifact, ChainStore, ChainStoreAccess, Error, Provenance};
 use near_chain_configs::test_utils::{TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use near_chain_configs::{DEFAULT_GC_NUM_EPOCHS_TO_KEEP, Genesis, ProtocolVersionCheckConfig};
+use near_client::sync::epoch::EpochSyncRunResult;
 use near_client::test_utils::create_chunk_on_height;
 use near_client::{GetBlockWithMerkleTree, ProcessTxResponse, ProduceChunkResult};
 use near_crypto::{InMemorySigner, KeyType, Signature};
@@ -1454,7 +1455,7 @@ fn test_reject_block_headers_during_epoch_sync() {
             highest_height,
             &highest_height_peers
         ),
-        Ok(()),
+        Ok(EpochSyncRunResult::Ok),
         "Epoch sync failure"
     );
 

--- a/test-loop-tests/src/tests/continuous_epoch_sync.rs
+++ b/test-loop-tests/src/tests/continuous_epoch_sync.rs
@@ -1,12 +1,17 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use near_async::time::Duration;
 use near_epoch_manager::epoch_sync::derive_epoch_sync_proof_from_last_block;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+use near_store::EPOCH_SYNC_RESET_MARKER;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::epoch_store::EpochStoreAdapter;
 
-use crate::setup::builder::TestLoopBuilder;
+use crate::setup::builder::{NodeStateBuilder, TestLoopBuilder};
+use crate::setup::state::NodeExecutionData;
 use crate::utils::account::{create_validators_spec, validators_spec_clients};
 
 // Test that epoch sync proof is correctly updated after each epoch.
@@ -118,6 +123,177 @@ fn test_epoch_sync_proof_update_with_forks() {
     }
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(10));
+}
+
+// Test that a brand-new node joining after the network has advanced catches up via epoch sync.
+// The new node starts from genesis and goes through the full sync status progression:
+// AwaitingPeers → NoSync → EpochSync → EpochSyncDone → HeaderSync → StateSync →
+// StateSyncDone → BlockSync → NoSync
+#[test]
+fn test_epoch_sync_catchup_fresh_node() {
+    if !ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+
+    init_test_logger();
+    let epoch_length = 10;
+    let validators_spec = create_validators_spec(4, 0);
+    let clients = validators_spec_clients(&validators_spec);
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .validators_spec(validators_spec)
+        .build();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(clients)
+        .build()
+        .warmup();
+
+    // Run the network to target_height = 8 * epoch_length = 80.
+    // epoch_sync_horizon_num_epochs defaults to 4, so epoch sync triggers when the node is
+    // 4 * epoch_length = 40 blocks behind the highest height.
+    let target_height = 8 * epoch_length;
+    env.node_runner(0).run_until_head_height(target_height);
+
+    // Add a brand-new node from genesis state.
+    let genesis = env.shared_state.genesis.clone();
+    let tempdir_path = env.shared_state.tempdir.path().to_path_buf();
+    let fresh_identifier = format!("new-account{}", env.node_datas.len());
+    let fresh_account_id = fresh_identifier.parse().unwrap();
+    let node_state =
+        NodeStateBuilder::new(genesis, tempdir_path).account_id(fresh_account_id).build();
+    env.add_node(&fresh_identifier, node_state);
+
+    let fresh_node_handle = env.node_datas.last().unwrap().client_sender.actor_handle();
+    let stable_node_handle = env.node_datas[0].client_sender.actor_handle();
+
+    // Track sync status transitions on the fresh node.
+    let sync_status_history = Rc::new(RefCell::new(Vec::new()));
+    {
+        let sync_status_history = sync_status_history.clone();
+        let fresh_handle = fresh_node_handle.clone();
+        env.test_loop.set_every_event_callback(move |test_loop_data| {
+            let client = &test_loop_data.get(&fresh_handle).client;
+            let header_head_height = client.chain.header_head().unwrap().height;
+            let head_height = client.chain.head().unwrap().height;
+            tracing::info!(
+                ?client.sync_handler.sync_status,
+                ?header_head_height,
+                ?head_height,
+                "fresh node sync status"
+            );
+            let sync_status = client.sync_handler.sync_status.as_variant_name();
+            let mut history = sync_status_history.borrow_mut();
+            if history.last().map(|s| s as &str) != Some(sync_status) {
+                history.push(sync_status.to_string());
+            }
+        });
+    }
+
+    // Run until the fresh node catches up to the stable node.
+    env.test_loop.run_until(
+        |test_loop_data| {
+            let fresh_height =
+                test_loop_data.get(&fresh_node_handle).client.chain.head().unwrap().height;
+            let stable_height =
+                test_loop_data.get(&stable_node_handle).client.chain.head().unwrap().height;
+            fresh_height == stable_height
+        },
+        Duration::seconds(10),
+    );
+
+    // Verify the sync status transitions.
+    assert_eq!(
+        sync_status_history.borrow().as_slice(),
+        &[
+            "AwaitingPeers",
+            "NoSync",
+            "EpochSync",
+            "EpochSyncDone",
+            "HeaderSync",
+            "StateSync",
+            "StateSyncDone",
+            "BlockSync",
+            "NoSync",
+        ]
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>()
+    );
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(10));
+}
+
+// Test that an existing node killed and restarted writes an epoch sync reset marker and shuts down.
+// When a node with tip != genesis enters epoch sync, it detects stale data, writes a marker file,
+// and fires the shutdown signal.
+#[test]
+fn test_epoch_sync_marker_and_shutdown() {
+    if !ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+
+    init_test_logger();
+    let epoch_length = 10;
+    let validators_spec = create_validators_spec(4, 0);
+    let clients = validators_spec_clients(&validators_spec);
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .validators_spec(validators_spec)
+        .build();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(clients)
+        .build()
+        .warmup();
+
+    // Run all nodes for 3 epochs so node 0 has data (tip >> genesis).
+    let kill_height = 3 * epoch_length;
+    env.node_runner(0).run_until_head_height(kill_height);
+
+    // Kill node 0.
+    let restart_identifier = env.node_datas[0].identifier.clone();
+    let killed_node_state = env.kill_node(&restart_identifier);
+
+    // Advance the remaining nodes well past the epoch_sync_horizon (4 epochs = 40 blocks).
+    // Target: kill_height + 8 * epoch_length = 30 + 80 = 110.
+    let advance_target = kill_height + 8 * epoch_length;
+    env.node_runner(1).run_until_head_height(advance_target);
+
+    // Restart node 0 with its killed state (stale data, tip != genesis).
+    let new_identifier = format!("{}-restart", restart_identifier);
+    env.restart_node(&new_identifier, killed_node_state);
+
+    let restarted_node_handle = env.node_datas.last().unwrap().client_sender.actor_handle();
+    let restarted_head_before =
+        env.test_loop.data.get(&restarted_node_handle).client.chain.head().unwrap().height;
+
+    // Run briefly — epoch_sync.run() sees tip != genesis, writes marker, fires shutdown.
+    env.test_loop.run_for(Duration::seconds(10));
+
+    // Assert: marker file exists at the restarted node's home directory.
+    let homedir = NodeExecutionData::homedir(&env.shared_state.tempdir, &new_identifier);
+    let marker_path = homedir.join("data").join(EPOCH_SYNC_RESET_MARKER);
+    assert!(marker_path.exists(), "epoch sync reset marker should exist at {marker_path:?}");
+
+    // Assert: restarted node stopped advancing (shutdown denylisted it).
+    let restarted_head_after =
+        env.test_loop.data.get(&restarted_node_handle).client.chain.head().unwrap().height;
+    tracing::info!(
+        restarted_head_before,
+        restarted_head_after,
+        "restarted node head heights (should not have advanced)"
+    );
+    assert_eq!(
+        restarted_head_before, restarted_head_after,
+        "restarted node should not have advanced past its kill height"
+    );
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(5));
 }
 
 // Validate that the epoch sync proof stored in epoch_store matches the one derived


### PR DESCRIPTION
- When a node with stale data (tip past genesis) falls behind the epoch sync horizon, `epoch_sync.run()` now writes a `.needs_epoch_sync_reset` marker file and returns `NeedsDataReset`, which propagates up through `SyncHandler` to `ClientActor` where it fires the shutdown signal.
- The horizon check is ordered before the stale-data check so that nodes that just completed epoch sync (and are now within the horizon) early-return without triggering a false reset.
- Adds two new test-loop tests: `test_epoch_sync_catchup_fresh_node` verifies a brand-new node catches up via epoch sync through the full sync status progression, and `test_epoch_sync_marker_and_shutdown` verifies a killed-and-restarted node writes the marker and shuts down.