### PR TITLE
refactor(test-loop): simplify tests to use auto-derive genesis API

### DIFF
--- a/test-loop-tests/src/tests/block_chunk_signature.rs
+++ b/test-loop-tests/src/tests/block_chunk_signature.rs
@@ -10,7 +10,6 @@ use near_primitives::block_body::BlockBody;
 use near_primitives::sharding::ShardChunkHeader;
 
 use crate::setup::builder::TestLoopBuilder;
-use crate::utils::account::{create_validators_spec, validators_spec_clients};
 
 const TIMEOUT_SECONDS: i64 = 5;
 
@@ -18,12 +17,7 @@ const TIMEOUT_SECONDS: i64 = 5;
 fn block_chunk_signature_rejection() {
     init_test_logger();
 
-    let validators_spec = create_validators_spec(2, 0);
-    let clients = validators_spec_clients(&validators_spec);
-    let genesis = TestLoopBuilder::new_genesis_builder().validators_spec(validators_spec).build();
-    let mut builder = TestLoopBuilder::new().skip_warmup();
-    builder = builder.genesis(genesis).epoch_config_store_from_genesis().clients(clients);
-    let mut env = builder.build();
+    let mut env = TestLoopBuilder::new().validators(2, 0).skip_warmup().build();
 
     let mutated_blocks = Arc::new(AtomicUsize::new(0));
 

--- a/test-loop-tests/src/tests/continuous_epoch_sync.rs
+++ b/test-loop-tests/src/tests/continuous_epoch_sync.rs
@@ -11,7 +11,6 @@ use near_store::adapter::StoreAdapter;
 use near_store::adapter::epoch_store::EpochStoreAdapter;
 
 use crate::setup::builder::TestLoopBuilder;
-use crate::utils::account::{create_validators_spec, validators_spec_clients};
 
 // Test that epoch sync proof is correctly updated after each epoch.
 // Validate the updated proof against derive_epoch_sync_proof_from_last_block.
@@ -24,19 +23,7 @@ fn test_epoch_sync_proof_update() {
 
     init_test_logger();
     let epoch_length = 10;
-    let validators_spec = create_validators_spec(1, 0);
-    let clients = validators_spec_clients(&validators_spec);
-
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(epoch_length)
-        .validators_spec(validators_spec)
-        .build();
-    let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
-        .build()
-        .warmup();
+    let mut env = TestLoopBuilder::new().epoch_length(epoch_length).build().warmup();
 
     let epoch_store = env.validator().client().chain.chain_store.epoch_store();
 
@@ -68,19 +55,7 @@ fn test_epoch_sync_proof_update_with_forks() {
 
     init_test_logger();
     let epoch_length = 10;
-    let validators_spec = create_validators_spec(1, 0);
-    let clients = validators_spec_clients(&validators_spec);
-
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(epoch_length)
-        .validators_spec(validators_spec)
-        .build();
-    let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
-        .build()
-        .warmup();
+    let mut env = TestLoopBuilder::new().epoch_length(epoch_length).build().warmup();
 
     // Run for 5 epochs
     for _ in 0..5 {
@@ -136,19 +111,8 @@ fn test_epoch_sync_stale_node_triggers_reset() {
     init_test_logger();
     let epoch_length = 10;
     // Use 4 validators so 3 remaining can continue after node 0 is killed.
-    let validators_spec = create_validators_spec(4, 0);
-    let clients = validators_spec_clients(&validators_spec);
-
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(epoch_length)
-        .validators_spec(validators_spec)
-        .build();
-    let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
-        .build()
-        .warmup();
+    let mut env =
+        TestLoopBuilder::new().validators(4, 0).epoch_length(epoch_length).build().warmup();
 
     // Run all nodes to height 30 (3 epochs), then kill node 0.
     let kill_height = 3 * epoch_length;
@@ -195,19 +159,8 @@ fn test_epoch_sync_bootstrap_fresh_node() {
 
     init_test_logger();
     let epoch_length = 10;
-    let validators_spec = create_validators_spec(4, 0);
-    let clients = validators_spec_clients(&validators_spec);
-
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(epoch_length)
-        .validators_spec(validators_spec)
-        .build();
-    let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
-        .build()
-        .warmup();
+    let mut env =
+        TestLoopBuilder::new().validators(4, 0).epoch_length(epoch_length).build().warmup();
 
     // Run for 8 epochs (80 blocks), well past the default 4-epoch horizon (40 blocks).
     let target_height = 8 * epoch_length;

--- a/test-loop-tests/src/tests/global_contracts.rs
+++ b/test-loop-tests/src/tests/global_contracts.rs
@@ -23,9 +23,7 @@ use near_vm_runner::ContractCode;
 
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
-use crate::utils::account::{
-    create_account_ids, create_validators_spec, validators_spec_clients_with_rpc,
-};
+use crate::utils::account::create_account_ids;
 use crate::utils::transactions;
 
 const GAS_PRICE: Balance = Balance::from_yoctonear(1);
@@ -239,25 +237,18 @@ impl GlobalContractsTestEnv {
 
         let boundary_accounts = create_account_ids(["account1"]).to_vec();
         let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
-        let validators_spec = create_validators_spec(2, 2);
-        let clients = validators_spec_clients_with_rpc(&validators_spec);
-
-        let genesis = TestLoopBuilder::new_genesis_builder()
-            .validators_spec(validators_spec)
-            .shard_layout(shard_layout)
-            .add_user_accounts_simple(
-                &[account_shard_0.clone(), account_shard_1.clone(), deploy_account.clone()],
-                initial_balance,
-            )
-            .add_user_account_simple(zero_balance_account.clone(), Balance::ZERO)
-            .gas_prices(GAS_PRICE, GAS_PRICE)
-            .build();
 
         let runtime_config_store = RuntimeConfigStore::new(None);
         let env = TestLoopBuilder::new()
-            .genesis(genesis)
-            .epoch_config_store_from_genesis()
-            .clients(clients)
+            .validators(2, 2)
+            .enable_rpc()
+            .shard_layout(shard_layout)
+            .add_user_accounts(
+                &[account_shard_0.clone(), account_shard_1.clone(), deploy_account.clone()],
+                initial_balance,
+            )
+            .add_user_account(&zero_balance_account, Balance::ZERO)
+            .gas_prices(GAS_PRICE, GAS_PRICE)
             .runtime_config_store(runtime_config_store.clone())
             .build()
             .warmup();

--- a/test-loop-tests/src/tests/indexer.rs
+++ b/test-loop-tests/src/tests/indexer.rs
@@ -15,7 +15,6 @@ use near_indexer::{
 use near_o11y::testonly::init_test_logger;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
 use near_primitives::types::{AccountId, Balance, Finality, Nonce, NumBlocks};
@@ -27,9 +26,7 @@ use tokio::sync::mpsc;
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
 use crate::setup::state::NodeExecutionData;
-use crate::utils::account::{
-    create_account_id, create_validators_spec, validators_spec_clients_with_rpc,
-};
+use crate::utils::account::create_account_id;
 
 #[test]
 fn test_indexer_basic() {
@@ -358,22 +355,13 @@ const TX_VALIDITY_PERIOD: NumBlocks = 5;
 const GAS_LIMIT: Gas = Gas::from_teragas(300);
 
 fn setup() -> TestLoopEnv {
-    let validators_spec = create_validators_spec(1, 0);
-    let clients = validators_spec_clients_with_rpc(&validators_spec);
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .shard_layout(ShardLayout::single_shard())
-        .validators_spec(validators_spec)
+    TestLoopBuilder::new()
+        .enable_rpc()
         .gas_limit(GAS_LIMIT)
-        .add_user_account_simple(user_account(), Balance::from_near(1000))
+        .add_user_account(&user_account(), Balance::from_near(1000))
         .transaction_validity_period(TX_VALIDITY_PERIOD)
-        .build();
-    let env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
         .build()
-        .warmup();
-    env
+        .warmup()
 }
 
 fn start_indexer(env: &TestLoopEnv, sync_mode: SyncModeEnum) -> mpsc::Receiver<StreamerMessage> {

--- a/test-loop-tests/src/tests/jsonrpc.rs
+++ b/test-loop-tests/src/tests/jsonrpc.rs
@@ -1,5 +1,4 @@
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::ValidatorsSpec;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::serialize::to_base64;
 use near_primitives::test_utils::create_user_test_signer;
@@ -7,25 +6,13 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, Balance, BlockId};
 
 use crate::setup::builder::TestLoopBuilder;
-use crate::utils::account::{create_validators_spec, validators_spec_clients_with_rpc};
 
 /// Get a block by height using jsonrpc
 #[test]
 fn test_rpc_block_by_height() {
     init_test_logger();
 
-    let validators_spec = create_validators_spec(1, 0);
-    let clients = validators_spec_clients_with_rpc(&validators_spec);
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(10)
-        .validators_spec(validators_spec)
-        .build();
-    let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
-        .build()
-        .warmup();
+    let mut env = TestLoopBuilder::new().enable_rpc().epoch_length(10).build().warmup();
 
     let result = env
         .rpc_runner()
@@ -43,17 +30,10 @@ fn test_rpc_broadcast_tx_commit_transfer() {
     init_test_logger();
 
     let validator_account: AccountId = "validator0".parse().unwrap();
-    let validators_spec = ValidatorsSpec::desired_roles(&[validator_account.as_str()], &[]);
-    let clients = validators_spec_clients_with_rpc(&validators_spec);
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(10)
-        .validators_spec(validators_spec)
-        .add_user_accounts_simple(&[validator_account.clone()], Balance::from_near(1_000))
-        .build();
     let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
+        .enable_rpc()
+        .epoch_length(10)
+        .add_user_account(&validator_account, Balance::from_near(1_000))
         .build()
         .warmup();
 

--- a/test-loop-tests/src/tests/malicious_chunk_producer.rs
+++ b/test-loop-tests/src/tests/malicious_chunk_producer.rs
@@ -3,7 +3,6 @@
 
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
-use crate::utils::account::{create_validators_spec, validators_spec_clients};
 use crate::utils::node::TestLoopNode;
 use near_async::messaging::CanSend as _;
 use near_async::time::Duration;
@@ -151,17 +150,8 @@ fn test_producer_with_expired_transactions() {
 fn test_producer_sending_large_encoded_length_chunks() {
     init_test_logger();
 
-    let num_validators = 2;
-    let validators_spec = create_validators_spec(num_validators, 0);
-    let clients = validators_spec_clients(&validators_spec);
-    let genesis = TestLoopBuilder::new_genesis_builder().validators_spec(validators_spec).build();
-    let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
-        .gc_num_epochs_to_keep(20)
-        .build()
-        .warmup();
+    let mut env =
+        TestLoopBuilder::new().validators(2, 0).gc_num_epochs_to_keep(20).build().warmup();
 
     let epoch_manager = env.node(0).client().epoch_manager.clone();
     let peer_manager_actor_handle = env.node_datas[0].peer_manager_sender.actor_handle();

--- a/test-loop-tests/src/tests/network_drop.rs
+++ b/test-loop-tests/src/tests/network_drop.rs
@@ -6,7 +6,6 @@ use parking_lot::RwLock;
 use rand::{Rng, SeedableRng};
 
 use crate::setup::builder::TestLoopBuilder;
-use crate::utils::account::{create_validators_spec, validators_spec_clients};
 
 const TARGET_HEIGHT: u64 = 20;
 const DROP_RATIO_NUMERATOR: u32 = 1;
@@ -20,15 +19,7 @@ fn network_drop_random_messages() {
     let rng: rand::rngs::StdRng = rand::rngs::StdRng::seed_from_u64(42);
     let rng = Arc::new(RwLock::new(rng));
 
-    let validators_spec = create_validators_spec(3, 0);
-    let clients = validators_spec_clients(&validators_spec);
-    let genesis = TestLoopBuilder::new_genesis_builder().validators_spec(validators_spec).build();
-    let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
-        .build()
-        .warmup();
+    let mut env = TestLoopBuilder::new().validators(3, 0).build().warmup();
 
     // Configure the PeerActors to drop some events. This is actually a bit
     // unrealistic on the network level because we use a reliable transport

--- a/test-loop-tests/src/tests/processed_receipts_gc.rs
+++ b/test-loop-tests/src/tests/processed_receipts_gc.rs
@@ -6,7 +6,6 @@ use near_primitives::gas::Gas;
 use near_primitives::receipt::{
     ProcessedReceiptMetadata, Receipt, ReceiptSource, VersionedReceiptEnum,
 };
-use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{Balance, ShardId};
@@ -14,7 +13,7 @@ use near_primitives::utils::get_block_shard_id;
 use near_store::DBCol;
 
 use crate::setup::builder::TestLoopBuilder;
-use crate::utils::account::{create_account_id, create_validators_spec, validators_spec_clients};
+use crate::utils::account::create_account_id;
 
 const EPOCH_LENGTH: u64 = 5;
 const GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
@@ -30,21 +29,11 @@ const GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
 fn test_processed_receipt_ids_gc() {
     init_test_logger();
 
-    let validators_spec = create_validators_spec(1, 0);
-    let clients = validators_spec_clients(&validators_spec);
     let user_account = create_account_id("account0");
 
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(EPOCH_LENGTH)
-        .shard_layout(ShardLayout::single_shard())
-        .validators_spec(validators_spec)
-        .add_user_accounts_simple(&[user_account.clone()], Balance::from_near(1_000_000))
-        .build();
-
     let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
+        .epoch_length(EPOCH_LENGTH)
+        .add_user_account(&user_account, Balance::from_near(1_000_000))
         .gc_num_epochs_to_keep(GC_NUM_EPOCHS_TO_KEEP)
         .build()
         .warmup();

--- a/test-loop-tests/src/tests/shutdown_signal.rs
+++ b/test-loop-tests/src/tests/shutdown_signal.rs
@@ -4,7 +4,6 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::types::BlockHeight;
 
 use crate::setup::builder::TestLoopBuilder;
-use crate::utils::account::{create_validators_spec, validators_spec_clients};
 
 /// Test that the shutdown signal integration with test-loop works correctly.
 /// When ClientActor's expected_shutdown triggers, it consumes the shutdown_signal,
@@ -15,18 +14,10 @@ fn test_shutdown_signal_in_testloop() {
     let epoch_length = 10;
     // Use 4 validators so the remaining 3 can continue producing blocks
     // after node 0 shuts down (need >2/3 stake for doomslug).
-    let validators_spec = create_validators_spec(4, 0);
-    let clients = validators_spec_clients(&validators_spec);
-
     let shutdown_height: BlockHeight = 15;
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(epoch_length)
-        .validators_spec(validators_spec)
-        .build();
     let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
+        .validators(4, 0)
+        .epoch_length(epoch_length)
         .config_modifier(move |config, idx| {
             if idx == 0 {
                 config.expected_shutdown =

--- a/test-loop-tests/src/tests/view_requests.rs
+++ b/test-loop-tests/src/tests/view_requests.rs
@@ -1,6 +1,5 @@
 use near_async::messaging::Handler;
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::ValidatorsSpec;
 use near_client::GetStateChanges;
 use near_crypto::{KeyType, SecretKey};
 use near_o11y::testonly::init_test_logger;
@@ -12,7 +11,6 @@ use near_primitives::views::{StateChangeValueView, StateChangesRequestView};
 use near_primitives_core::account::AccessKey;
 
 use crate::setup::builder::TestLoopBuilder;
-use crate::utils::account::validators_spec_clients_with_rpc;
 use crate::utils::transactions::get_shared_block_hash;
 
 #[test]
@@ -21,20 +19,12 @@ fn test_access_key_changes_includes_gas_key_nonces() {
     init_test_logger();
 
     let epoch_length = 10;
-    let accounts: Vec<AccountId> = (0..3).map(|i| format!("account{i}").parse().unwrap()).collect();
-    let validators: Vec<&str> = accounts.iter().take(2).map(|a| a.as_str()).collect();
-    let submitter = accounts[2].clone();
-    let validators_spec = ValidatorsSpec::desired_roles(&validators, &[]);
-    let clients = validators_spec_clients_with_rpc(&validators_spec);
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .epoch_length(epoch_length)
-        .validators_spec(validators_spec)
-        .add_user_accounts_simple(&accounts, Balance::from_near(1_000_000))
-        .build();
+    let submitter: AccountId = "account2".parse().unwrap();
     let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
+        .validators(2, 0)
+        .enable_rpc()
+        .epoch_length(epoch_length)
+        .add_user_account(&submitter, Balance::from_near(1_000_000))
         .build()
         .warmup();
 

--- a/test-loop-tests/src/tests/yield_resume.rs
+++ b/test-loop-tests/src/tests/yield_resume.rs
@@ -98,25 +98,9 @@ fn prepare_env() -> TestLoopEnv {
     let test_account: AccountId = "test0".parse().unwrap();
     let test_account_signer = create_user_test_signer(&test_account).into();
 
-    let shard_layout = ShardLayout::single_shard();
-    let user_accounts = vec![test_account.clone()];
-    let initial_balance = Balance::from_near(1_000_000);
-    let validators_spec = ValidatorsSpec::DesiredRoles {
-        block_and_chunk_producers: vec!["validator0".parse().unwrap()],
-        chunk_validators_only: Vec::new(),
-    };
-    let clients = validators_spec_clients(&validators_spec);
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .shard_layout(shard_layout)
-        .validators_spec(validators_spec)
-        .genesis_height(0)
-        .add_user_accounts_simple(&user_accounts, initial_balance)
-        .build();
-
     let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
+        .genesis_height(0)
+        .add_user_account(&test_account, Balance::from_near(1_000_000))
         .skip_warmup()
         .build();
 


### PR DESCRIPTION
- Migrate 13 test files to use the `TestLoopBuilder` auto API (`.validators()`, `.enable_rpc()`, `.epoch_length()`, etc.) instead of manually wiring `create_validators_spec` + `validators_spec_clients` + `new_genesis_builder()` + `.genesis()` + `.clients()` + `.epoch_config_store_from_genesis()`.
- Tests that require custom epoch configs (resharding, spice, bug_repro) or `ValidatorsSpec::raw` are left unchanged.
- Follows up on #15242 which introduced the auto-derive genesis API.