### PR TITLE
refactor(test-loop): simplify eth_implicit_global_contract test

### DIFF
--- a/test-loop-tests/src/tests/eth_implicit_global_contract.rs
+++ b/test-loop-tests/src/tests/eth_implicit_global_contract.rs
@@ -112,7 +112,8 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
         GlobalContractDeployMode::CodeHash,
     );
     env.validator_runner().run_tx(deploy_tx, Duration::seconds(5));
-    env.test_loop.run_for(Duration::seconds(2));
+    // Make sure that global contract propagation finishes
+    env.validator_runner().run_for_number_of_blocks(2);
 
     // Phase 4: Old account still works after upgrade (rlp_execute transfer).
     let before = env.validator().view_account_query(&receiver).unwrap().amount;
@@ -126,7 +127,6 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
         &relayer,
     );
     env.validator_runner().run_tx(tx, Duration::seconds(5));
-    env.test_loop.run_for(Duration::seconds(2));
     let after = env.validator().view_account_query(&receiver).unwrap().amount;
     assert_eq!(after.checked_sub(before).unwrap(), transfer_amount, "old account transfer failed");
 
@@ -137,8 +137,6 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
     let create_eth_new_tx =
         env.validator().tx_send_money(&relayer, &eth_new, Balance::from_near(5));
     env.validator_runner().run_tx(create_eth_new_tx, Duration::seconds(5));
-    env.test_loop.run_for(Duration::seconds(2));
-
     assert_eq!(
         env.validator().view_account_query(&eth_new).unwrap().global_contract_hash,
         Some(expected_hash)
@@ -156,7 +154,6 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
         &relayer,
     );
     env.validator_runner().run_tx(tx, Duration::seconds(5));
-    env.test_loop.run_for(Duration::seconds(2));
     let after = env.validator().view_account_query(&receiver).unwrap().amount;
     assert_eq!(after.checked_sub(before).unwrap(), transfer_amount, "new account transfer failed");
 }


### PR DESCRIPTION
- Use `env.validator().tx_from_actions()`, `tx_send_money()`, and `tx_deploy_global_contract()` instead of manually constructing `SignedTransaction` with explicit nonce and block hash management
- Extract `build_rlp_execute_tx_args` to separate ETH tx arg building from NEAR tx construction
- Use `create_validators_spec`/`validators_spec_clients`/`create_account_id` helpers
- Use `TestLoopBuilder::new_genesis_builder()` and `TestEpochConfigBuilder::from_genesis()`
- Remove `view_global_contract_hash` helper in favor of inline `view_account_query`
- Flatten grouped imports to module-level granularity
- Remove unnecessary `run_for` calls after transactions
- Use `run_for_number_of_blocks` after global contract deploy to ensure propagation
- Reduce epoch length from 10 to 5