### PR TITLE
fix(chain): remove orphan assert

### DIFF
--- a/chain/chain/src/orphan.rs
+++ b/chain/chain/src/orphan.rs
@@ -231,13 +231,6 @@ impl OrphanBlockPool {
                     debug_assert!(_visited.insert(*hash));
                 }
             }
-
-            // probably something serious went wrong here because there shouldn't be so many forks
-            assert!(
-                res.len() <= 100 * target_depth as usize,
-                "found too many orphans {:?}, probably something is wrong with the chain",
-                res
-            );
         }
         res
     }


### PR DESCRIPTION
There's an old assert that checks for "weird behavior".  Let's remove it, having 300 forks is not a valid reason to crash the node.

For context, the assert was added in https://github.com/near/nearcore/pull/5224. I didn't find any reasoning behind it.