### PR TITLE
refactor(chain): remove needless result returns from core chain logic

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -938,7 +938,7 @@ impl Chain {
                 header.height(),
                 header.approvals(),
                 info,
-            )? {
+            ) {
                 return Err(Error::InvalidApprovals);
             };
 
@@ -1359,7 +1359,7 @@ impl Chain {
                 &block_context.to_key_source(),
                 &chunks,
                 shard_id,
-            )?;
+            );
             shard_update_keys.push(cached_shard_update_key);
             let job = self.get_update_shard_job(
                 cached_shard_update_key,
@@ -2742,7 +2742,7 @@ impl Chain {
         chunks: &Chunks,
         prev_block_header: &BlockHeader,
         is_new_chunk: bool,
-    ) -> Result<ApplyChunkBlockContext, Error> {
+    ) -> ApplyChunkBlockContext {
         // Before `FixApplyChunks` feature, gas price was taken from current
         // block by mistake. Preserve it for backwards compatibility.
         let gas_price = if is_new_chunk {
@@ -2757,19 +2757,19 @@ impl Chain {
         let congestion_info = chunks.block_congestion_info();
         let bandwidth_requests = chunks.block_bandwidth_requests();
 
-        Ok(ApplyChunkBlockContext::from_header(
+        ApplyChunkBlockContext::from_header(
             block_header,
             gas_price,
             congestion_info,
             bandwidth_requests,
-        ))
+        )
     }
 
     pub fn get_apply_chunk_block_context(
         block: &Block,
         prev_block_header: &BlockHeader,
         is_new_chunk: bool,
-    ) -> Result<ApplyChunkBlockContext, Error> {
+    ) -> ApplyChunkBlockContext {
         Self::get_apply_chunk_block_context_from_block_header(
             block.header(),
             &block.chunks(),
@@ -3119,13 +3119,13 @@ impl Chain {
                 &chunk_headers,
                 prev_block.header(),
                 chunk_header.is_new_chunk(),
-            )?;
+            );
 
             let cached_shard_update_key = Self::get_cached_shard_update_key(
                 &block_context.to_key_source(),
                 chunk_headers,
                 shard_id,
-            )?;
+            );
             update_shard_args.push((block_context, cached_shard_update_key));
         }
 
@@ -3225,7 +3225,7 @@ impl Chain {
         block: &OptimisticBlockKeySource,
         chunk_headers: &Chunks,
         shard_id: ShardId,
-    ) -> Result<CachedShardUpdateKey, Error> {
+    ) -> CachedShardUpdateKey {
         const BYTES_LEN: usize =
             size_of::<CryptoHash>() + size_of::<CryptoHash>() + size_of::<u64>();
 
@@ -3236,7 +3236,7 @@ impl Chain {
         bytes.extend_from_slice(&hash(&borsh::to_vec(&chunks_key_source).unwrap()).0);
         bytes.extend_from_slice(&shard_id.to_le_bytes());
 
-        Ok(CachedShardUpdateKey::new(hash(&bytes)))
+        CachedShardUpdateKey::new(hash(&bytes))
     }
 
     /// This method returns the closure that is responsible for updating a shard.

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -604,11 +604,7 @@ impl ChainStore {
 }
 
 impl<'a> ChainStoreUpdate<'a> {
-    fn clear_header_data_for_heights(
-        &mut self,
-        start: BlockHeight,
-        end: BlockHeight,
-    ) -> Result<(), Error> {
+    fn clear_header_data_for_heights(&mut self, start: BlockHeight, end: BlockHeight) {
         for height in start..=end {
             let header_hashes = self.chain_store().get_all_header_hashes_by_height(height);
             for header_hash in header_hashes {
@@ -621,7 +617,6 @@ impl<'a> ChainStoreUpdate<'a> {
             let key = index_to_bytes(height);
             self.gc_col(DBCol::HeaderHashesByHeight, &key);
         }
-        Ok(())
     }
 
     fn clear_chunk_data_and_headers(&mut self, min_chunk_height: BlockHeight) -> Result<(), Error> {
@@ -1008,7 +1003,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
         self.clear_chunk_data_at_height(head_height)?;
 
-        self.clear_header_data_for_heights(head_height, header_head_height)?;
+        self.clear_header_data_for_heights(head_height, header_head_height);
 
         Ok(())
     }

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -207,7 +207,7 @@ fn get_state_witness_block_range(
             0 => {
                 let header = store.get_block_header(&prev_prev_hash)?;
                 let block_context =
-                    Chain::get_apply_chunk_block_context(&position.prev_block, &header, false)?;
+                    Chain::get_apply_chunk_block_context(&position.prev_block, &header, false);
                 implicit_transition_params
                     .push(ImplicitTransitionParams::ApplyOldChunk(block_context, shard_uid));
             }
@@ -402,7 +402,7 @@ pub fn pre_validate_chunk_state_witness(
                 chunk_hash: Some(chunk_header.chunk_hash().clone()),
                 transactions,
                 receipts: receipts_to_apply,
-                block: Chain::get_apply_chunk_block_context(last_chunk_block, &header, true)?,
+                block: Chain::get_apply_chunk_block_context(last_chunk_block, &header, true),
                 storage_context: StorageContext {
                     storage_data_source: StorageDataSource::Recorded(PartialStorage {
                         nodes: state_witness.main_state_transition().base_state.clone(),

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -653,7 +653,7 @@ impl ChunkExecutorActor {
         chain_update.commit()?;
         if let Some(final_execution_head) = final_execution_head {
             self.update_flat_storage_head(&shard_layout, &final_execution_head)?;
-            self.gc_memtrie_roots(&shard_layout, &final_execution_head)?;
+            self.gc_memtrie_roots(&shard_layout, &final_execution_head);
         }
         Ok(())
     }
@@ -944,21 +944,16 @@ impl ChunkExecutorActor {
         Ok(())
     }
 
-    fn gc_memtrie_roots(
-        &self,
-        shard_layout: &ShardLayout,
-        final_execution_head: &Tip,
-    ) -> Result<(), Error> {
+    fn gc_memtrie_roots(&self, shard_layout: &ShardLayout, final_execution_head: &Tip) {
         let header =
             self.chain_store.get_block_header(&final_execution_head.last_block_hash).unwrap();
         let Some(prev_height) = header.prev_height() else {
-            return Ok(());
+            return;
         };
         for shard_uid in shard_layout.shard_uids() {
             let tries = self.runtime_adapter.get_tries();
             tries.delete_memtrie_roots_up_to_height(shard_uid, prev_height);
         }
-        Ok(())
     }
 
     fn process_all_ready_blocks(&mut self) -> Result<(), Error> {

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -678,7 +678,7 @@ impl ChunkProducer {
         };
         let shard_id = shard_uid.shard_id();
         let prev_chunk_shard_update_key: CachedShardUpdateKey =
-            Chain::get_cached_shard_update_key(&prev_block_context, &chunks, shard_id).unwrap();
+            Chain::get_cached_shard_update_key(&prev_block_context, &chunks, shard_id);
 
         let prepare_job_key = PrepareTransactionsJobKey {
             shard_uid,

--- a/chain/client/src/tests/spice_chunk_validator_actor.rs
+++ b/chain/client/src/tests/spice_chunk_validator_actor.rs
@@ -491,7 +491,6 @@ fn simulate_chunk_application(
             {
                 let is_new_chunk = true;
                 Chain::get_apply_chunk_block_context(&block, prev_block.header(), is_new_chunk)
-                    .unwrap()
             },
             &TEST_RECEIPTS,
             transactions,

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -304,7 +304,7 @@ impl ReplayController {
         };
 
         let block_context =
-            Chain::get_apply_chunk_block_context(block, prev_block.header(), is_new_chunk)?;
+            Chain::get_apply_chunk_block_context(block, prev_block.header(), is_new_chunk);
 
         let update_reason = if is_new_chunk {
             let receipts = self.collect_incoming_receipts(


### PR DESCRIPTION
Seven functions in core chain logic return `Result` but never produce an error — they always return `Ok(...)`. This removes the unnecessary `Result` wrapping, simplifying call sites by eliminating `?` operators and `.unwrap()` calls that could never fail.

Functions changed:
- `verify_approval_with_approvers_info` — `Result<bool, Error>` → `bool`
- `get_heuristic_block_approvers_ordered` — `Result<Vec<ApprovalStake>, EpochError>` → `Vec<ApprovalStake>`
- `get_apply_chunk_block_context_from_block_header` and its wrapper `get_apply_chunk_block_context` — `Result<ApplyChunkBlockContext, Error>` → `ApplyChunkBlockContext`
- `get_cached_shard_update_key` — `Result<CachedShardUpdateKey, Error>` → `CachedShardUpdateKey`
- `clear_header_data_for_heights` — `Result<(), Error>` → `()`
- `gc_memtrie_roots` — `Result<(), Error>` → `()`
- `should_catch_up_shard` — `Result<bool, Error>` → `bool`