### PR TITLE
refactor(test-loop): express archival client config via type system

### DIFF
--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -5,7 +5,6 @@ use near_chain_configs::test_genesis::{
 use near_chain_configs::test_utils::TestClientConfigParams;
 use near_primitives::shard_layout::ShardLayout;
 use near_store::archive::cloud_storage::config::test_cloud_archival_config;
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -46,12 +45,6 @@ pub(crate) struct TestLoopBuilder {
     /// constructing fresh new tempdir, use the provided one (to test with
     /// existing data from a previous test loop run).
     test_loop_data_dir: TempDir,
-    /// Accounts whose clients should be configured as cold DB split store archival node.
-    /// This should be a subset of the accounts in the `clients` list.
-    cold_storage_archival_clients: HashSet<AccountId>,
-    /// Accounts whose clients should be configured as a cloud archival node.
-    /// This should be a subset of the accounts in the `clients` list.
-    cloud_storage_archival_clients: HashSet<AccountId>,
     /// Number of latest epochs to keep before garbage collecting associated data.
     gc_num_epochs_to_keep: Option<u64>,
     /// The store of runtime configurations to be passed into runtime adapters.
@@ -76,8 +69,6 @@ impl TestLoopBuilder {
             setup_config: SetupConfig::Undecided,
             epoch_config_store: None,
             test_loop_data_dir: tempfile::tempdir().unwrap(),
-            cold_storage_archival_clients: HashSet::new(),
-            cloud_storage_archival_clients: HashSet::new(),
             gc_num_epochs_to_keep: None,
             runtime_config_store: None,
             config_modifier: None,
@@ -113,7 +104,10 @@ impl TestLoopBuilder {
     pub(crate) fn clients(mut self, clients: Vec<AccountId>) -> Self {
         let (_, clients_slot) = self.setup_config.ensure_manual();
         assert!(clients_slot.is_empty(), "clients are already set");
-        *clients_slot = clients;
+        *clients_slot = clients
+            .into_iter()
+            .map(|account_id| ClientSpec { account_id, client_type: ClientType::Regular })
+            .collect();
         self
     }
 
@@ -256,6 +250,34 @@ impl TestLoopBuilder {
         self
     }
 
+    /// Set the accounts whose clients should be configured as cold DB split store archival nodes in the test loop.
+    /// These accounts must already be in the `clients` list.
+    pub(crate) fn cold_storage_archival_clients(self, accounts: Vec<AccountId>) -> Self {
+        self.set_archival_clients(accounts, ClientType::enable_archival_cold)
+    }
+
+    /// Set the accounts whose clients should be configured as cloud archival nodes in the test loop.
+    /// These accounts must already be in the `clients` list.
+    pub(crate) fn cloud_storage_archival_clients(self, accounts: Vec<AccountId>) -> Self {
+        self.set_archival_clients(accounts, ClientType::enable_archival_cloud)
+    }
+
+    fn set_archival_clients(
+        mut self,
+        accounts: Vec<AccountId>,
+        type_setter: fn(&mut ClientType),
+    ) -> Self {
+        let (_, clients) = self.setup_config.ensure_manual();
+        for account_id in &accounts {
+            let client = clients
+                .iter_mut()
+                .find(|c| &c.account_id == account_id)
+                .unwrap_or_else(|| panic!("client {account_id} not found"));
+            type_setter(&mut client.client_type);
+        }
+        self
+    }
+
     // -- Shared methods (work with both API paths) --
 
     pub(crate) fn epoch_config_store(mut self, epoch_config_store: EpochConfigStore) -> Self {
@@ -270,20 +292,6 @@ impl TestLoopBuilder {
 
     pub(crate) fn runtime_config_store(mut self, runtime_config_store: RuntimeConfigStore) -> Self {
         self.runtime_config_store = Some(runtime_config_store);
-        self
-    }
-
-    /// Set the accounts whose clients should be configured as cold DB split store archival nodes in the test loop.
-    /// These accounts should be a subset of the accounts provided to the `clients` method.
-    pub(crate) fn cold_storage_archival_clients(mut self, clients: HashSet<AccountId>) -> Self {
-        self.cold_storage_archival_clients = clients;
-        self
-    }
-
-    /// Set the accounts whose clients should be configured as cloud archival nodes in the test loop.
-    /// These accounts should be a subset of the accounts provided to the `clients` method.
-    pub(crate) fn cloud_storage_archival_clients(mut self, clients: HashSet<AccountId>) -> Self {
-        self.cloud_storage_archival_clients = clients;
         self
     }
 
@@ -335,7 +343,7 @@ impl TestLoopBuilder {
         self.build_impl(genesis, clients)
     }
 
-    fn resolve_setup_config(&mut self) -> (Genesis, Vec<AccountId>) {
+    fn resolve_setup_config(&mut self) -> (Genesis, Vec<ClientSpec>) {
         let setup_config = std::mem::replace(&mut self.setup_config, SetupConfig::Undecided);
         setup_config.resolve()
     }
@@ -347,14 +355,8 @@ impl TestLoopBuilder {
         }
     }
 
-    fn build_impl(mut self, genesis: Genesis, clients: Vec<AccountId>) -> TestLoopEnv {
+    fn build_impl(mut self, genesis: Genesis, clients: Vec<ClientSpec>) -> TestLoopEnv {
         self.ensure_epoch_config_store(&genesis);
-
-        assert!(
-            self.cold_storage_archival_clients
-                .is_subset(&HashSet::from_iter(clients.iter().cloned())),
-            "Archival accounts must be subset of the clients"
-        );
 
         let warmup_pending = self.warmup_pending.clone();
         self.test_loop.send_adhoc_event("warmup_pending".into(), move |_| {
@@ -406,11 +408,16 @@ impl TestLoopBuilder {
         &self,
         idx: usize,
         genesis: &Genesis,
-        clients: &[AccountId],
+        clients: &[ClientSpec],
     ) -> NodeSetupState {
-        let account_id = clients[idx].clone();
-        let enable_cold_storage = self.cold_storage_archival_clients.contains(&account_id);
-        let enable_cloud_storage = self.cloud_storage_archival_clients.contains(&account_id);
+        let client = &clients[idx];
+        let account_id = client.account_id.clone();
+        let (enable_cold_storage, enable_cloud_storage) = match &client.client_type {
+            ClientType::Regular => (false, false),
+            ClientType::Archival(ArchivalKind::Cold) => (true, false),
+            ClientType::Archival(ArchivalKind::Cloud) => (false, true),
+            ClientType::Archival(ArchivalKind::ColdAndCloud) => (true, true),
+        };
         let config_modifier = |client_config: &mut ClientConfig| {
             if let Some(num_epochs) = self.gc_num_epochs_to_keep {
                 client_config.gc.gc_num_epochs_to_keep = num_epochs;
@@ -549,7 +556,7 @@ enum SetupConfig {
     /// New API: builder auto-derives genesis and clients from high-level topology.
     Auto(AutoSetupConfig),
     /// Old API: manually provided genesis and clients.
-    Manual { genesis: Option<Genesis>, clients: Vec<AccountId> },
+    Manual { genesis: Option<Genesis>, clients: Vec<ClientSpec> },
 }
 
 /// Data for auto-derived setup (new API).
@@ -586,7 +593,7 @@ impl SetupConfig {
 
     /// Transitions `Undecided` to `Manual`, or returns existing `Manual`
     /// fields. Panics if `Auto`.
-    fn ensure_manual(&mut self) -> (&mut Option<Genesis>, &mut Vec<AccountId>) {
+    fn ensure_manual(&mut self) -> (&mut Option<Genesis>, &mut Vec<ClientSpec>) {
         if matches!(self, SetupConfig::Undecided) {
             *self = SetupConfig::Manual { genesis: None, clients: vec![] };
         }
@@ -599,7 +606,7 @@ impl SetupConfig {
         }
     }
 
-    fn resolve(self) -> (Genesis, Vec<AccountId>) {
+    fn resolve(self) -> (Genesis, Vec<ClientSpec>) {
         match self {
             SetupConfig::Undecided => AutoSetupConfig::new().resolve(),
             SetupConfig::Auto(auto) => auto.resolve(),
@@ -630,7 +637,7 @@ impl AutoSetupConfig {
         }
     }
 
-    fn resolve(self) -> (Genesis, Vec<AccountId>) {
+    fn resolve(self) -> (Genesis, Vec<ClientSpec>) {
         let validators_spec = self.validators_spec.unwrap_or_else(|| create_validators_spec(1, 0));
         let mut genesis_builder =
             TestLoopBuilder::new_genesis_builder().validators_spec(validators_spec.clone());
@@ -666,13 +673,62 @@ impl AutoSetupConfig {
             genesis_builder = genesis_builder.add_user_account_simple(account_id, balance);
         }
         let genesis = genesis_builder.build();
-        let clients = if self.enable_rpc {
+        let account_ids = if self.enable_rpc {
             validators_spec_clients_with_rpc(&validators_spec)
         } else {
             validators_spec_clients(&validators_spec)
         };
+        let clients = account_ids
+            .into_iter()
+            .map(|account_id| ClientSpec { account_id, client_type: ClientType::Regular })
+            .collect();
         (genesis, clients)
     }
+}
+
+#[derive(Clone)]
+pub(crate) enum ArchivalKind {
+    Cold,
+    Cloud,
+    ColdAndCloud,
+}
+
+#[derive(Clone)]
+pub(crate) enum ClientType {
+    Regular,
+    Archival(ArchivalKind),
+}
+
+impl ClientType {
+    fn enable_archival_cold(&mut self) {
+        match self {
+            ClientType::Archival(ArchivalKind::Cloud) => {
+                *self = ClientType::Archival(ArchivalKind::ColdAndCloud)
+            }
+            ClientType::Archival(ArchivalKind::Cold | ArchivalKind::ColdAndCloud) => {
+                panic!("cold storage is already enabled")
+            }
+            _ => *self = ClientType::Archival(ArchivalKind::Cold),
+        }
+    }
+
+    fn enable_archival_cloud(&mut self) {
+        match self {
+            ClientType::Archival(ArchivalKind::Cold) => {
+                *self = ClientType::Archival(ArchivalKind::ColdAndCloud)
+            }
+            ClientType::Archival(ArchivalKind::Cloud | ArchivalKind::ColdAndCloud) => {
+                panic!("cloud storage is already enabled")
+            }
+            _ => *self = ClientType::Archival(ArchivalKind::Cloud),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ClientSpec {
+    pub account_id: AccountId,
+    pub client_type: ClientType,
 }
 
 fn default_testloop_state_sync_config(tempdir: &PathBuf) -> StateSyncConfig {

--- a/test-loop-tests/src/tests/bug_repro.rs
+++ b/test-loop-tests/src/tests/bug_repro.rs
@@ -191,7 +191,7 @@ fn slow_test_sync_from_archival_node() {
         .genesis(genesis)
         .epoch_config_store(epoch_config_store)
         .clients(clients.clone())
-        .cold_storage_archival_clients([clients[0].clone()].into())
+        .cold_storage_archival_clients(vec![clients[0].clone()])
         .config_modifier(move |config, idx| {
             config.min_block_production_delay = block_prod_time;
             config.max_block_production_delay = 3 * block_prod_time;

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_o11y::testonly::init_test_logger;
@@ -78,11 +76,9 @@ fn test_cloud_archival_base(params: TestCloudArchivalParameters) {
 
     let archival_id: AccountId = "archival".parse().unwrap();
     let all_clients = vec![archival_id.clone(), validator_id];
-    let mut cold_storage_archival_clients = HashSet::<AccountId>::new();
-    if params.enable_cold_storage {
-        cold_storage_archival_clients.insert(archival_id.clone());
-    }
-    let cloud_storage_archival_clients = [archival_id.clone()].into_iter().collect();
+    let cold_storage_archival_clients =
+        if params.enable_cold_storage { vec![archival_id.clone()] } else { vec![] };
+    let cloud_storage_archival_clients = vec![archival_id.clone()];
     let archival_index = all_clients.iter().position(|id| id == &archival_id).unwrap();
 
     let mut builder = TestLoopBuilder::new()

--- a/test-loop-tests/src/tests/resharding_v3.rs
+++ b/test-loop-tests/src/tests/resharding_v3.rs
@@ -497,7 +497,7 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
         .genesis(genesis)
         .epoch_config_store(epoch_config_store)
         .clients(params.clients)
-        .cold_storage_archival_clients(params.archivals.iter().cloned().collect())
+        .cold_storage_archival_clients(params.archivals.clone())
         .load_memtries_for_tracked_shards(params.load_memtries_for_tracked_shards)
         .gc_num_epochs_to_keep(GC_NUM_EPOCHS_TO_KEEP)
         .build()

--- a/test-loop-tests/src/tests/view_requests_to_archival_node.rs
+++ b/test-loop-tests/src/tests/view_requests_to_archival_node.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use itertools::Itertools;
 use near_async::messaging::Handler;
@@ -62,8 +62,7 @@ fn slow_test_view_requests_to_archival_node() {
     let all_clients: Vec<AccountId> =
         accounts.iter().take(NUM_VALIDATORS + 1).cloned().collect_vec();
     // Contains the account of the non-validator archival node.
-    let archival_clients: HashSet<AccountId> =
-        vec![all_clients[NUM_VALIDATORS].clone()].into_iter().collect();
+    let archival_clients: Vec<AccountId> = vec![all_clients[NUM_VALIDATORS].clone()];
     let boundary_accounts =
         ["account3", "account5", "account7"].iter().map(|a| a.parse().unwrap()).collect();
     let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);


### PR DESCRIPTION
- Introduce `ClientType` enum and `Client` struct to encode archival configuration (cold/cloud storage) in the type system
- Remove loose `HashSet<AccountId>` fields (`cold_storage_archival_clients`, `cloud_storage_archival_clients`) from `TestLoopBuilder`
- Move `SetupConfig::Manual` to store `Vec<Client>` instead of `Vec<AccountId>`
- Archival setter methods now look up clients in the manual config and set `ClientType` in-place, panicking if account not found
- Change archival setter parameter types from `HashSet` to `Vec` for consistency
- Extract common archival-setting logic into `ClientType::enable_archival_cold`/`enable_archival_cloud` methods and a shared `set_archival_clients` helper