### PR TITLE
feat(ptq): whole implementation and tests of pending transaction queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8098,6 +8098,7 @@ dependencies = [
  "near-vm-runner",
  "near-wallet-contract",
  "nearcore",
+ "node-runtime",
  "parking_lot 0.12.1",
  "primitive-types 0.10.1",
  "rand 0.8.5",

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1,9 +1,9 @@
 use crate::Error;
 use crate::types::{
-    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, PendingTxCheckResult,
-    PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions,
-    RuntimeAdapter, RuntimeStorageConfig, SkippedTransactions, StatePartValidationResult,
-    StateRootNodeValidationResult, StorageDataSource, Tip,
+    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, HasContract,
+    PendingTxCheckResult, PrepareTransactionsBlockContext, PrepareTransactionsLimit,
+    PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig, SkippedTransactions,
+    StatePartValidationResult, StateRootNodeValidationResult, StorageDataSource, Tip,
 };
 use errors::FromStateViewerErrors;
 use near_async::time::{Duration, Instant};
@@ -812,7 +812,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
-        check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
+        check_pending: &mut dyn FnMut(&SignedTransaction, HasContract) -> PendingTxCheckResult,
         time_limit: Option<Duration>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
@@ -969,7 +969,11 @@ impl RuntimeAdapter for NightshadeRuntime {
                 };
 
                 // Check pending transaction queue constraints.
-                let has_contract = cache.account.contract().is_some();
+                let has_contract = if cache.account.contract().is_some() {
+                    HasContract::Yes
+                } else {
+                    HasContract::No
+                };
                 let pending_constraints =
                     match check_pending(validated_tx.to_signed_tx(), has_contract) {
                         PendingTxCheckResult::Admit(constraints) => constraints,

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1,6 +1,6 @@
 use crate::Error;
 use crate::types::{
-    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext,
+    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, PendingTxCheckResult,
     PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions,
     RuntimeAdapter, RuntimeStorageConfig, SkippedTransactions, StatePartValidationResult,
     StateRootNodeValidationResult, StorageDataSource, Tip,
@@ -781,6 +781,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             transaction_groups,
             chain_validate,
             HashSet::new(),
+            &mut PendingTxCheckResult::always_admit(),
             time_limit,
             None,
         ) // skip_tx_hashes is empty, so there will be no skipped transactions
@@ -811,6 +812,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
+        check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
         time_limit: Option<Duration>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
@@ -966,6 +968,17 @@ impl RuntimeAdapter for NightshadeRuntime {
                     }
                 };
 
+                // Check pending transaction queue constraints.
+                let has_contract = cache.account.contract().is_some();
+                let pending_constraints =
+                    match check_pending(validated_tx.to_signed_tx(), has_contract) {
+                        PendingTxCheckResult::Admit(constraints) => constraints,
+                        PendingTxCheckResult::Skip => {
+                            skipped_transactions.push(validated_tx);
+                            continue;
+                        }
+                    };
+
                 let cost = match tx_cost(
                     runtime_config,
                     &validated_tx.to_tx(),
@@ -987,7 +1000,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         validated_tx.to_tx(),
                         &cost,
                         Some(next_block_height),
-                        &PendingConstraints::default(),
+                        &pending_constraints,
                     )
                 } else {
                     verify_and_charge_tx_ephemeral(
@@ -998,7 +1011,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &cost,
                         Some(next_block_height),
                         protocol_version,
-                        &PendingConstraints::default(),
+                        &pending_constraints,
                     )
                 };
                 match verdict {

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -53,9 +53,9 @@ use node_runtime::adapter::ViewRuntimeAdapter;
 use node_runtime::config::tx_cost;
 use node_runtime::state_viewer::{TrieViewer, ViewApplyState};
 use node_runtime::{
-    ApplyState, Runtime, SignedValidPeriodTransactions, TxVerdict, ValidatorAccountsUpdate,
-    get_signer_and_access_key, validate_transaction, verify_and_charge_gas_key_tx_ephemeral,
-    verify_and_charge_tx_ephemeral,
+    ApplyState, PendingConstraints, Runtime, SignedValidPeriodTransactions, TxVerdict,
+    ValidatorAccountsUpdate, get_signer_and_access_key, validate_transaction,
+    verify_and_charge_gas_key_tx_ephemeral, verify_and_charge_tx_ephemeral,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -671,6 +671,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         state_root: StateRoot,
         validated_tx: &ValidatedTransaction,
         current_protocol_version: ProtocolVersion,
+        pending_constraints: &PendingConstraints,
     ) -> Result<(), InvalidTxError> {
         let runtime_config = self.runtime_config_store.get_config(current_protocol_version);
         let tx = validated_tx.to_tx();
@@ -703,6 +704,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 &tx,
                 &cost,
                 block_height,
+                pending_constraints,
             ) {
                 TxVerdict::Success(_) => Ok(()),
                 TxVerdict::DepositFailed { error, .. } | TxVerdict::Failed(error) => Err(error),
@@ -716,6 +718,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 &cost,
                 block_height,
                 current_protocol_version,
+                pending_constraints,
             ) {
                 TxVerdict::Success(_) => Ok(()),
                 TxVerdict::Failed(error) => Err(error),
@@ -984,6 +987,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         validated_tx.to_tx(),
                         &cost,
                         Some(next_block_height),
+                        &PendingConstraints::default(),
                     )
                 } else {
                     verify_and_charge_tx_ephemeral(
@@ -994,6 +998,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &cost,
                         Some(next_block_height),
                         protocol_version,
+                        &PendingConstraints::default(),
                     )
                 };
                 match verdict {

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1651,7 +1651,7 @@ fn prepare_transactions_extra(
     chain: &Chain,
     transaction_groups: &mut dyn TransactionGroupIterator,
     skip_tx_hashes: HashSet<CryptoHash>,
-    check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
+    check_pending: &mut dyn FnMut(&SignedTransaction, HasContract) -> PendingTxCheckResult,
     cancel: Option<Arc<AtomicBool>>,
 ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
     let prev_hash = env.head.prev_block_hash;

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1537,13 +1537,10 @@ fn test_genesis_hash() {
 /// Creates a signed transaction between each pair of `signers`,
 /// where transaction outcomes from a single signer differ by nonce.
 /// The transactions are then shuffled and used to fill a transaction pool.
-fn generate_transaction_pool(
-    signers: &[Signer],
-    block_hash: CryptoHash,
-    num_rounds: usize,
-) -> TransactionPool {
+fn generate_transaction_pool(signers: &[Signer], block_hash: CryptoHash) -> TransactionPool {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let signer_count = signers.len();
+    let num_rounds = signer_count - 1;
 
     let mut transactions = vec![];
     for round in 1..=num_rounds {
@@ -1569,7 +1566,7 @@ fn generate_transaction_pool(
     pool
 }
 
-fn get_test_env_with_chain_and_pool(num_rounds: usize) -> (TestEnv, Chain, TransactionPool) {
+fn get_test_env_with_chain_and_pool() -> (TestEnv, Chain, TransactionPool) {
     let validators = (0..NUM_TEST_SIGNERS)
         .map(|i| AccountId::try_from(format!("test{}", i + 1)).unwrap())
         .collect::<Vec<_>>();
@@ -1608,8 +1605,7 @@ fn get_test_env_with_chain_and_pool(num_rounds: usize) -> (TestEnv, Chain, Trans
     env.step_default(vec![]);
 
     let signers: Vec<_> = validators.iter().map(|id| InMemorySigner::test_signer(&id)).collect();
-    let transaction_pool =
-        generate_transaction_pool(&signers, env.head.prev_block_hash, num_rounds);
+    let transaction_pool = generate_transaction_pool(&signers, env.head.prev_block_hash);
     (env, chain, transaction_pool)
 }
 
@@ -1691,7 +1687,7 @@ fn prepare_transactions_extra(
 
 #[test]
 fn test_prepare_transactions_duplicate_nonces() {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
 
     // Insert a transaction with a duplicate (public key, nonce) pair into the pool.
     let mut iter = transaction_pool.pool_iterator();
@@ -1756,7 +1752,7 @@ fn test_prepare_transactions_empty_storage_proof() {
 fn test_prepare_transactions_helper(
     storage_source: StorageDataSource,
 ) -> Result<(usize, PreparedTransactions), Error> {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
     let transactions_count = transaction_pool.len();
 
     let storage_config = RuntimeStorageConfig {
@@ -1779,7 +1775,7 @@ fn test_prepare_transactions_helper(
 
 #[test]
 fn test_prepare_transactions_extra() {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
 
     // First run the preparation without any extra arguments
     let (prepared, skipped) = prepare_transactions_extra(
@@ -1865,7 +1861,7 @@ fn test_prepare_transactions_extra() {
 fn test_prepare_transactions_pending_skip() {
     let num_rounds = NUM_TEST_SIGNERS - 1;
     let total_txs = NUM_TEST_SIGNERS * num_rounds;
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(num_rounds);
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
 
     // Skip every other transaction.
     let mut call_count = 0usize;
@@ -1897,7 +1893,7 @@ fn test_prepare_transactions_pending_skip() {
 /// subsequent transactions should fail balance validation.
 #[test]
 fn test_prepare_transactions_pending_balance_constraint() {
-    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, _) = get_test_env_with_chain_and_pool();
 
     // Create a pool with a small transfer from test1.
     let signer = InMemorySigner::test_signer(&"test1".parse::<AccountId>().unwrap());
@@ -1948,7 +1944,7 @@ fn test_prepare_transactions_pending_balance_constraint() {
 /// floor is raised. Transactions with nonces <= max_nonce should be rejected.
 #[test]
 fn test_prepare_transactions_pending_nonce_constraint() {
-    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+    let (env, chain, _) = get_test_env_with_chain_and_pool();
 
     let signer = InMemorySigner::test_signer(&"test1".parse::<AccountId>().unwrap());
     // Create two transactions with nonces 1 and 2.

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -54,6 +54,9 @@ use primitive_types::U256;
 use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 use std::collections::{BTreeSet, HashSet};
 
+const TEST_SEED: RngSeed = [3; 32];
+const NUM_TEST_SIGNERS: usize = 4;
+
 struct TestEnvConfig {
     epoch_length: BlockHeightDelta,
     has_reward: bool,
@@ -1534,13 +1537,16 @@ fn test_genesis_hash() {
 /// Creates a signed transaction between each pair of `signers`,
 /// where transaction outcomes from a single signer differ by nonce.
 /// The transactions are then shuffled and used to fill a transaction pool.
-fn generate_transaction_pool(signers: &Vec<Signer>, block_hash: CryptoHash) -> TransactionPool {
-    const TEST_SEED: RngSeed = [3; 32];
+fn generate_transaction_pool(
+    signers: &[Signer],
+    block_hash: CryptoHash,
+    num_rounds: usize,
+) -> TransactionPool {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let signer_count = signers.len();
 
     let mut transactions = vec![];
-    for round in 1..signer_count {
+    for round in 1..=num_rounds {
         for i in 0..signer_count {
             let transaction = SignedTransaction::send_money(
                 round.try_into().unwrap(),
@@ -1563,9 +1569,8 @@ fn generate_transaction_pool(signers: &Vec<Signer>, block_hash: CryptoHash) -> T
     pool
 }
 
-fn get_test_env_with_chain_and_pool() -> (TestEnv, Chain, TransactionPool) {
-    let num_nodes = 4;
-    let validators = (0..num_nodes)
+fn get_test_env_with_chain_and_pool(num_rounds: usize) -> (TestEnv, Chain, TransactionPool) {
+    let validators = (0..NUM_TEST_SIGNERS)
         .map(|i| AccountId::try_from(format!("test{}", i + 1)).unwrap())
         .collect::<Vec<_>>();
     let chain_genesis = ChainGenesis::new(&GenesisConfig::test(Clock::real()));
@@ -1603,8 +1608,8 @@ fn get_test_env_with_chain_and_pool() -> (TestEnv, Chain, TransactionPool) {
     env.step_default(vec![]);
 
     let signers: Vec<_> = validators.iter().map(|id| InMemorySigner::test_signer(&id)).collect();
-
-    let transaction_pool = generate_transaction_pool(&signers, env.head.prev_block_hash);
+    let transaction_pool =
+        generate_transaction_pool(&signers, env.head.prev_block_hash, num_rounds);
     (env, chain, transaction_pool)
 }
 
@@ -1646,6 +1651,7 @@ fn prepare_transactions_extra(
     chain: &Chain,
     transaction_groups: &mut dyn TransactionGroupIterator,
     skip_tx_hashes: HashSet<CryptoHash>,
+    check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
     cancel: Option<Arc<AtomicBool>>,
 ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
     let prev_hash = env.head.prev_block_hash;
@@ -1677,6 +1683,7 @@ fn prepare_transactions_extra(
                 .is_ok()
         },
         skip_tx_hashes,
+        check_pending,
         default_produce_chunk_add_transactions_time_limit(),
         cancel,
     )
@@ -1684,7 +1691,7 @@ fn prepare_transactions_extra(
 
 #[test]
 fn test_prepare_transactions_duplicate_nonces() {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
 
     // Insert a transaction with a duplicate (public key, nonce) pair into the pool.
     let mut iter = transaction_pool.pool_iterator();
@@ -1749,7 +1756,7 @@ fn test_prepare_transactions_empty_storage_proof() {
 fn test_prepare_transactions_helper(
     storage_source: StorageDataSource,
 ) -> Result<(usize, PreparedTransactions), Error> {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
     let transactions_count = transaction_pool.len();
 
     let storage_config = RuntimeStorageConfig {
@@ -1772,7 +1779,7 @@ fn test_prepare_transactions_helper(
 
 #[test]
 fn test_prepare_transactions_extra() {
-    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
 
     // First run the preparation without any extra arguments
     let (prepared, skipped) = prepare_transactions_extra(
@@ -1780,6 +1787,7 @@ fn test_prepare_transactions_extra() {
         &chain,
         &mut PoolIteratorWrapper::new(&mut transaction_pool),
         HashSet::new(),
+        &mut PendingTxCheckResult::always_admit(),
         None,
     )
     .unwrap();
@@ -1801,6 +1809,7 @@ fn test_prepare_transactions_extra() {
         &chain,
         &mut PoolIteratorWrapper::new(&mut transaction_pool),
         HashSet::new(),
+        &mut PendingTxCheckResult::always_admit(),
         Some(Arc::new(AtomicBool::new(false))),
     )
     .unwrap();
@@ -1818,6 +1827,7 @@ fn test_prepare_transactions_extra() {
         &chain,
         &mut PoolIteratorWrapper::new(&mut transaction_pool),
         HashSet::new(),
+        &mut PendingTxCheckResult::always_admit(),
         Some(Arc::new(AtomicBool::new(true))),
     )
     .unwrap();
@@ -1833,6 +1843,7 @@ fn test_prepare_transactions_extra() {
         &chain,
         &mut PoolIteratorWrapper::new(&mut transaction_pool),
         skip_tx_hashes.clone(),
+        &mut PendingTxCheckResult::always_admit(),
         None,
     )
     .unwrap();
@@ -1846,6 +1857,138 @@ fn test_prepare_transactions_extra() {
     assert_eq!(skipped_hashes, skip_tx_hashes);
 
     assert_eq!(transaction_pool.len(), 0);
+}
+
+/// When check_pending returns Skip for a transaction, it should appear in
+/// skipped_transactions (for reintroduction to pool), not in prepared.
+#[test]
+fn test_prepare_transactions_pending_skip() {
+    let num_rounds = NUM_TEST_SIGNERS - 1;
+    let total_txs = NUM_TEST_SIGNERS * num_rounds;
+    let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool(num_rounds);
+
+    // Skip every other transaction.
+    let mut call_count = 0usize;
+    let (prepared, skipped) = prepare_transactions_extra(
+        &env,
+        &chain,
+        &mut PoolIteratorWrapper::new(&mut transaction_pool),
+        HashSet::new(),
+        &mut |_, _| {
+            call_count += 1;
+            if call_count % 2 == 0 {
+                PendingTxCheckResult::Skip
+            } else {
+                PendingTxCheckResult::Admit(PendingConstraints::default())
+            }
+        },
+        None,
+    )
+    .unwrap();
+
+    // No transactions should be lost: all are either prepared or skipped.
+    assert_eq!(prepared.transactions.len() + skipped.0.len(), total_txs);
+    assert_eq!(prepared.transactions.len(), total_txs / 2);
+    assert_eq!(skipped.0.len(), total_txs / 2);
+}
+
+/// When check_pending returns Admit with paid_from_balance, the available
+/// balance for validation is reduced. With a large enough paid_from_balance,
+/// subsequent transactions should fail balance validation.
+#[test]
+fn test_prepare_transactions_pending_balance_constraint() {
+    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+
+    // Create a pool with a small transfer from test1.
+    let signer = InMemorySigner::test_signer(&"test1".parse::<AccountId>().unwrap());
+    let tx = SignedTransaction::send_money(
+        1,
+        signer.get_account_id(),
+        "test2".parse().unwrap(),
+        &signer,
+        Balance::from_yoctonear(1),
+        env.head.prev_block_hash,
+    );
+    let mut pool = TransactionPool::new(TEST_SEED, None, "");
+    pool.insert_transaction(ValidatedTransaction::new_for_test(tx));
+
+    // Without pending constraints, the transfer should succeed.
+    let (prepared, _) = prepare_transactions_extra(
+        &env,
+        &chain,
+        &mut PoolIteratorWrapper::new(&mut pool),
+        HashSet::new(),
+        &mut PendingTxCheckResult::always_admit(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(prepared.transactions.len(), 1);
+
+    // Reinsert and try again with paid_from_balance consuming all balance.
+    pool.insert_transaction(prepared.transactions[0].clone());
+    let (prepared, _) = prepare_transactions_extra(
+        &env,
+        &chain,
+        &mut PoolIteratorWrapper::new(&mut pool),
+        HashSet::new(),
+        &mut |_, _| {
+            PendingTxCheckResult::Admit(PendingConstraints {
+                paid_from_balance: TESTING_INIT_BALANCE,
+                ..PendingConstraints::default()
+            })
+        },
+        None,
+    )
+    .unwrap();
+    // The transaction should fail balance validation (balance reduced to 0).
+    assert_eq!(prepared.transactions.len(), 0);
+}
+
+/// When check_pending returns Admit with max_nonce, the effective nonce
+/// floor is raised. Transactions with nonces <= max_nonce should be rejected.
+#[test]
+fn test_prepare_transactions_pending_nonce_constraint() {
+    let (env, chain, _) = get_test_env_with_chain_and_pool(NUM_TEST_SIGNERS - 1);
+
+    let signer = InMemorySigner::test_signer(&"test1".parse::<AccountId>().unwrap());
+    // Create two transactions with nonces 1 and 2.
+    let tx1 = SignedTransaction::send_money(
+        1,
+        signer.get_account_id(),
+        "test2".parse().unwrap(),
+        &signer,
+        Balance::from_yoctonear(1),
+        env.head.prev_block_hash,
+    );
+    let tx2 = SignedTransaction::send_money(
+        2,
+        signer.get_account_id(),
+        "test2".parse().unwrap(),
+        &signer,
+        Balance::from_yoctonear(1),
+        env.head.prev_block_hash,
+    );
+    let mut pool = TransactionPool::new(TEST_SEED, None, "");
+    pool.insert_transaction(ValidatedTransaction::new_for_test(tx1));
+    pool.insert_transaction(ValidatedTransaction::new_for_test(tx2));
+
+    // With max_nonce=1, nonce 1 should be rejected (<=max_nonce), nonce 2 accepted.
+    let (prepared, _) = prepare_transactions_extra(
+        &env,
+        &chain,
+        &mut PoolIteratorWrapper::new(&mut pool),
+        HashSet::new(),
+        &mut |_, _| {
+            PendingTxCheckResult::Admit(PendingConstraints {
+                max_nonce: 1,
+                ..PendingConstraints::default()
+            })
+        },
+        None,
+    )
+    .unwrap();
+    assert_eq!(prepared.transactions.len(), 1);
+    assert_eq!(prepared.transactions[0].nonce().nonce(), 2);
 }
 
 #[test]

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -101,7 +101,7 @@ impl SpiceCoreReader {
         self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key)
     }
 
-    fn get_uncertified_chunks(
+    pub fn get_uncertified_chunks(
         &self,
         block_hash: &CryptoHash,
     ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -101,7 +101,7 @@ impl SpiceCoreReader {
         self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key)
     }
 
-    pub fn get_uncertified_chunks(
+    fn get_uncertified_chunks(
         &self,
         block_hash: &CryptoHash,
     ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -101,7 +101,10 @@ impl SpiceCoreReader {
         self.chain_store.store().caching_get_ser(DBCol::execution_results(), &key)
     }
 
-    fn get_uncertified_chunks(
+    /// Returns the list of uncertified chunks as of the given block.
+    /// Returns an empty vec for genesis or non-Spice blocks.
+    /// Errors if a Spice block is missing uncertified_chunks in storage.
+    pub fn get_uncertified_chunks(
         &self,
         block_hash: &CryptoHash,
     ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {
@@ -546,6 +549,26 @@ fn find_oldest_uncertified_block_header(
         .map(|block_hash| chain_store.get_block_header(block_hash))
         .collect::<Result<Vec<_>, Error>>()?;
     Ok(uncertified_block_headers.into_iter().min_by_key(|header| header.height()))
+}
+
+/// Returns block hashes that became fully certified due to the execution results
+/// in `core_statements`. A block is newly certified when all of its previously
+/// uncertified chunks appear in the execution results.
+pub fn find_newly_certified_block_hashes(
+    prev_uncertified_chunks: &[SpiceUncertifiedChunkInfo],
+    core_statements: &SpiceCoreStatements,
+) -> Vec<CryptoHash> {
+    let newly_certified_chunk_ids: HashSet<&SpiceChunkId> =
+        core_statements.iter_execution_results().map(|(id, _)| id).collect();
+    // Group uncertified chunks by block hash, tracking whether all are now certified.
+    let mut blocks: HashMap<CryptoHash, bool> = HashMap::new();
+    for chunk_info in prev_uncertified_chunks {
+        let block_entry = blocks.entry(chunk_info.chunk_id.block_hash).or_insert(true);
+        if !newly_certified_chunk_ids.contains(&chunk_info.chunk_id) {
+            *block_entry = false;
+        }
+    }
+    blocks.into_iter().filter(|(_, all_certified)| *all_certified).map(|(hash, _)| hash).collect()
 }
 
 /// Returns the header of the last fully certified block relative to the given block.

--- a/chain/chain/src/tests/spice_core.rs
+++ b/chain/chain/src/tests/spice_core.rs
@@ -19,14 +19,17 @@ use near_primitives::stateless_validation::spice_chunk_endorsement::{
 use near_primitives::test_utils::{TestBlockBuilder, create_test_signer};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{
-    BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, SpiceChunkId,
+    BlockExecutionResults, ChunkExecutionResult, ChunkExecutionResultHash, ShardId, SpiceChunkId,
+    SpiceUncertifiedChunkInfo,
 };
 use near_store::adapter::StoreAdapter as _;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use crate::spice_core::{SpiceCoreReader, record_uncertified_chunks_for_block};
+use crate::spice_core::{
+    SpiceCoreReader, find_newly_certified_block_hashes, record_uncertified_chunks_for_block,
+};
 use crate::spice_core_writer_actor::{ProcessedBlock, SpiceCoreWriterActor};
 use crate::test_utils::{
     get_chain_with_genesis, get_fake_next_block_chunk_headers, process_block_sync,
@@ -1385,4 +1388,72 @@ fn endorsement_into_core_statement(endorsement: SpiceChunkEndorsement) -> SpiceC
     verified
         .to_stored()
         .into_core_statement(verified.chunk_id().clone(), verified.account_id().clone())
+}
+
+fn uncertified_chunk_info(block_hash: CryptoHash, shard_id: ShardId) -> SpiceUncertifiedChunkInfo {
+    SpiceUncertifiedChunkInfo {
+        chunk_id: SpiceChunkId { block_hash, shard_id },
+        missing_endorsements: vec![],
+        present_endorsements: vec![],
+    }
+}
+
+fn execution_result_core_statement(
+    block_hash: CryptoHash,
+    shard_id: ShardId,
+) -> SpiceCoreStatement {
+    SpiceCoreStatement::ChunkExecutionResult {
+        chunk_id: SpiceChunkId { block_hash, shard_id },
+        execution_result: ChunkExecutionResult {
+            chunk_extra: ChunkExtra::new_with_only_state_root(&CryptoHash::default()),
+            outgoing_receipts_root: CryptoHash::default(),
+        },
+    }
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_find_newly_certified_empty_inputs() {
+    let result = find_newly_certified_block_hashes(&[], SpiceCoreStatements::empty());
+    assert!(result.is_empty());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_find_newly_certified_partial_certification() {
+    let block_hash = CryptoHash::hash_bytes(&[1]);
+    let shard_0 = ShardId::new(0);
+    let shard_1 = ShardId::new(1);
+    let uncertified = vec![
+        uncertified_chunk_info(block_hash, shard_0),
+        uncertified_chunk_info(block_hash, shard_1),
+    ];
+    // Only shard 0 gets certified.
+    let statements =
+        SpiceCoreStatements::new(vec![execution_result_core_statement(block_hash, shard_0)]);
+    let result = find_newly_certified_block_hashes(&uncertified, &statements);
+    assert!(result.is_empty());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_find_newly_certified_full_certification() {
+    let block_a = CryptoHash::hash_bytes(&[1]);
+    let block_b = CryptoHash::hash_bytes(&[2]);
+    let shard_0 = ShardId::new(0);
+    let shard_1 = ShardId::new(1);
+    let uncertified = vec![
+        uncertified_chunk_info(block_a, shard_0),
+        uncertified_chunk_info(block_a, shard_1),
+        uncertified_chunk_info(block_b, shard_0),
+        uncertified_chunk_info(block_b, shard_1),
+    ];
+    // Block A is fully certified, block B only partially.
+    let statements = SpiceCoreStatements::new(vec![
+        execution_result_core_statement(block_a, shard_0),
+        execution_result_core_statement(block_a, shard_1),
+        execution_result_core_statement(block_b, shard_0),
+    ]);
+    let result = find_newly_certified_block_hashes(&uncertified, &statements);
+    assert_eq!(result, vec![block_a]);
 }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -420,6 +420,13 @@ impl PreparedTransactions {
 #[derive(Debug, Clone)]
 pub struct SkippedTransactions(pub Vec<ValidatedTransaction>);
 
+/// Whether the transaction's signer account has a deployed contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HasContract {
+    Yes,
+    No,
+}
+
 /// Result of checking pending transaction queue admission for a transaction.
 #[derive(Debug, PartialEq, Eq)]
 pub enum PendingTxCheckResult {
@@ -432,7 +439,7 @@ pub enum PendingTxCheckResult {
 
 impl PendingTxCheckResult {
     /// Returns a closure that always admits with default constraints.
-    pub fn always_admit() -> impl FnMut(&SignedTransaction, bool) -> PendingTxCheckResult {
+    pub fn always_admit() -> impl FnMut(&SignedTransaction, HasContract) -> PendingTxCheckResult {
         |_, _| PendingTxCheckResult::Admit(PendingConstraints::default())
     }
 }
@@ -573,7 +580,7 @@ pub trait RuntimeAdapter: Send + Sync {
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
-        check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
+        check_pending: &mut dyn FnMut(&SignedTransaction, HasContract) -> PendingTxCheckResult,
         time_limit: Option<Duration>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error>;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -50,6 +50,7 @@ use near_store::flat::FlatStorageManager;
 use near_store::{PartialStorage, ShardTries, Store, Trie, WrappedTrieChanges};
 use near_vm_runner::ContractCode;
 use near_vm_runner::ContractRuntimeCache;
+pub use node_runtime::PendingConstraints;
 use node_runtime::PostStateReadyCallback;
 use node_runtime::SignedValidPeriodTransactions;
 use num_rational::Rational32;
@@ -516,6 +517,7 @@ pub trait RuntimeAdapter: Send + Sync {
         state_root: StateRoot,
         validated_tx: &ValidatedTransaction,
         current_protocol_version: ProtocolVersion,
+        pending_constraints: &PendingConstraints,
     ) -> Result<(), InvalidTxError>;
 
     /// Returns an ordered list of valid transactions from the pool up the given limits.

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -420,6 +420,23 @@ impl PreparedTransactions {
 #[derive(Debug, Clone)]
 pub struct SkippedTransactions(pub Vec<ValidatedTransaction>);
 
+/// Result of checking pending transaction queue admission for a transaction.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PendingTxCheckResult {
+    /// Admitted. Use these constraints for balance/nonce validation.
+    Admit(PendingConstraints),
+    /// Violates PTQ constraints (P_MAX, deploy exclusivity).
+    /// Push to skipped_transactions for reintroduction to pool.
+    Skip,
+}
+
+impl PendingTxCheckResult {
+    /// Returns a closure that always admits with default constraints.
+    pub fn always_admit() -> impl FnMut(&SignedTransaction, bool) -> PendingTxCheckResult {
+        |_, _| PendingTxCheckResult::Admit(PendingConstraints::default())
+    }
+}
+
 /// Chunk producer prepares transactions from the transaction pool
 /// until it hits some limit (too many transactions, too much gas used, etc).
 /// This enum describes which limit was hit when preparing transactions.
@@ -556,6 +573,7 @@ pub trait RuntimeAdapter: Send + Sync {
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
+        check_pending: &mut dyn FnMut(&SignedTransaction, bool) -> PendingTxCheckResult,
         time_limit: Option<Duration>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error>;

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -1,11 +1,13 @@
 use crate::debug::PRODUCTION_TIMES_CACHE_SIZE;
 use crate::metrics;
+use crate::pending_transaction_queue::{PendingTxSession, ShardedPendingTransactionQueue};
 use crate::prepare_transactions::{
     PrepareTransactionsJobInputs, PrepareTransactionsJobKey, PrepareTransactionsManager,
 };
 use itertools::Itertools;
 use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt};
 use near_async::time::{Clock, Duration, Instant};
+use near_chain::spice_core::get_last_certified_block_header;
 use near_chain::types::{
     PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions,
     RuntimeAdapter, RuntimeStorageConfig,
@@ -96,6 +98,7 @@ pub struct ChunkProducer {
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     // TODO: put mutex on individual shards instead of the complete pool
     pub sharded_tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    pub pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
     /// A ReedSolomon instance to encode shard chunks.
     reed_solomon_encoder: ReedSolomon,
     /// Chunk production timing information. Used only for debug purposes.
@@ -135,6 +138,7 @@ impl ChunkProducer {
                 rng_seed,
                 transaction_pool_size_limit,
             ))),
+            pending_transaction_queue: Arc::new(Mutex::new(ShardedPendingTransactionQueue::new())),
             reed_solomon_encoder: ReedSolomon::new(data_parts, parity_parts).unwrap(),
             chunk_production_info: lru::LruCache::new(
                 NonZeroUsize::new(PRODUCTION_TIMES_CACHE_SIZE).unwrap(),
@@ -449,7 +453,9 @@ impl ChunkProducer {
     ) -> Result<PreparedTransactions, Error> {
         let shard_id = shard_uid.shard_id();
         let mut pool_guard = self.sharded_tx_pool.lock();
-        let prepared_transactions = if let Some(mut iter) = pool_guard.get_pool_iterator(shard_uid)
+        // (prepared_transactions, skipped_transactions_to_reintroduce)
+        let (prepared_transactions, skipped_transactions) = if let Some(mut iter) =
+            pool_guard.get_pool_iterator(shard_uid)
         {
             #[cfg(feature = "test_features")]
             let skip_verification = matches!(
@@ -459,16 +465,53 @@ impl ChunkProducer {
             #[cfg(not(feature = "test_features"))]
             let skip_verification = false;
 
-            if skip_verification || ProtocolFeature::Spice.enabled(protocol_version) {
-                // TODO(spice): properly implement transaction preparation to respect limits
+            if skip_verification {
                 let mut res = vec![];
                 while let Some(iter) = iter.next() {
                     res.push(iter.next().unwrap());
                 }
-                PreparedTransactions {
-                    transactions: res,
-                    limited_by: PrepareTransactionsLimit::NoMoreTxsInPool,
-                }
+                (
+                    PreparedTransactions {
+                        transactions: res,
+                        limited_by: PrepareTransactionsLimit::NoMoreTxsInPool,
+                    },
+                    Vec::new(),
+                )
+            } else if ProtocolFeature::Spice.enabled(protocol_version) {
+                // SPICE path: use prepare_transactions_extra with pending transaction queue
+                // constraints. Use the last certified block's ChunkExtra for
+                // state validation (the certified block is guaranteed to have
+                // been executed, so its state root is available).
+                let certified_header =
+                    get_last_certified_block_header(&self.chain, &prev_block.hash())?;
+                let certified_chunk_extra = self
+                    .chain
+                    .chunk_store()
+                    .get_chunk_extra(certified_header.hash(), &shard_uid)?;
+                let trie = self.runtime_adapter.get_trie_for_shard(
+                    shard_id,
+                    certified_header.hash(),
+                    *certified_chunk_extra.state_root(),
+                    true,
+                )?;
+                let trie = trie.recording_reads_new_recorder();
+                let state_update = TrieUpdate::new(trie);
+                let prev_block_context =
+                    PrepareTransactionsBlockContext::new(prev_block, &*self.epoch_manager)?;
+                let mut session =
+                    PendingTxSession::new(Arc::clone(&self.pending_transaction_queue), shard_uid);
+                let (prepared, skipped) = self.runtime_adapter.prepare_transactions_extra(
+                    state_update,
+                    shard_id,
+                    prev_block_context,
+                    &mut iter,
+                    chain_validate,
+                    std::collections::HashSet::new(),
+                    &mut |tx, has_contract| session.check_pending(tx, has_contract),
+                    self.chunk_transactions_time_limit.get(),
+                    None,
+                )?;
+                (prepared, skipped.0)
             } else {
                 let storage_config = RuntimeStorageConfig {
                     state_root: *chunk_extra.state_root(),
@@ -478,22 +521,29 @@ impl ChunkProducer {
                 };
                 let prev_block_context =
                     PrepareTransactionsBlockContext::new(prev_block, &*self.epoch_manager)?;
-                self.runtime_adapter.prepare_transactions(
-                    storage_config,
-                    shard_id,
-                    prev_block_context,
-                    &mut iter,
-                    chain_validate,
-                    self.chunk_transactions_time_limit.get(),
-                )?
+                (
+                    self.runtime_adapter.prepare_transactions(
+                        storage_config,
+                        shard_id,
+                        prev_block_context,
+                        &mut iter,
+                        chain_validate,
+                        self.chunk_transactions_time_limit.get(),
+                    )?,
+                    Vec::new(),
+                )
             }
         } else {
-            PreparedTransactions::new()
+            (PreparedTransactions::new(), Vec::new())
         };
-        // Reintroduce valid transactions back to the pool. They will be removed when the chunk is
-        // included into the block.
+        // Reintroduce valid transactions back to the pool. They will be removed
+        // when the chunk is included into the block.
         let reintroduced_count = pool_guard
             .reintroduce_transactions(shard_uid, prepared_transactions.transactions.clone());
+        // Reintroduce skipped transactions (from pending transaction queue constraints) back to pool.
+        if !skipped_transactions.is_empty() {
+            pool_guard.reintroduce_transactions(shard_uid, skipped_transactions);
+        }
 
         if reintroduced_count < prepared_transactions.transactions.len() {
             tracing::debug!(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -562,20 +562,17 @@ impl Client {
         let prev_block_header = self.chain.get_block_header(block.header().prev_hash())?;
         let gas_price = prev_block_header.next_gas_price();
 
-        // Remove certified chunks (core statements in this block).
-        {
+        // Remove newly certified blocks from the pending transaction queue.
+        let prev_uncertified =
+            self.chain.spice_core_reader.get_uncertified_chunks(block.header().prev_hash())?;
+        let certified_block_hashes = near_chain::spice_core::find_newly_certified_block_hashes(
+            &prev_uncertified,
+            block.spice_core_statements(),
+        );
+        if !certified_block_hashes.is_empty() {
             let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
-            for (chunk_id, _) in block.spice_core_statements().iter_execution_results() {
-                let cert_epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
-                let shard_uid = shard_id_to_uid(
-                    self.epoch_manager.as_ref(),
-                    chunk_id.shard_id,
-                    &cert_epoch_id,
-                )?;
-                let Some(queue) = ptq.get_mut(&shard_uid) else {
-                    continue;
-                };
-                queue.remove_certified_chunk(&chunk_id.block_hash);
+            for block_hash in &certified_block_hashes {
+                ptq.remove_certified_block(block_hash);
             }
         }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -560,8 +560,6 @@ impl Client {
         let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         let config = self.runtime_adapter.get_runtime_config(protocol_version);
-        let prev_block_header = self.chain.get_block_header(block.header().prev_hash())?;
-        let gas_price = prev_block_header.next_gas_price();
 
         // Remove newly certified blocks from the pending transaction queue.
         let prev_uncertified =
@@ -576,6 +574,7 @@ impl Client {
         }
 
         // Add new block's chunk transactions.
+        let gas_price = self.chain.get_block_header(block.header().prev_hash())?.next_gas_price();
         for chunk_header in block.chunks().iter_new() {
             let shard_id = chunk_header.shard_id();
             let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, &epoch_id)?;

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -599,18 +599,86 @@ impl Client {
 
     /// Re-initialize the pending transaction queue from uncertified chunks for the given chain head.
     /// Called on startup and after reorgs.
-    ///
-    /// TODO(spice): implement once PendingTransactionQueue has real logic.
     fn reinitialize_pending_transaction_queue(
         pending_transaction_queue: &Mutex<ShardedPendingTransactionQueue>,
-        _chain: &Chain,
-        _epoch_manager: &dyn EpochManagerAdapter,
-        _runtime_adapter: &dyn RuntimeAdapter,
-        _shard_tracker: &ShardTracker,
-        _head_hash: &CryptoHash,
+        chain: &Chain,
+        epoch_manager: &dyn EpochManagerAdapter,
+        runtime_adapter: &dyn RuntimeAdapter,
+        shard_tracker: &ShardTracker,
+        head_hash: &CryptoHash,
     ) -> Result<(), Error> {
         let mut ptq = pending_transaction_queue.lock();
         ptq.clear();
+
+        let head_block = chain.get_block(head_hash)?;
+        if !head_block.is_spice_block() {
+            return Ok(());
+        }
+
+        let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
+        let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
+        for chunk_info in &uncertified_chunks {
+            uncertified_block_hashes.insert(chunk_info.chunk_id.block_hash);
+        }
+
+        let total_blocks = uncertified_block_hashes.len();
+        let mut loaded_blocks = 0usize;
+        for block_hash in &uncertified_block_hashes {
+            let block = match chain.get_block(block_hash) {
+                Ok(block) => block,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "client",
+                        ?block_hash,
+                        ?err,
+                        "failed to load block for pending transaction queue initialization"
+                    );
+                    continue;
+                }
+            };
+            let Ok(epoch_id) = epoch_manager.get_epoch_id(block_hash) else {
+                continue;
+            };
+            let Ok(protocol_version) = epoch_manager.get_epoch_protocol_version(&epoch_id) else {
+                continue;
+            };
+            let config = runtime_adapter.get_runtime_config(protocol_version);
+            let Ok(prev_header) = chain.get_block_header(block.header().prev_hash()) else {
+                continue;
+            };
+            let gas_price = prev_header.next_gas_price();
+
+            for chunk_header in block.chunks().iter_new() {
+                let shard_id = chunk_header.shard_id();
+                let Ok(shard_uid) = shard_id_to_uid(epoch_manager, shard_id, &epoch_id) else {
+                    continue;
+                };
+                if !shard_tracker
+                    .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
+                {
+                    continue;
+                }
+                let Ok(chunk) = chain.get_chunk(&chunk_header.chunk_hash()) else {
+                    continue;
+                };
+                let transactions = chunk.to_transactions();
+                ptq.get_or_create(shard_uid).add_chunk_transactions(
+                    *block_hash,
+                    transactions,
+                    &config,
+                    gas_price,
+                );
+            }
+            loaded_blocks += 1;
+        }
+        if loaded_blocks < total_blocks {
+            tracing::warn!(
+                target: "client",
+                loaded_blocks,
+                total_blocks,
+                "pending transaction queue reinitialized with incomplete uncertified blocks"
+            );
+        }
         Ok(())
     }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -33,6 +33,7 @@ use near_chain::chain::{
 use near_chain::orphan::OrphanMissingChunks;
 use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::resharding::types::ReshardingSender;
+use near_chain::spice_core::find_newly_certified_block_hashes;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::test_utils::format_hash;
 use near_chain::types::{ChainConfig, LatestKnown, RuntimeAdapter};
@@ -565,10 +566,8 @@ impl Client {
         // Remove newly certified blocks from the pending transaction queue.
         let prev_uncertified =
             self.chain.spice_core_reader.get_uncertified_chunks(block.header().prev_hash())?;
-        let certified_block_hashes = near_chain::spice_core::find_newly_certified_block_hashes(
-            &prev_uncertified,
-            block.spice_core_statements(),
-        );
+        let certified_block_hashes =
+            find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
         if !certified_block_hashes.is_empty() {
             let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
             for block_hash in &certified_block_hashes {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -607,13 +607,11 @@ impl Client {
         shard_tracker: &ShardTracker,
         head_hash: &CryptoHash,
     ) -> Result<(), Error> {
-        let mut ptq = pending_transaction_queue.lock();
-        ptq.clear();
-
         let head_block = chain.get_block(head_hash)?;
         if !head_block.is_spice_block() {
             return Ok(());
         }
+        pending_transaction_queue.lock().clear();
 
         let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
         let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
@@ -662,7 +660,7 @@ impl Client {
                     continue;
                 };
                 let transactions = chunk.to_transactions();
-                ptq.get_or_create(shard_uid).add_chunk_transactions(
+                pending_transaction_queue.lock().get_or_create(shard_uid).add_chunk_transactions(
                     *block_hash,
                     transactions,
                     &config,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -598,86 +598,18 @@ impl Client {
 
     /// Re-initialize the pending transaction queue from uncertified chunks for the given chain head.
     /// Called on startup and after reorgs.
+    ///
+    /// TODO(spice): implement once PendingTransactionQueue has real logic.
     fn reinitialize_pending_transaction_queue(
         pending_transaction_queue: &Mutex<ShardedPendingTransactionQueue>,
-        chain: &Chain,
-        epoch_manager: &dyn EpochManagerAdapter,
-        runtime_adapter: &dyn RuntimeAdapter,
-        shard_tracker: &ShardTracker,
-        head_hash: &CryptoHash,
+        _chain: &Chain,
+        _epoch_manager: &dyn EpochManagerAdapter,
+        _runtime_adapter: &dyn RuntimeAdapter,
+        _shard_tracker: &ShardTracker,
+        _head_hash: &CryptoHash,
     ) -> Result<(), Error> {
         let mut ptq = pending_transaction_queue.lock();
         ptq.clear();
-
-        let head_block = chain.get_block(head_hash)?;
-        if !head_block.is_spice_block() {
-            return Ok(());
-        }
-
-        let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
-        let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
-        for chunk_info in &uncertified_chunks {
-            uncertified_block_hashes.insert(chunk_info.chunk_id.block_hash);
-        }
-
-        let total_blocks = uncertified_block_hashes.len();
-        let mut loaded_blocks = 0usize;
-        for block_hash in &uncertified_block_hashes {
-            let block = match chain.get_block(block_hash) {
-                Ok(block) => block,
-                Err(err) => {
-                    tracing::warn!(
-                        target: "client",
-                        ?block_hash,
-                        ?err,
-                        "failed to load block for pending transaction queue initialization"
-                    );
-                    continue;
-                }
-            };
-            let Ok(epoch_id) = epoch_manager.get_epoch_id(block_hash) else {
-                continue;
-            };
-            let Ok(protocol_version) = epoch_manager.get_epoch_protocol_version(&epoch_id) else {
-                continue;
-            };
-            let config = runtime_adapter.get_runtime_config(protocol_version);
-            let Ok(prev_header) = chain.get_block_header(block.header().prev_hash()) else {
-                continue;
-            };
-            let gas_price = prev_header.next_gas_price();
-
-            for chunk_header in block.chunks().iter_new() {
-                let shard_id = chunk_header.shard_id();
-                let Ok(shard_uid) = shard_id_to_uid(epoch_manager, shard_id, &epoch_id) else {
-                    continue;
-                };
-                if !shard_tracker
-                    .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
-                {
-                    continue;
-                }
-                let Ok(chunk) = chain.get_chunk(&chunk_header.chunk_hash()) else {
-                    continue;
-                };
-                let transactions = chunk.to_transactions();
-                ptq.get_or_create(shard_uid).add_chunk_transactions(
-                    *block_hash,
-                    transactions,
-                    &config,
-                    gas_price,
-                );
-            }
-            loaded_blocks += 1;
-        }
-        if loaded_blocks < total_blocks {
-            tracing::warn!(
-                target: "client",
-                loaded_blocks,
-                total_blocks,
-                "pending transaction queue reinitialized with incomplete uncertified blocks"
-            );
-        }
         Ok(())
     }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -9,6 +9,7 @@ use crate::chunk_producer::AdvProduceChunksMode;
 use crate::chunk_producer::ChunkProducer;
 use crate::client_actor::ClientSenderForClient;
 use crate::debug::BlockProductionTracker;
+use crate::pending_transaction_queue::ShardedPendingTransactionQueue;
 use crate::spice_timer::SpiceTimer;
 use crate::stateless_validation::chunk_endorsement::ChunkEndorsementTracker;
 use crate::stateless_validation::chunk_validation_actor::ChunkValidationSender;
@@ -73,6 +74,7 @@ use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::{CatchupStatusView, DroppedReason};
+use parking_lot::Mutex;
 use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -389,7 +391,26 @@ impl Client {
         );
 
         let chunk_distribution_network = ChunkDistributionNetwork::from_config(&config);
-        Ok(Self {
+
+        // Initialize pending transaction queue from uncertified chunks for the chain head.
+        if let Ok(head) = chain.head() {
+            if let Err(err) = Self::reinitialize_pending_transaction_queue(
+                &chunk_producer.pending_transaction_queue,
+                &chain,
+                epoch_manager.as_ref(),
+                runtime_adapter.as_ref(),
+                &shard_tracker,
+                &head.last_block_hash,
+            ) {
+                tracing::debug!(
+                    target: "client",
+                    ?err,
+                    "pending transaction queue initialization on startup failed"
+                );
+            }
+        }
+
+        let client = Self {
             #[cfg(feature = "test_features")]
             adv_produce_blocks: None,
             #[cfg(feature = "sandbox")]
@@ -438,7 +459,8 @@ impl Client {
             chunk_producer_accounts_cache: None,
             shadow_validation_reed_solomon: OnceLock::new(),
             block_notification_watch_sender,
-        })
+        };
+        Ok(client)
     }
 
     // Checks if it's been at least `stall_timeout` since the last time the head was updated, or
@@ -524,6 +546,137 @@ impl Client {
                             "reintroduced transactions");
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Add a new block's transactions to the pending transaction queue and remove certified chunks.
+    /// Called on BlockStatus::Next.
+    fn update_pending_transaction_queue_for_block(&self, block: &Block) -> Result<(), Error> {
+        if !block.is_spice_block() {
+            return Ok(());
+        }
+        let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let config = self.runtime_adapter.get_runtime_config(protocol_version);
+        let prev_block_header = self.chain.get_block_header(block.header().prev_hash())?;
+        let gas_price = prev_block_header.next_gas_price();
+        let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
+
+        // Remove certified chunks (core statements in this block).
+        for (chunk_id, _) in block.spice_core_statements().iter_execution_results() {
+            let cert_epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
+            let shard_uid =
+                shard_id_to_uid(self.epoch_manager.as_ref(), chunk_id.shard_id, &cert_epoch_id)?;
+            let Some(queue) = ptq.get_mut(&shard_uid) else {
+                continue;
+            };
+            queue.remove_certified_chunk(&chunk_id.block_hash);
+        }
+
+        // Add new block's chunk transactions.
+        for chunk_header in block.chunks().iter_new() {
+            let shard_id = chunk_header.shard_id();
+            let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, &epoch_id)?;
+            if !self
+                .shard_tracker
+                .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
+            {
+                continue;
+            }
+            let chunk = self.chain.get_chunk(&chunk_header.chunk_hash())?;
+            let transactions = chunk.to_transactions();
+            ptq.get_or_create(shard_uid).add_chunk_transactions(
+                *block.hash(),
+                transactions,
+                &config,
+                gas_price,
+            );
+        }
+        Ok(())
+    }
+
+    /// Re-initialize the pending transaction queue from uncertified chunks for the given chain head.
+    /// Called on startup and after reorgs.
+    fn reinitialize_pending_transaction_queue(
+        pending_transaction_queue: &Mutex<ShardedPendingTransactionQueue>,
+        chain: &Chain,
+        epoch_manager: &dyn EpochManagerAdapter,
+        runtime_adapter: &dyn RuntimeAdapter,
+        shard_tracker: &ShardTracker,
+        head_hash: &CryptoHash,
+    ) -> Result<(), Error> {
+        let mut ptq = pending_transaction_queue.lock();
+        ptq.clear();
+
+        let head_block = chain.get_block(head_hash)?;
+        if !head_block.is_spice_block() {
+            return Ok(());
+        }
+
+        let uncertified_chunks = chain.spice_core_reader.get_uncertified_chunks(head_hash)?;
+        let mut uncertified_block_hashes: HashSet<CryptoHash> = HashSet::new();
+        for chunk_info in &uncertified_chunks {
+            uncertified_block_hashes.insert(chunk_info.chunk_id.block_hash);
+        }
+
+        let total_blocks = uncertified_block_hashes.len();
+        let mut loaded_blocks = 0usize;
+        for block_hash in &uncertified_block_hashes {
+            let block = match chain.get_block(block_hash) {
+                Ok(block) => block,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "client",
+                        ?block_hash,
+                        ?err,
+                        "failed to load block for pending transaction queue initialization"
+                    );
+                    continue;
+                }
+            };
+            let Ok(epoch_id) = epoch_manager.get_epoch_id(block_hash) else {
+                continue;
+            };
+            let Ok(protocol_version) = epoch_manager.get_epoch_protocol_version(&epoch_id) else {
+                continue;
+            };
+            let config = runtime_adapter.get_runtime_config(protocol_version);
+            let Ok(prev_header) = chain.get_block_header(block.header().prev_hash()) else {
+                continue;
+            };
+            let gas_price = prev_header.next_gas_price();
+
+            for chunk_header in block.chunks().iter_new() {
+                let shard_id = chunk_header.shard_id();
+                let Ok(shard_uid) = shard_id_to_uid(epoch_manager, shard_id, &epoch_id) else {
+                    continue;
+                };
+                if !shard_tracker
+                    .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
+                {
+                    continue;
+                }
+                let Ok(chunk) = chain.get_chunk(&chunk_header.chunk_hash()) else {
+                    continue;
+                };
+                let transactions = chunk.to_transactions();
+                ptq.get_or_create(shard_uid).add_chunk_transactions(
+                    *block_hash,
+                    transactions,
+                    &config,
+                    gas_price,
+                );
+            }
+            loaded_blocks += 1;
+        }
+        if loaded_blocks < total_blocks {
+            tracing::warn!(
+                target: "client",
+                loaded_blocks,
+                total_blocks,
+                "pending transaction queue reinitialized with incomplete uncertified blocks"
+            );
         }
         Ok(())
     }
@@ -1734,6 +1887,14 @@ impl Client {
                         );
                     }
                 }
+                // Update pending transaction queue: remove certified chunks, add new block's txs.
+                if let Err(err) = self.update_pending_transaction_queue_for_block(block) {
+                    tracing::error!(
+                        target: "client",
+                        ?err,
+                        "updating pending transaction queue for block failed"
+                    );
+                }
             }
             BlockStatus::Fork => {
                 // If it's a fork, no need to reconcile transactions or produce chunks.
@@ -1797,6 +1958,22 @@ impl Client {
                             }
                         }
                     }
+                }
+
+                // Re-initialize pending transaction queue from uncertified chunks for the new head.
+                if let Err(err) = Self::reinitialize_pending_transaction_queue(
+                    &self.chunk_producer.pending_transaction_queue,
+                    &self.chain,
+                    self.epoch_manager.as_ref(),
+                    self.runtime_adapter.as_ref(),
+                    &self.shard_tracker,
+                    block.hash(),
+                ) {
+                    tracing::error!(
+                        target: "client",
+                        ?err,
+                        "re-initializing pending transaction queue after reorg failed"
+                    );
                 }
             }
         };

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -402,7 +402,7 @@ impl Client {
                 &shard_tracker,
                 &head.last_block_hash,
             ) {
-                tracing::debug!(
+                tracing::error!(
                     target: "client",
                     ?err,
                     "pending transaction queue initialization on startup failed"

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -557,9 +557,6 @@ impl Client {
         if !block.is_spice_block() {
             return Ok(());
         }
-        let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        let config = self.runtime_adapter.get_runtime_config(protocol_version);
 
         // Remove newly certified blocks from the pending transaction queue.
         let prev_uncertified =
@@ -574,6 +571,9 @@ impl Client {
         }
 
         // Add new block's chunk transactions.
+        let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let config = self.runtime_adapter.get_runtime_config(protocol_version);
         let gas_price = self.chain.get_block_header(block.header().prev_hash())?.next_gas_price();
         for chunk_header in block.chunks().iter_new() {
             let shard_id = chunk_header.shard_id();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -561,17 +561,22 @@ impl Client {
         let config = self.runtime_adapter.get_runtime_config(protocol_version);
         let prev_block_header = self.chain.get_block_header(block.header().prev_hash())?;
         let gas_price = prev_block_header.next_gas_price();
-        let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
 
         // Remove certified chunks (core statements in this block).
-        for (chunk_id, _) in block.spice_core_statements().iter_execution_results() {
-            let cert_epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
-            let shard_uid =
-                shard_id_to_uid(self.epoch_manager.as_ref(), chunk_id.shard_id, &cert_epoch_id)?;
-            let Some(queue) = ptq.get_mut(&shard_uid) else {
-                continue;
-            };
-            queue.remove_certified_chunk(&chunk_id.block_hash);
+        {
+            let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
+            for (chunk_id, _) in block.spice_core_statements().iter_execution_results() {
+                let cert_epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
+                let shard_uid = shard_id_to_uid(
+                    self.epoch_manager.as_ref(),
+                    chunk_id.shard_id,
+                    &cert_epoch_id,
+                )?;
+                let Some(queue) = ptq.get_mut(&shard_uid) else {
+                    continue;
+                };
+                queue.remove_certified_chunk(&chunk_id.block_hash);
+            }
         }
 
         // Add new block's chunk transactions.
@@ -586,6 +591,7 @@ impl Client {
             }
             let chunk = self.chain.get_chunk(&chunk_header.chunk_hash())?;
             let transactions = chunk.to_transactions();
+            let mut ptq = self.chunk_producer.pending_transaction_queue.lock();
             ptq.get_or_create(shard_uid).add_chunk_transactions(
                 *block.hash(),
                 transactions,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -13,6 +13,7 @@ use crate::client::{CatchupState, Client, EPOCH_START_INFO_BLOCKS};
 use crate::config_updater::ConfigUpdater;
 use crate::debug::new_network_info_view;
 use crate::info::{InfoHelper, display_sync_status};
+use crate::pending_transaction_queue::ShardedPendingTransactionQueue;
 use crate::stateless_validation::chunk_endorsement::ChunkEndorsementTracker;
 use crate::stateless_validation::chunk_validation_actor::{
     ChunkValidationActor, ChunkValidationSender,
@@ -144,6 +145,7 @@ fn wait_until_genesis(genesis_time: &Utc) {
 pub struct StartClientResult {
     pub client_actor: TokioRuntimeHandle<ClientActor>,
     pub tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    pub pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
     pub chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
     pub chunk_validation_actor: MultithreadRuntimeHandle<ChunkValidationActor>,
 }
@@ -268,6 +270,8 @@ pub fn start_client(
     )
     .unwrap();
     let tx_pool = client_actor_inner.client.chunk_producer.sharded_tx_pool.clone();
+    let pending_transaction_queue =
+        client_actor_inner.client.chunk_producer.pending_transaction_queue.clone();
     let chunk_endorsement_tracker =
         Arc::clone(&client_actor_inner.client.chunk_endorsement_tracker);
     let client_actor = actor_system.spawn_tokio_actor(client_actor_inner);
@@ -280,6 +284,7 @@ pub fn start_client(
     StartClientResult {
         client_actor,
         tx_pool,
+        pending_transaction_queue,
         chunk_endorsement_tracker,
         chunk_validation_actor: chunk_validation_actor_addr,
     }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -50,6 +50,7 @@ pub mod debug;
 pub mod gc_actor;
 mod info;
 pub mod metrics;
+pub mod pending_transaction_queue;
 mod prepare_transactions;
 mod rpc_handler;
 pub mod spice_chunk_validator_actor;

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -2,12 +2,35 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use near_chain::types::{HasContract, PendingConstraints, PendingTxCheckResult};
+use near_crypto::PublicKey;
 use near_parameters::RuntimeConfig;
+use near_primitives::action::Action;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::Balance;
+use near_primitives::types::{AccountId, Balance, Nonce, NonceIndex};
+use node_runtime::config::tx_cost;
 use parking_lot::Mutex;
+
+/// Checked subtraction that falls back to `Default::default()` on underflow,
+/// logging an error and firing a debug_assert so tests catch the invariant violation.
+macro_rules! checked_sub_or_default {
+    ($a:expr, $b:expr, $msg:expr) => {
+        match ($a).checked_sub($b) {
+            Some(v) => v,
+            None => {
+                debug_assert!(false, $msg);
+                tracing::error!(target: "client", $msg);
+                Default::default()
+            }
+        }
+    };
+}
+
+/// Maximum number of access key transactions allowed for accounts with contracts.
+/// Per NEP-611, accounts with deployed contracts cannot have more than P_MAX
+/// pending access key transactions across all uncertified blocks.
+pub const P_MAX: usize = 4;
 
 /// Maps ShardUId -> per-shard PendingTransactionQueue.
 pub struct ShardedPendingTransactionQueue {
@@ -44,35 +67,305 @@ impl ShardedPendingTransactionQueue {
 
 /// Per-shard pending transaction queue. Tracks transactions that have been
 /// included in blocks but not yet certified (executed).
-///
-/// This is a no-op stub. The real implementation will maintain per-account
-/// balance/nonce/count aggregates across uncertified chunks.
-pub struct PendingTransactionQueue;
+pub struct PendingTransactionQueue {
+    /// Per-chunk aggregate data, keyed by block hash (since SpiceChunkId
+    /// is (block_hash, shard_id) and the shard is implicit).
+    chunks: HashMap<CryptoHash, PendingChunkData>,
+    /// Per-account aggregates (P_MAX counts, balance commitments).
+    pending_accounts: HashMap<AccountId, PendingAccount>,
+    /// Per-nonce-index nonce tracking.
+    pending_nonces: HashMap<(AccountId, PublicKey, Option<NonceIndex>), PendingNonce>,
+    /// Per-gas-key cost. Includes gas_key_cost from gas key txs + WithdrawFromGasKey amounts.
+    pending_gas_key_costs: HashMap<(AccountId, PublicKey), Balance>,
+}
+
+/// Nonce tracking for a single (account, key, nonce_index).
+struct PendingNonce {
+    max_nonce: Nonce,
+    /// Number of chunks contributing to this entry. When this drops to zero
+    /// on chunk removal, the entry is removed.
+    chunk_count: usize,
+}
+
+/// Per-chunk aggregate. No individual transaction records stored.
+struct PendingChunkData {
+    /// Per-account aggregates for this chunk.
+    accounts: HashMap<AccountId, PendingAccount>,
+    /// Per-nonce-index max nonce for this chunk.
+    nonces: HashMap<(AccountId, PublicKey, Option<NonceIndex>), Nonce>,
+    /// Per-gas-key costs for this chunk (gas_key_cost + WithdrawFromGasKey).
+    gas_key_costs: HashMap<(AccountId, PublicKey), Balance>,
+}
+
+/// Aggregate for a set of transactions, per account.
+/// Used both per-chunk and as pending transaction queue totals. Supports add/subtract.
+#[derive(Clone, Default)]
+struct PendingAccount {
+    access_key_tx_count: usize,
+    deploy_tx_count: usize,
+    /// Access key total_cost + gas key deposit_cost.
+    paid_from_balance: Balance,
+}
+
+impl PendingAccount {
+    fn add(&mut self, other: &PendingAccount) {
+        self.access_key_tx_count += other.access_key_tx_count;
+        self.deploy_tx_count += other.deploy_tx_count;
+        self.paid_from_balance = self.paid_from_balance.saturating_add(other.paid_from_balance);
+    }
+
+    fn subtract(&mut self, other: &PendingAccount) {
+        self.access_key_tx_count = checked_sub_or_default!(
+            self.access_key_tx_count,
+            other.access_key_tx_count,
+            "access_key_tx_count underflow in pending transaction queue subtract"
+        );
+        self.deploy_tx_count = checked_sub_or_default!(
+            self.deploy_tx_count,
+            other.deploy_tx_count,
+            "deploy_tx_count underflow in pending transaction queue subtract"
+        );
+        self.paid_from_balance = checked_sub_or_default!(
+            self.paid_from_balance,
+            other.paid_from_balance,
+            "paid_from_balance underflow in pending transaction queue subtract"
+        );
+    }
+
+    fn is_zero(&self) -> bool {
+        self.access_key_tx_count == 0
+            && self.deploy_tx_count == 0
+            && self.paid_from_balance.is_zero()
+    }
+}
+
+/// Returns true if the action is a deploy-like action per NEP-611:
+/// DeployContract, UseGlobalContract, DeterministicStateInit, or
+/// Delegate wrapping a deploy-like action.
+fn is_deploy_like_action(action: &Action) -> bool {
+    match action {
+        Action::DeployContract(_)
+        | Action::DeployGlobalContract(_)
+        | Action::UseGlobalContract(_)
+        | Action::DeterministicStateInit(_) => true,
+        Action::Delegate(signed_delegate) => {
+            signed_delegate.delegate_action.get_actions().iter().any(is_deploy_like_action)
+        }
+        Action::CreateAccount(_)
+        | Action::FunctionCall(_)
+        | Action::Transfer(_)
+        | Action::Stake(_)
+        | Action::AddKey(_)
+        | Action::DeleteKey(_)
+        | Action::DeleteAccount(_)
+        | Action::TransferToGasKey(_)
+        | Action::WithdrawFromGasKey(_) => false,
+    }
+}
+
+/// Returns true if any action in the list is deploy-like.
+fn has_deploy_action(actions: &[Action]) -> bool {
+    actions.iter().any(is_deploy_like_action)
+}
 
 impl PendingTransactionQueue {
     pub fn new() -> Self {
-        Self
+        Self {
+            chunks: HashMap::new(),
+            pending_accounts: HashMap::new(),
+            pending_nonces: HashMap::new(),
+            pending_gas_key_costs: HashMap::new(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        true
+        self.chunks.is_empty()
+            && self.pending_accounts.is_empty()
+            && self.pending_nonces.is_empty()
+            && self.pending_gas_key_costs.is_empty()
     }
 
+    /// Add transactions from a newly accepted block's chunk.
     pub fn add_chunk_transactions(
         &mut self,
-        _block_hash: CryptoHash,
-        _transactions: &[SignedTransaction],
-        _config: &RuntimeConfig,
-        _gas_price: Balance,
+        block_hash: CryptoHash,
+        transactions: &[SignedTransaction],
+        config: &RuntimeConfig,
+        gas_price: Balance,
     ) {
+        let mut chunk_data = PendingChunkData {
+            accounts: HashMap::new(),
+            nonces: HashMap::new(),
+            gas_key_costs: HashMap::new(),
+        };
+
+        for signed_tx in transactions {
+            let tx = &signed_tx.transaction;
+            let signer_id = tx.signer_id().clone();
+            let public_key = tx.public_key().clone();
+            let nonce_index = tx.nonce().nonce_index();
+            let nonce = tx.nonce().nonce();
+            let is_gas_key_tx = nonce_index.is_some();
+
+            let cost = match tx_cost(config, tx, gas_price) {
+                Ok(cost) => cost,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "client",
+                        ?e,
+                        "tx_cost failed for block transaction in pending transaction queue"
+                    );
+                    continue;
+                }
+            };
+
+            // Update per-account aggregates.
+            let chunk_account = chunk_data.accounts.entry(signer_id.clone()).or_default();
+            if is_gas_key_tx {
+                // Gas key tx: only deposit_cost is paid from account balance.
+                chunk_account.paid_from_balance =
+                    chunk_account.paid_from_balance.saturating_add(cost.deposit_cost);
+            } else {
+                // Access key tx: total_cost is paid from account balance.
+                chunk_account.access_key_tx_count += 1;
+                chunk_account.paid_from_balance =
+                    chunk_account.paid_from_balance.saturating_add(cost.total_cost);
+            }
+            if has_deploy_action(tx.actions()) {
+                chunk_account.deploy_tx_count += 1;
+            }
+
+            // Track gas key costs (gas_key_cost for gas key txs).
+            if is_gas_key_tx {
+                let gas_key_entry = chunk_data
+                    .gas_key_costs
+                    .entry((signer_id.clone(), public_key.clone()))
+                    .or_insert(Balance::ZERO);
+                *gas_key_entry = gas_key_entry.saturating_add(cost.gas_cost);
+            }
+
+            // Scan actions for WithdrawFromGasKey (affects gas key balance).
+            for action in tx.actions() {
+                if let Action::WithdrawFromGasKey(withdraw) = action {
+                    let gas_key_entry = chunk_data
+                        .gas_key_costs
+                        .entry((signer_id.clone(), withdraw.public_key.clone()))
+                        .or_insert(Balance::ZERO);
+                    *gas_key_entry = gas_key_entry.saturating_add(withdraw.amount);
+                }
+            }
+
+            // Track nonces. Done last to consume signer_id and public_key.
+            let max_nonce =
+                chunk_data.nonces.entry((signer_id, public_key, nonce_index)).or_insert(0);
+            *max_nonce = std::cmp::max(*max_nonce, nonce);
+        }
+
+        // Merge chunk data into pending transaction queue totals.
+        for (account_id, chunk_account) in &chunk_data.accounts {
+            let total_account = self.pending_accounts.entry(account_id.clone()).or_default();
+            total_account.add(chunk_account);
+        }
+        for (nonce_key, &chunk_nonce) in &chunk_data.nonces {
+            let entry = self
+                .pending_nonces
+                .entry(nonce_key.clone())
+                .or_insert(PendingNonce { max_nonce: 0, chunk_count: 0 });
+            entry.max_nonce = std::cmp::max(entry.max_nonce, chunk_nonce);
+            entry.chunk_count += 1;
+        }
+        for (gas_key, &chunk_gas_key_cost) in &chunk_data.gas_key_costs {
+            let entry = self.pending_gas_key_costs.entry(gas_key.clone()).or_insert(Balance::ZERO);
+            *entry = entry.saturating_add(chunk_gas_key_cost);
+        }
+
+        debug_assert!(
+            !self.chunks.contains_key(&block_hash),
+            "duplicate block_hash in pending transaction queue"
+        );
+        self.chunks.insert(block_hash, chunk_data);
     }
 
-    pub fn remove_certified_chunk_by_block_hash(&mut self, _block_hash: &CryptoHash) {}
+    /// Remove a certified chunk's transactions from the pending transaction queue.
+    pub fn remove_certified_chunk_by_block_hash(&mut self, block_hash: &CryptoHash) {
+        let Some(chunk_data) = self.chunks.remove(block_hash) else {
+            tracing::debug!(
+                target: "client",
+                ?block_hash,
+                "chunk not found in pending transaction queue during removal"
+            );
+            return;
+        };
 
-    pub fn clear(&mut self) {}
+        // Reverse per-account aggregates.
+        for (account_id, chunk_account) in &chunk_data.accounts {
+            if let Some(total_account) = self.pending_accounts.get_mut(account_id) {
+                total_account.subtract(chunk_account);
+                if total_account.is_zero() {
+                    self.pending_accounts.remove(account_id);
+                }
+            }
+        }
 
-    pub fn get_pending_constraints(&self, _tx: &SignedTransaction) -> PendingConstraints {
-        PendingConstraints::default()
+        // Reverse nonce tracking. Note: max_nonce is NOT recomputed on removal -- this is not an
+        // issue as chunks should become certified in order.
+        for (nonce_key, _) in &chunk_data.nonces {
+            if let Some(entry) = self.pending_nonces.get_mut(nonce_key) {
+                entry.chunk_count = checked_sub_or_default!(
+                    entry.chunk_count,
+                    1,
+                    "chunk_count underflow in remove_certified_chunk"
+                );
+                if entry.chunk_count == 0 {
+                    self.pending_nonces.remove(nonce_key);
+                }
+            }
+        }
+
+        // Reverse gas key costs.
+        for (gas_key, &chunk_gas_key_cost) in &chunk_data.gas_key_costs {
+            if let Some(entry) = self.pending_gas_key_costs.get_mut(gas_key) {
+                *entry = checked_sub_or_default!(
+                    *entry,
+                    chunk_gas_key_cost,
+                    "gas key cost underflow in remove_certified_chunk"
+                );
+                if entry.is_zero() {
+                    self.pending_gas_key_costs.remove(gas_key);
+                }
+            }
+        }
+    }
+
+    /// Clear all pending transaction data (used for reorg re-initialization).
+    pub fn clear(&mut self) {
+        self.chunks.clear();
+        self.pending_accounts.clear();
+        self.pending_nonces.clear();
+        self.pending_gas_key_costs.clear();
+    }
+
+    /// Extract constraints for a given transaction without Skip/Admit logic.
+    /// Used by the RPC handler for balance/nonce verification against certified state.
+    pub fn get_pending_constraints(&self, tx: &SignedTransaction) -> PendingConstraints {
+        let signer_id = tx.transaction.signer_id();
+        let public_key = tx.transaction.public_key();
+        let nonce_index = tx.transaction.nonce().nonce_index();
+
+        let paid_from_balance = self
+            .pending_accounts
+            .get(signer_id)
+            .map(|a| a.paid_from_balance)
+            .unwrap_or(Balance::ZERO);
+
+        let gas_key = (signer_id.clone(), public_key.clone());
+        let paid_from_gas_key =
+            self.pending_gas_key_costs.get(&gas_key).copied().unwrap_or(Balance::ZERO);
+
+        let nonce_key = (gas_key.0, gas_key.1, nonce_index);
+        let max_nonce = self.pending_nonces.get(&nonce_key).map(|n| n.max_nonce).unwrap_or(0);
+
+        PendingConstraints { paid_from_balance, paid_from_gas_key, max_nonce }
     }
 }
 
@@ -80,6 +373,7 @@ impl PendingTransactionQueue {
 /// with session-local tracking for P_MAX / deploy exclusivity constraints.
 ///
 /// This is a no-op stub that always admits transactions.
+/// The real implementation will enforce P_MAX and deploy exclusivity per NEP-611.
 pub struct PendingTxSession {
     _pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
     _shard_uid: ShardUId,
@@ -99,5 +393,159 @@ impl PendingTxSession {
         _has_contract: HasContract,
     ) -> PendingTxCheckResult {
         PendingTxCheckResult::Admit(PendingConstraints::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use near_crypto::{InMemorySigner, KeyType, Signer};
+    use near_primitives::action::TransferAction;
+    use near_primitives::transaction::SignedTransaction;
+
+    const TEST_SHARD_UID: ShardUId = ShardUId { version: 0, shard_id: 0 };
+    const TEST_GAS_PRICE: Balance = Balance::from_yoctonear(100_000_000);
+    const TEST_DEPOSIT: Balance = Balance::from_yoctonear(1);
+
+    fn test_signer() -> Signer {
+        InMemorySigner::from_seed("alice.near".parse().unwrap(), KeyType::ED25519, "seed")
+    }
+
+    fn make_transfer_tx(
+        signer: &Signer,
+        receiver: &str,
+        nonce: Nonce,
+        deposit: Balance,
+    ) -> SignedTransaction {
+        SignedTransaction::send_money(
+            nonce,
+            signer.get_account_id(),
+            receiver.parse().unwrap(),
+            signer,
+            deposit,
+            CryptoHash::default(),
+        )
+    }
+
+    fn with_shard_ptq<R>(
+        sharded: &Mutex<ShardedPendingTransactionQueue>,
+        f: impl FnOnce(&mut PendingTransactionQueue) -> R,
+    ) -> R {
+        f(sharded.lock().get_or_create(TEST_SHARD_UID))
+    }
+
+    fn add_chunk_txs(
+        sharded: &Mutex<ShardedPendingTransactionQueue>,
+        block_hash: CryptoHash,
+        txs: &[SignedTransaction],
+        config: &RuntimeConfig,
+        gas_price: Balance,
+    ) {
+        with_shard_ptq(sharded, |ptq| {
+            ptq.add_chunk_transactions(block_hash, txs, config, gas_price)
+        });
+    }
+
+    fn make_sharded_ptq() -> Arc<Mutex<ShardedPendingTransactionQueue>> {
+        Arc::new(Mutex::new(ShardedPendingTransactionQueue::new()))
+    }
+
+    #[test]
+    fn test_add_and_remove_chunk() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        let tx1 = make_transfer_tx(&signer, "bob.near", 1, TEST_DEPOSIT);
+        let tx2 = make_transfer_tx(&signer, "bob.near", 2, TEST_DEPOSIT);
+        let block_hash = CryptoHash::hash_bytes(&[1]);
+        add_chunk_txs(&sharded, block_hash, &[tx1, tx2], &config, TEST_GAS_PRICE);
+
+        with_shard_ptq(&sharded, |ptq| {
+            let account = ptq.pending_accounts.get(&signer.get_account_id()).unwrap();
+            assert_eq!(account.access_key_tx_count, 2);
+            assert!(!account.paid_from_balance.is_zero());
+        });
+        with_shard_ptq(&sharded, |ptq| ptq.remove_certified_chunk_by_block_hash(&block_hash));
+        with_shard_ptq(&sharded, |ptq| assert!(ptq.is_empty()));
+    }
+
+    #[test]
+    fn test_incremental_chunk_removal() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        let hash1 = CryptoHash::hash_bytes(&[1]);
+        let hash2 = CryptoHash::hash_bytes(&[2]);
+        let tx1 = make_transfer_tx(&signer, "bob.near", 1, TEST_DEPOSIT);
+        let tx2 = make_transfer_tx(&signer, "bob.near", 2, TEST_DEPOSIT);
+        add_chunk_txs(&sharded, hash1, &[tx1], &config, TEST_GAS_PRICE);
+        add_chunk_txs(&sharded, hash2, &[tx2], &config, TEST_GAS_PRICE);
+        let nonce_key = (signer.get_account_id(), signer.public_key(), None);
+
+        with_shard_ptq(&sharded, |ptq| {
+            assert_eq!(
+                ptq.pending_accounts.get(&signer.get_account_id()).unwrap().access_key_tx_count,
+                2
+            );
+            assert_eq!(ptq.pending_nonces.get(&nonce_key).unwrap().chunk_count, 2);
+            assert_eq!(ptq.pending_nonces.get(&nonce_key).unwrap().max_nonce, 2);
+        });
+        with_shard_ptq(&sharded, |ptq| ptq.remove_certified_chunk_by_block_hash(&hash1));
+        with_shard_ptq(&sharded, |ptq| {
+            assert_eq!(
+                ptq.pending_accounts.get(&signer.get_account_id()).unwrap().access_key_tx_count,
+                1
+            );
+            assert_eq!(ptq.pending_nonces.get(&nonce_key).unwrap().chunk_count, 1);
+        });
+        with_shard_ptq(&sharded, |ptq| ptq.remove_certified_chunk_by_block_hash(&hash2));
+        with_shard_ptq(&sharded, |ptq| assert!(ptq.is_empty()));
+    }
+
+    #[test]
+    fn test_clear() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        let tx = make_transfer_tx(&signer, "bob.near", 1, TEST_DEPOSIT);
+        add_chunk_txs(&sharded, CryptoHash::hash_bytes(&[1]), &[tx], &config, TEST_GAS_PRICE);
+
+        with_shard_ptq(&sharded, |ptq| ptq.clear());
+        with_shard_ptq(&sharded, |ptq| assert!(ptq.is_empty()));
+    }
+
+    #[test]
+    fn test_get_pending_constraints() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        let tx1 = make_transfer_tx(&signer, "bob.near", 1, TEST_DEPOSIT);
+        let expected_cost = tx_cost(&config, &tx1.transaction, TEST_GAS_PRICE).unwrap().total_cost;
+
+        // Before adding anything, constraints should be all zero/default.
+        assert!(sharded.lock().get(&TEST_SHARD_UID).is_none());
+
+        // Add a chunk with two transactions.
+        let tx2 = make_transfer_tx(&signer, "bob.near", 2, TEST_DEPOSIT);
+        let expected_cost2 = tx_cost(&config, &tx2.transaction, TEST_GAS_PRICE).unwrap().total_cost;
+        let block_hash = CryptoHash::hash_bytes(&[1]);
+        add_chunk_txs(&sharded, block_hash, &[tx1.clone(), tx2], &config, TEST_GAS_PRICE);
+        with_shard_ptq(&sharded, |ptq| {
+            assert_eq!(
+                ptq.get_pending_constraints(&tx1),
+                PendingConstraints {
+                    paid_from_balance: expected_cost.saturating_add(expected_cost2),
+                    paid_from_gas_key: Balance::ZERO,
+                    max_nonce: 2,
+                },
+            );
+        });
+
+        // After removing the chunk, constraints go back to zero.
+        with_shard_ptq(&sharded, |ptq| ptq.remove_certified_chunk_by_block_hash(&block_hash));
+        with_shard_ptq(&sharded, |ptq| {
+            assert_eq!(ptq.get_pending_constraints(&tx1), PendingConstraints::default());
+        });
     }
 }

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -367,16 +367,69 @@ impl PendingTransactionQueue {
 
         PendingConstraints { paid_from_balance, paid_from_gas_key, max_nonce }
     }
+
+    /// Query pending state for a single transaction. Extracts the counts and
+    /// constraints needed by `PendingTxSession::check_pending`. This is called
+    /// under the lock and should be fast.
+    fn query_pending_state(
+        &self,
+        signer_id: &AccountId,
+        public_key: &PublicKey,
+        nonce_index: Option<NonceIndex>,
+    ) -> PendingStateSnapshot {
+        let pending_account = self.pending_accounts.get(signer_id);
+        let access_key_tx_count = pending_account.map(|a| a.access_key_tx_count).unwrap_or(0);
+        let deploy_tx_count = pending_account.map(|a| a.deploy_tx_count).unwrap_or(0);
+        let paid_from_balance =
+            pending_account.map(|a| a.paid_from_balance).unwrap_or(Balance::ZERO);
+
+        let gas_key = (signer_id.clone(), public_key.clone());
+        let pending_gas_key_cost =
+            self.pending_gas_key_costs.get(&gas_key).copied().unwrap_or(Balance::ZERO);
+
+        let nonce_key = (gas_key.0, gas_key.1, nonce_index);
+        let max_nonce = self.pending_nonces.get(&nonce_key).map(|n| n.max_nonce).unwrap_or(0);
+
+        PendingStateSnapshot {
+            access_key_tx_count,
+            deploy_tx_count,
+            paid_from_balance,
+            max_nonce,
+            pending_gas_key_cost,
+        }
+    }
 }
 
-/// Per-chunk-production session that combines pending transaction queue state
-/// with session-local tracking for P_MAX / deploy exclusivity constraints.
+/// Snapshot of pending state for a single transaction's signer, extracted
+/// under the lock and used outside it.
+#[derive(Default)]
+struct PendingStateSnapshot {
+    access_key_tx_count: usize,
+    deploy_tx_count: usize,
+    paid_from_balance: Balance,
+    max_nonce: Nonce,
+    pending_gas_key_cost: Balance,
+}
+
+/// Per-chunk-production session. Combines pending transaction queue state with session-local tracking
+/// for constraints NOT handled by the ephemeral TrieUpdate.
 ///
-/// This is a no-op stub that always admits transactions.
-/// The real implementation will enforce P_MAX and deploy exclusivity per NEP-611.
+/// The ephemeral TrieUpdate handles within-chunk accumulation for balance
+/// (deducts cost), gas key balance (deducts gas_key_cost), and nonces
+/// (advances after each accepted tx). The session only tracks what the
+/// ephemeral state does NOT cover:
+/// - P_MAX / deploy exclusivity counts (per account)
+/// - WithdrawFromGasKey amounts (action effects not applied by ephemeral state)
+///
+/// The session holds an `Arc<Mutex<ShardedPendingTransactionQueue>>` and acquires the lock briefly
+/// per transaction rather than holding it for the entire chunk production duration. This avoids
+/// blocking block processing and RPC handlers.
 pub struct PendingTxSession {
-    _pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
-    _shard_uid: ShardUId,
+    pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
+    shard_uid: ShardUId,
+    session_access_key_tx_counts: HashMap<AccountId, usize>,
+    session_deploy_tx_counts: HashMap<AccountId, usize>,
+    session_gas_key_withdrawals: HashMap<(AccountId, PublicKey), Balance>,
 }
 
 impl PendingTxSession {
@@ -384,15 +437,102 @@ impl PendingTxSession {
         pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
         shard_uid: ShardUId,
     ) -> Self {
-        Self { _pending_transaction_queue: pending_transaction_queue, _shard_uid: shard_uid }
+        Self {
+            pending_transaction_queue,
+            shard_uid,
+            session_access_key_tx_counts: HashMap::new(),
+            session_deploy_tx_counts: HashMap::new(),
+            session_gas_key_withdrawals: HashMap::new(),
+        }
     }
 
+    /// Check if a transaction can be admitted given pending constraints.
+    /// If admitted, updates session state and returns constraints
+    /// for the runtime's balance/nonce validation.
+    ///
+    /// Acquires the PTQ lock briefly to read pending state, then releases it.
     pub fn check_pending(
         &mut self,
-        _tx: &SignedTransaction,
-        _has_contract: HasContract,
+        tx: &SignedTransaction,
+        has_contract: HasContract,
     ) -> PendingTxCheckResult {
-        PendingTxCheckResult::Admit(PendingConstraints::default())
+        let signer_id = tx.transaction.signer_id();
+        let public_key = tx.transaction.public_key();
+        let nonce_index = tx.transaction.nonce().nonce_index();
+        let is_gas_key_tx = nonce_index.is_some();
+
+        let snapshot = {
+            let guard = self.pending_transaction_queue.lock();
+            match guard.get(&self.shard_uid) {
+                Some(ptq) => ptq.query_pending_state(signer_id, public_key, nonce_index),
+                None => PendingStateSnapshot::default(),
+            }
+        };
+
+        let session_access_key_count =
+            self.session_access_key_tx_counts.get(signer_id).copied().unwrap_or(0);
+        let session_deploy_count =
+            self.session_deploy_tx_counts.get(signer_id).copied().unwrap_or(0);
+        let total_access_key_count = snapshot.access_key_tx_count + session_access_key_count;
+        let total_deploy_count = snapshot.deploy_tx_count + session_deploy_count;
+        let tx_has_deploy = has_deploy_action(tx.transaction.actions());
+
+        // Deploy exclusivity: a deploy cannot coexist with any other access
+        // key tx (including another deploy) in the pending window.
+        if !is_gas_key_tx {
+            if total_deploy_count > 0 {
+                return PendingTxCheckResult::Skip;
+            }
+            if tx_has_deploy && total_access_key_count > 0 {
+                return PendingTxCheckResult::Skip;
+            }
+        }
+
+        // P_MAX for contract accounts.
+        if has_contract == HasContract::Yes && !is_gas_key_tx && total_access_key_count >= P_MAX {
+            return PendingTxCheckResult::Skip;
+        }
+
+        // Build constraints for runtime validation.
+        let gas_key = (signer_id.clone(), public_key.clone());
+        let session_gas_key_withdrawal =
+            self.session_gas_key_withdrawals.get(&gas_key).copied().unwrap_or(Balance::ZERO);
+        let paid_from_gas_key =
+            snapshot.pending_gas_key_cost.saturating_add(session_gas_key_withdrawal);
+
+        // Update session state optimistically (assumes tx will be accepted).
+        // If the runtime subsequently rejects the tx (e.g. insufficient
+        // balance), these counts are not rolled back. This means a rejected tx
+        // may consume a P_MAX or deploy exclusivity slot for the remainder of
+        // this chunk production session. Affected transactions are reintroduced
+        // to the pool and retried in a future chunk, so this only impacts
+        // throughput under high contention, not correctness. The risk is
+        // mitigated by the fact that check_pending is called after signature
+        // verification and basic validation, so only transactions with valid
+        // signatures can reach this point -- an adversary cannot cheaply spam
+        // rejected txs to exhaust slots.
+        if !is_gas_key_tx {
+            *self.session_access_key_tx_counts.entry(signer_id.clone()).or_insert(0) += 1;
+        }
+        if tx_has_deploy {
+            *self.session_deploy_tx_counts.entry(signer_id.clone()).or_insert(0) += 1;
+        }
+        // Track WithdrawFromGasKey amounts from this tx's actions.
+        for action in tx.transaction.actions() {
+            if let Action::WithdrawFromGasKey(withdraw) = action {
+                let entry = self
+                    .session_gas_key_withdrawals
+                    .entry((signer_id.clone(), withdraw.public_key.clone()))
+                    .or_insert(Balance::ZERO);
+                *entry = entry.saturating_add(withdraw.amount);
+            }
+        }
+
+        PendingTxCheckResult::Admit(PendingConstraints {
+            paid_from_balance: snapshot.paid_from_balance,
+            paid_from_gas_key,
+            max_nonce: snapshot.max_nonce,
+        })
     }
 }
 
@@ -401,7 +541,8 @@ mod tests {
     use super::*;
 
     use near_crypto::{InMemorySigner, KeyType, Signer};
-    use near_primitives::transaction::SignedTransaction;
+    use near_primitives::action::{DeployContractAction, TransferAction};
+    use near_primitives::transaction::{SignedTransaction, TransactionNonce};
 
     const TEST_SHARD_UID: ShardUId = ShardUId { version: 0, shard_id: 0 };
     const TEST_GAS_PRICE: Balance = Balance::from_yoctonear(100_000_000);
@@ -427,11 +568,35 @@ mod tests {
         )
     }
 
-    fn with_shard_ptq<R>(
-        sharded: &Mutex<ShardedPendingTransactionQueue>,
-        f: impl FnOnce(&mut PendingTransactionQueue) -> R,
-    ) -> R {
-        f(sharded.lock().get_or_create(TEST_SHARD_UID))
+    fn make_deploy_tx(signer: &Signer, nonce: Nonce) -> SignedTransaction {
+        SignedTransaction::from_actions(
+            nonce,
+            signer.get_account_id(),
+            signer.get_account_id(),
+            signer,
+            vec![Action::DeployContract(DeployContractAction { code: vec![0u8; 10] })],
+            CryptoHash::default(),
+        )
+    }
+
+    fn make_gas_key_deploy_tx(
+        signer: &Signer,
+        nonce: Nonce,
+        nonce_index: NonceIndex,
+    ) -> SignedTransaction {
+        SignedTransaction::from_actions_v1(
+            TransactionNonce::from_nonce_and_index(nonce, nonce_index),
+            signer.get_account_id(),
+            signer.get_account_id(),
+            signer,
+            vec![Action::DeployContract(DeployContractAction { code: vec![0u8; 10] })],
+            CryptoHash::default(),
+        )
+    }
+
+    /// Wrap a sharded PTQ in Arc<Mutex<...>>.
+    fn make_sharded_ptq() -> Arc<Mutex<ShardedPendingTransactionQueue>> {
+        Arc::new(Mutex::new(ShardedPendingTransactionQueue::new()))
     }
 
     fn add_chunk_txs(
@@ -446,8 +611,15 @@ mod tests {
         });
     }
 
-    fn make_sharded_ptq() -> Arc<Mutex<ShardedPendingTransactionQueue>> {
-        Arc::new(Mutex::new(ShardedPendingTransactionQueue::new()))
+    fn with_shard_ptq<R>(
+        sharded: &Mutex<ShardedPendingTransactionQueue>,
+        f: impl FnOnce(&mut PendingTransactionQueue) -> R,
+    ) -> R {
+        f(sharded.lock().get_or_create(TEST_SHARD_UID))
+    }
+
+    fn make_session(sharded: &Arc<Mutex<ShardedPendingTransactionQueue>>) -> PendingTxSession {
+        PendingTxSession::new(Arc::clone(sharded), TEST_SHARD_UID)
     }
 
     #[test]
@@ -503,6 +675,26 @@ mod tests {
     }
 
     #[test]
+    fn test_session_p_max_enforcement() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        let txs: Vec<_> = (1..=P_MAX)
+            .map(|i| make_transfer_tx(&signer, "bob.near", i as Nonce, TEST_DEPOSIT))
+            .collect();
+        add_chunk_txs(&sharded, CryptoHash::hash_bytes(&[1]), &txs, &config, TEST_GAS_PRICE);
+        let next_tx = make_transfer_tx(&signer, "bob.near", (P_MAX + 1) as Nonce, TEST_DEPOSIT);
+
+        // The next access key tx from a contract account should be skipped.
+        let mut session = make_session(&sharded);
+        assert_eq!(session.check_pending(&next_tx, HasContract::Yes), PendingTxCheckResult::Skip);
+
+        // But from a non-contract account it should be admitted.
+        let mut session2 = make_session(&sharded);
+        assert!(matches!(session2.check_pending(&next_tx, HasContract::No), PendingTxCheckResult::Admit(_)));
+    }
+
+    #[test]
     fn test_clear() {
         let config = RuntimeConfig::test();
         let sharded = make_sharded_ptq();
@@ -512,6 +704,119 @@ mod tests {
 
         with_shard_ptq(&sharded, |ptq| ptq.clear());
         with_shard_ptq(&sharded, |ptq| assert!(ptq.is_empty()));
+    }
+
+    #[test]
+    fn test_deploy_exclusivity_pending_deploy_blocks_new_access_key_tx() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        add_chunk_txs(
+            &sharded,
+            CryptoHash::hash_bytes(&[1]),
+            &[make_deploy_tx(&signer, 1)],
+            &config,
+            TEST_GAS_PRICE,
+        );
+
+        // A non-deploy access key tx should be skipped (deploy is pending).
+        let mut session = make_session(&sharded);
+        let transfer_tx = make_transfer_tx(&signer, "bob.near", 2, TEST_DEPOSIT);
+        assert_eq!(session.check_pending(&transfer_tx, HasContract::No), PendingTxCheckResult::Skip);
+    }
+
+    #[test]
+    fn test_deploy_exclusivity_pending_access_key_tx_blocks_deploy() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        let transfer_tx = make_transfer_tx(&signer, "bob.near", 1, TEST_DEPOSIT);
+        add_chunk_txs(
+            &sharded,
+            CryptoHash::hash_bytes(&[1]),
+            &[transfer_tx],
+            &config,
+            TEST_GAS_PRICE,
+        );
+
+        // A deploy tx should be skipped (non-deploy access key tx is pending).
+        let mut session = make_session(&sharded);
+        let deploy_tx = make_deploy_tx(&signer, 2);
+        assert_eq!(session.check_pending(&deploy_tx, HasContract::No), PendingTxCheckResult::Skip);
+    }
+
+    #[test]
+    fn test_deploy_exclusivity_gas_key_deploy_blocks_access_key_tx() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        // A gas key tx with a deploy action is pending.
+        add_chunk_txs(
+            &sharded,
+            CryptoHash::hash_bytes(&[1]),
+            &[make_gas_key_deploy_tx(&signer, 1, 0)],
+            &config,
+            TEST_GAS_PRICE,
+        );
+
+        // An access key tx should be skipped (gas key deploy is pending).
+        let mut session = make_session(&sharded);
+        let transfer_tx = make_transfer_tx(&signer, "bob.near", 2, TEST_DEPOSIT);
+        assert_eq!(session.check_pending(&transfer_tx, HasContract::No), PendingTxCheckResult::Skip);
+
+        // But another gas key tx should still be admitted.
+        let gas_key_transfer = SignedTransaction::from_actions_v1(
+            TransactionNonce::from_nonce_and_index(3, 0),
+            signer.get_account_id(),
+            "bob.near".parse().unwrap(),
+            &signer,
+            vec![Action::Transfer(TransferAction { deposit: TEST_DEPOSIT })],
+            CryptoHash::default(),
+        );
+        assert!(matches!(
+            session.check_pending(&gas_key_transfer, HasContract::No),
+            PendingTxCheckResult::Admit(_)
+        ));
+    }
+
+    #[test]
+    fn test_session_accumulates_across_calls() {
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        let mut session = make_session(&sharded);
+
+        // Admit P_MAX access key txs from a contract account within a single session.
+        for i in 1..=P_MAX {
+            let tx = make_transfer_tx(&signer, "bob.near", i as Nonce, TEST_DEPOSIT);
+            assert!(
+                matches!(session.check_pending(&tx, HasContract::Yes), PendingTxCheckResult::Admit(_)),
+                "tx {} should be admitted",
+                i
+            );
+        }
+        // The (P_MAX + 1)th should be skipped.
+        let tx = make_transfer_tx(&signer, "bob.near", (P_MAX + 1) as Nonce, TEST_DEPOSIT);
+        assert_eq!(session.check_pending(&tx, HasContract::Yes), PendingTxCheckResult::Skip);
+    }
+
+    #[test]
+    fn test_constraints_include_pending_balance() {
+        let config = RuntimeConfig::test();
+        let sharded = make_sharded_ptq();
+        let signer = test_signer();
+        let tx = make_transfer_tx(&signer, "bob.near", 1, TEST_DEPOSIT);
+        let expected_cost = tx_cost(&config, &tx.transaction, TEST_GAS_PRICE).unwrap().total_cost;
+        add_chunk_txs(&sharded, CryptoHash::hash_bytes(&[1]), &[tx], &config, TEST_GAS_PRICE);
+        let mut session = make_session(&sharded);
+        let next_tx = make_transfer_tx(&signer, "bob.near", 2, TEST_DEPOSIT);
+        assert_eq!(
+            session.check_pending(&next_tx, HasContract::No),
+            PendingTxCheckResult::Admit(PendingConstraints {
+                paid_from_balance: expected_cost,
+                paid_from_gas_key: Balance::ZERO,
+                max_nonce: 1,
+            }),
+        );
     }
 
     #[test]

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use near_chain::types::{HasContract, PendingConstraints, PendingTxCheckResult};
+use near_parameters::RuntimeConfig;
+use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::ShardUId;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::Balance;
+use parking_lot::Mutex;
+
+/// Maps ShardUId -> per-shard PendingTransactionQueue.
+pub struct ShardedPendingTransactionQueue {
+    queues: HashMap<ShardUId, PendingTransactionQueue>,
+}
+
+impl ShardedPendingTransactionQueue {
+    pub fn new() -> Self {
+        Self { queues: HashMap::new() }
+    }
+
+    pub fn get_or_create(&mut self, shard_uid: ShardUId) -> &mut PendingTransactionQueue {
+        self.queues.entry(shard_uid).or_insert_with(PendingTransactionQueue::new)
+    }
+
+    pub fn get(&self, shard_uid: &ShardUId) -> Option<&PendingTransactionQueue> {
+        self.queues.get(shard_uid)
+    }
+
+    pub fn get_mut(&mut self, shard_uid: &ShardUId) -> Option<&mut PendingTransactionQueue> {
+        self.queues.get_mut(shard_uid)
+    }
+
+    pub fn clear(&mut self) {
+        self.queues.clear();
+    }
+}
+
+/// Per-shard pending transaction queue. Tracks transactions that have been
+/// included in blocks but not yet certified (executed).
+///
+/// This is a no-op stub. The real implementation will maintain per-account
+/// balance/nonce/count aggregates across uncertified chunks.
+pub struct PendingTransactionQueue;
+
+impl PendingTransactionQueue {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+
+    pub fn add_chunk_transactions(
+        &mut self,
+        _block_hash: CryptoHash,
+        _transactions: &[SignedTransaction],
+        _config: &RuntimeConfig,
+        _gas_price: Balance,
+    ) {
+    }
+
+    pub fn remove_certified_chunk(&mut self, _block_hash: &CryptoHash) {}
+
+    pub fn clear(&mut self) {}
+
+    pub fn get_pending_constraints(&self, _tx: &SignedTransaction) -> PendingConstraints {
+        PendingConstraints::default()
+    }
+}
+
+/// Per-chunk-production session that combines pending transaction queue state
+/// with session-local tracking for P_MAX / deploy exclusivity constraints.
+///
+/// This is a no-op stub that always admits transactions.
+pub struct PendingTxSession {
+    _pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
+    _shard_uid: ShardUId,
+}
+
+impl PendingTxSession {
+    pub fn new(
+        pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
+        shard_uid: ShardUId,
+    ) -> Self {
+        Self { _pending_transaction_queue: pending_transaction_queue, _shard_uid: shard_uid }
+    }
+
+    pub fn check_pending(
+        &mut self,
+        _tx: &SignedTransaction,
+        _has_contract: HasContract,
+    ) -> PendingTxCheckResult {
+        PendingTxCheckResult::Admit(PendingConstraints::default())
+    }
+}

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -450,7 +450,7 @@ impl PendingTxSession {
     /// If admitted, updates session state and returns constraints
     /// for the runtime's balance/nonce validation.
     ///
-    /// Acquires the PTQ lock briefly to read pending state, then releases it.
+    /// Acquires the pending transaction queue lock briefly to read pending state, then releases it.
     pub fn check_pending(
         &mut self,
         tx: &SignedTransaction,
@@ -594,7 +594,7 @@ mod tests {
         )
     }
 
-    /// Wrap a sharded PTQ in Arc<Mutex<...>>.
+    /// Wrap a sharded pending transaction queue in Arc<Mutex<...>>.
     fn make_sharded_ptq() -> Arc<Mutex<ShardedPendingTransactionQueue>> {
         Arc::new(Mutex::new(ShardedPendingTransactionQueue::new()))
     }

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -691,7 +691,10 @@ mod tests {
 
         // But from a non-contract account it should be admitted.
         let mut session2 = make_session(&sharded);
-        assert!(matches!(session2.check_pending(&next_tx, HasContract::No), PendingTxCheckResult::Admit(_)));
+        assert!(matches!(
+            session2.check_pending(&next_tx, HasContract::No),
+            PendingTxCheckResult::Admit(_)
+        ));
     }
 
     #[test]
@@ -722,7 +725,10 @@ mod tests {
         // A non-deploy access key tx should be skipped (deploy is pending).
         let mut session = make_session(&sharded);
         let transfer_tx = make_transfer_tx(&signer, "bob.near", 2, TEST_DEPOSIT);
-        assert_eq!(session.check_pending(&transfer_tx, HasContract::No), PendingTxCheckResult::Skip);
+        assert_eq!(
+            session.check_pending(&transfer_tx, HasContract::No),
+            PendingTxCheckResult::Skip
+        );
     }
 
     #[test]
@@ -762,7 +768,10 @@ mod tests {
         // An access key tx should be skipped (gas key deploy is pending).
         let mut session = make_session(&sharded);
         let transfer_tx = make_transfer_tx(&signer, "bob.near", 2, TEST_DEPOSIT);
-        assert_eq!(session.check_pending(&transfer_tx, HasContract::No), PendingTxCheckResult::Skip);
+        assert_eq!(
+            session.check_pending(&transfer_tx, HasContract::No),
+            PendingTxCheckResult::Skip
+        );
 
         // But another gas key tx should still be admitted.
         let gas_key_transfer = SignedTransaction::from_actions_v1(
@@ -789,7 +798,10 @@ mod tests {
         for i in 1..=P_MAX {
             let tx = make_transfer_tx(&signer, "bob.near", i as Nonce, TEST_DEPOSIT);
             assert!(
-                matches!(session.check_pending(&tx, HasContract::Yes), PendingTxCheckResult::Admit(_)),
+                matches!(
+                    session.check_pending(&tx, HasContract::Yes),
+                    PendingTxCheckResult::Admit(_)
+                ),
                 "tx {} should be admitted",
                 i
             );

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -502,15 +502,14 @@ impl PendingTxSession {
 
         // Update session state optimistically (assumes tx will be accepted).
         // If the runtime subsequently rejects the tx (e.g. insufficient
-        // balance), these counts are not rolled back. This means a rejected tx
-        // may consume a P_MAX or deploy exclusivity slot for the remainder of
-        // this chunk production session. Affected transactions are reintroduced
-        // to the pool and retried in a future chunk, so this only impacts
-        // throughput under high contention, not correctness. The risk is
-        // mitigated by the fact that check_pending is called after signature
-        // verification and basic validation, so only transactions with valid
-        // signatures can reach this point -- an adversary cannot cheaply spam
-        // rejected txs to exhaust slots.
+        // balance), these counts are not rolled back and the tx is discarded
+        // (not reintroduced to the pool). This means a rejected tx may consume
+        // a P_MAX or deploy exclusivity slot for the remainder of this chunk
+        // production session, reducing throughput under high contention. The
+        // risk is mitigated by the fact that check_pending is called after
+        // signature verification and basic validation, so only transactions
+        // with valid signatures can reach this point -- an adversary cannot
+        // cheaply spam rejected txs to exhaust slots.
         if !is_gas_key_tx {
             *self.session_access_key_tx_counts.entry(signer_id.clone()).or_insert(0) += 1;
         }

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -33,7 +33,7 @@ impl ShardedPendingTransactionQueue {
 
     pub fn remove_certified_block(&mut self, block_hash: &CryptoHash) {
         for queue in self.queues.values_mut() {
-            queue.remove_certified_chunk(block_hash);
+            queue.remove_certified_chunk_by_block_hash(block_hash);
         }
     }
 
@@ -67,7 +67,7 @@ impl PendingTransactionQueue {
     ) {
     }
 
-    pub fn remove_certified_chunk(&mut self, _block_hash: &CryptoHash) {}
+    pub fn remove_certified_chunk_by_block_hash(&mut self, _block_hash: &CryptoHash) {}
 
     pub fn clear(&mut self) {}
 

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -31,6 +31,12 @@ impl ShardedPendingTransactionQueue {
         self.queues.get_mut(shard_uid)
     }
 
+    pub fn remove_certified_block(&mut self, block_hash: &CryptoHash) {
+        for queue in self.queues.values_mut() {
+            queue.remove_certified_chunk(block_hash);
+        }
+    }
+
     pub fn clear(&mut self) {
         self.queues.clear();
     }

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -348,24 +348,16 @@ impl PendingTransactionQueue {
     /// Extract constraints for a given transaction without Skip/Admit logic.
     /// Used by the RPC handler for balance/nonce verification against certified state.
     pub fn get_pending_constraints(&self, tx: &SignedTransaction) -> PendingConstraints {
-        let signer_id = tx.transaction.signer_id();
-        let public_key = tx.transaction.public_key();
-        let nonce_index = tx.transaction.nonce().nonce_index();
-
-        let paid_from_balance = self
-            .pending_accounts
-            .get(signer_id)
-            .map(|a| a.paid_from_balance)
-            .unwrap_or(Balance::ZERO);
-
-        let gas_key = (signer_id.clone(), public_key.clone());
-        let paid_from_gas_key =
-            self.pending_gas_key_costs.get(&gas_key).copied().unwrap_or(Balance::ZERO);
-
-        let nonce_key = (gas_key.0, gas_key.1, nonce_index);
-        let max_nonce = self.pending_nonces.get(&nonce_key).map(|n| n.max_nonce).unwrap_or(0);
-
-        PendingConstraints { paid_from_balance, paid_from_gas_key, max_nonce }
+        let snapshot = self.query_pending_state(
+            tx.transaction.signer_id(),
+            tx.transaction.public_key(),
+            tx.transaction.nonce().nonce_index(),
+        );
+        PendingConstraints {
+            paid_from_balance: snapshot.paid_from_balance,
+            paid_from_gas_key: snapshot.pending_gas_key_cost,
+            max_nonce: snapshot.max_nonce,
+        }
     }
 
     /// Query pending state for a single transaction. Extracts the counts and

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -401,7 +401,6 @@ mod tests {
     use super::*;
 
     use near_crypto::{InMemorySigner, KeyType, Signer};
-    use near_primitives::action::TransferAction;
     use near_primitives::transaction::SignedTransaction;
 
     const TEST_SHARD_UID: ShardUId = ShardUId { version: 0, shard_id: 0 };

--- a/chain/client/src/prepare_transactions.rs
+++ b/chain/client/src/prepare_transactions.rs
@@ -5,7 +5,8 @@ use std::sync::atomic::AtomicBool;
 
 use near_async::time::Duration;
 use near_chain::types::{
-    PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions, RuntimeAdapter,
+    PendingTxCheckResult, PrepareTransactionsBlockContext, PrepareTransactionsLimit,
+    PreparedTransactions, RuntimeAdapter,
 };
 use near_chunks::client::ShardedTransactionPool;
 use near_client_primitives::types::Error;
@@ -136,6 +137,7 @@ impl PrepareTransactionsJob {
             &mut iter,
             &inputs.tx_validity_period_check,
             inputs.prev_chunk_tx_hashes,
+            &mut PendingTxCheckResult::always_admit(),
             inputs.time_limit,
             Some((&self).cancel.clone()),
         );

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -197,6 +197,10 @@ impl RpcHandlerActor {
 
         if self.shard_tracker.cares_about_shard_this_or_next_epoch(&head.last_block_hash, shard_id)
         {
+            // TODO(spice): get_last_certified_block_header does multiple DB reads per
+            // incoming tx (loading uncertified chunks + block headers). Cache the last
+            // certified block header for the current head, or store the last-certified
+            // hash in chain state so this is O(1).
             let (state_root, constraints) = if ProtocolFeature::Spice.enabled(protocol_version) {
                 let certified_header =
                     get_last_certified_block_header(&self.chain_store, &head.last_block_hash)?;

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -228,7 +228,7 @@ impl RpcHandlerActor {
                     Err(_) => {
                         if is_forwarded {
                             return Err(near_client_primitives::types::Error::Other(
-                                "node has not caught up yet".to_string(),
+                                "Node has not caught up yet".to_string(),
                             ));
                         } else {
                             self.forward_tx(&epoch_id, signed_tx)?;

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -2,6 +2,7 @@ use near_async::messaging::CanSend;
 use near_async::messaging::Handler;
 use near_async::{ActorSystem, messaging};
 use near_chain::check_transaction_validity_period;
+use near_chain::types::PendingConstraints;
 use near_chain::types::RuntimeAdapter;
 use near_chain::types::Tip;
 use near_chain_configs::MutableValidatorSigner;
@@ -213,6 +214,7 @@ impl RpcHandlerActor {
                     state_root,
                     &validated_tx,
                     protocol_version,
+                    &PendingConstraints::default(),
                 ) {
                     tracing::debug!(target: "client", ?err, "invalid tx");
                     return Ok(ProcessTxResponse::InvalidTx(err));

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -206,7 +206,7 @@ impl RpcHandlerActor {
                     Err(_) => {
                         if is_forwarded {
                             return Err(near_client_primitives::types::Error::Other(
-                                "node has not caught up yet".to_string(),
+                                "Node has not caught up yet".to_string(),
                             ));
                         } else {
                             self.forward_tx(&epoch_id, signed_tx)?;

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -2,6 +2,7 @@ use near_async::messaging::CanSend;
 use near_async::messaging::Handler;
 use near_async::{ActorSystem, messaging};
 use near_chain::check_transaction_validity_period;
+use near_chain::spice_core::get_last_certified_block_header;
 use near_chain::types::PendingConstraints;
 use near_chain::types::RuntimeAdapter;
 use near_chain::types::Tip;
@@ -31,6 +32,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::metrics;
+use crate::pending_transaction_queue::ShardedPendingTransactionQueue;
 use near_async::multithread::MultithreadRuntimeHandle;
 
 impl Handler<ProcessTxRequest> for RpcHandlerActor {
@@ -52,6 +54,7 @@ pub fn spawn_rpc_handler_actor(
     actor_system: ActorSystem,
     config: RpcHandlerConfig,
     tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
     shard_tracker: ShardTracker,
     validator_signer: MutableValidatorSigner,
@@ -61,6 +64,7 @@ pub fn spawn_rpc_handler_actor(
     let actor = RpcHandlerActor::new(
         config.clone(),
         tx_pool,
+        pending_transaction_queue,
         epoch_manager,
         shard_tracker,
         validator_signer,
@@ -88,6 +92,7 @@ pub struct RpcHandlerActor {
     config: RpcHandlerConfig,
 
     tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
 
     chain_store: ChainStoreAdapter,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
@@ -101,6 +106,7 @@ impl RpcHandlerActor {
     pub fn new(
         config: RpcHandlerConfig,
         tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+        pending_transaction_queue: Arc<Mutex<ShardedPendingTransactionQueue>>,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         shard_tracker: ShardTracker,
         validator_signer: MutableValidatorSigner,
@@ -112,6 +118,7 @@ impl RpcHandlerActor {
         Self {
             config,
             tx_pool,
+            pending_transaction_queue,
             validator_signer,
             chain_store,
             epoch_manager,
@@ -190,35 +197,57 @@ impl RpcHandlerActor {
 
         if self.shard_tracker.cares_about_shard_this_or_next_epoch(&head.last_block_hash, shard_id)
         {
-            if !ProtocolFeature::Spice.enabled(protocol_version) {
+            let (state_root, constraints) = if ProtocolFeature::Spice.enabled(protocol_version) {
+                let certified_header =
+                    get_last_certified_block_header(&self.chain_store, &head.last_block_hash)?;
                 let chunk_store = self.chain_store.chunk_store();
-                let state_root =
-                    match chunk_store.get_chunk_extra(&head.last_block_hash, &shard_uid) {
-                        Ok(chunk_extra) => *chunk_extra.state_root(),
-                        Err(_) => {
-                            // Not being able to fetch a state root most likely implies that we haven't
-                            //     caught up with the next epoch yet.
-                            if is_forwarded {
-                                return Err(near_client_primitives::types::Error::Other(
-                                    "Node has not caught up yet".to_string(),
-                                ));
-                            } else {
-                                self.forward_tx(&epoch_id, signed_tx)?;
-                                return Ok(ProcessTxResponse::RequestRouted);
-                            }
+                let root = match chunk_store.get_chunk_extra(certified_header.hash(), &shard_uid) {
+                    Ok(chunk_extra) => *chunk_extra.state_root(),
+                    Err(_) => {
+                        if is_forwarded {
+                            return Err(near_client_primitives::types::Error::Other(
+                                "node has not caught up yet".to_string(),
+                            ));
+                        } else {
+                            self.forward_tx(&epoch_id, signed_tx)?;
+                            return Ok(ProcessTxResponse::RequestRouted);
                         }
-                    };
-                if let Err(err) = self.runtime.can_verify_and_charge_tx(
-                    &shard_layout,
-                    gas_price,
-                    state_root,
-                    &validated_tx,
-                    protocol_version,
-                    &PendingConstraints::default(),
-                ) {
-                    tracing::debug!(target: "client", ?err, "invalid tx");
-                    return Ok(ProcessTxResponse::InvalidTx(err));
-                }
+                    }
+                };
+                let constraints = {
+                    let ptq = self.pending_transaction_queue.lock();
+                    ptq.get(&shard_uid)
+                        .map(|q| q.get_pending_constraints(&signed_tx))
+                        .unwrap_or_default()
+                };
+                (root, constraints)
+            } else {
+                let chunk_store = self.chain_store.chunk_store();
+                let root = match chunk_store.get_chunk_extra(&head.last_block_hash, &shard_uid) {
+                    Ok(chunk_extra) => *chunk_extra.state_root(),
+                    Err(_) => {
+                        if is_forwarded {
+                            return Err(near_client_primitives::types::Error::Other(
+                                "node has not caught up yet".to_string(),
+                            ));
+                        } else {
+                            self.forward_tx(&epoch_id, signed_tx)?;
+                            return Ok(ProcessTxResponse::RequestRouted);
+                        }
+                    }
+                };
+                (root, PendingConstraints::default())
+            };
+            if let Err(err) = self.runtime.can_verify_and_charge_tx(
+                &shard_layout,
+                gas_price,
+                state_root,
+                &validated_tx,
+                protocol_version,
+                &constraints,
+            ) {
+                tracing::debug!(target: "client", ?err, "invalid tx");
+                return Ok(ProcessTxResponse::InvalidTx(err));
             }
             if check_only {
                 return Ok(ProcessTxResponse::ValidTx);

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -184,6 +184,7 @@ pub fn create_test_setup_with_accounts_and_validity(
         actor_system.clone(),
         rpc_handler_config,
         client_result.tx_pool,
+        client_result.pending_transaction_queue,
         epoch_manager,
         shard_tracker,
         signer,

--- a/integration-tests/src/env/setup.rs
+++ b/integration-tests/src/env/setup.rs
@@ -203,6 +203,7 @@ fn setup(
     let StartClientResult {
         client_actor,
         tx_pool,
+        pending_transaction_queue,
         chunk_endorsement_tracker,
         chunk_validation_actor,
         ..
@@ -249,6 +250,7 @@ fn setup(
         actor_system.clone(),
         rpc_handler_config,
         tx_pool,
+        pending_transaction_queue,
         epoch_manager.clone(),
         shard_tracker.clone(),
         signer,
@@ -620,6 +622,7 @@ pub fn setup_tx_request_handler(
     RpcHandlerActor::new(
         config,
         client.chunk_producer.sharded_tx_pool.clone(),
+        client.chunk_producer.pending_transaction_queue.clone(),
         epoch_manager,
         shard_tracker,
         client.validator_signer.clone(),

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -109,7 +109,13 @@ fn setup_network_node(
     let (block_notification_watch_sender, _block_notification_watch_receiver) =
         tokio::sync::watch::channel(None);
     let adv = near_client::adversarial::Controls::default();
-    let StartClientResult { client_actor, tx_pool, chunk_endorsement_tracker, .. } = start_client(
+    let StartClientResult {
+        client_actor,
+        tx_pool,
+        pending_transaction_queue,
+        chunk_endorsement_tracker,
+        ..
+    } = start_client(
         Clock::real(),
         actor_system.clone(),
         client_config.clone(),
@@ -170,6 +176,7 @@ fn setup_network_node(
         actor_system.clone(),
         rpc_handler_config,
         tx_pool,
+        pending_transaction_queue,
         epoch_manager.clone(),
         shard_tracker.clone(),
         validator_signer.clone(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -613,6 +613,7 @@ pub async fn start_with_config_and_synchronization_impl(
     let StartClientResult {
         client_actor,
         tx_pool,
+        pending_transaction_queue,
         chunk_endorsement_tracker,
         chunk_validation_actor,
     } = start_client(
@@ -691,6 +692,7 @@ pub async fn start_with_config_and_synchronization_impl(
         actor_system.clone(),
         rpc_handler_config,
         tx_pool,
+        pending_transaction_queue,
         view_epoch_manager.clone(),
         view_shard_tracker,
         config.validator_signer.clone(),

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -28,8 +28,8 @@ use near_vm_runner::FilesystemContractRuntimeCache;
 use near_vm_runner::logic::LimitConfig;
 use node_runtime::config::tx_cost;
 use node_runtime::{
-    ApplyState, Runtime, SignedValidPeriodTransactions, TxVerdict, get_signer_and_access_key,
-    set_tx_state_changes, verify_and_charge_tx_ephemeral,
+    ApplyState, PendingConstraints, Runtime, SignedValidPeriodTransactions, TxVerdict,
+    get_signer_and_access_key, set_tx_state_changes, verify_and_charge_tx_ephemeral,
 };
 use std::collections::{HashMap, VecDeque};
 use std::iter;
@@ -471,6 +471,7 @@ impl Testbed<'_> {
             &cost,
             block_height,
             PROTOCOL_VERSION,
+            &PendingConstraints::default(),
         ) else {
             panic!("tx verification should not fail in estimator");
         };

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -233,6 +233,28 @@ pub struct ValidatorAccountsUpdate {
     pub protocol_treasury_account_id: Option<AccountId>,
 }
 
+/// Constraints from pending (included-but-not-yet-certified) transactions
+/// for balance and nonce validation during chunk production.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingConstraints {
+    /// Total balance already committed by this account's pending access key
+    /// transactions (total_cost) plus pending gas key deposit costs.
+    pub paid_from_balance: Balance,
+    /// Total gas key cost already committed by pending gas key transactions
+    /// signed with this key, plus any pending WithdrawFromGasKey amounts
+    /// targeting this key.
+    pub paid_from_gas_key: Balance,
+    /// Maximum nonce seen among pending transactions for this (account, key,
+    /// nonce_index) combination.
+    pub max_nonce: Nonce,
+}
+
+impl Default for PendingConstraints {
+    fn default() -> Self {
+        Self { paid_from_balance: Balance::ZERO, paid_from_gas_key: Balance::ZERO, max_nonce: 0 }
+    }
+}
+
 /// Outcome of transaction verification and charging.
 ///
 /// Returned by both `verify_and_charge_tx_ephemeral` and
@@ -1931,6 +1953,7 @@ impl Runtime {
                     &tx.transaction,
                     &cost,
                     Some(block_height),
+                    &PendingConstraints::default(),
                 )
             } else {
                 // Regular access key transaction
@@ -1942,6 +1965,7 @@ impl Runtime {
                     &cost,
                     Some(block_height),
                     processing_state.protocol_version,
+                    &PendingConstraints::default(),
                 )
             };
 

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -1,6 +1,6 @@
 use crate::config::{TransactionCost, total_prepaid_gas};
 use crate::near_primitives::account::Account;
-use crate::{AccessKeyUpdate, TxVerdict, VerificationResult};
+use crate::{AccessKeyUpdate, PendingConstraints, TxVerdict, VerificationResult};
 use near_crypto::PublicKey;
 use near_crypto::key_conversion::is_valid_staking_key;
 use near_parameters::RuntimeConfig;
@@ -287,6 +287,7 @@ pub fn verify_and_charge_tx_ephemeral(
     transaction_cost: &TransactionCost,
     block_height: Option<BlockHeight>,
     protocol_version: ProtocolVersion,
+    pending: &PendingConstraints,
 ) -> TxVerdict {
     // It's the caller's responsibility to NOT call this function for transactions with
     // nonce_index (i.e. gas key transactions).
@@ -311,18 +312,25 @@ pub fn verify_and_charge_tx_ephemeral(
     } = *transaction_cost;
     let account_id = tx.signer_id();
     let tx_nonce = tx.nonce().nonce();
-    if let Err(e) = verify_nonce(tx_nonce, access_key.nonce, block_height) {
+    let effective_nonce = std::cmp::max(access_key.nonce, pending.max_nonce);
+    if let Err(e) = verify_nonce(tx_nonce, effective_nonce, block_height) {
         return TxVerdict::Failed(e);
     }
 
-    let balance = account.amount();
-    let Some(new_amount) = balance.checked_sub(total_cost) else {
+    // saturating_sub is fine here: on the consensus path pending constraints
+    // are always default (zero), so the subtraction is exact. On the RPC /
+    // chunk-production path it is best-effort and does not affect consensus.
+    let available_balance = account.amount().saturating_sub(pending.paid_from_balance);
+    if available_balance < total_cost {
         return TxVerdict::Failed(InvalidTxError::NotEnoughBalance {
             signer_id: account_id.clone(),
-            balance,
+            balance: available_balance,
             cost: total_cost,
         });
-    };
+    }
+    // Debit only this tx's cost, not the pending amount (which was already
+    // charged in prior chunks and will be applied at execution time).
+    let new_amount = account.amount().checked_sub(total_cost).unwrap();
 
     let new_allowance = match check_and_compute_new_allowance(
         access_key,
@@ -388,6 +396,7 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
     tx: &Transaction,
     transaction_cost: &TransactionCost,
     block_height: Option<BlockHeight>,
+    pending: &PendingConstraints,
 ) -> TxVerdict {
     // It's the caller's responsibility to ONLY call this function for transactions with
     // nonce_index (i.e. gas key transactions).
@@ -424,18 +433,38 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
     }
 
     let tx_nonce = tx.nonce().nonce();
-    if let Err(e) = verify_nonce(tx_nonce, current_nonce, block_height) {
+    let effective_nonce = std::cmp::max(current_nonce, pending.max_nonce);
+    if let Err(e) = verify_nonce(tx_nonce, effective_nonce, block_height) {
         return TxVerdict::Failed(e);
     }
 
-    // Check gas key has enough balance for gas costs
-    let Some(new_gas_key_balance) = gas_key_info.balance.checked_sub(gas_cost) else {
+    // Check gas key has enough balance for gas costs, accounting for
+    // pending gas key costs (prior gas key txs + pending WithdrawFromGasKey).
+    // Unlike account balance, gas key balance only changes through transactions
+    // that PTQ explicitly tracks, so pending should never exceed the balance.
+    let Some(available_gas_key_balance) =
+        gas_key_info.balance.checked_sub(pending.paid_from_gas_key)
+    else {
+        tracing::error!(
+            target: "runtime",
+            balance = %gas_key_info.balance,
+            paid_from_gas_key = %pending.paid_from_gas_key,
+            "pending gas key costs exceed gas key balance"
+        );
         return TxVerdict::Failed(InvalidTxError::NotEnoughGasKeyBalance {
             signer_id: account_id.clone(),
-            balance: gas_key_info.balance,
+            balance: Balance::ZERO,
             cost: gas_cost,
         });
     };
+    if available_gas_key_balance < gas_cost {
+        return TxVerdict::Failed(InvalidTxError::NotEnoughGasKeyBalance {
+            signer_id: account_id.clone(),
+            balance: available_gas_key_balance,
+            cost: gas_cost,
+        });
+    }
+    let new_gas_key_balance = gas_key_info.balance.checked_sub(gas_cost).unwrap();
 
     // Validate FunctionCall permission constraints if applicable
     if let Some(function_call_permission) = access_key.permission.function_call_permission() {
@@ -454,25 +483,31 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
         access_key_update: gas_key_update,
     };
 
-    // Check account has enough balance for deposits
-    let account_balance = account.amount();
-    let Some(new_account_amount) = account_balance.checked_sub(deposit_cost) else {
+    // Check account has enough balance for deposits, accounting for
+    // pending balance costs from prior txs. saturating_sub is fine: on the
+    // consensus path pending constraints are always default (zero), so the
+    // subtraction is exact. On the RPC / chunk-production path it is
+    // best-effort.
+    let available_balance = account.amount().saturating_sub(pending.paid_from_balance);
+    if available_balance < deposit_cost {
         return TxVerdict::DepositFailed {
-            result: make_result(account_balance),
+            result: make_result(account.amount()),
             error: InvalidTxError::NotEnoughBalanceForDeposit {
                 signer_id: account_id.clone(),
-                balance: account_balance,
+                balance: available_balance,
                 cost: deposit_cost,
                 reason: DepositCostFailureReason::NotEnoughBalance,
             },
         };
-    };
+    }
+    // Debit only this tx's deposit cost, not the pending amount.
+    let new_account_amount = account.amount().checked_sub(deposit_cost).unwrap();
 
     match check_storage_stake(account, new_account_amount, config) {
         Ok(()) => {}
         Err(StorageStakingError::LackBalanceForStorageStaking(amount)) => {
             return TxVerdict::DepositFailed {
-                result: make_result(account_balance),
+                result: make_result(account.amount()),
                 error: InvalidTxError::NotEnoughBalanceForDeposit {
                     signer_id: account_id.clone(),
                     balance: new_account_amount,
@@ -1223,6 +1258,7 @@ mod tests {
             &cost,
             None,
             current_protocol_version,
+            &PendingConstraints::default(),
         ) else {
             panic!("expected Failed verdict");
         };
@@ -1258,6 +1294,7 @@ mod tests {
                 tx,
                 &transaction_cost,
                 block_height,
+                &PendingConstraints::default(),
             )
         } else {
             verify_and_charge_tx_ephemeral(
@@ -1268,6 +1305,7 @@ mod tests {
                 &transaction_cost,
                 block_height,
                 current_protocol_version,
+                &PendingConstraints::default(),
             )
         };
         let result = match verdict {
@@ -3317,6 +3355,7 @@ mod tests {
             tx,
             &cost,
             None,
+            &PendingConstraints::default(),
         ) else {
             panic!("expected DepositFailed");
         };
@@ -3380,6 +3419,7 @@ mod tests {
             tx,
             &cost,
             None,
+            &PendingConstraints::default(),
         ) else {
             panic!("expected DepositFailed");
         };

--- a/test-loop-tests/Cargo.toml
+++ b/test-loop-tests/Cargo.toml
@@ -53,6 +53,7 @@ near-parameters.workspace = true
 near-primitives.workspace = true
 near-primitives-core.workspace = true
 near-store.workspace = true
+node-runtime.workspace = true
 near-test-contracts.workspace = true
 near-vm-runner.workspace = true
 near-wallet-contract.workspace = true

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -323,6 +323,7 @@ pub fn setup_client(
     let rpc_handler = RpcHandlerActor::new(
         rpc_handler_config,
         client_actor.client.chunk_producer.sharded_tx_pool.clone(),
+        client_actor.client.chunk_producer.pending_transaction_queue.clone(),
         epoch_manager.clone(),
         shard_tracker.clone(),
         validator_signer.clone(),

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -35,6 +35,7 @@ mod multinode_stateless_validators;
 #[cfg(feature = "test_features")]
 mod network_drop;
 mod optimistic_block;
+mod pending_transaction_queue;
 mod process_blocks;
 mod processed_receipts_gc;
 mod protocol_upgrade;

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -306,7 +306,8 @@ fn test_ptq_accumulates_across_blocks() {
     // Run blocks up to just before the first batch gets certified.
     // The extra tx should not get included while P_MAX uncertified txs are pending.
     let current_height = env.validator().head().height;
-    let blocks_until_certification = first_inclusion_height + execution_delay - current_height - 1;
+    let target_height = first_inclusion_height + execution_delay - 1;
+    let blocks_until_certification = target_height.saturating_sub(current_height);
     env.validator_runner().run_for_number_of_blocks(blocks_until_certification as usize);
     assert!(!is_included_in_head(&env.validator(), &[extra_hash]));
 

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -491,10 +491,11 @@ fn test_ptq_gas_key_balance_enforcement() {
 
 /// WithdrawFromGasKey reduces available gas key balance.
 ///
-/// Create a gas key with 1 milliNEAR, submit an access key tx withdrawing
-/// the full balance, and wait for inclusion. Then submit a gas key tx via
-/// execute_tx. The PTQ counts the pending withdrawal, so the RPC rejects
-/// the gas key tx with NotEnoughGasKeyBalance.
+/// Create a gas key with 1 milliNEAR, submit two access key txs each
+/// withdrawing half the balance, and wait for inclusion. Then submit a gas
+/// key tx via execute_tx. The pending transaction queue accumulates both
+/// withdrawals, so the RPC rejects the gas key tx with
+/// NotEnoughGasKeyBalance.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_ptq_withdraw_from_gas_key() {
@@ -503,32 +504,44 @@ fn test_ptq_withdraw_from_gas_key() {
     let account = create_account_id("withdraw_account");
     let receiver = create_account_id("receiver");
     let fund_amount = Balance::from_millinear(1);
+    let half = fund_amount.checked_div(2).unwrap();
     let setup = setup_gas_key_spice_env(&account, &receiver, 1, fund_amount);
     let mut env = setup.env;
 
-    // Submit an access key tx that withdraws the full gas key balance.
+    // Submit two access key txs, each withdrawing half the gas key balance.
     let block_hash = env.validator().head().last_block_hash;
-    let withdraw_tx = SignedTransaction::from_actions(
-        setup.next_access_key_nonce,
+    let mut next_nonce = setup.next_access_key_nonce;
+    let withdraw_tx1 = SignedTransaction::from_actions(
+        next_nonce,
         account.clone(),
         account.clone(),
         &create_user_test_signer(&account),
         vec![Action::WithdrawFromGasKey(Box::new(WithdrawFromGasKeyAction {
             public_key: setup.gas_key_signer.public_key(),
-            amount: fund_amount,
+            amount: half,
         }))],
         block_hash,
     );
-    let withdraw_hash = withdraw_tx.get_hash();
-    env.validator().submit_tx(withdraw_tx);
+    next_nonce += 1;
+    let withdraw_tx2 = SignedTransaction::from_actions(
+        next_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(&account),
+        vec![Action::WithdrawFromGasKey(Box::new(WithdrawFromGasKeyAction {
+            public_key: setup.gas_key_signer.public_key(),
+            amount: half,
+        }))],
+        block_hash,
+    );
+    let hashes = [withdraw_tx1.get_hash(), withdraw_tx2.get_hash()];
+    env.validator().submit_tx(withdraw_tx1);
+    env.validator().submit_tx(withdraw_tx2);
+    env.validator_runner().run_until_included(&hashes);
 
-    // Wait for the withdraw tx to be included so the PTQ tracks
-    // the withdrawal against the gas key balance.
-    env.validator_runner().run_until_included(&[withdraw_hash]);
-
-    // Now submit a gas key tx via execute_tx. The PTQ should count the
-    // pending withdrawal against the gas key balance, so the RPC handler
-    // should reject it with NotEnoughGasKeyBalance.
+    // Submit a gas key tx via execute_tx. The pending transaction queue
+    // should accumulate both withdrawals against the gas key balance,
+    // so the RPC handler should reject it with NotEnoughGasKeyBalance.
     let block_hash = env.validator().head().last_block_hash;
     let gas_key_tx = SignedTransaction::from_actions_v1(
         TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[0] + 1, 0),

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -108,7 +108,9 @@ fn test_ptq_p_max_contract_account() {
     let tx_hashes = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, num_txs);
     // Only P_MAX txs should be included before certification.
     env.validator_runner().run_until_included(&tx_hashes[..P_MAX]);
-    assert!(!is_included_in_head(&env.validator(), &tx_hashes[P_MAX..]));
+    for tx_hash in &tx_hashes[P_MAX..] {
+        assert!(!is_included_in_head(&env.validator(), std::slice::from_ref(tx_hash)));
+    }
     // The remaining txs are included after certification advances.
     let remaining: Vec<_> = tx_hashes[P_MAX..].to_vec();
     env.validator_runner().run_until_included(&remaining);

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -1,0 +1,665 @@
+use std::collections::HashSet;
+
+use near_async::time::Duration;
+use near_client::pending_transaction_queue::P_MAX;
+use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_o11y::testonly::init_test_logger;
+use near_parameters::RuntimeConfigStore;
+use near_primitives::account::AccessKey;
+use near_primitives::action::{
+    AddKeyAction, DeployContractAction, TransferToGasKeyAction, WithdrawFromGasKeyAction,
+};
+use near_primitives::errors::InvalidTxError;
+use near_primitives::hash::CryptoHash;
+use near_primitives::test_utils::create_user_test_signer;
+use near_primitives::transaction::{Action, SignedTransaction, TransactionNonce, TransferAction};
+use near_primitives::types::Nonce;
+use near_primitives::types::{AccountId, Balance, NonceIndex};
+use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::views::{QueryRequest, QueryResponseKind};
+use node_runtime::config::tx_cost;
+
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::env::TestLoopEnv;
+use crate::utils::account::create_account_id;
+use crate::utils::node::TestLoopNode;
+
+use super::spice_utils::delay_endorsements_propagation;
+
+const TEST_GAS_PRICE: Balance = Balance::from_yoctonear(1);
+
+fn gas_cost_per_transfer() -> Balance {
+    let config_store = RuntimeConfigStore::new(None);
+    let config = config_store.get_config(PROTOCOL_VERSION);
+    let dummy_account = create_account_id("dummy");
+    let sample_tx = SignedTransaction::send_money(
+        1,
+        dummy_account.clone(),
+        dummy_account.clone(),
+        &create_user_test_signer(&dummy_account),
+        Balance::from_yoctonear(0),
+        CryptoHash::default(),
+    );
+    tx_cost(&config, &sample_tx.transaction, TEST_GAS_PRICE).unwrap().gas_cost
+}
+
+/// Submit `count` transfer transactions from `sender` to `receiver`.
+/// Returns the tx hashes. Increments `next_nonce`.
+fn submit_transfers(
+    env: &TestLoopEnv,
+    sender: &AccountId,
+    receiver: &AccountId,
+    next_nonce: &mut u64,
+    count: usize,
+) -> Vec<CryptoHash> {
+    let block_hash = env.validator().head().last_block_hash;
+    let mut tx_hashes = Vec::new();
+    for _ in 0..count {
+        let tx = SignedTransaction::send_money(
+            *next_nonce,
+            sender.clone(),
+            receiver.clone(),
+            &create_user_test_signer(sender),
+            Balance::from_millinear(1),
+            block_hash,
+        );
+        *next_nonce += 1;
+        tx_hashes.push(tx.get_hash());
+        env.validator().submit_tx(tx);
+    }
+    tx_hashes
+}
+
+/// Deploy a contract on `account` and wait for certification to advance past
+/// the deploy (so deploy exclusivity doesn't block subsequent txs).
+fn deploy_contract_and_certify(env: &mut TestLoopEnv, account: &AccountId) {
+    let deploy_tx = env.validator().tx_deploy_test_contract(account);
+    env.validator_runner().run_tx(deploy_tx, Duration::seconds(20));
+    let height = env.validator().head().height;
+    env.validator_runner().run_until_certified(height);
+}
+
+/// P_MAX enforcement for contract accounts.
+///
+/// Deploy a contract, then submit P_MAX + 2 transactions. The PTQ should
+/// throttle inclusion to at most P_MAX at a time from a contract account.
+/// All transactions are eventually included after certification frees slots.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_p_max_contract_account() {
+    init_test_logger();
+
+    let contract_account = create_account_id("contract_account");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&contract_account, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+    deploy_contract_and_certify(&mut env, &contract_account);
+
+    // Submit P_MAX + 2 transfer transactions from the contract account.
+    let num_txs = P_MAX + 2;
+    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
+    let tx_hashes = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, num_txs);
+    // Only P_MAX txs should be included before certification.
+    env.validator_runner().run_until_included(&tx_hashes[..P_MAX]);
+    assert!(!is_included_in_head(&env.validator(), &tx_hashes[P_MAX..]));
+    // The remaining txs are included after certification advances.
+    let remaining: Vec<_> = tx_hashes[P_MAX..].to_vec();
+    env.validator_runner().run_until_included(&remaining);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// No P_MAX restriction for non-contract accounts.
+///
+/// Submit more than P_MAX transactions from an account without a contract.
+/// All should be included without restriction.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_no_p_max_for_non_contract_account() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&sender, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+
+    let num_txs = P_MAX + 2;
+    let mut next_nonce: u64 = 1;
+    let tx_hashes = submit_transfers(&env, &sender, &receiver, &mut next_nonce, num_txs);
+    // All should be included without P_MAX throttling.
+    env.validator_runner().run_until_included(&tx_hashes);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Nonce constraint from PTQ.
+///
+/// Submit a transaction, wait for inclusion (but not certification). Then
+/// submit another transaction reusing the same nonce. The certified state
+/// still has the old nonce, but PTQ's max_nonce should cause the RPC to
+/// reject the replay with InvalidNonce.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_nonce_constraint() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&sender, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+
+    // Submit a tx with nonce 1 and wait for inclusion.
+    let block_hash = env.validator().head().last_block_hash;
+    let tx = SignedTransaction::send_money(
+        1,
+        sender.clone(),
+        receiver.clone(),
+        &create_user_test_signer(&sender),
+        Balance::from_millinear(1),
+        block_hash,
+    );
+    env.validator().submit_tx(tx.clone());
+    env.validator_runner().run_until_included(&[tx.get_hash()]);
+
+    // Submit another tx reusing nonce 1. The certified state still has
+    // nonce 0, but PTQ's max_nonce should cause rejection.
+    let block_hash = env.validator().head().last_block_hash;
+    let replay_tx = SignedTransaction::send_money(
+        1,
+        sender.clone(),
+        receiver,
+        &create_user_test_signer(&sender),
+        Balance::from_millinear(2),
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(replay_tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::InvalidNonce { .. })));
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Deploy exclusivity.
+///
+/// Submit a DeployContract transaction and a transfer from the same account
+/// simultaneously. The deploy should be included first, and the transfer
+/// should be blocked while the deploy is uncertified. After certification,
+/// the transfer is included.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_deploy_exclusivity() {
+    init_test_logger();
+
+    let account = create_account_id("deployer");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&account, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+
+    // Submit a deploy tx and a transfer tx from the same account.
+    let mut next_nonce: u64 = 1;
+    let block_hash = env.validator().head().last_block_hash;
+    let deploy_tx = SignedTransaction::from_actions(
+        next_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(&account),
+        vec![Action::DeployContract(DeployContractAction {
+            code: near_test_contracts::rs_contract().to_vec(),
+        })],
+        block_hash,
+    );
+    next_nonce += 1;
+    let transfer_tx = SignedTransaction::send_money(
+        next_nonce,
+        account.clone(),
+        receiver,
+        &create_user_test_signer(&account),
+        Balance::from_millinear(1),
+        block_hash,
+    );
+    let deploy_hash = deploy_tx.get_hash();
+    let transfer_hash = transfer_tx.get_hash();
+
+    env.validator().submit_tx(deploy_tx);
+    env.validator().submit_tx(transfer_tx);
+
+    // Deploy should be included first (lower nonce, picked first from pool).
+    env.validator_runner().run_until_included(&[deploy_hash]);
+    // Deploy exclusivity should prevent the transfer from being included
+    // while the deploy is uncertified. Run up to just before certification.
+    env.validator_runner().run_for_number_of_blocks(execution_delay as usize - 1);
+    assert!(!is_included_in_head(&env.validator(), &[transfer_hash]));
+
+    // Transfer should be included after certification advances.
+    env.validator_runner().run_until_included(&[transfer_hash]);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// PTQ accumulates across blocks.
+///
+/// Submit transactions across multiple blocks. Verify that P_MAX counts
+/// transactions from all uncertified blocks, not just the latest one.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_accumulates_across_blocks() {
+    init_test_logger();
+
+    let contract_account = create_account_id("contract_account");
+    let receiver = create_account_id("receiver");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&contract_account, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+    deploy_contract_and_certify(&mut env, &contract_account);
+
+    // Submit transactions in two batches, let the first batch get included,
+    // then submit the rest. Total across uncertified blocks should be P_MAX.
+    let first_batch_size = P_MAX / 2;
+    let second_batch_size = P_MAX - first_batch_size;
+    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
+    let first_batch =
+        submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, first_batch_size);
+    let first_inclusion_height = env.validator_runner().run_until_included(&first_batch);
+
+    // Submit and include the second batch.
+    let second_batch =
+        submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, second_batch_size);
+    env.validator_runner().run_until_included(&second_batch);
+
+    // Submit a (P_MAX+1)th tx. This should be blocked by P_MAX since there
+    // are already P_MAX uncertified txs from this contract account.
+    let extra = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, 1);
+    let extra_hash = extra[0];
+
+    // Run blocks up to just before the first batch gets certified.
+    // The extra tx should not get included while P_MAX uncertified txs are pending.
+    let current_height = env.validator().head().height;
+    let blocks_until_certification = first_inclusion_height + execution_delay - current_height - 1;
+    env.validator_runner().run_for_number_of_blocks(blocks_until_certification as usize);
+    assert!(!is_included_in_head(&env.validator(), &[extra_hash]));
+
+    // Wait for the extra tx to be included after certification.
+    env.validator_runner().run_until_included(&[extra_hash]);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// PTQ cleanup on certification.
+///
+/// Submit transactions, wait for certification to advance past them, then
+/// verify new transactions from the same account are admitted freely.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_cleanup_on_certification() {
+    init_test_logger();
+
+    let contract_account = create_account_id("contract_account");
+    let receiver = create_account_id("receiver");
+
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(&contract_account, Balance::from_near(1_000))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+    deploy_contract_and_certify(&mut env, &contract_account);
+
+    // Submit P_MAX transactions and wait for inclusion + certification.
+    let mut next_nonce = env.validator().get_next_nonce(&contract_account);
+    let first_batch = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, P_MAX);
+    env.validator_runner().run_until_included(&first_batch);
+    let height = env.validator().head().height;
+    env.validator_runner().run_until_certified(height);
+
+    // Submit P_MAX more. All should be admitted since the first batch is certified.
+    let second_batch = submit_transfers(&env, &contract_account, &receiver, &mut next_nonce, P_MAX);
+    env.validator_runner().run_until_included(&second_batch);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+struct GasKeySpiceEnv {
+    env: TestLoopEnv,
+    gas_key_signer: Signer,
+    next_access_key_nonce: u64,
+    /// Per-index gas key nonces (one per nonce index).
+    gas_key_nonces: Vec<Nonce>,
+}
+
+/// Helper: set up a SPICE env with a gas key on `account`.
+/// The gas key has `num_nonces` nonce indices and `fund_amount` balance.
+fn setup_gas_key_spice_env(
+    account: &AccountId,
+    receiver: &AccountId,
+    num_nonces: NonceIndex,
+    fund_amount: Balance,
+) -> GasKeySpiceEnv {
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 1)
+        .add_user_account(account, Balance::from_near(1_000))
+        .add_user_account(receiver, Balance::from_near(0))
+        .gas_prices(TEST_GAS_PRICE, TEST_GAS_PRICE)
+        .build();
+    let execution_delay = 4;
+    delay_endorsements_propagation(&mut env, execution_delay);
+    let mut env = env.warmup();
+    let gas_key_signer: Signer =
+        InMemorySigner::from_seed(account.clone(), KeyType::ED25519, "gas_key").into();
+    let mut next_nonce: u64 = 1;
+
+    // Add gas key.
+    let block_hash = env.validator().head().last_block_hash;
+    let add_key_tx = SignedTransaction::from_actions(
+        next_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(account),
+        vec![Action::AddKey(Box::new(AddKeyAction {
+            public_key: gas_key_signer.public_key(),
+            access_key: AccessKey::gas_key_full_access(num_nonces),
+        }))],
+        block_hash,
+    );
+    env.validator_runner().run_tx(add_key_tx, Duration::seconds(20));
+    next_nonce += 1;
+
+    // Fund the gas key.
+    let block_hash = env.validator().head().last_block_hash;
+    let fund_tx = SignedTransaction::from_actions(
+        next_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(account),
+        vec![Action::TransferToGasKey(Box::new(TransferToGasKeyAction {
+            public_key: gas_key_signer.public_key(),
+            deposit: fund_amount,
+        }))],
+        block_hash,
+    );
+    env.validator_runner().run_tx(fund_tx, Duration::seconds(20));
+    next_nonce += 1;
+
+    // Wait for certification to advance past the setup blocks so the certified
+    // state includes the funded gas key (needed for RPC tx verification).
+    let height = env.validator().head().height;
+    env.validator_runner().run_until_certified(height);
+
+    let response = env
+        .validator()
+        .runtime_query(QueryRequest::ViewGasKeyNonces {
+            account_id: account.clone(),
+            public_key: gas_key_signer.public_key(),
+        })
+        .unwrap();
+    let QueryResponseKind::GasKeyNonces(view) = response.kind else {
+        panic!("expected GasKeyNonces response");
+    };
+    GasKeySpiceEnv {
+        env,
+        gas_key_signer,
+        next_access_key_nonce: next_nonce,
+        gas_key_nonces: view.nonces,
+    }
+}
+
+/// Gas key balance enforcement.
+///
+/// Create a gas key with enough balance for exactly 2 txs. Submit 2 gas key
+/// txs and wait for inclusion (but not certification). Then submit one more
+/// via execute_tx. The PTQ tracks the first 2 as pending, so the RPC rejects
+/// the third with NotEnoughGasKeyBalance.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_gas_key_balance_enforcement() {
+    init_test_logger();
+
+    let account = create_account_id("gas_key_account");
+    let receiver = create_account_id("receiver");
+
+    // Fund the gas key with enough for exactly 2 txs but not 3.
+    let fund_amount = gas_cost_per_transfer().checked_mul(2).unwrap();
+    let setup = setup_gas_key_spice_env(&account, &receiver, 1, fund_amount);
+    let mut env = setup.env;
+    let mut gas_key_nonce = setup.gas_key_nonces[0];
+
+    // Submit the first 2 txs and wait for them to be included.
+    let mut tx_hashes = Vec::new();
+    let block_hash = env.validator().head().last_block_hash;
+    for _ in 0..2 {
+        gas_key_nonce += 1;
+        let tx = SignedTransaction::from_actions_v1(
+            TransactionNonce::from_nonce_and_index(gas_key_nonce, 0),
+            account.clone(),
+            receiver.clone(),
+            &setup.gas_key_signer,
+            vec![Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(0) })],
+            block_hash,
+        );
+        tx_hashes.push(tx.get_hash());
+        env.validator().submit_tx(tx);
+    }
+    env.validator_runner().run_until_included(&tx_hashes);
+
+    // Submit one more tx via execute_tx. The PTQ tracks the first 2 as
+    // uncertified, so the RPC handler should reject it with
+    // NotEnoughGasKeyBalance.
+    gas_key_nonce += 1;
+    let block_hash = env.validator().head().last_block_hash;
+    let tx = SignedTransaction::from_actions_v1(
+        TransactionNonce::from_nonce_and_index(gas_key_nonce, 0),
+        account,
+        receiver,
+        &setup.gas_key_signer,
+        vec![Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(0) })],
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::NotEnoughGasKeyBalance { .. })),);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// WithdrawFromGasKey reduces available gas key balance.
+///
+/// Create a gas key with 1 milliNEAR, submit an access key tx withdrawing
+/// the full balance, and wait for inclusion. Then submit a gas key tx via
+/// execute_tx. The PTQ counts the pending withdrawal, so the RPC rejects
+/// the gas key tx with NotEnoughGasKeyBalance.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_withdraw_from_gas_key() {
+    init_test_logger();
+
+    let account = create_account_id("withdraw_account");
+    let receiver = create_account_id("receiver");
+    let fund_amount = Balance::from_millinear(1);
+    let setup = setup_gas_key_spice_env(&account, &receiver, 1, fund_amount);
+    let mut env = setup.env;
+
+    // Submit an access key tx that withdraws the full gas key balance.
+    let block_hash = env.validator().head().last_block_hash;
+    let withdraw_tx = SignedTransaction::from_actions(
+        setup.next_access_key_nonce,
+        account.clone(),
+        account.clone(),
+        &create_user_test_signer(&account),
+        vec![Action::WithdrawFromGasKey(Box::new(WithdrawFromGasKeyAction {
+            public_key: setup.gas_key_signer.public_key(),
+            amount: fund_amount,
+        }))],
+        block_hash,
+    );
+    let withdraw_hash = withdraw_tx.get_hash();
+    env.validator().submit_tx(withdraw_tx);
+
+    // Wait for the withdraw tx to be included so the PTQ tracks
+    // the withdrawal against the gas key balance.
+    env.validator_runner().run_until_included(&[withdraw_hash]);
+
+    // Now submit a gas key tx via execute_tx. The PTQ should count the
+    // pending withdrawal against the gas key balance, so the RPC handler
+    // should reject it with NotEnoughGasKeyBalance.
+    let block_hash = env.validator().head().last_block_hash;
+    let gas_key_tx = SignedTransaction::from_actions_v1(
+        TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[0] + 1, 0),
+        account,
+        receiver,
+        &setup.gas_key_signer,
+        vec![Action::Transfer(TransferAction { deposit: Balance::from_millinear(0) })],
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(gas_key_tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::NotEnoughGasKeyBalance { .. })),);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Gas key with multiple nonce indices shares balance.
+///
+/// Create a gas key with 4 nonce indices, funded for exactly 2 txs. Submit
+/// 2 txs on different indices to exhaust the shared balance, then submit a
+/// 3rd on yet another index. The 3rd should be rejected, proving the balance
+/// is pooled across indices rather than tracked independently.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_gas_key_multiple_nonce_indices() {
+    init_test_logger();
+
+    let account = create_account_id("multi_nonce_account");
+    let receiver = create_account_id("receiver");
+    let num_nonces: NonceIndex = 4;
+
+    // Fund gas key with enough for exactly 2 txs.
+    let fund_amount = gas_cost_per_transfer().checked_mul(2).unwrap();
+    let setup = setup_gas_key_spice_env(&account, &receiver, num_nonces, fund_amount);
+    let mut env = setup.env;
+
+    // Submit 2 txs on different nonce indices and wait for inclusion.
+    let mut tx_hashes = Vec::new();
+    let block_hash = env.validator().head().last_block_hash;
+    for i in 0..2 {
+        let tx = SignedTransaction::from_actions_v1(
+            TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[i] + 1, i as NonceIndex),
+            account.clone(),
+            receiver.clone(),
+            &setup.gas_key_signer,
+            vec![Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(0) })],
+            block_hash,
+        );
+        tx_hashes.push(tx.get_hash());
+        env.validator().submit_tx(tx);
+    }
+    env.validator_runner().run_until_included(&tx_hashes);
+
+    // Submit a 3rd tx on a different nonce index. The shared gas key balance
+    // is exhausted, so the RPC should reject it.
+    let block_hash = env.validator().head().last_block_hash;
+    let tx = SignedTransaction::from_actions_v1(
+        TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[2] + 1, 2),
+        account,
+        receiver,
+        &setup.gas_key_signer,
+        vec![Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(0) })],
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::NotEnoughGasKeyBalance { .. })),);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Account balance enforcement across access key and gas key transactions.
+///
+/// Submit an access key tx with a large deposit that nearly exhausts the
+/// account balance (1000 NEAR). Then submit a gas key tx whose deposit
+/// exceeds the remaining balance. The gas key tx's deposit is paid from the
+/// account balance, so the PTQ's paid_from_balance constraint causes
+/// the RPC to reject it with NotEnoughBalanceForDeposit.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_ptq_account_balance_access_key_gas_key_combined() {
+    init_test_logger();
+
+    let account = create_account_id("combo_account");
+    let receiver = create_account_id("receiver");
+    let fund_amount = Balance::from_millinear(100);
+    let setup = setup_gas_key_spice_env(&account, &receiver, 1, fund_amount);
+    let mut env = setup.env;
+
+    // Submit an access key tx with a large deposit that nearly exhausts the
+    // 1000 NEAR account balance.
+    let block_hash = env.validator().head().last_block_hash;
+    let access_key_tx = SignedTransaction::send_money(
+        setup.next_access_key_nonce,
+        account.clone(),
+        receiver.clone(),
+        &create_user_test_signer(&account),
+        Balance::from_near(999),
+        block_hash,
+    );
+    env.validator().submit_tx(access_key_tx.clone());
+
+    // Wait for inclusion so the PTQ tracks paid_from_balance.
+    let access_key_hash = access_key_tx.get_hash();
+    env.validator_runner().run_until_included(&[access_key_hash]);
+
+    // Submit a gas key tx whose deposit exceeds the remaining balance.
+    // Gas is paid from the gas key, but deposit is paid from the account.
+    let block_hash = env.validator().head().last_block_hash;
+    let gas_key_tx = SignedTransaction::from_actions_v1(
+        TransactionNonce::from_nonce_and_index(setup.gas_key_nonces[0] + 1, 0),
+        account,
+        receiver,
+        &setup.gas_key_signer,
+        vec![Action::Transfer(TransferAction { deposit: Balance::from_near(2) })],
+        block_hash,
+    );
+    let result = env.validator_runner().execute_tx(gas_key_tx, Duration::seconds(5));
+    assert!(matches!(result, Err(InvalidTxError::NotEnoughBalanceForDeposit { .. })),);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+fn is_included_in_head(node: &TestLoopNode<'_>, tx_hashes: &[CryptoHash]) -> bool {
+    let client = node.client();
+    let head = client.chain.head().unwrap();
+    let block = client.chain.get_block(&head.last_block_hash).unwrap();
+    let mut included: HashSet<CryptoHash> = HashSet::new();
+    for chunk_header in block.chunks().iter() {
+        let chunk = client.chain.get_chunk(&chunk_header.chunk_hash()).unwrap();
+        for tx in chunk.to_transactions() {
+            included.insert(tx.get_hash());
+        }
+    }
+    tx_hashes.iter().all(|h| included.contains(h))
+}

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -81,8 +81,9 @@ fn deploy_contract_and_certify(env: &mut TestLoopEnv, account: &AccountId) {
 
 /// P_MAX enforcement for contract accounts.
 ///
-/// Deploy a contract, then submit P_MAX + 2 transactions. The PTQ should
-/// throttle inclusion to at most P_MAX at a time from a contract account.
+/// Deploy a contract, then submit P_MAX + 2 transactions. The pending
+/// transaction queue should throttle inclusion to at most P_MAX at a time
+/// from a contract account.
 /// All transactions are eventually included after certification frees slots.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
@@ -144,12 +145,12 @@ fn test_ptq_no_p_max_for_non_contract_account() {
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }
 
-/// Nonce constraint from PTQ.
+/// Nonce constraint from pending transaction queue.
 ///
 /// Submit a transaction, wait for inclusion (but not certification). Then
 /// submit another transaction reusing the same nonce. The certified state
-/// still has the old nonce, but PTQ's max_nonce should cause the RPC to
-/// reject the replay with InvalidNonce.
+/// still has the old nonce, but the pending transaction queue's max_nonce
+/// should cause the RPC to reject the replay with InvalidNonce.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_ptq_nonce_constraint() {
@@ -180,7 +181,8 @@ fn test_ptq_nonce_constraint() {
     env.validator_runner().run_until_included(&[tx.get_hash()]);
 
     // Submit another tx reusing nonce 1. The certified state still has
-    // nonce 0, but PTQ's max_nonce should cause rejection.
+    // nonce 0, but the pending transaction queue's max_nonce should cause
+    // rejection.
     let block_hash = env.validator().head().last_block_hash;
     let replay_tx = SignedTransaction::send_money(
         1,
@@ -259,7 +261,7 @@ fn test_ptq_deploy_exclusivity() {
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }
 
-/// PTQ accumulates across blocks.
+/// Pending transaction queue accumulates across blocks.
 ///
 /// Submit transactions across multiple blocks. Verify that P_MAX counts
 /// transactions from all uncertified blocks, not just the latest one.
@@ -312,7 +314,7 @@ fn test_ptq_accumulates_across_blocks() {
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }
 
-/// PTQ cleanup on certification.
+/// Pending transaction queue cleanup on certification.
 ///
 /// Submit transactions, wait for certification to advance past them, then
 /// verify new transactions from the same account are admitted freely.
@@ -436,8 +438,8 @@ fn setup_gas_key_spice_env(
 ///
 /// Create a gas key with enough balance for exactly 2 txs. Submit 2 gas key
 /// txs and wait for inclusion (but not certification). Then submit one more
-/// via execute_tx. The PTQ tracks the first 2 as pending, so the RPC rejects
-/// the third with NotEnoughGasKeyBalance.
+/// via execute_tx. The pending transaction queue tracks the first 2 as
+/// pending, so the RPC rejects the third with NotEnoughGasKeyBalance.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_ptq_gas_key_balance_enforcement() {
@@ -470,9 +472,9 @@ fn test_ptq_gas_key_balance_enforcement() {
     }
     env.validator_runner().run_until_included(&tx_hashes);
 
-    // Submit one more tx via execute_tx. The PTQ tracks the first 2 as
-    // uncertified, so the RPC handler should reject it with
-    // NotEnoughGasKeyBalance.
+    // Submit one more tx via execute_tx. The pending transaction queue
+    // tracks the first 2 as uncertified, so the RPC handler should reject
+    // it with NotEnoughGasKeyBalance.
     gas_key_nonce += 1;
     let block_hash = env.validator().head().last_block_hash;
     let tx = SignedTransaction::from_actions_v1(
@@ -616,8 +618,8 @@ fn test_ptq_gas_key_multiple_nonce_indices() {
 /// Submit an access key tx with a large deposit that nearly exhausts the
 /// account balance (1000 NEAR). Then submit a gas key tx whose deposit
 /// exceeds the remaining balance. The gas key tx's deposit is paid from the
-/// account balance, so the PTQ's paid_from_balance constraint causes
-/// the RPC to reject it with NotEnoughBalanceForDeposit.
+/// account balance, so the pending transaction queue's paid_from_balance
+/// constraint causes the RPC to reject it with NotEnoughBalanceForDeposit.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_ptq_account_balance_access_key_gas_key_combined() {
@@ -642,7 +644,7 @@ fn test_ptq_account_balance_access_key_gas_key_combined() {
     );
     env.validator().submit_tx(access_key_tx.clone());
 
-    // Wait for inclusion so the PTQ tracks paid_from_balance.
+    // Wait for inclusion so the pending transaction queue tracks paid_from_balance.
     let access_key_hash = access_key_tx.get_hash();
     env.validator_runner().run_until_included(&[access_key_hash]);
 

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -405,6 +405,45 @@ impl<'a> NodeRunner<'a> {
         );
     }
 
+    /// Run until all given transactions appear in the head block.
+    /// Returns the height of the block containing the transactions.
+    pub fn run_until_included(&mut self, tx_hashes: &[CryptoHash]) -> BlockHeight {
+        let tx_hashes = tx_hashes.to_vec();
+        self.run_until(
+            |node| {
+                let head = node.head();
+                let block = node.client().chain.get_block(&head.last_block_hash).unwrap();
+                let mut included = std::collections::HashSet::new();
+                for chunk_header in block.chunks().iter() {
+                    let chunk = node.client().chain.get_chunk(&chunk_header.chunk_hash()).unwrap();
+                    for tx in chunk.to_transactions() {
+                        included.insert(tx.get_hash());
+                    }
+                }
+                tx_hashes.iter().all(|h| included.contains(h))
+            },
+            Duration::seconds(20),
+        );
+        self.head().height
+    }
+
+    /// Run until the last certified block height is at least `height`.
+    pub fn run_until_certified(&mut self, height: BlockHeight) {
+        let initial_height = self.head().height;
+        let height_diff = height.saturating_sub(initial_height) as usize;
+        let extra = self.node_data.expected_execution_delay() as usize;
+        let timeout = self.calculate_block_distance_timeout(height_diff + extra + 1);
+        self.run_until(
+            |node| {
+                let chain_store = &node.client().chain.chain_store;
+                let head_hash = chain_store.head().unwrap().last_block_hash;
+                near_chain::spice_core::get_last_certified_block_header(chain_store, &head_hash)
+                    .map_or(false, |h| h.height() >= height)
+            },
+            timeout,
+        );
+    }
+
     pub fn run_until_new_epoch(&mut self) {
         let curr_epoch_id = self.head().epoch_id;
         let epoch_length = self.client().config.epoch_length as usize;


### PR DESCRIPTION
Adds a pending transaction queue that tracks transactions included in blocks but not yet certified, enforcing balance, nonce, gas key, P\_MAX, and deploy exclusivity constraints per NEP-611.

**Stacked PRs:**

- #15314 
- #15316 
- #15319
- #15320 
- #15321 
- #15322 
- #15323 

**Key changes:**

- `PendingTransactionQueue`: per-shard tracking of uncertified chunk transactions with add/remove/clear operations, accumulating paid_from_balance, paid_from_gas_key, max_nonce, access_key_tx_count, deploy_tx_count, and gas_key_costs
- `PendingTxSession`: per-chunk-production session combining PTQ state with session-local tracking for P_MAX, deploy exclusivity, and WithdrawFromGasKey amounts
- Wiring into `Client` (block processing, startup, reorg), `ChunkProducer` (SPICE prepare_transactions path), and `RpcHandlerActor` (certified state + pending constraints for tx verification)
- Lock scope minimized: scoped locks for certified chunk removal, per-chunk lock for add, brief per-tx lock in session
- test-loop integration tests covering P_MAX enforcement, nonce constraints, deploy exclusivity, cross-block accumulation, certification cleanup, gas key balance/withdrawal tracking, multi-nonce-index shared balance, and combined access-key/gas-key balance enforcement