### PR TITLE
fix(dynamic-resharding): clear `proposed_split`

### DIFF
--- a/chain/chain/src/resharding/manager.rs
+++ b/chain/chain/src/resharding/manager.rs
@@ -252,6 +252,10 @@ impl ReshardingManager {
             let mut child_chunk_extra = ChunkExtra::clone(&parent_chunk_extra);
             *child_chunk_extra.state_root_mut() = trie_changes.new_root;
             *child_chunk_extra.congestion_info_mut() = child_congestion_info;
+            // Clear the parent's proposed_split so it doesn't get carried over
+            // to the child shard. A stale proposed_split on a child shard can
+            // cause DuplicateBoundaryAccount errors during epoch finalization.
+            child_chunk_extra.clear_proposed_split();
 
             chain_store_update.save_chunk_extra(
                 block_hash,

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1057,6 +1057,14 @@ pub mod chunk_extra {
                 ChunkExtra::V5(v5) => v5.proposed_split.as_ref(),
             }
         }
+
+        #[inline]
+        pub fn clear_proposed_split(&mut self) {
+            match self {
+                Self::V1(_) | Self::V2(_) | Self::V3(_) | Self::V4(_) => {}
+                ChunkExtra::V5(v5) => v5.proposed_split = None,
+            }
+        }
     }
 }
 


### PR DESCRIPTION
When resharding, clear the `proposed_split` stored in parent shard's `ChunkExtra` to avoid potential errors during epoch finalization.