### PR TITLE
fix: properly include accessed contracts for eth implicit account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,6 +5049,7 @@ dependencies = [
  "near-stdx",
  "near-time",
  "near-vm-runner",
+ "near-wallet-contract",
  "num_cpus",
  "parking_lot 0.12.1",
  "rand 0.8.5",

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -62,6 +62,7 @@ near-primitives.workspace = true
 near-schema-checker-lib.workspace = true
 near-time.workspace = true
 near-vm-runner.workspace = true
+near-wallet-contract.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
@@ -103,6 +104,7 @@ nightly = [
     "near-parameters/nightly",
     "near-primitives/nightly",
     "near-vm-runner/nightly",
+    "near-wallet-contract/nightly",
     "testlib/nightly",
 ]
 protocol_schema = [

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -5,17 +5,19 @@ use crate::contract::ContractStorage;
 use crate::trie::TrieAccess;
 use crate::trie::{KeyLookupMode, TrieChanges};
 use near_primitives::account::AccountContract;
+use near_primitives::account::id::AccountType;
 use near_primitives::action::GlobalContractIdentifier;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::global_contract::ContractIsLocalError;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
-use near_primitives::trie_key::{SmallKeyVec, TrieKey};
+use near_primitives::trie_key::{GlobalContractCodeIdentifier, SmallKeyVec, TrieKey};
 use near_primitives::types::{
     AccountId, RawStateChange, RawStateChanges, RawStateChangesWithTrieKey, StateChangeCause,
     StateRoot,
 };
 use near_vm_runner::ContractCode;
+use near_wallet_contract::{eth_wallet_global_contract_hash, wallet_contract};
 use std::collections::BTreeMap;
 
 mod iterator;
@@ -318,6 +320,8 @@ impl TrieUpdate {
         code_hash: CryptoHash,
         account_contract: &AccountContract,
         apply_reason: ApplyChunkReason,
+        eth_implicit_global_contract: bool,
+        chain_id: &str,
     ) -> Result<(), StorageError> {
         // The recording of contracts when they are excluded from the witness are only for
         // distributing them to the validators, and not needed for validating the chunks, thus we
@@ -330,11 +334,34 @@ impl TrieUpdate {
         // deployed to the given account. This avoids recording contracts that do not exist or are
         // newly-deployed to the account. Note that the check below to see if the contract exists
         // has no side effects (not charging gas or recording trie nodes)
-        let trie_key = match GlobalContractIdentifier::try_from(account_contract.clone()) {
-            Err(ContractIsLocalError::NotDeployed) => return Ok(()),
-            Err(ContractIsLocalError::Deployed(_)) => TrieKey::ContractCode { account_id },
-            Ok(identifier) => TrieKey::GlobalContractCode { identifier: identifier.into() },
-        };
+        //
+        // For old ETH implicit accounts with wallet contract magic bytes as their code_hash,
+        // the VM uses the global wallet contract hash (not the magic bytes hash). We look up the
+        // global contract in the trie instead of the local one, so that we record the correct
+        // hash for distribution to validators.
+        let (trie_key, expected_hash) =
+            match GlobalContractIdentifier::try_from(account_contract.clone()) {
+                Err(ContractIsLocalError::NotDeployed) => return Ok(()),
+                Err(ContractIsLocalError::Deployed(_)) => {
+                    if eth_implicit_global_contract
+                        && account_id.get_account_type() == AccountType::EthImplicitAccount
+                        && wallet_contract(code_hash).is_some()
+                    {
+                        let global_hash = eth_wallet_global_contract_hash(chain_id);
+                        (
+                            TrieKey::GlobalContractCode {
+                                identifier: GlobalContractCodeIdentifier::CodeHash(global_hash),
+                            },
+                            global_hash,
+                        )
+                    } else {
+                        (TrieKey::ContractCode { account_id }, code_hash)
+                    }
+                }
+                Ok(identifier) => {
+                    (TrieKey::GlobalContractCode { identifier: identifier.into() }, code_hash)
+                }
+            };
         let mut key = SmallKeyVec::new_const();
         trie_key.append_into(&mut key);
         let contract_ref = self
@@ -346,9 +373,9 @@ impl TrieUpdate {
                 if matches!(err, StorageError::MissingTrieValue(_)) { Ok(None) } else { Err(err) }
             })?;
         let contract_exists =
-            contract_ref.is_some_and(|value_ref| value_ref.value_hash() == code_hash);
+            contract_ref.is_some_and(|value_ref| value_ref.value_hash() == expected_hash);
         if contract_exists {
-            self.contract_storage.record_call(code_hash);
+            self.contract_storage.record_call(expected_hash);
         }
         Ok(())
     }

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -56,6 +56,8 @@ pub(crate) fn action_function_call(
         code_hash,
         account_contract.as_ref(),
         apply_state.apply_reason.clone(),
+        config.wasm_config.eth_implicit_global_contract,
+        &epoch_info_provider.chain_id(),
     )?;
 
     #[cfg(feature = "test_features")]


### PR DESCRIPTION
A follow-up for #15132.
Mirrors `RuntimeContractExt`:
```
    fn hash(&self) -> CryptoHash {
        // For eth implicit accounts return the wallet contract code hash.
        // The account.code_hash() contains hash of the magic bytes, not the contract hash.
        if self.account_id.get_account_type() == AccountType::EthImplicitAccount {
            // There are old eth implicit accounts without magic bytes in the code hash.
            // Result can be None and it's a valid option. See https://github.com/near/nearcore/pull/11606
            if let Some(wc) = wallet_contract(self.code_hash) {
                if self.config.eth_implicit_global_contract {
                    return eth_wallet_global_contract_hash(&self.chain_id);
                } else {
                    return *wc.hash();
                }
            }
        }

        self.code_hash
    }
```

This is a short term fix to stop the bleeding on testnet while working on a proper solution.