### PR TITLE
refactor: clean up chunk validation in shards manager (1/3)

### DIFF
--- a/chain/chunks-primitives/src/error.rs
+++ b/chain/chunks-primitives/src/error.rs
@@ -1,5 +1,4 @@
 use near_primitives::errors::EpochError;
-use near_primitives::sharding::EncodedShardChunk;
 use std::fmt;
 
 #[derive(Debug)]
@@ -10,9 +9,6 @@ pub enum Error {
     InvalidMerkleProof,
     InvalidChunkSignature,
     InvalidChunkHeader,
-    /// Chunk body is invalid (Byzantine chunk producer). Contains the encoded
-    /// chunk to be forwarded to the client as evidence.
-    InvalidChunk(Box<EncodedShardChunk>),
     DuplicateChunkHeight,
     UnknownChunk,
     KnownPart,

--- a/chain/chunks-primitives/src/error.rs
+++ b/chain/chunks-primitives/src/error.rs
@@ -1,4 +1,5 @@
 use near_primitives::errors::EpochError;
+use near_primitives::sharding::EncodedShardChunk;
 use std::fmt;
 
 #[derive(Debug)]
@@ -9,7 +10,9 @@ pub enum Error {
     InvalidMerkleProof,
     InvalidChunkSignature,
     InvalidChunkHeader,
-    InvalidChunk,
+    /// Chunk body is invalid (Byzantine chunk producer). Contains the encoded
+    /// chunk to be forwarded to the client as evidence.
+    InvalidChunk(Box<EncodedShardChunk>),
     DuplicateChunkHeight,
     UnknownChunk,
     KnownPart,

--- a/chain/chunks-primitives/src/error.rs
+++ b/chain/chunks-primitives/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     InvalidMerkleProof,
     InvalidChunkSignature,
     InvalidChunkHeader,
+    InvalidChunk,
     DuplicateChunkHeight,
     UnknownChunk,
     KnownPart,

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -154,7 +154,7 @@ enum ChunkStatus {
 }
 
 #[derive(Debug)]
-pub enum ProcessPartialEncodedChunkResult {
+enum ProcessPartialEncodedChunkResult {
     /// The information included in the partial encoded chunk is already known, no processing is needed
     Known,
     /// All parts and receipts in the chunk are received and the chunk has been processed
@@ -187,7 +187,7 @@ pub(crate) struct ChunkRequestInfo {
 }
 
 #[derive(Debug)]
-pub enum HandleNetworkRequestResult {
+pub(crate) enum HandleNetworkRequestResult {
     Ok,
     /// request failed and could be retried after some duration
     RetryProcessing(Box<ShardsManagerRequestFromNetwork>, Duration),
@@ -1206,6 +1206,8 @@ impl ShardsManagerActor {
 
         let chunk =
             ShardChunkWithEncoding::from_encoded_shard_chunk(chunk).map_err(|(err, chunk)| {
+                // Not expected to be reachable because reed_solomon_decode above already
+                // deserializes the content as TransactionReceipt.
                 tracing::debug!(target: "chunks", ?err, "invalid, failed to decode");
                 Error::InvalidChunk(Box::new(chunk))
             })?;
@@ -2266,7 +2268,7 @@ impl ShardsManagerActor {
         }
     }
 
-    pub fn handle_network_request(
+    pub(crate) fn handle_network_request(
         &mut self,
         request: ShardsManagerRequestFromNetwork,
     ) -> HandleNetworkRequestResult {
@@ -2343,7 +2345,7 @@ impl ShardsManagerActor {
 
 /// Indicates where we fetched the response to a PartialEncodedChunkRequest.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PartialEncodedChunkResponseSource {
+enum PartialEncodedChunkResponseSource {
     /// No lookup was performed.
     None,
     /// We only had to look into the in-memory partial chunk cache.

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -147,11 +147,10 @@ const CHUNK_FORWARD_CACHE_SIZE: usize = 1000;
 // Only request chunks from peers whose latest height >= chunk_height - CHUNK_REQUEST_PEER_HORIZON
 const CHUNK_REQUEST_PEER_HORIZON: BlockHeightDelta = 5;
 
-#[derive(PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum ChunkStatus {
-    Complete(Vec<MerklePath>),
+    Complete(Vec<MerklePath>, ShardChunkWithEncoding),
     Incomplete,
-    Invalid,
 }
 
 #[derive(Debug)]
@@ -1171,10 +1170,13 @@ impl ShardsManagerActor {
         }
     }
 
-    fn check_chunk_complete(&self, chunk: &mut EncodedShardChunk) -> ChunkStatus {
+    fn check_chunk_complete_and_valid(
+        &self,
+        mut chunk: EncodedShardChunk,
+    ) -> Result<ChunkStatus, Error> {
         let _span = debug_span!(
             target: "chunks",
-            "check_chunk_complete",
+            "check_chunk_complete_and_valid",
             height_included = chunk.cloned_header().height_included(),
             shard_id = %chunk.cloned_header().shard_id(),
             chunk_hash = ?chunk.chunk_hash())
@@ -1183,7 +1185,7 @@ impl ShardsManagerActor {
         let data_parts = self.epoch_manager.num_data_parts();
         if chunk.content().num_fetched_parts() < data_parts {
             tracing::debug!(target: "chunks", num_fetched_parts = chunk.content().num_fetched_parts(), data_parts, "incomplete");
-            return ChunkStatus::Incomplete;
+            return Ok(ChunkStatus::Incomplete);
         }
 
         let encoded_length = chunk.encoded_length();
@@ -1193,16 +1195,26 @@ impl ShardsManagerActor {
             encoded_length as usize,
         ) {
             tracing::debug!(target: "chunks", ?err, "invalid, failed to decode");
-            return ChunkStatus::Invalid;
+            return Err(Error::InvalidChunk(Box::new(chunk)));
         }
 
         let (merkle_root, merkle_paths) = chunk.content().get_merkle_hash_and_paths();
         if &merkle_root != chunk.encoded_merkle_root() {
             tracing::debug!(target: "chunks", ?merkle_root, chunk_encoded_merkle_root = ?chunk.encoded_merkle_root(), "invalid, wrong merkle root");
-            return ChunkStatus::Invalid;
+            return Err(Error::InvalidChunk(Box::new(chunk)));
         }
 
-        ChunkStatus::Complete(merkle_paths)
+        let chunk =
+            ShardChunkWithEncoding::from_encoded_shard_chunk(chunk).map_err(|(err, chunk)| {
+                tracing::debug!(target: "chunks", ?err, "invalid, failed to decode");
+                Error::InvalidChunk(Box::new(chunk))
+            })?;
+
+        if !validate_chunk_proofs(chunk.to_shard_chunk(), self.epoch_manager.as_ref())? {
+            return Err(Error::InvalidChunk(Box::new(chunk.into_parts().1)));
+        }
+
+        Ok(ChunkStatus::Complete(merkle_paths, chunk))
     }
 
     /// Add a part to current encoded chunk stored in memory. It's present only if One Part was present and signed correctly.
@@ -1231,17 +1243,13 @@ impl ShardsManagerActor {
 
     fn decode_encoded_chunk_if_complete(
         &mut self,
-        mut encoded_chunk: EncodedShardChunk,
+        encoded_chunk: EncodedShardChunk,
         me: Option<&AccountId>,
     ) -> Result<Option<(ShardChunk, PartialEncodedChunk)>, Error> {
-        match self.check_chunk_complete(&mut encoded_chunk) {
-            ChunkStatus::Complete(merkle_paths) => {
-                self.requested_partial_encoded_chunks.remove(&encoded_chunk.chunk_hash());
-                let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)
-                    .map_err(|(_, chunk)| Error::InvalidChunk(Box::new(chunk)))?;
-                if !validate_chunk_proofs(chunk.to_shard_chunk(), self.epoch_manager.as_ref())? {
-                    return Err(Error::InvalidChunk(Box::new(chunk.into_parts().1)));
-                }
+        match self.check_chunk_complete_and_valid(encoded_chunk)? {
+            ChunkStatus::Complete(merkle_paths, chunk) => {
+                self.requested_partial_encoded_chunks
+                    .remove(&chunk.to_encoded_shard_chunk().chunk_hash());
                 match create_partial_chunk(
                     &chunk,
                     merkle_paths,
@@ -1259,11 +1267,6 @@ impl ShardsManagerActor {
                 }
             }
             ChunkStatus::Incomplete => Ok(None),
-            ChunkStatus::Invalid => {
-                let chunk_hash = encoded_chunk.chunk_hash();
-                self.encoded_chunks.remove(&chunk_hash);
-                Err(Error::InvalidChunk(Box::new(encoded_chunk)))
-            }
         }
     }
 

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -174,8 +174,6 @@ enum ProcessPartialEncodedChunkResult {
     /// The PartialEncodedChunk is not within the horizon of the chain head.
     /// The chunk has been dropped without processing any part of it.
     OutsideHorizon,
-    /// Chunk was fully received but failed validation (malicious chunk producer).
-    DecodeFailed,
 }
 
 #[derive(Clone, Debug)]
@@ -1910,7 +1908,7 @@ impl ShardsManagerActor {
                     let chunk_hash = encoded_chunk.chunk_hash();
                     self.encoded_chunks.remove(&chunk_hash);
                     self.requested_partial_encoded_chunks.remove(&chunk_hash);
-                    return Ok(ProcessPartialEncodedChunkResult::DecodeFailed);
+                    return Err(Error::InvalidChunk);
                 }
             }
         }
@@ -2293,8 +2291,7 @@ impl ShardsManagerActor {
                     Ok(ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts) |
                     Ok(ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts) |
                     Ok(ProcessPartialEncodedChunkResult::NeedBlock) |
-                    Ok(ProcessPartialEncodedChunkResult::OutsideHorizon) |
-                    Ok(ProcessPartialEncodedChunkResult::DecodeFailed) => { return HandleNetworkRequestResult::Ok; }
+                    Ok(ProcessPartialEncodedChunkResult::OutsideHorizon) => { return HandleNetworkRequestResult::Ok; }
                     Err(e) => {
                         tracing::debug!(target: "chunks", ?e, "error processing partial encoded chunk");
                         return HandleNetworkRequestResult::Err;

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1209,7 +1209,7 @@ impl ShardsManagerActor {
                 // Not expected to be reachable because reed_solomon_decode above already
                 // deserializes the content as TransactionReceipt.
                 tracing::debug!(target: "chunks", ?err, "invalid, failed to decode");
-                Error::InvalidChunk(Box::new(chunk))
+                Error::InvalidChunk(chunk)
             })?;
 
         if !validate_chunk_proofs(chunk.to_shard_chunk(), self.epoch_manager.as_ref())? {
@@ -1248,7 +1248,17 @@ impl ShardsManagerActor {
         encoded_chunk: EncodedShardChunk,
         me: Option<&AccountId>,
     ) -> Result<Option<(ShardChunk, PartialEncodedChunk)>, Error> {
-        match self.check_chunk_complete_and_valid(encoded_chunk)? {
+        let status = match self.check_chunk_complete_and_valid(encoded_chunk) {
+            Ok(status) => status,
+            Err(Error::InvalidChunk(chunk)) => {
+                let chunk_hash = chunk.chunk_hash();
+                self.encoded_chunks.remove(&chunk_hash);
+                self.requested_partial_encoded_chunks.remove(&chunk_hash);
+                return Err(Error::InvalidChunk(chunk));
+            }
+            Err(err) => return Err(err),
+        };
+        match status {
             ChunkStatus::Complete(merkle_paths, chunk) => {
                 self.requested_partial_encoded_chunks
                     .remove(&chunk.to_encoded_shard_chunk().chunk_hash());

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -147,10 +147,13 @@ const CHUNK_FORWARD_CACHE_SIZE: usize = 1000;
 // Only request chunks from peers whose latest height >= chunk_height - CHUNK_REQUEST_PEER_HORIZON
 const CHUNK_REQUEST_PEER_HORIZON: BlockHeightDelta = 5;
 
+/// Result of attempting to decode and validate a complete encoded chunk.
 #[allow(clippy::large_enum_variant)]
-enum ChunkStatus {
-    Complete(Vec<MerklePath>, ShardChunkWithEncoding),
-    Incomplete,
+enum ChunkDecodeResult {
+    /// Chunk decoded and passed validation.
+    Decoded(ShardChunk, PartialEncodedChunk),
+    /// Chunk failed validation (malicious chunk producer).
+    Invalid(EncodedShardChunk),
 }
 
 #[derive(Debug)]
@@ -171,6 +174,8 @@ enum ProcessPartialEncodedChunkResult {
     /// The PartialEncodedChunk is not within the horizon of the chain head.
     /// The chunk has been dropped without processing any part of it.
     OutsideHorizon,
+    /// Chunk was fully received but failed validation (malicious chunk producer).
+    DecodeFailed,
 }
 
 #[derive(Clone, Debug)]
@@ -187,7 +192,7 @@ pub(crate) struct ChunkRequestInfo {
 }
 
 #[derive(Debug)]
-pub(crate) enum HandleNetworkRequestResult {
+pub enum HandleNetworkRequestResult {
     Ok,
     /// request failed and could be retried after some duration
     RetryProcessing(Box<ShardsManagerRequestFromNetwork>, Duration),
@@ -1170,23 +1175,18 @@ impl ShardsManagerActor {
         }
     }
 
-    fn check_chunk_complete_and_valid(
-        &self,
+    fn decode_encoded_chunk_if_complete(
+        &mut self,
         mut chunk: EncodedShardChunk,
-    ) -> Result<ChunkStatus, Error> {
+        me: Option<&AccountId>,
+    ) -> Result<ChunkDecodeResult, Error> {
         let _span = debug_span!(
             target: "chunks",
-            "check_chunk_complete_and_valid",
+            "decode_encoded_chunk_if_complete",
             height_included = chunk.cloned_header().height_included(),
             shard_id = %chunk.cloned_header().shard_id(),
             chunk_hash = ?chunk.chunk_hash())
         .entered();
-
-        let data_parts = self.epoch_manager.num_data_parts();
-        if chunk.content().num_fetched_parts() < data_parts {
-            tracing::debug!(target: "chunks", num_fetched_parts = chunk.content().num_fetched_parts(), data_parts, "incomplete");
-            return Ok(ChunkStatus::Incomplete);
-        }
 
         let encoded_length = chunk.encoded_length();
         if let Err(err) = reed_solomon_decode::<TransactionReceipt>(
@@ -1195,28 +1195,45 @@ impl ShardsManagerActor {
             encoded_length as usize,
         ) {
             tracing::debug!(target: "chunks", ?err, "invalid, failed to decode");
-            return Err(Error::InvalidChunk(Box::new(chunk)));
+            return Ok(ChunkDecodeResult::Invalid(chunk));
         }
 
         let (merkle_root, merkle_paths) = chunk.content().get_merkle_hash_and_paths();
         if &merkle_root != chunk.encoded_merkle_root() {
             tracing::debug!(target: "chunks", ?merkle_root, chunk_encoded_merkle_root = ?chunk.encoded_merkle_root(), "invalid, wrong merkle root");
-            return Err(Error::InvalidChunk(Box::new(chunk)));
+            return Ok(ChunkDecodeResult::Invalid(chunk));
         }
 
-        let chunk =
-            ShardChunkWithEncoding::from_encoded_shard_chunk(chunk).map_err(|(err, chunk)| {
+        let chunk = match ShardChunkWithEncoding::from_encoded_shard_chunk(chunk) {
+            Ok(chunk) => chunk,
+            Err((err, chunk)) => {
                 // Not expected to be reachable because reed_solomon_decode above already
                 // deserializes the content as TransactionReceipt.
                 tracing::debug!(target: "chunks", ?err, "invalid, failed to decode");
-                Error::InvalidChunk(chunk)
-            })?;
+                return Ok(ChunkDecodeResult::Invalid(*chunk));
+            }
+        };
 
         if !validate_chunk_proofs(chunk.to_shard_chunk(), self.epoch_manager.as_ref())? {
-            return Err(Error::InvalidChunk(Box::new(chunk.into_parts().1)));
+            return Ok(ChunkDecodeResult::Invalid(chunk.into_parts().1));
         }
 
-        Ok(ChunkStatus::Complete(merkle_paths, chunk))
+        self.requested_partial_encoded_chunks.remove(&chunk.to_encoded_shard_chunk().chunk_hash());
+        match create_partial_chunk(
+            &chunk,
+            merkle_paths,
+            me,
+            self.epoch_manager.as_ref(),
+            &self.shard_tracker,
+        ) {
+            Ok(partial_encoded_chunk) => {
+                Ok(ChunkDecodeResult::Decoded(chunk.into_parts().0, partial_encoded_chunk))
+            }
+            Err(err) => {
+                self.encoded_chunks.remove(&chunk.to_encoded_shard_chunk().chunk_hash());
+                Err(err)
+            }
+        }
     }
 
     /// Add a part to current encoded chunk stored in memory. It's present only if One Part was present and signed correctly.
@@ -1240,45 +1257,6 @@ impl ShardsManagerActor {
             Ok(())
         } else {
             Err(Error::InvalidChunkPartId)
-        }
-    }
-
-    fn decode_encoded_chunk_if_complete(
-        &mut self,
-        encoded_chunk: EncodedShardChunk,
-        me: Option<&AccountId>,
-    ) -> Result<Option<(ShardChunk, PartialEncodedChunk)>, Error> {
-        let status = match self.check_chunk_complete_and_valid(encoded_chunk) {
-            Ok(status) => status,
-            Err(Error::InvalidChunk(chunk)) => {
-                let chunk_hash = chunk.chunk_hash();
-                self.encoded_chunks.remove(&chunk_hash);
-                self.requested_partial_encoded_chunks.remove(&chunk_hash);
-                return Err(Error::InvalidChunk(chunk));
-            }
-            Err(err) => return Err(err),
-        };
-        match status {
-            ChunkStatus::Complete(merkle_paths, chunk) => {
-                self.requested_partial_encoded_chunks
-                    .remove(&chunk.to_encoded_shard_chunk().chunk_hash());
-                match create_partial_chunk(
-                    &chunk,
-                    merkle_paths,
-                    me,
-                    self.epoch_manager.as_ref(),
-                    &self.shard_tracker,
-                ) {
-                    Ok(partial_encoded_chunk) => {
-                        Ok(Some((chunk.into_parts().0, partial_encoded_chunk)))
-                    }
-                    Err(err) => {
-                        self.encoded_chunks.remove(&chunk.to_encoded_shard_chunk().chunk_hash());
-                        Err(err)
-                    }
-                }
-            }
-            ChunkStatus::Incomplete => Ok(None),
         }
     }
 
@@ -1842,7 +1820,8 @@ impl ShardsManagerActor {
         let entry = self.encoded_chunks.get(&chunk_hash).unwrap();
         let have_all_parts = self.has_all_parts(&prev_block_hash, entry, me)?;
         let have_all_receipts = self.has_all_receipts(&prev_block_hash, entry)?;
-        let can_reconstruct = entry.parts.len() >= self.epoch_manager.num_data_parts();
+        let num_data_parts = self.epoch_manager.num_data_parts();
+        let can_reconstruct = entry.parts.len() >= num_data_parts;
 
         if can_reconstruct {
             self.encoded_chunks.mark_can_reconstruct(&chunk_hash);
@@ -1909,20 +1888,31 @@ impl ShardsManagerActor {
                 encoded_chunk.content_mut().parts[*part_ord as usize] =
                     Some(part_entry.part.clone());
             }
+            let num_fetched_parts = encoded_chunk.content().num_fetched_parts();
+            assert!(
+                num_fetched_parts >= num_data_parts,
+                "expected enough parts to reconstruct chunk, got {num_fetched_parts}/{num_data_parts}",
+            );
 
-            let (shard_chunk, partial_chunk) = self
-                .decode_encoded_chunk_if_complete(encoded_chunk, me)?
-                .expect("decoding shouldn't fail");
-
-            // For consistency, only persist shard_chunk if we actually care about the shard.
-            // Don't persist if we don't care about the shard, even if we accidentally got enough
-            // parts to reconstruct the full shard.
-            if cares_about_shard {
-                self.complete_chunk(partial_chunk, Some(shard_chunk));
-            } else {
-                self.complete_chunk(partial_chunk, None);
+            match self.decode_encoded_chunk_if_complete(encoded_chunk, me)? {
+                ChunkDecodeResult::Decoded(shard_chunk, partial_chunk) => {
+                    // For consistency, only persist shard_chunk if we actually care about the
+                    // shard. Don't persist if we don't care about the shard, even if we
+                    // accidentally got enough parts to reconstruct the full shard.
+                    if cares_about_shard {
+                        self.complete_chunk(partial_chunk, Some(shard_chunk));
+                    } else {
+                        self.complete_chunk(partial_chunk, None);
+                    }
+                    return Ok(ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts);
+                }
+                ChunkDecodeResult::Invalid(encoded_chunk) => {
+                    let chunk_hash = encoded_chunk.chunk_hash();
+                    self.encoded_chunks.remove(&chunk_hash);
+                    self.requested_partial_encoded_chunks.remove(&chunk_hash);
+                    return Ok(ProcessPartialEncodedChunkResult::DecodeFailed);
+                }
             }
-            return Ok(ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts);
         }
         Ok(ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts)
     }
@@ -2278,7 +2268,7 @@ impl ShardsManagerActor {
         }
     }
 
-    pub(crate) fn handle_network_request(
+    pub fn handle_network_request(
         &mut self,
         request: ShardsManagerRequestFromNetwork,
     ) -> HandleNetworkRequestResult {
@@ -2303,7 +2293,8 @@ impl ShardsManagerActor {
                     Ok(ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts) |
                     Ok(ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts) |
                     Ok(ProcessPartialEncodedChunkResult::NeedBlock) |
-                    Ok(ProcessPartialEncodedChunkResult::OutsideHorizon) => { return HandleNetworkRequestResult::Ok; }
+                    Ok(ProcessPartialEncodedChunkResult::OutsideHorizon) |
+                    Ok(ProcessPartialEncodedChunkResult::DecodeFailed) => { return HandleNetworkRequestResult::Ok; }
                     Err(e) => {
                         tracing::debug!(target: "chunks", ?e, "error processing partial encoded chunk");
                         return HandleNetworkRequestResult::Err;
@@ -2355,7 +2346,7 @@ impl ShardsManagerActor {
 
 /// Indicates where we fetched the response to a PartialEncodedChunkRequest.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum PartialEncodedChunkResponseSource {
+pub enum PartialEncodedChunkResponseSource {
     /// No lookup was performed.
     None,
     /// We only had to look into the in-memory partial chunk cache.

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -148,7 +148,7 @@ const CHUNK_FORWARD_CACHE_SIZE: usize = 1000;
 const CHUNK_REQUEST_PEER_HORIZON: BlockHeightDelta = 5;
 
 #[allow(clippy::large_enum_variant)]
-pub enum ChunkStatus {
+enum ChunkStatus {
     Complete(Vec<MerklePath>, ShardChunkWithEncoding),
     Incomplete,
 }

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1237,9 +1237,10 @@ impl ShardsManagerActor {
         match self.check_chunk_complete(&mut encoded_chunk) {
             ChunkStatus::Complete(merkle_paths) => {
                 self.requested_partial_encoded_chunks.remove(&encoded_chunk.chunk_hash());
-                let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)?;
+                let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)
+                    .map_err(|(_, chunk)| Error::InvalidChunk(Box::new(chunk)))?;
                 if !validate_chunk_proofs(chunk.to_shard_chunk(), self.epoch_manager.as_ref())? {
-                    return Err(Error::InvalidChunk);
+                    return Err(Error::InvalidChunk(Box::new(chunk.into_parts().1)));
                 }
                 match create_partial_chunk(
                     &chunk,
@@ -1261,7 +1262,7 @@ impl ShardsManagerActor {
             ChunkStatus::Invalid => {
                 let chunk_hash = encoded_chunk.chunk_hash();
                 self.encoded_chunks.remove(&chunk_hash);
-                Err(Error::InvalidChunk)
+                Err(Error::InvalidChunk(Box::new(encoded_chunk)))
             }
         }
     }

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1209,7 +1209,7 @@ impl ShardsManagerActor {
             Err((err, chunk)) => {
                 // Not expected to be reachable because reed_solomon_decode above already
                 // deserializes the content as TransactionReceipt.
-                tracing::debug!(target: "chunks", ?err, "invalid, failed to decode");
+                tracing::error!(target: "chunks", ?err, "invalid, failed to decode");
                 return Ok(ChunkDecodeResult::Invalid(*chunk));
             }
         };

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -254,7 +254,9 @@ pub fn create_chunk(
         .max_gas_price(Balance::from_yoctonear(100))
         .block_merkle_tree(&mut block_merkle_tree)
         .build();
-    let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk).unwrap();
+    let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)
+        .map_err(|(err, _)| err)
+        .unwrap();
     (ProduceChunkResult { chunk, encoded_chunk_parts_paths: merkle_paths, receipts }, block)
 }
 

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1523,13 +1523,12 @@ impl ShardChunkWithEncoding {
         (Self { shard_chunk, bytes: encoded_shard_chunk }, merkle_paths)
     }
 
-    #[allow(clippy::result_large_err)]
     pub fn from_encoded_shard_chunk(
         bytes: EncodedShardChunk,
-    ) -> Result<Self, (std::io::Error, EncodedShardChunk)> {
+    ) -> Result<Self, (std::io::Error, Box<EncodedShardChunk>)> {
         match bytes.decode_chunk() {
             Ok(shard_chunk) => Ok(Self { shard_chunk, bytes }),
-            Err(err) => Err((err, bytes)),
+            Err(err) => Err((err, Box::new(bytes))),
         }
     }
 

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1523,9 +1523,14 @@ impl ShardChunkWithEncoding {
         (Self { shard_chunk, bytes: encoded_shard_chunk }, merkle_paths)
     }
 
-    pub fn from_encoded_shard_chunk(bytes: EncodedShardChunk) -> Result<Self, std::io::Error> {
-        let shard_chunk = bytes.decode_chunk()?;
-        Ok(Self { shard_chunk, bytes })
+    #[allow(clippy::result_large_err)]
+    pub fn from_encoded_shard_chunk(
+        bytes: EncodedShardChunk,
+    ) -> Result<Self, (std::io::Error, EncodedShardChunk)> {
+        match bytes.decode_chunk() {
+            Ok(shard_chunk) => Ok(Self { shard_chunk, bytes }),
+            Err(err) => Err((err, bytes)),
+        }
     }
 
     pub fn to_shard_chunk(&self) -> &ShardChunk {

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1956,7 +1956,9 @@ fn test_validate_chunk_extra() {
     let chunk_header = encoded_chunk.cloned_header();
     let signer = env.clients[0].validator_signer.get();
     let validator_id = signer.as_ref().unwrap().validator_id().clone();
-    let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk).unwrap();
+    let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)
+        .map_err(|(err, _)| err)
+        .unwrap();
     env.clients[0]
         .distribute_and_persist_encoded_chunk(chunk, merkle_paths, receipts, validator_id)
         .unwrap();


### PR DESCRIPTION
Prepare chunk validation code for upcoming SPICE invalid-chunk handling.
Refactors chunk decode/validation to replace the intermediate `ChunkStatus` enum with a `ChunkDecodeResult` enum.

- Introduce `ChunkDecodeResult` enum with `Decoded` and `Invalid` variants, replacing `ChunkStatus`
- Inline `check_chunk_complete` into `decode_encoded_chunk_if_complete`, eliminating the intermediate `ChunkStatus` enum
- Move the completeness check (`num_fetched_parts >= num_data_parts`) to the caller as an assert, since `can_reconstruct` is already verified before entry
- Change `ShardChunkWithEncoding::from_encoded_shard_chunk` to return the `EncodedShardChunk` on error (boxed) so callers retain access to the evidence
- Fix `Invalid` path to also clean up `requested_partial_encoded_chunks`