### PR TITLE
chore(state-sync): downgrade sync_hash protocol version log to debug

### DIFF
--- a/chain/client/src/state_request_actor.rs
+++ b/chain/client/src/state_request_actor.rs
@@ -249,7 +249,7 @@ impl Handler<StateRequestHeader, Option<StatePartOrHeader>> for StateRequestActo
         let protocol_version = self
             .get_protocol_version_from_sync_hash(&sync_hash)
             .inspect_err(|err| {
-                tracing::error!(target: "sync", ?err, "failed to get sync_hash protocol version");
+                tracing::debug!(target: "sync", ?err, "failed to get sync_hash protocol version");
             })
             .ok()?;
 
@@ -301,7 +301,7 @@ impl Handler<StateRequestPart, Option<StatePartOrHeader>> for StateRequestActor 
         let protocol_version = self
             .get_protocol_version_from_sync_hash(&sync_hash)
             .inspect_err(|err| {
-                tracing::error!(target: "sync", ?err, "failed to get sync_hash protocol version");
+                tracing::debug!(target: "sync", ?err, "failed to get sync_hash protocol version");
             })
             .ok()?;
 


### PR DESCRIPTION
- Downgrade `tracing::error!` to `tracing::debug!` for `failed to get sync_hash protocol version` in state request handlers.
- This error is expected during header sync (node hasn't processed the block yet) and can also be triggered by malicious peers sending bogus sync hashes, making it a log spam vector at error level.