### PR TITLE
feat(state-sync): show download/apply parts progress in sync status

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -38,12 +38,12 @@ impl From<near_primitives::errors::EpochError> for Error {
 }
 
 /// Various status of syncing a specific shard.
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum ShardSyncStatus {
     StateDownloadHeader,
     StateDownloadParts,
     StateApplyScheduling,
-    StateApplyInProgress,
+    StateApplyInProgress { done: u64, total: u64 },
     StateApplyFinalizing,
     StateSyncDone,
 }
@@ -58,7 +58,7 @@ impl ShardSyncStatus {
             ShardSyncStatus::StateDownloadHeader => 0,
             ShardSyncStatus::StateDownloadParts => 1,
             ShardSyncStatus::StateApplyScheduling => 2,
-            ShardSyncStatus::StateApplyInProgress => 3,
+            ShardSyncStatus::StateApplyInProgress { .. } => 3,
             ShardSyncStatus::StateApplyFinalizing => 4,
             ShardSyncStatus::StateSyncDone => 5,
         }
@@ -80,7 +80,9 @@ impl ToString for ShardSyncStatus {
             ShardSyncStatus::StateDownloadHeader => "header".to_string(),
             ShardSyncStatus::StateDownloadParts => "parts".to_string(),
             ShardSyncStatus::StateApplyScheduling => "apply scheduling".to_string(),
-            ShardSyncStatus::StateApplyInProgress => "apply in progress".to_string(),
+            ShardSyncStatus::StateApplyInProgress { done, total } => {
+                format!("apply in progress ({done}/{total})")
+            }
             ShardSyncStatus::StateApplyFinalizing => "apply finalizing".to_string(),
             ShardSyncStatus::StateSyncDone => "done".to_string(),
         }

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -41,7 +41,7 @@ impl From<near_primitives::errors::EpochError> for Error {
 #[derive(Clone, Copy, Debug)]
 pub enum ShardSyncStatus {
     StateDownloadHeader,
-    StateDownloadParts,
+    StateDownloadParts { done: u64, total: u64 },
     StateApplyScheduling,
     StateApplyInProgress { done: u64, total: u64 },
     StateApplyFinalizing,
@@ -56,7 +56,7 @@ impl ShardSyncStatus {
             // Avoid reusing values for different states.
             // When introducing a new state, always assign a unique, new value to prevent confusion.
             ShardSyncStatus::StateDownloadHeader => 0,
-            ShardSyncStatus::StateDownloadParts => 1,
+            ShardSyncStatus::StateDownloadParts { .. } => 1,
             ShardSyncStatus::StateApplyScheduling => 2,
             ShardSyncStatus::StateApplyInProgress { .. } => 3,
             ShardSyncStatus::StateApplyFinalizing => 4,
@@ -78,7 +78,9 @@ impl ToString for ShardSyncStatus {
     fn to_string(&self) -> String {
         match self {
             ShardSyncStatus::StateDownloadHeader => "header".to_string(),
-            ShardSyncStatus::StateDownloadParts => "parts".to_string(),
+            ShardSyncStatus::StateDownloadParts { done, total } => {
+                format!("parts ({done}/{total})")
+            }
             ShardSyncStatus::StateApplyScheduling => "apply scheduling".to_string(),
             ShardSyncStatus::StateApplyInProgress { done, total } => {
                 format!("apply in progress ({done}/{total})")

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -414,7 +414,7 @@ impl StateSync {
             sync_status.sync_status.insert(*shard_id, status);
             metrics::STATE_SYNC_STAGE
                 .with_label_values(&[&shard_id.to_string()])
-                .set(status as i64);
+                .set(status.repr() as i64);
             if status != ShardSyncStatus::StateSyncDone {
                 all_done = false;
             }

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -90,6 +90,7 @@ pub(super) async fn run_state_sync_for_shard(
         .set(num_parts as i64);
 
     return_if_cancelled!(cancel);
+    let mut parts_downloaded: u64 = 0;
     *status.lock() = ShardSyncStatus::StateDownloadParts { done: 0, total: num_parts };
     let mut parts_to_download: Vec<u64> = (0..num_parts).collect();
     {
@@ -120,6 +121,15 @@ pub(super) async fn run_state_sync_for_shard(
                 respawn_for_parallelism(&*future_spawner, "state sync download part", future)
             })
             .buffered(concurrency_limit.into())
+            .inspect(|result| {
+                if result.is_ok() {
+                    parts_downloaded += 1;
+                    *status.lock() = ShardSyncStatus::StateDownloadParts {
+                        done: parts_downloaded,
+                        total: num_parts,
+                    };
+                }
+            })
             .collect::<Vec<_>>()
             .await;
         attempt_count += 1;
@@ -131,10 +141,6 @@ pub(super) async fn run_state_sync_for_shard(
                 res.as_ref().err().map(|_| parts_to_download[task_index])
             })
             .collect();
-        *status.lock() = ShardSyncStatus::StateDownloadParts {
-            done: num_parts - parts_to_download.len() as u64,
-            total: num_parts,
-        };
         // Wait before retrying the failed parts
         if !parts_to_download.is_empty() {
             tracing::debug!(

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -150,7 +150,7 @@ pub(super) async fn run_state_sync_for_shard(
     }
 
     return_if_cancelled!(cancel);
-    *status.lock() = ShardSyncStatus::StateApplyInProgress;
+    *status.lock() = ShardSyncStatus::StateApplyInProgress { done: 0, total: num_parts };
     runtime.get_tries().unload_memtrie(&shard_uid);
 
     // Clear flat storage before applying state parts.
@@ -191,7 +191,8 @@ pub(super) async fn run_state_sync_for_shard(
     }
 
     return_if_cancelled!(cancel);
-    let _results = tokio_stream::iter(0..num_parts)
+    let mut parts_done: u64 = 0;
+    tokio_stream::iter(0..num_parts)
         .map(|part_id| {
             let store = store.clone();
             let runtime = runtime.clone();
@@ -213,7 +214,12 @@ pub(super) async fn run_state_sync_for_shard(
             respawn_for_parallelism(&*future_spawner, "state sync apply part", future)
         })
         .buffer_unordered(concurrency_limit.into())
-        .try_collect::<Vec<_>>()
+        .try_for_each(|_| {
+            parts_done += 1;
+            *status.lock() =
+                ShardSyncStatus::StateApplyInProgress { done: parts_done, total: num_parts };
+            futures::future::ready(Ok(()))
+        })
         .await?;
 
     return_if_cancelled!(cancel);

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -90,7 +90,7 @@ pub(super) async fn run_state_sync_for_shard(
         .set(num_parts as i64);
 
     return_if_cancelled!(cancel);
-    *status.lock() = ShardSyncStatus::StateDownloadParts;
+    *status.lock() = ShardSyncStatus::StateDownloadParts { done: 0, total: num_parts };
     let mut parts_to_download: Vec<u64> = (0..num_parts).collect();
     {
         // Peer selection is designed such that different nodes downloading the same part will tend
@@ -131,6 +131,10 @@ pub(super) async fn run_state_sync_for_shard(
                 res.as_ref().err().map(|_| parts_to_download[task_index])
             })
             .collect();
+        *status.lock() = ShardSyncStatus::StateDownloadParts {
+            done: num_parts - parts_to_download.len() as u64,
+            total: num_parts,
+        };
         // Wait before retrying the failed parts
         if !parts_to_download.is_empty() {
             tracing::debug!(

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -121,14 +121,12 @@ pub(super) async fn run_state_sync_for_shard(
                 respawn_for_parallelism(&*future_spawner, "state sync download part", future)
             })
             .buffered(concurrency_limit.into())
-            .inspect(|result| {
-                if result.is_ok() {
-                    parts_downloaded += 1;
-                    *status.lock() = ShardSyncStatus::StateDownloadParts {
-                        done: parts_downloaded,
-                        total: num_parts,
-                    };
-                }
+            .inspect_ok(|_| {
+                parts_downloaded += 1;
+                *status.lock() = ShardSyncStatus::StateDownloadParts {
+                    done: parts_downloaded,
+                    total: num_parts,
+                };
             })
             .collect::<Vec<_>>()
             .await;
@@ -224,12 +222,12 @@ pub(super) async fn run_state_sync_for_shard(
             respawn_for_parallelism(&*future_spawner, "state sync apply part", future)
         })
         .buffer_unordered(concurrency_limit.into())
-        .try_for_each(|_| {
+        .inspect_ok(|_| {
             parts_done += 1;
             *status.lock() =
                 ShardSyncStatus::StateApplyInProgress { done: parts_done, total: num_parts };
-            futures::future::ready(Ok(()))
         })
+        .try_collect::<Vec<_>>()
         .await?;
 
     return_if_cancelled!(cancel);


### PR DESCRIPTION
Add per-part progress to the `StateDownloadParts` and `StateApplyInProgress` sync status so that the RPC status endpoint shows e.g. `"apply in progress (42/100)"` instead of just `"apply in progress"`. This makes it easier to monitor state sync progress during the (often slow) apply phase.