### PR TITLE
chore(cli): adjust logging for expected kernel params

### DIFF
--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -947,7 +947,7 @@ fn normalize_whitespace(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// Checks the provided kernel parameter  from /proc/sys
+/// Checks the provided kernel parameter from /proc/sys
 /// and prints a warning if it is not set to the expected value.
 #[cfg(target_os = "linux")]
 fn check_kernel_param(param_name: &str, expected_value: &str) {


### PR DESCRIPTION
warn is appropriate here since the node can continue to operate, but under suboptimal conditions, and is actionable by the node operator.

I don't see the necessity to print an info log for when parameters are as expected.