### PR TITLE
fix: epoch sync response processing

### DIFF
--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -601,6 +601,15 @@ impl Handler<EpochSyncRequestMessage> for ClientActor {
 
 impl Handler<EpochSyncResponseMessage> for ClientActor {
     fn handle(&mut self, msg: EpochSyncResponseMessage) {
+        // Pre-check: only decode if we are expecting an epoch sync response from this peer.
+        // This avoids wasting resources processing unsolicited responses.
+        match &self.client.sync_handler.sync_status {
+            SyncStatus::EpochSync(status) if status.source_peer_id == msg.from_peer => {}
+            _ => {
+                tracing::warn!(from_peer = %msg.from_peer, "ignoring unsolicited epoch sync response");
+                return;
+            }
+        }
         let (proof, _) = match msg.proof.decode() {
             Ok(proof) => proof,
             Err(err) => {

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -114,6 +114,10 @@ impl Config {
             RateLimitedPeerMessageKey::EpochSyncRequest,
             SingleMessageConfig::new(1, 1.0 / 30.0, None),
         );
+        config.rate_limits.insert(
+            RateLimitedPeerMessageKey::EpochSyncResponse,
+            SingleMessageConfig::new(1, 1.0 / 30.0, None),
+        );
         config
     }
 
@@ -178,6 +182,7 @@ pub enum RateLimitedPeerMessageKey {
     ContractCodeResponse,
     PartialEncodedContractDeploys,
     EpochSyncRequest,
+    EpochSyncResponse,
     OptimisticBlock,
     SpicePartialData,
     SpiceChunkEndorsement,
@@ -253,7 +258,7 @@ fn get_key_and_token_cost(message: &PeerMessage) -> Option<(RateLimitedPeerMessa
         PeerMessage::StateRequestPart(_, _, _) => Some((StateRequestPart, 1)),
         PeerMessage::VersionedStateResponse(_) => Some((VersionedStateResponse, 1)),
         PeerMessage::EpochSyncRequest => Some((EpochSyncRequest, 1)),
-        PeerMessage::EpochSyncResponse(_) => None,
+        PeerMessage::EpochSyncResponse(_) => Some((EpochSyncResponse, 1)),
         PeerMessage::Tier1Handshake(_)
         | PeerMessage::Tier2Handshake(_)
         | PeerMessage::Tier3Handshake(_)
@@ -476,5 +481,22 @@ mod tests {
         assert!(!rate_limits.is_allowed(&PeerMessage::EpochSyncRequest, clock.now()));
         clock.advance(Duration::seconds(30));
         assert!(rate_limits.is_allowed(&PeerMessage::EpochSyncRequest, clock.now()));
+    }
+
+    #[test]
+    fn test_epoch_sync_response_rate_limit() {
+        let config = Config::standard_preset();
+        let clock = FakeClock::default();
+        let mut rate_limits = RateLimits::from_config(&config, clock.now());
+        let dummy_proof = near_primitives::epoch_sync::CompressedEpochSyncProof::from(
+            vec![0u8; 10].into_boxed_slice(),
+        );
+        let msg = PeerMessage::EpochSyncResponse(dummy_proof);
+        assert!(rate_limits.is_allowed(&msg, clock.now()));
+        assert!(!rate_limits.is_allowed(&msg, clock.now()));
+        clock.advance(Duration::seconds(1));
+        assert!(!rate_limits.is_allowed(&msg, clock.now()));
+        clock.advance(Duration::seconds(30));
+        assert!(rate_limits.is_allowed(&msg, clock.now()));
     }
 }


### PR DESCRIPTION
Add rate limit to epoch sync message response.
Prevent processing if the sync proof was not requested. 
Original: https://github.com/near/nearcore-private/pull/190