### PR TITLE
chore(state-sync): replace rust-s3 with object_store aws backend

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -45,9 +45,7 @@ ignore = [
     # of existence naturally.
     "RUSTSEC-2024-0436",
 
-    # rustls-pemfile is no longer maintained, but it's indirectly required by rust-s3,
-    # which cannot be updated without moving to Rust 1.88
-    # TODO(#14768): Remove this and updated necessary crates to get rid of rustls-pemfile
+    # rustls-pemfile is unmaintained, but it's indirectly required by object_store and reqwest
     "RUSTSEC-2025-0134",
 
     # time has a DoS vulnerability (stack exhaustion), fixed in 0.3.47+ which requires Rust 1.88

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,22 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "attohttpc"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262c3f7f5d61249d8c00e5546e2685cd15ebeeb1bc0f3cc5449350a1cb07319e"
-dependencies = [
- "http 0.2.12",
- "log",
- "native-tls",
- "openssl",
- "serde",
- "serde_json",
- "url",
- "wildmatch",
-]
-
-[[package]]
 name = "aurora-engine-modexp"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,22 +434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "aws-creds"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeeee1a5defa63cba39097a510dfe63ef53658fc8995202a610f6a8a4d03639"
-dependencies = [
- "attohttpc",
- "dirs",
- "rust-ini",
- "serde",
- "serde-xml-rs",
- "thiserror 1.0.50",
- "time",
- "url",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,15 +453,6 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
-]
-
-[[package]]
-name = "aws-region"
-version = "0.25.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
-dependencies = [
- "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -725,16 +684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block_on_proc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b872f3528eeeb4370ee73b51194dc1cd93680c2d0eb6c7a223889038d2c1a167"
-dependencies = [
- "quote",
- "syn 1.0.103",
 ]
 
 [[package]]
@@ -1927,12 +1876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
 
 [[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,19 +3010,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.28",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -3113,7 +3043,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -3919,30 +3849,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "maybe-async"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "md-5"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b48670c893079d3c2ed79114e3644b7004df1c361a4e0ad52e2e6940d07c3d"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
+ "cfg-if",
  "digest 0.10.7",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -4021,15 +3935,6 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "minidom"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45614075738ce1b77a1768912a60c0227525971b03e09122a05b8a34a2a6278"
-dependencies = [
- "rxml",
 ]
 
 [[package]]
@@ -4382,7 +4287,6 @@ dependencies = [
  "reed-solomon-erasure",
  "regex",
  "reqwest 0.13.2",
- "rust-s3",
  "serde",
  "serde_json",
  "strum",
@@ -4551,7 +4455,6 @@ dependencies = [
  "object_store",
  "percent-encoding",
  "reqwest 0.13.2",
- "rust-s3",
  "serde",
  "serde_json",
  "tracing",
@@ -5872,6 +5775,7 @@ dependencies = [
  "humantime",
  "hyper 1.7.0",
  "itertools 0.14.0",
+ "md-5",
  "parking_lot 0.12.1",
  "percent-encoding",
  "quick-xml",
@@ -6056,16 +5960,6 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "serde",
-]
-
-[[package]]
-name = "ordered-multimap"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
-dependencies = [
- "dlv-list",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -6955,48 +6849,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.0",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
@@ -7021,7 +6873,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.22.4",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7036,7 +6888,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg 0.52.0",
+ "winreg",
 ]
 
 [[package]]
@@ -7057,7 +6909,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.7.0",
  "hyper-rustls 0.27.7",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -7294,16 +7146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
-
-[[package]]
 name = "rust-multipart-rfc7578_2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7316,38 +7158,6 @@ dependencies = [
  "mime",
  "rand 0.9.0",
  "thiserror 2.0.16",
-]
-
-[[package]]
-name = "rust-s3"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6009d9d4cf910505534d62d380a0aa305805a2af0b5c3ad59a3024a0715b847"
-dependencies = [
- "async-trait",
- "aws-creds",
- "aws-region",
- "base64 0.13.0",
- "block_on_proc",
- "cfg-if",
- "hex",
- "hmac 0.12.1",
- "http 0.2.12",
- "log",
- "maybe-async",
- "md5",
- "minidom",
- "percent-encoding",
- "reqwest 0.11.27",
- "serde",
- "serde-xml-rs",
- "serde_derive",
- "sha2 0.10.6",
- "thiserror 1.0.50",
- "time",
- "tokio",
- "tokio-stream",
- "url",
 ]
 
 [[package]]
@@ -7444,7 +7254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe 0.1.5",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.6.1",
@@ -7460,15 +7270,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.0",
 ]
 
 [[package]]
@@ -7545,23 +7346,6 @@ name = "rustversion"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
-
-[[package]]
-name = "rxml"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98f186c7a2f3abbffb802984b7f1dfd65dac8be1aafdaabbca4137f53f0dff7"
-dependencies = [
- "bytes",
- "rxml_validation",
- "smartstring",
-]
-
-[[package]]
-name = "rxml_validation"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a197350ece202f19a166d1ad6d9d6de145e1d2a8ef47db299abe164dbd7530"
 
 [[package]]
 name = "ryu"
@@ -7745,18 +7529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-xml-rs"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
-dependencies = [
- "log",
- "serde",
- "thiserror 1.0.50",
- "xml-rs",
 ]
 
 [[package]]
@@ -8324,34 +8096,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.3",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.3",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -9753,12 +9504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wildmatch"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10185,16 +9930,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
@@ -10254,12 +9989,6 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xshell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ num-traits = "0.2.15"
 num-integer = "0.1.46"
 
 okapi = { git = "https://github.com/near/near-okapi-fork.git", rev = "fd7de89e130ab99a546f04e3faefcd53044f98d0", features = ["schemars-alpha"] } # Upstream crate can be used as soon as schemars 1.0 is supported https://github.com/GREsau/okapi/pull/161
-object_store = { version = "0.13", features = ["gcp"] }
+object_store = { version = "0.13", features = ["aws", "gcp"] }
 openssl-probe = "0.1.4"
 opentelemetry = { version = "0.30", features = ["trace"] }
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
@@ -348,7 +348,6 @@ rlp = "0.5.2"
 rocksdb = { version = "0.21.0", default-features = false }
 rusqlite = { version = "0.29.0", features = ["bundled", "chrono", "functions"] }
 rustc-demangle = "0.1"
-rust-s3 = { version = "0.32.3", features = ["blocking"] }
 rustix = "1"
 secp256k1 = { version = "0.27.0", default-features = false }
 semver = "1.0.4"

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -25,7 +25,6 @@ rayon.workspace = true
 reed-solomon-erasure.workspace = true
 regex.workspace = true
 reqwest.workspace = true
-rust-s3.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 strum.workspace = true
@@ -107,5 +106,3 @@ sandbox = [
     "near-o11y/sandbox",
 ]
 
-[package.metadata.cargo-machete]
-ignored = ["rust-s3"]

--- a/chain/client/src/stateless_validation/state_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/state_witness_tracker.rs
@@ -4,9 +4,9 @@ use lru::LruCache;
 use near_async::time::Clock;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::stateless_validation::state_witness::ChunkStateWitnessAck;
-use s3::creds::time::ext::InstantExt as _;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
+use time::ext::InstantExt as _;
 
 /// Limit to the number of witnesses tracked.
 ///

--- a/core/external-storage/Cargo.toml
+++ b/core/external-storage/Cargo.toml
@@ -17,12 +17,8 @@ object_store.workspace = true
 futures.workspace = true
 percent-encoding.workspace = true
 reqwest.workspace = true
-rust-s3.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 
 near-chain-configs.workspace = true
-
-[package.metadata.cargo-machete]
-ignored = ["rust-s3"]

--- a/core/external-storage/src/lib.rs
+++ b/core/external-storage/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use futures::TryStreamExt;
 use near_chain_configs::ExternalStorageLocation;
 use object_store::aws::AmazonS3Builder;
+use object_store::path::Path as StorePath;
 use object_store::{ClientOptions, ObjectStore, ObjectStoreExt, PutPayload};
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -110,7 +111,7 @@ impl ExternalConnection {
         match self {
             ExternalConnection::S3 { s3_client } => {
                 tracing::debug!(target: "external", path, "reading from S3");
-                let obj_path = object_store::path::Path::parse(path)
+                let obj_path = StorePath::parse(path)
                     .with_context(|| format!("{path} isn't a valid S3 path"))?;
                 let result = s3_client.get(&obj_path).await?;
                 Ok(result.bytes().await?.to_vec())
@@ -147,7 +148,7 @@ impl ExternalConnection {
         match self {
             ExternalConnection::S3 { s3_client } => {
                 tracing::debug!(target: "external", path, "writing to S3");
-                let obj_path = object_store::path::Path::parse(path)
+                let obj_path = StorePath::parse(path)
                     .with_context(|| format!("{path} isn't a valid S3 path"))?;
                 s3_client.put(&obj_path, PutPayload::from_bytes(value.to_vec().into())).await?;
                 Ok(())
@@ -167,7 +168,7 @@ impl ExternalConnection {
                 Ok(())
             }
             ExternalConnection::GCS { gcs_client, .. } => {
-                let path = object_store::path::Path::parse(path)
+                let path = StorePath::parse(path)
                     .with_context(|| format!("{path} isn't a valid path for GCP"))?;
                 tracing::debug!(target: "external", ?path, "writing to GCS");
                 gcs_client.put(&path, PutPayload::from_bytes(value.to_vec().into())).await?;
@@ -185,7 +186,7 @@ impl ExternalConnection {
             ExternalConnection::S3 { s3_client } => {
                 let prefix = format!("{}/", directory_path);
                 tracing::debug!(target: "external", directory_path, "list directory in S3");
-                let obj_prefix = object_store::path::Path::parse(&prefix)
+                let obj_prefix = StorePath::parse(&prefix)
                     .with_context(|| format!("can't parse {prefix} as path"))?;
                 let result = s3_client.list_with_delimiter(Some(&obj_prefix)).await?;
                 Ok(result
@@ -211,7 +212,7 @@ impl ExternalConnection {
                 tracing::debug!(target: "external", directory_path, "list directory in GCS");
                 Ok(gcs_client
                     .list(Some(
-                        &object_store::path::Path::parse(&prefix)
+                        &StorePath::parse(&prefix)
                             .with_context(|| format!("can't parse {prefix} as path"))?,
                     ))
                     .try_collect::<Vec<_>>()

--- a/core/external-storage/src/lib.rs
+++ b/core/external-storage/src/lib.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
 use futures::TryStreamExt;
 use near_chain_configs::ExternalStorageLocation;
-use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
+use object_store::aws::AmazonS3Builder;
+use object_store::{ClientOptions, ObjectStore, ObjectStoreExt, PutPayload};
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -13,7 +14,7 @@ use std::time::Duration;
 #[derive(Clone)]
 pub enum ExternalConnection {
     /// Authenticated S3 client (read-only or read/write).
-    S3 { bucket: Arc<s3::Bucket> },
+    S3 { s3_client: Arc<object_store::aws::AmazonS3> },
     /// Local filesystem root directory.
     Filesystem { root_dir: PathBuf },
     /// GCS client (upload/list via SDK, anonymous downloads via HTTP).
@@ -59,21 +60,21 @@ impl ExternalConnection {
             ExternalStorageLocation::S3 { bucket, region, .. } => {
                 let S3AccessConfig { is_readonly, timeout } = s3_access_config
                     .expect("S3 access config not provided with S3 external storage location");
-                let bucket = if is_readonly {
-                    create_s3_bucket_readonly(&bucket, &region, timeout)
+                let s3_client = if is_readonly {
+                    create_s3_bucket_readonly(bucket, region, timeout)
                 } else {
-                    create_s3_bucket_read_write(&bucket, &region, timeout, credentials_file)
+                    create_s3_bucket_read_write(bucket, region, timeout, credentials_file)
                 };
-                if let Err(err) = bucket {
+                if let Err(err) = s3_client {
                     if is_readonly {
-                        panic!("Failed to create an S3 bucket: {err}");
+                        panic!("failed to create an S3 client: {err}");
                     } else {
                         panic!(
-                            "Failed to authenticate connection to S3. Please either provide AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the environment, or create a credentials file and link it in config.json as 's3_credentials_file'. Error: {err}"
+                            "failed to authenticate connection to S3. Please either provide AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the environment, or create a credentials file and link it in config.json as 's3_credentials_file'. Error: {err}"
                         );
                     }
                 }
-                ExternalConnection::S3 { bucket: Arc::new(bucket.unwrap()) }
+                ExternalConnection::S3 { s3_client: Arc::new(s3_client.unwrap()) }
             }
             ExternalStorageLocation::Filesystem { root_dir } => {
                 ExternalConnection::Filesystem { root_dir: root_dir.clone() }
@@ -107,14 +108,12 @@ impl ExternalConnection {
     /// Download an object at `path` as bytes.
     pub async fn get(&self, path: &str) -> Result<Vec<u8>, anyhow::Error> {
         match self {
-            ExternalConnection::S3 { bucket } => {
+            ExternalConnection::S3 { s3_client } => {
                 tracing::debug!(target: "external", path, "reading from S3");
-                let response = bucket.get_object(path).await?;
-                if response.status_code() == 200 {
-                    Ok(response.bytes().to_vec())
-                } else {
-                    Err(anyhow::anyhow!("Bad response status code: {}", response.status_code()))
-                }
+                let obj_path = object_store::path::Path::parse(path)
+                    .with_context(|| format!("{path} isn't a valid S3 path"))?;
+                let result = s3_client.get(&obj_path).await?;
+                Ok(result.bytes().await?.to_vec())
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(path);
@@ -146,9 +145,11 @@ impl ExternalConnection {
     /// Upload/overwrite an object at `path` with `value`.
     pub async fn put(&self, path: &str, value: &[u8]) -> Result<(), anyhow::Error> {
         match self {
-            ExternalConnection::S3 { bucket } => {
+            ExternalConnection::S3 { s3_client } => {
                 tracing::debug!(target: "external", path, "writing to S3");
-                bucket.put_object(path, value).await?;
+                let obj_path = object_store::path::Path::parse(path)
+                    .with_context(|| format!("{path} isn't a valid S3 path"))?;
+                s3_client.put(&obj_path, PutPayload::from_bytes(value.to_vec().into())).await?;
                 Ok(())
             }
             ExternalConnection::Filesystem { root_dir } => {
@@ -181,17 +182,17 @@ impl ExternalConnection {
     /// Recursive for GCS (lists all objects within the given directory).
     pub async fn list(&self, directory_path: &str) -> Result<Vec<String>, anyhow::Error> {
         match self {
-            ExternalConnection::S3 { bucket } => {
+            ExternalConnection::S3 { s3_client } => {
                 let prefix = format!("{}/", directory_path);
-                let list_results = bucket.list(prefix.clone(), Some("/".to_string())).await?;
                 tracing::debug!(target: "external", directory_path, "list directory in S3");
-                let mut file_names = vec![];
-                for res in list_results {
-                    for obj in res.contents {
-                        file_names.push(extract_file_name_from_full_path(obj.key))
-                    }
-                }
-                Ok(file_names)
+                let obj_prefix = object_store::path::Path::parse(&prefix)
+                    .with_context(|| format!("can't parse {prefix} as path"))?;
+                let result = s3_client.list_with_delimiter(Some(&obj_prefix)).await?;
+                Ok(result
+                    .objects
+                    .into_iter()
+                    .map(|obj| obj.location.filename().unwrap_or_default().to_string())
+                    .collect())
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(directory_path);
@@ -223,24 +224,24 @@ impl ExternalConnection {
     }
 }
 
-/// Extract file name from a full (string) path.
-fn extract_file_name_from_full_path(full_path: String) -> String {
-    return extract_file_name_from_path_buf(PathBuf::from(full_path));
-}
-
 /// Extract file name from a PathBuf.
 fn extract_file_name_from_path_buf(path_buf: PathBuf) -> String {
     return path_buf.file_name().unwrap().to_str().unwrap().to_string();
 }
 
-/// Create an anonymous, read-only S3 bucket handle.
-pub fn create_s3_bucket_readonly(
+/// Create an anonymous, read-only S3 client.
+fn create_s3_bucket_readonly(
     bucket: &str,
     region: &str,
     timeout: Duration,
-) -> Result<s3::Bucket, anyhow::Error> {
-    let creds = s3::creds::Credentials::anonymous()?;
-    create_s3_bucket(bucket, region, timeout, creds)
+) -> Result<object_store::aws::AmazonS3, anyhow::Error> {
+    AmazonS3Builder::new()
+        .with_bucket_name(bucket)
+        .with_region(region)
+        .with_skip_signature(true)
+        .with_client_options(ClientOptions::new().with_timeout(timeout))
+        .build()
+        .map_err(Into::into)
 }
 
 /// Credentials for S3 read/write access (from JSON file).
@@ -250,41 +251,33 @@ struct S3CredentialsConfig {
     secret_key: String,
 }
 
-/// Create a read/write S3 bucket handle, optionally using a JSON credentials file.
-pub fn create_s3_bucket_read_write(
+/// Create a read/write S3 client, optionally using a JSON credentials file.
+fn create_s3_bucket_read_write(
     bucket: &str,
     region: &str,
     timeout: Duration,
     credentials_file: Option<PathBuf>,
-) -> Result<s3::Bucket, anyhow::Error> {
-    let creds = match credentials_file {
+) -> Result<object_store::aws::AmazonS3, anyhow::Error> {
+    let client_options = ClientOptions::new().with_timeout(timeout);
+    let s3 = match credentials_file {
         Some(credentials_file) => {
             let mut file = std::fs::File::open(credentials_file)?;
             let mut json_config_str = String::new();
             file.read_to_string(&mut json_config_str)?;
             let credentials_config: S3CredentialsConfig = serde_json::from_str(&json_config_str)?;
-            s3::creds::Credentials::new(
-                Some(&credentials_config.access_key),
-                Some(&credentials_config.secret_key),
-                None,
-                None,
-                None,
-            )
+            AmazonS3Builder::new()
+                .with_bucket_name(bucket)
+                .with_region(region)
+                .with_access_key_id(&credentials_config.access_key)
+                .with_secret_access_key(&credentials_config.secret_key)
+                .with_client_options(client_options)
+                .build()?
         }
-        None => s3::creds::Credentials::default(),
-    }?;
-    create_s3_bucket(bucket, region, timeout, creds)
-}
-
-/// Build an S3 bucket client and set request timeout.
-fn create_s3_bucket(
-    bucket: &str,
-    region: &str,
-    timeout: Duration,
-    creds: s3::creds::Credentials,
-) -> Result<s3::Bucket, anyhow::Error> {
-    let mut bucket = s3::Bucket::new(bucket, region.parse::<s3::Region>()?, creds)?;
-    // Ensure requests finish in finite amount of time.
-    bucket.set_request_timeout(Some(timeout));
-    Ok(bucket)
+        None => AmazonS3Builder::from_env()
+            .with_bucket_name(bucket)
+            .with_region(region)
+            .with_client_options(client_options)
+            .build()?,
+    };
+    Ok(s3)
 }

--- a/core/external-storage/src/lib.rs
+++ b/core/external-storage/src/lib.rs
@@ -62,9 +62,9 @@ impl ExternalConnection {
                 let S3AccessConfig { is_readonly, timeout } = s3_access_config
                     .expect("S3 access config not provided with S3 external storage location");
                 let s3_client = if is_readonly {
-                    create_s3_bucket_readonly(bucket, region, timeout)
+                    create_s3_client_readonly(bucket, region, timeout)
                 } else {
-                    create_s3_bucket_read_write(bucket, region, timeout, credentials_file)
+                    create_s3_client_read_write(bucket, region, timeout, credentials_file)
                 };
                 if let Err(err) = s3_client {
                     if is_readonly {
@@ -231,7 +231,7 @@ fn extract_file_name_from_path_buf(path_buf: PathBuf) -> String {
 }
 
 /// Create an anonymous, read-only S3 client.
-fn create_s3_bucket_readonly(
+fn create_s3_client_readonly(
     bucket: &str,
     region: &str,
     timeout: Duration,
@@ -253,7 +253,7 @@ struct S3CredentialsConfig {
 }
 
 /// Create a read/write S3 client, optionally using a JSON credentials file.
-fn create_s3_bucket_read_write(
+fn create_s3_client_read_write(
     bucket: &str,
     region: &str,
     timeout: Duration,

--- a/core/external-storage/src/lib.rs
+++ b/core/external-storage/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use futures::TryStreamExt;
 use near_chain_configs::ExternalStorageLocation;
-use object_store::aws::AmazonS3Builder;
+use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path as StorePath;
 use object_store::{ClientOptions, ObjectStore, ObjectStoreExt, PutPayload};
 use std::io::{Read, Write};
@@ -15,7 +15,7 @@ use std::time::Duration;
 #[derive(Clone)]
 pub enum ExternalConnection {
     /// Authenticated S3 client (read-only or read/write).
-    S3 { s3_client: Arc<object_store::aws::AmazonS3> },
+    S3 { s3_client: Arc<AmazonS3> },
     /// Local filesystem root directory.
     Filesystem { root_dir: PathBuf },
     /// GCS client (upload/list via SDK, anonymous downloads via HTTP).
@@ -235,7 +235,7 @@ fn create_s3_bucket_readonly(
     bucket: &str,
     region: &str,
     timeout: Duration,
-) -> Result<object_store::aws::AmazonS3, anyhow::Error> {
+) -> Result<AmazonS3, anyhow::Error> {
     AmazonS3Builder::new()
         .with_bucket_name(bucket)
         .with_region(region)
@@ -258,7 +258,7 @@ fn create_s3_bucket_read_write(
     region: &str,
     timeout: Duration,
     credentials_file: Option<PathBuf>,
-) -> Result<object_store::aws::AmazonS3, anyhow::Error> {
+) -> Result<AmazonS3, anyhow::Error> {
     let client_options = ClientOptions::new().with_timeout(timeout);
     let s3 = match credentials_file {
         Some(credentials_file) => {

--- a/core/external-storage/src/lib.rs
+++ b/core/external-storage/src/lib.rs
@@ -192,7 +192,7 @@ impl ExternalConnection {
                 Ok(result
                     .objects
                     .into_iter()
-                    .map(|obj| obj.location.filename().unwrap_or_default().to_string())
+                    .filter_map(|obj| obj.location.filename().map(|f| f.to_string()))
                     .collect())
             }
             ExternalConnection::Filesystem { root_dir } => {


### PR DESCRIPTION
- Replace `rust-s3` crate with `object_store`'s `"aws"` feature for S3 external storage, unifying S3 and GCS on a single storage library.
- Remove `rust-s3` and ~20 unique transitive dependencies (aws-creds, aws-region, minidom, serde-xml-rs, reqwest 0.11, etc.) from the dependency tree.
- Fix dead `use s3::creds::time::ext::InstantExt` import in `state_witness_tracker.rs` (replaced with `time::ext::InstantExt`).
- Update RUSTSEC-2025-0134 audit ignore comment (`rustls-pemfile` is still pulled by `object_store`/`reqwest`).