### PR TITLE
fix(store): skip chain-dependent migration steps for state snapshot DBs

### DIFF
--- a/core/store/src/node_storage/opener.rs
+++ b/core/store/src/node_storage/opener.rs
@@ -182,6 +182,14 @@ pub struct StoreOpener<'a> {
 
     /// Opener for an instance of cloud storage if one was configured.
     cloud: Option<CloudStorageOpener>,
+
+    /// Whether this opener is for a state snapshot database.
+    ///
+    /// State snapshot DBs only contain a subset of columns (see
+    /// `STATE_SNAPSHOT_COLUMNS`) and lack epoch/chain data needed by most
+    /// migrations. This flag is passed through to `StoreMigrator::migrate`
+    /// so individual migrations can skip steps that require missing data.
+    is_snapshot: bool,
 }
 
 /// Opener for a single RocksDB instance.
@@ -215,7 +223,7 @@ impl<'a> StoreOpener<'a> {
         let cold =
             cold_store_config.map(|config| DBOpener::new(home_dir, config, Temperature::Cold));
         let cloud = cloud_storage_context.map(|context| CloudStorageOpener::new(context));
-        Self { hot, cold, migrator: None, cloud }
+        Self { hot, cold, migrator: None, cloud, is_snapshot: false }
     }
 
     /// Returns true if this opener is for an archival node.
@@ -230,6 +238,15 @@ impl<'a> StoreOpener<'a> {
     /// attempt to perform migrations.
     pub fn with_migrator(mut self, migrator: &'a dyn StoreMigrator) -> Self {
         self.migrator = Some(migrator);
+        self
+    }
+
+    /// Marks this opener as opening a state snapshot database.
+    ///
+    /// State snapshot DBs lack most chain/epoch data. This flag is forwarded
+    /// to `StoreMigrator::migrate` so migrations can skip inapplicable steps.
+    pub fn as_snapshot(mut self) -> Self {
+        self.is_snapshot = true;
         self
     }
 
@@ -313,7 +330,8 @@ impl<'a> StoreOpener<'a> {
             }
 
             let opener = NodeStorage::opener(&snapshot_path, &config, None, None)
-                .with_migrator(self.migrator.unwrap());
+                .with_migrator(self.migrator.unwrap())
+                .as_snapshot();
             let _ = opener.open_in_mode(Mode::ReadWrite)?;
         }
         Ok(())
@@ -339,8 +357,13 @@ impl<'a> StoreOpener<'a> {
             Self::ensure_kind(mode, cold, self.is_archive(), Temperature::Cold)?;
         }
 
-        let (hot_snapshot, cold_snapshot) =
-            Self::ensure_version(mode, &self.hot, self.cold.as_ref(), &self.migrator)?;
+        let (hot_snapshot, cold_snapshot) = Self::ensure_version(
+            mode,
+            &self.hot,
+            self.cold.as_ref(),
+            &self.migrator,
+            self.is_snapshot,
+        )?;
 
         if let Err(error) = self.migrate_state_snapshots() {
             // If migration fails the node may not be able to share state parts.
@@ -393,8 +416,13 @@ impl<'a> StoreOpener<'a> {
             Self::ensure_kind(mode, cold, self.is_archive(), Temperature::Cold)?;
         }
 
-        let (hot_snapshot, cold_snapshot) =
-            Self::ensure_version(mode, &self.hot, self.cold.as_ref(), &self.migrator)?;
+        let (hot_snapshot, cold_snapshot) = Self::ensure_version(
+            mode,
+            &self.hot,
+            self.cold.as_ref(),
+            &self.migrator,
+            self.is_snapshot,
+        )?;
 
         // If ensure_version didn't create snapshots (no migration needed), create them now
         let hot_snapshot =
@@ -484,6 +512,7 @@ impl<'a> StoreOpener<'a> {
         hot_opener: &DBOpener,
         cold_opener: Option<&DBOpener>,
         migrator: &Option<&dyn StoreMigrator>,
+        is_snapshot: bool,
     ) -> Result<(Snapshot, Snapshot), StoreOpenerError> {
         tracing::debug!(
             target: "db_opener",
@@ -570,7 +599,7 @@ impl<'a> StoreOpener<'a> {
 
             // Run migration on both stores
             migrator
-                .migrate(&hot_store, cold_db.as_ref(), version)
+                .migrate(&hot_store, cold_db.as_ref(), version, is_snapshot)
                 .map_err(StoreOpenerError::MigrationError)?;
 
             // Update versions in both stores
@@ -703,6 +732,11 @@ pub trait StoreMigrator {
     /// It doesn't update database's metadata (i.e. what version is stored in
     /// the database) which is responsibility of the caller.
     ///
+    /// When `is_snapshot` is true, the store being migrated is a state snapshot
+    /// database which only contains a subset of columns (see
+    /// `STATE_SNAPSHOT_COLUMNS`). Migrations should skip steps that depend on
+    /// data not present in snapshot DBs (e.g. epoch/chain data).
+    ///
     /// **Panics** if `version` is not supported (the caller is supposed to
     /// check support via [`Self::check_support`] method) or if it's greater or
     /// equal to [`DB_VERSION`].
@@ -711,6 +745,7 @@ pub trait StoreMigrator {
         hot_store: &Store,
         cold_db: Option<&ColdDB>,
         version: DbVersion,
+        is_snapshot: bool,
     ) -> anyhow::Result<()>;
 }
 

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -48,6 +48,7 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
         hot_store: &Store,
         cold_db: Option<&ColdDB>,
         version: DbVersion,
+        is_snapshot: bool,
     ) -> anyhow::Result<()> {
         match version {
             0..MIN_SUPPORTED_DB_VERSION => unreachable!(),
@@ -63,6 +64,7 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
                 hot_store,
                 cold_db,
                 self.config.genesis.config.transaction_validity_period,
+                is_snapshot,
             ),
             DB_VERSION.. => unreachable!(),
         }
@@ -163,14 +165,14 @@ fn migrate_48_to_49(
     hot_store: &Store,
     cold_db: Option<&ColdDB>,
     transaction_validity_period: BlockHeightDelta,
+    is_snapshot: bool,
 ) -> anyhow::Result<()> {
     tracing::info!(target: "migrations", "starting migration from DB version 48 to 49");
 
-    // State snapshot DBs only contain state data — no chain or epoch data.
-    // All steps in this migration are chain-dependent, so skip them.
-    let chain_store = hot_store.chain_store();
-    if chain_store.final_head().is_err() {
-        tracing::info!(target: "migrations", "no chain data found (state snapshot DB), skipping migration steps");
+    // State snapshot DBs only contain flat storage columns and lack the
+    // epoch/chain data that every step of this migration requires. Skip them.
+    if is_snapshot {
+        tracing::info!(target: "migrations", "state snapshot DB, skipping chain-dependent migration steps");
         return Ok(());
     }
 


### PR DESCRIPTION
## The bug

During DB migration 48→49, `migrate_state_snapshots()` runs the same migration on each state snapshot DB. This causes a logged `EpochOutOfBounds` error on every node upgrade with state snapshots enabled. Detected on mainnet archive canary after upgrading to 912e3d9.

## Root cause

State snapshot DBs are created via RocksDB `Checkpoint`, which copies all data, then drops columns not in `STATE_SNAPSHOT_COLUMNS`. The snapshot retains `DbVersion`, `BlockMisc`, `FlatState`, `FlatStateChanges`, `FlatStateDeltaMetadata`, and `FlatStorageStatus` — but no epoch data (`EpochInfo`, `EpochStart`, etc.).

When `migrate_48_to_49` calls `update_epoch_sync_proof`, it reaches `find_target_epoch_to_produce_proof_for` which queries epoch data that doesn't exist, causing `EpochOutOfBounds`.

The error is caught by the opener and only logged, so the node continues. However, the snapshot DB version stays at 48 (migration returned an error before the version bump). This later causes `DbVersionMismatchOnRead` when opening the snapshot for state part generation.

## Fix

The `StoreOpener` now carries an `is_snapshot` flag, set via `.as_snapshot()` in `migrate_state_snapshots()`. This flag flows through `ensure_version` → `StoreMigrator::migrate` → `migrate_48_to_49`, which early-returns for snapshots.

This replaces the previous heuristic (`chain_store.final_head().is_err()`) which didn't work because snapshot DBs include `BlockMisc` with `FINAL_HEAD_KEY` populated — so `final_head()` succeeds and the check never triggers.