### PR TITLE
feat(ptq): add check_pending to prepare_transactions_extra as noop 2/7

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1,10 +1,10 @@
 use crate::Error;
 use crate::runtime::signer_overlay::SignerOverlay;
 use crate::types::{
-    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, PendingTxCheckResult,
-    PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions,
-    RuntimeAdapter, RuntimeStorageConfig, SkippedTransactions, StatePartValidationResult,
-    StateRootNodeValidationResult, StorageDataSource, Tip,
+    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, HasContract,
+    PendingTxCheckResult, PrepareTransactionsBlockContext, PrepareTransactionsLimit,
+    PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig, SkippedTransactions,
+    StatePartValidationResult, StateRootNodeValidationResult, StorageDataSource, Tip,
 };
 use errors::FromStateViewerErrors;
 use near_async::thread_pool::contract_compilation_pool;
@@ -858,7 +858,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         validate_tx_ttl: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
-        check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
+        check_pending: &mut dyn FnMut(&SignedTransaction, HasContract) -> PendingTxCheckResult,
         time_limit: Option<Duration>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
@@ -1014,7 +1014,8 @@ impl RuntimeAdapter for NightshadeRuntime {
                 )?;
 
                 // Check pending transaction queue constraints.
-                let has_contract = account.contract().is_some();
+                let has_contract =
+                    if account.contract().is_some() { HasContract::Yes } else { HasContract::No };
                 let pending_constraints =
                     match check_pending(validated_tx.to_signed_tx(), has_contract) {
                         PendingTxCheckResult::Admit(constraints) => constraints,

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1,7 +1,7 @@
 use crate::Error;
 use crate::runtime::signer_overlay::SignerOverlay;
 use crate::types::{
-    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext,
+    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, PendingTxCheckResult,
     PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions,
     RuntimeAdapter, RuntimeStorageConfig, SkippedTransactions, StatePartValidationResult,
     StateRootNodeValidationResult, StorageDataSource, Tip,
@@ -826,6 +826,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             chain_validate,
             validate_tx_ttl,
             HashSet::new(),
+            &mut PendingTxCheckResult::always_admit(),
             time_limit,
             None,
         ) // skip_tx_hashes is empty, so there will be no skipped transactions
@@ -857,6 +858,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         validate_tx_ttl: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
+        check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
         time_limit: Option<Duration>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
@@ -1011,6 +1013,17 @@ impl RuntimeAdapter for NightshadeRuntime {
                     nonce_index,
                 )?;
 
+                // Check pending transaction queue constraints.
+                let has_contract = account.contract().is_some();
+                let pending_constraints =
+                    match check_pending(validated_tx.to_signed_tx(), has_contract) {
+                        PendingTxCheckResult::Admit(constraints) => constraints,
+                        PendingTxCheckResult::Skip => {
+                            skipped_transactions.push(validated_tx);
+                            continue;
+                        }
+                    };
+
                 let cost = match tx_cost(
                     runtime_config,
                     &validated_tx.to_tx(),
@@ -1036,7 +1049,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         validated_tx.to_tx(),
                         &cost,
                         Some(next_block_height),
-                        &PendingConstraints::default(),
+                        &pending_constraints,
                     )
                 } else {
                     verify_and_charge_tx_ephemeral(
@@ -1047,7 +1060,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &cost,
                         Some(next_block_height),
                         protocol_version,
-                        &PendingConstraints::default(),
+                        &pending_constraints,
                     )
                 };
                 match verdict {

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1551,13 +1551,10 @@ fn test_genesis_hash() {
 /// Creates a signed transaction between each pair of `signers`,
 /// where transaction outcomes from a single signer differ by nonce.
 /// The transactions are then shuffled and used to fill a transaction pool.
-fn generate_transaction_pool(
-    signers: &[Signer],
-    block_hash: CryptoHash,
-    num_rounds: usize,
-) -> TransactionPool {
+fn generate_transaction_pool(signers: &[Signer], block_hash: CryptoHash) -> TransactionPool {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let signer_count = signers.len();
+    let num_rounds = signer_count - 1;
 
     let mut transactions = vec![];
     for round in 1..=num_rounds {
@@ -1583,7 +1580,7 @@ fn generate_transaction_pool(
     pool
 }
 
-fn get_test_env_with_chain_and_pool(num_rounds: usize) -> (TestEnv, Chain, TransactionPool) {
+fn get_test_env_with_chain_and_pool() -> (TestEnv, Chain, TransactionPool) {
     let validators = (0..NUM_TEST_SIGNERS)
         .map(|i| AccountId::try_from(format!("test{}", i + 1)).unwrap())
         .collect::<Vec<_>>();
@@ -1623,8 +1620,7 @@ fn get_test_env_with_chain_and_pool(num_rounds: usize) -> (TestEnv, Chain, Trans
     env.step_default(vec![]);
 
     let signers: Vec<_> = validators.iter().map(|id| InMemorySigner::test_signer(&id)).collect();
-    let transaction_pool =
-        generate_transaction_pool(&signers, env.head.prev_block_hash, num_rounds);
+    let transaction_pool = generate_transaction_pool(&signers, env.head.prev_block_hash);
     (env, chain, transaction_pool)
 }
 
@@ -1709,7 +1705,7 @@ fn prepare_transactions_extra(
 
 #[test]
 fn test_prepare_transactions_duplicate_nonces() {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
 
     // Insert a transaction with a duplicate (public key, nonce) pair into the pool.
     let mut iter = transaction_pool.pool_iterator();
@@ -1755,7 +1751,7 @@ fn test_prepare_transactions_duplicate_nonces() {
 /// Otherwise each key's group sees the full balance independently.
 #[test]
 fn test_prepare_transactions_shared_balance_across_keys() {
-    let (mut env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (mut env, chain, _) = get_test_env_with_chain_and_pool();
 
     let account_id: AccountId = "test1".parse().unwrap();
     let signer1 = InMemorySigner::test_signer(&account_id);
@@ -1853,7 +1849,7 @@ fn test_prepare_transactions_empty_storage_proof() {
 fn test_prepare_transactions_helper(
     storage_source: StorageDataSource,
 ) -> Result<(usize, PreparedTransactions), Error> {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
     let transactions_count = transaction_pool.len();
 
     let storage_config = RuntimeStorageConfig {
@@ -1876,7 +1872,7 @@ fn test_prepare_transactions_helper(
 
 #[test]
 fn test_prepare_transactions_extra() {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
     let validate_tx_ttl = &|_: &SignedTransaction| true;
 
     // First run the preparation without any extra arguments
@@ -1967,7 +1963,7 @@ fn test_prepare_transactions_extra() {
 fn test_prepare_transactions_pending_skip() {
     let num_rounds = NUM_TEST_SIGNERS - 1;
     let total_txs = NUM_TEST_SIGNERS * num_rounds;
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(num_rounds);
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
 
     // Skip every other transaction.
     let mut call_count = 0usize;
@@ -2000,7 +1996,7 @@ fn test_prepare_transactions_pending_skip() {
 /// subsequent transactions should fail balance validation.
 #[test]
 fn test_prepare_transactions_pending_balance_constraint() {
-    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, _) = get_test_env_with_chain_and_pool();
 
     // Create a pool with a small transfer from test1.
     let signer = InMemorySigner::test_signer(&"test1".parse::<AccountId>().unwrap());
@@ -2053,7 +2049,7 @@ fn test_prepare_transactions_pending_balance_constraint() {
 /// floor is raised. Transactions with nonces <= max_nonce should be rejected.
 #[test]
 fn test_prepare_transactions_pending_nonce_constraint() {
-    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, _) = get_test_env_with_chain_and_pool();
 
     let signer = InMemorySigner::test_signer(&"test1".parse::<AccountId>().unwrap());
     // Create two transactions with nonces 1 and 2.
@@ -2099,7 +2095,7 @@ fn test_prepare_transactions_pending_nonce_constraint() {
 
 #[test]
 fn test_strict_nonce_u64_max_not_included() {
-    let (env, chain, _transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, _transaction_pool) = get_test_env_with_chain_and_pool();
     let prev_hash = env.head.prev_block_hash;
     let shard_layout = env.epoch_manager.get_shard_layout_from_prev_block(&prev_hash).unwrap();
     let shard_uid = shard_layout.shard_uids().next().unwrap();
@@ -2259,7 +2255,7 @@ fn test_strict_nonce_gap_does_not_count_towards_state_size_soft_limit() {
 /// the same signer group and across different signers are all evicted.
 #[test]
 fn test_strict_nonce_gap_ttl_eviction() {
-    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, _) = get_test_env_with_chain_and_pool();
     let prev_hash = env.head.prev_block_hash;
     // env.head.height == 1, prev_hash is genesis (height 0).
 

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::types::{
-    BlockType, ChainConfig, RuntimeStorageConfig, StatePartValidationResult,
+    BlockType, ChainConfig, HasContract, RuntimeStorageConfig, StatePartValidationResult,
     StateRootNodeValidationResult,
 };
 use crate::{Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode};
@@ -1668,7 +1668,7 @@ fn prepare_transactions_extra(
     transaction_groups: &mut dyn TransactionGroupIterator,
     skip_tx_hashes: HashSet<CryptoHash>,
     validate_tx_ttl: &dyn Fn(&SignedTransaction) -> bool,
-    check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
+    check_pending: &mut dyn FnMut(&SignedTransaction, HasContract) -> PendingTxCheckResult,
     cancel: Option<Arc<AtomicBool>>,
 ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
     let prev_hash = env.head.prev_block_hash;

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -59,6 +59,9 @@ use primitive_types::U256;
 use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 use std::collections::{BTreeSet, HashSet};
 
+const TEST_SEED: RngSeed = [3; 32];
+const NUM_TEST_SIGNERS: usize = 4;
+
 struct TestEnvConfig {
     epoch_length: BlockHeightDelta,
     has_reward: bool,
@@ -1548,13 +1551,16 @@ fn test_genesis_hash() {
 /// Creates a signed transaction between each pair of `signers`,
 /// where transaction outcomes from a single signer differ by nonce.
 /// The transactions are then shuffled and used to fill a transaction pool.
-fn generate_transaction_pool(signers: &Vec<Signer>, block_hash: CryptoHash) -> TransactionPool {
-    const TEST_SEED: RngSeed = [3; 32];
+fn generate_transaction_pool(
+    signers: &[Signer],
+    block_hash: CryptoHash,
+    num_rounds: usize,
+) -> TransactionPool {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let signer_count = signers.len();
 
     let mut transactions = vec![];
-    for round in 1..signer_count {
+    for round in 1..=num_rounds {
         for i in 0..signer_count {
             let transaction = SignedTransaction::send_money(
                 round.try_into().unwrap(),
@@ -1577,9 +1583,8 @@ fn generate_transaction_pool(signers: &Vec<Signer>, block_hash: CryptoHash) -> T
     pool
 }
 
-fn get_test_env_with_chain_and_pool() -> (TestEnv, Chain, TransactionPool) {
-    let num_nodes = 4;
-    let validators = (0..num_nodes)
+fn get_test_env_with_chain_and_pool(num_rounds: usize) -> (TestEnv, Chain, TransactionPool) {
+    let validators = (0..NUM_TEST_SIGNERS)
         .map(|i| AccountId::try_from(format!("test{}", i + 1)).unwrap())
         .collect::<Vec<_>>();
     let chain_genesis = ChainGenesis::new(&GenesisConfig::test(Clock::real()));
@@ -1618,8 +1623,8 @@ fn get_test_env_with_chain_and_pool() -> (TestEnv, Chain, TransactionPool) {
     env.step_default(vec![]);
 
     let signers: Vec<_> = validators.iter().map(|id| InMemorySigner::test_signer(&id)).collect();
-
-    let transaction_pool = generate_transaction_pool(&signers, env.head.prev_block_hash);
+    let transaction_pool =
+        generate_transaction_pool(&signers, env.head.prev_block_hash, num_rounds);
     (env, chain, transaction_pool)
 }
 
@@ -1663,6 +1668,7 @@ fn prepare_transactions_extra(
     transaction_groups: &mut dyn TransactionGroupIterator,
     skip_tx_hashes: HashSet<CryptoHash>,
     validate_tx_ttl: &dyn Fn(&SignedTransaction) -> bool,
+    check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
     cancel: Option<Arc<AtomicBool>>,
 ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
     let prev_hash = env.head.prev_block_hash;
@@ -1695,6 +1701,7 @@ fn prepare_transactions_extra(
         },
         validate_tx_ttl,
         skip_tx_hashes,
+        check_pending,
         default_produce_chunk_add_transactions_time_limit(),
         cancel,
     )
@@ -1702,7 +1709,7 @@ fn prepare_transactions_extra(
 
 #[test]
 fn test_prepare_transactions_duplicate_nonces() {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
 
     // Insert a transaction with a duplicate (public key, nonce) pair into the pool.
     let mut iter = transaction_pool.pool_iterator();
@@ -1748,7 +1755,7 @@ fn test_prepare_transactions_duplicate_nonces() {
 /// Otherwise each key's group sees the full balance independently.
 #[test]
 fn test_prepare_transactions_shared_balance_across_keys() {
-    let (mut env, chain, _) = get_test_env_with_chain_and_pool();
+    let (mut env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
 
     let account_id: AccountId = "test1".parse().unwrap();
     let signer1 = InMemorySigner::test_signer(&account_id);
@@ -1846,7 +1853,7 @@ fn test_prepare_transactions_empty_storage_proof() {
 fn test_prepare_transactions_helper(
     storage_source: StorageDataSource,
 ) -> Result<(usize, PreparedTransactions), Error> {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
     let transactions_count = transaction_pool.len();
 
     let storage_config = RuntimeStorageConfig {
@@ -1869,7 +1876,7 @@ fn test_prepare_transactions_helper(
 
 #[test]
 fn test_prepare_transactions_extra() {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
     let validate_tx_ttl = &|_: &SignedTransaction| true;
 
     // First run the preparation without any extra arguments
@@ -1879,6 +1886,7 @@ fn test_prepare_transactions_extra() {
         &mut PoolIteratorWrapper::new(&mut transaction_pool),
         HashSet::new(),
         validate_tx_ttl,
+        &mut PendingTxCheckResult::always_admit(),
         None,
     )
     .unwrap();
@@ -1901,6 +1909,7 @@ fn test_prepare_transactions_extra() {
         &mut PoolIteratorWrapper::new(&mut transaction_pool),
         HashSet::new(),
         validate_tx_ttl,
+        &mut PendingTxCheckResult::always_admit(),
         Some(Arc::new(AtomicBool::new(false))),
     )
     .unwrap();
@@ -1919,6 +1928,7 @@ fn test_prepare_transactions_extra() {
         &mut PoolIteratorWrapper::new(&mut transaction_pool),
         HashSet::new(),
         validate_tx_ttl,
+        &mut PendingTxCheckResult::always_admit(),
         Some(Arc::new(AtomicBool::new(true))),
     )
     .unwrap();
@@ -1935,6 +1945,7 @@ fn test_prepare_transactions_extra() {
         &mut PoolIteratorWrapper::new(&mut transaction_pool),
         skip_tx_hashes.clone(),
         validate_tx_ttl,
+        &mut PendingTxCheckResult::always_admit(),
         None,
     )
     .unwrap();
@@ -1950,9 +1961,145 @@ fn test_prepare_transactions_extra() {
     assert_eq!(transaction_pool.len(), 0);
 }
 
+/// When check_pending returns Skip for a transaction, it should appear in
+/// skipped_transactions (for reintroduction to pool), not in prepared.
+#[test]
+fn test_prepare_transactions_pending_skip() {
+    let num_rounds = NUM_TEST_SIGNERS - 1;
+    let total_txs = NUM_TEST_SIGNERS * num_rounds;
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(num_rounds);
+
+    // Skip every other transaction.
+    let mut call_count = 0usize;
+    let (prepared, skipped) = prepare_transactions_extra(
+        &env,
+        &chain,
+        &mut PoolIteratorWrapper::new(&mut transaction_pool),
+        HashSet::new(),
+        &|_| true,
+        &mut |_, _| {
+            call_count += 1;
+            if call_count % 2 == 0 {
+                PendingTxCheckResult::Skip
+            } else {
+                PendingTxCheckResult::Admit(PendingConstraints::default())
+            }
+        },
+        None,
+    )
+    .unwrap();
+
+    // No transactions should be lost: all are either prepared or skipped.
+    assert_eq!(prepared.transactions.len() + skipped.0.len(), total_txs);
+    assert_eq!(prepared.transactions.len(), total_txs / 2);
+    assert_eq!(skipped.0.len(), total_txs / 2);
+}
+
+/// When check_pending returns Admit with paid_from_balance, the available
+/// balance for validation is reduced. With a large enough paid_from_balance,
+/// subsequent transactions should fail balance validation.
+#[test]
+fn test_prepare_transactions_pending_balance_constraint() {
+    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+
+    // Create a pool with a small transfer from test1.
+    let signer = InMemorySigner::test_signer(&"test1".parse::<AccountId>().unwrap());
+    let tx = SignedTransaction::send_money(
+        1,
+        signer.get_account_id(),
+        "test2".parse().unwrap(),
+        &signer,
+        Balance::from_yoctonear(1),
+        env.head.prev_block_hash,
+    );
+    let mut pool = TransactionPool::new(TEST_SEED, None, "");
+    pool.insert_transaction(ValidatedTransaction::new_for_test(tx));
+
+    // Without pending constraints, the transfer should succeed.
+    let (prepared, _) = prepare_transactions_extra(
+        &env,
+        &chain,
+        &mut PoolIteratorWrapper::new(&mut pool),
+        HashSet::new(),
+        &|_| true,
+        &mut PendingTxCheckResult::always_admit(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(prepared.transactions.len(), 1);
+
+    // Reinsert and try again with paid_from_balance consuming all balance.
+    pool.insert_transaction(prepared.transactions[0].clone());
+    let (prepared, _) = prepare_transactions_extra(
+        &env,
+        &chain,
+        &mut PoolIteratorWrapper::new(&mut pool),
+        HashSet::new(),
+        &|_| true,
+        &mut |_, _| {
+            PendingTxCheckResult::Admit(PendingConstraints {
+                paid_from_balance: TESTING_INIT_BALANCE,
+                ..PendingConstraints::default()
+            })
+        },
+        None,
+    )
+    .unwrap();
+    // The transaction should fail balance validation (balance reduced to 0).
+    assert_eq!(prepared.transactions.len(), 0);
+}
+
+/// When check_pending returns Admit with max_nonce, the effective nonce
+/// floor is raised. Transactions with nonces <= max_nonce should be rejected.
+#[test]
+fn test_prepare_transactions_pending_nonce_constraint() {
+    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+
+    let signer = InMemorySigner::test_signer(&"test1".parse::<AccountId>().unwrap());
+    // Create two transactions with nonces 1 and 2.
+    let tx1 = SignedTransaction::send_money(
+        1,
+        signer.get_account_id(),
+        "test2".parse().unwrap(),
+        &signer,
+        Balance::from_yoctonear(1),
+        env.head.prev_block_hash,
+    );
+    let tx2 = SignedTransaction::send_money(
+        2,
+        signer.get_account_id(),
+        "test2".parse().unwrap(),
+        &signer,
+        Balance::from_yoctonear(1),
+        env.head.prev_block_hash,
+    );
+    let mut pool = TransactionPool::new(TEST_SEED, None, "");
+    pool.insert_transaction(ValidatedTransaction::new_for_test(tx1));
+    pool.insert_transaction(ValidatedTransaction::new_for_test(tx2));
+
+    // With max_nonce=1, nonce 1 should be rejected (<=max_nonce), nonce 2 accepted.
+    let (prepared, _) = prepare_transactions_extra(
+        &env,
+        &chain,
+        &mut PoolIteratorWrapper::new(&mut pool),
+        HashSet::new(),
+        &|_| true,
+        &mut |_, _| {
+            PendingTxCheckResult::Admit(PendingConstraints {
+                max_nonce: 1,
+                ..PendingConstraints::default()
+            })
+        },
+        None,
+    )
+    .unwrap();
+    assert_eq!(prepared.transactions.len(), 1);
+    assert_eq!(prepared.transactions[0].nonce().nonce(), 2);
+}
+
 #[test]
 fn test_strict_nonce_u64_max_not_included() {
-    let (env, chain, _transaction_pool) = get_test_env_with_chain_and_pool();
+    let (env, chain, _transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
     let prev_hash = env.head.prev_block_hash;
     let shard_layout = env.epoch_manager.get_shard_layout_from_prev_block(&prev_hash).unwrap();
     let shard_uid = shard_layout.shard_uids().next().unwrap();
@@ -2015,6 +2162,7 @@ fn test_strict_nonce_u64_max_not_included() {
             },
             &|_| true,
             HashSet::new(),
+            &mut PendingTxCheckResult::always_admit(),
             default_produce_chunk_add_transactions_time_limit(),
             None,
         )
@@ -2090,6 +2238,7 @@ fn test_strict_nonce_gap_does_not_count_towards_state_size_soft_limit() {
             &|_| true,
             &|_| true,
             HashSet::new(),
+            &mut PendingTxCheckResult::always_admit(),
             None,
             None,
         )
@@ -2110,7 +2259,7 @@ fn test_strict_nonce_gap_does_not_count_towards_state_size_soft_limit() {
 /// the same signer group and across different signers are all evicted.
 #[test]
 fn test_strict_nonce_gap_ttl_eviction() {
-    let (env, chain, _) = get_test_env_with_chain_and_pool();
+    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
     let prev_hash = env.head.prev_block_hash;
     // env.head.height == 1, prev_hash is genesis (height 0).
 
@@ -2153,6 +2302,7 @@ fn test_strict_nonce_gap_ttl_eviction() {
         &mut PoolIteratorWrapper::new(&mut pool),
         HashSet::new(),
         &ttl_valid,
+        &mut PendingTxCheckResult::always_admit(),
         None,
     )
     .unwrap();
@@ -2168,6 +2318,7 @@ fn test_strict_nonce_gap_ttl_eviction() {
         &mut PoolIteratorWrapper::new(&mut pool),
         HashSet::new(),
         &ttl_expired,
+        &mut PendingTxCheckResult::always_admit(),
         None,
     )
     .unwrap();

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -103,7 +103,7 @@ impl SpiceCoreReader {
         self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key)
     }
 
-    fn get_uncertified_chunks(
+    pub fn get_uncertified_chunks(
         &self,
         block_hash: &CryptoHash,
     ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -103,7 +103,7 @@ impl SpiceCoreReader {
         self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key)
     }
 
-    pub fn get_uncertified_chunks(
+    fn get_uncertified_chunks(
         &self,
         block_hash: &CryptoHash,
     ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -422,6 +422,23 @@ impl PreparedTransactions {
 #[derive(Debug, Clone)]
 pub struct SkippedTransactions(pub Vec<ValidatedTransaction>);
 
+/// Result of checking pending transaction queue admission for a transaction.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PendingTxCheckResult {
+    /// Admitted. Use these constraints for balance/nonce validation.
+    Admit(PendingConstraints),
+    /// Violates PTQ constraints (P_MAX, deploy exclusivity).
+    /// Push to skipped_transactions for reintroduction to pool.
+    Skip,
+}
+
+impl PendingTxCheckResult {
+    /// Returns a closure that always admits with default constraints.
+    pub fn always_admit() -> impl FnMut(&SignedTransaction, bool) -> PendingTxCheckResult {
+        |_, _| PendingTxCheckResult::Admit(PendingConstraints::default())
+    }
+}
+
 /// Chunk producer prepares transactions from the transaction pool
 /// until it hits some limit (too many transactions, too much gas used, etc).
 /// This enum describes which limit was hit when preparing transactions.
@@ -560,6 +577,7 @@ pub trait RuntimeAdapter: Send + Sync {
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         validate_tx_ttl: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
+        check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
         time_limit: Option<Duration>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error>;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -422,6 +422,13 @@ impl PreparedTransactions {
 #[derive(Debug, Clone)]
 pub struct SkippedTransactions(pub Vec<ValidatedTransaction>);
 
+/// Whether the transaction's signer account has a deployed contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HasContract {
+    Yes,
+    No,
+}
+
 /// Result of checking pending transaction queue admission for a transaction.
 #[derive(Debug, PartialEq, Eq)]
 pub enum PendingTxCheckResult {
@@ -434,7 +441,7 @@ pub enum PendingTxCheckResult {
 
 impl PendingTxCheckResult {
     /// Returns a closure that always admits with default constraints.
-    pub fn always_admit() -> impl FnMut(&SignedTransaction, bool) -> PendingTxCheckResult {
+    pub fn always_admit() -> impl FnMut(&SignedTransaction, HasContract) -> PendingTxCheckResult {
         |_, _| PendingTxCheckResult::Admit(PendingConstraints::default())
     }
 }
@@ -577,7 +584,7 @@ pub trait RuntimeAdapter: Send + Sync {
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         validate_tx_ttl: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
-        check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
+        check_pending: &mut dyn FnMut(&SignedTransaction, HasContract) -> PendingTxCheckResult,
         time_limit: Option<Duration>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error>;

--- a/chain/client/src/prepare_transactions.rs
+++ b/chain/client/src/prepare_transactions.rs
@@ -1,6 +1,7 @@
 use near_async::time::Duration;
 use near_chain::types::{
-    PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions, RuntimeAdapter,
+    PendingTxCheckResult, PrepareTransactionsBlockContext, PrepareTransactionsLimit,
+    PreparedTransactions, RuntimeAdapter,
 };
 use near_chunks::client::ShardedTransactionPool;
 use near_client_primitives::types::Error;
@@ -141,6 +142,7 @@ impl PrepareTransactionsJob {
             &inputs.tx_validity_period_check,
             &inputs.validate_tx_ttl,
             inputs.prev_chunk_tx_hashes,
+            &mut PendingTxCheckResult::always_admit(),
             inputs.time_limit,
             Some((&self).cancel.clone()),
         );


### PR DESCRIPTION
Preparatory refactor for the pending transaction queue (PTQ) in SPICE. Adds a `check_pending` callback to `prepare_transactions_extra` so callers can control per-transaction admission (this will be used by chunk production) and supply `PendingConstraints` for balance/nonce validation (these will be used by RPC+chunk production).

- Add `PendingTxCheckResult` enum with `Admit(PendingConstraints)` and `Skip` variants.
- Thread `check_pending` callback through `prepare_transactions_extra` trait and impl; when it returns `Skip`, the transaction goes to `SkippedTransactions` for pool reintroduction.
- All current callers pass `always_admit()` -- no behavioral change.
- Add tests for skip, balance constraint, and nonce constraint behaviors.
- Depends on #15314.