### PR TITLE
doc(changelog): prepare for 2.11 release, add missing protocol changes description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,24 @@
 ## [unreleased]
 
 ### Protocol Changes
-* Contract gas limit is increased from 300 TGas to 1 PGas.
 * The contract runtime has been upgraded to use the new Wasmtime-based runtime;
 * The contract runtime now allows for bulk memory instructions in Wasm code.
+
+### Non-protocol Changes
+
+## [2.11.0]
+
+### Protocol Changes
+* Contract gas limit is increased from 300 TGas to 1 PGas.
 * Yield/Resume improvements - from now on, calling `promise_yield_resume` after `promise_yield_create` will always work. Previously there were some cases where calling `resume` would fail if called too quickly after `create`. See the [github issue](https://github.com/near/nearcore/issues/14904) for details. Strictly speaking, this could be a breaking change for contracts which expected the resume to fail in these situations, but it shouldn't affect normal use cases.
 * A promise with a single `DeleteAccount` action and no input promises will be executed immediately after the receipt that created it, before any other receipts for this account.
 * ETH implicit accounts now use a globally deployed contract instead of a contract embedded in the neard binary.
+* Invalid transactions now generate execution outcomes, allowing indexers and RPC to report outcomes for all transactions including failed ones.
+* Existing contract code is excluded from chunk state witnesses for deploy-contract and delete-account actions, reducing witness size by using internal trie nodes to check code size instead.
+* Fix access key allowance being incorrectly decremented before validation checks that could fail. Previously, allowance was mutated in-place before storage stake and function call permission checks, so a failed transaction could incorrectly reduce the allowance.
+* Include tokens burnt as part of global contract deploys in the corresponding execution outcome's `tokens_burnt` field.
+* Fix deterministic account ID creation to allow creation by any incoming transfer (unless it's a refund) and correctly check whether the feature is enabled.
+* Add nonce-based idempotency for global contract distribution receipts. Each distribution carries an auto-incremented nonce, and any distribution receipt with a stale nonce is dropped, preventing race conditions during multiple distribution attempts for the same contract.
 
 ### Non-protocol Changes
 * Replace polling for transaction status with event notifications to improve jsonrpc response latency


### PR DESCRIPTION
- Add descriptions for six protocol version 83 features that were missing from the 2.11.0 changelog section:
  - `InvalidTxGenerateOutcomes`: invalid transactions now generate execution outcomes
  - `ExcludeExistingCodeFromWitnessForCodeLen`: exclude existing contract code from chunk state witnesses
  - `FixAccessKeyAllowanceCharging`: fix allowance mutation before validation checks
  - `IncludeDeployGlobalContractOutcomeBurntStorage`: include tokens burnt for global contract deploys in outcome
  - `FixDeterministicAccountIdCreation`: fix deterministic account ID creation for transfers
  - `GlobalContractDistributionNonce`: nonce-based idempotency for global contract distribution