### PR TITLE
fix(state-sync): fix race between state part caching and epoch boundary cleanup

### DIFF
--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -342,11 +342,18 @@ impl ChainStateSyncAdapter {
         self.requested_state_parts
             .save_state_part_elapsed(&sync_hash, &shard_id, &part_id, elapsed_ms);
 
-        // Saving the part data
-        let mut store_update = self.chain_store.store().store_update();
-        let bytes = state_part.to_bytes(protocol_version);
-        store_update.set(DBCol::StateParts, &key, &bytes);
-        store_update.commit();
+        // Cache the part data, but only if the corresponding header is also cached.
+        // At epoch boundaries, clear_all_downloaded_parts() deletes all cached headers
+        // and parts. Since serving runs on a separate actor, a part request can arrive
+        // after the clear and re-create a StatePartKey without its StateHeaderKey,
+        // which the storage validator treats as an inconsistency.
+        let header_key = borsh::to_vec(&StateHeaderKey(shard_id, sync_hash)).unwrap();
+        if self.chain_store.store_ref().exists(DBCol::StateHeaders, &header_key) {
+            let mut store_update = self.chain_store.store().store_update();
+            let bytes = state_part.to_bytes(protocol_version);
+            store_update.set(DBCol::StateParts, &key, &bytes);
+            store_update.commit();
+        }
 
         Ok(state_part)
     }


### PR DESCRIPTION
Fixes a flaky storage validation failure in `pytest sanity/catchup_flat_storage_deletions.py`.

Failing test: https://nayduck.nearone.org/#/test/1255787

## The bug

A `StatePartKey` is found in the DB without a corresponding `StateHeaderKey`, causing the storage validator to flag the node as inconsistent and kill it.

## Root cause

A race condition between two concurrent operations on the same node:

- `ClientActor` (block processing thread): at each epoch boundary, calls `clear_all_downloaded_parts()` which bulk-deletes all entries from `DBCol::StateHeaders` and `DBCol::StateParts`.
- `StateRequestActor` (separate thread pool): when serving a state part request from a peer, `get_state_response_part()` computes the part (takes seconds), then caches it by writing a `StatePartKey` to `DBCol::StateParts`.

The interleaving that triggers the bug:
1. `StateRequestActor` starts computing a state part (expensive, seconds-long)
2. `ClientActor` processes an epoch-boundary block and deletes all state headers and parts
3. `StateRequestActor` finishes and writes the `StatePartKey` — but the corresponding `StateHeaderKey` was deleted in step 2 and is never re-created
4. Storage validator finds the orphaned `StatePartKey` and declares inconsistency

Short epoch lengths (e.g. `EPOCH_LENGTH=10` in this test) amplify the race by making epoch boundaries frequent while state part computation is actively in progress.

## Fix

Before caching a computed state part, check that the corresponding `StateHeaderKey` still exists. If it was cleared by the epoch boundary cleanup, skip the cache write. The part is still returned to the requesting peer — only the local cache write is skipped.