### PR TITLE
fix(gas-keys): check function call permission in delegate action

### DIFF
--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -826,8 +826,8 @@ mod tests {
     use crate::actions_test_utils::{setup_account, test_delete_large_account};
     use crate::near_primitives::shard_layout::ShardUId;
     use near_primitives::account::FunctionCallPermission;
-    use near_primitives::action::delegate::NonDelegateAction;
     use near_primitives::action::FunctionCallAction;
+    use near_primitives::action::delegate::NonDelegateAction;
     use near_primitives::apply::ApplyChunkReason;
     use near_primitives::bandwidth_scheduler::BlockBandwidthRequests;
     use near_primitives::congestion_info::BlockCongestionInfo;


### PR DESCRIPTION
`validate_delegate_action_key` used a raw `if let AccessKeyPermission::FunctionCall(...)` pattern match that only matched the `FunctionCall` variant, not `GasKeyFunctionCall`. This meant a `GasKeyFunctionCall` access key could sign arbitrary delegate actions (transfers, add key, etc.) to any receiver with no permission check.

- Replace the raw pattern match with the `function_call_permission()` helper that correctly handles both `FunctionCall` and `GasKeyFunctionCall` variants, matching the approach already used in the regular transaction path (`verifier.rs`)
- Adds tests