### PR TITLE
ci: add standalone workflow for publishing sandbox Docker images

### DIFF
--- a/.github/workflows/sandbox_docker_publish.yml
+++ b/.github/workflows/sandbox_docker_publish.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   # Hardcoded for testing on this branch. Once merged, this job uses inputs.version instead.
-  SANDBOX_VERSION: "2.10.7"
+  SANDBOX_VERSION: "2.11.0-rc.3"
 
 jobs:
   publish:


### PR DESCRIPTION
- Allows publishing `nearprotocol/sandbox:{version}` without triggering a full neard binary release
- Validates S3 binaries exist before building
- Supports optional `latest` tag
- Useful for backfilling version tags that were missed before the sandbox docker job was added to the release pipeline

Testing by triggering the workflow from this branch with `version: 2.10.7`.