### PR TITLE
fix(tests): require test_features for resharding_global_contract tests

### DIFF
--- a/test-loop-tests/src/tests/resharding_v3.rs
+++ b/test-loop-tests/src/tests/resharding_v3.rs
@@ -1223,6 +1223,7 @@ fn slow_test_resharding_v3_delayed_receipts_left_child() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_resharding_v3_global_contract_by_hash() {
@@ -1235,6 +1236,7 @@ fn slow_test_resharding_v3_global_contract_by_hash() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_resharding_v3_global_contract_by_account_id() {


### PR DESCRIPTION
These tests don't pass without `test_features`:
```shell
$ cargo nextest run --cargo-profile dev-release --no-fail-fast --ignore-default-filter slow_test_resharding_v3_global_contract

Summary [   3.299s] 2 tests run: 0 passed, 2 failed, 2715 skipped
FAIL [   1.601s] (1/2) test-loop-tests tests::resharding_v3::slow_test_resharding_v3_global_contract_by_hash
FAIL [   1.619s] (2/2) test-loop-tests tests::resharding_v3::slow_test_resharding_v3_global_contract_by_account_id
```
With `test_features` they pass:
```shell
$ cargo nextest run --cargo-profile dev-release --no-fail-fast --features test_features --ignore-default-filter slow_test_resharding_v3_global_contract
PASS [   8.391s] (1/2) test-loop-tests tests::resharding_v3::slow_test_resharding_v3_global_contract_by_account_id
PASS [   8.578s] (2/2) test-loop-tests tests::resharding_v3::slow_test_resharding_v3_global_contract_by_hash
Summary [   8.804s] 2 tests run: 2 passed, 2743 skipped
```

Let's ignore them when the `test_features` feature is not enabled.