### PR TITLE
feat(new-storage): add FunctionCallV2 and DeployContractV2 actions

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -507,6 +507,10 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                 near_primitives::transaction::Action::DeterministicStateInit(_) => {
                     // TODO(#14073): Implement rosetta adapter, probably first requires global contracts, too
                 }
+                near_primitives::transaction::Action::FunctionCallV2(_)
+                | near_primitives::transaction::Action::DeployContractV2(_) => {
+                    // TODO: Implement storage gas support in rosetta adapter
+                }
                 near_primitives::transaction::Action::TransferToGasKey(action) => {
                     let initiate_op_id = crate::models::OperationIdentifier::new(&operations);
                     operations.push(

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::PublicKey;
-use near_primitives_core::account::AccessKey;
+use near_primitives_core::account::{AccessKey, StoragePayment};
 pub use near_primitives_core::global_contract::GlobalContractIdentifier;
 use near_primitives_core::types::{AccountId, Balance, Gas};
 use near_schema_checker_lib::ProtocolSchema;
@@ -252,6 +252,73 @@ impl fmt::Debug for FunctionCallAction {
     }
 }
 
+/// Function call action with support for storage gas.
+#[serde_as]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    ProtocolSchema,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct FunctionCallV2Action {
+    pub method_name: String,
+    #[serde_as(as = "Base64")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub args: Vec<u8>,
+    pub gas: Gas,
+    /// Prepaid storage gas for storage growth on StoragePayment::StorageGas accounts.
+    pub storage_gas: Gas,
+    pub deposit: Balance,
+}
+
+impl fmt::Debug for FunctionCallV2Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FunctionCallV2Action")
+            .field("method_name", &format_args!("{}", &self.method_name))
+            .field("args", &format_args!("{}", base64(&self.args)))
+            .field("gas", &format_args!("{}", &self.gas))
+            .field("storage_gas", &format_args!("{}", &self.storage_gas))
+            .field("deposit", &format_args!("{}", &self.deposit))
+            .finish()
+    }
+}
+
+/// Deploy contract action with storage payment opt-in.
+#[serde_as]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    ProtocolSchema,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct DeployContractV2Action {
+    /// WebAssembly binary
+    #[serde_as(as = "Base64")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub code: Vec<u8>,
+    /// How storage is paid for on this account after deployment.
+    pub storage_payment: StoragePayment,
+}
+
+impl fmt::Debug for DeployContractV2Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeployContractV2Action")
+            .field("code", &format_args!("{}", base64(&self.code)))
+            .field("storage_payment", &self.storage_payment)
+            .finish()
+    }
+}
+
 /// An action which stakes signer_id tokens and setup's validator public key
 #[derive(
     BorshSerialize,
@@ -365,6 +432,8 @@ pub enum Action {
     DeterministicStateInit(Box<DeterministicStateInitAction>) = 11,
     TransferToGasKey(Box<TransferToGasKeyAction>) = 12,
     WithdrawFromGasKey(Box<WithdrawFromGasKeyAction>) = 13,
+    FunctionCallV2(Box<FunctionCallV2Action>) = 14,
+    DeployContractV2(Box<DeployContractV2Action>) = 15,
 }
 
 const _: () = assert!(
@@ -379,12 +448,20 @@ impl Action {
     pub fn get_prepaid_gas(&self) -> Gas {
         match self {
             Action::FunctionCall(a) => a.gas,
+            Action::FunctionCallV2(a) => a.gas,
+            _ => Gas::ZERO,
+        }
+    }
+    pub fn get_prepaid_storage_gas(&self) -> Gas {
+        match self {
+            Action::FunctionCallV2(a) => a.storage_gas,
             _ => Gas::ZERO,
         }
     }
     pub fn get_deposit_balance(&self) -> Balance {
         match self {
             Action::FunctionCall(a) => a.deposit,
+            Action::FunctionCallV2(a) => a.deposit,
             Action::Transfer(a) => a.deposit,
             Action::DeterministicStateInit(a) => a.deposit,
             Action::TransferToGasKey(a) => a.deposit,

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -1,6 +1,7 @@
 pub use crate::action::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
-    DeployContractAction, FunctionCallAction, StakeAction, TransferAction,
+    DeployContractAction, DeployContractV2Action, FunctionCallAction, FunctionCallV2Action,
+    StakeAction, TransferAction,
 };
 use crate::errors::{InvalidTxError, TxExecutionError};
 use crate::hash::{CryptoHash, hash};

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -6,9 +6,9 @@
 use crate::account::{AccessKey, AccessKeyPermission, Account, FunctionCallPermission};
 use crate::action::delegate::{DelegateAction, SignedDelegateAction};
 use crate::action::{
-    DeployGlobalContractAction, DeterministicStateInitAction, GlobalContractDeployMode,
-    GlobalContractIdentifier, TransferToGasKeyAction, UseGlobalContractAction,
-    WithdrawFromGasKeyAction,
+    DeployContractV2Action, DeployGlobalContractAction, DeterministicStateInitAction,
+    FunctionCallV2Action, GlobalContractDeployMode, GlobalContractIdentifier,
+    TransferToGasKeyAction, UseGlobalContractAction, WithdrawFromGasKeyAction,
 };
 use crate::bandwidth_scheduler::BandwidthRequests;
 use crate::block::{Block, BlockHeader, Tip};
@@ -1477,6 +1477,22 @@ pub enum ActionView {
         public_key: PublicKey,
         amount: Balance,
     } = 15,
+    FunctionCallV2 {
+        method_name: String,
+        args: FunctionArgs,
+        gas: Gas,
+        storage_gas: Gas,
+        deposit: Balance,
+    } = 16,
+    DeployContractV2 {
+        #[serde_as(as = "Base64")]
+        #[cfg_attr(
+            feature = "schemars",
+            schemars(schema_with = "crate::serialize::base64_schema")
+        )]
+        code: Vec<u8>,
+        storage_payment: near_primitives_core::account::StoragePayment,
+    } = 17,
 }
 
 impl From<Action> for ActionView {
@@ -1543,6 +1559,17 @@ impl From<Action> for ActionView {
                 public_key: action.public_key,
                 amount: action.amount,
             },
+            Action::FunctionCallV2(action) => ActionView::FunctionCallV2 {
+                method_name: action.method_name,
+                args: action.args.into(),
+                gas: action.gas,
+                storage_gas: action.storage_gas,
+                deposit: action.deposit,
+            },
+            Action::DeployContractV2(action) => {
+                let code = hash(&action.code).as_ref().to_vec();
+                ActionView::DeployContractV2 { code, storage_payment: action.storage_payment }
+            }
         }
     }
 }
@@ -1619,6 +1646,18 @@ impl TryFrom<ActionView> for Action {
                     public_key,
                     amount,
                 }))
+            }
+            ActionView::FunctionCallV2 { method_name, args, gas, storage_gas, deposit } => {
+                Action::FunctionCallV2(Box::new(FunctionCallV2Action {
+                    method_name,
+                    args: args.into(),
+                    gas,
+                    storage_gas,
+                    deposit,
+                }))
+            }
+            ActionView::DeployContractV2 { code, storage_payment } => {
+                Action::DeployContractV2(Box::new(DeployContractV2Action { code, storage_payment }))
             }
         })
     }

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -621,41 +621,42 @@ fn validate_delegate_action_key(
             .into());
             return Ok(());
         }
-        if let Some(Action::FunctionCall(function_call)) = actions.get(0) {
-            if function_call.deposit > Balance::ZERO {
+        let (fc_deposit, fc_method_name) = match actions.get(0) {
+            Some(Action::FunctionCall(fc)) => (fc.deposit, &fc.method_name),
+            Some(Action::FunctionCallV2(fc)) => (fc.deposit, &fc.method_name),
+            _ => {
+                // There should be Action::FunctionCall when "function call" permission is used
                 result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
-                    InvalidAccessKeyError::DepositWithFunctionCall,
-                )
-                .into());
-            }
-            if delegate_action.receiver_id != function_call_permission.receiver_id {
-                result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
-                    InvalidAccessKeyError::ReceiverMismatch {
-                        tx_receiver: delegate_action.receiver_id.clone(),
-                        ak_receiver: function_call_permission.receiver_id.clone(),
-                    },
+                    InvalidAccessKeyError::RequiresFullAccess,
                 )
                 .into());
                 return Ok(());
             }
-            if !function_call_permission.method_names.is_empty()
-                && function_call_permission
-                    .method_names
-                    .iter()
-                    .all(|method_name| &function_call.method_name != method_name)
-            {
-                result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
-                    InvalidAccessKeyError::MethodNameMismatch {
-                        method_name: function_call.method_name.clone(),
-                    },
-                )
-                .into());
-                return Ok(());
-            }
-        } else {
-            // There should Action::FunctionCall when "function call" permission is used
+        };
+        if fc_deposit > Balance::ZERO {
             result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
-                InvalidAccessKeyError::RequiresFullAccess,
+                InvalidAccessKeyError::DepositWithFunctionCall,
+            )
+            .into());
+        }
+        if delegate_action.receiver_id != function_call_permission.receiver_id {
+            result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::ReceiverMismatch {
+                    tx_receiver: delegate_action.receiver_id.clone(),
+                    ak_receiver: function_call_permission.receiver_id.clone(),
+                },
+            )
+            .into());
+            return Ok(());
+        }
+        if !function_call_permission.method_names.is_empty()
+            && function_call_permission
+                .method_names
+                .iter()
+                .all(|method_name| fc_method_name != method_name)
+        {
+            result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::MethodNameMismatch { method_name: fc_method_name.clone() },
             )
             .into());
             return Ok(());
@@ -680,6 +681,7 @@ pub(crate) fn check_actor_permissions(
 ) -> Result<(), ActionError> {
     match action {
         Action::DeployContract(_)
+        | Action::DeployContractV2(_)
         | Action::Stake(_)
         | Action::AddKey(_)
         | Action::DeleteKey(_)
@@ -712,6 +714,7 @@ pub(crate) fn check_actor_permissions(
         }
         Action::CreateAccount(_)
         | Action::FunctionCall(_)
+        | Action::FunctionCallV2(_)
         | Action::Transfer(_)
         | Action::TransferToGasKey(_) => (),
         Action::Delegate(_) => (),
@@ -772,7 +775,9 @@ pub(crate) fn check_account_existence(
             // allow optional init before other actions.
         }
         Action::DeployContract(_)
+        | Action::DeployContractV2(_)
         | Action::FunctionCall(_)
+        | Action::FunctionCallV2(_)
         | Action::Stake(_)
         | Action::AddKey(_)
         | Action::DeleteKey(_)

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -172,6 +172,27 @@ pub fn total_send_fees(
             WithdrawFromGasKey(action) => {
                 gas_key_transfer_send_fee(fees, sender_is_receiver, action.public_key.len()).total()
             }
+            FunctionCallV2(function_call_action) => {
+                let num_bytes = function_call_action.method_name.as_bytes().len() as u64
+                    + function_call_action.args.len() as u64;
+                let base_fee =
+                    fees.fee(ActionCosts::function_call_base).send_fee(sender_is_receiver);
+                let byte_fee =
+                    fees.fee(ActionCosts::function_call_byte).send_fee(sender_is_receiver);
+                let all_bytes_fee = byte_fee.checked_mul(num_bytes).unwrap();
+
+                base_fee.checked_add(all_bytes_fee).unwrap()
+            }
+            DeployContractV2(deploy_contract) => {
+                let num_bytes = deploy_contract.code.len() as u64;
+                let base_fee =
+                    fees.fee(ActionCosts::deploy_contract_base).send_fee(sender_is_receiver);
+                let byte_fee =
+                    fees.fee(ActionCosts::deploy_contract_byte).send_fee(sender_is_receiver);
+                let all_bytes_fee = byte_fee.checked_mul(num_bytes).unwrap();
+
+                base_fee.checked_add(all_bytes_fee).unwrap()
+            }
         };
         result = result.checked_add_result(delta)?;
     }
@@ -315,6 +336,23 @@ pub fn exec_fee(config: &RuntimeConfig, action: &Action, receiver_id: &AccountId
         }
         WithdrawFromGasKey(action) => {
             gas_key_transfer_exec_fee(fees, receiver_id.len(), action.public_key.len()).total()
+        }
+        FunctionCallV2(function_call_action) => {
+            let num_bytes = function_call_action.method_name.as_bytes().len() as u64
+                + function_call_action.args.len() as u64;
+            let base_fee = fees.fee(ActionCosts::function_call_base).exec_fee();
+            let byte_fee = fees.fee(ActionCosts::function_call_byte).exec_fee();
+            let all_bytes_fee = byte_fee.checked_mul(num_bytes).unwrap();
+
+            base_fee.checked_add(all_bytes_fee).unwrap()
+        }
+        DeployContractV2(deploy_contract) => {
+            let num_bytes = deploy_contract.code.len() as u64;
+            let base_fee = fees.fee(ActionCosts::deploy_contract_base).exec_fee();
+            let byte_fee = fees.fee(ActionCosts::deploy_contract_byte).exec_fee();
+            let all_bytes_fee = byte_fee.checked_mul(num_bytes).unwrap();
+
+            base_fee.checked_add(all_bytes_fee).unwrap()
         }
     }
 }
@@ -464,6 +502,23 @@ pub fn total_prepaid_gas(actions: &[Action]) -> Result<Gas, IntegerOverflowError
             action_gas = total_prepaid_gas(&actions)?;
         } else {
             action_gas = action.get_prepaid_gas();
+        }
+
+        total_gas = total_gas.checked_add_result(action_gas)?;
+    }
+    Ok(total_gas)
+}
+
+/// Get the total sum of prepaid storage gas for given actions.
+pub fn total_prepaid_storage_gas(actions: &[Action]) -> Result<Gas, IntegerOverflowError> {
+    let mut total_gas = Gas::ZERO;
+    for action in actions {
+        let action_gas;
+        if let Action::Delegate(signed_delegate_action) = action {
+            let actions = signed_delegate_action.delegate_action.get_actions();
+            action_gas = total_prepaid_storage_gas(&actions)?;
+        } else {
+            action_gas = action.get_prepaid_storage_gas();
         }
 
         total_gas = total_gas.checked_add_result(action_gas)?;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -58,8 +58,8 @@ use near_primitives::sandbox::state_patch::SandboxStatePatch;
 use near_primitives::state_record::StateRecord;
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
 use near_primitives::transaction::{
-    Action, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus, LogEntry,
-    SignedTransaction, TransferAction,
+    Action, DeployContractAction, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId,
+    ExecutionStatus, FunctionCallAction, LogEntry, SignedTransaction, TransferAction,
 };
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::PromiseYieldStatus;
@@ -659,6 +659,51 @@ impl Runtime {
                     &mut result,
                     account_id,
                     withdraw_from_gas_key,
+                )?;
+            }
+            Action::FunctionCallV2(function_call) => {
+                metrics::ACTION_CALLED_COUNT.function_call.inc();
+                let account = account.as_mut().expect(EXPECT_ACCOUNT_EXISTS);
+                let account_contract = account.contract();
+                let code_hash = account_contract.into_owned().hash(&state_update)?;
+                let contract =
+                    preparation_pipeline.get_contract(receipt, code_hash, action_index, None);
+                let is_last_action = action_index + 1 == actions.len();
+                let v1 = FunctionCallAction {
+                    method_name: function_call.method_name.clone(),
+                    args: function_call.args.clone(),
+                    gas: function_call.gas,
+                    deposit: function_call.deposit,
+                };
+                action_function_call(
+                    state_update,
+                    apply_state,
+                    account,
+                    receipt,
+                    action_receipt,
+                    promise_results,
+                    &mut result,
+                    account_id,
+                    &v1,
+                    action_hash,
+                    code_hash,
+                    &apply_state.config,
+                    is_last_action,
+                    epoch_info_provider,
+                    contract,
+                )?;
+            }
+            Action::DeployContractV2(deploy_contract) => {
+                metrics::ACTION_CALLED_COUNT.deploy_contract.inc();
+                let v1 = DeployContractAction { code: deploy_contract.code.clone() };
+                action_deploy_contract(
+                    state_update,
+                    account.as_mut().expect(EXPECT_ACCOUNT_EXISTS),
+                    account_id,
+                    &v1,
+                    Arc::clone(&apply_state.config.wasm_config),
+                    apply_state.cache.as_deref(),
+                    apply_state.current_protocol_version,
                 )?;
             }
         };

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -141,6 +141,7 @@ impl ReceiptPreparationPipeline {
             let account_id = account_id.clone();
             match action {
                 Action::DeployContract(_)
+                | Action::DeployContractV2(_)
                 | Action::UseGlobalContract(_)
                 | Action::DeterministicStateInit(_) => {
                     // FIXME: instead of blocking these accounts, move the handling of
@@ -149,6 +150,7 @@ impl ReceiptPreparationPipeline {
                     return self.block_accounts.insert(account_id);
                 }
                 Action::FunctionCall(function_call) => {
+                    let (fc_gas, fc_method_name) = (function_call.gas, &function_call.method_name);
                     let account = if let Some(account) = &account {
                         account
                     } else {
@@ -198,7 +200,7 @@ impl ReceiptPreparationPipeline {
                         }
                     };
                     let key = PrepareTaskKey { receipt_id: receipt.get_hash(), action_index };
-                    let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
+                    let gas_counter = self.gas_counter(view_config.as_ref(), fc_gas);
                     let entry = match self.map.entry(key) {
                         std::collections::btree_map::Entry::Vacant(v) => v,
                         // Already been submitted.
@@ -209,7 +211,97 @@ impl ReceiptPreparationPipeline {
                     let cache = self.contract_cache.as_ref().map(|c| c.handle());
                     let storage = self.storage.clone();
                     let created = Instant::now();
-                    let method_name = function_call.method_name.clone();
+                    let method_name = fc_method_name.clone();
+                    let chain_id = self.chain_id.clone();
+                    let status = Mutex::new(PrepareTaskStatus::Pending);
+                    let task = Arc::new(PrepareTask { status, condvar: Condvar::new() });
+                    entry.insert(Arc::clone(&task));
+                    PIPELINING_ACTIONS_SUBMITTED.inc_by(1);
+                    rayon::spawn_fifo(move || {
+                        let task_status = {
+                            let mut status = task.status.lock();
+                            std::mem::replace(&mut *status, PrepareTaskStatus::Working)
+                        };
+                        let PrepareTaskStatus::Pending = task_status else {
+                            return;
+                        };
+                        PIPELINING_ACTIONS_TASK_DELAY_TIME.inc_by(created.elapsed().as_secs_f64());
+                        let start = Instant::now();
+                        let contract = prepare_function_call(
+                            &storage,
+                            cache.as_deref(),
+                            config,
+                            gas_counter,
+                            code_hash,
+                            &account_id,
+                            &method_name,
+                            chain_id,
+                        );
+
+                        let mut status = task.status.lock();
+                        *status = PrepareTaskStatus::Prepared(contract);
+                        PIPELINING_ACTIONS_TASK_WORKING_TIME.inc_by(start.elapsed().as_secs_f64());
+                        task.condvar.notify_all();
+                    });
+                    any_function_calls = true;
+                }
+                Action::FunctionCallV2(function_call) => {
+                    let (fc_gas, fc_method_name) = (function_call.gas, &function_call.method_name);
+                    let account = if let Some(account) = &account {
+                        account
+                    } else {
+                        let key = TrieKey::Account { account_id: account_id.clone() };
+                        let Ok(Some(receiver)) = get_pure::<Account>(state_update, &key) else {
+                            continue;
+                        };
+                        account.insert(receiver)
+                    };
+                    let code_hash = match account.contract().as_ref() {
+                        AccountContract::None => continue,
+                        AccountContract::Local(code_hash) => *code_hash,
+                        AccountContract::Global(global_code_hash) => {
+                            if self
+                                .block_global_contracts
+                                .contains(&GlobalContractIdentifier::CodeHash(*global_code_hash))
+                            {
+                                continue;
+                            }
+                            *global_code_hash
+                        }
+                        AccountContract::GlobalByAccount(global_contract_account_id) => {
+                            if self.block_global_contracts.contains(
+                                &GlobalContractIdentifier::AccountId(
+                                    global_contract_account_id.clone(),
+                                ),
+                            ) {
+                                continue;
+                            }
+                            let key = TrieKey::GlobalContractCode {
+                                identifier: GlobalContractCodeIdentifier::AccountId(
+                                    global_contract_account_id.clone(),
+                                ),
+                            };
+                            let Ok(Some(value_ref)) = state_update.get_ref(
+                                &key,
+                                KeyLookupMode::MemOrFlatOrTrie,
+                                AccessOptions::NO_SIDE_EFFECTS,
+                            ) else {
+                                continue;
+                            };
+                            value_ref.value_hash()
+                        }
+                    };
+                    let key = PrepareTaskKey { receipt_id: receipt.get_hash(), action_index };
+                    let gas_counter = self.gas_counter(view_config.as_ref(), fc_gas);
+                    let entry = match self.map.entry(key) {
+                        std::collections::btree_map::Entry::Vacant(v) => v,
+                        std::collections::btree_map::Entry::Occupied(_) => continue,
+                    };
+                    let config = Arc::clone(&self.config.wasm_config);
+                    let cache = self.contract_cache.as_ref().map(|c| c.handle());
+                    let storage = self.storage.clone();
+                    let created = Instant::now();
+                    let method_name = fc_method_name.clone();
                     let chain_id = self.chain_id.clone();
                     let status = Mutex::new(PrepareTaskStatus::Pending);
                     let task = Arc::new(PrepareTask { status, condvar: Condvar::new() });
@@ -291,13 +383,15 @@ impl ReceiptPreparationPipeline {
                 panic!("attempting to get_contract with a non-action receipt!?")
             }
         };
-        let Action::FunctionCall(function_call) = action else {
-            panic!("referenced receipt action is not a function call!");
+        let (fc_gas, fc_method_name) = match action {
+            Action::FunctionCall(fc) => (fc.gas, &fc.method_name),
+            Action::FunctionCallV2(fc) => (fc.gas, &fc.method_name),
+            _ => panic!("referenced receipt action is not a function call!"),
         };
         let key = PrepareTaskKey { receipt_id: receipt.get_hash(), action_index };
         let Some(task) = self.map.get(&key) else {
             let start = Instant::now();
-            let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
+            let gas_counter = self.gas_counter(view_config.as_ref(), fc_gas);
             if !self.block_accounts.contains(account_id) {
                 tracing::debug!(
                     target: "runtime::pipelining",
@@ -313,7 +407,7 @@ impl ReceiptPreparationPipeline {
                 gas_counter,
                 code_hash,
                 &account_id,
-                &function_call.method_name,
+                fc_method_name,
                 self.chain_id.clone(),
             );
             PIPELINING_ACTIONS_NOT_SUBMITTED.inc_by(1);
@@ -334,9 +428,9 @@ impl ReceiptPreparationPipeline {
                         receipt=%receipt.get_hash(),
                         action_index
                     );
-                    let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
+                    let gas_counter = self.gas_counter(view_config.as_ref(), fc_gas);
                     let cache = self.contract_cache.as_ref().map(|c| c.handle());
-                    let method_name = function_call.method_name.clone();
+                    let method_name = fc_method_name.clone();
                     let contract = prepare_function_call(
                         &self.storage,
                         cache.as_deref(),

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -7,8 +7,8 @@ use near_parameters::RuntimeConfig;
 use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
 use near_primitives::action::delegate::SignedDelegateAction;
 use near_primitives::action::{
-    AddKeyAction, DeployGlobalContractAction, DeterministicStateInitAction,
-    GlobalContractIdentifier, UseGlobalContractAction,
+    AddKeyAction, DeployContractV2Action, DeployGlobalContractAction, DeterministicStateInitAction,
+    FunctionCallV2Action, GlobalContractIdentifier, UseGlobalContractAction,
 };
 use near_primitives::errors::{
     ActionsValidationError, DepositCostFailureReason, InvalidAccessKeyError, InvalidTxError,
@@ -194,12 +194,16 @@ fn verify_function_call_permission(
             InvalidAccessKeyError::RequiresFullAccess,
         ));
     }
-    let Some(Action::FunctionCall(function_call)) = tx.actions().get(0) else {
-        return Err(InvalidTxError::InvalidAccessKeyError(
-            InvalidAccessKeyError::RequiresFullAccess,
-        ));
+    let (fc_deposit, fc_method_name) = match tx.actions().get(0) {
+        Some(Action::FunctionCall(fc)) => (fc.deposit, &fc.method_name),
+        Some(Action::FunctionCallV2(fc)) => (fc.deposit, &fc.method_name),
+        _ => {
+            return Err(InvalidTxError::InvalidAccessKeyError(
+                InvalidAccessKeyError::RequiresFullAccess,
+            ));
+        }
     };
-    if function_call.deposit > Balance::ZERO {
+    if fc_deposit > Balance::ZERO {
         return Err(InvalidTxError::InvalidAccessKeyError(
             InvalidAccessKeyError::DepositWithFunctionCall,
         ));
@@ -218,12 +222,10 @@ fn verify_function_call_permission(
         && function_call_permission
             .method_names
             .iter()
-            .all(|method_name| &function_call.method_name != method_name)
+            .all(|method_name| fc_method_name != method_name)
     {
         return Err(InvalidTxError::InvalidAccessKeyError(
-            InvalidAccessKeyError::MethodNameMismatch {
-                method_name: function_call.method_name.clone(),
-            },
+            InvalidAccessKeyError::MethodNameMismatch { method_name: fc_method_name.clone() },
         ));
     }
     Ok(())
@@ -679,6 +681,22 @@ pub fn validate_action(
         Action::WithdrawFromGasKey(_) => {
             validate_withdraw_from_gas_key_action(current_protocol_version)
         }
+        Action::FunctionCallV2(a) => {
+            require_protocol_feature(
+                ProtocolFeature::StorageGas,
+                "StorageGas",
+                current_protocol_version,
+            )?;
+            validate_function_call_action_v2(limit_config, a)
+        }
+        Action::DeployContractV2(a) => {
+            require_protocol_feature(
+                ProtocolFeature::StorageGas,
+                "StorageGas",
+                current_protocol_version,
+            )?;
+            validate_deploy_contract_v2_action(limit_config, a)
+        }
     }
 }
 
@@ -752,6 +770,47 @@ fn validate_function_call_action(
         return Err(ActionsValidationError::FunctionCallArgumentsLengthExceeded {
             length: action.args.len() as u64,
             limit: limit_config.max_arguments_length,
+        });
+    }
+
+    Ok(())
+}
+
+/// Validates `FunctionCallV2Action`. Same checks as V1.
+fn validate_function_call_action_v2(
+    limit_config: &LimitConfig,
+    action: &FunctionCallV2Action,
+) -> Result<(), ActionsValidationError> {
+    if action.gas == Gas::ZERO {
+        return Err(ActionsValidationError::FunctionCallZeroAttachedGas);
+    }
+
+    if action.method_name.len() as u64 > limit_config.max_length_method_name {
+        return Err(ActionsValidationError::FunctionCallMethodNameLengthExceeded {
+            length: action.method_name.len() as u64,
+            limit: limit_config.max_length_method_name,
+        });
+    }
+
+    if action.args.len() as u64 > limit_config.max_arguments_length {
+        return Err(ActionsValidationError::FunctionCallArgumentsLengthExceeded {
+            length: action.args.len() as u64,
+            limit: limit_config.max_arguments_length,
+        });
+    }
+
+    Ok(())
+}
+
+/// Validates `DeployContractV2Action`. Same checks as V1.
+fn validate_deploy_contract_v2_action(
+    limit_config: &LimitConfig,
+    action: &DeployContractV2Action,
+) -> Result<(), ActionsValidationError> {
+    if action.code.len() as u64 > limit_config.max_contract_size {
+        return Err(ActionsValidationError::ContractSizeExceeded {
+            size: action.code.len() as u64,
+            limit: limit_config.max_contract_size,
         });
     }
 

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1443,7 +1443,11 @@ impl<T: ChainAccess> TxMirror<T> {
         // is only logically included, and we won't see it in the receipts in any chunk,
         // so handle that case here
         if tx.transaction.signer_id() == tx.transaction.receiver_id()
-            && tx.transaction.actions().iter().any(|a| matches!(a, Action::FunctionCall(_)))
+            && tx
+                .transaction
+                .actions()
+                .iter()
+                .any(|a| matches!(a, Action::FunctionCall(_) | Action::FunctionCallV2(_)))
         {
             let tx_hash = tx.get_hash();
             if let Some(receipt_id) = self
@@ -1484,7 +1488,10 @@ impl<T: ChainAccess> TxMirror<T> {
         txs: &mut Vec<TargetChainTx>,
     ) -> anyhow::Result<()> {
         if let ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) = receipt.receipt() {
-            if r.actions.iter().any(|a| matches!(a, Action::FunctionCall(_))) {
+            if r.actions
+                .iter()
+                .any(|a| matches!(a, Action::FunctionCall(_) | Action::FunctionCallV2(_)))
+            {
                 self.add_function_call_keys(
                     tracker,
                     tx_block_queue,

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -367,6 +367,8 @@ fn map_action(action: &Action) -> ActionType {
         Action::DeterministicStateInit(_) => ActionType::DeterministicStateInit,
         Action::TransferToGasKey(_) => ActionType::TransferToGasKey,
         Action::WithdrawFromGasKey(_) => ActionType::WithdrawFromGasKey,
+        Action::FunctionCallV2(_) => ActionType::FunctionCall,
+        Action::DeployContractV2(_) => ActionType::DeployContract,
     }
 }
 


### PR DESCRIPTION
- Add FunctionCallV2Action with storage_gas field for prepaid storage gas.
- Add DeployContractV2Action with storage_payment field for account opt-in.
- Add Action::FunctionCallV2 (=14) and Action::DeployContractV2 (=15) variants.
- Update all Action match arms across the codebase: views, validation, config fees, pipelining, rosetta, mirror, state-viewer.
- Add total_prepaid_storage_gas() function TransactionCost.storage_gas_remaining for gas buying.
- Gate new actions behind ProtocolFeature::StorageGas.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>