### PR TITLE
chore(primitives): remove unused ConsolidatedStateChange type

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -237,13 +237,6 @@ pub struct RawStateChangesWithTrieKey {
     pub changes: Vec<RawStateChange>,
 }
 
-/// Consolidate state change of trie_key and the final value the trie key will be changed to
-#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, ProtocolSchema)]
-pub struct ConsolidatedStateChange {
-    pub trie_key: TrieKey,
-    pub value: Option<Vec<u8>>,
-}
-
 /// key that was updated -> list of updates with the corresponding indexing event.
 pub type RawStateChanges = std::collections::BTreeMap<Vec<u8>, RawStateChangesWithTrieKey>;
 

--- a/tools/protocol-schema-check/res/protocol_schema.toml
+++ b/tools/protocol-schema-check/res/protocol_schema.toml
@@ -94,7 +94,6 @@ CompressedEpochSyncProof = 1117061636
 CongestionInfo = 3786930682
 CongestionInfoV1 = 2571332168
 ConnectionInfoRepr = 307237471
-ConsolidatedStateChange = 3677625656
 ContractCacheKey = 145520910
 ContractCodeRequest = 3853664214
 ContractCodeRequestInner = 1643875081


### PR DESCRIPTION
Remove `ConsolidatedStateChange` from `core/primitives/src/types.rs`. This type is not referenced anywhere in the codebase — it is not persisted to DB, not sent over the wire, and no code constructs or uses it. Also remove its entry from the protocol schema.