### PR TITLE
chore(ci): gitignore claude code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ testdir/
 
 **/.ipynb_checkpoints/*
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # Editor config files
 .vscode
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider


### PR DESCRIPTION
Add `.claude/settings.local.json` to `.gitignore` to prevent user-specific Claude Code permission settings from being committed.