### PR TITLE
chore(state-sync): remove block_fetch_horizon config

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -334,7 +334,6 @@ impl Client {
         let block_sync = BlockSync::new(
             clock.clone(),
             network_adapter.clone(),
-            config.block_fetch_horizon,
             config.archive,
             config.state_sync_enabled,
         );

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -12651,12 +12651,6 @@
             "description": "Not clear old data, set `true` for archive nodes.",
             "type": "boolean"
           },
-          "block_fetch_horizon": {
-            "description": "Horizon at which instead of fetching block, fetch full state.",
-            "format": "uint64",
-            "minimum": 0,
-            "type": "integer"
-          },
           "block_header_fetch_horizon": {
             "description": "Behind this horizon header fetch kicks in.",
             "format": "uint64",

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -8081,12 +8081,6 @@
             "description": "Not clear old data, set `true` for archive nodes.",
             "type": "boolean"
           },
-          "block_fetch_horizon": {
-            "description": "Horizon at which instead of fetching block, fetch full state.",
-            "format": "uint64",
-            "minimum": 0,
-            "type": "integer"
-          },
           "block_header_fetch_horizon": {
             "description": "Behind this horizon header fetch kicks in.",
             "format": "uint64",
@@ -8616,7 +8610,6 @@
           "epoch_length",
           "num_block_producer_seats",
           "ttl_account_id_router",
-          "block_fetch_horizon",
           "catchup_step_period",
           "chunk_request_retry_period",
           "doomslug_step_period",

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -759,8 +759,6 @@ pub struct ClientConfig {
     /// Time to persist Accounts Id in the router without removing them.
     #[cfg_attr(feature = "schemars", schemars(with = "DurationSchemarsProvider"))]
     pub ttl_account_id_router: Duration,
-    /// Horizon at which instead of fetching block, fetch full state.
-    pub block_fetch_horizon: BlockHeightDelta,
     /// Time between check to perform catchup.
     #[cfg_attr(feature = "schemars", schemars(with = "DurationSchemarsProvider"))]
     pub catchup_step_period: Duration,

--- a/core/chain-configs/src/test_utils.rs
+++ b/core/chain-configs/src/test_utils.rs
@@ -297,7 +297,6 @@ impl ClientConfig {
             epoch_length: 10,
             num_block_producer_seats,
             ttl_account_id_router: Duration::seconds(60 * 60),
-            block_fetch_horizon: 50,
             catchup_step_period: Duration::milliseconds(100),
             chunk_request_retry_period: min(
                 Duration::milliseconds(100),

--- a/integration-tests/src/tests/client/block_sync.rs
+++ b/integration-tests/src/tests/client/block_sync.rs
@@ -73,15 +73,9 @@ fn test_env_with_epoch_length(epoch_length: u64) -> TestEnv {
 fn test_block_sync() {
     let mut capture = TracingCapture::enable();
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
-    let block_fetch_horizon = 10;
     let max_block_requests = 10;
-    let mut block_sync = BlockSync::new(
-        Clock::real(),
-        network_adapter.as_multi_sender(),
-        block_fetch_horizon,
-        false,
-        true,
-    );
+    let mut block_sync =
+        BlockSync::new(Clock::real(), network_adapter.as_multi_sender(), false, true);
     let mut env = test_env_with_epoch_length(100);
     let mut blocks = vec![];
     for i in 1..5 * max_block_requests + 1 {
@@ -152,15 +146,9 @@ fn test_block_sync() {
 #[test]
 fn test_block_sync_archival() {
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
-    let block_fetch_horizon = 10;
     let max_block_requests = 10;
-    let mut block_sync = BlockSync::new(
-        Clock::real(),
-        network_adapter.as_multi_sender(),
-        block_fetch_horizon,
-        true,
-        true,
-    );
+    let mut block_sync =
+        BlockSync::new(Clock::real(), network_adapter.as_multi_sender(), true, true);
     let mut env = test_env_with_epoch_length(5);
     let mut blocks = vec![];
     for i in 1..41 {

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -52,7 +52,6 @@ async fn ultra_slow_test_sync_state_dump() {
     // Produce more blocks to make sure that state sync gets triggered when the second node starts.
     let state_sync_horizon = 50;
     let block_header_fetch_horizon = 1;
-    let block_fetch_horizon = 1;
 
     let mut near1 = load_test_config("test1", port1, genesis.clone());
     near1.client_config.min_num_peers = 0;
@@ -97,7 +96,6 @@ async fn ultra_slow_test_sync_state_dump() {
                         near2.client_config.max_block_production_delay =
                             Duration::milliseconds(600);
                         near2.client_config.block_header_fetch_horizon = block_header_fetch_horizon;
-                        near2.client_config.block_fetch_horizon = block_fetch_horizon;
                         near2.client_config.tracked_shards_config = TrackedShardsConfig::AllShards;
                         near2.client_config.state_sync_enabled = true;
                         near2.client_config.state_sync_external_timeout = Duration::seconds(2);

--- a/nearcore/res/example-config-gc.json
+++ b/nearcore/res/example-config-gc.json
@@ -78,7 +78,6 @@
             "nanos": 0
         },
         "produce_empty_blocks": true,
-        "block_fetch_horizon": 50,
         "block_header_fetch_horizon": 50,
         "catchup_step_period": {
             "secs": 0,

--- a/nearcore/res/example-config-no-gc.json
+++ b/nearcore/res/example-config-no-gc.json
@@ -78,7 +78,6 @@
             "nanos": 0
         },
         "produce_empty_blocks": true,
-        "block_fetch_horizon": 50,
         "block_header_fetch_horizon": 50,
         "catchup_step_period": {
             "secs": 0,

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -89,9 +89,6 @@ pub const MAX_BLOCK_WAIT_DELAY: i64 = 6_000;
 /// Multiplier for the wait time for all chunks to be received.
 pub const CHUNK_WAIT_DENOMINATOR: i32 = 3;
 
-/// Horizon at which instead of fetching block, fetch full state.
-const BLOCK_FETCH_HORIZON: BlockHeightDelta = 50;
-
 /// Behind this horizon header fetch kicks in.
 const BLOCK_HEADER_FETCH_HORIZON: BlockHeightDelta = 50;
 
@@ -139,8 +136,6 @@ pub struct Consensus {
     pub chunk_wait_mult: Rational32,
     /// Produce empty blocks, use `false` for testing.
     pub produce_empty_blocks: bool,
-    /// Horizon at which instead of fetching block, fetch full state.
-    pub block_fetch_horizon: BlockHeightDelta,
     /// Behind this horizon header fetch kicks in.
     pub block_header_fetch_horizon: BlockHeightDelta,
     /// Time between check to perform catchup.
@@ -208,7 +203,6 @@ impl Default for Consensus {
             max_block_wait_delay: Duration::milliseconds(MAX_BLOCK_WAIT_DELAY),
             chunk_wait_mult: Rational32::new(1, CHUNK_WAIT_DENOMINATOR),
             produce_empty_blocks: true,
-            block_fetch_horizon: BLOCK_FETCH_HORIZON,
             block_header_fetch_horizon: BLOCK_HEADER_FETCH_HORIZON,
             catchup_step_period: Duration::milliseconds(CATCHUP_STEP_PERIOD),
             chunk_request_retry_period: Duration::milliseconds(CHUNK_REQUEST_RETRY_PERIOD),
@@ -719,8 +713,6 @@ impl NearConfig {
                 epoch_length: genesis.config.epoch_length,
                 num_block_producer_seats: genesis.config.num_block_producer_seats,
                 ttl_account_id_router: config.network.ttl_account_id_router,
-                // TODO(1047): this should be adjusted depending on the speed of sync of state.
-                block_fetch_horizon: config.consensus.block_fetch_horizon,
                 block_header_fetch_horizon: config.consensus.block_header_fetch_horizon,
                 catchup_step_period: config.consensus.catchup_step_period,
                 chunk_request_retry_period: config.consensus.chunk_request_retry_period,

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -1165,7 +1165,6 @@ def apply_config_changes(node_dir: str,
     # when None.
     allowed_missing_configs = (
         'archive',
-        'consensus.block_fetch_horizon',
         'consensus.block_header_fetch_horizon',
         'consensus.min_block_production_delay',
         'consensus.max_block_production_delay',

--- a/pytest/tests/sanity/block_sync.py
+++ b/pytest/tests/sanity/block_sync.py
@@ -14,12 +14,7 @@ import utils
 
 BLOCKS = 10
 
-consensus_config0 = {
-    "consensus": {
-        "block_fetch_horizon": 30,
-        "block_header_fetch_horizon": 30
-    }
-}
+consensus_config0 = {"consensus": {"block_header_fetch_horizon": 30}}
 consensus_config1 = {
     "consensus": {
         "min_block_production_delay": {

--- a/pytest/tests/sanity/gc_after_sync.py
+++ b/pytest/tests/sanity/gc_after_sync.py
@@ -30,7 +30,6 @@ node_config["consensus.max_block_production_delay"] = {
     "nanos": 300000000
 }
 node_config["consensus.max_block_wait_delay"] = {"secs": 0, "nanos": 600000000}
-node_config["consensus.block_fetch_horizon"] = 1
 node_config["gc_step_period"] = {"secs": 0, "nanos": 100000000}
 
 nodes = start_cluster(

--- a/pytest/tests/sanity/gc_after_sync1.py
+++ b/pytest/tests/sanity/gc_after_sync1.py
@@ -26,7 +26,6 @@ node0_config.update({"gc_blocks_limit": 10})
 
 node1_config.update({
     "consensus": {
-        "block_fetch_horizon": 10,
         "block_header_fetch_horizon": 10,
     },
     "tracked_shards_config": "AllShards",

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -95,8 +95,6 @@ tracker.reset(
 )  # the transition might have happened before we initialized the tracker
 if catch_up_height >= 100:
     assert tracker.check("transition to state sync")
-elif catch_up_height <= 30:
-    assert not tracker.check("transition to state sync")
 
 if mode == 'manytx':
     while ctx.get_balances() != ctx.expected_balances:

--- a/pytest/tests/sanity/state_sync_missing_chunks.py
+++ b/pytest/tests/sanity/state_sync_missing_chunks.py
@@ -32,7 +32,6 @@ class StateSyncMissingChunks(unittest.TestCase):
         # state sync earlier.
         (config_dump, config_sync) = get_state_sync_configs_pair()
         config_sync["consensus"] = {
-            "block_fetch_horizon": epoch_length,
             "block_header_fetch_horizon": epoch_length,
         }
         client_config_changes = {0: config_dump, 1: config_sync}

--- a/test-loop-tests/src/tests/continuous_epoch_sync.rs
+++ b/test-loop-tests/src/tests/continuous_epoch_sync.rs
@@ -222,7 +222,6 @@ fn test_epoch_sync_bootstrap_fresh_node() {
         .account_id(account_id)
         .config_modifier(|config| {
             config.block_header_fetch_horizon = 8;
-            config.block_fetch_horizon = 3;
         })
         .build();
     env.add_node(identifier, node_state);

--- a/test-loop-tests/src/tests/epoch_sync.rs
+++ b/test-loop-tests/src/tests/epoch_sync.rs
@@ -89,8 +89,6 @@ fn bootstrap_node_via_epoch_sync(mut env: TestLoopEnv, source_node: usize) -> Te
             config.epoch_sync.epoch_sync_horizon_num_epochs = 3;
             // Make header sync horizon small enough to trigger it.
             config.block_header_fetch_horizon = 8;
-            // Make block sync horizon small enough to trigger it.
-            config.block_fetch_horizon = 3;
         })
         .build();
     env.add_node(&identifier, node_state);

--- a/test-loop-tests/src/tests/state_sync.rs
+++ b/test-loop-tests/src/tests/state_sync.rs
@@ -460,8 +460,6 @@ fn run_test_with_added_node(state: TestState) {
     let new_node_state = NodeStateBuilder::new(genesis, tempdir_path)
         .account_id(account_id.clone())
         .config_modifier(move |config| {
-            // Lower the threshold at which state sync is chosen over block sync
-            config.block_fetch_horizon = 5;
             config.tracked_shards_config = TrackedShardsConfig::AllShards;
         })
         .build();
@@ -1077,8 +1075,6 @@ fn slow_test_state_sync_no_parts_provided() {
     let new_node_state = NodeStateBuilder::new(genesis, tempdir_path)
         .account_id(account_id.clone())
         .config_modifier(move |config| {
-            // Lower the threshold at which state sync is chosen over block sync
-            config.block_fetch_horizon = 5;
             config.tracked_shards_config = TrackedShardsConfig::AllShards;
             config.state_sync_enabled = true;
             config.state_sync = StateSyncConfig::default();


### PR DESCRIPTION
## Motivation

`block_fetch_horizon` is a testing-only knob with no production value. The code comment at `block.rs` explicitly says it is "used for testing to prevent test nodes from switching to State Sync too eagerly."

State sync triggers in `check_state_needed()` when all three conditions are true:
```rust
head.epoch_id != header_head.epoch_id           // different epochs
    && head.next_epoch_id != header_head.epoch_id   // 2+ epochs apart
    && head.height + block_fetch_horizon < header_head.height  // height gap > horizon
```

For mainnet (`epoch_length=43200`), conditions 1+2 alone require a ~86,400 block gap before state sync can trigger. The 50-block horizon (condition 3) is completely irrelevant — it can never be the deciding factor.

The config only has an effect in tests with small epoch lengths (5-100 blocks), where it acts as an artificial gate preventing state sync even when a node is multiple epochs behind. This causes test behavior to deviate from production.

## Relevance to #15244

When `ContinuousEpochSync` is enabled and a node falls 2-3 epochs behind, state sync triggers and calls `reset_data_pre_state_sync` (wiping `BlockInfo`), but epoch sync doesn't trigger (needs 4+ epochs). The destroyed `BlockInfo` causes `extend_epoch_sync_proof` to fail permanently.

Removing `block_fetch_horizon` is the first step toward aligning these triggers — it eliminates the artificial height-based gate so that state sync decisions are purely epoch-boundary-based, matching production behavior.

## Changes

- Remove `block_fetch_horizon` from `BlockSync` struct, `ClientConfig`, `Consensus` config, and all test defaults.
- Simplify `check_state_needed()` to a pure epoch boundary check: state sync triggers when the head is 2+ epochs behind the header head.
- Keep `block_header_fetch_horizon` — it serves a different purpose (preventing wasteful block sync attempts while headers are still downloading).
- Clean up all Rust tests, Python tests, and example configs that referenced this config.
- Fix `state_sync.py` assertion that incorrectly expected no state sync at `catch_up_height <= 30` with `epoch_length=10` — at 3 epochs behind, state sync is the correct behavior.