### PR TITLE
feat(test-loop): add simplified transaction API to TestLoopNode

### DIFF
--- a/test-loop-tests/README.md
+++ b/test-loop-tests/README.md
@@ -134,7 +134,7 @@ The `src/examples/` directory contains minimal self-contained tests demonstratin
 
 | Example | Demonstrates |
 |---|---|
-| `basic.rs` | Token transfer, contract deploy & call, JSON-RPC queries |
+| `basic.rs` | Token transfer, contract deploy & call, account create & delete, JSON-RPC queries |
 | `setup.rs` | Builder API: defaults, validators, shards, user accounts, genesis overrides, manual setup |
 | `node_lifecycle.rs` | Killing/restarting a node, adding a new node to a running cluster |
 | `archival.rs` | Archival node with cold storage |
@@ -163,6 +163,42 @@ env.add_node(identifier, new_node_state);
 ```
 
 ## Utilities
+
+### Transaction helpers
+
+`TestLoopNode` provides `tx_*` methods that build signed transactions, automatically resolving the nonce, block hash, and test signer. Instead of:
+
+```rust
+let signer = create_user_test_signer(&sender);
+let nonce = get_next_nonce(&env.test_loop.data, &env.node_datas, &sender);
+let block_hash = env.rpc_node().head().last_block_hash;
+let tx = SignedTransaction::send_money(nonce, sender.clone(), receiver.clone(), &signer, amount, block_hash);
+```
+
+Write:
+
+```rust
+let tx = env.rpc_node().tx_send_money(&sender, &receiver, amount);
+```
+
+Available methods:
+
+| Method | Description |
+|---|---|
+| `tx_send_money(sender, receiver, amount)` | Transfer tokens |
+| `tx_deploy_contract(account, code)` | Deploy contract code |
+| `tx_deploy_test_contract(account)` | Deploy the standard test contract |
+| `tx_call(sender, contract, method, args, deposit, gas)` | Call a contract method |
+| `tx_create_account(originator, new_account, amount)` | Create a sub-account |
+| `tx_delete_account(account, beneficiary)` | Delete an account |
+| `tx_from_actions(signer, receiver, actions)` | Build from raw actions |
+
+For batch-submitting multiple transactions without waiting (where auto-nonce won't work), use `get_next_nonce` and manage nonces manually:
+
+```rust
+let mut nonce = env.rpc_node().get_next_nonce(&account);
+// build multiple txs, incrementing nonce each time
+```
 
 ### Account helpers
 

--- a/test-loop-tests/src/examples/basic.rs
+++ b/test-loop-tests/src/examples/basic.rs
@@ -1,8 +1,8 @@
+use assert_matches::assert_matches;
 use near_async::time::Duration;
+use near_client::QueryError;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::gas::Gas;
-use near_primitives::test_utils::create_user_test_signer;
-use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{Balance, BlockId};
 
 use crate::setup::builder::TestLoopBuilder;
@@ -24,15 +24,7 @@ fn test_basic_token_transfer() {
         .build()
         .warmup();
 
-    let block_hash = env.rpc_node().head().last_block_hash;
-    let tx = SignedTransaction::send_money(
-        1,
-        sender.clone(),
-        receiver.clone(),
-        &create_user_test_signer(&sender),
-        transfer_amount,
-        block_hash,
-    );
+    let tx = env.rpc_node().tx_send_money(&sender, &receiver, transfer_amount);
     env.rpc_runner().run_tx(tx, Duration::seconds(5));
     // Run for 1 more block for the transfer to be reflected in chunks prev state root.
     env.rpc_runner().run_for_number_of_blocks(1);
@@ -61,33 +53,60 @@ fn test_deploy_and_call_contract() {
         .build()
         .warmup();
 
-    let signer = create_user_test_signer(&user);
-
     // Deploy the test contract.
-    let deploy_tx = SignedTransaction::deploy_contract(
-        1,
-        &user,
-        near_test_contracts::rs_contract().to_vec(),
-        &signer,
-        env.rpc_node().head().last_block_hash,
-    );
+    let deploy_tx = env.rpc_node().tx_deploy_test_contract(&user);
     env.rpc_runner().run_tx(deploy_tx, Duration::seconds(5));
 
     // Call "log_something" which logs "hello".
-    let call_tx = SignedTransaction::call(
-        2,
-        user.clone(),
-        user,
-        &signer,
-        Balance::ZERO,
-        "log_something".to_owned(),
+    let call_tx = env.rpc_node().tx_call(
+        &user,
+        &user,
+        "log_something",
         vec![],
+        Balance::ZERO,
         Gas::from_teragas(300),
-        env.rpc_node().head().last_block_hash,
     );
     let outcome = env.rpc_runner().execute_tx(call_tx, Duration::seconds(5)).unwrap();
 
     assert_eq!(outcome.receipts_outcome[0].outcome.logs, vec!["hello"]);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Demonstrates creating and deleting an account.
+#[test]
+fn test_create_and_delete_account() {
+    init_test_logger();
+
+    let originator = create_account_id("originator");
+    // The new account needs to be a sub-accounts of the originator.
+    let new_account = create_account_id("new_account.originator");
+    let initial_balance = Balance::from_near(100);
+    let new_account_balance = Balance::from_near(10);
+
+    let mut env = TestLoopBuilder::new()
+        .enable_rpc()
+        .add_user_account(&originator, initial_balance)
+        .build()
+        .warmup();
+
+    // Create a new account.
+    let tx = env.rpc_node().tx_create_account(&originator, &new_account, new_account_balance);
+    env.rpc_runner().run_tx(tx, Duration::seconds(5));
+    env.rpc_runner().run_for_number_of_blocks(1);
+
+    assert_eq!(env.rpc_node().query_balance(&new_account), new_account_balance);
+
+    // Delete the account, sending remaining balance to the originator.
+    let tx = env.rpc_node().tx_delete_account(&new_account, &originator);
+    env.rpc_runner().run_tx(tx, Duration::seconds(5));
+    env.rpc_runner().run_for_number_of_blocks(1);
+
+    // Verify the account no longer exists.
+    assert_matches!(
+        env.rpc_node().view_account_query(&new_account),
+        Err(QueryError::UnknownAccount { .. })
+    );
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }

--- a/test-loop-tests/src/examples/delayed_receipts.rs
+++ b/test-loop-tests/src/examples/delayed_receipts.rs
@@ -8,7 +8,7 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::gas::Gas;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
-use near_primitives::types::{Balance, Nonce};
+use near_primitives::types::Balance;
 
 use crate::setup::builder::TestLoopBuilder;
 use crate::utils::account::create_account_id;
@@ -29,27 +29,18 @@ fn delayed_receipt_example_test() {
         .build()
         .warmup();
 
-    let mut nonce: Nonce = 0;
-    let mut next_nonce = || {
-        nonce += 1;
-        nonce
-    };
-
-    let deploy_test_contract_tx = SignedTransaction::deploy_contract(
-        next_nonce(),
-        &user_account,
-        near_test_contracts::rs_contract().to_vec(),
-        &create_user_test_signer(&user_account),
-        env.rpc_node().head().last_block_hash,
-    );
-    env.rpc_runner().run_tx(deploy_test_contract_tx, Duration::seconds(2));
+    let deploy_tx = env.rpc_node().tx_deploy_test_contract(&user_account);
+    env.rpc_runner().run_tx(deploy_tx, Duration::seconds(2));
 
     // Each transaction generates local receipt consuming more than a half
     // the chunk space, so chunk can only fit 2 such receipts.
+    // These 3 transactions are submitted in batch, so nonces must be managed
+    // manually (auto-nonce would return the same value for all three).
     let gas_to_burn = gas_limit.checked_div(2).unwrap().checked_add(Gas::from_gas(1)).unwrap();
+    let mut nonce = env.rpc_node().get_next_nonce(&user_account);
     let txs = repeat_with(|| {
-        SignedTransaction::call(
-            next_nonce(),
+        let tx = SignedTransaction::call(
+            nonce,
             user_account.clone(),
             user_account.clone(),
             &create_user_test_signer(&user_account),
@@ -58,7 +49,9 @@ fn delayed_receipt_example_test() {
             gas_to_burn.as_gas().to_le_bytes().to_vec(),
             gas_limit,
             env.rpc_node().head().last_block_hash,
-        )
+        );
+        nonce += 1;
+        tx
     })
     .take(3)
     .collect_vec();

--- a/test-loop-tests/src/examples/gas_limit.rs
+++ b/test-loop-tests/src/examples/gas_limit.rs
@@ -3,9 +3,7 @@ use near_async::time::Duration;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::errors::{ActionErrorKind, FunctionCallError, TxExecutionError};
 use near_primitives::gas::Gas;
-use near_primitives::test_utils::create_user_test_signer;
-use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{Balance, Nonce};
+use near_primitives::types::Balance;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::FinalExecutionStatus;
 
@@ -35,26 +33,20 @@ fn test_gas_limit() {
     assert_eq!(limit_config.max_total_prepaid_gas, one_petagas);
 
     // Deploy the test contract.
-    let deploy_tx = SignedTransaction::deploy_contract(
-        1,
-        &user_account,
-        near_test_contracts::rs_contract().to_vec(),
-        &create_user_test_signer(&user_account),
-        env.rpc_node().head().last_block_hash,
-    );
+    let deploy_tx = env.rpc_node().tx_deploy_test_contract(&user_account);
     env.rpc_runner().run_tx(deploy_tx, Duration::seconds(5));
 
     let prepaid_gas = Gas::from_teragas(1000);
 
     // Burning 998 TGas should succeed.
     let (status, gas_burnt) =
-        burn_gas(&mut env, &user_account, 2, Gas::from_teragas(998), prepaid_gas);
+        burn_gas(&mut env, &user_account, Gas::from_teragas(998), prepaid_gas);
     assert_matches!(status, FinalExecutionStatus::SuccessValue(_));
     assert!(gas_burnt < Gas::from_teragas(1000));
 
     // Burning 1001 TGas should fail with gas exceeded error.
     let (status, gas_burnt) =
-        burn_gas(&mut env, &user_account, 3, Gas::from_teragas(1001), prepaid_gas);
+        burn_gas(&mut env, &user_account, Gas::from_teragas(1001), prepaid_gas);
     assert_matches!(
         status,
         FinalExecutionStatus::Failure(TxExecutionError::ActionError(ref err))
@@ -72,20 +64,16 @@ fn test_gas_limit() {
 fn burn_gas(
     env: &mut TestLoopEnv,
     user_account: &near_primitives::types::AccountId,
-    nonce: Nonce,
     gas_to_burn: Gas,
     prepaid_gas: Gas,
 ) -> (FinalExecutionStatus, Gas) {
-    let tx = SignedTransaction::call(
-        nonce,
-        user_account.clone(),
-        user_account.clone(),
-        &create_user_test_signer(user_account),
-        Balance::ZERO,
-        "burn_gas_raw".to_owned(),
+    let tx = env.rpc_node().tx_call(
+        user_account,
+        user_account,
+        "burn_gas_raw",
         gas_to_burn.as_gas().to_le_bytes().to_vec(),
+        Balance::ZERO,
         prepaid_gas,
-        env.rpc_node().head().last_block_hash,
     );
     let outcome = env.rpc_runner().execute_tx(tx, Duration::seconds(5)).unwrap();
     let gas_burnt = outcome.receipts_outcome[0].outcome.gas_burnt;

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -14,10 +14,13 @@ use near_client::{Client, ProcessTxRequest, Query, QueryError, ViewClientActor};
 use near_crypto::PublicKey;
 use near_jsonrpc::client::JsonRpcClient;
 use near_jsonrpc_primitives::errors::RpcError;
+use near_primitives::action::Action;
 use near_primitives::errors::InvalidTxError;
+use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::ShardChunk;
+use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::{
     ExecutionOutcomeWithId, ExecutionOutcomeWithIdAndProof, SignedTransaction,
 };
@@ -179,6 +182,121 @@ impl<'a> TestLoopNode<'a> {
         let process_tx_request =
             ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false };
         self.node_data.rpc_handler_sender.send(process_tx_request);
+    }
+
+    /// Build a signed transaction from raw actions, auto-determining nonce,
+    /// signer, and block hash from the node's current state.
+    #[allow(dead_code)]
+    pub fn tx_from_actions(
+        &self,
+        signer_id: &AccountId,
+        receiver_id: &AccountId,
+        actions: Vec<Action>,
+    ) -> SignedTransaction {
+        SignedTransaction::from_actions(
+            self.get_next_nonce(signer_id),
+            signer_id.clone(),
+            receiver_id.clone(),
+            &create_user_test_signer(signer_id),
+            actions,
+            self.head().last_block_hash,
+        )
+    }
+
+    /// Build a transfer transaction.
+    pub fn tx_send_money(
+        &self,
+        sender_id: &AccountId,
+        receiver_id: &AccountId,
+        amount: Balance,
+    ) -> SignedTransaction {
+        SignedTransaction::send_money(
+            self.get_next_nonce(sender_id),
+            sender_id.clone(),
+            receiver_id.clone(),
+            &create_user_test_signer(sender_id),
+            amount,
+            self.head().last_block_hash,
+        )
+    }
+
+    /// Build a deploy-contract transaction (sender == contract account).
+    pub fn tx_deploy_contract(&self, contract_id: &AccountId, code: Vec<u8>) -> SignedTransaction {
+        SignedTransaction::deploy_contract(
+            self.get_next_nonce(contract_id),
+            contract_id,
+            code,
+            &create_user_test_signer(contract_id),
+            self.head().last_block_hash,
+        )
+    }
+
+    /// Deploy the standard test contract (`near_test_contracts::rs_contract`).
+    pub fn tx_deploy_test_contract(&self, contract_id: &AccountId) -> SignedTransaction {
+        self.tx_deploy_contract(contract_id, near_test_contracts::rs_contract().to_vec())
+    }
+
+    /// Build a function-call transaction.
+    pub fn tx_call(
+        &self,
+        sender_id: &AccountId,
+        contract_id: &AccountId,
+        method_name: &str,
+        args: Vec<u8>,
+        deposit: Balance,
+        gas: Gas,
+    ) -> SignedTransaction {
+        SignedTransaction::call(
+            self.get_next_nonce(sender_id),
+            sender_id.clone(),
+            contract_id.clone(),
+            &create_user_test_signer(sender_id),
+            deposit,
+            method_name.to_owned(),
+            args,
+            gas,
+            self.head().last_block_hash,
+        )
+    }
+
+    /// Build a create-account transaction.
+    pub fn tx_create_account(
+        &self,
+        originator: &AccountId,
+        new_account_id: &AccountId,
+        amount: Balance,
+    ) -> SignedTransaction {
+        SignedTransaction::create_account(
+            self.get_next_nonce(originator),
+            originator.clone(),
+            new_account_id.clone(),
+            amount,
+            create_user_test_signer(new_account_id).public_key(),
+            &create_user_test_signer(originator),
+            self.head().last_block_hash,
+        )
+    }
+
+    /// Build a delete-account transaction.
+    pub fn tx_delete_account(
+        &self,
+        account_id: &AccountId,
+        beneficiary_id: &AccountId,
+    ) -> SignedTransaction {
+        SignedTransaction::delete_account(
+            self.get_next_nonce(account_id),
+            account_id.clone(),
+            account_id.clone(),
+            beneficiary_id.clone(),
+            &create_user_test_signer(account_id),
+            self.head().last_block_hash,
+        )
+    }
+
+    pub fn get_next_nonce(&self, account_id: &AccountId) -> u64 {
+        let signer = create_user_test_signer(account_id);
+        let access_key = self.view_access_key_query(account_id, &signer.public_key()).unwrap();
+        access_key.nonce + 1
     }
 }
 


### PR DESCRIPTION
- Add `tx_send_money`, `tx_deploy_contract`, `tx_deploy_test_contract`, `tx_call`, `tx_create_account`, `tx_delete_account`, and `tx_from_actions` methods to `TestLoopNode` that auto-determine nonce, block hash, and test signer
- Make `get_next_nonce` public for cases where manual nonce management is needed (e.g. batch-submitted transactions)
- Update all example tests to use the new API
- Add `test_create_and_delete_account` example demonstrating the new account lifecycle helpers