### PR TITLE
refactor: move gas key fee helpers to near-parameters

### DIFF
--- a/core/parameters/src/lib.rs
+++ b/core/parameters/src/lib.rs
@@ -11,8 +11,9 @@ pub mod vm;
 pub use config::{AccountCreationConfig, RuntimeConfig};
 pub use config_store::RuntimeConfigStore;
 pub use cost::{
-    ActionCosts, ExtCosts, ExtCostsConfig, Fee, ParameterCost, RuntimeFeesConfig,
-    StorageUsageConfig, transfer_exec_fee, transfer_send_fee,
+    ActionCosts, ExtCosts, ExtCostsConfig, Fee, GasKeyTransferFee, ParameterCost,
+    RuntimeFeesConfig, StorageUsageConfig, gas_key_transfer_exec_fee, gas_key_transfer_send_fee,
+    transfer_exec_fee, transfer_send_fee,
 };
 pub use parameter::Parameter;
 pub use view::{RuntimeConfigView, RuntimeFeesConfigView};

--- a/core/primitives-core/src/lib.rs
+++ b/core/primitives-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod gas;
 pub mod global_contract;
 pub mod hash;
 pub mod serialize;
+pub mod trie_key;
 pub mod types;
 pub mod version;
 

--- a/core/primitives-core/src/trie_key.rs
+++ b/core/primitives-core/src/trie_key.rs
@@ -1,0 +1,15 @@
+use std::mem::size_of;
+
+/// Length of the column prefix byte in a trie key (a single `u8`).
+const COLUMN_PREFIX_LEN: usize = size_of::<u8>();
+
+/// Length of the access key separator byte in a trie key (a single `u8`).
+const ACCESS_KEY_SEPARATOR_LEN: usize = size_of::<u8>();
+
+/// Returns the length of the trie key for an access key.
+///
+/// The trie key format is: `[col_prefix] [account_id] [separator] [public_key]`
+/// where the prefix and separator are each a single `u8` byte.
+pub fn access_key_key_len(account_id_len: usize, public_key_len: usize) -> usize {
+    COLUMN_PREFIX_LEN + account_id_len + ACCESS_KEY_SEPARATOR_LEN + public_key_len
+}


### PR DESCRIPTION
Move gas key fee computation out of `node-runtime` into `near-parameters` so it can be reused by other crates (e.g. vm-runner for host functions).

- Extract `access_key_key_len` into `near-primitives-core::trie_key` taking `usize` params instead of `&AccountId`/`&PublicKey`, making it usable without high-level types
- Move `gas_key_transfer_send_fee` and `gas_key_transfer_exec_fee` from `runtime/runtime/src/config.rs` to `core/parameters/src/cost.rs`
- Introduce `GasKeyTransferFee` struct that splits base vs per-byte components for gas profiling attribution (for later use in host function)
- Add test verifying `access_key_key_len` stays in sync with actual `TrieKey::AccessKey` serialization
- No behavioral changes -- all callers produce identical gas values via `.total()`