### PR TITLE
fix(chain): fix a bug in get_orphans_within_depth

### DIFF
--- a/chain/chain/src/orphan.rs
+++ b/chain/chain/src/orphan.rs
@@ -501,8 +501,7 @@ mod tests {
         // Create children of D and E
         let block_f =
             TestBlockBuilder::from_prev_block(clock.clone(), &block_d, signer.clone()).build();
-        let block_g =
-            TestBlockBuilder::from_prev_block(clock.clone(), &block_e, signer.clone()).build();
+        let block_g = TestBlockBuilder::from_prev_block(clock.clone(), &block_e, signer).build();
 
         // Add all 6 blocks as orphans.
         let mut pool = OrphanBlockPool::new();
@@ -510,8 +509,8 @@ mod tests {
         pool.add(make_orphan(&clock, block_c.clone()), false);
         pool.add(make_orphan(&clock, block_d.clone()), false);
         pool.add(make_orphan(&clock, block_e.clone()), false);
-        pool.add(make_orphan(&clock, block_f.clone()), false);
-        pool.add(make_orphan(&clock, block_g.clone()), false);
+        pool.add(make_orphan(&clock, block_f), false);
+        pool.add(make_orphan(&clock, block_g), false);
 
         // Query for all orphans within depth 2 from block_a.
         let result = pool.get_orphans_within_depth(*block_a.hash(), 2);


### PR DESCRIPTION
Follow up on https://github.com/near/nearcore/pull/15306#discussion_r2888899963

There is a bug in `get_orphans_within_depth` - the function is meant to collect all blocks within `n` blocks of the parent block, but it uses a DFS-style queue and as soon as it reaches the `n-th` block, it exits the function. Because it's DFS, one branch can reach the max depth before other branches were even able to process items at lower depths. See the attached test, it doesn't pass before the fix.

This is not a big problem for two reasons:
* Triggering the bug would require a scenario with two long forks, very hard to achieve on mainnet without a lot of malicious block producers
* Even if the bug gets triggered, `get_orphans_within_depth` is only used to prefetch chunks for the blocks that might get processed soon. It's an optimization, not code that would be critical for correctness.

Still worth fixing.

I asked claude to create a scenario where a malicious block producer would exploit this, it worked for an hour but wasn't able to create anything. I also can't find any realistic examples.