### PR TITLE
feat: add migrate-pytest claude skill

### DIFF
--- a/.claude/skills/migrate-pytest/SKILL.md
+++ b/.claude/skills/migrate-pytest/SKILL.md
@@ -58,8 +58,7 @@ Present the plan to the user and get confirmation before writing code.
 
 - Delete the original pytest file
 - Remove its entries from `nightly/pytest-sanity.txt` (check for both regular and `--features nightly` variants, and commented-out spice variants)
-- Search for any other references to the pytest filename:
-  `grep -r "<pytest_filename>" nightly/ scripts/ .github/`
+- Search for any other references to the pytest filename
 
 ## 7. Summary
 


### PR DESCRIPTION
- Add a Claude Code skill (`/migrate-pytest`) that standardizes the workflow for migrating pytest integration tests to the test-loop framework
- The skill guides through analyzing the pytest, studying relevant test-loop examples, designing and writing the test, verifying it compiles and passes, and cleaning up the old pytest and its nightly references
- Example usage: `/migrate-pytest pytest/tests/sanity/split_storage.py`

I've worked with claude on #15277 and then asked it to create a skill from that session.