### PR TITLE
refactor(sync): store max_block_requests in BlockSync struct

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -337,6 +337,7 @@ impl Client {
             config.block_fetch_horizon,
             config.archive,
             config.state_sync_enabled,
+            config.sync_max_block_requests,
         );
 
         let state_sync = StateSync::new(

--- a/chain/client/src/sync/block.rs
+++ b/chain/client/src/sync/block.rs
@@ -41,6 +41,9 @@ pub struct BlockSync {
 
     /// Whether State Sync should be enabled when a node falls far enough behind.
     state_sync_enabled: bool,
+
+    /// Maximum number of blocks to request in a single batch.
+    max_block_requests: usize,
 }
 
 impl BlockSync {
@@ -50,6 +53,7 @@ impl BlockSync {
         block_fetch_horizon: BlockHeightDelta,
         archive: bool,
         state_sync_enabled: bool,
+        max_block_requests: usize,
     ) -> Self {
         BlockSync {
             clock,
@@ -58,6 +62,7 @@ impl BlockSync {
             block_fetch_horizon,
             archive,
             state_sync_enabled,
+            max_block_requests,
         }
     }
 
@@ -69,7 +74,6 @@ impl BlockSync {
         chain: &Chain,
         highest_height: BlockHeight,
         highest_height_peers: &[HighestHeightPeerInfo],
-        max_block_requests: usize,
     ) -> Result<bool, near_chain::Error> {
         let _span =
             tracing::debug_span!(target: "sync", "run_sync", sync_type = "BlockSync").entered();
@@ -82,7 +86,7 @@ impl BlockSync {
                 return Ok(true);
             }
             BlockSyncDue::RequestBlock => {
-                self.block_sync(chain, highest_height_peers, max_block_requests)?;
+                self.block_sync(chain, highest_height_peers)?;
             }
             BlockSyncDue::WaitForBlock => {
                 // Do nothing.
@@ -182,7 +186,6 @@ impl BlockSync {
         &mut self,
         chain: &Chain,
         highest_height_peers: &[HighestHeightPeerInfo],
-        max_block_requests: usize,
     ) -> Result<(), near_chain::Error> {
         // Update last request now because we want to update it whether or not
         // the rest of the logic succeeds.
@@ -209,7 +212,7 @@ impl BlockSync {
         // blocks that we don't have yet.
         let mut next_hash = reference_hash;
         let mut num_requests = 0;
-        for _ in 0..max_block_requests {
+        for _ in 0..self.max_block_requests {
             next_hash = match chain.chain_store().get_next_block_hash(&next_hash) {
                 Ok(hash) => hash,
                 Err(e) => match e {

--- a/chain/client/src/sync/handler.rs
+++ b/chain/client/src/sync/handler.rs
@@ -213,7 +213,6 @@ impl SyncHandler {
             &chain,
             highest_height,
             highest_height_peers,
-            self.config.sync_max_block_requests,
         )?;
         Ok(block_sync_result)
     }

--- a/integration-tests/src/tests/client/block_sync.rs
+++ b/integration-tests/src/tests/client/block_sync.rs
@@ -81,6 +81,7 @@ fn test_block_sync() {
         block_fetch_horizon,
         false,
         true,
+        max_block_requests,
     );
     let mut env = test_env_with_epoch_length(100);
     let mut blocks = vec![];
@@ -95,7 +96,7 @@ fn test_block_sync() {
 
     // fetch three blocks at a time
     for i in 0..3 {
-        block_sync.block_sync(&env.clients[1].chain, &peer_infos, max_block_requests).unwrap();
+        block_sync.block_sync(&env.clients[1].chain, &peer_infos).unwrap();
 
         let expected_blocks: Vec<_> =
             blocks[i * max_block_requests..(i + 1) * max_block_requests].to_vec();
@@ -111,7 +112,7 @@ fn test_block_sync() {
 
     // Now test when the node receives the block out of order
     // fetch the next three blocks
-    block_sync.block_sync(&env.clients[1].chain, &peer_infos, max_block_requests).unwrap();
+    block_sync.block_sync(&env.clients[1].chain, &peer_infos).unwrap();
     check_hashes_from_network_adapter(
         &network_adapter,
         (3 * max_block_requests..4 * max_block_requests).map(|h| *blocks[h].hash()).collect(),
@@ -123,7 +124,7 @@ fn test_block_sync() {
     );
 
     // the next block sync should not request block[4*max_block_requests-1] again
-    block_sync.block_sync(&env.clients[1].chain, &peer_infos, max_block_requests).unwrap();
+    block_sync.block_sync(&env.clients[1].chain, &peer_infos).unwrap();
     check_hashes_from_network_adapter(
         &network_adapter,
         (3 * max_block_requests..4 * max_block_requests - 1).map(|h| *blocks[h].hash()).collect(),
@@ -137,7 +138,7 @@ fn test_block_sync() {
             .process_block_test(MaybeValidated::from(blocks[i].clone()), Provenance::NONE);
     }
 
-    block_sync.block_sync(&env.clients[1].chain, &peer_infos, max_block_requests).unwrap();
+    block_sync.block_sync(&env.clients[1].chain, &peer_infos).unwrap();
     let requested_block_hashes = collect_hashes_from_network_adapter(&network_adapter);
     assert!(requested_block_hashes.is_empty(), "{:?}", requested_block_hashes);
 
@@ -160,6 +161,7 @@ fn test_block_sync_archival() {
         block_fetch_horizon,
         true,
         true,
+        max_block_requests,
     );
     let mut env = test_env_with_epoch_length(5);
     let mut blocks = vec![];
@@ -172,7 +174,7 @@ fn test_block_sync_archival() {
     let peer_infos = create_highest_height_peer_infos(2);
     env.clients[1].chain.sync_block_headers(block_headers).unwrap();
 
-    block_sync.block_sync(&env.clients[1].chain, &peer_infos, max_block_requests).unwrap();
+    block_sync.block_sync(&env.clients[1].chain, &peer_infos).unwrap();
     let requested_block_hashes = collect_hashes_from_network_adapter(&network_adapter);
     // We don't have archival peers, and thus cannot request any blocks
     assert_eq!(requested_block_hashes, HashSet::new());
@@ -182,7 +184,7 @@ fn test_block_sync_archival() {
         peer.archival = true;
     }
 
-    block_sync.block_sync(&env.clients[1].chain, &peer_infos, max_block_requests).unwrap();
+    block_sync.block_sync(&env.clients[1].chain, &peer_infos).unwrap();
     let requested_block_hashes = collect_hashes_from_network_adapter(&network_adapter);
     assert_eq!(
         requested_block_hashes,


### PR DESCRIPTION
- Move `max_block_requests` from a parameter passed through `run()` and `block_sync()` into a field on the `BlockSync` struct, since the value always comes from config and never changes.
- Update `BlockSync::new()` to accept the value, and update all callers accordingly.