### PR TITLE
chore(network): downgrade peer manager stopping log to debug

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -202,7 +202,7 @@ impl messaging::Actor for PeerManagerActor {
 
     /// Try to gracefully disconnect from connected peers.
     fn stop_actor(&mut self) {
-        tracing::warn!("peer manager stopping");
+        tracing::debug!(target: "network", "peer manager stopping");
         self.state.tier2.broadcast_message(Arc::new(PeerMessage::Disconnect(Disconnect {
             remove_from_connection_store: false,
         })));


### PR DESCRIPTION
Change "peer manager stopping" log from warn to debug with target "network", as this is expected behavior during shutdown and not worth warning about.