### PR TITLE
doc: remove nearup from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,6 @@ Overall, *NEAR* provides a wide range of tools for developers to easily build ap
 
 ## Join the Network
 
-The easiest way to join the network, is by using the `nearup` command, which you can install as follows:
-
-```bash
-pip3 install --user nearup
-```
-
-You can join all the active networks:
-* mainnet: `nearup run mainnet`
-* testnet: `nearup run testnet`
-* betanet: `nearup run betanet`
-
-Check the `nearup` repository for [more details](https://github.com/near/nearup) on how to run with or without docker.
-
 To learn how to become a validator, checkout [documentation](https://near-nodes.io/validator/staking-and-delegation).
 
 ## Contributing


### PR DESCRIPTION
[nearup](https://github.com/near/nearup) is deprecated, I'm not sure what is the current alternative, so removing it from the root README for now.