### PR TITLE
fix: properly handle genesis in BlockInfo::from_header

### DIFF
--- a/core/primitives/src/epoch_block_info.rs
+++ b/core/primitives/src/epoch_block_info.rs
@@ -97,7 +97,13 @@ impl BlockInfo {
             current_protocol_version,
             header.latest_protocol_version(),
             header.raw_timestamp(),
-            header.chunk_endorsements().cloned().expect("header should include chunk endorsements"),
+            header.chunk_endorsements().cloned().unwrap_or_else(|| {
+                if header.is_genesis() {
+                    Default::default()
+                } else {
+                    panic!("non-genesis header should include chunk endorsements")
+                }
+            }),
             header.shard_split().cloned(),
         )
     }


### PR DESCRIPTION
See [#releases/2.11 > mpc startup crash when syncing from genesis](https://near.zulipchat.com/#narrow/channel/533300-releases.2F2.2E11/topic/mpc.20startup.20crash.20when.20syncing.20from.20genesis/with/578878832)