### PR TITLE
fix(network): gracefully handle expired peer in peer_connection_attempt

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -663,9 +663,7 @@ impl PeerManagerActor {
                         if let Err(ref err) = result {
                             tracing::info!(target: "network", ?err, %peer_info, "tier2 failed to connect");
                         }
-                        if state.peer_store.peer_connection_attempt(&clock, &peer_info.id, result).is_err() {
-                            tracing::error!(target: "network", ?peer_info, "failed to store connection attempt");
-                        }
+                        state.peer_store.peer_connection_attempt(&clock, &peer_info.id, result);
                     }.instrument(tracing::trace_span!(target: "network", "monitor_peers_trigger_connect"))
                 });
             }

--- a/chain/network/src/peer_manager/peer_store/mod.rs
+++ b/chain/network/src/peer_manager/peer_store/mod.rs
@@ -393,9 +393,8 @@ impl PeerStore {
         clock: &time::Clock,
         peer_id: &PeerId,
         result: Result<(), anyhow::Error>,
-    ) -> anyhow::Result<()> {
+    ) {
         let mut inner = self.0.lock();
-
         let Some(peer_state) = inner.peer_states.get_mut(peer_id) else {
             // The peer can be removed from the store (e.g., expired by remove_expired)
             // while the outbound connection attempt is in flight. If the connection
@@ -403,9 +402,10 @@ impl PeerStore {
             // unexpected happened.
             if result.is_err() {
                 tracing::debug!(target: "network", %peer_id, "peer expired from store during failed connection attempt");
-                return Ok(());
+            } else {
+                tracing::error!(target: "network", %peer_id, "failed to store connection attempt");
             }
-            bail!("Peer {} is missing in the peer store", peer_id);
+            return;
         };
         if result.is_err() {
             // Marks the peer status as Unknown (as we failed to connect to it).
@@ -414,8 +414,6 @@ impl PeerStore {
         peer_state.last_outbound_attempt =
             Some((clock.now_utc(), result.map_err(|err| err.to_string())));
         peer_state.last_seen = clock.now_utc();
-
-        Ok(())
     }
 
     pub fn peer_ban(

--- a/chain/network/src/peer_manager/peer_store/tests.rs
+++ b/chain/network/src/peer_manager/peer_store/tests.rs
@@ -136,13 +136,11 @@ fn test_unknown_vs_not_connected() {
     );
 
     // And fail when trying to reconnect to b.
-    peer_store
-        .peer_connection_attempt(
-            &clock.clock(),
-            &peer_info_b.id,
-            Err(anyhow::anyhow!("b failed to connect error")),
-        )
-        .unwrap();
+    peer_store.peer_connection_attempt(
+        &clock.clock(),
+        &peer_info_b.id,
+        Err(anyhow::anyhow!("b failed to connect error")),
+    );
 
     // It should move 'back' into Unknown state.
     assert_eq!(get_in_memory_status(&peer_store), [Some(Connected), Some(Unknown), Some(Unknown)]);


### PR DESCRIPTION
- During sync, outbound connection attempts can take a long time (e.g., TCP timeout to unreachable peers). Meanwhile, `remove_expired` can delete the peer from the store. When the connection attempt finally completes with a failure, `peer_connection_attempt` would bail with an error logged at ERROR level.
- Instead, if the connection failed and the peer is gone from the store, return Ok silently (with a debug log). We were only going to mark the peer as Unknown, and it's already deleted.
- Keep the bail for the unexpected case where the connection succeeded but the peer is missing.