### PR TITLE
chore: add `AccountContract::is_some()` method

### DIFF
--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -115,6 +115,10 @@ impl AccountContract {
         matches!(self, Self::None)
     }
 
+    pub fn is_some(&self) -> bool {
+        !self.is_none()
+    }
+
     pub fn is_local(&self) -> bool {
         matches!(self, Self::Local(_))
     }

--- a/tools/amend-genesis/src/lib.rs
+++ b/tools/amend-genesis/src/lib.rs
@@ -178,7 +178,7 @@ fn parse_extra_records(
     near_chain_configs::stream_records_from_file(reader, |r| {
         match r {
             StateRecord::Account { account_id, account } => {
-                if !account.contract().is_none() {
+                if account.contract().is_some() {
                     result = Err(anyhow::anyhow!(
                         "FIXME: accounts in --extra-records with code_hash set not supported"
                     ));


### PR DESCRIPTION
Preventing double negatives.

- Add `AccountContract::is_some()` convenience method, symmetric with the existing `is_none()`.
- Use it in `amend-genesis` to replace `!account.contract().is_none()`.