### PR TITLE
chore(ci): bump actions/checkout to v6

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: "write"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       id-token: "write"
     steps:
       - if: github.event_name != 'pull_request' || matrix.run_on_pr
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
         with:
           persist-credentials: false
@@ -116,7 +116,7 @@ jobs:
     name: "Protobuf Backward Compatibility"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: bufbuild/buf-setup-action@1158f4fa81bc02e1ff62abcca6d516c9e24c77da
@@ -136,7 +136,7 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: gcp-auth
@@ -188,7 +188,7 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: gcp-auth
@@ -216,7 +216,7 @@ jobs:
     name: "Style"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e
@@ -233,7 +233,7 @@ jobs:
     name: "Cargo Fmt"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e
@@ -248,7 +248,7 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: gcp-auth
@@ -278,7 +278,7 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: gcp-auth
@@ -304,7 +304,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e
@@ -317,7 +317,7 @@ jobs:
     name: "Cargo Deny"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e
@@ -329,7 +329,7 @@ jobs:
     name: "Themis"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e
@@ -341,7 +341,7 @@ jobs:
     name: "Cargo machete (unused dependencies)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e
@@ -356,7 +356,7 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: gcp-auth
@@ -386,7 +386,7 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: gcp-auth
@@ -413,7 +413,7 @@ jobs:
     name: "Cargo Audit"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e
@@ -433,7 +433,7 @@ jobs:
           - type: unit
             profraws: unit
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1000 # have enough history to find the merge-base between PR and master
           persist-credentials: false
@@ -480,7 +480,7 @@ jobs:
       - cargo_nextest
       - pytest_nightly_tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/download-artifact@v4
@@ -529,7 +529,7 @@ jobs:
         if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         name: Check if job should be skipped
         run: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.run-job.outcome == 'success'
         with:
           persist-credentials: false
@@ -563,7 +563,7 @@ jobs:
     name: "OpenAPI Spec"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: taiki-e/install-action@e797ba6a25dbd8669057e123b02812e16138589e

--- a/.github/workflows/lychee_lints.yml
+++ b/.github/workflows/lychee_lints.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Lychee Lints"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       # cspell:disable-next-line

--- a/.github/workflows/mac_m1_binary.yml
+++ b/.github/workflows/mac_m1_binary.yml
@@ -40,14 +40,14 @@ jobs:
         # for release events we need to checkout all branches to be able to determine
         # later branch name
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name == 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false

--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -23,7 +23,7 @@ jobs:
       - run: sudo swapon /swap-file
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
   

--- a/.github/workflows/nayduck_ci.yml
+++ b/.github/workflows/nayduck_ci.yml
@@ -28,13 +28,13 @@ jobs:
 
       - name: Checkout nearcore repository
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Checkout nearcore repository for workflow dispatch
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{github.event.inputs.neard-branch}}
           persist-credentials: false
@@ -89,7 +89,7 @@ jobs:
     runs-on: warp-ubuntu-2404-x64-8x
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: WarpBuilds/setup-python@v5

--- a/.github/workflows/nayduck_ci_dev.yml
+++ b/.github/workflows/nayduck_ci_dev.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt install jq
 
       - name: Checkout nearcore repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/near_crates_publish.yml
+++ b/.github/workflows/near_crates_publish.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout near/nearcore's ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/neard_assertion_binary.yml
+++ b/.github/workflows/neard_assertion_binary.yml
@@ -29,14 +29,14 @@ jobs:
 
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false
 
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/neard_custom_binary.yml
+++ b/.github/workflows/neard_custom_binary.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false

--- a/.github/workflows/neard_nightly_binary.yml
+++ b/.github/workflows/neard_nightly_binary.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false

--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false
@@ -46,7 +46,7 @@ jobs:
         # for release events we need to checkout all branches to be able to determine
         # later branch name
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name == 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout repository for master branch
         # In case of master branch we want to checkout with depth 1
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false
@@ -121,7 +121,7 @@ jobs:
         # for release events we need to checkout all branches to be able to determine
         # later branch name
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name == 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -129,7 +129,7 @@ jobs:
       - name: Checkout  repository for master branch
         # In case of master branch we want to checkout with depth 1
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -40,13 +40,13 @@ jobs:
 
       - name: Checkout Release/RC branch
         if: contains(fromJSON('["released", "prereleased"]'), github.event.action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Checkout ${{ github.event.inputs.branch_ref }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch_ref }}
           persist-credentials: false


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 across all GitHub workflows. Pure CI maintenance update with no logic changes