### PR TITLE
chore: reduce log noise when optional config file is missing

### DIFF
--- a/nearcore/src/dyn_config.rs
+++ b/nearcore/src/dyn_config.rs
@@ -97,7 +97,11 @@ where
         },
         Err(err) => match err.kind() {
             std::io::ErrorKind::NotFound => {
-                tracing::info!(target: "neard", ?err, ?path, "reset the config because the config file doesn't exist");
+                tracing::info!(
+                    target: "neard",
+                    path = %path.display(),
+                    "config file does not exist → resetting to defaults"
+                );
                 Ok(None)
             }
             _ => Err(UpdatableConfigLoaderError::OpenAndRead { file: path.to_path_buf(), err }),


### PR DESCRIPTION
Reduce log noise when optional config file is missing. Removes unnecessary io::Error logging for the NotFound case and logs only the file path instead.