### PR TITLE
refactor(runtime): wasmtime logic.rs takes Ctx+memory instead of Caller

### DIFF
--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -1,4 +1,8 @@
-use super::{Ctx, Export};
+// Many host functions take `memory: &mut [u8]` for a uniform signature even
+// when they don't write to memory.
+#![allow(clippy::needless_pass_by_ref_mut)]
+
+use super::Ctx;
 use crate::logic::alt_bn128;
 use crate::logic::bls12381;
 use crate::logic::errors::InconsistentStateError;
@@ -24,21 +28,6 @@ use near_primitives_core::config::INLINE_DISK_VALUE_THRESHOLD;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, EpochHeight, Gas, GasWeight, StorageUsage};
 use std::rc::Rc;
-use wasmtime::{Caller, Extern, Memory};
-
-// Lookup the memory export and cache it on success.
-fn get_memory(caller: &mut Caller<'_, Ctx>) -> Result<Memory> {
-    match caller.data().memory {
-        Export::Unresolved(memory) => {
-            let Some(Extern::Memory(memory)) = caller.get_module_export(&memory) else {
-                return Err(HostError::MemoryAccessViolation.into());
-            };
-            caller.data_mut().memory = Export::Resolved(memory);
-            Ok(memory)
-        }
-        Export::Resolved(memory) => Ok(memory),
-    }
-}
 
 macro_rules! bls12381_impl {
     (
@@ -51,14 +40,12 @@ macro_rules! bls12381_impl {
     ) => {
         #[doc = $doc]
         pub fn $fn_name(
-            caller: &mut Caller<'_, Ctx>,
+            ctx: &mut Ctx,
+            memory: &mut [u8],
             value_len: u64,
             value_ptr: u64,
             register_id: u64,
         ) -> Result<u64> {
-            let memory = get_memory(caller)?;
-            let (memory, ctx) = memory.data_and_store_mut(caller);
-
             ctx.result_state.gas_counter.pay_base($bls12381_base)?;
 
             let elements_count = value_len / $ITEM_SIZE;
@@ -186,77 +173,83 @@ fn set_u128(gas_counter: &mut GasCounter, memory: &mut [u8], ptr: u64, value: u1
 // #########################
 // # Finite-wasm internals #
 // #########################
-pub fn finite_wasm_gas(caller: &mut Caller<'_, Ctx>, gas: u64) -> Result<()> {
-    consume_gas(&mut caller.data_mut().result_state.gas_counter, gas)
+pub fn finite_wasm_gas(ctx: &mut Ctx, _memory: &mut [u8], gas: u64) -> Result<()> {
+    consume_gas(&mut ctx.result_state.gas_counter, gas)
 }
 
-fn linear_gas(caller: &mut Caller<'_, Ctx>, count: u32, linear: u64, constant: u64) -> Result<u32> {
+fn linear_gas(ctx: &mut Ctx, count: u32, linear: u64, constant: u64) -> Result<u32> {
     let linear = u64::from(count).checked_mul(linear).ok_or(HostError::IntegerOverflow)?;
     let gas = constant.checked_add(linear).ok_or(HostError::IntegerOverflow)?;
-    consume_gas(&mut caller.data_mut().result_state.gas_counter, gas)?;
+    consume_gas(&mut ctx.result_state.gas_counter, gas)?;
     Ok(count)
 }
 
 pub fn finite_wasm_memory_copy(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     count: u32,
     linear: u64,
     constant: u64,
 ) -> Result<u32> {
-    linear_gas(caller, count, linear, constant)
+    linear_gas(ctx, count, linear, constant)
 }
 
 pub fn finite_wasm_memory_fill(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     count: u32,
     linear: u64,
     constant: u64,
 ) -> Result<u32> {
-    linear_gas(caller, count, linear, constant)
+    linear_gas(ctx, count, linear, constant)
 }
 
 pub fn finite_wasm_memory_init(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     count: u32,
     linear: u64,
     constant: u64,
 ) -> Result<u32> {
-    linear_gas(caller, count, linear, constant)
+    linear_gas(ctx, count, linear, constant)
 }
 
 pub fn finite_wasm_table_copy(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     count: u32,
     linear: u64,
     constant: u64,
 ) -> Result<u32> {
-    linear_gas(caller, count, linear, constant)
+    linear_gas(ctx, count, linear, constant)
 }
 
 pub fn finite_wasm_table_fill(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     count: u32,
     linear: u64,
     constant: u64,
 ) -> Result<u32> {
-    linear_gas(caller, count, linear, constant)
+    linear_gas(ctx, count, linear, constant)
 }
 
 pub fn finite_wasm_table_init(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     count: u32,
     linear: u64,
     constant: u64,
 ) -> Result<u32> {
-    linear_gas(caller, count, linear, constant)
+    linear_gas(ctx, count, linear, constant)
 }
 
 pub fn finite_wasm_stack(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     operand_size: u64,
     frame_size: u64,
 ) -> Result<()> {
-    let ctx = caller.data_mut();
     ctx.remaining_stack =
         match ctx.remaining_stack.checked_sub(operand_size.saturating_add(frame_size)) {
             Some(s) => s,
@@ -268,11 +261,11 @@ pub fn finite_wasm_stack(
 }
 
 pub fn finite_wasm_unstack(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     operand_size: u64,
     frame_size: u64,
 ) -> Result<()> {
-    let ctx = caller.data_mut();
     ctx.remaining_stack = ctx
         .remaining_stack
         .checked_add(operand_size.saturating_add(frame_size))
@@ -280,8 +273,7 @@ pub fn finite_wasm_unstack(
     Ok(())
 }
 
-pub fn finite_wasm_gas_exhausted(caller: &mut Caller<'_, Ctx>) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn finite_wasm_gas_exhausted(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<()> {
     // Burn all remaining gas
     ctx.result_state.gas_counter.burn_gas(ctx.result_state.gas_counter.remaining_gas())?;
     // This function will only ever be called by instrumentation on overflow, otherwise
@@ -289,7 +281,7 @@ pub fn finite_wasm_gas_exhausted(caller: &mut Caller<'_, Ctx>) -> Result<()> {
     Err(VMLogicError::HostError(HostError::IntegerOverflow))
 }
 
-pub fn finite_wasm_stack_exhausted(_caller: &mut Caller<'_, Ctx>) -> Result<()> {
+pub fn finite_wasm_stack_exhausted(_ctx: &mut Ctx, _memory: &mut [u8]) -> Result<()> {
     Err(VMLogicError::HostError(HostError::MemoryAccessViolation))
 }
 
@@ -317,10 +309,7 @@ pub fn finite_wasm_stack_exhausted(_caller: &mut Caller<'_, Ctx>) -> Result<()> 
 /// # Cost
 ///
 /// `base + read_register_base + read_register_byte * num_bytes + write_memory_base + write_memory_byte * num_bytes`
-pub fn read_register(caller: &mut Caller<'_, Ctx>, register_id: u64, ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
-
+pub fn read_register(ctx: &mut Ctx, memory: &mut [u8], register_id: u64, ptr: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     let buf = ctx.registers.get(&mut ctx.result_state.gas_counter, register_id)?;
     write_memory(&mut ctx.result_state.gas_counter, memory, ptr, buf)?;
@@ -338,8 +327,7 @@ pub fn read_register(caller: &mut Caller<'_, Ctx>, register_id: u64, ptr: u64) -
 /// # Cost
 ///
 /// `base`
-pub fn register_len(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<u64> {
-    let ctx = caller.data_mut();
+pub fn register_len(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<u64> {
     ctx.result_state.gas_counter.pay_base(base)?;
     Ok(ctx.registers.get_len(register_id).unwrap_or(u64::MAX))
 }
@@ -358,13 +346,12 @@ pub fn register_len(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<u6
 ///
 /// `base + read_memory_base + read_memory_bytes * num_bytes + write_register_base + write_register_bytes * num_bytes`
 pub fn write_register(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     register_id: u64,
     data_len: u64,
     data_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     let memory = read_memory(&mut ctx.result_state.gas_counter, memory, data_ptr, data_len)?;
     ctx.registers.set(
@@ -438,9 +425,7 @@ fn get_utf8_string(
 /// * The cost is 0
 /// * It's up to the caller to set correct len
 #[cfg(feature = "sandbox")]
-fn sandbox_get_utf8_string(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<String> {
-    let memory = get_memory(caller)?;
-    let memory = memory.data(&caller);
+fn sandbox_get_utf8_string(memory: &[u8], len: u64, ptr: u64) -> Result<String> {
     let buf = read_memory_for_free(memory, ptr, len)?;
     String::from_utf8(buf.into()).map_err(|_| HostError::BadUTF8.into())
 }
@@ -559,8 +544,7 @@ fn get_public_key(
 /// # Cost
 ///
 /// `base + write_register_base + write_register_byte * num_bytes`
-pub fn current_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn current_account_id(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     ctx.registers.set(
         &mut ctx.result_state.gas_counter,
@@ -583,8 +567,7 @@ pub fn current_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Res
 /// # Cost
 ///
 /// `base + write_register_base + write_register_byte * num_bytes`
-pub fn signer_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn signer_account_id(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
 
     if ctx.context.is_view() {
@@ -612,8 +595,7 @@ pub fn signer_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Resu
 /// # Cost
 ///
 /// `base + write_register_base + write_register_byte * num_bytes`
-pub fn signer_account_pk(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn signer_account_pk(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
 
     if ctx.context.is_view() {
@@ -641,8 +623,7 @@ pub fn signer_account_pk(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Resu
 /// # Cost
 ///
 /// `base + write_register_base + write_register_byte * num_bytes`
-pub fn predecessor_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn predecessor_account_id(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
 
     if ctx.context.is_view() {
@@ -672,8 +653,7 @@ pub fn predecessor_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) ->
 /// # Cost
 ///
 /// `base + write_register_base + write_register_byte * num_bytes`
-pub fn refund_to_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn refund_to_account_id(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
 
     if ctx.context.is_view() {
@@ -697,8 +677,7 @@ pub fn refund_to_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) -> R
 /// # Cost
 ///
 /// `base + write_register_base + write_register_byte * num_bytes`
-pub fn input(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn input(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
 
     let charge_bytes_gas = !ctx.config.deterministic_account_ids;
@@ -719,8 +698,7 @@ pub fn input(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
 /// # Cost
 ///
 /// `base`
-pub fn block_index(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
-    let ctx = caller.data_mut();
+pub fn block_index(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
     ctx.result_state.gas_counter.pay_base(base)?;
     Ok(ctx.context.block_height)
 }
@@ -730,8 +708,7 @@ pub fn block_index(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
 /// # Cost
 ///
 /// `base`
-pub fn block_timestamp(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
-    let ctx = caller.data_mut();
+pub fn block_timestamp(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
     ctx.result_state.gas_counter.pay_base(base)?;
     Ok(ctx.context.block_timestamp)
 }
@@ -741,8 +718,7 @@ pub fn block_timestamp(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
 /// # Cost
 ///
 /// `base`
-pub fn epoch_height(caller: &mut Caller<'_, Ctx>) -> Result<EpochHeight> {
-    let ctx = caller.data_mut();
+pub fn epoch_height(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<EpochHeight> {
     ctx.result_state.gas_counter.pay_base(base)?;
     Ok(ctx.context.epoch_height)
 }
@@ -754,13 +730,12 @@ pub fn epoch_height(caller: &mut Caller<'_, Ctx>) -> Result<EpochHeight> {
 ///
 /// `base + memory_write_base + memory_write_size * 16 + utf8_decoding_base + utf8_decoding_byte * account_id_len + validator_stake_base`.
 pub fn validator_stake(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     account_id_len: u64,
     account_id_ptr: u64,
     stake_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     let account_id = read_and_parse_account_id(
         &mut ctx.result_state.gas_counter,
@@ -782,9 +757,7 @@ pub fn validator_stake(
 /// # Cost
 ///
 /// `base + memory_write_base + memory_write_size * 16 + validator_total_stake_base`
-pub fn validator_total_stake(caller: &mut Caller<'_, Ctx>, stake_ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn validator_total_stake(ctx: &mut Ctx, memory: &mut [u8], stake_ptr: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     ctx.result_state.gas_counter.pay_base(validator_total_stake_base)?;
     let total_stake = ctx.ext.validator_total_stake()?;
@@ -801,8 +774,7 @@ pub fn validator_total_stake(caller: &mut Caller<'_, Ctx>, stake_ptr: u64) -> Re
 /// # Cost
 ///
 /// `base`
-pub fn storage_usage(caller: &mut Caller<'_, Ctx>) -> Result<StorageUsage> {
-    let ctx = caller.data_mut();
+pub fn storage_usage(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<StorageUsage> {
     ctx.result_state.gas_counter.pay_base(base)?;
     Ok(ctx.result_state.current_storage_usage)
 }
@@ -817,9 +789,7 @@ pub fn storage_usage(caller: &mut Caller<'_, Ctx>) -> Result<StorageUsage> {
 /// # Cost
 ///
 /// `base + memory_write_base + memory_write_size * 16`
-pub fn account_balance(caller: &mut Caller<'_, Ctx>, balance_ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn account_balance(ctx: &mut Ctx, memory: &mut [u8], balance_ptr: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     set_u128(
         &mut ctx.result_state.gas_counter,
@@ -834,9 +804,7 @@ pub fn account_balance(caller: &mut Caller<'_, Ctx>, balance_ptr: u64) -> Result
 /// # Cost
 ///
 /// `base + memory_write_base + memory_write_size * 16`
-pub fn account_locked_balance(caller: &mut Caller<'_, Ctx>, balance_ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn account_locked_balance(ctx: &mut Ctx, memory: &mut [u8], balance_ptr: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     set_u128(
         &mut ctx.result_state.gas_counter,
@@ -856,9 +824,7 @@ pub fn account_locked_balance(caller: &mut Caller<'_, Ctx>, balance_ptr: u64) ->
 /// # Cost
 ///
 /// `base + memory_write_base + memory_write_size * 16`
-pub fn attached_deposit(caller: &mut Caller<'_, Ctx>, balance_ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn attached_deposit(ctx: &mut Ctx, memory: &mut [u8], balance_ptr: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     set_u128(
         &mut ctx.result_state.gas_counter,
@@ -877,8 +843,7 @@ pub fn attached_deposit(caller: &mut Caller<'_, Ctx>, balance_ptr: u64) -> Resul
 /// # Cost
 ///
 /// `base`
-pub fn prepaid_gas(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
-    let ctx = caller.data_mut();
+pub fn prepaid_gas(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView { method_name: "prepaid_gas".to_string() }.into());
@@ -895,8 +860,7 @@ pub fn prepaid_gas(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
 /// # Cost
 ///
 /// `base`
-pub fn used_gas(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
-    let ctx = caller.data_mut();
+pub fn used_gas(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView { method_name: "used_gas".to_string() }.into());
@@ -938,13 +902,12 @@ pub fn used_gas(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
 ///
 /// cspell:words Pippenger
 pub fn alt_bn128_g1_multiexp(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     value_len: u64,
     value_ptr: u64,
     register_id: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(alt_bn128_g1_multiexp_base)?;
     let data = get_memory_or_register(
         &mut ctx.result_state.gas_counter,
@@ -989,13 +952,12 @@ pub fn alt_bn128_g1_multiexp(
 /// `base + write_register_base + write_register_byte * num_bytes +
 /// alt_bn128_g1_sum_base + alt_bn128_g1_sum_element * num_elements`
 pub fn alt_bn128_g1_sum(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     value_len: u64,
     value_ptr: u64,
     register_id: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(alt_bn128_g1_sum_base)?;
     let data = get_memory_or_register(
         &mut ctx.result_state.gas_counter,
@@ -1041,12 +1003,11 @@ pub fn alt_bn128_g1_sum(
 ///
 /// `base + write_register_base + write_register_byte * num_bytes + alt_bn128_pairing_base + alt_bn128_pairing_element * num_elements`
 pub fn alt_bn128_pairing_check(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     value_len: u64,
     value_ptr: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(alt_bn128_pairing_check_base)?;
     let data = get_memory_or_register(
         &mut ctx.result_state.gas_counter,
@@ -1361,12 +1322,11 @@ bls12381_map_fp2_to_g2_base + bls12381_map_fp2_to_g2_element * num_elements`
 /// `base + write_register_base + write_register_byte * num_bytes +
 ///   bls12381_pairing_base + bls12381_pairing_element * num_elements`
 pub fn bls12381_pairing_check(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     value_len: u64,
     value_ptr: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(bls12381_pairing_base)?;
 
     const BLS_P1_SIZE: usize = 96;
@@ -1488,8 +1448,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
 /// # Cost
 ///
 /// `base + write_register_base + write_register_byte * num_bytes`.
-pub fn random_seed(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn random_seed(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     ctx.registers.set(
         &mut ctx.result_state.gas_counter,
@@ -1510,13 +1469,12 @@ pub fn random_seed(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()>
 ///
 /// `base + write_register_base + write_register_byte * num_bytes + sha256_base + sha256_byte * num_bytes`
 pub fn sha256(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     value_len: u64,
     value_ptr: u64,
     register_id: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(sha256_base)?;
     let value = get_memory_or_register(
         &mut ctx.result_state.gas_counter,
@@ -1549,13 +1507,12 @@ pub fn sha256(
 ///
 /// `base + write_register_base + write_register_byte * num_bytes + keccak256_base + keccak256_byte * num_bytes`
 pub fn keccak256(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     value_len: u64,
     value_ptr: u64,
     register_id: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(keccak256_base)?;
     let value = get_memory_or_register(
         &mut ctx.result_state.gas_counter,
@@ -1588,13 +1545,12 @@ pub fn keccak256(
 ///
 /// `base + write_register_base + write_register_byte * num_bytes + keccak512_base + keccak512_byte * num_bytes`
 pub fn keccak512(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     value_len: u64,
     value_ptr: u64,
     register_id: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(keccak512_base)?;
     let value = get_memory_or_register(
         &mut ctx.result_state.gas_counter,
@@ -1629,13 +1585,12 @@ pub fn keccak512(
 ///
 /// `base + write_register_base + write_register_byte * num_bytes + ripemd160_base + ripemd160_block * message_blocks`
 pub fn ripemd160(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     value_len: u64,
     value_ptr: u64,
     register_id: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(ripemd160_base)?;
     let value = get_memory_or_register(
         &mut ctx.result_state.gas_counter,
@@ -1683,7 +1638,8 @@ pub fn ripemd160(
 ///
 /// `base + write_register_base + write_register_byte * 64 + ecrecover_base`
 pub fn ecrecover(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     hash_len: u64,
     hash_ptr: u64,
     sig_len: u64,
@@ -1692,8 +1648,6 @@ pub fn ecrecover(
     malleability_flag: u64,
     register_id: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(ecrecover_base)?;
 
     let signature = {
@@ -1799,7 +1753,8 @@ pub fn ecrecover(
 ///  input_cost(num_bytes_public_key) + ed25519_verify_base +
 ///  ed25519_verify_byte * num_bytes_message`
 pub fn ed25519_verify(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     signature_len: u64,
     signature_ptr: u64,
     message_len: u64,
@@ -1808,9 +1763,6 @@ pub fn ed25519_verify(
     public_key_ptr: u64,
 ) -> Result<u64> {
     use ed25519_dalek::Verifier;
-
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
 
     ctx.result_state.gas_counter.pay_base(ed25519_verify_base)?;
 
@@ -1890,8 +1842,8 @@ pub fn gas_opcodes(result_state: &mut ExecutionResultState, opcodes: u32) -> Res
 
 /// An alias for [`consume_gas`].
 #[cfg(feature = "test_features")]
-pub fn burn_gas(caller: &mut Caller<'_, Ctx>, gas: u64) -> Result<()> {
-    consume_gas(&mut caller.data_mut().result_state.gas_counter, gas)
+pub fn burn_gas(ctx: &mut Ctx, _memory: &mut [u8], gas: u64) -> Result<()> {
+    consume_gas(&mut ctx.result_state.gas_counter, gas)
 }
 
 /// This is the function that is exposed to WASM contracts under the name `gas`.
@@ -1900,12 +1852,12 @@ pub fn burn_gas(caller: &mut Caller<'_, Ctx>, gas: u64) -> Result<()> {
 /// be made to be a no-op.
 ///
 /// This function might be intrinsified.
-pub fn gas_seen_from_wasm(caller: &mut Caller<'_, Ctx>, opcodes: u32) -> Result<()> {
-    gas_opcodes(&mut caller.data_mut().result_state, opcodes)
+pub fn gas_seen_from_wasm(ctx: &mut Ctx, _memory: &mut [u8], opcodes: u32) -> Result<()> {
+    gas_opcodes(&mut ctx.result_state, opcodes)
 }
 
 #[cfg(feature = "test_features")]
-pub fn sleep_nanos(_caller: &mut Caller<'_, Ctx>, nanos: u64) -> Result<()> {
+pub fn sleep_nanos(_ctx: &mut Ctx, _memory: &mut [u8], nanos: u64) -> Result<()> {
     let duration = std::time::Duration::from_nanos(nanos);
     std::thread::sleep(duration);
     Ok(())
@@ -1971,7 +1923,8 @@ fn pay_gas_for_new_receipt(
 /// `promise_create` is a convenience wrapper around `promise_batch_create` and
 /// `promise_batch_action_function_call`. This means it charges the `base` cost twice.
 pub fn promise_create(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     account_id_len: u64,
     account_id_ptr: u64,
     method_name_len: u64,
@@ -1981,9 +1934,10 @@ pub fn promise_create(
     amount_ptr: u64,
     gas: u64,
 ) -> Result<u64> {
-    let new_promise_idx = promise_batch_create(caller, account_id_len, account_id_ptr)?;
+    let new_promise_idx = promise_batch_create(ctx, memory, account_id_len, account_id_ptr)?;
     promise_batch_action_function_call(
-        caller,
+        ctx,
+        memory,
         new_promise_idx,
         method_name_len,
         method_name_ptr,
@@ -2015,7 +1969,8 @@ pub fn promise_create(
 /// `promise_then` is a convenience wrapper around `promise_batch_then` and
 /// `promise_batch_action_function_call`. This means it charges the `base` cost twice.
 pub fn promise_then(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     account_id_len: u64,
     account_id_ptr: u64,
@@ -2026,9 +1981,11 @@ pub fn promise_then(
     amount_ptr: u64,
     gas: u64,
 ) -> Result<u64> {
-    let new_promise_idx = promise_batch_then(caller, promise_idx, account_id_len, account_id_ptr)?;
+    let new_promise_idx =
+        promise_batch_then(ctx, memory, promise_idx, account_id_len, account_id_ptr)?;
     promise_batch_action_function_call(
-        caller,
+        ctx,
+        memory,
         new_promise_idx,
         method_name_len,
         method_name_ptr,
@@ -2066,12 +2023,11 @@ pub fn promise_then(
 ///
 /// `base + promise_and_base + promise_and_per_promise * num_promises + cost of reading promise ids from memory`.
 pub fn promise_and(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx_ptr: u64,
     promise_idx_count: u64,
 ) -> Result<PromiseIndex> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView { method_name: "promise_and".to_string() }.into());
@@ -2137,12 +2093,11 @@ pub fn promise_and(
 /// `burnt_gas := base + cost of reading and decoding the account id + dispatch cost of the receipt`.
 /// `used_gas := burnt_gas + exec cost of the receipt`.
 pub fn promise_batch_create(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     account_id_len: u64,
     account_id_ptr: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -2187,13 +2142,12 @@ pub fn promise_batch_create(
 /// `base + cost of reading and decoding the account id + dispatch&execution cost of the receipt
 ///  + dispatch&execution base cost for each data dependency`
 pub fn promise_batch_then(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     account_id_len: u64,
     account_id_ptr: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(
@@ -2243,14 +2197,12 @@ pub fn promise_batch_then(
 ///
 /// `base + cost of reading and decoding the account id`
 pub fn promise_set_refund_to(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     account_id_len: u64,
     account_id_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
-
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -2316,10 +2268,10 @@ fn promise_idx_to_receipt_idx_with_sir(
 /// `burnt_gas := base + dispatch action fee`
 /// `used_gas := burnt_gas + exec action fee`
 pub fn promise_batch_action_create_account(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     promise_idx: u64,
 ) -> Result<()> {
-    let ctx = caller.data_mut();
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -2358,13 +2310,12 @@ pub fn promise_batch_action_create_account(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_deploy_contract(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     code_len: u64,
     code_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -2424,13 +2375,15 @@ pub fn promise_batch_action_deploy_contract(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_deploy_global_contract(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     code_len: u64,
     code_ptr: u64,
 ) -> Result<()> {
     promise_batch_action_deploy_global_contract_impl(
-        caller,
+        ctx,
+        memory,
         promise_idx,
         code_len,
         code_ptr,
@@ -2457,13 +2410,15 @@ pub fn promise_batch_action_deploy_global_contract(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_deploy_global_contract_by_account_id(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     code_len: u64,
     code_ptr: u64,
 ) -> Result<()> {
     promise_batch_action_deploy_global_contract_impl(
-        caller,
+        ctx,
+        memory,
         promise_idx,
         code_len,
         code_ptr,
@@ -2473,16 +2428,14 @@ pub fn promise_batch_action_deploy_global_contract_by_account_id(
 }
 
 fn promise_batch_action_deploy_global_contract_impl(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     code_len: u64,
     code_ptr: u64,
     mode: GlobalContractDeployMode,
     method_name: &str,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
-
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView { method_name: method_name.to_owned() }.into());
@@ -2539,13 +2492,15 @@ fn promise_batch_action_deploy_global_contract_impl(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_use_global_contract(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     code_hash_len: u64,
     code_hash_ptr: u64,
 ) -> Result<()> {
     promise_batch_action_use_global_contract_impl(
-        caller,
+        ctx,
+        memory,
         promise_idx,
         GlobalContractIdentifierPtrData::CodeHash { code_hash_len, code_hash_ptr },
         "promise_batch_action_use_global_contract",
@@ -2571,13 +2526,15 @@ pub fn promise_batch_action_use_global_contract(
 /// + cost of reading vector from memory + cost of reading and parsing account name`
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_use_global_contract_by_account_id(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     account_id_len: u64,
     account_id_ptr: u64,
 ) -> Result<()> {
     promise_batch_action_use_global_contract_impl(
-        caller,
+        ctx,
+        memory,
         promise_idx,
         GlobalContractIdentifierPtrData::AccountId { account_id_len, account_id_ptr },
         "promise_batch_action_use_global_contract_by_account_id",
@@ -2585,13 +2542,12 @@ pub fn promise_batch_action_use_global_contract_by_account_id(
 }
 
 fn promise_batch_action_use_global_contract_impl(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     contract_id_ptr: GlobalContractIdentifierPtrData,
     method_name: &str,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView { method_name: method_name.to_owned() }.into());
@@ -2672,14 +2628,16 @@ fn read_contract_id(
 ///
 /// `used_gas`  := burnt_gas + exec action base fee
 pub fn promise_batch_action_state_init(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     code_hash_len: u64,
     code_hash_ptr: u64,
     amount_ptr: u64,
 ) -> Result<u64> {
     promise_batch_action_state_init_impl(
-        caller,
+        ctx,
+        memory,
         promise_idx,
         GlobalContractIdentifierPtrData::CodeHash { code_hash_len, code_hash_ptr },
         amount_ptr,
@@ -2710,14 +2668,16 @@ pub fn promise_batch_action_state_init(
 ///
 /// `used_gas`  := burnt_gas + exec action base fee
 pub fn promise_batch_action_state_init_by_account_id(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     account_id_len: u64,
     account_id_ptr: u64,
     amount_ptr: u64,
 ) -> Result<u64> {
     promise_batch_action_state_init_impl(
-        caller,
+        ctx,
+        memory,
         promise_idx,
         GlobalContractIdentifierPtrData::AccountId { account_id_len, account_id_ptr },
         amount_ptr,
@@ -2726,14 +2686,13 @@ pub fn promise_batch_action_state_init_by_account_id(
 }
 
 fn promise_batch_action_state_init_impl(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     contract_id_ptr: GlobalContractIdentifierPtrData,
     amount_ptr: u64,
     method_name: &str,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView { method_name: method_name.to_owned() }.into());
@@ -2779,7 +2738,8 @@ fn promise_batch_action_state_init_impl(
 ///             + deterministic_state_init_entry exec fee
 ///             + deterministic_state_init_byte exec fee * (key_len + value_len)
 pub fn set_state_init_data_entry(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     action_index: u64,
     key_len: u64,
@@ -2787,8 +2747,6 @@ pub fn set_state_init_data_entry(
     value_len: u64,
     value_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -2855,7 +2813,8 @@ pub fn set_state_init_data_entry(
 ///  + cost of reading u128, method_name and arguments from the memory`
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_function_call(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     method_name_len: u64,
     method_name_ptr: u64,
@@ -2865,7 +2824,8 @@ pub fn promise_batch_action_function_call(
     gas: u64,
 ) -> Result<()> {
     promise_batch_action_function_call_weight(
-        caller,
+        ctx,
+        memory,
         promise_idx,
         method_name_len,
         method_name_ptr,
@@ -2914,7 +2874,8 @@ pub fn promise_batch_action_function_call(
 /// `MemoryAccessViolation`.
 /// * If called as view function returns `ProhibitedInView`.
 pub fn promise_batch_action_function_call_weight(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     method_name_len: u64,
     method_name_ptr: u64,
@@ -2924,8 +2885,6 @@ pub fn promise_batch_action_function_call_weight(
     gas: u64,
     gas_weight: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3004,12 +2963,11 @@ pub fn promise_batch_action_function_call_weight(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading u128 from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_transfer(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     amount_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3063,14 +3021,13 @@ pub fn promise_batch_action_transfer(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key and u128 from memory`
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_transfer_to_gas_key(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     public_key_len: u64,
     public_key_ptr: u64,
     amount_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3129,14 +3086,13 @@ pub fn promise_batch_action_transfer_to_gas_key(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key from memory + gas key send fee`
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes + gas key exec fee`
 pub fn promise_batch_action_add_gas_key_with_full_access(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     public_key_len: u64,
     public_key_ptr: u64,
     num_nonces: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3199,7 +3155,8 @@ pub fn promise_batch_action_add_gas_key_with_full_access(
 ///  + cost of reading u128, method_names and public key from the memory + cost of reading and parsing account name + gas key send fee`
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes + gas key exec fee`
 pub fn promise_batch_action_add_gas_key_with_function_call(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     public_key_len: u64,
     public_key_ptr: u64,
@@ -3210,8 +3167,6 @@ pub fn promise_batch_action_add_gas_key_with_function_call(
     method_names_len: u64,
     method_names_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3302,14 +3257,13 @@ pub fn promise_batch_action_add_gas_key_with_function_call(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_stake(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     amount_ptr: u64,
     public_key_len: u64,
     public_key_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3351,14 +3305,13 @@ pub fn promise_batch_action_stake(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_add_key_with_full_access(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     public_key_len: u64,
     public_key_ptr: u64,
     nonce: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3404,7 +3357,8 @@ pub fn promise_batch_action_add_key_with_full_access(
 ///  + cost of reading u128, method_names and public key from the memory + cost of reading and parsing account name`
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_add_key_with_function_call(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     public_key_len: u64,
     public_key_ptr: u64,
@@ -3415,8 +3369,6 @@ pub fn promise_batch_action_add_key_with_function_call(
     method_names_len: u64,
     method_names_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3500,13 +3452,12 @@ pub fn promise_batch_action_add_key_with_function_call(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
 pub fn promise_batch_action_delete_key(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     public_key_len: u64,
     public_key_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3549,13 +3500,12 @@ pub fn promise_batch_action_delete_key(
 /// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading and parsing account id from memory `
 /// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes + fees for transferring funds to the beneficiary`
 pub fn promise_batch_action_delete_account(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     promise_idx: u64,
     beneficiary_id_len: u64,
     beneficiary_id_ptr: u64,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3625,7 +3575,8 @@ pub fn promise_batch_action_delete_account(
 /// * Fees for writing the Data ID to the output register;
 /// * Fees for setting up the receipt and the eventual function call of the method.
 pub fn promise_yield_create(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     method_name_len: u64,
     method_name_ptr: u64,
     arguments_len: u64,
@@ -3634,8 +3585,6 @@ pub fn promise_yield_create(
     gas_weight: u64,
     register_id: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3736,14 +3685,13 @@ pub fn promise_yield_create(
 /// * `yield_resume_byte` for each byte of `payload`;
 /// * Fees for reading the `data_id` and `payload`.
 pub fn promise_yield_resume(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     data_id_len: u64,
     data_id_ptr: u64,
     payload_len: u64,
     payload_ptr: u64,
 ) -> Result<u32, VMLogicError> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3797,8 +3745,7 @@ pub fn promise_yield_resume(
 /// # Cost
 ///
 /// `base`
-pub fn promise_results_count(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
-    let ctx = caller.data_mut();
+pub fn promise_results_count(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView {
@@ -3832,11 +3779,11 @@ pub fn promise_results_count(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
 ///
 /// `base + cost of writing data into a register`
 pub fn promise_result(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
     result_idx: u64,
     register_id: u64,
 ) -> Result<u64> {
-    let ctx = caller.data_mut();
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(
@@ -3876,8 +3823,7 @@ pub fn promise_result(
 /// # Cost
 ///
 /// `base + promise_return`
-pub fn promise_return(caller: &mut Caller<'_, Ctx>, promise_idx: u64) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn promise_return(ctx: &mut Ctx, _memory: &mut [u8], promise_idx: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     ctx.result_state.gas_counter.pay_base(ExtCosts::promise_return)?;
     if ctx.context.is_view() {
@@ -3913,9 +3859,12 @@ pub fn promise_return(caller: &mut Caller<'_, Ctx>, promise_idx: u64) -> Result<
 ///
 /// # Cost
 /// `base + cost of reading return value from memory or register + dispatch&exec cost per byte of the data sent * num data receivers`
-pub fn value_return(caller: &mut Caller<'_, Ctx>, value_len: u64, value_ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn value_return(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     let return_val = get_memory_or_register(
         &mut ctx.result_state.gas_counter,
@@ -3968,8 +3917,7 @@ pub fn value_return(caller: &mut Caller<'_, Ctx>, value_len: u64, value_ptr: u64
 /// # Cost
 ///
 /// `base`
-pub fn panic(caller: &mut Caller<'_, Ctx>) -> Result<()> {
-    let ctx = caller.data_mut();
+pub fn panic(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     Err(HostError::GuestPanic { panic_msg: "explicit guest panic".to_string() }.into())
 }
@@ -3985,9 +3933,7 @@ pub fn panic(caller: &mut Caller<'_, Ctx>) -> Result<()> {
 ///
 /// # Cost
 /// `base + cost of reading and decoding a utf8 string`
-pub fn panic_utf8(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn panic_utf8(ctx: &mut Ctx, memory: &mut [u8], len: u64, ptr: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     Err(HostError::GuestPanic {
         panic_msg: get_utf8_string(&mut ctx.result_state, memory, len, ptr)?,
@@ -4010,9 +3956,7 @@ pub fn panic_utf8(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()
 /// # Cost
 ///
 /// `base + log_base + log_byte + num_bytes + utf8 decoding cost`
-pub fn log_utf8(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn log_utf8(ctx: &mut Ctx, memory: &mut [u8], len: u64, ptr: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     ctx.result_state.check_can_add_a_log_message()?;
     let message = get_utf8_string(&mut ctx.result_state, memory, len, ptr)?;
@@ -4036,9 +3980,7 @@ pub fn log_utf8(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()> 
 /// # Cost
 ///
 /// `base + log_base + log_byte * num_bytes + utf16 decoding cost`
-pub fn log_utf16(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn log_utf16(ctx: &mut Ctx, memory: &mut [u8], len: u64, ptr: u64) -> Result<()> {
     ctx.result_state.gas_counter.pay_base(base)?;
     ctx.result_state.check_can_add_a_log_message()?;
     let message = get_utf16_string(&mut ctx.result_state, memory, len, ptr)?;
@@ -4064,14 +4006,13 @@ pub fn log_utf16(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()>
 ///
 /// `base +  log_base + log_byte * num_bytes + utf16 decoding cost`
 pub fn abort(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     msg_ptr: u32,
     filename_ptr: u32,
     line: u32,
     col: u32,
 ) -> Result<()> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if msg_ptr < 4 || filename_ptr < 4 {
         return Err(HostError::BadUTF16.into());
@@ -4114,8 +4055,7 @@ pub fn abort(
 ///
 /// `base` - the base cost for a simple host function call `write_memory_base` + 16 *
 /// `write_memory_byte` - the cost of writing the data to the register
-pub fn current_contract_code(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<u64> {
-    let ctx = caller.data_mut();
+pub fn current_contract_code(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<u64> {
     ctx.result_state.gas_counter.pay_base(base)?;
     match &ctx.context.account_contract {
         AccountContract::None => Ok(0),
@@ -4214,15 +4154,14 @@ fn read_and_parse_account_id(
 ///
 /// If a value was evicted it costs additional `storage_write_value_evicted_byte * num_evicted_bytes + internal_write_register_cost`.
 pub fn storage_write(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     key_len: u64,
     key_ptr: u64,
     value_len: u64,
     value_ptr: u64,
     register_id: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(HostError::ProhibitedInView { method_name: "storage_write".to_string() }.into());
@@ -4315,13 +4254,12 @@ pub fn storage_write(
 /// `base + storage_read_base + storage_read_key_byte * num_key_bytes + storage_read_value_byte + num_value_bytes
 ///  cost to read key from register + cost to write value into register`.
 pub fn storage_read(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     key_len: u64,
     key_ptr: u64,
     register_id: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     ctx.result_state.gas_counter.pay_base(storage_read_base)?;
     let key = get_memory_or_register(
@@ -4391,13 +4329,12 @@ pub fn storage_read(
 /// `base + storage_remove_base + storage_remove_key_byte * num_key_bytes + storage_remove_ret_value_byte * num_value_bytes
 /// + cost to read the key + cost to write the value`.
 pub fn storage_remove(
-    caller: &mut Caller<'_, Ctx>,
+    ctx: &mut Ctx,
+    memory: &mut [u8],
     key_len: u64,
     key_ptr: u64,
     register_id: u64,
 ) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
     ctx.result_state.gas_counter.pay_base(base)?;
     if ctx.context.is_view() {
         return Err(
@@ -4457,9 +4394,12 @@ pub fn storage_remove(
 /// # Cost
 ///
 /// `base + storage_has_key_base + storage_has_key_byte * num_bytes + cost of reading key`
-pub fn storage_has_key(caller: &mut Caller<'_, Ctx>, key_len: u64, key_ptr: u64) -> Result<u64> {
-    let memory = get_memory(caller)?;
-    let (memory, ctx) = memory.data_and_store_mut(caller);
+pub fn storage_has_key(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    key_len: u64,
+    key_ptr: u64,
+) -> Result<u64> {
     ctx.result_state.gas_counter.pay_base(base)?;
     ctx.result_state.gas_counter.pay_base(storage_has_key_base)?;
     let key = get_memory_or_register(
@@ -4494,8 +4434,8 @@ pub fn storage_has_key(caller: &mut Caller<'_, Ctx>, key_len: u64, key_ptr: u64)
 ///
 /// 0
 #[cfg(feature = "sandbox")]
-pub fn sandbox_debug_log(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Result<()> {
-    let message = sandbox_get_utf8_string(caller, len, ptr)?;
+pub fn sandbox_debug_log(_ctx: &mut Ctx, memory: &mut [u8], len: u64, ptr: u64) -> Result<()> {
+    let message = sandbox_get_utf8_string(memory, len, ptr)?;
     tracing::debug!(target: "sandbox", message = &message[..]);
     Ok(())
 }
@@ -4518,7 +4458,8 @@ pub fn sandbox_debug_log(caller: &mut Caller<'_, Ctx>, len: u64, ptr: u64) -> Re
 /// `base + storage_iter_create_prefix_base + storage_iter_create_key_byte * num_prefix_bytes
 ///  cost of reading the prefix`.
 pub fn storage_iter_prefix(
-    _caller: &mut Caller<'_, Ctx>,
+    _ctx: &mut Ctx,
+    _memory: &mut [u8],
     _prefix_len: u64,
     _prefix_ptr: u64,
 ) -> Result<u64> {
@@ -4545,7 +4486,8 @@ pub fn storage_iter_prefix(
 /// `base + storage_iter_create_range_base + storage_iter_create_from_byte * num_from_bytes
 ///  + storage_iter_create_to_byte * num_to_bytes + reading from prefix + reading to prefix`.
 pub fn storage_iter_range(
-    _caller: &mut Caller<'_, Ctx>,
+    _ctx: &mut Ctx,
+    _memory: &mut [u8],
     _start_len: u64,
     _start_ptr: u64,
     _end_len: u64,
@@ -4585,7 +4527,8 @@ pub fn storage_iter_range(
 /// `base + storage_iter_next_base + storage_iter_next_key_byte * num_key_bytes + storage_iter_next_value_byte * num_value_bytes
 ///  + writing key to register + writing value to register`.
 pub fn storage_iter_next(
-    _caller: &mut Caller<'_, Ctx>,
+    _ctx: &mut Ctx,
+    _memory: &mut [u8],
     _iterator_id: u64,
     _key_register_id: u64,
     _value_register_id: u64,

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -897,6 +897,21 @@ impl std::fmt::Display for ErrorContainer {
     }
 }
 
+/// Lookup the memory export and cache it on success.
+fn get_memory(caller: &mut wasmtime::Caller<'_, Ctx>) -> Result<Memory, VMLogicError> {
+    use crate::logic::HostError;
+    match caller.data().memory {
+        Export::Unresolved(memory) => {
+            let Some(Extern::Memory(memory)) = caller.get_module_export(&memory) else {
+                return Err(HostError::MemoryAccessViolation.into());
+            };
+            caller.data_mut().memory = Export::Resolved(memory);
+            Ok(memory)
+        }
+        Export::Resolved(memory) => Ok(memory),
+    }
+}
+
 fn link(linker: &mut wasmtime::Linker<Ctx>, config: &Config) {
     macro_rules! add_import {
         (
@@ -908,7 +923,12 @@ fn link(linker: &mut wasmtime::Linker<Ctx>, config: &Config) {
                 let _span = TRACE.then(|| {
                     tracing::trace_span!(target: "vm::host_function", stringify!($name)).entered()
                 });
-                match logic::$func(&mut caller, $( $arg_name as $arg_type, )*) {
+                let memory = match get_memory(&mut caller) {
+                    Ok(m) => m,
+                    Err(err) => return Err(ErrorContainer(parking_lot::Mutex::new(Some(err))).into()),
+                };
+                let (memory, ctx) = memory.data_and_store_mut(&mut caller);
+                match logic::$func(ctx, memory, $( $arg_name as $arg_type, )*) {
                     Ok(result) => Ok(result as ($( $returns ),* ) ),
                     Err(err) => {
                         Err(ErrorContainer(parking_lot::Mutex::new(Some(err))).into())

--- a/runtime/near-vm-runner/src/wasmtime_runner/test_logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/test_logic.rs
@@ -1,78 +1,18 @@
-use super::{Ctx, ErrorContainer, Export, link};
-use crate::imports;
+use super::Ctx;
+use super::logic;
 use crate::logic::errors::VMLogicError;
 use crate::logic::gas_counter::GasCounter;
 use crate::logic::mocks::mock_external::MockedExternal;
 use crate::logic::vmstate::Registers;
 use crate::logic::{Config, ExecutionResultState, MemSlice, VMContext, VMOutcome};
-use crate::tests::test_vm_config;
 use near_parameters::RuntimeFeesConfig;
 use std::sync::Arc;
-use wasmtime::{Engine, Instance, Linker, Memory, Module, Store};
+use wasmtime::{Engine, Memory, Store};
 
-/// Size of the guest memory in the test WAT shim (1 page = 64KB).
-/// Matches `MockedMemory::MEMORY_SIZE`.
-const MEMORY_PAGES: u32 = 1;
-const MEMORY_SIZE: u64 = MEMORY_PAGES as u64 * 64 * 1024;
-
-fn extract_vm_logic_error(err: anyhow::Error) -> VMLogicError {
-    let cause = err.root_cause();
-    if let Some(container) = cause.downcast_ref::<ErrorContainer>() {
-        container.take().expect("error already taken")
-    } else {
-        panic!("unexpected wasmtime error: {err:?}");
-    }
-}
-
-/// Build a WAT module that imports all host functions and re-exports them, plus
-/// exports a 1-page linear memory. This lets us call host functions through the
-/// normal wasmtime path (which creates `Caller` internally).
-#[allow(clippy::large_stack_frames)]
-fn build_wat_shim(config: &Config) -> String {
-    let mut imports = String::new();
-    let mut exports = String::new();
-
-    fn wat_type(t: &str) -> &str {
-        match t {
-            "u64" => "i64",
-            "u32" => "i32",
-            other => panic!("unexpected wasm type: {other}"),
-        }
-    }
-
-    macro_rules! add_wat {
-        ($mod:ident / $name:ident : $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >) => {{
-            let params: &[&str] = &[$(wat_type(stringify!($arg_type))),*];
-            let results: &[&str] = &[$(wat_type(stringify!($returns))),*];
-            let param_str = if params.is_empty() {
-                String::new()
-            } else {
-                format!(" (param{})", params.iter().map(|t| format!(" {t}")).collect::<String>())
-            };
-            let result_str = if results.is_empty() {
-                String::new()
-            } else {
-                format!(" (result{})", results.iter().map(|t| format!(" {t}")).collect::<String>())
-            };
-            imports.push_str(&format!(
-                "  (import \"{}\" \"{}\" (func ${}{}{}))\n",
-                stringify!($mod), stringify!($name), stringify!($name), param_str, result_str,
-            ));
-            exports.push_str(&format!(
-                "  (export \"{}\" (func ${}))\n",
-                stringify!($name), stringify!($name),
-            ));
-        }};
-    }
-
-    imports::for_each_available_import!(config, add_wat);
-
-    format!("(module\n{imports}{exports}  (memory (export \"memory\") {MEMORY_PAGES})\n)")
-}
+const MEMORY_SIZE: u64 = 64 * 1024;
 
 pub(crate) struct WasmtimeTestLogic {
     store: Store<Ctx>,
-    instance: Instance,
     memory: Memory,
     mem_write_offset: u64,
 }
@@ -93,296 +33,47 @@ impl WasmtimeTestLogic {
         let context: &'static VMContext = unsafe { core::mem::transmute(context) };
 
         let config = Arc::new(config);
-        let wat = build_wat_shim(&config);
-        let wat_bytes = wat::parse_str(&wat).expect("failed to parse WAT shim");
-
         let engine = Engine::default();
-        let module = Module::new(&engine, &wat_bytes).expect("failed to compile WAT shim");
-
-        let mut linker = Linker::new(&engine);
-        link(&mut linker, &config);
 
         let result_state = ExecutionResultState::new(
             context,
             context.make_gas_counter(&config),
             Arc::clone(&config),
         );
-        let memory_export = module.get_export_index("memory").expect("WAT shim must export memory");
-        let ctx = Ctx::new(ext, context, Arc::new(fees_config), result_state, memory_export);
+        // Create a dummy ModuleExport for the memory field in Ctx. We'll
+        // pre-resolve it immediately after creating the store, so the
+        // Unresolved value is never actually used.
+        let dummy_wasm = wat::parse_str("(module (memory (export \"memory\") 1))").unwrap();
+        let dummy_memory_export = wasmtime::Module::new(&engine, &dummy_wasm)
+            .unwrap()
+            .get_export_index("memory")
+            .unwrap();
+        let ctx = Ctx::new(ext, context, Arc::new(fees_config), result_state, dummy_memory_export);
 
         let mut store = Store::new(&engine, ctx);
         store.limiter(|ctx| &mut ctx.limits);
 
-        let pre = linker.instantiate_pre(&module).expect("failed to pre-instantiate WAT shim");
-        let instance = pre.instantiate(&mut store).expect("failed to instantiate WAT shim");
-        let memory =
-            instance.get_memory(&mut store, "memory").expect("WAT shim must export memory");
+        let memory = Memory::new(&mut store, wasmtime::MemoryType::new(1, Some(1))).unwrap();
+        store.data_mut().memory = super::Export::Resolved(memory);
 
-        // Pre-resolve the memory in Ctx so that host functions don't need to
-        // call `caller.get_module_export` (which fails with on-demand
-        // allocation since those create "Dummy" instances).
-        store.data_mut().memory = Export::Resolved(memory);
-
-        Self { store, instance, memory, mem_write_offset: 0 }
+        Self { store, memory, mem_write_offset: 0 }
     }
 
-    // ---------------------------------------------------------------
-    // Generic call helpers
-    //
-    // Uses `get_export` + `into_func` + `typed` instead of
-    // `get_typed_func` because wasmtime's on-demand allocator creates
-    // "Dummy" instances that don't support `get_typed_func`.
-    // ---------------------------------------------------------------
-
-    fn get_func(&mut self, name: &str) -> wasmtime::Func {
-        let wasmtime::Extern::Func(func) = self
-            .instance
-            .get_export(&mut self.store, name)
-            .unwrap_or_else(|| panic!("export {name:?} not found"))
-        else {
-            panic!("export {name:?} is not a function");
-        };
-        func
+    /// Returns `(&mut [u8], &mut Ctx)` — guest memory and store context.
+    fn ctx_and_mem(&mut self) -> (&mut [u8], &mut Ctx) {
+        self.memory.data_and_store_mut(&mut self.store)
     }
 
-    fn call_0(&mut self, name: &str) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(), ()>(&self.store).unwrap();
-        func.call(&mut self.store, ()).map_err(extract_vm_logic_error)
-    }
-
-    fn call_0_ret(&mut self, name: &str) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(), u64>(&self.store).unwrap();
-        func.call(&mut self.store, ()).map_err(extract_vm_logic_error)
-    }
-
-    fn call_1(&mut self, name: &str, a: u64) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64,), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a,)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_1_ret(&mut self, name: &str, a: u64) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64,), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (a,)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_2(&mut self, name: &str, a: u64, b: u64) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_2_ret(&mut self, name: &str, a: u64, b: u64) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_3(&mut self, name: &str, a: u64, b: u64, c: u64) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_3_ret(&mut self, name: &str, a: u64, b: u64, c: u64) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_4(&mut self, name: &str, a: u64, b: u64, c: u64, d: u64) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64, u64), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_4_ret(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-    ) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64, u64), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_5(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-    ) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64, u64, u64), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_5_ret(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-    ) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64, u64, u64), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_6(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-        f: u64,
-    ) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64, u64, u64, u64), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e, f)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_7(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-        f: u64,
-        g: u64,
-    ) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64, u64, u64, u64, u64), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e, f, g)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_7_ret(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-        f: u64,
-        g: u64,
-    ) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64, u64, u64, u64, u64), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e, f, g)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_8(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-        f: u64,
-        g: u64,
-        h: u64,
-    ) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func = func.typed::<(u64, u64, u64, u64, u64, u64, u64, u64), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e, f, g, h)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_8_ret(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-        f: u64,
-        g: u64,
-        h: u64,
-    ) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func =
-            func.typed::<(u64, u64, u64, u64, u64, u64, u64, u64), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e, f, g, h)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_9(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-        f: u64,
-        g: u64,
-        h: u64,
-        i: u64,
-    ) -> Result<(), VMLogicError> {
-        let func = self.get_func(name);
-        let func =
-            func.typed::<(u64, u64, u64, u64, u64, u64, u64, u64, u64), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e, f, g, h, i)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_9_ret(
-        &mut self,
-        name: &str,
-        a: u64,
-        b: u64,
-        c: u64,
-        d: u64,
-        e: u64,
-        f: u64,
-        g: u64,
-        h: u64,
-        i: u64,
-    ) -> Result<u64, VMLogicError> {
-        let func = self.get_func(name);
-        let func =
-            func.typed::<(u64, u64, u64, u64, u64, u64, u64, u64, u64), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (a, b, c, d, e, f, g, h, i)).map_err(extract_vm_logic_error)
-    }
-
-    fn call_abort(
-        &mut self,
-        msg_ptr: u32,
-        filename_ptr: u32,
-        line: u32,
-        col: u32,
-    ) -> Result<(), VMLogicError> {
-        let func = self.get_func("abort");
-        let func = func.typed::<(u32, u32, u32, u32), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (msg_ptr, filename_ptr, line, col))
-            .map_err(extract_vm_logic_error)
-    }
-
-    // ---------------------------------------------------------------
     // Registers API
-    // ---------------------------------------------------------------
 
     pub(crate) fn read_register(&mut self, register_id: u64, ptr: u64) -> Result<(), VMLogicError> {
-        self.call_2("read_register", register_id, ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::read_register(ctx, mem, register_id, ptr)
     }
 
     pub(crate) fn register_len(&mut self, register_id: u64) -> Result<u64, VMLogicError> {
-        self.call_1_ret("register_len", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::register_len(ctx, mem, register_id)
     }
 
     pub(crate) fn write_register(
@@ -391,79 +82,89 @@ impl WasmtimeTestLogic {
         data_len: u64,
         data_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("write_register", register_id, data_len, data_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::write_register(ctx, mem, register_id, data_len, data_ptr)
     }
 
-    // ---------------------------------------------------------------
     // Context API
-    // ---------------------------------------------------------------
 
     pub(crate) fn current_account_id(&mut self, register_id: u64) -> Result<(), VMLogicError> {
-        self.call_1("current_account_id", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::current_account_id(ctx, mem, register_id)
     }
 
     pub(crate) fn signer_account_id(&mut self, register_id: u64) -> Result<(), VMLogicError> {
-        self.call_1("signer_account_id", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::signer_account_id(ctx, mem, register_id)
     }
 
     pub(crate) fn signer_account_pk(&mut self, register_id: u64) -> Result<(), VMLogicError> {
-        self.call_1("signer_account_pk", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::signer_account_pk(ctx, mem, register_id)
     }
 
     pub(crate) fn predecessor_account_id(&mut self, register_id: u64) -> Result<(), VMLogicError> {
-        self.call_1("predecessor_account_id", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::predecessor_account_id(ctx, mem, register_id)
     }
 
     pub(crate) fn input(&mut self, register_id: u64) -> Result<(), VMLogicError> {
-        self.call_1("input", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::input(ctx, mem, register_id)
     }
 
     pub(crate) fn block_index(&mut self) -> Result<u64, VMLogicError> {
-        self.call_0_ret("block_index")
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::block_index(ctx, mem)
     }
 
     pub(crate) fn block_timestamp(&mut self) -> Result<u64, VMLogicError> {
-        self.call_0_ret("block_timestamp")
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::block_timestamp(ctx, mem)
     }
 
     pub(crate) fn epoch_height(&mut self) -> Result<u64, VMLogicError> {
-        self.call_0_ret("epoch_height")
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::epoch_height(ctx, mem)
     }
 
     pub(crate) fn storage_usage(&mut self) -> Result<u64, VMLogicError> {
-        self.call_0_ret("storage_usage")
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::storage_usage(ctx, mem)
     }
 
-    // ---------------------------------------------------------------
     // Economics API
-    // ---------------------------------------------------------------
 
     pub(crate) fn account_balance(&mut self, balance_ptr: u64) -> Result<(), VMLogicError> {
-        self.call_1("account_balance", balance_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::account_balance(ctx, mem, balance_ptr)
     }
 
     pub(crate) fn account_locked_balance(&mut self, balance_ptr: u64) -> Result<(), VMLogicError> {
-        self.call_1("account_locked_balance", balance_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::account_locked_balance(ctx, mem, balance_ptr)
     }
 
     pub(crate) fn attached_deposit(&mut self, balance_ptr: u64) -> Result<(), VMLogicError> {
-        self.call_1("attached_deposit", balance_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::attached_deposit(ctx, mem, balance_ptr)
     }
 
     pub(crate) fn prepaid_gas(&mut self) -> Result<u64, VMLogicError> {
-        self.call_0_ret("prepaid_gas")
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::prepaid_gas(ctx, mem)
     }
 
     pub(crate) fn used_gas(&mut self) -> Result<u64, VMLogicError> {
-        self.call_0_ret("used_gas")
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::used_gas(ctx, mem)
     }
 
-    // ---------------------------------------------------------------
     // Math API
-    // ---------------------------------------------------------------
 
     pub(crate) fn random_seed(&mut self, register_id: u64) -> Result<(), VMLogicError> {
-        self.call_1("random_seed", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::random_seed(ctx, mem, register_id)
     }
 
     pub(crate) fn sha256(
@@ -472,7 +173,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("sha256", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::sha256(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn keccak256(
@@ -481,7 +183,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("keccak256", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::keccak256(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn keccak512(
@@ -490,7 +193,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("keccak512", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::keccak512(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn ripemd160(
@@ -499,7 +203,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("ripemd160", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::ripemd160(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn ecrecover(
@@ -512,8 +217,10 @@ impl WasmtimeTestLogic {
         malleability_flag: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_7_ret(
-            "ecrecover",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::ecrecover(
+            ctx,
+            mem,
             hash_len,
             hash_ptr,
             sign_len,
@@ -533,38 +240,48 @@ impl WasmtimeTestLogic {
         pub_key_len: u64,
         pub_key_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        let func = self.get_func("ed25519_verify");
-        let func = func.typed::<(u64, u64, u64, u64, u64, u64), u64>(&self.store).unwrap();
-        func.call(&mut self.store, (sig_len, sig_ptr, msg_len, msg_ptr, pub_key_len, pub_key_ptr))
-            .map_err(extract_vm_logic_error)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::ed25519_verify(
+            ctx,
+            mem,
+            sig_len,
+            sig_ptr,
+            msg_len,
+            msg_ptr,
+            pub_key_len,
+            pub_key_ptr,
+        )
     }
 
-    // ---------------------------------------------------------------
     // Miscellaneous API
-    // ---------------------------------------------------------------
 
     pub(crate) fn value_return(
         &mut self,
         value_len: u64,
         value_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_2("value_return", value_len, value_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::value_return(ctx, mem, value_len, value_ptr)
     }
 
     pub(crate) fn panic(&mut self) -> Result<(), VMLogicError> {
-        self.call_0("panic")
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::panic(ctx, mem)
     }
 
     pub(crate) fn panic_utf8(&mut self, len: u64, ptr: u64) -> Result<(), VMLogicError> {
-        self.call_2("panic_utf8", len, ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::panic_utf8(ctx, mem, len, ptr)
     }
 
     pub(crate) fn log_utf8(&mut self, len: u64, ptr: u64) -> Result<(), VMLogicError> {
-        self.call_2("log_utf8", len, ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::log_utf8(ctx, mem, len, ptr)
     }
 
     pub(crate) fn log_utf16(&mut self, len: u64, ptr: u64) -> Result<(), VMLogicError> {
-        self.call_2("log_utf16", len, ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::log_utf16(ctx, mem, len, ptr)
     }
 
     pub(crate) fn abort(
@@ -574,12 +291,11 @@ impl WasmtimeTestLogic {
         line: u32,
         col: u32,
     ) -> Result<(), VMLogicError> {
-        self.call_abort(msg_ptr, filename_ptr, line, col)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::abort(ctx, mem, msg_ptr, filename_ptr, line, col)
     }
 
-    // ---------------------------------------------------------------
     // Promises API
-    // ---------------------------------------------------------------
 
     pub(crate) fn promise_create(
         &mut self,
@@ -592,8 +308,10 @@ impl WasmtimeTestLogic {
         amount_ptr: u64,
         gas: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_8_ret(
-            "promise_create",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_create(
+            ctx,
+            mem,
             account_id_len,
             account_id_ptr,
             method_name_len,
@@ -617,8 +335,10 @@ impl WasmtimeTestLogic {
         amount_ptr: u64,
         gas: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_9_ret(
-            "promise_then",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_then(
+            ctx,
+            mem,
             promise_index,
             account_id_len,
             account_id_ptr,
@@ -636,7 +356,8 @@ impl WasmtimeTestLogic {
         promise_idx_ptr: u64,
         promise_idx_count: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_2_ret("promise_and", promise_idx_ptr, promise_idx_count)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_and(ctx, mem, promise_idx_ptr, promise_idx_count)
     }
 
     pub(crate) fn promise_batch_create(
@@ -644,7 +365,8 @@ impl WasmtimeTestLogic {
         account_id_len: u64,
         account_id_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_2_ret("promise_batch_create", account_id_len, account_id_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_create(ctx, mem, account_id_len, account_id_ptr)
     }
 
     pub(crate) fn promise_batch_then(
@@ -653,7 +375,8 @@ impl WasmtimeTestLogic {
         account_id_len: u64,
         account_id_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("promise_batch_then", promise_index, account_id_len, account_id_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_then(ctx, mem, promise_index, account_id_len, account_id_ptr)
     }
 
     pub(crate) fn promise_set_refund_to(
@@ -662,7 +385,8 @@ impl WasmtimeTestLogic {
         account_id_len: u64,
         account_id_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("promise_set_refund_to", promise_index, account_id_len, account_id_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_set_refund_to(ctx, mem, promise_index, account_id_len, account_id_ptr)
     }
 
     pub(crate) fn promise_batch_action_state_init(
@@ -672,8 +396,10 @@ impl WasmtimeTestLogic {
         code_ptr: u64,
         amount_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_4_ret(
-            "promise_batch_action_state_init",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_state_init(
+            ctx,
+            mem,
             promise_idx,
             code_len,
             code_ptr,
@@ -688,8 +414,10 @@ impl WasmtimeTestLogic {
         code_hash_ptr: u64,
         amount_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_4_ret(
-            "promise_batch_action_state_init_by_account_id",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_state_init_by_account_id(
+            ctx,
+            mem,
             promise_idx,
             account_id_len,
             code_hash_ptr,
@@ -706,8 +434,10 @@ impl WasmtimeTestLogic {
         value_len: u64,
         value_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_6(
-            "set_state_init_data_entry",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::set_state_init_data_entry(
+            ctx,
+            mem,
             promise_idx,
             action_index,
             key_len,
@@ -718,22 +448,23 @@ impl WasmtimeTestLogic {
     }
 
     pub(crate) fn current_contract_code(&mut self, register_id: u64) -> Result<u64, VMLogicError> {
-        self.call_1_ret("current_contract_code", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::current_contract_code(ctx, mem, register_id)
     }
 
     pub(crate) fn refund_to_account_id(&mut self, register_id: u64) -> Result<(), VMLogicError> {
-        self.call_1("refund_to_account_id", register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::refund_to_account_id(ctx, mem, register_id)
     }
 
-    // ---------------------------------------------------------------
-    // Promise API actions
-    // ---------------------------------------------------------------
+    // Promise batch actions
 
     pub(crate) fn promise_batch_action_create_account(
         &mut self,
         promise_index: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_1("promise_batch_action_create_account", promise_index)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_create_account(ctx, mem, promise_index)
     }
 
     pub(crate) fn promise_batch_action_deploy_contract(
@@ -742,7 +473,8 @@ impl WasmtimeTestLogic {
         code_len: u64,
         code_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("promise_batch_action_deploy_contract", promise_index, code_len, code_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_deploy_contract(ctx, mem, promise_index, code_len, code_ptr)
     }
 
     pub(crate) fn promise_batch_action_deploy_global_contract(
@@ -751,8 +483,10 @@ impl WasmtimeTestLogic {
         code_len: u64,
         code_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3(
-            "promise_batch_action_deploy_global_contract",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_deploy_global_contract(
+            ctx,
+            mem,
             promise_index,
             code_len,
             code_ptr,
@@ -765,8 +499,10 @@ impl WasmtimeTestLogic {
         code_len: u64,
         code_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3(
-            "promise_batch_action_deploy_global_contract_by_account_id",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_deploy_global_contract_by_account_id(
+            ctx,
+            mem,
             promise_index,
             code_len,
             code_ptr,
@@ -779,8 +515,10 @@ impl WasmtimeTestLogic {
         code_hash_len: u64,
         code_hash_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3(
-            "promise_batch_action_use_global_contract",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_use_global_contract(
+            ctx,
+            mem,
             promise_index,
             code_hash_len,
             code_hash_ptr,
@@ -793,8 +531,10 @@ impl WasmtimeTestLogic {
         account_id_len: u64,
         account_id_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3(
-            "promise_batch_action_use_global_contract_by_account_id",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_use_global_contract_by_account_id(
+            ctx,
+            mem,
             promise_index,
             account_id_len,
             account_id_ptr,
@@ -811,8 +551,10 @@ impl WasmtimeTestLogic {
         amount_ptr: u64,
         gas: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_7(
-            "promise_batch_action_function_call",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_function_call(
+            ctx,
+            mem,
             promise_index,
             method_name_len,
             method_name_ptr,
@@ -834,8 +576,10 @@ impl WasmtimeTestLogic {
         gas: u64,
         gas_weight: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_8(
-            "promise_batch_action_function_call_weight",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_function_call_weight(
+            ctx,
+            mem,
             promise_index,
             method_name_len,
             method_name_ptr,
@@ -852,7 +596,8 @@ impl WasmtimeTestLogic {
         promise_index: u64,
         amount_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_2("promise_batch_action_transfer", promise_index, amount_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_transfer(ctx, mem, promise_index, amount_ptr)
     }
 
     pub(crate) fn promise_batch_action_stake(
@@ -862,8 +607,10 @@ impl WasmtimeTestLogic {
         public_key_len: u64,
         public_key_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_4(
-            "promise_batch_action_stake",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_stake(
+            ctx,
+            mem,
             promise_index,
             amount_ptr,
             public_key_len,
@@ -878,8 +625,10 @@ impl WasmtimeTestLogic {
         public_key_ptr: u64,
         nonce: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_4(
-            "promise_batch_action_add_key_with_full_access",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_add_key_with_full_access(
+            ctx,
+            mem,
             promise_index,
             public_key_len,
             public_key_ptr,
@@ -899,8 +648,10 @@ impl WasmtimeTestLogic {
         method_names_len: u64,
         method_names_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_9(
-            "promise_batch_action_add_key_with_function_call",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_add_key_with_function_call(
+            ctx,
+            mem,
             promise_index,
             public_key_len,
             public_key_ptr,
@@ -919,8 +670,10 @@ impl WasmtimeTestLogic {
         public_key_len: u64,
         public_key_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3(
-            "promise_batch_action_delete_key",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_delete_key(
+            ctx,
+            mem,
             promise_index,
             public_key_len,
             public_key_ptr,
@@ -933,8 +686,10 @@ impl WasmtimeTestLogic {
         beneficiary_id_len: u64,
         beneficiary_id_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3(
-            "promise_batch_action_delete_account",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_delete_account(
+            ctx,
+            mem,
             promise_index,
             beneficiary_id_len,
             beneficiary_id_ptr,
@@ -948,8 +703,10 @@ impl WasmtimeTestLogic {
         public_key_ptr: u64,
         amount_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_4(
-            "promise_batch_action_transfer_to_gas_key",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_transfer_to_gas_key(
+            ctx,
+            mem,
             promise_index,
             public_key_len,
             public_key_ptr,
@@ -964,8 +721,10 @@ impl WasmtimeTestLogic {
         public_key_ptr: u64,
         num_nonces: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_4(
-            "promise_batch_action_add_gas_key_with_full_access",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_add_gas_key_with_full_access(
+            ctx,
+            mem,
             promise_index,
             public_key_len,
             public_key_ptr,
@@ -985,8 +744,10 @@ impl WasmtimeTestLogic {
         method_names_len: u64,
         method_names_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_9(
-            "promise_batch_action_add_gas_key_with_function_call",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_batch_action_add_gas_key_with_function_call(
+            ctx,
+            mem,
             promise_index,
             public_key_len,
             public_key_ptr,
@@ -999,9 +760,7 @@ impl WasmtimeTestLogic {
         )
     }
 
-    // ---------------------------------------------------------------
-    // Promise API yield/resume
-    // ---------------------------------------------------------------
+    // Promise yield/resume
 
     pub(crate) fn promise_yield_create(
         &mut self,
@@ -1013,8 +772,10 @@ impl WasmtimeTestLogic {
         gas_weight: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_7_ret(
-            "promise_yield_create",
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_yield_create(
+            ctx,
+            mem,
             method_name_len,
             method_name_ptr,
             arguments_len,
@@ -1032,18 +793,15 @@ impl WasmtimeTestLogic {
         payload_len: u64,
         payload_ptr: u64,
     ) -> Result<u32, VMLogicError> {
-        let func = self.get_func("promise_yield_resume");
-        let func = func.typed::<(u64, u64, u64, u64), u32>(&self.store).unwrap();
-        func.call(&mut self.store, (data_id_len, data_id_ptr, payload_len, payload_ptr))
-            .map_err(extract_vm_logic_error)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_yield_resume(ctx, mem, data_id_len, data_id_ptr, payload_len, payload_ptr)
     }
 
-    // ---------------------------------------------------------------
-    // Promise API results
-    // ---------------------------------------------------------------
+    // Promise results
 
     pub(crate) fn promise_results_count(&mut self) -> Result<u64, VMLogicError> {
-        self.call_0_ret("promise_results_count")
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_results_count(ctx, mem)
     }
 
     pub(crate) fn promise_result(
@@ -1051,16 +809,16 @@ impl WasmtimeTestLogic {
         result_idx: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_2_ret("promise_result", result_idx, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_result(ctx, mem, result_idx, register_id)
     }
 
     pub(crate) fn promise_return(&mut self, promise_idx: u64) -> Result<(), VMLogicError> {
-        self.call_1("promise_return", promise_idx)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::promise_return(ctx, mem, promise_idx)
     }
 
-    // ---------------------------------------------------------------
     // Storage API
-    // ---------------------------------------------------------------
 
     pub(crate) fn storage_write(
         &mut self,
@@ -1070,7 +828,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_5_ret("storage_write", key_len, key_ptr, value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::storage_write(ctx, mem, key_len, key_ptr, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn storage_read(
@@ -1079,7 +838,8 @@ impl WasmtimeTestLogic {
         key_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("storage_read", key_len, key_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::storage_read(ctx, mem, key_len, key_ptr, register_id)
     }
 
     pub(crate) fn storage_remove(
@@ -1088,7 +848,8 @@ impl WasmtimeTestLogic {
         key_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("storage_remove", key_len, key_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::storage_remove(ctx, mem, key_len, key_ptr, register_id)
     }
 
     pub(crate) fn storage_has_key(
@@ -1096,7 +857,8 @@ impl WasmtimeTestLogic {
         key_len: u64,
         key_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_2_ret("storage_has_key", key_len, key_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::storage_has_key(ctx, mem, key_len, key_ptr)
     }
 
     pub(crate) fn storage_iter_prefix(
@@ -1104,7 +866,8 @@ impl WasmtimeTestLogic {
         prefix_len: u64,
         prefix_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_2_ret("storage_iter_prefix", prefix_len, prefix_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::storage_iter_prefix(ctx, mem, prefix_len, prefix_ptr)
     }
 
     pub(crate) fn storage_iter_range(
@@ -1114,7 +877,8 @@ impl WasmtimeTestLogic {
         end_len: u64,
         end_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_4_ret("storage_iter_range", start_len, start_ptr, end_len, end_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::storage_iter_range(ctx, mem, start_len, start_ptr, end_len, end_ptr)
     }
 
     pub(crate) fn storage_iter_next(
@@ -1123,29 +887,22 @@ impl WasmtimeTestLogic {
         key_register_id: u64,
         value_register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("storage_iter_next", iterator_id, key_register_id, value_register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::storage_iter_next(ctx, mem, iterator_id, key_register_id, value_register_id)
     }
 
-    // ---------------------------------------------------------------
     // Gas
-    // ---------------------------------------------------------------
 
     pub(crate) fn gas_seen_from_wasm(&mut self, opcodes: u32) -> Result<(), VMLogicError> {
-        let func = self.get_func("gas");
-        let func = func.typed::<(u32,), ()>(&self.store).unwrap();
-        func.call(&mut self.store, (opcodes,)).map_err(extract_vm_logic_error)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::gas_seen_from_wasm(ctx, mem, opcodes)
     }
 
     pub(crate) fn gas_opcodes(&mut self, opcodes: u32) -> Result<(), VMLogicError> {
-        let config = Arc::clone(&self.store.data().config);
-        let gas = opcodes as u64 * config.regular_op_cost as u64;
-        let ctx = self.store.data_mut();
-        ctx.result_state.gas_counter.burn_gas(near_primitives_core::gas::Gas::from_gas(gas))
+        logic::gas_opcodes(&mut self.store.data_mut().result_state, opcodes)
     }
 
-    // ---------------------------------------------------------------
     // Validator API
-    // ---------------------------------------------------------------
 
     pub(crate) fn validator_stake(
         &mut self,
@@ -1153,16 +910,16 @@ impl WasmtimeTestLogic {
         account_id_ptr: u64,
         stake_ptr: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("validator_stake", account_id_len, account_id_ptr, stake_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::validator_stake(ctx, mem, account_id_len, account_id_ptr, stake_ptr)
     }
 
     pub(crate) fn validator_total_stake(&mut self, stake_ptr: u64) -> Result<(), VMLogicError> {
-        self.call_1("validator_total_stake", stake_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::validator_total_stake(ctx, mem, stake_ptr)
     }
 
-    // ---------------------------------------------------------------
     // Alt BN128
-    // ---------------------------------------------------------------
 
     pub(crate) fn alt_bn128_g1_multiexp(
         &mut self,
@@ -1170,7 +927,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("alt_bn128_g1_multiexp", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::alt_bn128_g1_multiexp(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn alt_bn128_g1_sum(
@@ -1179,7 +937,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<(), VMLogicError> {
-        self.call_3("alt_bn128_g1_sum", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::alt_bn128_g1_sum(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn alt_bn128_pairing_check(
@@ -1187,12 +946,11 @@ impl WasmtimeTestLogic {
         value_len: u64,
         value_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_2_ret("alt_bn128_pairing_check", value_len, value_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::alt_bn128_pairing_check(ctx, mem, value_len, value_ptr)
     }
 
-    // ---------------------------------------------------------------
     // BLS12-381
-    // ---------------------------------------------------------------
 
     pub(crate) fn bls12381_p1_sum(
         &mut self,
@@ -1200,7 +958,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("bls12381_p1_sum", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_p1_sum(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn bls12381_p2_sum(
@@ -1209,7 +968,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("bls12381_p2_sum", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_p2_sum(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn bls12381_g1_multiexp(
@@ -1218,7 +978,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("bls12381_g1_multiexp", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_g1_multiexp(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn bls12381_g2_multiexp(
@@ -1227,7 +988,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("bls12381_g2_multiexp", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_g2_multiexp(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn bls12381_map_fp_to_g1(
@@ -1236,7 +998,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("bls12381_map_fp_to_g1", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_map_fp_to_g1(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn bls12381_map_fp2_to_g2(
@@ -1245,7 +1008,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("bls12381_map_fp2_to_g2", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_map_fp2_to_g2(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn bls12381_pairing_check(
@@ -1253,7 +1017,8 @@ impl WasmtimeTestLogic {
         value_len: u64,
         value_ptr: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_2_ret("bls12381_pairing_check", value_len, value_ptr)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_pairing_check(ctx, mem, value_len, value_ptr)
     }
 
     pub(crate) fn bls12381_p1_decompress(
@@ -1262,7 +1027,8 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("bls12381_p1_decompress", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_p1_decompress(ctx, mem, value_len, value_ptr, register_id)
     }
 
     pub(crate) fn bls12381_p2_decompress(
@@ -1271,12 +1037,11 @@ impl WasmtimeTestLogic {
         value_ptr: u64,
         register_id: u64,
     ) -> Result<u64, VMLogicError> {
-        self.call_3_ret("bls12381_p2_decompress", value_len, value_ptr, register_id)
+        let (mem, ctx) = self.ctx_and_mem();
+        logic::bls12381_p2_decompress(ctx, mem, value_len, value_ptr, register_id)
     }
 
-    // ---------------------------------------------------------------
-    // Test helpers — access Ctx directly (no wasm call needed)
-    // ---------------------------------------------------------------
+    // Test helpers
 
     pub(crate) fn gas_counter(&mut self) -> &mut GasCounter {
         &mut self.store.data_mut().result_state.gas_counter
@@ -1337,27 +1102,5 @@ impl WasmtimeTestLogic {
 
     pub(crate) fn compute_outcome(self) -> VMOutcome {
         self.store.into_data().result_state.compute_outcome()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn wat_shim_covers_all_host_functions() {
-        let config = test_vm_config(None);
-        let wat = build_wat_shim(&config);
-        let wat_bytes = wat::parse_str(&wat).expect("WAT shim should parse");
-        let engine = Engine::default();
-        let module = Module::new(&engine, &wat_bytes).expect("WAT shim should compile");
-        let func_export_count = module.exports().filter(|e| e.ty().func().is_some()).count();
-        // If you add a host function to imports.rs, update this count and add
-        // a delegate method to WasmtimeTestLogic.
-        let expected = if cfg!(feature = "nightly") { 98 } else { 95 };
-        assert_eq!(
-            func_export_count, expected,
-            "WAT shim export count changed — did you add/remove a host function?"
-        );
     }
 }


### PR DESCRIPTION
Alternative approach that removes the WAT shim by changing host function signatures from Caller to (Ctx, memory). Simplifies test_logic.rs but touches ~70 production function signatures.
