### PR TITLE
test(ptq): add test-loops for pending transction queue 7/7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8467,6 +8467,7 @@ dependencies = [
  "near-vm-runner",
  "near-wallet-contract",
  "nearcore",
+ "node-runtime",
  "p256",
  "parking_lot 0.12.1",
  "primitive-types 0.10.1",

--- a/test-loop-tests/Cargo.toml
+++ b/test-loop-tests/Cargo.toml
@@ -56,6 +56,7 @@ near-parameters.workspace = true
 near-primitives.workspace = true
 near-primitives-core.workspace = true
 near-store.workspace = true
+node-runtime.workspace = true
 near-test-contracts.workspace = true
 near-vm-runner.workspace = true
 near-wallet-contract.workspace = true

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -38,6 +38,7 @@ mod multinode_stateless_validators;
 mod network_drop;
 mod optimistic_block;
 mod p256_verify;
+mod pending_transaction_queue;
 mod process_blocks;
 mod processed_receipts_gc;
 mod protocol_upgrade;

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -295,7 +295,8 @@ fn test_ptq_accumulates_across_blocks() {
     // Run blocks up to just before the first batch gets certified.
     // The extra tx should not get included while P_MAX uncertified txs are pending.
     let current_height = env.validator().head().height;
-    let blocks_until_certification = first_inclusion_height + execution_delay - current_height - 1;
+    let target_height = first_inclusion_height + execution_delay - 1;
+    let blocks_until_certification = target_height.saturating_sub(current_height);
     env.validator_runner().run_for_number_of_blocks(blocks_until_certification as usize);
     assert!(!is_included_in_head(&env.validator(), &[extra_hash]));
 

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -93,6 +93,7 @@ fn test_ptq_p_max_contract_account() {
         .validators(1, 1)
         .add_user_account(&contract_account, Balance::from_near(1_000))
         .add_user_account(&receiver, Balance::from_near(0))
+        .delay_warmup()
         .build();
     let execution_delay = 4;
     delay_endorsements_propagation(&mut env, execution_delay);
@@ -128,6 +129,7 @@ fn test_ptq_no_p_max_for_non_contract_account() {
         .validators(1, 1)
         .add_user_account(&sender, Balance::from_near(1_000))
         .add_user_account(&receiver, Balance::from_near(0))
+        .delay_warmup()
         .build();
     let execution_delay = 4;
     delay_endorsements_propagation(&mut env, execution_delay);
@@ -157,6 +159,7 @@ fn test_ptq_nonce_constraint() {
         .validators(1, 1)
         .add_user_account(&sender, Balance::from_near(1_000))
         .add_user_account(&receiver, Balance::from_near(0))
+        .delay_warmup()
         .build();
     let execution_delay = 4;
     delay_endorsements_propagation(&mut env, execution_delay);
@@ -208,6 +211,7 @@ fn test_ptq_deploy_exclusivity() {
         .validators(1, 1)
         .add_user_account(&account, Balance::from_near(1_000))
         .add_user_account(&receiver, Balance::from_near(0))
+        .delay_warmup()
         .build();
     let execution_delay = 4;
     delay_endorsements_propagation(&mut env, execution_delay);
@@ -267,6 +271,7 @@ fn test_ptq_accumulates_across_blocks() {
         .validators(1, 1)
         .add_user_account(&contract_account, Balance::from_near(1_000))
         .add_user_account(&receiver, Balance::from_near(0))
+        .delay_warmup()
         .build();
     let execution_delay = 4;
     delay_endorsements_propagation(&mut env, execution_delay);
@@ -320,6 +325,7 @@ fn test_ptq_cleanup_on_certification() {
         .validators(1, 1)
         .add_user_account(&contract_account, Balance::from_near(1_000))
         .add_user_account(&receiver, Balance::from_near(0))
+        .delay_warmup()
         .build();
     let execution_delay = 4;
     delay_endorsements_propagation(&mut env, execution_delay);
@@ -359,6 +365,7 @@ fn setup_gas_key_spice_env(
         .add_user_account(account, Balance::from_near(1_000))
         .add_user_account(receiver, Balance::from_near(0))
         .gas_prices(TEST_GAS_PRICE, TEST_GAS_PRICE)
+        .delay_warmup()
         .build();
     let execution_delay = 4;
     delay_endorsements_propagation(&mut env, execution_delay);

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -78,8 +78,9 @@ fn deploy_contract_and_certify(env: &mut TestLoopEnv, account: &AccountId) {
 
 /// P_MAX enforcement for contract accounts.
 ///
-/// Deploy a contract, then submit P_MAX + 2 transactions. The PTQ should
-/// throttle inclusion to at most P_MAX at a time from a contract account.
+/// Deploy a contract, then submit P_MAX + 2 transactions. The pending
+/// transaction queue should throttle inclusion to at most P_MAX at a time
+/// from a contract account.
 /// All transactions are eventually included after certification frees slots.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
@@ -137,12 +138,12 @@ fn test_ptq_no_p_max_for_non_contract_account() {
     env.validator_runner().run_until_included(&tx_hashes);
 }
 
-/// Nonce constraint from PTQ.
+/// Nonce constraint from pending transaction queue.
 ///
 /// Submit a transaction, wait for inclusion (but not certification). Then
 /// submit another transaction reusing the same nonce. The certified state
-/// still has the old nonce, but PTQ's max_nonce should cause the RPC to
-/// reject the replay with InvalidNonce.
+/// still has the old nonce, but the pending transaction queue's max_nonce
+/// should cause the RPC to reject the replay with InvalidNonce.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_ptq_nonce_constraint() {
@@ -173,7 +174,8 @@ fn test_ptq_nonce_constraint() {
     env.validator_runner().run_until_included(&[tx.get_hash()]);
 
     // Submit another tx reusing nonce 1. The certified state still has
-    // nonce 0, but PTQ's max_nonce should cause rejection.
+    // nonce 0, but the pending transaction queue's max_nonce should cause
+    // rejection.
     let block_hash = env.validator().head().last_block_hash;
     let replay_tx = SignedTransaction::send_money(
         1,
@@ -248,7 +250,7 @@ fn test_ptq_deploy_exclusivity() {
     env.validator_runner().run_until_included(&[transfer_hash]);
 }
 
-/// PTQ accumulates across blocks.
+/// Pending transaction queue accumulates across blocks.
 ///
 /// Submit transactions across multiple blocks. Verify that P_MAX counts
 /// transactions from all uncertified blocks, not just the latest one.
@@ -299,7 +301,7 @@ fn test_ptq_accumulates_across_blocks() {
     env.validator_runner().run_until_included(&[extra_hash]);
 }
 
-/// PTQ cleanup on certification.
+/// Pending transaction queue cleanup on certification.
 ///
 /// Submit transactions, wait for certification to advance past them, then
 /// verify new transactions from the same account are admitted freely.
@@ -421,8 +423,8 @@ fn setup_gas_key_spice_env(
 ///
 /// Create a gas key with enough balance for exactly 2 txs. Submit 2 gas key
 /// txs and wait for inclusion (but not certification). Then submit one more
-/// via execute_tx. The PTQ tracks the first 2 as pending, so the RPC rejects
-/// the third with NotEnoughGasKeyBalance.
+/// via execute_tx. The pending transaction queue tracks the first 2 as
+/// pending, so the RPC rejects the third with NotEnoughGasKeyBalance.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_ptq_gas_key_balance_enforcement() {
@@ -455,9 +457,9 @@ fn test_ptq_gas_key_balance_enforcement() {
     }
     env.validator_runner().run_until_included(&tx_hashes);
 
-    // Submit one more tx via execute_tx. The PTQ tracks the first 2 as
-    // uncertified, so the RPC handler should reject it with
-    // NotEnoughGasKeyBalance.
+    // Submit one more tx via execute_tx. The pending transaction queue
+    // tracks the first 2 as uncertified, so the RPC handler should reject
+    // it with NotEnoughGasKeyBalance.
     gas_key_nonce += 1;
     let block_hash = env.validator().head().last_block_hash;
     let tx = SignedTransaction::from_actions_v1(
@@ -595,8 +597,8 @@ fn test_ptq_gas_key_multiple_nonce_indices() {
 /// Submit an access key tx with a large deposit that nearly exhausts the
 /// account balance (1000 NEAR). Then submit a gas key tx whose deposit
 /// exceeds the remaining balance. The gas key tx's deposit is paid from the
-/// account balance, so the PTQ's paid_from_balance constraint causes
-/// the RPC to reject it with NotEnoughBalanceForDeposit.
+/// account balance, so the pending transaction queue's paid_from_balance
+/// constraint causes the RPC to reject it with NotEnoughBalanceForDeposit.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_ptq_account_balance_access_key_gas_key_combined() {
@@ -621,7 +623,7 @@ fn test_ptq_account_balance_access_key_gas_key_combined() {
     );
     env.validator().submit_tx(access_key_tx.clone());
 
-    // Wait for inclusion so the PTQ tracks paid_from_balance.
+    // Wait for inclusion so the pending transaction queue tracks paid_from_balance.
     let access_key_hash = access_key_tx.get_hash();
     env.validator_runner().run_until_included(&[access_key_hash]);
 

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -1,0 +1,642 @@
+use super::spice_utils::delay_endorsements_propagation;
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::env::TestLoopEnv;
+use crate::utils::account::create_account_id;
+use crate::utils::node::TestLoopNode;
+use near_async::time::Duration;
+use near_client::pending_transaction_queue::P_MAX;
+use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_o11y::testonly::init_test_logger;
+use near_parameters::RuntimeConfigStore;
+use near_primitives::account::AccessKey;
+use near_primitives::action::{
+    AddKeyAction, DeployContractAction, TransferToGasKeyAction, WithdrawFromGasKeyAction,
+};
+use near_primitives::errors::InvalidTxError;
+use near_primitives::hash::CryptoHash;
+use near_primitives::test_utils::create_user_test_signer;
+use near_primitives::transaction::{Action, SignedTransaction, TransactionNonce, TransferAction};
+use near_primitives::types::Nonce;
+use near_primitives::types::{AccountId, Balance, NonceIndex};
+use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::views::{QueryRequest, QueryResponseKind};
+use node_runtime::config::tx_cost;
+use std::collections::HashSet;
+
+const TEST_GAS_PRICE: Balance = Balance::from_yoctonear(1);
+
+fn gas_cost_per_transfer() -> Balance {
+    let config_store = RuntimeConfigStore::new(None);
+    let config = config_store.get_config(PROTOCOL_VERSION);
+    let dummy_account = create_account_id("dummy");
+    let sample_tx = SignedTransaction::send_money(
+        1,
+        dummy_account.clone(),
+        dummy_account.clone(),
+        &create_user_test_signer(&dummy_account),
+        Balance::from_yoctonear(0),
+        CryptoHash::default(),
+    );
+    tx_cost(&config, &sample_tx.transaction, TEST_GAS_PRICE).unwrap().gas_cost
+}
+
+/// Submit `count` transfer transactions from `sender` to `receiver`.
+/// Returns the tx hashes. Increments `next_nonce`.
+fn submit_transfers(
+    env: &TestLoopEnv,
+    sender: &AccountId,
+    receiver: &AccountId,
+    next_nonce: &mut u64,
+    count: usize,
+) -> Vec<CryptoHash> {
+    let block_hash = env.validator().head().last_block_hash;
+    let mut tx_hashes = Vec::new();
+    for _ in 0..count {
+        let tx = SignedTransaction::send_money(
+            *next_nonce,
+            sender.clone(),
+            receiver.clone(),
+            &create_user_test_signer(sender),
+            Balance::from_millinear(1),
+            block_hash,
+        );
+        *next_nonce += 1;
+        tx_hashes.push(tx.get_hash());
+        env.validator().submit_tx(tx);
+    }
+    tx_hashes
+}
+
+/// Deploy a contract on `account` and wait for certification to advance past
+/// the deploy (so deploy exclusivity doesn't block subsequent txs).
+fn deploy_contract_and_certify(env: &mut TestLoopEnv, account: &AccountId) {
+    let deploy_tx = env.validator().tx_deploy_test_contract(account);
+    env.validator_runner().run_tx(deploy_tx, Duration::seconds(20));
+    let height = env.validator().head().height;
+    env.validator_runner().run_until_certified(height);
+}
+
+/// P_MAX enforcement for contract accounts.
+///
+/// Deploy a contract, then submit P_MAX + 2 transactions. The PTQ should
+/// throttle inclusion to at most P_MAX at a time from a contract account.
+/// All transactions are eventually included after certification frees slots.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_p_max_contract_account() {
+    init_test_logger();
+
+    let contract_account = create_account_id("contract_account");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&contract_account, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+    deploy_contract_and_certify(&mut env, &contract_account);
+
+    // Submit P_MAX + 2 transfer transactions from the contract account.
+    let num_txs = P_MAX + 2;
+    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
+    let tx_hashes = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, num_txs);
+    // Only P_MAX txs should be included before certification.
+    env.validator_runner().run_until_included(&tx_hashes[..P_MAX]);
+    assert!(!is_included_in_head(&env.validator(), &tx_hashes[P_MAX..]));
+    // The remaining txs are included after certification advances.
+    let remaining: Vec<_> = tx_hashes[P_MAX..].to_vec();
+    env.validator_runner().run_until_included(&remaining);
+}
+
+/// No P_MAX restriction for non-contract accounts.
+///
+/// Submit more than P_MAX transactions from an account without a contract.
+/// All should be included without restriction.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_no_p_max_for_non_contract_account() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&sender, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+
+    let num_txs = P_MAX + 2;
+    let mut next_nonce: u64 = 1;
+    let tx_hashes = submit_transfers(&env, &sender, &receiver, &mut next_nonce, num_txs);
+    // All should be included without P_MAX throttling.
+    env.validator_runner().run_until_included(&tx_hashes);
+}
+
+/// Nonce constraint from PTQ.
+///
+/// Submit a transaction, wait for inclusion (but not certification). Then
+/// submit another transaction reusing the same nonce. The certified state
+/// still has the old nonce, but PTQ's max_nonce should cause the RPC to
+/// reject the replay with InvalidNonce.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_nonce_constraint() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&sender, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+
+    // Submit a tx with nonce 1 and wait for inclusion.
+    let block_hash = env.validator().head().last_block_hash;
+    let tx = SignedTransaction::send_money(
+        1,
+        sender.clone(),
+        receiver.clone(),
+        &create_user_test_signer(&sender),
+        Balance::from_millinear(1),
+        block_hash,
+    );
+    env.validator().submit_tx(tx.clone());
+    env.validator_runner().run_until_included(&[tx.get_hash()]);
+
+    // Submit another tx reusing nonce 1. The certified state still has
+    // nonce 0, but PTQ's max_nonce should cause rejection.
+    let block_hash = env.validator().head().last_block_hash;
+    let replay_tx = SignedTransaction::send_money(
+        1,
+        sender.clone(),
+        receiver,
+        &create_user_test_signer(&sender),
+        Balance::from_millinear(2),
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(replay_tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::InvalidNonce { .. })));
+}
+
+/// Deploy exclusivity.
+///
+/// Submit a DeployContract transaction and a transfer from the same account
+/// simultaneously. The deploy should be included first, and the transfer
+/// should be blocked while the deploy is uncertified. After certification,
+/// the transfer is included.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_deploy_exclusivity() {
+    init_test_logger();
+
+    let account = create_account_id("deployer");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&account, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+
+    // Submit a deploy tx and a transfer tx from the same account.
+    let mut next_nonce: u64 = 1;
+    let block_hash = env.validator().head().last_block_hash;
+    let deploy_tx = SignedTransaction::from_actions(
+        next_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(&account),
+        vec![Action::DeployContract(DeployContractAction {
+            code: near_test_contracts::rs_contract().to_vec(),
+        })],
+        block_hash,
+    );
+    next_nonce += 1;
+    let transfer_tx = SignedTransaction::send_money(
+        next_nonce,
+        account.clone(),
+        receiver,
+        &create_user_test_signer(&account),
+        Balance::from_millinear(1),
+        block_hash,
+    );
+    let deploy_hash = deploy_tx.get_hash();
+    let transfer_hash = transfer_tx.get_hash();
+
+    env.validator().submit_tx(deploy_tx);
+    env.validator().submit_tx(transfer_tx);
+
+    // Deploy should be included first (lower nonce, picked first from pool).
+    env.validator_runner().run_until_included(&[deploy_hash]);
+    // Deploy exclusivity should prevent the transfer from being included
+    // while the deploy is uncertified. Run up to just before certification.
+    env.validator_runner().run_for_number_of_blocks(execution_delay as usize - 1);
+    assert!(!is_included_in_head(&env.validator(), &[transfer_hash]));
+
+    // Transfer should be included after certification advances.
+    env.validator_runner().run_until_included(&[transfer_hash]);
+}
+
+/// PTQ accumulates across blocks.
+///
+/// Submit transactions across multiple blocks. Verify that P_MAX counts
+/// transactions from all uncertified blocks, not just the latest one.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_accumulates_across_blocks() {
+    init_test_logger();
+
+    let contract_account = create_account_id("contract_account");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&contract_account, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+    deploy_contract_and_certify(&mut env, &contract_account);
+
+    // Submit transactions in two batches, let the first batch get included,
+    // then submit the rest. Total across uncertified blocks should be P_MAX.
+    let first_batch_size = P_MAX / 2;
+    let second_batch_size = P_MAX - first_batch_size;
+    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
+    let first_batch =
+        submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, first_batch_size);
+    let first_inclusion_height = env.validator_runner().run_until_included(&first_batch);
+
+    // Submit and include the second batch.
+    let second_batch =
+        submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, second_batch_size);
+    env.validator_runner().run_until_included(&second_batch);
+
+    // Submit a (P_MAX+1)th tx. This should be blocked by P_MAX since there
+    // are already P_MAX uncertified txs from this contract account.
+    let extra = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, 1);
+    let extra_hash = extra[0];
+
+    // Run blocks up to just before the first batch gets certified.
+    // The extra tx should not get included while P_MAX uncertified txs are pending.
+    let current_height = env.validator().head().height;
+    let blocks_until_certification = first_inclusion_height + execution_delay - current_height - 1;
+    env.validator_runner().run_for_number_of_blocks(blocks_until_certification as usize);
+    assert!(!is_included_in_head(&env.validator(), &[extra_hash]));
+
+    // Wait for the extra tx to be included after certification.
+    env.validator_runner().run_until_included(&[extra_hash]);
+}
+
+/// PTQ cleanup on certification.
+///
+/// Submit transactions, wait for certification to advance past them, then
+/// verify new transactions from the same account are admitted freely.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_cleanup_on_certification() {
+    init_test_logger();
+
+    let contract_account = create_account_id("contract_account");
+    let receiver = create_account_id("receiver");
+
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&contract_account, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+    deploy_contract_and_certify(&mut env, &contract_account);
+
+    // Submit P_MAX transactions and wait for inclusion + certification.
+    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
+    let first_batch = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, P_MAX);
+    env.validator_runner().run_until_included(&first_batch);
+    let height = env.validator().head().height;
+    env.validator_runner().run_until_certified(height);
+
+    // Submit P_MAX more. All should be admitted since the first batch is certified.
+    let second_batch = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, P_MAX);
+    env.validator_runner().run_until_included(&second_batch);
+}
+
+struct GasKeySpiceEnv {
+    env: TestLoopEnv,
+    gas_key_signer: Signer,
+    next_access_key_nonce: u64,
+    /// Per-index gas key nonces (one per nonce index).
+    gas_key_nonces: Vec<Nonce>,
+}
+
+/// Helper: set up a SPICE env with a gas key on `account`.
+/// The gas key has `num_nonces` nonce indices and `fund_amount` balance.
+fn setup_gas_key_spice_env(
+    account: &AccountId,
+    receiver: &AccountId,
+    num_nonces: NonceIndex,
+    fund_amount: Balance,
+) -> GasKeySpiceEnv {
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(account, Balance::from_near(1_000))
+        .add_user_account(receiver, Balance::from_near(0))
+        .gas_prices(TEST_GAS_PRICE, TEST_GAS_PRICE)
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+    let gas_key_signer: Signer =
+        InMemorySigner::from_seed(account.clone(), KeyType::ED25519, "gas_key").into();
+    let mut next_nonce: u64 = 1;
+
+    // Add gas key.
+    let block_hash = env.validator().head().last_block_hash;
+    let add_key_tx = SignedTransaction::from_actions(
+        next_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(account),
+        vec![Action::AddKey(Box::new(AddKeyAction {
+            public_key: gas_key_signer.public_key(),
+            access_key: AccessKey::gas_key_full_access(num_nonces),
+        }))],
+        block_hash,
+    );
+    env.validator_runner().run_tx(add_key_tx, Duration::seconds(20));
+    next_nonce += 1;
+
+    // Fund the gas key.
+    let block_hash = env.validator().head().last_block_hash;
+    let fund_tx = SignedTransaction::from_actions(
+        next_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(account),
+        vec![Action::TransferToGasKey(Box::new(TransferToGasKeyAction {
+            public_key: gas_key_signer.public_key(),
+            deposit: fund_amount,
+        }))],
+        block_hash,
+    );
+    env.validator_runner().run_tx(fund_tx, Duration::seconds(20));
+    next_nonce += 1;
+
+    // Wait for certification to advance past the setup blocks so the certified
+    // state includes the funded gas key (needed for RPC tx verification).
+    let height = env.validator().head().height;
+    env.validator_runner().run_until_certified(height);
+
+    let response = env
+        .validator()
+        .runtime_query(QueryRequest::ViewGasKeyNonces {
+            account_id: account.clone(),
+            public_key: gas_key_signer.public_key(),
+        })
+        .unwrap();
+    let QueryResponseKind::GasKeyNonces(view) = response.kind else {
+        panic!("expected GasKeyNonces response");
+    };
+    GasKeySpiceEnv {
+        env,
+        gas_key_signer,
+        next_access_key_nonce: next_nonce,
+        gas_key_nonces: view.nonces,
+    }
+}
+
+/// Gas key balance enforcement.
+///
+/// Create a gas key with enough balance for exactly 2 txs. Submit 2 gas key
+/// txs and wait for inclusion (but not certification). Then submit one more
+/// via execute_tx. The PTQ tracks the first 2 as pending, so the RPC rejects
+/// the third with NotEnoughGasKeyBalance.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_gas_key_balance_enforcement() {
+    init_test_logger();
+
+    let account = create_account_id("gas_key_account");
+    let receiver = create_account_id("receiver");
+
+    // Fund the gas key with enough for exactly 2 txs but not 3.
+    let fund_amount = gas_cost_per_transfer().checked_mul(2).unwrap();
+    let setup = setup_gas_key_spice_env(&account, &receiver, 1, fund_amount);
+    let mut env = setup.env;
+    let mut gas_key_nonce = setup.gas_key_nonces[0];
+
+    // Submit the first 2 txs and wait for them to be included.
+    let mut tx_hashes = Vec::new();
+    let block_hash = env.validator().head().last_block_hash;
+    for _ in 0..2 {
+        gas_key_nonce += 1;
+        let tx = SignedTransaction::from_actions_v1(
+            TransactionNonce::from_nonce_and_index(gas_key_nonce, 0),
+            account.clone(),
+            receiver.clone(),
+            &setup.gas_key_signer,
+            vec![Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(0) })],
+            block_hash,
+        );
+        tx_hashes.push(tx.get_hash());
+        env.validator().submit_tx(tx);
+    }
+    env.validator_runner().run_until_included(&tx_hashes);
+
+    // Submit one more tx via execute_tx. The PTQ tracks the first 2 as
+    // uncertified, so the RPC handler should reject it with
+    // NotEnoughGasKeyBalance.
+    gas_key_nonce += 1;
+    let block_hash = env.validator().head().last_block_hash;
+    let tx = SignedTransaction::from_actions_v1(
+        TransactionNonce::from_nonce_and_index(gas_key_nonce, 0),
+        account,
+        receiver,
+        &setup.gas_key_signer,
+        vec![Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(0) })],
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::NotEnoughGasKeyBalance { .. })),);
+}
+
+/// WithdrawFromGasKey reduces available gas key balance.
+///
+/// Create a gas key with 1 milliNEAR, submit an access key tx withdrawing
+/// the full balance, and wait for inclusion. Then submit a gas key tx via
+/// execute_tx. The PTQ counts the pending withdrawal, so the RPC rejects
+/// the gas key tx with NotEnoughGasKeyBalance.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_withdraw_from_gas_key() {
+    init_test_logger();
+
+    let account = create_account_id("withdraw_account");
+    let receiver = create_account_id("receiver");
+    let fund_amount = Balance::from_millinear(1);
+    let setup = setup_gas_key_spice_env(&account, &receiver, 1, fund_amount);
+    let mut env = setup.env;
+
+    // Submit an access key tx that withdraws the full gas key balance.
+    let block_hash = env.validator().head().last_block_hash;
+    let withdraw_tx = SignedTransaction::from_actions(
+        setup.next_access_key_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(&account),
+        vec![Action::WithdrawFromGasKey(Box::new(WithdrawFromGasKeyAction {
+            public_key: setup.gas_key_signer.public_key(),
+            amount: fund_amount,
+        }))],
+        block_hash,
+    );
+    let withdraw_hash = withdraw_tx.get_hash();
+    env.validator().submit_tx(withdraw_tx);
+
+    // Wait for the withdraw tx to be included so the PTQ tracks
+    // the withdrawal against the gas key balance.
+    env.validator_runner().run_until_included(&[withdraw_hash]);
+
+    // Now submit a gas key tx via execute_tx. The PTQ should count the
+    // pending withdrawal against the gas key balance, so the RPC handler
+    // should reject it with NotEnoughGasKeyBalance.
+    let block_hash = env.validator().head().last_block_hash;
+    let gas_key_tx = SignedTransaction::from_actions_v1(
+        TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[0] + 1, 0),
+        account,
+        receiver,
+        &setup.gas_key_signer,
+        vec![Action::Transfer(TransferAction { deposit: Balance::from_millinear(0) })],
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(gas_key_tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::NotEnoughGasKeyBalance { .. })),);
+}
+
+/// Gas key with multiple nonce indices shares balance.
+///
+/// Create a gas key with 4 nonce indices, funded for exactly 2 txs. Submit
+/// 2 txs on different indices to exhaust the shared balance, then submit a
+/// 3rd on yet another index. The 3rd should be rejected, proving the balance
+/// is pooled across indices rather than tracked independently.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_gas_key_multiple_nonce_indices() {
+    init_test_logger();
+
+    let account = create_account_id("multi_nonce_account");
+    let receiver = create_account_id("receiver");
+    let num_nonces: NonceIndex = 4;
+
+    // Fund gas key with enough for exactly 2 txs.
+    let fund_amount = gas_cost_per_transfer().checked_mul(2).unwrap();
+    let setup = setup_gas_key_spice_env(&account, &receiver, num_nonces, fund_amount);
+    let mut env = setup.env;
+
+    // Submit 2 txs on different nonce indices and wait for inclusion.
+    let mut tx_hashes = Vec::new();
+    let block_hash = env.validator().head().last_block_hash;
+    for i in 0..2 {
+        let tx = SignedTransaction::from_actions_v1(
+            TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[i] + 1, i as NonceIndex),
+            account.clone(),
+            receiver.clone(),
+            &setup.gas_key_signer,
+            vec![Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(0) })],
+            block_hash,
+        );
+        tx_hashes.push(tx.get_hash());
+        env.validator().submit_tx(tx);
+    }
+    env.validator_runner().run_until_included(&tx_hashes);
+
+    // Submit a 3rd tx on a different nonce index. The shared gas key balance
+    // is exhausted, so the RPC should reject it.
+    let block_hash = env.validator().head().last_block_hash;
+    let tx = SignedTransaction::from_actions_v1(
+        TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[2] + 1, 2),
+        account,
+        receiver,
+        &setup.gas_key_signer,
+        vec![Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(0) })],
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::NotEnoughGasKeyBalance { .. })),);
+}
+
+/// Account balance enforcement across access key and gas key transactions.
+///
+/// Submit an access key tx with a large deposit that nearly exhausts the
+/// account balance (1000 NEAR). Then submit a gas key tx whose deposit
+/// exceeds the remaining balance. The gas key tx's deposit is paid from the
+/// account balance, so the PTQ's paid_from_balance constraint causes
+/// the RPC to reject it with NotEnoughBalanceForDeposit.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_account_balance_access_key_gas_key_combined() {
+    init_test_logger();
+
+    let account = create_account_id("combo_account");
+    let receiver = create_account_id("receiver");
+    let fund_amount = Balance::from_millinear(100);
+    let setup = setup_gas_key_spice_env(&account, &receiver, 1, fund_amount);
+    let mut env = setup.env;
+
+    // Submit an access key tx with a large deposit that nearly exhausts the
+    // 1000 NEAR account balance.
+    let block_hash = env.validator().head().last_block_hash;
+    let access_key_tx = SignedTransaction::send_money(
+        setup.next_access_key_nonce,
+        account.clone(),
+        receiver.clone(),
+        &create_user_test_signer(&account),
+        Balance::from_near(999),
+        block_hash,
+    );
+    env.validator().submit_tx(access_key_tx.clone());
+
+    // Wait for inclusion so the PTQ tracks paid_from_balance.
+    let access_key_hash = access_key_tx.get_hash();
+    env.validator_runner().run_until_included(&[access_key_hash]);
+
+    // Submit a gas key tx whose deposit exceeds the remaining balance.
+    // Gas is paid from the gas key, but deposit is paid from the account.
+    let block_hash = env.validator().head().last_block_hash;
+    let gas_key_tx = SignedTransaction::from_actions_v1(
+        TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[0] + 1, 0),
+        account,
+        receiver,
+        &setup.gas_key_signer,
+        vec![Action::Transfer(TransferAction { deposit: Balance::from_near(2) })],
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(gas_key_tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::NotEnoughBalanceForDeposit { .. })),);
+}
+
+fn is_included_in_head(node: &TestLoopNode<'_>, tx_hashes: &[CryptoHash]) -> bool {
+    let client = node.client();
+    let head = client.chain.head().unwrap();
+    let block = client.chain.get_block(&head.last_block_hash).unwrap();
+    let mut included: HashSet<CryptoHash> = HashSet::new();
+    for chunk_header in block.chunks().iter() {
+        let chunk = client.chain.get_chunk(&chunk_header.chunk_hash()).unwrap();
+        for tx in chunk.to_transactions() {
+            included.insert(tx.get_hash());
+        }
+    }
+    tx_hashes.iter().all(|h| included.contains(h))
+}

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -105,7 +105,9 @@ fn test_ptq_p_max_contract_account() {
     let tx_hashes = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, num_txs);
     // Only P_MAX txs should be included before certification.
     env.validator_runner().run_until_included(&tx_hashes[..P_MAX]);
-    assert!(!is_included_in_head(&env.validator(), &tx_hashes[P_MAX..]));
+    for tx_hash in &tx_hashes[P_MAX..] {
+        assert!(!is_included_in_head(&env.validator(), std::slice::from_ref(tx_hash)));
+    }
     // The remaining txs are included after certification advances.
     let remaining: Vec<_> = tx_hashes[P_MAX..].to_vec();
     env.validator_runner().run_until_included(&remaining);

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -474,10 +474,11 @@ fn test_ptq_gas_key_balance_enforcement() {
 
 /// WithdrawFromGasKey reduces available gas key balance.
 ///
-/// Create a gas key with 1 milliNEAR, submit an access key tx withdrawing
-/// the full balance, and wait for inclusion. Then submit a gas key tx via
-/// execute_tx. The PTQ counts the pending withdrawal, so the RPC rejects
-/// the gas key tx with NotEnoughGasKeyBalance.
+/// Create a gas key with 1 milliNEAR, submit two access key txs each
+/// withdrawing half the balance, and wait for inclusion. Then submit a gas
+/// key tx via execute_tx. The pending transaction queue accumulates both
+/// withdrawals, so the RPC rejects the gas key tx with
+/// NotEnoughGasKeyBalance.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_ptq_withdraw_from_gas_key() {
@@ -486,32 +487,44 @@ fn test_ptq_withdraw_from_gas_key() {
     let account = create_account_id("withdraw_account");
     let receiver = create_account_id("receiver");
     let fund_amount = Balance::from_millinear(1);
+    let half = fund_amount.checked_div(2).unwrap();
     let setup = setup_gas_key_spice_env(&account, &receiver, 1, fund_amount);
     let mut env = setup.env;
 
-    // Submit an access key tx that withdraws the full gas key balance.
+    // Submit two access key txs, each withdrawing half the gas key balance.
     let block_hash = env.validator().head().last_block_hash;
-    let withdraw_tx = SignedTransaction::from_actions(
-        setup.next_access_key_nonce,
+    let mut next_nonce = setup.next_access_key_nonce;
+    let withdraw_tx1 = SignedTransaction::from_actions(
+        next_nonce,
         account.clone(),
         account.clone(),
         &create_user_test_signer(&account),
         vec![Action::WithdrawFromGasKey(Box::new(WithdrawFromGasKeyAction {
             public_key: setup.gas_key_signer.public_key(),
-            amount: fund_amount,
+            amount: half,
         }))],
         block_hash,
     );
-    let withdraw_hash = withdraw_tx.get_hash();
-    env.validator().submit_tx(withdraw_tx);
+    next_nonce += 1;
+    let withdraw_tx2 = SignedTransaction::from_actions(
+        next_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(&account),
+        vec![Action::WithdrawFromGasKey(Box::new(WithdrawFromGasKeyAction {
+            public_key: setup.gas_key_signer.public_key(),
+            amount: half,
+        }))],
+        block_hash,
+    );
+    let hashes = [withdraw_tx1.get_hash(), withdraw_tx2.get_hash()];
+    env.validator().submit_tx(withdraw_tx1);
+    env.validator().submit_tx(withdraw_tx2);
+    env.validator_runner().run_until_included(&hashes);
 
-    // Wait for the withdraw tx to be included so the PTQ tracks
-    // the withdrawal against the gas key balance.
-    env.validator_runner().run_until_included(&[withdraw_hash]);
-
-    // Now submit a gas key tx via execute_tx. The PTQ should count the
-    // pending withdrawal against the gas key balance, so the RPC handler
-    // should reject it with NotEnoughGasKeyBalance.
+    // Submit a gas key tx via execute_tx. The pending transaction queue
+    // should accumulate both withdrawals against the gas key balance,
+    // so the RPC handler should reject it with NotEnoughGasKeyBalance.
     let block_hash = env.validator().head().last_block_hash;
     let gas_key_tx = SignedTransaction::from_actions_v1(
         TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[0] + 1, 0),

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -41,30 +41,21 @@ fn gas_cost_per_transfer() -> Balance {
 }
 
 /// Submit `count` transfer transactions from `sender` to `receiver`.
-/// Returns the tx hashes. Increments `next_nonce`.
+/// Returns the tx hashes. Nonces are auto-tracked by `TestLoopNode`.
 fn submit_transfers(
     env: &TestLoopEnv,
     sender: &AccountId,
     receiver: &AccountId,
-    next_nonce: &mut u64,
     count: usize,
 ) -> Vec<CryptoHash> {
-    let block_hash = env.validator().head().last_block_hash;
-    let mut tx_hashes = Vec::new();
-    for _ in 0..count {
-        let tx = SignedTransaction::send_money(
-            *next_nonce,
-            sender.clone(),
-            receiver.clone(),
-            &create_user_test_signer(sender),
-            Balance::from_millinear(1),
-            block_hash,
-        );
-        *next_nonce += 1;
-        tx_hashes.push(tx.get_hash());
-        env.validator().submit_tx(tx);
-    }
-    tx_hashes
+    (0..count)
+        .map(|_| {
+            let tx = env.validator().tx_send_money(sender, receiver, Balance::from_millinear(1));
+            let hash = tx.get_hash();
+            env.validator().submit_tx(tx);
+            hash
+        })
+        .collect()
 }
 
 /// Deploy a contract on `account` and wait for certification to advance past
@@ -102,8 +93,7 @@ fn test_ptq_p_max_contract_account() {
 
     // Submit P_MAX + 2 transfer transactions from the contract account.
     let num_txs = P_MAX + 2;
-    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
-    let tx_hashes = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, num_txs);
+    let tx_hashes = submit_transfers(&env, &contract_account, &receiver, num_txs);
     // Only P_MAX txs should be included before certification.
     env.validator_runner().run_until_included(&tx_hashes[..P_MAX]);
     for tx_hash in &tx_hashes[P_MAX..] {
@@ -136,8 +126,7 @@ fn test_ptq_no_p_max_for_non_contract_account() {
     let mut env = env.warmup();
 
     let num_txs = P_MAX + 2;
-    let mut next_nonce: u64 = 1;
-    let tx_hashes = submit_transfers(&env, &sender, &receiver, &mut next_nonce, num_txs);
+    let tx_hashes = submit_transfers(&env, &sender, &receiver, num_txs);
     // All should be included without P_MAX throttling.
     env.validator_runner().run_until_included(&tx_hashes);
 }
@@ -282,19 +271,16 @@ fn test_ptq_accumulates_across_blocks() {
     // then submit the rest. Total across uncertified blocks should be P_MAX.
     let first_batch_size = P_MAX / 2;
     let second_batch_size = P_MAX - first_batch_size;
-    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
-    let first_batch =
-        submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, first_batch_size);
+    let first_batch = submit_transfers(&env, &contract_account, &receiver, first_batch_size);
     let first_inclusion_height = env.validator_runner().run_until_included(&first_batch);
 
     // Submit and include the second batch.
-    let second_batch =
-        submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, second_batch_size);
+    let second_batch = submit_transfers(&env, &contract_account, &receiver, second_batch_size);
     env.validator_runner().run_until_included(&second_batch);
 
     // Submit a (P_MAX+1)th tx. This should be blocked by P_MAX since there
     // are already P_MAX uncertified txs from this contract account.
-    let extra = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, 1);
+    let extra = submit_transfers(&env, &contract_account, &receiver, 1);
     let extra_hash = extra[0];
 
     // Run blocks up to just before the first batch gets certified.
@@ -333,14 +319,13 @@ fn test_ptq_cleanup_on_certification() {
     deploy_contract_and_certify(&mut env, &contract_account);
 
     // Submit P_MAX transactions and wait for inclusion + certification.
-    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
-    let first_batch = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, P_MAX);
+    let first_batch = submit_transfers(&env, &contract_account, &receiver, P_MAX);
     env.validator_runner().run_until_included(&first_batch);
     let height = env.validator().head().height;
     env.validator_runner().run_until_certified(height);
 
     // Submit P_MAX more. All should be admitted since the first batch is certified.
-    let second_batch = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, P_MAX);
+    let second_batch = submit_transfers(&env, &contract_account, &receiver, P_MAX);
     env.validator_runner().run_until_included(&second_batch);
 }
 

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -467,6 +467,45 @@ impl<'a> NodeRunner<'a> {
         );
     }
 
+    /// Run until all given transactions appear in the head block.
+    /// Returns the height of the block containing the transactions.
+    pub fn run_until_included(&mut self, tx_hashes: &[CryptoHash]) -> BlockHeight {
+        let tx_hashes = tx_hashes.to_vec();
+        self.run_until(
+            |node| {
+                let head = node.head();
+                let block = node.client().chain.get_block(&head.last_block_hash).unwrap();
+                let mut included = std::collections::HashSet::new();
+                for chunk_header in block.chunks().iter() {
+                    let chunk = node.client().chain.get_chunk(&chunk_header.chunk_hash()).unwrap();
+                    for tx in chunk.to_transactions() {
+                        included.insert(tx.get_hash());
+                    }
+                }
+                tx_hashes.iter().all(|h| included.contains(h))
+            },
+            Duration::seconds(20),
+        );
+        self.head().height
+    }
+
+    /// Run until the last certified block height is at least `height`.
+    pub fn run_until_certified(&mut self, height: BlockHeight) {
+        let initial_height = self.head().height;
+        let height_diff = height.saturating_sub(initial_height) as usize;
+        let extra = self.node_data.expected_execution_delay() as usize;
+        let timeout = self.calculate_block_distance_timeout(height_diff + extra + 1);
+        self.run_until(
+            |node| {
+                let chain_store = &node.client().chain.chain_store;
+                let head_hash = chain_store.head().unwrap().last_block_hash;
+                near_chain::spice_core::get_last_certified_block_header(chain_store, &head_hash)
+                    .map_or(false, |h| h.height() >= height)
+            },
+            timeout,
+        );
+    }
+
     pub fn run_until_new_epoch(&mut self) {
         let curr_epoch_id = self.head().epoch_id;
         let epoch_length = self.client().config.epoch_length as usize;


### PR DESCRIPTION
Add test-loop tests for the pending transaction queue (PTQ) introduced in the SPICE feature.

- `test_ptq_p_max_contract_account`: verifies P_MAX limits concurrent uncertified txs from contract accounts
- `test_ptq_no_p_max_for_non_contract_account`: verifies no P_MAX restriction for non-contract accounts
- `test_ptq_nonce_constraint`: verifies PTQ nonce tracking rejects replayed nonces before certification
- `test_ptq_deploy_exclusivity`: verifies deploy transactions block other txs from the same account until certified
- `test_ptq_accumulates_across_blocks`: verifies P_MAX counts uncertified txs across multiple blocks
- `test_ptq_cleanup_on_certification`: verifies certified txs are removed from PTQ
- `test_ptq_gas_key_balance_enforcement`: verifies gas key balance tracking rejects txs when balance is exhausted
- `test_ptq_withdraw_from_gas_key`: verifies `WithdrawFromGasKey` reduces available gas key balance
- `test_ptq_gas_key_multiple_nonce_indices`: verifies gas key balance is shared across nonce indices
- `test_ptq_account_balance_access_key_gas_key_combined`: verifies account balance tracking across access key and gas key txs
- Adds `run_until_included` and `run_until_certified` helpers to `NodeRunner` for test convenience