### PR TITLE
feat(ptq): add noop PendingConstraints to verifier 1/7

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -56,9 +56,9 @@ use node_runtime::adapter::ViewRuntimeAdapter;
 use node_runtime::config::tx_cost;
 use node_runtime::state_viewer::{TrieViewer, ViewApplyState};
 use node_runtime::{
-    ApplyState, Runtime, SignedValidPeriodTransactions, TxVerdict, ValidatorAccountsUpdate,
-    get_signer_and_access_key, validate_transaction, verify_and_charge_gas_key_tx_ephemeral,
-    verify_and_charge_tx_ephemeral,
+    ApplyState, PendingConstraints, Runtime, SignedValidPeriodTransactions, TxVerdict,
+    ValidatorAccountsUpdate, get_signer_and_access_key, validate_transaction,
+    verify_and_charge_gas_key_tx_ephemeral, verify_and_charge_tx_ephemeral,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -714,6 +714,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         state_root: StateRoot,
         validated_tx: &ValidatedTransaction,
         current_protocol_version: ProtocolVersion,
+        pending_constraints: &PendingConstraints,
     ) -> Result<(), InvalidTxError> {
         let runtime_config = self.runtime_config_store.get_config(current_protocol_version);
         let tx = validated_tx.to_tx();
@@ -746,6 +747,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 &tx,
                 &cost,
                 block_height,
+                pending_constraints,
             ) {
                 TxVerdict::Success(_) => Ok(()),
                 TxVerdict::DepositFailed { error, .. } | TxVerdict::Failed(error) => Err(error),
@@ -759,6 +761,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 &cost,
                 block_height,
                 current_protocol_version,
+                pending_constraints,
             ) {
                 TxVerdict::Success(_) => Ok(()),
                 TxVerdict::Failed(error) => Err(error),
@@ -1033,6 +1036,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         validated_tx.to_tx(),
                         &cost,
                         Some(next_block_height),
+                        &PendingConstraints::default(),
                     )
                 } else {
                     verify_and_charge_tx_ephemeral(
@@ -1043,6 +1047,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &cost,
                         Some(next_block_height),
                         protocol_version,
+                        &PendingConstraints::default(),
                     )
                 };
                 match verdict {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -46,6 +46,7 @@ use near_store::flat::FlatStorageManager;
 use near_store::{PartialStorage, ShardTries, Store, Trie, WrappedTrieChanges};
 use near_vm_runner::ContractCode;
 use near_vm_runner::ContractRuntimeCache;
+pub use node_runtime::PendingConstraints;
 use node_runtime::PostStateReadyCallback;
 use node_runtime::SignedValidPeriodTransactions;
 use num_rational::Rational32;
@@ -518,6 +519,7 @@ pub trait RuntimeAdapter: Send + Sync {
         state_root: StateRoot,
         validated_tx: &ValidatedTransaction,
         current_protocol_version: ProtocolVersion,
+        pending_constraints: &PendingConstraints,
     ) -> Result<(), InvalidTxError>;
 
     /// Returns an ordered list of valid transactions from the pool up the given limits.

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -4,6 +4,7 @@ use near_async::messaging::Handler;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::{ActorSystem, messaging};
 use near_chain::check_transaction_validity_period;
+use near_chain::types::PendingConstraints;
 use near_chain::types::RuntimeAdapter;
 use near_chain::types::Tip;
 use near_chain_configs::MutableValidatorSigner;
@@ -212,6 +213,7 @@ impl RpcHandlerActor {
                     state_root,
                     &validated_tx,
                     protocol_version,
+                    &PendingConstraints::default(),
                 ) {
                     tracing::debug!(target: "client", ?err, "invalid tx");
                     return Ok(ProcessTxResponse::InvalidTx(err));

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -28,8 +28,8 @@ use near_vm_runner::FilesystemContractRuntimeCache;
 use near_vm_runner::logic::LimitConfig;
 use node_runtime::config::tx_cost;
 use node_runtime::{
-    ApplyState, Runtime, SignedValidPeriodTransactions, TxVerdict, get_signer_and_access_key,
-    set_tx_state_changes, verify_and_charge_tx_ephemeral,
+    ApplyState, PendingConstraints, Runtime, SignedValidPeriodTransactions, TxVerdict,
+    get_signer_and_access_key, set_tx_state_changes, verify_and_charge_tx_ephemeral,
 };
 use std::collections::{HashMap, VecDeque};
 use std::iter;
@@ -473,6 +473,7 @@ impl Testbed<'_> {
             &cost,
             block_height,
             PROTOCOL_VERSION,
+            &PendingConstraints::default(),
         ) else {
             panic!("tx verification should not fail in estimator");
         };

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -229,6 +229,28 @@ pub struct ValidatorAccountsUpdate {
     pub protocol_treasury_account_id: Option<AccountId>,
 }
 
+/// Constraints from pending (included-but-not-yet-certified) transactions
+/// for balance and nonce validation during chunk production.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingConstraints {
+    /// Total balance already committed by this account's pending access key
+    /// transactions (total_cost) plus pending gas key deposit costs.
+    pub paid_from_balance: Balance,
+    /// Total gas key cost already committed by pending gas key transactions
+    /// signed with this key, plus any pending WithdrawFromGasKey amounts
+    /// targeting this key.
+    pub paid_from_gas_key: Balance,
+    /// Maximum nonce seen among pending transactions for this (account, key,
+    /// nonce_index) combination.
+    pub max_nonce: Nonce,
+}
+
+impl Default for PendingConstraints {
+    fn default() -> Self {
+        Self { paid_from_balance: Balance::ZERO, paid_from_gas_key: Balance::ZERO, max_nonce: 0 }
+    }
+}
+
 /// Outcome of transaction verification and charging.
 ///
 /// Returned by both `verify_and_charge_tx_ephemeral` and
@@ -1879,6 +1901,7 @@ impl Runtime {
                     &tx.transaction,
                     &cost,
                     Some(block_height),
+                    &PendingConstraints::default(),
                 )
             } else {
                 // Regular access key transaction
@@ -1890,6 +1913,7 @@ impl Runtime {
                     &cost,
                     Some(block_height),
                     processing_state.protocol_version,
+                    &PendingConstraints::default(),
                 )
             };
 

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -1,6 +1,6 @@
 use crate::config::{TransactionCost, total_prepaid_gas};
 use crate::near_primitives::account::Account;
-use crate::{AccessKeyUpdate, TxVerdict, VerificationResult};
+use crate::{AccessKeyUpdate, PendingConstraints, TxVerdict, VerificationResult};
 use near_crypto::PublicKey;
 use near_crypto::key_conversion::is_valid_staking_key;
 use near_parameters::RuntimeConfig;
@@ -286,6 +286,7 @@ pub fn verify_and_charge_tx_ephemeral(
     transaction_cost: &TransactionCost,
     block_height: Option<BlockHeight>,
     protocol_version: ProtocolVersion,
+    pending: &PendingConstraints,
 ) -> TxVerdict {
     // It's the caller's responsibility to NOT call this function for transactions with
     // nonce_index (i.e. gas key transactions).
@@ -311,18 +312,25 @@ pub fn verify_and_charge_tx_ephemeral(
     } = *transaction_cost;
     let account_id = tx.signer_id();
     let tx_nonce = tx.nonce().nonce();
-    if let Err(e) = verify_nonce(tx_nonce, access_key.nonce, block_height, tx.nonce_mode()) {
+    let effective_nonce = std::cmp::max(access_key.nonce, pending.max_nonce);
+    if let Err(e) = verify_nonce(tx_nonce, effective_nonce, block_height, tx.nonce_mode()) {
         return TxVerdict::Failed(e);
     }
 
-    let balance = account.amount();
-    let Some(new_amount) = balance.checked_sub(total_cost) else {
+    // saturating_sub is fine here: on the consensus path pending constraints
+    // are always default (zero), so the subtraction is exact. On the RPC /
+    // chunk-production path it is best-effort and does not affect consensus.
+    let available_balance = account.amount().saturating_sub(pending.paid_from_balance);
+    if available_balance < total_cost {
         return TxVerdict::Failed(InvalidTxError::NotEnoughBalance {
             signer_id: account_id.clone(),
-            balance,
+            balance: available_balance,
             cost: total_cost,
         });
-    };
+    }
+    // Debit only this tx's cost, not the pending amount (which was already
+    // charged in prior chunks and will be applied at execution time).
+    let new_amount = account.amount().checked_sub(total_cost).unwrap();
 
     let new_allowance = match check_and_compute_new_allowance(
         access_key,
@@ -389,6 +397,7 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
     tx: &Transaction,
     transaction_cost: &TransactionCost,
     block_height: Option<BlockHeight>,
+    pending: &PendingConstraints,
 ) -> TxVerdict {
     // It's the caller's responsibility to ONLY call this function for transactions with
     // nonce_index (i.e. gas key transactions).
@@ -426,18 +435,38 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
     }
 
     let tx_nonce = tx.nonce().nonce();
-    if let Err(e) = verify_nonce(tx_nonce, current_nonce, block_height, tx.nonce_mode()) {
+    let effective_nonce = std::cmp::max(current_nonce, pending.max_nonce);
+    if let Err(e) = verify_nonce(tx_nonce, effective_nonce, block_height, tx.nonce_mode()) {
         return TxVerdict::Failed(e);
     }
 
-    // Check gas key has enough balance for gas costs
-    let Some(new_gas_key_balance) = gas_key_info.balance.checked_sub(gas_cost) else {
+    // Check gas key has enough balance for gas costs, accounting for
+    // pending gas key costs (prior gas key txs + pending WithdrawFromGasKey).
+    // Unlike account balance, gas key balance only changes through transactions
+    // that PTQ explicitly tracks, so pending should never exceed the balance.
+    let Some(available_gas_key_balance) =
+        gas_key_info.balance.checked_sub(pending.paid_from_gas_key)
+    else {
+        tracing::error!(
+            target: "runtime",
+            balance = %gas_key_info.balance,
+            paid_from_gas_key = %pending.paid_from_gas_key,
+            "pending gas key costs exceed gas key balance"
+        );
         return TxVerdict::Failed(InvalidTxError::NotEnoughGasKeyBalance {
             signer_id: account_id.clone(),
-            balance: gas_key_info.balance,
+            balance: Balance::ZERO,
             cost: gas_cost,
         });
     };
+    if available_gas_key_balance < gas_cost {
+        return TxVerdict::Failed(InvalidTxError::NotEnoughGasKeyBalance {
+            signer_id: account_id.clone(),
+            balance: available_gas_key_balance,
+            cost: gas_cost,
+        });
+    }
+    let new_gas_key_balance = gas_key_info.balance.checked_sub(gas_cost).unwrap();
 
     // Validate FunctionCall permission constraints if applicable
     if let Some(function_call_permission) = access_key.permission.function_call_permission() {
@@ -457,25 +486,31 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
         access_key_update: gas_key_update,
     };
 
-    // Check account has enough balance for deposits
-    let account_balance = account.amount();
-    let Some(new_account_amount) = account_balance.checked_sub(deposit_cost) else {
+    // Check account has enough balance for deposits, accounting for
+    // pending balance costs from prior txs. saturating_sub is fine: on the
+    // consensus path pending constraints are always default (zero), so the
+    // subtraction is exact. On the RPC / chunk-production path it is
+    // best-effort.
+    let available_balance = account.amount().saturating_sub(pending.paid_from_balance);
+    if available_balance < deposit_cost {
         return TxVerdict::DepositFailed {
-            result: make_result(account_balance),
+            result: make_result(account.amount()),
             error: InvalidTxError::NotEnoughBalanceForDeposit {
                 signer_id: account_id.clone(),
-                balance: account_balance,
+                balance: available_balance,
                 cost: deposit_cost,
                 reason: DepositCostFailureReason::NotEnoughBalance,
             },
         };
-    };
+    }
+    // Debit only this tx's deposit cost, not the pending amount.
+    let new_account_amount = account.amount().checked_sub(deposit_cost).unwrap();
 
     match check_storage_stake(account, new_account_amount, config) {
         Ok(()) => {}
         Err(StorageStakingError::LackBalanceForStorageStaking(amount)) => {
             return TxVerdict::DepositFailed {
-                result: make_result(account_balance),
+                result: make_result(account.amount()),
                 error: InvalidTxError::NotEnoughBalanceForDeposit {
                     signer_id: account_id.clone(),
                     balance: new_account_amount,
@@ -1295,6 +1330,7 @@ mod tests {
             &cost,
             None,
             current_protocol_version,
+            &PendingConstraints::default(),
         ) else {
             panic!("expected Failed verdict");
         };
@@ -1330,6 +1366,7 @@ mod tests {
                 tx,
                 &transaction_cost,
                 block_height,
+                &PendingConstraints::default(),
             )
         } else {
             verify_and_charge_tx_ephemeral(
@@ -1340,6 +1377,7 @@ mod tests {
                 &transaction_cost,
                 block_height,
                 current_protocol_version,
+                &PendingConstraints::default(),
             )
         };
         let result = match verdict {
@@ -3609,6 +3647,7 @@ mod tests {
             tx,
             &cost,
             None,
+            &PendingConstraints::default(),
         ) else {
             panic!("expected DepositFailed");
         };
@@ -3672,6 +3711,7 @@ mod tests {
             tx,
             &cost,
             None,
+            &PendingConstraints::default(),
         ) else {
             panic!("expected DepositFailed");
         };


### PR DESCRIPTION
Add `PendingConstraints` struct and thread it through `verify_and_charge_tx_ephemeral` and `verify_and_charge_gas_key_tx_ephemeral`. This is a preparatory refactor for the pending transaction queue (PTQ) in SPICE, where chunk production and RPC validation will pass non-default constraints to account for transactions that are included but not yet certified.

- Add `PendingConstraints` struct in `runtime/runtime/src/lib.rs` with `paid_from_balance`, `paid_from_gas_key`, and `max_nonce` fields.
- Update `verify_and_charge_tx_ephemeral` to use `pending.max_nonce` as a nonce floor and `pending.paid_from_balance` to reduce available balance.
- Update `verify_and_charge_gas_key_tx_ephemeral` similarly, also accounting for `pending.paid_from_gas_key`.
- Update `can_verify_and_charge_tx` trait method signature and all callers.
- All callers currently pass `PendingConstraints::default()` so there is no behavioral change.