### PR TITLE
refactor(vm-runner): replace JSON with direct asserts in promise tests

### DIFF
--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[allow(dead_code)] // The value is never read because this is a mock.
 struct GasWeightSer(u64);
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub enum MockAction {
     CreateReceipt {
         receipt_indices: Vec<ReceiptIndex>,

--- a/runtime/near-vm-runner/src/logic/tests/promises.rs
+++ b/runtime/near-vm-runner/src/logic/tests/promises.rs
@@ -1,19 +1,50 @@
-use crate::logic::mocks::mock_external::MockedExternal;
+use crate::logic::mocks::mock_external::MockAction;
 use crate::logic::tests::helpers::*;
 use crate::logic::tests::vm_logic_builder::VMLogicBuilder;
-use crate::logic::types::PromiseResult;
+use crate::logic::types::{GlobalContractDeployMode, GlobalContractIdentifier, PromiseResult};
 use crate::map;
 
 use near_crypto::PublicKey;
 use near_parameters::{ActionCosts, ExtCosts};
 use near_primitives_core::config::AccountIdValidityRulesVersion;
+use near_primitives_core::deterministic_account_id::{
+    DeterministicAccountStateInit, DeterministicAccountStateInitV1,
+};
 use near_primitives_core::hash::CryptoHash;
-use near_primitives_core::types::Gas;
+use near_primitives_core::types::{Balance, Gas, GasWeight};
 use near_primitives_core::version::{PROTOCOL_VERSION, ProtocolFeature};
-use serde_json;
 
-fn vm_receipts<'a>(ext: &'a MockedExternal) -> Vec<impl serde::Serialize + 'a> {
-    ext.action_log.clone()
+fn test_public_key() -> PublicKey {
+    "ed25519:5do5nkAEVhL8iteDvXNgxi4pWK78Y7DDadX11ArFNyrf".parse().unwrap()
+}
+
+/// Asserts the common promise_create preamble (CreateReceipt + FunctionCallWeight) in the
+/// action log. Returns the remaining actions after the preamble.
+#[track_caller]
+fn assert_promise_create_preamble<'a>(
+    action_log: &'a [MockAction],
+    expected_receiver: &str,
+) -> &'a [MockAction] {
+    assert!(action_log.len() >= 2, "expected at least 2 actions, got {}", action_log.len());
+    assert_eq!(
+        action_log[0],
+        MockAction::CreateReceipt {
+            receipt_indices: vec![],
+            receiver_id: expected_receiver.parse().unwrap(),
+        }
+    );
+    assert_eq!(
+        action_log[1],
+        MockAction::FunctionCallWeight {
+            receipt_index: 0,
+            method_name: b"promise_create".to_vec(),
+            args: b"args".to_vec(),
+            attached_deposit: Balance::ZERO,
+            prepaid_gas: Gas::ZERO,
+            gas_weight: GasWeight(0),
+        }
+    );
+    &action_log[2..]
 }
 
 #[test]
@@ -78,103 +109,18 @@ fn test_promise_batch_action_function_call() {
 
     promise_batch_action_function_call(&mut logic, index, 0, Gas::ZERO)
         .expect("should add an action to receipt");
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                98,
-                97,
-                116,
-                99,
-                104,
-                95,
-                97,
-                99,
-                116,
-                105,
-                111,
-                110
-              ],
-              "args": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                98,
-                97,
-                116,
-                99,
-                104,
-                95,
-                97,
-                99,
-                116,
-                105,
-                111,
-                110,
-                95,
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(
+        actions,
+        &[MockAction::FunctionCallWeight {
+            receipt_index: 0,
+            method_name: b"promise_batch_action".to_vec(),
+            args: b"promise_batch_action_args".to_vec(),
+            attached_deposit: Balance::ZERO,
+            prepaid_gas: Gas::ZERO,
+            gas_weight: GasWeight(0),
+        }]
+    );
 }
 
 #[test]
@@ -220,51 +166,8 @@ fn test_promise_batch_action_create_account() {
         .promise_batch_action_create_account(index)
         .expect("should add an action to create account");
     assert_eq!(logic.used_gas().unwrap(), 12578263688564);
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "CreateAccount": {
-              "receipt_index": 0
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(actions, &[MockAction::CreateAccount { receipt_index: 0 }]);
 }
 
 #[test]
@@ -289,59 +192,11 @@ fn test_promise_batch_action_deploy_contract() {
         .promise_batch_action_deploy_contract(index, code.len, code.ptr)
         .expect("should add an action to deploy contract");
     assert_eq!(logic.used_gas().unwrap(), 5255774958146);
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "DeployContract": {
-              "receipt_index": 0,
-              "code": [
-                115,
-                97,
-                109,
-                112,
-                108,
-                101
-              ]
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(
+        actions,
+        &[MockAction::DeployContract { receipt_index: 0, code: b"sample".to_vec() }]
+    );
 }
 
 #[test]
@@ -366,60 +221,15 @@ fn test_promise_batch_action_deploy_global_contract() {
         .promise_batch_action_deploy_global_contract(index, code.len, code.ptr)
         .expect("should add an action to deploy contract");
     assert_eq!(logic.used_gas().unwrap(), 5256154080152);
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "DeployGlobalContract": {
-              "receipt_index": 0,
-              "code": [
-                115,
-                97,
-                109,
-                112,
-                108,
-                101
-              ],
-              "mode": "CodeHash"
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(
+        actions,
+        &[MockAction::DeployGlobalContract {
+            receipt_index: 0,
+            code: b"sample".to_vec(),
+            mode: GlobalContractDeployMode::CodeHash,
+        }]
+    );
 }
 
 #[test]
@@ -452,54 +262,14 @@ fn test_promise_batch_action_use_global_contract() {
         .promise_batch_action_use_global_contract(index, code_hash.len, code_hash.ptr)
         .expect("should add an action to deploy contract");
     assert_eq!(logic.used_gas().unwrap(), 5262559186522);
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "UseGlobalContract": {
-              "receipt_index": 0,
-              "contract_id": {
-                "CodeHash": "A6buRpeED4eLGiYvbboigf7WSicK52xwKtdRNFwKcFgv"
-              }
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(
+        actions,
+        &[MockAction::UseGlobalContract {
+            receipt_index: 0,
+            contract_id: GlobalContractIdentifier::CodeHash(CryptoHash::hash_bytes(b"arbitrary")),
+        }]
+    );
 }
 
 #[test]
@@ -526,52 +296,11 @@ fn test_promise_batch_action_transfer() {
         .expect("should add an action to transfer money");
     logic.promise_batch_action_transfer(index, num_1u128.ptr).expect_err("not enough money");
     assert_eq!(logic.used_gas().unwrap(), 5349703444787);
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "Transfer": {
-              "receipt_index": 0,
-              "deposit": "110"
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(
+        actions,
+        &[MockAction::Transfer { receipt_index: 0, deposit: Balance::from_yoctonear(110) }]
+    );
 }
 
 #[test]
@@ -579,10 +308,7 @@ fn test_promise_batch_action_transfer_to_gas_key() {
     let mut logic_builder = VMLogicBuilder::default();
     let mut logic = logic_builder.build();
     let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
-    let key = borsh::to_vec(
-        &"ed25519:5do5nkAEVhL8iteDvXNgxi4pWK78Y7DDadX11ArFNyrf".parse::<PublicKey>().unwrap(),
-    )
-    .unwrap();
+    let key = borsh::to_vec(&test_public_key()).unwrap();
 
     let key = logic.internal_mem_write(&key);
     let index_ptr = logic.internal_mem_write(&index.to_le_bytes()).ptr;
@@ -604,53 +330,15 @@ fn test_promise_batch_action_transfer_to_gas_key() {
     logic
         .promise_batch_action_transfer_to_gas_key(index, key.len, key.ptr, num_1u128.ptr)
         .expect_err("not enough money");
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "TransferToGasKey": {
-              "receipt_index": 0,
-              "public_key": "ed25519:5do5nkAEVhL8iteDvXNgxi4pWK78Y7DDadX11ArFNyrf",
-              "deposit": "110"
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(
+        actions,
+        &[MockAction::TransferToGasKey {
+            receipt_index: 0,
+            public_key: test_public_key(),
+            deposit: Balance::from_yoctonear(110),
+        }]
+    );
 }
 
 #[test]
@@ -658,10 +346,7 @@ fn test_promise_batch_action_stake() {
     let mut logic_builder = VMLogicBuilder::default();
     let mut logic = logic_builder.build();
     let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
-    let key = borsh::to_vec(
-        &"ed25519:5do5nkAEVhL8iteDvXNgxi4pWK78Y7DDadX11ArFNyrf".parse::<PublicKey>().unwrap(),
-    )
-    .unwrap();
+    let key = borsh::to_vec(&test_public_key()).unwrap();
 
     let key = logic.internal_mem_write(&key);
     let index_ptr = logic.internal_mem_write(&index.to_le_bytes()).ptr;
@@ -680,53 +365,15 @@ fn test_promise_batch_action_stake() {
         .promise_batch_action_stake(index, num_110u128.ptr, key.len, key.ptr)
         .expect("should add an action to stake");
     assert_eq!(logic.used_gas().unwrap(), 5138414976215);
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "Stake": {
-              "receipt_index": 0,
-              "stake": "110",
-              "public_key": "ed25519:5do5nkAEVhL8iteDvXNgxi4pWK78Y7DDadX11ArFNyrf"
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(
+        actions,
+        &[MockAction::Stake {
+            receipt_index: 0,
+            stake: Balance::from_yoctonear(110),
+            public_key: test_public_key(),
+        }]
+    );
 }
 
 #[test]
@@ -735,10 +382,7 @@ fn test_promise_batch_action_add_key_with_function_call() {
     let mut logic = logic_builder.build();
     let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
     let index_ptr = logic.internal_mem_write(&index.to_le_bytes()).ptr;
-    let key = borsh::to_vec(
-        &"ed25519:5do5nkAEVhL8iteDvXNgxi4pWK78Y7DDadX11ArFNyrf".parse::<PublicKey>().unwrap(),
-    )
-    .unwrap();
+    let key = borsh::to_vec(&test_public_key()).unwrap();
     let nonce = 1;
     let allowance = 999u128;
     let receiver_id = b"sam";
@@ -778,67 +422,18 @@ fn test_promise_batch_action_add_key_with_function_call() {
     )
     .expect("should add allowance");
     assert_eq!(logic.used_gas().unwrap(), 5126680499695);
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "AddKeyWithFunctionCall": {
-              "receipt_index": 0,
-              "public_key": "ed25519:5do5nkAEVhL8iteDvXNgxi4pWK78Y7DDadX11ArFNyrf",
-              "nonce": 1,
-              "allowance": "999",
-              "receiver_id": "sam",
-              "method_names": [
-                [
-                  102,
-                  111,
-                  111
-                ],
-                [
-                  98,
-                  97,
-                  114
-                ]
-              ]
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    assert_eq!(
+        actions,
+        &[MockAction::AddKeyWithFunctionCall {
+            receipt_index: 0,
+            public_key: test_public_key(),
+            nonce: 1,
+            allowance: Some(Balance::from_yoctonear(999)),
+            receiver_id: "sam".parse().unwrap(),
+            method_names: vec![b"foo".to_vec(), b"bar".to_vec()],
+        }]
+    );
 }
 
 #[test]
@@ -865,62 +460,12 @@ fn test_promise_batch_then() {
         .promise_batch_then(index, account_id.len, account_id.ptr)
         .expect("promise batch should run ok");
     assert_eq!(logic.used_gas().unwrap(), 24124999601771);
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "FunctionCallWeight": {
-              "receipt_index": 0,
-              "method_name": [
-                112,
-                114,
-                111,
-                109,
-                105,
-                115,
-                101,
-                95,
-                99,
-                114,
-                101,
-                97,
-                116,
-                101
-              ],
-              "args": [
-                97,
-                114,
-                103,
-                115
-              ],
-              "attached_deposit": "0",
-              "prepaid_gas": 0,
-              "gas_weight": 0
-            }
-          },
-          {
-            "CreateReceipt": {
-              "receipt_indices": [
-                0
-              ],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "CreateReceipt": {
-              "receipt_indices": [
-                0
-              ],
-              "receiver_id": "rick.test"
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    let actions = assert_promise_create_preamble(&logic_builder.ext.action_log, "rick.test");
+    let expected_receipt = MockAction::CreateReceipt {
+        receipt_indices: vec![0],
+        receiver_id: "rick.test".parse().unwrap(),
+    };
+    assert_eq!(actions, &[expected_receipt.clone(), expected_receipt]);
 }
 
 #[test]
@@ -1040,31 +585,28 @@ fn test_promise_batch_action_state_init() {
         "unexpected action gas usage {profile:?}"
     );
 
-    expect_test::expect![[r#"
-        [
-          {
-            "CreateReceipt": {
-              "receipt_indices": [],
-              "receiver_id": "rick.test"
-            }
-          },
-          {
-            "DeterministicStateInit": {
-              "receipt_index": 0,
-              "state_init": {
-                "V1": {
-                  "code": {
-                    "AccountId": "global.near"
-                  },
-                  "data": {
-                    "a2V5": "dmFsdWU=",
-                    "a2V5Mg==": "dmFsdWUy"
-                  }
-                }
-              },
-              "amount": "110"
-            }
-          }
-        ]"#]]
-    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+    assert_eq!(
+        logic_builder.ext.action_log,
+        &[
+            MockAction::CreateReceipt {
+                receipt_indices: vec![],
+                receiver_id: "rick.test".parse().unwrap(),
+            },
+            MockAction::DeterministicStateInit {
+                receipt_index: 0,
+                state_init: DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
+                    code:
+                        near_primitives_core::global_contract::GlobalContractIdentifier::AccountId(
+                            "global.near".parse().unwrap(),
+                        ),
+                    data: [
+                        (b"key".to_vec(), b"value".to_vec()),
+                        (b"key2".to_vec(), b"value2".to_vec()),
+                    ]
+                    .into(),
+                }),
+                amount: Balance::from_yoctonear(110),
+            },
+        ]
+    );
 }

--- a/runtime/near-vm-runner/src/logic/types.rs
+++ b/runtime/near-vm-runner/src/logic/types.rs
@@ -41,13 +41,13 @@ pub enum PromiseResult {
     Failed,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub enum GlobalContractDeployMode {
     CodeHash,
     AccountId,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub enum GlobalContractIdentifier {
     CodeHash(CryptoHash),
     AccountId(AccountId),


### PR DESCRIPTION
Replace `expect_test` JSON snapshots in promise batch action tests with direct `MockAction` destructuring assertions. The byte-array serialized JSON was hard to read and maintain. Extract a shared `assert_promise_create_preamble` helper to deduplicate the common CreateReceipt + FunctionCallWeight checks across 10 of 11 tests.