### PR TITLE
chore(ci): fix crates.io publish workflow

### DIFF
--- a/.github/workflows/near_crates_publish.yml
+++ b/.github/workflows/near_crates_publish.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           PACKAGE_NAME="near-primitives"
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.metadata.workspaces.version')
-          RESPONSE=$(curl -sS https://crates.io/api/v1/crates/$PACKAGE_NAME/versions)
+          RESPONSE=$(curl -sS -A "nearcore-ci (https://github.com/near/nearcore)" https://crates.io/api/v1/crates/$PACKAGE_NAME/versions)
           echo "$RESPONSE" | head -c 1000
           PUBLISHED=$(echo "$RESPONSE" | jq -r '.versions[] | select(.num=="'"$VERSION"'") | .num')
           if [ "$PUBLISHED" == "$VERSION" ]; then


### PR DESCRIPTION
- Fix crates publish workflow failing with `jq: error (at <stdin>:0): Cannot iterate over null (null)` ([run](https://github.com/near/nearcore/actions/runs/22959862408))
- Set explicit `User-Agent` header on crates.io API request, which is required per their [data access policy](https://crates.io/data-access)
- Log the crates.io API response before parsing so future failures are easier to debug