### PR TITLE
feat(ci): add nayduck v2 CLI for inspecting runs, logs, and managing tests

### DIFF
--- a/scripts/nayduck_v2.py
+++ b/scripts/nayduck_v2.py
@@ -324,9 +324,9 @@ def _git_branch(sha: str = "") -> str:
 def api_get_runs(limit=20, branch=None, pr=None) -> typing.List[dict]:
     """Fetch recent runs, optionally filtered by branch or PR number."""
     data = _api_get(f"/api/runs?limit={min(limit, 100)}")
-    filt = f"pr-{pr}" if pr else branch
-    if filt:
-        data = [r for r in data if filt in r.get("branch", "")]
+    filtered = f"pr-{pr}" if pr else branch
+    if filtered:
+        data = [r for r in data if filtered in r.get("branch", "")]
     return data[:limit]
 
 


### PR DESCRIPTION
Add `scripts/nayduck_v2.py`, a comprehensive CLI for the NayDuck CI system that makes it easy to inspect test runs, fetch logs, and manage CI jobs directly from the terminal.

The primary motivation is enabling programmatic access to NayDuck data. The script exposes a clean Python API layer (`api_get_runs`, `api_get_test`, `api_fetch_log`, etc.) that can be imported by other scripts or used by tools like Claude Code to automatically fetch test logs and failure context when debugging CI failures — no manual browser navigation required.

Subcommands:
- `runs` — list recent runs with pass/fail summaries, filter by branch or PR number
- `run` — inspect a specific run's tests with statuses and durations
- `test` — deep-dive into a test: metadata, bisect info, available logs
- `logs` — fetch and display log content (auto-picks stack traces, supports `--tail`, `--all`, `--output`)
- `history` — show test flakiness across recent runs with pass rates
- `nightly` — quick-check the latest nightly run
- `build` — inspect build metadata and logs
- `schedule` — submit new test runs from test spec files
- `cancel` / `retry` — manage in-progress runs

Key design decisions:
- All read commands support `--json` for machine-readable output, making it straightforward to pipe into `jq` or consume from scripts
- 3-layer architecture (API / Display / CLI handlers) so the API functions can be imported directly: `from scripts.nayduck_v2 import api_get_runs`
- Self-contained — no imports from the existing `nayduck.py`, stdlib-only dependencies (plus `requests` which is already in pytest requirements)