### PR TITLE
feat(ptq): add PendingTransactionQueue stub 3/7

### DIFF
--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -103,7 +103,10 @@ impl SpiceCoreReader {
         self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key)
     }
 
-    fn get_uncertified_chunks(
+    /// Returns the list of uncertified chunks as of the given block.
+    /// Returns an empty vec for genesis or non-Spice blocks.
+    /// Errors if a Spice block is missing uncertified_chunks in storage.
+    pub fn get_uncertified_chunks(
         &self,
         block_hash: &CryptoHash,
     ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {
@@ -617,6 +620,26 @@ fn find_oldest_uncertified_block_header(
         .map(|block_hash| chain_store.get_block_header(block_hash))
         .collect::<Result<Vec<_>, Error>>()?;
     Ok(uncertified_block_headers.into_iter().min_by_key(|header| header.height()))
+}
+
+/// Returns block hashes that became fully certified due to the execution results
+/// in `core_statements`. A block is newly certified when all of its previously
+/// uncertified chunks appear in the execution results.
+pub fn find_newly_certified_block_hashes(
+    prev_uncertified_chunks: &[SpiceUncertifiedChunkInfo],
+    core_statements: &SpiceCoreStatements,
+) -> Vec<CryptoHash> {
+    let newly_certified_chunk_ids: HashSet<&SpiceChunkId> =
+        core_statements.iter_execution_results().map(|(id, _)| id).collect();
+    // Group uncertified chunks by block hash, tracking whether all are now certified.
+    let mut blocks: HashMap<CryptoHash, bool> = HashMap::new();
+    for chunk_info in prev_uncertified_chunks {
+        let block_entry = blocks.entry(chunk_info.chunk_id.block_hash).or_insert(true);
+        if !newly_certified_chunk_ids.contains(&chunk_info.chunk_id) {
+            *block_entry = false;
+        }
+    }
+    blocks.into_iter().filter(|(_, all_certified)| *all_certified).map(|(hash, _)| hash).collect()
 }
 
 /// Returns the header of the last fully certified block relative to the given block.

--- a/chain/chain/src/tests/spice_core.rs
+++ b/chain/chain/src/tests/spice_core.rs
@@ -1,4 +1,6 @@
-use crate::spice_core::{SpiceCoreReader, record_uncertified_chunks_for_block};
+use crate::spice_core::{
+    SpiceCoreReader, find_newly_certified_block_hashes, record_uncertified_chunks_for_block,
+};
 use crate::spice_core_writer_actor::{ProcessedBlock, SpiceCoreWriterActor};
 use crate::test_utils::{
     get_chain_with_genesis, get_fake_next_block_chunk_headers, process_block_sync,
@@ -30,7 +32,7 @@ use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     Balance, BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, ShardId,
-    SpiceChunkId,
+    SpiceChunkId, SpiceUncertifiedChunkInfo,
 };
 use near_primitives::utils::get_execution_results_key;
 use near_store::DBCol;
@@ -1438,6 +1440,27 @@ fn test_proposal(account: &str, stake: u128) -> ValidatorStake {
     ValidatorStake::new(account.parse().unwrap(), signer.public_key(), Balance::from_near(stake))
 }
 
+fn uncertified_chunk_info(block_hash: CryptoHash, shard_id: ShardId) -> SpiceUncertifiedChunkInfo {
+    SpiceUncertifiedChunkInfo {
+        chunk_id: SpiceChunkId { block_hash, shard_id },
+        missing_endorsements: vec![],
+        present_endorsements: vec![],
+    }
+}
+
+fn execution_result_core_statement(
+    block_hash: CryptoHash,
+    shard_id: ShardId,
+) -> SpiceCoreStatement {
+    SpiceCoreStatement::ChunkExecutionResult {
+        chunk_id: SpiceChunkId { block_hash, shard_id },
+        execution_result: ChunkExecutionResult {
+            chunk_extra: ChunkExtra::new_with_only_state_root(&CryptoHash::default()),
+            outgoing_receipts_root: CryptoHash::default(),
+        },
+    }
+}
+
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_uncertified_validator_proposals_single_chunk() {
@@ -1459,6 +1482,13 @@ fn test_uncertified_validator_proposals_single_chunk() {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].account_id().as_str(), "test0");
     assert_eq!(result[0].stake(), Balance::from_near(100));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_find_newly_certified_empty_inputs() {
+    let result = find_newly_certified_block_hashes(&[], SpiceCoreStatements::empty());
+    assert!(result.is_empty());
 }
 
 #[test]
@@ -1494,6 +1524,23 @@ fn test_uncertified_validator_proposals_multiple_heights_different_accounts() {
     assert_eq!(result[0].stake(), Balance::from_near(100));
     assert_eq!(result[1].account_id().as_str(), "test1");
     assert_eq!(result[1].stake(), Balance::from_near(200));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_find_newly_certified_partial_certification() {
+    let block_hash = CryptoHash::hash_bytes(&[1]);
+    let shard_0 = ShardId::new(0);
+    let shard_1 = ShardId::new(1);
+    let uncertified = vec![
+        uncertified_chunk_info(block_hash, shard_0),
+        uncertified_chunk_info(block_hash, shard_1),
+    ];
+    // Only shard 0 gets certified.
+    let statements =
+        SpiceCoreStatements::new(vec![execution_result_core_statement(block_hash, shard_0)]);
+    let result = find_newly_certified_block_hashes(&uncertified, &statements);
+    assert!(result.is_empty());
 }
 
 #[test]
@@ -1552,4 +1599,27 @@ fn test_uncertified_validator_proposals_execution_results_fallback() {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].account_id().as_str(), "test0");
     assert_eq!(result[0].stake(), Balance::from_near(100));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_find_newly_certified_full_certification() {
+    let block_a = CryptoHash::hash_bytes(&[1]);
+    let block_b = CryptoHash::hash_bytes(&[2]);
+    let shard_0 = ShardId::new(0);
+    let shard_1 = ShardId::new(1);
+    let uncertified = vec![
+        uncertified_chunk_info(block_a, shard_0),
+        uncertified_chunk_info(block_a, shard_1),
+        uncertified_chunk_info(block_b, shard_0),
+        uncertified_chunk_info(block_b, shard_1),
+    ];
+    // Block A is fully certified, block B only partially.
+    let statements = SpiceCoreStatements::new(vec![
+        execution_result_core_statement(block_a, shard_0),
+        execution_result_core_statement(block_a, shard_1),
+        execution_result_core_statement(block_b, shard_0),
+    ]);
+    let result = find_newly_certified_block_hashes(&uncertified, &statements);
+    assert_eq!(result, vec![block_a]);
 }

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -1,11 +1,13 @@
 use crate::debug::PRODUCTION_TIMES_CACHE_SIZE;
 use crate::metrics;
+use crate::pending_transaction_queue::{PendingTxSession, ShardedPendingTransactionQueue};
 use crate::prepare_transactions::{
     PrepareTransactionsJobInputs, PrepareTransactionsJobKey, PrepareTransactionsManager,
 };
 use itertools::Itertools;
 use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt};
 use near_async::time::{Clock, Duration, Instant};
+use near_chain::spice_core::get_last_certified_block_header;
 use near_chain::types::{
     PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions,
     RuntimeAdapter, RuntimeStorageConfig,
@@ -97,6 +99,7 @@ pub struct ChunkProducer {
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     // TODO: put mutex on individual shards instead of the complete pool
     pub sharded_tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    pub pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
     /// A ReedSolomon instance to encode shard chunks.
     reed_solomon_encoder: ReedSolomon,
     /// Chunk production timing information. Used only for debug purposes.
@@ -136,6 +139,7 @@ impl ChunkProducer {
                 rng_seed,
                 transaction_pool_size_limit,
             ))),
+            pending_transaction_queue: Arc::new(Mutex::new(ShardedPendingTransactionQueue::new())),
             reed_solomon_encoder: ReedSolomon::new(data_parts, parity_parts).unwrap(),
             chunk_production_info: lru::LruCache::new(
                 NonZeroUsize::new(PRODUCTION_TIMES_CACHE_SIZE).unwrap(),
@@ -463,7 +467,9 @@ impl ChunkProducer {
     ) -> Result<PreparedTransactions, Error> {
         let shard_id = shard_uid.shard_id();
         let mut pool_guard = self.sharded_tx_pool.lock();
-        let prepared_transactions = if let Some(mut iter) = pool_guard.get_pool_iterator(shard_uid)
+        // (prepared_transactions, skipped_transactions_to_reintroduce)
+        let (prepared_transactions, skipped_transactions) = if let Some(mut iter) =
+            pool_guard.get_pool_iterator(shard_uid)
         {
             #[cfg(feature = "test_features")]
             let skip_verification = matches!(
@@ -473,16 +479,54 @@ impl ChunkProducer {
             #[cfg(not(feature = "test_features"))]
             let skip_verification = false;
 
-            if skip_verification || ProtocolFeature::Spice.enabled(protocol_version) {
-                // TODO(spice): properly implement transaction preparation to respect limits
+            if skip_verification {
                 let mut res = vec![];
                 while let Some(iter) = iter.next() {
                     res.push(iter.next().unwrap());
                 }
-                PreparedTransactions {
-                    transactions: res,
-                    limited_by: PrepareTransactionsLimit::NoMoreTxsInPool,
-                }
+                (
+                    PreparedTransactions {
+                        transactions: res,
+                        limited_by: PrepareTransactionsLimit::NoMoreTxsInPool,
+                    },
+                    Vec::new(),
+                )
+            } else if ProtocolFeature::Spice.enabled(protocol_version) {
+                // SPICE path: use prepare_transactions_extra with pending transaction queue
+                // constraints. Use the last certified block's ChunkExtra for
+                // state validation (the certified block is guaranteed to have
+                // been executed, so its state root is available).
+                let certified_header =
+                    get_last_certified_block_header(&self.chain, &prev_block.hash())?;
+                let certified_chunk_extra = self
+                    .chain
+                    .chunk_store()
+                    .get_chunk_extra(certified_header.hash(), &shard_uid)?;
+                let trie = self.runtime_adapter.get_trie_for_shard(
+                    shard_id,
+                    certified_header.hash(),
+                    *certified_chunk_extra.state_root(),
+                    true,
+                )?;
+                let trie = trie.recording_reads_new_recorder();
+                let state_update = TrieUpdate::new(trie);
+                let prev_block_context =
+                    PrepareTransactionsBlockContext::new(prev_block, &*self.epoch_manager)?;
+                let mut session =
+                    PendingTxSession::new(Arc::clone(&self.pending_transaction_queue), shard_uid);
+                let (prepared, skipped) = self.runtime_adapter.prepare_transactions_extra(
+                    state_update,
+                    shard_id,
+                    prev_block_context,
+                    &mut iter,
+                    chain_validate,
+                    validate_tx_ttl,
+                    std::collections::HashSet::new(),
+                    &mut |tx, has_contract| session.check_pending(tx, has_contract),
+                    self.chunk_transactions_time_limit.get(),
+                    None,
+                )?;
+                (prepared, skipped.0)
             } else {
                 let storage_config = RuntimeStorageConfig {
                     state_root: *chunk_extra.state_root(),
@@ -492,23 +536,30 @@ impl ChunkProducer {
                 };
                 let prev_block_context =
                     PrepareTransactionsBlockContext::new(prev_block, &*self.epoch_manager)?;
-                self.runtime_adapter.prepare_transactions(
-                    storage_config,
-                    shard_id,
-                    prev_block_context,
-                    &mut iter,
-                    chain_validate,
-                    validate_tx_ttl,
-                    self.chunk_transactions_time_limit.get(),
-                )?
+                (
+                    self.runtime_adapter.prepare_transactions(
+                        storage_config,
+                        shard_id,
+                        prev_block_context,
+                        &mut iter,
+                        chain_validate,
+                        validate_tx_ttl,
+                        self.chunk_transactions_time_limit.get(),
+                    )?,
+                    Vec::new(),
+                )
             }
         } else {
-            PreparedTransactions::new()
+            (PreparedTransactions::new(), Vec::new())
         };
-        // Reintroduce valid transactions back to the pool. They will be removed when the chunk is
-        // included into the block.
+        // Reintroduce valid transactions back to the pool. They will be removed
+        // when the chunk is included into the block.
         let reintroduced_count = pool_guard
             .reintroduce_transactions(shard_uid, prepared_transactions.transactions.clone());
+        // Reintroduce skipped transactions (from pending transaction queue constraints) back to pool.
+        if !skipped_transactions.is_empty() {
+            pool_guard.reintroduce_transactions(shard_uid, skipped_transactions);
+        }
 
         if reintroduced_count < prepared_transactions.transactions.len() {
             tracing::debug!(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -613,9 +613,6 @@ impl Client {
         if !block.is_spice_block() {
             return Ok(());
         }
-        let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        let config = self.runtime_adapter.get_runtime_config(protocol_version);
 
         // Remove newly certified blocks from the pending transaction queue.
         let prev_uncertified =
@@ -630,6 +627,9 @@ impl Client {
         }
 
         // Add new block's chunk transactions.
+        let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let config = self.runtime_adapter.get_runtime_config(protocol_version);
         let gas_price = self.chain.get_block_header(block.header().prev_hash())?.next_gas_price();
         for chunk_header in block.chunks().iter_new() {
             let shard_id = chunk_header.shard_id();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -447,7 +447,7 @@ impl Client {
                 &shard_tracker,
                 &head.last_block_hash,
             ) {
-                tracing::debug!(
+                tracing::error!(
                     target: "client",
                     ?err,
                     "pending transaction queue initialization on startup failed"

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -33,6 +33,7 @@ use near_chain::chain::{
 use near_chain::orphan::OrphanMissingChunks;
 use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::resharding::types::ReshardingSender;
+use near_chain::spice_core::find_newly_certified_block_hashes;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::test_utils::format_hash;
 use near_chain::types::{ChainConfig, LatestKnown, RuntimeAdapter};
@@ -621,10 +622,8 @@ impl Client {
         // Remove newly certified blocks from the pending transaction queue.
         let prev_uncertified =
             self.chain.spice_core_reader.get_uncertified_chunks(block.header().prev_hash())?;
-        let certified_block_hashes = near_chain::spice_core::find_newly_certified_block_hashes(
-            &prev_uncertified,
-            block.spice_core_statements(),
-        );
+        let certified_block_hashes =
+            find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
         if !certified_block_hashes.is_empty() {
             let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
             for block_hash in &certified_block_hashes {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -618,20 +618,17 @@ impl Client {
         let prev_block_header = self.chain.get_block_header(block.header().prev_hash())?;
         let gas_price = prev_block_header.next_gas_price();
 
-        // Remove certified chunks (core statements in this block).
-        {
+        // Remove newly certified blocks from the pending transaction queue.
+        let prev_uncertified =
+            self.chain.spice_core_reader.get_uncertified_chunks(block.header().prev_hash())?;
+        let certified_block_hashes = near_chain::spice_core::find_newly_certified_block_hashes(
+            &prev_uncertified,
+            block.spice_core_statements(),
+        );
+        if !certified_block_hashes.is_empty() {
             let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
-            for (chunk_id, _) in block.spice_core_statements().iter_execution_results() {
-                let cert_epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
-                let shard_uid = shard_id_to_uid(
-                    self.epoch_manager.as_ref(),
-                    chunk_id.shard_id,
-                    &cert_epoch_id,
-                )?;
-                let Some(queue) = ptq.get_mut(&shard_uid) else {
-                    continue;
-                };
-                queue.remove_certified_chunk(&chunk_id.block_hash);
+            for block_hash in &certified_block_hashes {
+                ptq.remove_certified_block(block_hash);
             }
         }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -9,6 +9,7 @@ use crate::chunk_producer::AdvProduceChunksMode;
 use crate::chunk_producer::ChunkProducer;
 use crate::client_actor::ClientSenderForClient;
 use crate::debug::BlockProductionTracker;
+use crate::pending_transaction_queue::ShardedPendingTransactionQueue;
 use crate::spice_timer::SpiceTimer;
 use crate::stateless_validation::chunk_endorsement::ChunkEndorsementTracker;
 use crate::stateless_validation::chunk_validation_actor::ChunkValidationSender;
@@ -74,6 +75,7 @@ use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::{CatchupStatusView, DroppedReason};
+use parking_lot::Mutex;
 use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -434,7 +436,26 @@ impl Client {
         );
 
         let chunk_distribution_network = ChunkDistributionNetwork::from_config(&config);
-        Ok(Self {
+
+        // Initialize pending transaction queue from uncertified chunks for the chain head.
+        if let Ok(head) = chain.head() {
+            if let Err(err) = Self::reinitialize_pending_transaction_queue(
+                &chunk_producer.pending_transaction_queue,
+                &chain,
+                epoch_manager.as_ref(),
+                runtime_adapter.as_ref(),
+                &shard_tracker,
+                &head.last_block_hash,
+            ) {
+                tracing::debug!(
+                    target: "client",
+                    ?err,
+                    "pending transaction queue initialization on startup failed"
+                );
+            }
+        }
+
+        let client = Self {
             #[cfg(feature = "test_features")]
             adv_produce_blocks: None,
             #[cfg(feature = "sandbox")]
@@ -477,7 +498,8 @@ impl Client {
             shadow_validation_reed_solomon: OnceLock::new(),
             last_validator_key_check_epoch: None,
             block_notification_watch_sender,
-        })
+        };
+        Ok(client)
     }
 
     // Checks if it's been at least `stall_timeout` since the last time the head was updated, or
@@ -580,6 +602,137 @@ impl Client {
                             "reintroduced transactions");
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Add a new block's transactions to the pending transaction queue and remove certified chunks.
+    /// Called on BlockStatus::Next.
+    fn update_pending_transaction_queue_for_block(&self, block: &Block) -> Result<(), Error> {
+        if !block.is_spice_block() {
+            return Ok(());
+        }
+        let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let config = self.runtime_adapter.get_runtime_config(protocol_version);
+        let prev_block_header = self.chain.get_block_header(block.header().prev_hash())?;
+        let gas_price = prev_block_header.next_gas_price();
+        let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
+
+        // Remove certified chunks (core statements in this block).
+        for (chunk_id, _) in block.spice_core_statements().iter_execution_results() {
+            let cert_epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
+            let shard_uid =
+                shard_id_to_uid(self.epoch_manager.as_ref(), chunk_id.shard_id, &cert_epoch_id)?;
+            let Some(queue) = ptq.get_mut(&shard_uid) else {
+                continue;
+            };
+            queue.remove_certified_chunk(&chunk_id.block_hash);
+        }
+
+        // Add new block's chunk transactions.
+        for chunk_header in block.chunks().iter_new() {
+            let shard_id = chunk_header.shard_id();
+            let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, &epoch_id)?;
+            if !self
+                .shard_tracker
+                .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
+            {
+                continue;
+            }
+            let chunk = self.chain.get_chunk(&chunk_header.chunk_hash())?;
+            let transactions = chunk.to_transactions();
+            ptq.get_or_create(shard_uid).add_chunk_transactions(
+                *block.hash(),
+                transactions,
+                &config,
+                gas_price,
+            );
+        }
+        Ok(())
+    }
+
+    /// Re-initialize the pending transaction queue from uncertified chunks for the given chain head.
+    /// Called on startup and after reorgs.
+    fn reinitialize_pending_transaction_queue(
+        pending_transaction_queue: &Mutex<ShardedPendingTransactionQueue>,
+        chain: &Chain,
+        epoch_manager: &dyn EpochManagerAdapter,
+        runtime_adapter: &dyn RuntimeAdapter,
+        shard_tracker: &ShardTracker,
+        head_hash: &CryptoHash,
+    ) -> Result<(), Error> {
+        let mut ptq = pending_transaction_queue.lock();
+        ptq.clear();
+
+        let head_block = chain.get_block(head_hash)?;
+        if !head_block.is_spice_block() {
+            return Ok(());
+        }
+
+        let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
+        let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
+        for chunk_info in &uncertified_chunks {
+            uncertified_block_hashes.insert(chunk_info.chunk_id.block_hash);
+        }
+
+        let total_blocks = uncertified_block_hashes.len();
+        let mut loaded_blocks = 0usize;
+        for block_hash in &uncertified_block_hashes {
+            let block = match chain.get_block(block_hash) {
+                Ok(block) => block,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "client",
+                        ?block_hash,
+                        ?err,
+                        "failed to load block for pending transaction queue initialization"
+                    );
+                    continue;
+                }
+            };
+            let Ok(epoch_id) = epoch_manager.get_epoch_id(block_hash) else {
+                continue;
+            };
+            let Ok(protocol_version) = epoch_manager.get_epoch_protocol_version(&epoch_id) else {
+                continue;
+            };
+            let config = runtime_adapter.get_runtime_config(protocol_version);
+            let Ok(prev_header) = chain.get_block_header(block.header().prev_hash()) else {
+                continue;
+            };
+            let gas_price = prev_header.next_gas_price();
+
+            for chunk_header in block.chunks().iter_new() {
+                let shard_id = chunk_header.shard_id();
+                let Ok(shard_uid) = shard_id_to_uid(epoch_manager, shard_id, &epoch_id) else {
+                    continue;
+                };
+                if !shard_tracker
+                    .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
+                {
+                    continue;
+                }
+                let Ok(chunk) = chain.get_chunk(&chunk_header.chunk_hash()) else {
+                    continue;
+                };
+                let transactions = chunk.to_transactions();
+                ptq.get_or_create(shard_uid).add_chunk_transactions(
+                    *block_hash,
+                    transactions,
+                    &config,
+                    gas_price,
+                );
+            }
+            loaded_blocks += 1;
+        }
+        if loaded_blocks < total_blocks {
+            tracing::warn!(
+                target: "client",
+                loaded_blocks,
+                total_blocks,
+                "pending transaction queue reinitialized with incomplete uncertified blocks"
+            );
         }
         Ok(())
     }
@@ -1834,6 +1987,14 @@ impl Client {
                         );
                     }
                 }
+                // Update pending transaction queue: remove certified chunks, add new block's txs.
+                if let Err(err) = self.update_pending_transaction_queue_for_block(block) {
+                    tracing::error!(
+                        target: "client",
+                        ?err,
+                        "updating pending transaction queue for block failed"
+                    );
+                }
             }
             BlockStatus::Fork => {
                 // If it's a fork, no need to reconcile transactions or produce chunks.
@@ -1901,6 +2062,22 @@ impl Client {
                             }
                         }
                     }
+                }
+
+                // Re-initialize pending transaction queue from uncertified chunks for the new head.
+                if let Err(err) = Self::reinitialize_pending_transaction_queue(
+                    &self.chunk_producer.pending_transaction_queue,
+                    &self.chain,
+                    self.epoch_manager.as_ref(),
+                    self.runtime_adapter.as_ref(),
+                    &self.shard_tracker,
+                    block.hash(),
+                ) {
+                    tracing::error!(
+                        target: "client",
+                        ?err,
+                        "re-initializing pending transaction queue after reorg failed"
+                    );
                 }
             }
         };

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -616,8 +616,6 @@ impl Client {
         let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         let config = self.runtime_adapter.get_runtime_config(protocol_version);
-        let prev_block_header = self.chain.get_block_header(block.header().prev_hash())?;
-        let gas_price = prev_block_header.next_gas_price();
 
         // Remove newly certified blocks from the pending transaction queue.
         let prev_uncertified =
@@ -632,6 +630,7 @@ impl Client {
         }
 
         // Add new block's chunk transactions.
+        let gas_price = self.chain.get_block_header(block.header().prev_hash())?.next_gas_price();
         for chunk_header in block.chunks().iter_new() {
             let shard_id = chunk_header.shard_id();
             let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, &epoch_id)?;

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -654,86 +654,18 @@ impl Client {
 
     /// Re-initialize the pending transaction queue from uncertified chunks for the given chain head.
     /// Called on startup and after reorgs.
+    ///
+    /// TODO(spice): implement once PendingTransactionQueue has real logic.
     fn reinitialize_pending_transaction_queue(
         pending_transaction_queue: &Mutex<ShardedPendingTransactionQueue>,
-        chain: &Chain,
-        epoch_manager: &dyn EpochManagerAdapter,
-        runtime_adapter: &dyn RuntimeAdapter,
-        shard_tracker: &ShardTracker,
-        head_hash: &CryptoHash,
+        _chain: &Chain,
+        _epoch_manager: &dyn EpochManagerAdapter,
+        _runtime_adapter: &dyn RuntimeAdapter,
+        _shard_tracker: &ShardTracker,
+        _head_hash: &CryptoHash,
     ) -> Result<(), Error> {
         let mut ptq = pending_transaction_queue.lock();
         ptq.clear();
-
-        let head_block = chain.get_block(head_hash)?;
-        if !head_block.is_spice_block() {
-            return Ok(());
-        }
-
-        let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
-        let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
-        for chunk_info in &uncertified_chunks {
-            uncertified_block_hashes.insert(chunk_info.chunk_id.block_hash);
-        }
-
-        let total_blocks = uncertified_block_hashes.len();
-        let mut loaded_blocks = 0usize;
-        for block_hash in &uncertified_block_hashes {
-            let block = match chain.get_block(block_hash) {
-                Ok(block) => block,
-                Err(err) => {
-                    tracing::warn!(
-                        target: "client",
-                        ?block_hash,
-                        ?err,
-                        "failed to load block for pending transaction queue initialization"
-                    );
-                    continue;
-                }
-            };
-            let Ok(epoch_id) = epoch_manager.get_epoch_id(block_hash) else {
-                continue;
-            };
-            let Ok(protocol_version) = epoch_manager.get_epoch_protocol_version(&epoch_id) else {
-                continue;
-            };
-            let config = runtime_adapter.get_runtime_config(protocol_version);
-            let Ok(prev_header) = chain.get_block_header(block.header().prev_hash()) else {
-                continue;
-            };
-            let gas_price = prev_header.next_gas_price();
-
-            for chunk_header in block.chunks().iter_new() {
-                let shard_id = chunk_header.shard_id();
-                let Ok(shard_uid) = shard_id_to_uid(epoch_manager, shard_id, &epoch_id) else {
-                    continue;
-                };
-                if !shard_tracker
-                    .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
-                {
-                    continue;
-                }
-                let Ok(chunk) = chain.get_chunk(&chunk_header.chunk_hash()) else {
-                    continue;
-                };
-                let transactions = chunk.to_transactions();
-                ptq.get_or_create(shard_uid).add_chunk_transactions(
-                    *block_hash,
-                    transactions,
-                    &config,
-                    gas_price,
-                );
-            }
-            loaded_blocks += 1;
-        }
-        if loaded_blocks < total_blocks {
-            tracing::warn!(
-                target: "client",
-                loaded_blocks,
-                total_blocks,
-                "pending transaction queue reinitialized with incomplete uncertified blocks"
-            );
-        }
         Ok(())
     }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -617,17 +617,22 @@ impl Client {
         let config = self.runtime_adapter.get_runtime_config(protocol_version);
         let prev_block_header = self.chain.get_block_header(block.header().prev_hash())?;
         let gas_price = prev_block_header.next_gas_price();
-        let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
 
         // Remove certified chunks (core statements in this block).
-        for (chunk_id, _) in block.spice_core_statements().iter_execution_results() {
-            let cert_epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
-            let shard_uid =
-                shard_id_to_uid(self.epoch_manager.as_ref(), chunk_id.shard_id, &cert_epoch_id)?;
-            let Some(queue) = ptq.get_mut(&shard_uid) else {
-                continue;
-            };
-            queue.remove_certified_chunk(&chunk_id.block_hash);
+        {
+            let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
+            for (chunk_id, _) in block.spice_core_statements().iter_execution_results() {
+                let cert_epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
+                let shard_uid = shard_id_to_uid(
+                    self.epoch_manager.as_ref(),
+                    chunk_id.shard_id,
+                    &cert_epoch_id,
+                )?;
+                let Some(queue) = ptq.get_mut(&shard_uid) else {
+                    continue;
+                };
+                queue.remove_certified_chunk(&chunk_id.block_hash);
+            }
         }
 
         // Add new block's chunk transactions.
@@ -642,6 +647,7 @@ impl Client {
             }
             let chunk = self.chain.get_chunk(&chunk_header.chunk_hash())?;
             let transactions = chunk.to_transactions();
+            let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
             ptq.get_or_create(shard_uid).add_chunk_transactions(
                 *block.hash(),
                 transactions,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -13,6 +13,7 @@ use crate::client::{CatchupState, Client, EPOCH_START_INFO_BLOCKS};
 use crate::config_updater::ConfigUpdater;
 use crate::debug::new_network_info_view;
 use crate::info::{InfoHelper, display_sync_status};
+use crate::pending_transaction_queue::ShardedPendingTransactionQueue;
 use crate::stateless_validation::chunk_endorsement::ChunkEndorsementTracker;
 use crate::stateless_validation::chunk_validation_actor::{
     ChunkValidationActor, ChunkValidationSender,
@@ -144,6 +145,7 @@ fn wait_until_genesis(genesis_time: &Utc) {
 pub struct StartClientResult {
     pub client_actor: TokioRuntimeHandle<ClientActor>,
     pub tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    pub pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
     pub chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
     pub chunk_validation_actor: MultithreadRuntimeHandle<ChunkValidationActor>,
 }
@@ -265,6 +267,8 @@ pub fn start_client(
     )
     .unwrap();
     let tx_pool = client_actor_inner.client.chunk_producer.sharded_tx_pool.clone();
+    let pending_transaction_queue =
+        client_actor_inner.client.chunk_producer.pending_transaction_queue.clone();
     let chunk_endorsement_tracker =
         Arc::clone(&client_actor_inner.client.chunk_endorsement_tracker);
     let client_actor = actor_system.spawn_tokio_actor(client_actor_inner);
@@ -277,6 +281,7 @@ pub fn start_client(
     StartClientResult {
         client_actor,
         tx_pool,
+        pending_transaction_queue,
         chunk_endorsement_tracker,
         chunk_validation_actor: chunk_validation_actor_addr,
     }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -50,6 +50,7 @@ pub mod debug;
 pub mod gc_actor;
 mod info;
 pub mod metrics;
+pub mod pending_transaction_queue;
 mod prepare_transactions;
 mod rpc_handler;
 pub mod spice_chunk_validator_actor;

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -1,0 +1,96 @@
+use near_chain::types::{HasContract, PendingConstraints, PendingTxCheckResult};
+use near_parameters::RuntimeConfig;
+use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::ShardUId;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::Balance;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Maps ShardUId -> per-shard PendingTransactionQueue.
+pub struct ShardedPendingTransactionQueue {
+    queues: HashMap<ShardUId, PendingTransactionQueue>,
+}
+
+impl ShardedPendingTransactionQueue {
+    pub fn new() -> Self {
+        Self { queues: HashMap::new() }
+    }
+
+    pub fn get_or_create(&mut self, shard_uid: ShardUId) -> &mut PendingTransactionQueue {
+        self.queues.entry(shard_uid).or_insert_with(PendingTransactionQueue::new)
+    }
+
+    pub fn get(&self, shard_uid: &ShardUId) -> Option<&PendingTransactionQueue> {
+        self.queues.get(shard_uid)
+    }
+
+    pub fn get_mut(&mut self, shard_uid: &ShardUId) -> Option<&mut PendingTransactionQueue> {
+        self.queues.get_mut(shard_uid)
+    }
+
+    pub fn clear(&mut self) {
+        self.queues.clear();
+    }
+}
+
+/// Per-shard pending transaction queue. Tracks transactions that have been
+/// included in blocks but not yet certified (executed).
+///
+/// This is a no-op stub. The real implementation will maintain per-account
+/// balance/nonce/count aggregates across uncertified chunks.
+pub struct PendingTransactionQueue;
+
+impl PendingTransactionQueue {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+
+    pub fn add_chunk_transactions(
+        &mut self,
+        _block_hash: CryptoHash,
+        _transactions: &[SignedTransaction],
+        _config: &RuntimeConfig,
+        _gas_price: Balance,
+    ) {
+    }
+
+    pub fn remove_certified_chunk(&mut self, _block_hash: &CryptoHash) {}
+
+    pub fn clear(&mut self) {}
+
+    pub fn get_pending_constraints(&self, _tx: &SignedTransaction) -> PendingConstraints {
+        PendingConstraints::default()
+    }
+}
+
+/// Per-chunk-production session that combines pending transaction queue state
+/// with session-local tracking for P_MAX / deploy exclusivity constraints.
+///
+/// This is a no-op stub that always admits transactions.
+pub struct PendingTxSession {
+    _pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
+    _shard_uid: ShardUId,
+}
+
+impl PendingTxSession {
+    pub fn new(
+        pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
+        shard_uid: ShardUId,
+    ) -> Self {
+        Self { _pending_transaction_queue: pending_transaction_queue, _shard_uid: shard_uid }
+    }
+
+    pub fn check_pending(
+        &mut self,
+        _tx: &SignedTransaction,
+        _has_contract: HasContract,
+    ) -> PendingTxCheckResult {
+        PendingTxCheckResult::Admit(PendingConstraints::default())
+    }
+}

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -32,7 +32,7 @@ impl ShardedPendingTransactionQueue {
 
     pub fn remove_certified_block(&mut self, block_hash: &CryptoHash) {
         for queue in self.queues.values_mut() {
-            queue.remove_certified_chunk(block_hash);
+            queue.remove_certified_chunk_by_block_hash(block_hash);
         }
     }
 
@@ -66,7 +66,7 @@ impl PendingTransactionQueue {
     ) {
     }
 
-    pub fn remove_certified_chunk(&mut self, _block_hash: &CryptoHash) {}
+    pub fn remove_certified_chunk_by_block_hash(&mut self, _block_hash: &CryptoHash) {}
 
     pub fn clear(&mut self) {}
 

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -30,6 +30,12 @@ impl ShardedPendingTransactionQueue {
         self.queues.get_mut(shard_uid)
     }
 
+    pub fn remove_certified_block(&mut self, block_hash: &CryptoHash) {
+        for queue in self.queues.values_mut() {
+            queue.remove_certified_chunk(block_hash);
+        }
+    }
+
     pub fn clear(&mut self) {
         self.queues.clear();
     }

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -1,9 +1,11 @@
 use crate::metrics;
+use crate::pending_transaction_queue::ShardedPendingTransactionQueue;
 use near_async::messaging::CanSend;
 use near_async::messaging::Handler;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::{ActorSystem, messaging};
 use near_chain::check_transaction_validity_period;
+use near_chain::spice_core::get_last_certified_block_header;
 use near_chain::types::PendingConstraints;
 use near_chain::types::RuntimeAdapter;
 use near_chain::types::Tip;
@@ -51,6 +53,7 @@ pub fn spawn_rpc_handler_actor(
     actor_system: ActorSystem,
     config: RpcHandlerConfig,
     tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
     shard_tracker: ShardTracker,
     validator_signer: MutableValidatorSigner,
@@ -60,6 +63,7 @@ pub fn spawn_rpc_handler_actor(
     let actor = RpcHandlerActor::new(
         config.clone(),
         tx_pool,
+        pending_transaction_queue,
         epoch_manager,
         shard_tracker,
         validator_signer,
@@ -87,6 +91,7 @@ pub struct RpcHandlerActor {
     config: RpcHandlerConfig,
 
     tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
 
     chain_store: ChainStoreAdapter,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
@@ -100,6 +105,7 @@ impl RpcHandlerActor {
     pub fn new(
         config: RpcHandlerConfig,
         tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+        pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         shard_tracker: ShardTracker,
         validator_signer: MutableValidatorSigner,
@@ -111,6 +117,7 @@ impl RpcHandlerActor {
         Self {
             config,
             tx_pool,
+            pending_transaction_queue,
             validator_signer,
             chain_store,
             epoch_manager,
@@ -189,35 +196,57 @@ impl RpcHandlerActor {
 
         if self.shard_tracker.cares_about_shard_this_or_next_epoch(&head.last_block_hash, shard_id)
         {
-            if !ProtocolFeature::Spice.enabled(protocol_version) {
+            let (state_root, constraints) = if ProtocolFeature::Spice.enabled(protocol_version) {
+                let certified_header =
+                    get_last_certified_block_header(&self.chain_store, &head.last_block_hash)?;
                 let chunk_store = self.chain_store.chunk_store();
-                let state_root =
-                    match chunk_store.get_chunk_extra(&head.last_block_hash, &shard_uid) {
-                        Ok(chunk_extra) => *chunk_extra.state_root(),
-                        Err(_) => {
-                            // Not being able to fetch a state root most likely implies that we haven't
-                            //     caught up with the next epoch yet.
-                            if is_forwarded {
-                                return Err(near_client_primitives::types::Error::Other(
-                                    "Node has not caught up yet".to_string(),
-                                ));
-                            } else {
-                                self.forward_tx(&epoch_id, signed_tx)?;
-                                return Ok(ProcessTxResponse::RequestRouted);
-                            }
+                let root = match chunk_store.get_chunk_extra(certified_header.hash(), &shard_uid) {
+                    Ok(chunk_extra) => *chunk_extra.state_root(),
+                    Err(_) => {
+                        if is_forwarded {
+                            return Err(near_client_primitives::types::Error::Other(
+                                "node has not caught up yet".to_string(),
+                            ));
+                        } else {
+                            self.forward_tx(&epoch_id, signed_tx)?;
+                            return Ok(ProcessTxResponse::RequestRouted);
                         }
-                    };
-                if let Err(err) = self.runtime.can_verify_and_charge_tx(
-                    &shard_layout,
-                    gas_price,
-                    state_root,
-                    &validated_tx,
-                    protocol_version,
-                    &PendingConstraints::default(),
-                ) {
-                    tracing::debug!(target: "client", ?err, "invalid tx");
-                    return Ok(ProcessTxResponse::InvalidTx(err));
-                }
+                    }
+                };
+                let constraints = {
+                    let ptq = self.pending_transaction_queue.lock();
+                    ptq.get(&shard_uid)
+                        .map(|q| q.get_pending_constraints(&signed_tx))
+                        .unwrap_or_default()
+                };
+                (root, constraints)
+            } else {
+                let chunk_store = self.chain_store.chunk_store();
+                let root = match chunk_store.get_chunk_extra(&head.last_block_hash, &shard_uid) {
+                    Ok(chunk_extra) => *chunk_extra.state_root(),
+                    Err(_) => {
+                        if is_forwarded {
+                            return Err(near_client_primitives::types::Error::Other(
+                                "node has not caught up yet".to_string(),
+                            ));
+                        } else {
+                            self.forward_tx(&epoch_id, signed_tx)?;
+                            return Ok(ProcessTxResponse::RequestRouted);
+                        }
+                    }
+                };
+                (root, PendingConstraints::default())
+            };
+            if let Err(err) = self.runtime.can_verify_and_charge_tx(
+                &shard_layout,
+                gas_price,
+                state_root,
+                &validated_tx,
+                protocol_version,
+                &constraints,
+            ) {
+                tracing::debug!(target: "client", ?err, "invalid tx");
+                return Ok(ProcessTxResponse::InvalidTx(err));
             }
             if check_only {
                 return Ok(ProcessTxResponse::ValidTx);

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -227,7 +227,7 @@ impl RpcHandlerActor {
                     Err(_) => {
                         if is_forwarded {
                             return Err(near_client_primitives::types::Error::Other(
-                                "node has not caught up yet".to_string(),
+                                "Node has not caught up yet".to_string(),
                             ));
                         } else {
                             self.forward_tx(&epoch_id, signed_tx)?;

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -196,6 +196,10 @@ impl RpcHandlerActor {
 
         if self.shard_tracker.cares_about_shard_this_or_next_epoch(&head.last_block_hash, shard_id)
         {
+            // TODO(spice): get_last_certified_block_header does multiple DB reads per
+            // incoming tx (loading uncertified chunks + block headers). Cache the last
+            // certified block header for the current head, or store the last-certified
+            // hash in chain state so this is O(1).
             let (state_root, constraints) = if ProtocolFeature::Spice.enabled(protocol_version) {
                 let certified_header =
                     get_last_certified_block_header(&self.chain_store, &head.last_block_hash)?;

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -205,7 +205,7 @@ impl RpcHandlerActor {
                     Err(_) => {
                         if is_forwarded {
                             return Err(near_client_primitives::types::Error::Other(
-                                "node has not caught up yet".to_string(),
+                                "Node has not caught up yet".to_string(),
                             ));
                         } else {
                             self.forward_tx(&epoch_id, signed_tx)?;

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -188,6 +188,7 @@ pub fn create_test_setup_with_accounts_and_validity(
         actor_system.clone(),
         rpc_handler_config,
         client_result.tx_pool,
+        client_result.pending_transaction_queue,
         epoch_manager,
         shard_tracker.clone(),
         signer,

--- a/integration-tests/src/env/setup.rs
+++ b/integration-tests/src/env/setup.rs
@@ -203,6 +203,7 @@ fn setup(
     let StartClientResult {
         client_actor,
         tx_pool,
+        pending_transaction_queue,
         chunk_endorsement_tracker,
         chunk_validation_actor,
         ..
@@ -249,6 +250,7 @@ fn setup(
         actor_system.clone(),
         rpc_handler_config,
         tx_pool,
+        pending_transaction_queue,
         epoch_manager.clone(),
         shard_tracker.clone(),
         signer,
@@ -623,6 +625,7 @@ pub fn setup_tx_request_handler(
     RpcHandlerActor::new(
         config,
         client.chunk_producer.sharded_tx_pool.clone(),
+        client.chunk_producer.pending_transaction_queue.clone(),
         epoch_manager,
         shard_tracker,
         client.validator_signer.clone(),

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -110,7 +110,13 @@ fn setup_network_node_with_tcp(
     let (block_notification_watch_sender, _block_notification_watch_receiver) =
         tokio::sync::watch::channel(None);
     let adv = near_client::adversarial::Controls::default();
-    let StartClientResult { client_actor, tx_pool, chunk_endorsement_tracker, .. } = start_client(
+    let StartClientResult {
+        client_actor,
+        tx_pool,
+        pending_transaction_queue,
+        chunk_endorsement_tracker,
+        ..
+    } = start_client(
         Clock::real(),
         actor_system.clone(),
         client_config.clone(),
@@ -171,6 +177,7 @@ fn setup_network_node_with_tcp(
         actor_system.clone(),
         rpc_handler_config,
         tx_pool,
+        pending_transaction_queue,
         epoch_manager.clone(),
         shard_tracker.clone(),
         validator_signer.clone(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -608,6 +608,7 @@ pub async fn start_with_config_and_synchronization_impl(
     let StartClientResult {
         client_actor,
         tx_pool,
+        pending_transaction_queue,
         chunk_endorsement_tracker,
         chunk_validation_actor,
     } = start_client(
@@ -696,6 +697,7 @@ pub async fn start_with_config_and_synchronization_impl(
         actor_system.clone(),
         rpc_handler_config,
         tx_pool,
+        pending_transaction_queue,
         view_epoch_manager.clone(),
         view_shard_tracker,
         config.validator_signer.clone(),

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -330,6 +330,7 @@ pub fn setup_client(
     let rpc_handler = RpcHandlerActor::new(
         rpc_handler_config,
         client_actor.client.chunk_producer.sharded_tx_pool.clone(),
+        client_actor.client.chunk_producer.pending_transaction_queue.clone(),
         epoch_manager.clone(),
         shard_tracker.clone(),
         validator_signer.clone(),


### PR DESCRIPTION
Introduces a no-op `PendingTransactionQueue` stub and wires it through the client, chunk producer, and RPC handler. This prepares the integration points for the real PTQ implementation in a follow-up PR.

- Add `pending_transaction_queue.rs` with stub types: `ShardedPendingTransactionQueue`, `PendingTransactionQueue`, and `PendingTxSession` (all no-op, always admit)
- Wire `pending_transaction_queue` through `ChunkProducer`, `RpcHandlerActor`, `StartClientResult`, and all setup/test call sites
- SPICE chunk producer path: use `prepare_transactions_extra` with `PendingTxSession` and certified block state root instead of the previous `TODO(spice)` shortcut
- SPICE RPC handler path: look up state root from last certified block and query PTQ for pending constraints (returns defaults for now)
- Add `update_pending_transaction_queue_for_block` (BlockStatus::Next) and stubbed `reinitialize_pending_transaction_queue` (startup/reorg) to Client

Note I took a "block" oriented approach to the pending transaction queue. We could also take a "chunk" oriented approach. These should both be semantically equivalent (except for the edges cases where the pending tx queue's prediction is wrong due to contract moving balance, which could create a temporary difference between the two approaches).