### PR TITLE
refactor(runtime): remove needless Result from ReceiptManager and External trait methods

### DIFF
--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -325,10 +325,7 @@ pub trait External {
     /// # Panics
     ///
     /// Panics if the `receipt_index` does not refer to a known receipt.
-    fn append_action_create_account(
-        &mut self,
-        receipt_index: ReceiptIndex,
-    ) -> Result<(), VMLogicError>;
+    fn append_action_create_account(&mut self, receipt_index: ReceiptIndex);
 
     /// Attach the [`DeployContractAction`] action to an existing receipt.
     ///
@@ -340,11 +337,7 @@ pub trait External {
     /// # Panics
     ///
     /// Panics if the `receipt_index` does not refer to a known receipt.
-    fn append_action_deploy_contract(
-        &mut self,
-        receipt_index: ReceiptIndex,
-        code: Vec<u8>,
-    ) -> Result<(), VMLogicError>;
+    fn append_action_deploy_contract(&mut self, receipt_index: ReceiptIndex, code: Vec<u8>);
 
     /// Attach the [`DeployGlobalContractAction`] action to an existing receipt.
     ///
@@ -362,7 +355,7 @@ pub trait External {
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
         mode: GlobalContractDeployMode,
-    ) -> Result<(), VMLogicError>;
+    );
 
     /// Attach the [`UseGlobalContractAction`] action to an existing receipt.
     ///
@@ -378,7 +371,7 @@ pub trait External {
         &mut self,
         receipt_index: ReceiptIndex,
         contract_id: GlobalContractIdentifier,
-    ) -> Result<(), VMLogicError>;
+    );
 
     /// Attach the [`DeterministicStateInit`] action to an existing receipt.
     ///
@@ -401,7 +394,7 @@ pub trait External {
         receipt_index: ReceiptIndex,
         contract_id: GlobalContractIdentifier,
         amount: Balance,
-    ) -> Result<ActionIndex, VMLogicError>;
+    ) -> ActionIndex;
 
     /// Set a data entry to an existing [`DeterministicStateInit`] action.
     ///
@@ -463,11 +456,7 @@ pub trait External {
     /// # Panics
     ///
     /// Panics if the `receipt_index` does not refer to a known receipt.
-    fn append_action_transfer(
-        &mut self,
-        receipt_index: ReceiptIndex,
-        deposit: Balance,
-    ) -> Result<(), VMLogicError>;
+    fn append_action_transfer(&mut self, receipt_index: ReceiptIndex, deposit: Balance);
 
     /// Attach the [`StakeAction`] action to an existing receipt.
     ///
@@ -558,7 +547,7 @@ pub trait External {
         &mut self,
         receipt_index: ReceiptIndex,
         beneficiary_id: AccountId,
-    ) -> Result<(), VMLogicError>;
+    );
 
     /// # Panic
     ///

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -2235,7 +2235,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
 
         self.pay_action_base(ActionCosts::create_account, sir)?;
 
-        self.ext.append_action_create_account(receipt_idx)?;
+        self.ext.append_action_create_account(receipt_idx);
         Ok(())
     }
 
@@ -2282,7 +2282,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         self.pay_action_base(ActionCosts::deploy_contract_base, sir)?;
         self.pay_action_per_byte(ActionCosts::deploy_contract_byte, code_len, sir)?;
 
-        self.ext.append_action_deploy_contract(receipt_idx, code)?;
+        self.ext.append_action_deploy_contract(receipt_idx, code);
         Ok(())
     }
 
@@ -2375,7 +2375,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         self.pay_action_base(ActionCosts::deploy_global_contract_base, sir)?;
         self.pay_action_per_byte(ActionCosts::deploy_global_contract_byte, code_len, sir)?;
 
-        self.ext.append_action_deploy_global_contract(receipt_idx, code, mode)?;
+        self.ext.append_action_deploy_global_contract(receipt_idx, code, mode);
         Ok(())
     }
 
@@ -2458,7 +2458,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         let len = contract_id.len() as u64;
         self.pay_action_per_byte(ActionCosts::use_global_contract_byte, len, sir)?;
 
-        self.ext.append_action_use_global_contract(receipt_idx, contract_id)?;
+        self.ext.append_action_use_global_contract(receipt_idx, contract_id);
         Ok(())
     }
 
@@ -2573,7 +2573,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         self.pay_action_base(ActionCosts::deterministic_state_init_base, sir)?;
         self.result_state.deduct_balance(amount)?;
 
-        self.ext.append_action_deterministic_state_init(receipt_idx, code, amount)
+        Ok(self.ext.append_action_deterministic_state_init(receipt_idx, code, amount))
     }
 
     /// Appends a data entry to an existing `DeterministicStateInit` action.
@@ -2812,7 +2812,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
             ActionCosts::transfer,
         )?;
         self.result_state.deduct_balance(amount)?;
-        self.ext.append_action_transfer(receipt_idx, amount)?;
+        self.ext.append_action_transfer(receipt_idx, amount);
         Ok(())
     }
 
@@ -3032,7 +3032,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
         self.pay_action_base(ActionCosts::delete_account, sir)?;
 
-        self.ext.append_action_delete_account(receipt_idx, beneficiary_id)?;
+        self.ext.append_action_delete_account(receipt_idx, beneficiary_id);
         Ok(())
     }
 

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -246,21 +246,12 @@ impl External for MockedExternal {
         Ok(false)
     }
 
-    fn append_action_create_account(
-        &mut self,
-        receipt_index: ReceiptIndex,
-    ) -> Result<(), crate::logic::VMLogicError> {
+    fn append_action_create_account(&mut self, receipt_index: ReceiptIndex) {
         self.action_log.push(MockAction::CreateAccount { receipt_index });
-        Ok(())
     }
 
-    fn append_action_deploy_contract(
-        &mut self,
-        receipt_index: ReceiptIndex,
-        code: Vec<u8>,
-    ) -> Result<(), crate::logic::VMLogicError> {
+    fn append_action_deploy_contract(&mut self, receipt_index: ReceiptIndex, code: Vec<u8>) {
         self.action_log.push(MockAction::DeployContract { receipt_index, code });
-        Ok(())
     }
 
     fn append_action_deploy_global_contract(
@@ -268,18 +259,16 @@ impl External for MockedExternal {
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
         mode: crate::logic::types::GlobalContractDeployMode,
-    ) -> Result<(), crate::logic::VMLogicError> {
+    ) {
         self.action_log.push(MockAction::DeployGlobalContract { receipt_index, code, mode });
-        Ok(())
     }
 
     fn append_action_use_global_contract(
         &mut self,
         receipt_index: ReceiptIndex,
         contract_id: crate::logic::types::GlobalContractIdentifier,
-    ) -> Result<(), crate::logic::VMLogicError> {
+    ) {
         self.action_log.push(MockAction::UseGlobalContract { receipt_index, contract_id });
-        Ok(())
     }
 
     fn append_action_deterministic_state_init(
@@ -287,7 +276,7 @@ impl External for MockedExternal {
         receipt_index: ReceiptIndex,
         contract_id: crate::logic::types::GlobalContractIdentifier,
         amount: Balance,
-    ) -> Result<ActionIndex, crate::logic::VMLogicError> {
+    ) -> ActionIndex {
         let action_index = self.action_log.len();
         let state_init = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
             code: contract_id.into(),
@@ -298,7 +287,7 @@ impl External for MockedExternal {
             state_init,
             amount,
         });
-        Ok(action_index as u64)
+        action_index as u64
     }
 
     fn set_deterministic_state_init_data_entry(
@@ -346,13 +335,8 @@ impl External for MockedExternal {
         Ok(())
     }
 
-    fn append_action_transfer(
-        &mut self,
-        receipt_index: ReceiptIndex,
-        deposit: Balance,
-    ) -> Result<(), crate::logic::VMLogicError> {
+    fn append_action_transfer(&mut self, receipt_index: ReceiptIndex, deposit: Balance) {
         self.action_log.push(MockAction::Transfer { receipt_index, deposit });
-        Ok(())
     }
 
     fn append_action_stake(
@@ -405,9 +389,8 @@ impl External for MockedExternal {
         &mut self,
         receipt_index: ReceiptIndex,
         beneficiary_id: AccountId,
-    ) -> Result<(), crate::logic::VMLogicError> {
+    ) {
         self.action_log.push(MockAction::DeleteAccount { receipt_index, beneficiary_id });
-        Ok(())
     }
 
     fn get_receipt_receiver(&self, receipt_index: ReceiptIndex) -> &AccountId {

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -2335,7 +2335,7 @@ pub fn promise_batch_action_create_account(
         sir,
     )?;
 
-    ctx.ext.append_action_create_account(receipt_idx)?;
+    ctx.ext.append_action_create_account(receipt_idx);
     Ok(())
 }
 
@@ -2401,7 +2401,7 @@ pub fn promise_batch_action_deploy_contract(
         sir,
     )?;
 
-    ctx.ext.append_action_deploy_contract(receipt_idx, code)?;
+    ctx.ext.append_action_deploy_contract(receipt_idx, code);
     Ok(())
 }
 
@@ -2516,7 +2516,7 @@ fn promise_batch_action_deploy_global_contract_impl(
         sir,
     )?;
 
-    ctx.ext.append_action_deploy_global_contract(receipt_idx, code, mode)?;
+    ctx.ext.append_action_deploy_global_contract(receipt_idx, code, mode);
     Ok(())
 }
 
@@ -2614,7 +2614,7 @@ fn promise_batch_action_use_global_contract_impl(
         sir,
     )?;
 
-    ctx.ext.append_action_use_global_contract(receipt_idx, contract_id)?;
+    ctx.ext.append_action_use_global_contract(receipt_idx, contract_id);
     Ok(())
 }
 
@@ -2749,7 +2749,7 @@ fn promise_batch_action_state_init_impl(
         sir,
     )?;
     ctx.result_state.deduct_balance(amount)?;
-    ctx.ext.append_action_deterministic_state_init(receipt_idx, code, amount)
+    Ok(ctx.ext.append_action_deterministic_state_init(receipt_idx, code, amount))
 }
 
 /// Appends a data entry to an existing `DeterministicStateInit` action.
@@ -3040,7 +3040,7 @@ pub fn promise_batch_action_transfer(
         ActionCosts::transfer,
     )?;
     ctx.result_state.deduct_balance(amount)?;
-    ctx.ext.append_action_transfer(receipt_idx, amount)?;
+    ctx.ext.append_action_transfer(receipt_idx, amount);
     Ok(())
 }
 
@@ -3342,7 +3342,7 @@ pub fn promise_batch_action_delete_account(
         sir,
     )?;
 
-    ctx.ext.append_action_delete_account(receipt_idx, beneficiary_id)?;
+    ctx.ext.append_action_delete_account(receipt_idx, beneficiary_id);
     Ok(())
 }
 

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -348,10 +348,9 @@ impl<'a> External for RuntimeExt<'a> {
         receiver_id: AccountId,
     ) -> Result<(ReceiptIndex, CryptoHash), VMLogicError> {
         let input_data_id = self.generate_data_id();
-        let receipt_index = self
-            .receipt_manager
-            .create_promise_yield_receipt(input_data_id, receiver_id.clone())
-            .map(|receipt_index| (receipt_index, input_data_id))?;
+        let receipt_index =
+            self.receipt_manager.create_promise_yield_receipt(input_data_id, receiver_id.clone());
+        let receipt_index = (receipt_index, input_data_id);
 
         if ProtocolFeature::YieldResumeImprovements.enabled(self.current_protocol_version) {
             set_promise_yield_status(
@@ -380,7 +379,7 @@ impl<'a> External for RuntimeExt<'a> {
                     .map_err(wrap_storage_error)?;
 
             if has_yield_receipt_in_state || has_yield_status_in_state {
-                self.receipt_manager.create_promise_resume_receipt(data_id, data)?;
+                self.receipt_manager.create_promise_resume_receipt(data_id, data);
                 set_promise_yield_status(
                     &mut self.trie_update,
                     &self.account_id,
@@ -393,29 +392,22 @@ impl<'a> External for RuntimeExt<'a> {
             Ok(false)
         } else {
             if has_yield_receipt_in_state {
-                self.receipt_manager.create_promise_resume_receipt(data_id, data)?;
+                self.receipt_manager.create_promise_resume_receipt(data_id, data);
                 return Ok(true);
             }
 
             // If the yielded promise was created by the current transaction, we'll find it in the
             // receipt manager.
-            self.receipt_manager.checked_resolve_promise_yield(data_id, data)
+            Ok(self.receipt_manager.checked_resolve_promise_yield(data_id, data))
         }
     }
 
-    fn append_action_create_account(
-        &mut self,
-        receipt_index: ReceiptIndex,
-    ) -> Result<(), VMLogicError> {
-        self.receipt_manager.append_action_create_account(receipt_index)
+    fn append_action_create_account(&mut self, receipt_index: ReceiptIndex) {
+        self.receipt_manager.append_action_create_account(receipt_index);
     }
 
-    fn append_action_deploy_contract(
-        &mut self,
-        receipt_index: ReceiptIndex,
-        code: Vec<u8>,
-    ) -> Result<(), VMLogicError> {
-        self.receipt_manager.append_action_deploy_contract(receipt_index, code)
+    fn append_action_deploy_contract(&mut self, receipt_index: ReceiptIndex, code: Vec<u8>) {
+        self.receipt_manager.append_action_deploy_contract(receipt_index, code);
     }
 
     fn append_action_deploy_global_contract(
@@ -423,16 +415,16 @@ impl<'a> External for RuntimeExt<'a> {
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
         mode: GlobalContractDeployMode,
-    ) -> Result<(), VMLogicError> {
-        self.receipt_manager.append_action_deploy_global_contract(receipt_index, code, mode)
+    ) {
+        self.receipt_manager.append_action_deploy_global_contract(receipt_index, code, mode);
     }
 
     fn append_action_use_global_contract(
         &mut self,
         receipt_index: ReceiptIndex,
         contract_id: GlobalContractIdentifier,
-    ) -> Result<(), VMLogicError> {
-        self.receipt_manager.append_use_deploy_global_contract(receipt_index, contract_id)
+    ) {
+        self.receipt_manager.append_use_deploy_global_contract(receipt_index, contract_id);
     }
 
     fn append_action_deterministic_state_init(
@@ -440,7 +432,7 @@ impl<'a> External for RuntimeExt<'a> {
         receipt_index: ReceiptIndex,
         contract_id: GlobalContractIdentifier,
         amount: Balance,
-    ) -> Result<u64, VMLogicError> {
+    ) -> u64 {
         self.receipt_manager.append_deterministic_state_init(receipt_index, contract_id, amount)
     }
 
@@ -463,12 +455,8 @@ impl<'a> External for RuntimeExt<'a> {
         )
     }
 
-    fn append_action_transfer(
-        &mut self,
-        receipt_index: ReceiptIndex,
-        deposit: Balance,
-    ) -> Result<(), VMLogicError> {
-        self.receipt_manager.append_action_transfer(receipt_index, deposit)
+    fn append_action_transfer(&mut self, receipt_index: ReceiptIndex, deposit: Balance) {
+        self.receipt_manager.append_action_transfer(receipt_index, deposit);
     }
 
     fn append_action_stake(
@@ -524,8 +512,8 @@ impl<'a> External for RuntimeExt<'a> {
         &mut self,
         receipt_index: ReceiptIndex,
         beneficiary_id: AccountId,
-    ) -> Result<(), VMLogicError> {
-        self.receipt_manager.append_action_delete_account(receipt_index, beneficiary_id)
+    ) {
+        self.receipt_manager.append_action_delete_account(receipt_index, beneficiary_id);
     }
 
     fn get_receipt_receiver(&self, receipt_index: ReceiptIndex) -> &AccountId {


### PR DESCRIPTION
Remove `Result` return types from `ReceiptManager` methods and `External` trait methods that never error. These methods always return `Ok(...)` unconditionally. Sibling methods like `append_action_stake` and `append_action_delete_key` already return `()`.

- `ReceiptManager`: simplified 10 methods (`create_promise_yield_receipt`, `create_promise_resume_receipt`, `checked_resolve_promise_yield`, `append_action_create_account`, `append_action_deploy_contract`, `append_action_deploy_global_contract`, `append_use_deploy_global_contract`, `append_deterministic_state_init`, `append_action_transfer`, `append_action_delete_account`)
- `External` trait: simplified 7 method signatures to match
- Updated all call sites in `logic.rs`, `wasmtime_runner/logic.rs`, `ext.rs`, and `mock_external.rs`