### PR TITLE
refactor(ci): detect release build from cargo profile instead of makefile env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 export DOCKER_BUILDKIT = 1
 export CARGO_BUILD_RUSTFLAGS = -D warnings
-export NEAR_RELEASE_BUILD = no
 export OPENSSL_STATIC = 1
 export CARGO_TARGET_DIR = target
 
@@ -34,7 +33,6 @@ release: neard-release
 neard: neard-release
 	@echo 'neard binary ready in ./target/release/neard'
 
-neard-release: NEAR_RELEASE_BUILD=release
 neard-release:
 	cargo build -p neard --release
 
@@ -63,7 +61,6 @@ nightly-debug:
 	cargo build -p genesis-populate --features nearcore/nightly
 
 #? assertions-release: build release version of neard with open debug_assertions
-assertions-release: NEAR_RELEASE_BUILD=release
 assertions-release:
 	CARGO_PROFILE_RELEASE_DEBUG=true CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true cargo build -p neard --release
 
@@ -88,7 +85,6 @@ neard-sandbox-release:
 	cargo build -p neard --features sandbox --release
 
 #? test-features-release: build release version of neard with test_features feature
-test-features-release: NEAR_RELEASE_BUILD=release
 test-features-release:
 	cargo build -p neard --release --features test_features
 

--- a/neard/build.rs
+++ b/neard/build.rs
@@ -141,5 +141,10 @@ fn try_main() -> Result<()> {
 
     println!("cargo:rustc-env=NEARD_FEATURES={}", get_enabled_features());
 
+    let profile = std::env::var("PROFILE").unwrap_or_default();
+    if profile == "release" {
+        println!("cargo:rustc-env=NEAR_RELEASE_BUILD=release");
+    }
+
     Ok(())
 }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -362,15 +362,11 @@ pub(super) struct InitCmd {
 
 /// Warns if unsupported build of the executable is used on mainnet or testnet.
 ///
-/// Verifies that when running on mainnet or testnet chain a neard binary built
-/// with `make release` command is used.  That Makefile targets enable
-/// optimization options which aren’t enabled when building with different
-/// methods and is the only officially supported method of building the binary
-/// to run in production.
+/// Warns when running a debug or nightly build on mainnet or testnet.
 ///
 /// The detection is done by checking that `NEAR_RELEASE_BUILD` environment
-/// variable was set to `release` during compilation (which is what Makefile
-/// sets) and that the `nightly` feature is not enabled.
+/// variable was set to `release` during compilation (set by build.rs for
+/// release profile builds) and that the `nightly` feature is not enabled.
 fn check_release_build(chain: &str) {
     let is_release_build =
         option_env!("NEAR_RELEASE_BUILD") == Some("release") && !cfg!(feature = "nightly");
@@ -380,16 +376,11 @@ fn check_release_build(chain: &str) {
         tracing::warn!(
             target: "neard",
             %chain,
-            "running a neard executable which wasn't built with `make release` command isn't supported"
+            concat!(
+                "running a debug or nightly neard build on this chain is not recommended, ",
+                "consider recompiling with `cargo build -p neard --release`",
+            ),
         );
-        tracing::warn!(
-            target: "neard",
-            %chain,
-            "note that `cargo build --release` builds lack optimizations which may be needed to run properly"
-        );
-        tracing::warn!(
-            target: "neard",
-            "consider recompiling the binary using `make release` command");
     }
 }
 


### PR DESCRIPTION
- `NEAR_RELEASE_BUILD` was set by the Makefile to distinguish `make release` from `cargo build --release`, because the Makefile used to enable LTO via env vars. Since LTO is now in `[profile.release]` in Cargo.toml, the two produce identical binaries and the Makefile override is a leftover.
- Move `NEAR_RELEASE_BUILD` detection into `neard/build.rs` using Cargo's `PROFILE` env var, so `cargo build --release` is correctly recognized as a release build without needing Make.
- Remove all `NEAR_RELEASE_BUILD` plumbing from the Makefile.
- Consolidate and update the warning messages in `check_release_build`.