### PR TITLE
test(runtime): verify view contract calls in eth implicit global contract test

### DIFF
--- a/test-loop-tests/src/examples/basic.rs
+++ b/test-loop-tests/src/examples/basic.rs
@@ -106,7 +106,10 @@ fn test_jsonrpc_block_by_height() {
 
     let result = env
         .rpc_runner()
-        .run_jsonrpc_query(|client| client.block_by_id(BlockId::Height(1)), Duration::seconds(5))
+        .run_with_jsonrpc_client(
+            |client| client.block_by_id(BlockId::Height(1)),
+            Duration::seconds(5),
+        )
         .unwrap();
 
     assert_eq!(result.header.height, 1, "expected block height 1, got {}", result.header.height);

--- a/test-loop-tests/src/tests/eth_implicit_global_contract.rs
+++ b/test-loop-tests/src/tests/eth_implicit_global_contract.rs
@@ -8,18 +8,20 @@ use ethabi::ethereum_types::U256;
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::TestEpochConfigBuilder;
 use near_crypto::{KeyType, SecretKey};
+use near_jsonrpc_primitives::types::query::{QueryResponseKind, RpcQueryRequest};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::id::AccountIdRef;
 use near_primitives::action::{Action, FunctionCallAction, GlobalContractDeployMode};
 use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, Balance, Gas};
+use near_primitives::types::{AccountId, Balance, BlockReference, Finality, FunctionArgs, Gas};
 use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::utils::derive_eth_implicit_account_id;
 use near_primitives::version::ProtocolFeature;
+use near_primitives::views::QueryRequest;
 use near_vm_runner::ContractCode;
-use near_wallet_contract::eth_wallet_global_contract_hash;
+use near_wallet_contract::{LegacyEthWallet, eth_wallet_global_contract_hash};
 use sha3::{Digest, Keccak256};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -96,6 +98,17 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
     env.validator_runner().run_tx(create_eth_account_tx, Duration::seconds(5));
     assert_eq!(env.validator().view_account_query(&eth_old).unwrap().global_contract_hash, None);
 
+    // Verify view calls work at PV 82 (legacy wallet contract path).
+    // chain_id "mocknet" resolves to the localnet legacy wallet contract.
+    let code = rpc_view_code(&mut env, &eth_old);
+    let legacy_wasm = LegacyEthWallet::Localnet.contract();
+    assert_eq!(
+        code,
+        legacy_wasm.code(),
+        "ViewCode should return legacy localnet wallet contract at PV 82"
+    );
+    assert_eq!(rpc_get_nonce(&mut env, &eth_old), 0, "get_nonce should return 0 at PV 82");
+
     // Phase 2: Wait for protocol upgrade to PV 83.
     env.validator_runner().run_until(
         |node| {
@@ -120,6 +133,15 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
     // propagated as part of the witness distribution.
     env.node(chunk_validator_idx).clear_compiled_contract_cache();
 
+    // Verify view calls on old account at PV 83 (global contract path).
+    let code = rpc_view_code(&mut env, &eth_old);
+    assert_eq!(code, GLOBAL_CONTRACT_MAINNET_WASM, "ViewCode should return global contract WASM");
+    assert_eq!(
+        rpc_get_nonce(&mut env, &eth_old),
+        0,
+        "get_nonce should return 0 before any rlp_execute"
+    );
+
     // Phase 4: Old account still works after upgrade (rlp_execute transfer).
     let before = env.validator().view_account_query(&receiver).unwrap().amount;
     let tx = build_rlp_execute_tx(
@@ -134,6 +156,7 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
     env.validator_runner().run_tx(tx, Duration::seconds(5));
     let after = env.validator().view_account_query(&receiver).unwrap().amount;
     assert_eq!(after.checked_sub(before).unwrap(), transfer_amount, "old account transfer failed");
+    assert_eq!(rpc_get_nonce(&mut env, &eth_old), 1, "get_nonce should return 1 after rlp_execute");
 
     // Phase 5: Create new ETH implicit account at PV 83 (global contract path).
     let secret_key_new = SecretKey::from_seed(KeyType::SECP256K1, "test_new");
@@ -146,6 +169,11 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
         env.validator().view_account_query(&eth_new).unwrap().global_contract_hash,
         Some(expected_hash)
     );
+
+    // Verify view calls on new account at PV 83.
+    let code = rpc_view_code(&mut env, &eth_new);
+    assert_eq!(code, GLOBAL_CONTRACT_MAINNET_WASM, "ViewCode should return global contract WASM");
+    assert_eq!(rpc_get_nonce(&mut env, &eth_new), 0, "get_nonce should return 0 for new account");
 
     // Phase 6: New account works via rlp_execute transfer.
     let before = env.validator().view_account_query(&receiver).unwrap().amount;
@@ -161,6 +189,7 @@ fn test_eth_implicit_global_contract_mainnet_upgrade() {
     env.validator_runner().run_tx(tx, Duration::seconds(5));
     let after = env.validator().view_account_query(&receiver).unwrap().amount;
     assert_eq!(after.checked_sub(before).unwrap(), transfer_amount, "new account transfer failed");
+    assert_eq!(rpc_get_nonce(&mut env, &eth_new), 1, "get_nonce should return 1 after rlp_execute");
 }
 
 fn build_rlp_execute_tx_args(
@@ -249,4 +278,46 @@ fn derive_address(account_id: &AccountIdRef) -> aurora_engine_types::types::Addr
     }
     let hash: [u8; 32] = Keccak256::digest(account_id.as_bytes()).into();
     aurora_engine_types::types::Address::try_from_slice(&hash[12..32]).unwrap()
+}
+
+/// Query ViewCode via JSON-RPC and return the contract code bytes.
+fn rpc_view_code(env: &mut TestLoopEnv, account_id: &AccountId) -> Vec<u8> {
+    let result = env
+        .validator_runner()
+        .run_jsonrpc_query(
+            RpcQueryRequest {
+                block_reference: BlockReference::Finality(Finality::None),
+                request: QueryRequest::ViewCode { account_id: account_id.clone() },
+            },
+            Duration::seconds(5),
+        )
+        .unwrap();
+    match result.kind {
+        QueryResponseKind::ViewCode(view) => view.code,
+        other => panic!("expected ViewCode, got: {other:?}"),
+    }
+}
+
+/// Call `get_nonce` view function via JSON-RPC and return the decoded nonce.
+fn rpc_get_nonce(env: &mut TestLoopEnv, account_id: &AccountId) -> u64 {
+    let result = env
+        .validator_runner()
+        .run_jsonrpc_query(
+            RpcQueryRequest {
+                block_reference: BlockReference::Finality(Finality::None),
+                request: QueryRequest::CallFunction {
+                    account_id: account_id.clone(),
+                    method_name: "get_nonce".to_string(),
+                    args: FunctionArgs::from(vec![]),
+                },
+            },
+            Duration::seconds(5),
+        )
+        .unwrap();
+    let bytes = match result.kind {
+        QueryResponseKind::CallResult(call_result) => call_result.result,
+        other => panic!("expected CallResult, got: {other:?}"),
+    };
+    let nonce: String = serde_json::from_slice(&bytes).expect("get_nonce should return valid JSON");
+    nonce.parse().expect("get_nonce should return a numeric string")
 }

--- a/test-loop-tests/src/tests/jsonrpc.rs
+++ b/test-loop-tests/src/tests/jsonrpc.rs
@@ -15,7 +15,10 @@ fn test_rpc_block_by_height() {
 
     let result = env
         .rpc_runner()
-        .run_jsonrpc_query(|client| client.block_by_id(BlockId::Height(1)), Duration::seconds(5))
+        .run_with_jsonrpc_client(
+            |client| client.block_by_id(BlockId::Height(1)),
+            Duration::seconds(5),
+        )
         .unwrap();
 
     assert_eq!(result.header.height, 1, "expected block height 1, got {}", result.header.height);
@@ -46,7 +49,10 @@ fn test_rpc_broadcast_tx_commit_transfer() {
 
     let result = env
         .rpc_runner()
-        .run_jsonrpc_query(|client| client.broadcast_tx_commit(tx_base64), Duration::seconds(10))
+        .run_with_jsonrpc_client(
+            |client| client.broadcast_tx_commit(tx_base64),
+            Duration::seconds(10),
+        )
         .unwrap();
 
     // Extract the execution outcome.

--- a/test-loop-tests/src/tests/receipt_to_tx.rs
+++ b/test-loop-tests/src/tests/receipt_to_tx.rs
@@ -465,7 +465,7 @@ fn test_receipt_to_tx_rpc_direct() {
 
     let response = env
         .rpc_runner()
-        .run_jsonrpc_query(
+        .run_with_jsonrpc_client(
             |client| {
                 client.EXPERIMENTAL_receipt_to_tx(RpcReceiptToTxRequest {
                     receipt_reference: ReceiptReference { receipt_id },
@@ -539,7 +539,7 @@ fn test_receipt_to_tx_rpc_chain_walk() {
     // Query the refund receipt — should resolve through the chain back to the tx.
     let response = env
         .rpc_runner()
-        .run_jsonrpc_query(
+        .run_with_jsonrpc_client(
             |client| {
                 client.EXPERIMENTAL_receipt_to_tx(RpcReceiptToTxRequest {
                     receipt_reference: ReceiptReference { receipt_id: refund_receipt_id },
@@ -561,7 +561,7 @@ fn test_receipt_to_tx_rpc_unknown_receipt() {
     let mut env = TestLoopBuilder::new().enable_rpc().epoch_length(EPOCH_LENGTH).build();
 
     let fake_receipt_id = CryptoHash::hash_bytes(b"nonexistent");
-    let result = env.rpc_runner().run_jsonrpc_query(
+    let result = env.rpc_runner().run_with_jsonrpc_client(
         |client| {
             client.EXPERIMENTAL_receipt_to_tx(RpcReceiptToTxRequest {
                 receipt_reference: ReceiptReference { receipt_id: fake_receipt_id },
@@ -590,7 +590,7 @@ fn test_receipt_to_tx_rpc_unsupported_disabled() {
         .build();
 
     let fake_receipt_id = CryptoHash::hash_bytes(b"any");
-    let result = env.rpc_runner().run_jsonrpc_query(
+    let result = env.rpc_runner().run_with_jsonrpc_client(
         |client| {
             client.EXPERIMENTAL_receipt_to_tx(RpcReceiptToTxRequest {
                 receipt_reference: ReceiptReference { receipt_id: fake_receipt_id },
@@ -692,7 +692,7 @@ fn test_receipt_to_tx_rpc_deep_chain_walk() {
     // Query receipt_0 via RPC — should walk 4 hops to resolve back to tx_hash.
     let response = env
         .rpc_runner()
-        .run_jsonrpc_query(
+        .run_with_jsonrpc_client(
             |client| {
                 client.EXPERIMENTAL_receipt_to_tx(RpcReceiptToTxRequest {
                     receipt_reference: ReceiptReference { receipt_id: receipt_ids[0] },
@@ -798,7 +798,7 @@ fn test_receipt_to_tx_rpc_cross_shard() {
     // Query via RPC — should resolve the cross-shard receipt back to the original tx.
     let response = env
         .rpc_runner()
-        .run_jsonrpc_query(
+        .run_with_jsonrpc_client(
             |client| {
                 client.EXPERIMENTAL_receipt_to_tx(RpcReceiptToTxRequest {
                     receipt_reference: ReceiptReference { receipt_id },
@@ -821,7 +821,7 @@ fn test_receipt_to_tx_rpc_cross_shard() {
         let refund_receipt_id = action_outcome.outcome.receipt_ids[0];
         let refund_response = env
             .rpc_runner()
-            .run_jsonrpc_query(
+            .run_with_jsonrpc_client(
                 |client| {
                     client.EXPERIMENTAL_receipt_to_tx(RpcReceiptToTxRequest {
                         receipt_reference: ReceiptReference { receipt_id: refund_receipt_id },

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -96,7 +96,7 @@ fn test_rpc_view_account_forwarding() {
                                 account: &AccountId,
                                 expected_balance: Balance|
      -> Result<(), RpcError> {
-        let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
+        let result = h.env.runner_for_account(node_id).run_with_jsonrpc_client(
             |client| {
                 client.EXPERIMENTAL_view_account(RpcViewAccountRequest {
                     block_reference: BlockReference::Finality(Finality::None),
@@ -128,11 +128,9 @@ fn test_rpc_query_view_account_forwarding() {
                                       expected_balance: Balance|
      -> Result<(), RpcError> {
         let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
-            |client| {
-                client.query(RpcQueryRequest {
-                    block_reference: BlockReference::Finality(Finality::None),
-                    request: QueryRequest::ViewAccount { account_id: account.clone() },
-                })
+            RpcQueryRequest {
+                block_reference: BlockReference::Finality(Finality::None),
+                request: QueryRequest::ViewAccount { account_id: account.clone() },
             },
             Duration::seconds(5),
         )?;
@@ -159,28 +157,24 @@ fn test_rpc_query_view_access_key_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
 
-    let mut run_query_view_access_key =
-        |node_id: &AccountId, account: &AccountId| -> Result<(), RpcError> {
-            let public_key =
-                near_primitives::test_utils::create_user_test_signer(account.as_ref()).public_key();
-            let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
-                |client| {
-                    client.query(RpcQueryRequest {
-                        block_reference: BlockReference::Finality(Finality::None),
-                        request: QueryRequest::ViewAccessKey {
-                            account_id: account.clone(),
-                            public_key,
-                        },
-                    })
-                },
-                Duration::seconds(5),
-            )?;
-            match result.kind {
-                QueryResponseKind::AccessKey(_) => {}
-                other => panic!("expected AccessKey, got: {other:?}"),
-            }
-            Ok(())
-        };
+    let mut run_query_view_access_key = |node_id: &AccountId,
+                                         account: &AccountId|
+     -> Result<(), RpcError> {
+        let public_key =
+            near_primitives::test_utils::create_user_test_signer(account.as_ref()).public_key();
+        let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
+            RpcQueryRequest {
+                block_reference: BlockReference::Finality(Finality::None),
+                request: QueryRequest::ViewAccessKey { account_id: account.clone(), public_key },
+            },
+            Duration::seconds(5),
+        )?;
+        match result.kind {
+            QueryResponseKind::AccessKey(_) => {}
+            other => panic!("expected AccessKey, got: {other:?}"),
+        }
+        Ok(())
+    };
 
     // Cross-shard forwarding.
     run_query_view_access_key(&h.zoe_node, &h.alice).unwrap();
@@ -205,7 +199,7 @@ fn test_rpc_query_unknown_access_key_error_format() {
     let response = h
         .env
         .runner_for_account(&h.zoe_node)
-        .run_jsonrpc_query(
+        .run_with_jsonrpc_client(
             |client| {
                 let request = Message::request(
                     "query".to_string(),
@@ -252,11 +246,9 @@ fn test_rpc_query_view_code_forwarding() {
     let mut run_query_view_code =
         |node_id: &AccountId, account: &AccountId| -> Result<(), RpcError> {
             let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
-                |client| {
-                    client.query(RpcQueryRequest {
-                        block_reference: BlockReference::Finality(Finality::None),
-                        request: QueryRequest::ViewCode { account_id: account.clone() },
-                    })
+                RpcQueryRequest {
+                    block_reference: BlockReference::Finality(Finality::None),
+                    request: QueryRequest::ViewCode { account_id: account.clone() },
                 },
                 Duration::seconds(5),
             )?;
@@ -300,15 +292,13 @@ fn test_rpc_query_view_state_forwarding() {
     let mut run_query_view_state =
         |node_id: &AccountId, account: &AccountId| -> Result<(), RpcError> {
             let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
-                |client| {
-                    client.query(RpcQueryRequest {
-                        block_reference: BlockReference::Finality(Finality::None),
-                        request: QueryRequest::ViewState {
-                            account_id: account.clone(),
-                            prefix: StoreKey::from(vec![]),
-                            include_proof: false,
-                        },
-                    })
+                RpcQueryRequest {
+                    block_reference: BlockReference::Finality(Finality::None),
+                    request: QueryRequest::ViewState {
+                        account_id: account.clone(),
+                        prefix: StoreKey::from(vec![]),
+                        include_proof: false,
+                    },
                 },
                 Duration::seconds(5),
             )?;
@@ -336,11 +326,9 @@ fn test_rpc_query_view_access_key_list_forwarding() {
     let mut run_query_view_access_key_list =
         |node_id: &AccountId, account: &AccountId| -> Result<(), RpcError> {
             let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
-                |client| {
-                    client.query(RpcQueryRequest {
-                        block_reference: BlockReference::Finality(Finality::None),
-                        request: QueryRequest::ViewAccessKeyList { account_id: account.clone() },
-                    })
+                RpcQueryRequest {
+                    block_reference: BlockReference::Finality(Finality::None),
+                    request: QueryRequest::ViewAccessKeyList { account_id: account.clone() },
                 },
                 Duration::seconds(5),
             )?;
@@ -371,15 +359,13 @@ fn test_rpc_query_call_function_forwarding() {
     let mut run_query_call_function =
         |node_id: &AccountId, account: &AccountId| -> Result<(), RpcError> {
             let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
-                |client| {
-                    client.query(RpcQueryRequest {
-                        block_reference: BlockReference::Finality(Finality::None),
-                        request: QueryRequest::CallFunction {
-                            account_id: account.clone(),
-                            method_name: "log_something".to_string(),
-                            args: FunctionArgs::from(vec![]),
-                        },
-                    })
+                RpcQueryRequest {
+                    block_reference: BlockReference::Finality(Finality::None),
+                    request: QueryRequest::CallFunction {
+                        account_id: account.clone(),
+                        method_name: "log_something".to_string(),
+                        args: FunctionArgs::from(vec![]),
+                    },
                 },
                 Duration::seconds(5),
             )?;
@@ -411,14 +397,12 @@ fn test_rpc_query_view_gas_key_nonces_forwarding() {
             .env
             .runner_for_account(node_id)
             .run_jsonrpc_query(
-                |client| {
-                    client.query(RpcQueryRequest {
-                        block_reference: BlockReference::Finality(Finality::None),
-                        request: QueryRequest::ViewGasKeyNonces {
-                            account_id: account.clone(),
-                            public_key: public_key.clone(),
-                        },
-                    })
+                RpcQueryRequest {
+                    block_reference: BlockReference::Finality(Finality::None),
+                    request: QueryRequest::ViewGasKeyNonces {
+                        account_id: account.clone(),
+                        public_key,
+                    },
                 },
                 Duration::seconds(5),
             )
@@ -471,13 +455,11 @@ fn test_rpc_query_view_global_contract_code_by_account_id_forwarding() {
     let mut run_query_view_global_contract =
         |node_id: &AccountId, account: &AccountId| -> Result<(), RpcError> {
             let result = h.env.runner_for_account(node_id).run_jsonrpc_query(
-                |client| {
-                    client.query(RpcQueryRequest {
-                        block_reference: BlockReference::Finality(Finality::None),
-                        request: QueryRequest::ViewGlobalContractCodeByAccountId {
-                            account_id: account.clone(),
-                        },
-                    })
+                RpcQueryRequest {
+                    block_reference: BlockReference::Finality(Finality::None),
+                    request: QueryRequest::ViewGlobalContractCodeByAccountId {
+                        account_id: account.clone(),
+                    },
                 },
                 Duration::seconds(5),
             )?;
@@ -509,7 +491,7 @@ fn test_rpc_query_call_function_error_format() {
     let response = h
         .env
         .runner_for_account(&h.zoe_node)
-        .run_jsonrpc_query(
+        .run_with_jsonrpc_client(
             |client| {
                 let request = Message::request(
                     "query".to_string(),
@@ -573,7 +555,7 @@ fn test_rpc_receipt_forwarding() {
                              node_id: &AccountId,
                              receipt_id: CryptoHash|
      -> Result<RpcReceiptResponse, RpcError> {
-        h.env.runner_for_account(node_id).run_jsonrpc_query(
+        h.env.runner_for_account(node_id).run_with_jsonrpc_client(
             |client| {
                 client.EXPERIMENTAL_receipt(RpcReceiptRequest {
                     receipt_reference: ReceiptReference { receipt_id },

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -13,6 +13,7 @@ use near_client::{Client, ProcessTxRequest, Query, QueryError, ViewClientActor};
 use near_crypto::PublicKey;
 use near_jsonrpc::client::JsonRpcClient;
 use near_jsonrpc_primitives::errors::RpcError;
+use near_jsonrpc_primitives::types::query::{RpcQueryRequest, RpcQueryResponse};
 use near_primitives::action::{Action, GlobalContractDeployMode, GlobalContractIdentifier};
 use near_primitives::errors::InvalidTxError;
 use near_primitives::gas::Gas;
@@ -554,7 +555,7 @@ impl<'a> NodeRunner<'a> {
         result.lock().take().unwrap()
     }
 
-    pub fn run_jsonrpc_query<T>(
+    pub fn run_with_jsonrpc_client<T>(
         &mut self,
         make_query: impl FnOnce(&JsonRpcClient) -> BoxFuture<'static, Result<T, RpcError>>,
         maximum_duration: Duration,
@@ -564,6 +565,14 @@ impl<'a> NodeRunner<'a> {
     {
         let jsonrpc_client = self.node_data.jsonrpc_client();
         self.run_future("jsonrpc_query", make_query(&jsonrpc_client), maximum_duration)
+    }
+
+    pub fn run_jsonrpc_query(
+        &mut self,
+        request: RpcQueryRequest,
+        maximum_duration: Duration,
+    ) -> Result<RpcQueryResponse, RpcError> {
+        self.run_with_jsonrpc_client(|client| client.query(request), maximum_duration)
     }
 
     #[cfg(feature = "test_features")]


### PR DESCRIPTION
Extend `test_eth_implicit_global_contract_mainnet_upgrade` to verify ViewCode and CallFunction (`get_nonce`) RPC queries before and after the PV 82 -> 83 protocol upgrade, covering the code paths fixed in #15437.

- At PV 82: verify ViewCode returns the legacy localnet wallet contract WASM and `get_nonce` returns 0.
- At PV 83: verify ViewCode returns the deployed global contract WASM for both old (magic-bytes) and new ETH implicit accounts, `get_nonce` returns 0 before and 1 after `rlp_execute`.
- Refactor `NodeRunner::run_jsonrpc_query` into `run_with_jsonrpc_client` (generic, takes closure) and a new `run_jsonrpc_query` that directly accepts `RpcQueryRequest`, simplifying all query call sites.