### PR TITLE
test(test-loop): add archival node with cold storage example

### DIFF
--- a/test-loop-tests/README.md
+++ b/test-loop-tests/README.md
@@ -137,6 +137,7 @@ The `src/examples/` directory contains minimal self-contained tests demonstratin
 | `basic.rs` | Token transfer, contract deploy & call, JSON-RPC queries |
 | `setup.rs` | Builder API: defaults, validators, shards, user accounts, genesis overrides, manual setup |
 | `node_lifecycle.rs` | Killing/restarting a node, adding a new node to a running cluster |
+| `archival.rs` | Archival node with cold storage |
 | `gas_limit.rs` | Gas limit behavior verification |
 | `delayed_receipts.rs` | Creating and observing delayed receipts |
 | `missing_chunk.rs` | Triggering missing chunks using adversarial messages |

--- a/test-loop-tests/src/examples/archival.rs
+++ b/test-loop-tests/src/examples/archival.rs
@@ -1,0 +1,52 @@
+use near_async::messaging::Handler;
+use near_async::time::Duration;
+use near_client::GetBlock;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::types::{BlockId, BlockReference};
+
+use crate::setup::builder::{ArchivalKind, TestLoopBuilder};
+
+/// Demonstrates setting up an archival node with cold storage (split storage).
+///
+/// With cold storage, the archival node migrates old block data from the hot DB
+/// to a separate cold DB. The hot store is then garbage-collected to stay small,
+/// while the view client uses split storage to transparently serve data from
+/// both stores. This means old blocks remain accessible even after hot-store GC.
+///
+/// This example sets up 1 validator and 1 non-validator archival node with cold
+/// storage, runs the chain long enough for GC to trigger, and verifies that:
+/// - The validator cannot access early blocks after GC.
+/// - The archival node can still serve early blocks via its view client.
+/// - The cold head is advancing (data is being migrated to cold storage).
+#[test]
+fn test_archival_node_with_cold_storage() {
+    init_test_logger();
+
+    let epoch_length = 5;
+    let gc_num_epochs_to_keep = 3;
+    // Height 0 is the genesis block which is handled specially, so we pick
+    // height 1 as an early block that will be GC-ed by validators but retained
+    // by the archival node.
+    let early_height = 1;
+    let mut env = TestLoopBuilder::new()
+        .epoch_length(epoch_length)
+        .enable_archival_node(ArchivalKind::Cold)
+        .gc_num_epochs_to_keep(gc_num_epochs_to_keep)
+        .build()
+        .warmup();
+
+    // Run long enough for GC to kick in.
+    let target_height = epoch_length * (gc_num_epochs_to_keep + 2);
+    env.archival_runner().run_until_head_height(target_height);
+
+    let early_block_request = GetBlock(BlockReference::BlockId(BlockId::Height(early_height)));
+    // Validator cannot access an early block after GC.
+    let validator_result =
+        env.validator_mut().view_client_actor().handle(early_block_request.clone());
+    assert!(validator_result.is_err(), "validator should have GC'd the early block");
+    // Archival node can still serve the early block via split storage.
+    let archival_result = env.archival_node_mut().view_client_actor().handle(early_block_request);
+    assert!(archival_result.is_ok(), "archival node should retain all blocks via cold storage");
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}

--- a/test-loop-tests/src/examples/mod.rs
+++ b/test-loop-tests/src/examples/mod.rs
@@ -1,3 +1,4 @@
+mod archival;
 mod basic;
 #[cfg(feature = "test_features")]
 mod delayed_receipts;

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -27,7 +27,8 @@ use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::{TestNodeStorage, create_test_node_storage};
 
 use crate::utils::account::{
-    create_validators_spec, validators_spec_clients, validators_spec_clients_with_rpc,
+    archival_account_id, create_validators_spec, validators_spec_clients,
+    validators_spec_clients_with_rpc,
 };
 use crate::utils::peer_manager_actor::{TestLoopNetworkSharedState, UnreachableActor};
 
@@ -135,6 +136,13 @@ impl TestLoopBuilder {
         let auto = self.setup_config.ensure_auto();
         assert!(!auto.enable_rpc, "enable_rpc is already set");
         auto.enable_rpc = true;
+        self
+    }
+
+    pub(crate) fn enable_archival_node(mut self, kind: ArchivalKind) -> Self {
+        let auto = self.setup_config.ensure_auto();
+        assert!(auto.archival_node.is_none(), "archival_node is already set");
+        auto.archival_node = Some(kind);
         self
     }
 
@@ -563,6 +571,7 @@ enum SetupConfig {
 struct AutoSetupConfig {
     validators_spec: Option<ValidatorsSpec>,
     enable_rpc: bool,
+    archival_node: Option<ArchivalKind>,
     shard_layout: Option<ShardLayout>,
     user_accounts: Vec<(AccountId, Balance)>,
     epoch_length: Option<u64>,
@@ -624,6 +633,7 @@ impl AutoSetupConfig {
         Self {
             validators_spec: None,
             enable_rpc: false,
+            archival_node: None,
             shard_layout: None,
             user_accounts: vec![],
             epoch_length: None,
@@ -678,10 +688,16 @@ impl AutoSetupConfig {
         } else {
             validators_spec_clients(&validators_spec)
         };
-        let clients = account_ids
+        let mut clients: Vec<ClientSpec> = account_ids
             .into_iter()
             .map(|account_id| ClientSpec { account_id, client_type: ClientType::Regular })
             .collect();
+        if let Some(kind) = self.archival_node {
+            clients.push(ClientSpec {
+                account_id: archival_account_id(),
+                client_type: ClientType::Archival(kind),
+            });
+        }
         (genesis, clients)
     }
 }

--- a/test-loop-tests/src/setup/env.rs
+++ b/test-loop-tests/src/setup/env.rs
@@ -2,7 +2,7 @@ use super::builder::NodeStateBuilder;
 use super::drop_condition::DropCondition;
 use super::setup::setup_client;
 use super::state::{NodeExecutionData, NodeSetupState, SharedState};
-use crate::utils::account::rpc_account_id;
+use crate::utils::account::{archival_account_id, rpc_account_id};
 use crate::utils::node::{NodeRunner, TestLoopNode, TestLoopNodeMut};
 use near_async::test_loop::TestLoopV2;
 use near_async::test_loop::data::TestLoopData;
@@ -177,7 +177,6 @@ impl TestLoopEnv {
         self.node(0)
     }
 
-    #[cfg_attr(not(feature = "test_features"), allow(dead_code))]
     pub fn validator_mut(&mut self) -> TestLoopNodeMut<'_> {
         self.node_mut(0)
     }
@@ -238,6 +237,26 @@ impl TestLoopEnv {
 
     pub fn rpc_data_idx(&self) -> usize {
         self.account_data_idx(&rpc_account_id())
+    }
+
+    #[allow(dead_code)]
+    pub fn archival_node(&self) -> TestLoopNode<'_> {
+        let idx = self.archival_data_idx();
+        self.node(idx)
+    }
+
+    pub fn archival_node_mut(&mut self) -> TestLoopNodeMut<'_> {
+        let idx = self.archival_data_idx();
+        self.node_mut(idx)
+    }
+
+    pub fn archival_runner(&mut self) -> NodeRunner<'_> {
+        let idx = self.archival_data_idx();
+        self.node_runner(idx)
+    }
+
+    pub fn archival_data_idx(&self) -> usize {
+        self.account_data_idx(&archival_account_id())
     }
 
     pub fn node_state_builder(&self) -> NodeStateBuilder<'_> {

--- a/test-loop-tests/src/utils/account.rs
+++ b/test-loop-tests/src/utils/account.rs
@@ -21,6 +21,10 @@ pub fn rpc_account_id() -> AccountId {
     "rpc".parse().unwrap()
 }
 
+pub fn archival_account_id() -> AccountId {
+    "archival".parse().unwrap()
+}
+
 pub fn create_validators_spec(
     num_block_and_chunk_producers: usize,
     num_chunk_validators_only: usize,


### PR DESCRIPTION
- Add `enable_archival_node(ArchivalKind)` to the Auto API so tests can add an archival node without dropping to Manual mode
- Add `archival_account_id()` helper (mirrors `rpc_account_id()`)
- Add `archival_node()`, `archival_node_mut()`, `archival_runner()` helpers on `TestLoopEnv` (mirrors the RPC node helpers)
- Add test-loop example demonstrating archival node with cold storage (split storage): sets up 1 validator + 1 archival node, runs chain past GC, and verifies validators lose early blocks while the archival node retains them

Continuation of #15274