### PR TITLE
feat(ptq): add logic for reinitialize_pending_transaction_queue 4/7

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -663,13 +663,11 @@ impl Client {
         shard_tracker: &ShardTracker,
         head_hash: &CryptoHash,
     ) -> Result<(), Error> {
-        let mut ptq = pending_transaction_queue.lock();
-        ptq.clear();
-
         let head_block = chain.get_block(head_hash)?;
         if !head_block.is_spice_block() {
             return Ok(());
         }
+        pending_transaction_queue.lock().clear();
 
         let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
         let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
@@ -718,7 +716,7 @@ impl Client {
                     continue;
                 };
                 let transactions = chunk.to_transactions();
-                ptq.get_or_create(shard_uid).add_chunk_transactions(
+                pending_transaction_queue.lock().get_or_create(shard_uid).add_chunk_transactions(
                     *block_hash,
                     transactions,
                     &config,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -670,51 +670,26 @@ impl Client {
         pending_transaction_queue.lock().clear();
 
         let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
-        let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
-        for chunk_info in &uncertified_chunks {
-            uncertified_block_hashes.insert(chunk_info.chunk_id.block_hash);
-        }
+        let uncertified_block_hashes: HashSet<CryptoHash> =
+            uncertified_chunks.iter().map(|chunk_info| chunk_info.chunk_id.block_hash).collect();
 
-        let total_blocks = uncertified_block_hashes.len();
-        let mut loaded_blocks = 0usize;
         for block_hash in &uncertified_block_hashes {
-            let block = match chain.get_block(block_hash) {
-                Ok(block) => block,
-                Err(err) => {
-                    tracing::warn!(
-                        target: "client",
-                        ?block_hash,
-                        ?err,
-                        "failed to load block for pending transaction queue initialization"
-                    );
-                    continue;
-                }
-            };
-            let Ok(epoch_id) = epoch_manager.get_epoch_id(block_hash) else {
-                continue;
-            };
-            let Ok(protocol_version) = epoch_manager.get_epoch_protocol_version(&epoch_id) else {
-                continue;
-            };
+            let block = chain.get_block(block_hash)?;
+            let epoch_id = epoch_manager.get_epoch_id(block_hash)?;
+            let protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
             let config = runtime_adapter.get_runtime_config(protocol_version);
-            let Ok(prev_header) = chain.get_block_header(block.header().prev_hash()) else {
-                continue;
-            };
+            let prev_header = chain.get_block_header(block.header().prev_hash())?;
             let gas_price = prev_header.next_gas_price();
 
             for chunk_header in block.chunks().iter_new() {
                 let shard_id = chunk_header.shard_id();
-                let Ok(shard_uid) = shard_id_to_uid(epoch_manager, shard_id, &epoch_id) else {
-                    continue;
-                };
+                let shard_uid = shard_id_to_uid(epoch_manager, shard_id, &epoch_id)?;
                 if !shard_tracker
                     .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
                 {
                     continue;
                 }
-                let Ok(chunk) = chain.get_chunk(&chunk_header.chunk_hash()) else {
-                    continue;
-                };
+                let chunk = chain.get_chunk(&chunk_header.chunk_hash())?;
                 let transactions = chunk.to_transactions();
                 pending_transaction_queue.lock().get_or_create(shard_uid).add_chunk_transactions(
                     *block_hash,
@@ -723,15 +698,6 @@ impl Client {
                     gas_price,
                 );
             }
-            loaded_blocks += 1;
-        }
-        if loaded_blocks < total_blocks {
-            tracing::warn!(
-                target: "client",
-                loaded_blocks,
-                total_blocks,
-                "pending transaction queue reinitialized with incomplete uncertified blocks"
-            );
         }
         Ok(())
     }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -655,18 +655,86 @@ impl Client {
 
     /// Re-initialize the pending transaction queue from uncertified chunks for the given chain head.
     /// Called on startup and after reorgs.
-    ///
-    /// TODO(spice): implement once PendingTransactionQueue has real logic.
     fn reinitialize_pending_transaction_queue(
         pending_transaction_queue: &Mutex<ShardedPendingTransactionQueue>,
-        _chain: &Chain,
-        _epoch_manager: &dyn EpochManagerAdapter,
-        _runtime_adapter: &dyn RuntimeAdapter,
-        _shard_tracker: &ShardTracker,
-        _head_hash: &CryptoHash,
+        chain: &Chain,
+        epoch_manager: &dyn EpochManagerAdapter,
+        runtime_adapter: &dyn RuntimeAdapter,
+        shard_tracker: &ShardTracker,
+        head_hash: &CryptoHash,
     ) -> Result<(), Error> {
         let mut ptq = pending_transaction_queue.lock();
         ptq.clear();
+
+        let head_block = chain.get_block(head_hash)?;
+        if !head_block.is_spice_block() {
+            return Ok(());
+        }
+
+        let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
+        let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
+        for chunk_info in &uncertified_chunks {
+            uncertified_block_hashes.insert(chunk_info.chunk_id.block_hash);
+        }
+
+        let total_blocks = uncertified_block_hashes.len();
+        let mut loaded_blocks = 0usize;
+        for block_hash in &uncertified_block_hashes {
+            let block = match chain.get_block(block_hash) {
+                Ok(block) => block,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "client",
+                        ?block_hash,
+                        ?err,
+                        "failed to load block for pending transaction queue initialization"
+                    );
+                    continue;
+                }
+            };
+            let Ok(epoch_id) = epoch_manager.get_epoch_id(block_hash) else {
+                continue;
+            };
+            let Ok(protocol_version) = epoch_manager.get_epoch_protocol_version(&epoch_id) else {
+                continue;
+            };
+            let config = runtime_adapter.get_runtime_config(protocol_version);
+            let Ok(prev_header) = chain.get_block_header(block.header().prev_hash()) else {
+                continue;
+            };
+            let gas_price = prev_header.next_gas_price();
+
+            for chunk_header in block.chunks().iter_new() {
+                let shard_id = chunk_header.shard_id();
+                let Ok(shard_uid) = shard_id_to_uid(epoch_manager, shard_id, &epoch_id) else {
+                    continue;
+                };
+                if !shard_tracker
+                    .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
+                {
+                    continue;
+                }
+                let Ok(chunk) = chain.get_chunk(&chunk_header.chunk_hash()) else {
+                    continue;
+                };
+                let transactions = chunk.to_transactions();
+                ptq.get_or_create(shard_uid).add_chunk_transactions(
+                    *block_hash,
+                    transactions,
+                    &config,
+                    gas_price,
+                );
+            }
+            loaded_blocks += 1;
+        }
+        if loaded_blocks < total_blocks {
+            tracing::warn!(
+                target: "client",
+                loaded_blocks,
+                total_blocks,
+                "pending transaction queue reinitialized with incomplete uncertified blocks"
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
- Make `SpiceCoreReader::get_uncertified_chunks` public so `near-client` can call it
- On startup and after reorgs, iterates uncertified blocks and replays their chunk transactions into the PTQ