### PR TITLE
update wasmtime to v42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli 0.33.1",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,15 +155,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -324,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1128,9 +1137,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -1283,7 +1295,16 @@ version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba33ddc4e157cb1abe9da6c821e8824f99e56d057c2c22536850e0141f281d61"
 dependencies = [
- "cranelift-assembler-x64-meta",
+ "cranelift-assembler-x64-meta 0.123.6",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40630d663279bc855bff805d6f5e8a0b6a1867f9df95b010511ac6dc894e9395"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.129.1",
 ]
 
 [[package]]
@@ -1292,7 +1313,16 @@ version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b23dd6ea360e6fb28a3f3b40b7f126509668f58076a4729b2cfd656f26a0ad"
 dependencies = [
- "cranelift-srcgen",
+ "cranelift-srcgen 0.123.6",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee6aec5ceb55e5fdbcf7ef677d7c7195531360ff181ce39b2b31df11d57305f"
+dependencies = [
+ "cranelift-srcgen 0.129.1",
 ]
 
 [[package]]
@@ -1301,7 +1331,16 @@ version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d81afcee8fe27ee2536987df3fadcb2e161af4edb7dbe3ef36838d0ce74382"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.123.6",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a92d78cc3f087d7e7073828f08d98c7074a3a062b6b29a1b7783ce74305685e"
+dependencies = [
+ "cranelift-entity 0.129.1",
 ]
 
 [[package]]
@@ -1315,30 +1354,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bitset"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcc73d756f2e0d7eda6144fe64a2bc69c624de893cb1be51f1442aed77881d2"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
 name = "cranelift-codegen"
 version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0230a6ac0660bfe31eb244cbb43dcd4f2b3c1c4e0addc3e0348c6053ea60272e"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
+ "cranelift-assembler-x64 0.123.6",
+ "cranelift-bforest 0.123.6",
+ "cranelift-bitset 0.123.6",
+ "cranelift-codegen-meta 0.123.6",
+ "cranelift-codegen-shared 0.123.6",
+ "cranelift-control 0.123.6",
+ "cranelift-entity 0.123.6",
+ "cranelift-isle 0.123.6",
  "gimli 0.32.0",
  "hashbrown 0.15.2",
  "log",
- "pulley-interpreter",
- "regalloc2",
- "rustc-hash 2.0.0",
+ "pulley-interpreter 36.0.6",
+ "regalloc2 0.12.2",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "target-lexicon 0.13.1",
  "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d94c2cd0d73b41369b88da1129589bc3a2d99cf49979af1d14751f35b7a1b"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64 0.129.1",
+ "cranelift-bforest 0.129.1",
+ "cranelift-bitset 0.129.1",
+ "cranelift-codegen-meta 0.129.1",
+ "cranelift-codegen-shared 0.129.1",
+ "cranelift-control 0.129.1",
+ "cranelift-entity 0.129.1",
+ "cranelift-isle 0.129.1",
+ "gimli 0.33.1",
+ "hashbrown 0.15.2",
+ "libm",
+ "log",
+ "pulley-interpreter 42.0.1",
+ "regalloc2 0.13.5",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+ "target-lexicon 0.13.1",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1347,11 +1425,24 @@ version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d6817fdc15cb8f236fc9d8e610767d3a03327ceca4abff7a14d8e2154c405e"
 dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
+ "cranelift-assembler-x64-meta 0.123.6",
+ "cranelift-codegen-shared 0.123.6",
+ "cranelift-srcgen 0.123.6",
  "heck 0.5.0",
- "pulley-interpreter",
+ "pulley-interpreter 36.0.6",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235da0e52ee3a0052d0e944c3470ff025b1f4234f6ec4089d3109f2d2ffa6cbd"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.129.1",
+ "cranelift-codegen-shared 0.129.1",
+ "cranelift-srcgen 0.129.1",
+ "heck 0.5.0",
+ "pulley-interpreter 42.0.1",
 ]
 
 [[package]]
@@ -1359,6 +1450,12 @@ name = "cranelift-codegen-shared"
 version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0403796328e9e2e7df2b80191cdbb473fd9ea3889eb45ef5632d0fef168ea032"
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c07c6c440bd1bf920ff7597a1e743ede1f68dcd400730bd6d389effa7662af"
 
 [[package]]
 name = "cranelift-control"
@@ -1370,14 +1467,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-control"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8797c022e02521901e1aee483dea3ed3c67f2bf0a26405c9dd48e8ee7a70944b"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "cranelift-entity"
 version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f5e7391167605d505fe66a337e1a69583b3f34b63d359ffa5a430313c555e8"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.123.6",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d8e72637246edd2cba337939850caa8b201f6315925ec4c156fdd089999699"
+dependencies = [
+ "cranelift-bitset 0.129.1",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1386,7 +1504,19 @@ version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea5440792eb2b5ba0a0976df371b9f94031bd853ae56f389de610bca7128a7cb"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.123.6",
+ "log",
+ "smallvec",
+ "target-lexicon 0.13.1",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c31db0085c3dfa131e739c3b26f9f9c84d69a9459627aac1ac4ef8355e3411b"
+dependencies = [
+ "cranelift-codegen 0.129.1",
  "log",
  "smallvec",
  "target-lexicon 0.13.1",
@@ -1399,12 +1529,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e5c05fab6fce38d729088f3fa1060eaa1ad54eefd473588887205ed2ab2f79e"
 
 [[package]]
+name = "cranelift-isle"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524d804c1ebd8c542e6f64e71aa36934cec17c5da4a9ae3799796220317f5d23"
+
+[[package]]
 name = "cranelift-native"
 version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9a0607a028edf5ba5bba7e7cf5ca1b7f0a030e3ae84dcd401e8b9b05192280"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.123.6",
+ "libc",
+ "target-lexicon 0.13.1",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc9598f02540e382e1772416eba18e93c5275b746adbbf06ac1f3cf149415270"
+dependencies = [
+ "cranelift-codegen 0.129.1",
  "libc",
  "target-lexicon 0.13.1",
 ]
@@ -1414,6 +1561,12 @@ name = "cranelift-srcgen"
 version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0f2da72eb2472aaac6cfba4e785af42b1f2d82f5155f30c9c30e8cce351e17"
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.129.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d953932541249c91e3fa70a75ff1e52adc62979a2a8132145d4b9b3e6d1a9b6a"
 
 [[package]]
 name = "crc"
@@ -2263,7 +2416,7 @@ dependencies = [
  "num",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "typetag",
  "uuid",
 ]
@@ -2665,7 +2818,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
  "stable_deref_trait",
 ]
 
@@ -2687,7 +2852,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2706,7 +2871,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3368,13 +3533,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3477,7 +3643,7 @@ dependencies = [
  "strum",
  "tempfile",
  "testlib",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-util",
@@ -3673,9 +3839,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -3689,9 +3855,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "librocksdb-sys"
@@ -3806,15 +3972,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3835,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -3951,11 +4111,11 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memfd"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 0.38.44",
+ "rustix",
 ]
 
 [[package]]
@@ -4265,7 +4425,7 @@ dependencies = [
  "serde_json",
  "strum",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "thread-priority",
  "time",
  "tokio",
@@ -4304,7 +4464,7 @@ dependencies = [
  "near-crypto",
  "near-primitives",
  "near-time",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4388,7 +4548,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "testlib",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -4407,7 +4567,7 @@ dependencies = [
  "near-time",
  "serde",
  "strum",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4431,7 +4591,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "json_comments",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4461,7 +4621,7 @@ dependencies = [
  "sha2 0.10.6",
  "subtle",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4525,7 +4685,7 @@ dependencies = [
  "near-primitives",
  "near-time",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -4744,7 +4904,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -4827,7 +4987,7 @@ dependencies = [
  "sha2 0.10.6",
  "strum",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -4875,7 +5035,7 @@ dependencies = [
  "strum",
  "stun",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tracing",
@@ -4904,7 +5064,7 @@ dependencies = [
  "serde_json",
  "smartstring",
  "strum",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
@@ -4929,7 +5089,7 @@ dependencies = [
  "serde_repr",
  "serde_yaml",
  "strum",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5008,7 +5168,7 @@ dependencies = [
  "smart-default",
  "strum",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
@@ -5036,7 +5196,7 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "sha2 0.10.6",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5084,7 +5244,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tower-http",
  "utoipa",
@@ -5232,7 +5392,7 @@ dependencies = [
  "strum",
  "tempfile",
  "testlib",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zstd",
@@ -5333,7 +5493,7 @@ dependencies = [
  "near-vm-vm",
  "rkyv",
  "target-lexicon 0.12.16",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "wasmparser 0.99.0",
 ]
@@ -5381,8 +5541,8 @@ dependencies = [
  "parking_lot 0.12.1",
  "rkyv",
  "rustc-demangle",
- "rustix 1.0.7",
- "thiserror 2.0.16",
+ "rustix",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5431,21 +5591,22 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "ripemd",
- "rustix 1.0.7",
+ "rustix",
  "serde",
  "serde_json",
  "sha2 0.10.6",
  "sha3",
  "strum",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "wasm-encoder 0.236.0",
  "wasm-smith",
  "wasmparser 0.236.1",
  "wasmparser 0.78.2",
  "wasmprinter 0.236.1",
- "wasmtime",
+ "wasmtime 36.0.6",
+ "wasmtime 42.0.1",
  "wat",
  "zeropool-bn",
 ]
@@ -5457,7 +5618,7 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "finite-wasm 0.5.0",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-compiler-test-derive",
@@ -5471,7 +5632,7 @@ dependencies = [
  "target-lexicon 0.12.16",
  "tempfile",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "wat",
@@ -5490,10 +5651,10 @@ name = "near-vm-types"
 version = "0.0.0"
 dependencies = [
  "bolero",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "num-traits",
  "rkyv",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5511,7 +5672,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "region",
  "rkyv",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "winapi",
 ]
@@ -5522,7 +5683,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "wast",
 ]
 
@@ -5588,7 +5749,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "testlib",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5635,7 +5796,7 @@ dependencies = [
  "serde_json",
  "state-viewer",
  "strum",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -5704,7 +5865,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "testlib",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5866,7 +6027,7 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "memchr",
 ]
 
@@ -5897,7 +6058,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -6005,7 +6166,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -6020,7 +6181,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
 ]
@@ -6056,7 +6217,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.0",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -6287,9 +6448,9 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "postcard"
-version = "1.0.10"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -6564,10 +6725,22 @@ version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "499d922aa0f9faac8d92351416664f1b7acd914008a90fce2f0516d31efddf67"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.123.6",
  "log",
- "pulley-macros",
+ "pulley-macros 36.0.6",
  "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2d61e068654529dc196437f8df0981db93687fdc67dec6a5de92363120b9da"
+dependencies = [
+ "cranelift-bitset 0.129.1",
+ "log",
+ "pulley-macros 42.0.1",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -6575,6 +6748,17 @@ name = "pulley-macros"
 version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3848fb193d6dffca43a21f24ca9492f22aab88af1223d06bac7f8a0ef405b81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f210c61b6ecfaebbba806b6d9113a222519d4e5cc4ab2d5ecca047bb7927ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6602,10 +6786,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.2",
  "rustls 0.23.28",
  "socket2 0.6.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -6623,11 +6807,11 @@ dependencies = [
  "lru-slab",
  "rand 0.9.0",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.2",
  "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6649,9 +6833,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -6909,7 +7093,21 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.2",
  "log",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.2",
+ "smallvec",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.2",
+ "log",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
@@ -7106,7 +7304,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7160,7 +7358,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.16.1",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -7250,7 +7448,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_xorshift",
  "rocksdb",
- "rustix 1.0.7",
+ "rustix",
  "serde_json",
  "tempfile",
  "tracing",
@@ -7330,7 +7528,7 @@ dependencies = [
  "http 1.3.1",
  "mime",
  "rand 0.9.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7379,9 +7577,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc-hex"
@@ -7400,28 +7598,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.9.2",
- "windows-sys 0.59.0",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7755,10 +7940,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -7775,10 +7961,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7811,7 +8006,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "ryu",
@@ -7896,7 +8091,7 @@ version = "0.9.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15e0ef66bf939a7c890a0bf6d5a733c70202225f9888a89ed5c62298b019129"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -8177,7 +8372,7 @@ dependencies = [
  "serde_json",
  "strum",
  "testlib",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "yansi",
@@ -8407,7 +8602,7 @@ dependencies = [
  "fastrand 2.2.0",
  "getrandom 0.3.1",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -8532,11 +8727,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -8552,9 +8747,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8797,7 +8992,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "toml_datetime",
  "winnow 0.5.15",
 ]
@@ -8808,7 +9003,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "toml_datetime",
  "winnow 0.5.15",
 ]
@@ -8819,7 +9014,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "toml_datetime",
  "winnow 0.6.20",
 ]
@@ -8858,7 +9053,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -9202,7 +9397,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -9410,6 +9605,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasm-smith"
 version = "0.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9469,7 +9674,7 @@ checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "semver",
  "serde",
 ]
@@ -9482,7 +9687,20 @@ checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.2",
+ "indexmap 2.13.0",
  "semver",
  "serde",
 ]
@@ -9509,6 +9727,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmprinter"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmtime"
 version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9521,7 +9750,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "libc",
  "log",
  "mach2",
@@ -9529,25 +9758,63 @@ dependencies = [
  "object 0.37.3",
  "once_cell",
  "postcard",
- "pulley-interpreter",
+ "pulley-interpreter 36.0.6",
  "rayon",
- "rustix 1.0.7",
+ "rustix",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon 0.13.1",
  "wasmparser 0.236.1",
- "wasmtime-environ",
+ "wasmtime-environ 36.0.6",
  "wasmtime-internal-asm-macros",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-cranelift 36.0.6",
+ "wasmtime-internal-fiber 36.0.6",
+ "wasmtime-internal-jit-debug 36.0.6",
+ "wasmtime-internal-jit-icache-coherence 36.0.6",
  "wasmtime-internal-math",
  "wasmtime-internal-slab",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-unwinder 36.0.6",
+ "wasmtime-internal-versioned-export-macros 36.0.6",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bef52be4fb4c5b47d36f847172e896bc94b35c9c6a6f07117686bd16ed89a7"
+dependencies = [
+ "addr2line 0.26.1",
+ "async-trait",
+ "bitflags 2.11.0",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter 42.0.1",
+ "rayon",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon 0.13.1",
+ "wasmparser 0.244.0",
+ "wasmtime-environ 42.0.1",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift 42.0.1",
+ "wasmtime-internal-fiber 42.0.1",
+ "wasmtime-internal-jit-debug 42.0.1",
+ "wasmtime-internal-jit-icache-coherence 42.0.1",
+ "wasmtime-internal-unwinder 42.0.1",
+ "wasmtime-internal-versioned-export-macros 42.0.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9557,10 +9824,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733682a327755c77153ac7455b1ba8f2db4d9946c1738f8002fe1fbda1d52e83"
 dependencies = [
  "anyhow",
- "cranelift-bitset",
- "cranelift-entity",
+ "cranelift-bitset 0.123.6",
+ "cranelift-entity 0.123.6",
  "gimli 0.32.0",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "log",
  "object 0.37.3",
  "postcard",
@@ -9574,12 +9841,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-environ"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb637d5aa960ac391ca5a4cbf3e45807632e56beceeeb530e14dfa67fdfccc62"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset 0.129.1",
+ "cranelift-entity 0.129.1",
+ "gimli 0.33.1",
+ "hashbrown 0.15.2",
+ "indexmap 2.13.0",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon 0.13.1",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+ "wasmprinter 0.244.0",
+ "wasmtime-internal-core",
+]
+
+[[package]]
 name = "wasmtime-internal-asm-macros"
 version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68288980a2e02bcb368d436da32565897033ea21918007e3f2bae18843326cf9"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a4a3f055a804a2f3d86e816a9df78a8fa57762212a8506164959224a40cd48"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -9590,23 +9891,50 @@ checksum = "e89bb9ef571288e2be6b8a3c4763acc56c348dcd517500b1679d3ffad9e4a757"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
+ "cranelift-codegen 0.123.6",
+ "cranelift-control 0.123.6",
+ "cranelift-entity 0.123.6",
+ "cranelift-frontend 0.123.6",
+ "cranelift-native 0.123.6",
  "gimli 0.32.0",
  "itertools 0.14.0",
  "log",
  "object 0.37.3",
- "pulley-interpreter",
+ "pulley-interpreter 36.0.6",
  "smallvec",
  "target-lexicon 0.13.1",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "wasmparser 0.236.1",
- "wasmtime-environ",
+ "wasmtime-environ 36.0.6",
  "wasmtime-internal-math",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros 36.0.6",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55154a91d22ad51f9551124ce7fb49ddddc6a82c4910813db4c790c97c9ccf32"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen 0.129.1",
+ "cranelift-control 0.129.1",
+ "cranelift-entity 0.129.1",
+ "cranelift-frontend 0.129.1",
+ "cranelift-native 0.129.1",
+ "gimli 0.33.1",
+ "itertools 0.14.0",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter 42.0.1",
+ "smallvec",
+ "target-lexicon 0.13.1",
+ "thiserror 2.0.18",
+ "wasmparser 0.244.0",
+ "wasmtime-environ 42.0.1",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder 42.0.1",
+ "wasmtime-internal-versioned-export-macros 42.0.1",
 ]
 
 [[package]]
@@ -9619,10 +9947,25 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.0.7",
+ "rustix",
  "wasmtime-internal-asm-macros",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros 36.0.6",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05decfad1021ad2efcca5c1be9855acb54b6ee7158ac4467119b30b7481508e3"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-environ 42.0.1",
+ "wasmtime-internal-versioned-export-macros 42.0.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9632,7 +9975,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c803a9fec05c3d7fa03474d4595079d546e77a3c71c1d09b21f74152e2165c17"
 dependencies = [
  "cc",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros 36.0.6",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924980c50427885fd4feed2049b88380178e567768aaabf29045b02eb262eaa7"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros 42.0.1",
 ]
 
 [[package]]
@@ -9645,6 +9998,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57d24e8d1334a0e5a8b600286ffefa1fc4c3e8176b110dff6fbc1f43c4a599b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9670,9 +10035,22 @@ checksum = "13e1ad30e88988b20c0d1c56ea4b4fbc01a8c614653cbf12ca50c0dcc695e2f7"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen",
+ "cranelift-codegen 0.123.6",
  "log",
  "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1a144bd4393593a868ba9df09f34a6a360cb5db6e71815f20d3f649c6e6735"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen 0.129.1",
+ "log",
+ "object 0.37.3",
+ "wasmtime-environ 42.0.1",
 ]
 
 [[package]]
@@ -9680,6 +10058,17 @@ name = "wasmtime-internal-versioned-export-macros"
 version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549aefdaa1398c2fcfbf69a7b882956bb5b6e8e5b600844ecb91a3b5bf658ca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a6948b56bb00c62dbd205ea18a4f1ceccbe1e4b8479651fdb0bab2553790f20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10455,7 +10844,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.7.0",
+ "indexmap 2.13.0",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,6 +410,9 @@ wasm-smith = "0.236"
 wasmtime = { version = "36", default-features = false, features = [
     "cranelift",
 ] }
+wasmtime42 = { package = "wasmtime", version = "42", default-features = false, features = [
+    "cranelift",
+] }
 wast = "40.0"
 wat = "1.0.40"
 webrtc-util = "0.10"

--- a/core/parameters/res/runtime_configs/152.yaml
+++ b/core/parameters/res/runtime_configs/152.yaml
@@ -1,0 +1,1 @@
+vm_kind: { old: "Wasmtime", new: "Wasmtime42" }

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -62,6 +62,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (85, include_config!("85.yaml")),
     (129, include_config!("129.yaml")),
     (149, include_config!("149.yaml")),
+    (152, include_config!("152.yaml")),
 ];
 
 /// Testnet parameters for versions <= 29, which (incorrectly) differed from mainnet parameters

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -36,11 +36,17 @@ pub enum VMKind {
     Wasmer2,
     /// NearVM.
     NearVm,
+    /// Wasmtime 42 VM.
+    Wasmtime42,
 }
 
 impl VMKind {
     pub fn replace_with_wasmtime_if_unsupported(self) -> Self {
-        if cfg!(not(target_arch = "x86_64")) { Self::Wasmtime } else { self }
+        match self {
+            Self::NearVm if cfg!(not(target_arch = "x86_64")) => Self::Wasmtime,
+            Self::Wasmtime42 if cfg!(not(target_arch = "x86_64")) => Self::Wasmtime42,
+            _ => self,
+        }
     }
 }
 

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -381,6 +381,8 @@ pub enum ProtocolFeature {
     /// (sequential ordering). Transactions with a nonce gap are held in the
     /// pool rather than discarded.
     StrictNonce,
+    /// Upgrade to wasmtime 42.
+    Wasmtime42,
 }
 
 impl ProtocolFeature {
@@ -501,6 +503,7 @@ impl ProtocolFeature {
             ProtocolFeature::GasKeys => 149,
             ProtocolFeature::DynamicResharding => 150,
             ProtocolFeature::StrictNonce => 151,
+            ProtocolFeature::Wasmtime42 => 152,
 
             // Spice is setup to include nightly, but not be part of it for now so that features
             // that are released before spice can be tested properly.
@@ -524,7 +527,7 @@ pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 80;
 const STABLE_PROTOCOL_VERSION: ProtocolVersion = 85;
 
 // On nightly, pick big enough version to support all features.
-const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 151;
+const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 152;
 
 // TODO(spice): Once spice is mature and close to release make it part of nightly - at the point in
 // time cargo feature for spice should be removed as well.

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -48,6 +48,12 @@ wasmtime = { workspace = true, features = [
     "pooling-allocator",
     "runtime",
 ], optional = true }
+wasmtime42 = { workspace = true, features = [
+    "call-hook",
+    "parallel-compilation",
+    "pooling-allocator",
+    "runtime",
+], optional = true }
 
 near-crypto.workspace = true
 near-o11y = { workspace = true, optional = true }
@@ -84,8 +90,9 @@ wasm-smith.workspace = true
 wat.workspace = true
 
 [features]
-default = ["wasmtime_vm"]
+default = ["wasmtime_vm", "wasmtime42_vm"]
 wasmtime_vm = ["wasmtime", "anyhow", "prepare"]
+wasmtime42_vm = ["wasmtime42", "prepare"]
 near_vm = [
     "near-vm-compiler",
     "near-vm-compiler-singlepass",

--- a/runtime/near-vm-runner/src/features.rs
+++ b/runtime/near-vm-runner/src/features.rs
@@ -136,3 +136,12 @@ impl From<WasmFeatures> for wasmtime::Config {
         wasmtime::Config::default()
     }
 }
+
+#[cfg(feature = "wasmtime42_vm")]
+impl From<WasmFeatures> for wasmtime42::Config {
+    fn from(_: WasmFeatures) -> Self {
+        // preparation code did all the filtering necessary already. Default configuration supports
+        // all the necessary features (and, yes, enables more of them.)
+        wasmtime42::Config::default()
+    }
+}

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -19,6 +19,8 @@ mod runner;
 #[cfg(test)]
 mod tests;
 mod utils;
+#[cfg(feature = "wasmtime42_vm")]
+mod wasmtime42_runner;
 #[cfg(feature = "wasmtime_vm")]
 mod wasmtime_runner;
 
@@ -35,16 +37,16 @@ pub use near_primitives_core::code::ContractCode;
 pub use profile::ProfileDataV3;
 pub use runner::{Contract, PreparedContract, VM, contract_cached, prepare, run};
 
-#[cfg(any(feature = "prepare", feature = "wasmtime_vm"))]
+#[cfg(any(feature = "prepare", feature = "wasmtime_vm", feature = "wasmtime42_vm"))]
 pub(crate) const MEMORY_EXPORT: &str = "memory";
 
-#[cfg(any(feature = "prepare", feature = "wasmtime_vm"))]
+#[cfg(any(feature = "prepare", feature = "wasmtime_vm", feature = "wasmtime42_vm"))]
 pub(crate) const REMAINING_GAS_EXPORT: &str = "remaining_gas";
 
-#[cfg(any(feature = "prepare", feature = "wasmtime_vm"))]
+#[cfg(any(feature = "prepare", feature = "wasmtime_vm", feature = "wasmtime42_vm"))]
 pub(crate) const START_EXPORT: &str = "start";
 
-#[cfg(any(feature = "prepare", feature = "wasmtime_vm"))]
+#[cfg(any(feature = "prepare", feature = "wasmtime_vm", feature = "wasmtime42_vm"))]
 pub(crate) const EXPORT_PREFIX: &str = "\0";
 
 /// This is public for internal experimentation use only, and should otherwise be considered an

--- a/runtime/near-vm-runner/src/metrics.rs
+++ b/runtime/near-vm-runner/src/metrics.rs
@@ -66,12 +66,12 @@ struct Metrics {
     compiled_contract_cache_hits: u64,
 }
 
-#[cfg(any(feature = "near_vm", feature = "wasmtime_vm"))]
+#[cfg(any(feature = "near_vm", feature = "wasmtime_vm", feature = "wasmtime42_vm"))]
 pub(crate) fn compilation_duration(kind: near_parameters::vm::VMKind, duration: Duration) {
     use near_parameters::vm::VMKind;
     METRICS.with_borrow_mut(|m| match kind {
         VMKind::Wasmer0 => unreachable!(),
-        VMKind::Wasmtime => m.wasmtime_compilation_time += duration,
+        VMKind::Wasmtime | VMKind::Wasmtime42 => m.wasmtime_compilation_time += duration,
         VMKind::Wasmer2 => unreachable!(),
         VMKind::NearVm => m.near_vm_compilation_time += duration,
     });

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -25,7 +25,9 @@ pub fn prepare_contract(
     kind: VMKind,
 ) -> Result<Vec<u8>, PrepareError> {
     let features = crate::features::WasmFeatures::new(config);
-    if config.reftypes_bulk_memory || config.vm_kind == VMKind::Wasmtime {
+    if config.reftypes_bulk_memory
+        || matches!(config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42)
+    {
         prepare_v3::prepare_contract(original_code, features, config, kind)
     } else {
         prepare_v2::prepare_contract(original_code, features, config, kind)

--- a/runtime/near-vm-runner/src/prepare/prepare_v2.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v2.rs
@@ -123,7 +123,7 @@ impl<'a> PrepareContext<'a> {
                     self.validator
                         .memory_section(&reader)
                         .map_err(|_| PrepareError::Deserialization)?;
-                    if self.config.vm_kind == VMKind::Wasmtime {
+                    if matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                         wasm_encoder::MemorySection::new()
                             .memory(self.memory_type())
                             .append_to(&mut self.output_code);
@@ -146,9 +146,10 @@ impl<'a> PrepareContext<'a> {
                     for res in reader {
                         let wp::Export { name, kind, index } =
                             res.map_err(|_| PrepareError::Deserialization)?;
-                        let prefix = (self.config.vm_kind == VMKind::Wasmtime)
-                            .then_some(EXPORT_PREFIX)
-                            .unwrap_or_default();
+                        let prefix =
+                            (matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42))
+                                .then_some(EXPORT_PREFIX)
+                                .unwrap_or_default();
                         match kind {
                             wp::ExternalKind::Func => {
                                 new_section.export(
@@ -181,7 +182,7 @@ impl<'a> PrepareContext<'a> {
                             }
                         }
                     }
-                    if self.config.vm_kind == VMKind::Wasmtime {
+                    if matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                         new_section.export(MEMORY_EXPORT, wasm_encoder::ExportKind::Memory, 0);
                     }
                     new_section.append_to(&mut self.output_code)
@@ -305,7 +306,7 @@ impl<'a> PrepareContext<'a> {
             };
             new_section.import(import.module, import.name, new_type);
         }
-        if self.config.vm_kind != VMKind::Wasmtime {
+        if !matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
             new_section.import("env", "memory", self.memory_type());
         }
         // wasm_encoder a section with all imports and the imported standardized memory.
@@ -316,7 +317,7 @@ impl<'a> PrepareContext<'a> {
     fn ensure_import_section(&mut self) {
         if self.before_import_section {
             self.before_import_section = false;
-            if self.config.vm_kind != VMKind::Wasmtime {
+            if !matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                 // wasm_encoder a section with all imports and the imported standardized memory.
                 wasm_encoder::ImportSection::new()
                     .import("env", "memory", self.memory_type())
@@ -329,7 +330,7 @@ impl<'a> PrepareContext<'a> {
         self.ensure_import_section();
         if self.before_memory_section {
             self.before_memory_section = false;
-            if self.config.vm_kind == VMKind::Wasmtime {
+            if matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                 wasm_encoder::MemorySection::new()
                     .memory(self.memory_type())
                     .append_to(&mut self.output_code);
@@ -341,7 +342,7 @@ impl<'a> PrepareContext<'a> {
         self.ensure_memory_section();
         if self.before_export_section {
             self.before_export_section = false;
-            if self.config.vm_kind == VMKind::Wasmtime {
+            if matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                 wasm_encoder::ExportSection::new()
                     .export(MEMORY_EXPORT, wasm_encoder::ExportKind::Memory, 0)
                     .append_to(&mut self.output_code);
@@ -392,7 +393,7 @@ pub(crate) fn prepare_contract(
             }
             return Ok(lightly_steamed);
         }
-        VMKind::Wasmer0 | VMKind::Wasmtime | VMKind::Wasmer2 => {}
+        VMKind::Wasmer0 | VMKind::Wasmtime | VMKind::Wasmtime42 | VMKind::Wasmer2 => {}
     }
 
     let res = finite_wasm::Analysis::new()

--- a/runtime/near-vm-runner/src/prepare/prepare_v3.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v3.rs
@@ -125,7 +125,7 @@ impl<'a> PrepareContext<'a> {
                     self.validator
                         .memory_section(&reader)
                         .map_err(|_| PrepareError::Deserialization)?;
-                    if self.config.vm_kind == VMKind::Wasmtime {
+                    if matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                         wasm_encoder::MemorySection::new()
                             .memory(self.memory_type())
                             .append_to(&mut self.output_code);
@@ -148,9 +148,10 @@ impl<'a> PrepareContext<'a> {
                     for res in reader {
                         let wp::Export { name, kind, index } =
                             res.map_err(|_| PrepareError::Deserialization)?;
-                        let prefix = (self.config.vm_kind == VMKind::Wasmtime)
-                            .then_some(EXPORT_PREFIX)
-                            .unwrap_or_default();
+                        let prefix =
+                            (matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42))
+                                .then_some(EXPORT_PREFIX)
+                                .unwrap_or_default();
                         match kind {
                             wp::ExternalKind::Func => {
                                 new_section.export(
@@ -183,7 +184,7 @@ impl<'a> PrepareContext<'a> {
                             }
                         }
                     }
-                    if self.config.vm_kind == VMKind::Wasmtime {
+                    if matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                         new_section.export(MEMORY_EXPORT, wasm_encoder::ExportKind::Memory, 0);
                     }
                     new_section.append_to(&mut self.output_code)
@@ -318,7 +319,7 @@ impl<'a> PrepareContext<'a> {
             };
             new_section.import(import.module, import.name, new_type);
         }
-        if self.config.vm_kind != VMKind::Wasmtime {
+        if !matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
             new_section.import("env", "memory", self.memory_type());
         }
         // wasm_encoder a section with all imports and the imported standardized memory.
@@ -329,7 +330,7 @@ impl<'a> PrepareContext<'a> {
     fn ensure_import_section(&mut self) {
         if self.before_import_section {
             self.before_import_section = false;
-            if self.config.vm_kind != VMKind::Wasmtime {
+            if !matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                 // wasm_encoder a section with all imports and the imported standardized memory.
                 wasm_encoder::ImportSection::new()
                     .import("env", "memory", self.memory_type())
@@ -342,7 +343,7 @@ impl<'a> PrepareContext<'a> {
         self.ensure_import_section();
         if self.before_memory_section {
             self.before_memory_section = false;
-            if self.config.vm_kind == VMKind::Wasmtime {
+            if matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                 wasm_encoder::MemorySection::new()
                     .memory(self.memory_type())
                     .append_to(&mut self.output_code);
@@ -354,7 +355,7 @@ impl<'a> PrepareContext<'a> {
         self.ensure_memory_section();
         if self.before_export_section {
             self.before_export_section = false;
-            if self.config.vm_kind == VMKind::Wasmtime {
+            if matches!(self.config.vm_kind, VMKind::Wasmtime | VMKind::Wasmtime42) {
                 wasm_encoder::ExportSection::new()
                     .export(MEMORY_EXPORT, wasm_encoder::ExportKind::Memory, 0)
                     .append_to(&mut self.output_code);
@@ -406,7 +407,7 @@ pub(crate) fn prepare_contract(
             }
             return Ok(lightly_steamed);
         }
-        VMKind::Wasmer0 | VMKind::Wasmtime | VMKind::Wasmer2 => {}
+        VMKind::Wasmer0 | VMKind::Wasmtime | VMKind::Wasmtime42 | VMKind::Wasmer2 => {}
     }
 
     let analysis = finite_wasm_6::Analysis::new()

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -189,6 +189,7 @@ impl VMKindExt for VMKind {
             Self::Wasmer2 => false,
             Self::Wasmtime => cfg!(feature = "wasmtime_vm"),
             Self::NearVm => cfg!(all(feature = "near_vm", target_arch = "x86_64")),
+            Self::Wasmtime42 => cfg!(feature = "wasmtime42_vm"),
         }
     }
     fn runtime(&self, config: std::sync::Arc<Config>) -> Option<Box<dyn VM>> {
@@ -197,6 +198,8 @@ impl VMKindExt for VMKind {
             Self::Wasmtime => Some(Box::new(crate::wasmtime_runner::WasmtimeVM::new(config))),
             #[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
             Self::NearVm => Some(Box::new(crate::near_vm_runner::NearVM::new(config))),
+            #[cfg(feature = "wasmtime42_vm")]
+            Self::Wasmtime42 => Some(Box::new(crate::wasmtime42_runner::Wasmtime42VM::new(config))),
             #[allow(unreachable_patterns)] // reachable when some of the VMs are disabled.
             _ => {
                 let _ = config;

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -40,6 +40,9 @@ pub(crate) fn with_vm_variants(runner: impl Fn(VMKind) -> ()) {
     #[cfg(feature = "wasmtime_vm")]
     run(VMKind::Wasmtime);
 
+    #[cfg(feature = "wasmtime42_vm")]
+    run(VMKind::Wasmtime42);
+
     #[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
     run(VMKind::NearVm);
 }

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -20,7 +20,7 @@ fn test_caches_compilation_error() {
         let config = Arc::new(test_vm_config(Some(vm_kind)));
         // The cache is currently properly implemented only for NearVM
         match vm_kind {
-            VMKind::NearVm | VMKind::Wasmtime => {}
+            VMKind::NearVm | VMKind::Wasmtime | VMKind::Wasmtime42 => {}
             VMKind::Wasmer0 | VMKind::Wasmer2 => return,
         }
         let cache = MockContractRuntimeCache::default();
@@ -60,7 +60,7 @@ fn test_does_not_cache_io_error() {
     with_vm_variants(|vm_kind: VMKind| {
         let config = Arc::new(test_vm_config(Some(vm_kind)));
         match vm_kind {
-            VMKind::NearVm | VMKind::Wasmtime => {}
+            VMKind::NearVm | VMKind::Wasmtime | VMKind::Wasmtime42 => {}
             VMKind::Wasmer0 | VMKind::Wasmer2 => return,
         }
 

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -27,7 +27,9 @@ fn test_contract(vm_kind: VMKind) -> ContractCode {
         VMKind::Wasmer0 => unreachable!(),
         VMKind::Wasmer2 => unreachable!(),
         // production and developer environment, use a cutting-edge WASM
-        VMKind::Wasmtime | VMKind::NearVm => near_test_contracts::rs_contract(),
+        VMKind::Wasmtime | VMKind::Wasmtime42 | VMKind::NearVm => {
+            near_test_contracts::rs_contract()
+        }
     };
     ContractCode::new(code.to_vec(), None)
 }
@@ -232,7 +234,7 @@ pub fn test_out_of_memory() {
         assert_eq!(
             result.aborted,
             match vm_kind {
-                VMKind::NearVm | VMKind::Wasmtime =>
+                VMKind::NearVm | VMKind::Wasmtime | VMKind::Wasmtime42 =>
                     Some(FunctionCallError::WasmTrap(WasmTrap::Unreachable)),
                 VMKind::Wasmer2 | VMKind::Wasmer0 => unreachable!(),
             }

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -32,7 +32,7 @@ pub(crate) fn test_builder() -> TestBuilder {
         output_data_receivers: vec![],
     };
     let mut skip = HashSet::new();
-    for kind in [VMKind::NearVm, VMKind::Wasmtime] {
+    for kind in [VMKind::NearVm, VMKind::Wasmtime, VMKind::Wasmtime42] {
         if !kind.is_available() {
             skip.insert(kind);
         }
@@ -194,15 +194,14 @@ impl TestBuilder {
 
         for (want, &protocol_version) in wants.zip(&self.protocol_versions) {
             let mut results = vec![];
-            for vm_kind in [VMKind::NearVm, VMKind::Wasmtime] {
+            for vm_kind in [VMKind::NearVm, VMKind::Wasmtime, VMKind::Wasmtime42] {
                 if self.skip.contains(&vm_kind) {
                     println!("Skipping {:?}", vm_kind);
                     continue;
                 }
 
                 let runtime_config = runtime_config_store.get_config_mut(protocol_version);
-                let config =
-                    Arc::get_mut(&mut Arc::get_mut(runtime_config).unwrap().wasm_config).unwrap();
+                let config = Arc::make_mut(&mut Arc::make_mut(runtime_config).wasm_config);
                 config.vm_kind = vm_kind;
                 if let Some(max_gas_burnt) = self.max_gas_burnt {
                     config.limit_config.max_gas_burnt = max_gas_burnt;

--- a/runtime/near-vm-runner/src/wasmtime42_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime42_runner/logic.rs
@@ -1,0 +1,4586 @@
+// Many host functions take `memory: &mut [u8]` for a uniform signature even
+// when they don't write to memory.
+#![allow(clippy::needless_pass_by_ref_mut)]
+
+use super::Ctx;
+use crate::logic::alt_bn128;
+use crate::logic::bls12381;
+use crate::logic::errors::InconsistentStateError;
+use crate::logic::gas_counter::{FreeGasCounter, GasCounter};
+use crate::logic::logic::*;
+use crate::logic::types::{
+    GlobalContractDeployMode, GlobalContractIdentifier, PromiseIndex, PromiseResult, ReceiptIndex,
+    ReturnData,
+};
+use crate::logic::utils::{null_terminated_method_names_len, split_method_names};
+use crate::logic::vmstate::Registers;
+use crate::logic::{HostError, VMLogicError};
+use ExtCosts::*;
+use core::mem::size_of;
+use near_crypto::Secp256K1Signature;
+use near_parameters::vm::Config;
+use near_parameters::{
+    ActionCosts, ExtCosts, RuntimeFeesConfig, gas_key_add_key_exec_fee, gas_key_add_key_send_fee,
+    gas_key_transfer_exec_fee, gas_key_transfer_send_fee, transfer_exec_fee, transfer_send_fee,
+};
+use near_primitives_core::account::AccountContract;
+use near_primitives_core::config::INLINE_DISK_VALUE_THRESHOLD;
+use near_primitives_core::hash::CryptoHash;
+use near_primitives_core::types::{AccountId, Balance, EpochHeight, Gas, GasWeight, StorageUsage};
+use std::rc::Rc;
+
+macro_rules! bls12381_impl {
+    (
+        $doc:expr,
+        $fn_name:ident,
+        $ITEM_SIZE:expr,
+        $bls12381_base:ident,
+        $bls12381_element:ident,
+        $impl_fn_name:ident
+    ) => {
+        #[doc = $doc]
+        pub fn $fn_name(
+            ctx: &mut Ctx,
+            memory: &mut [u8],
+            value_len: u64,
+            value_ptr: u64,
+            register_id: u64,
+        ) -> Result<u64> {
+            ctx.result_state.gas_counter.pay_base($bls12381_base)?;
+
+            let elements_count = value_len / $ITEM_SIZE;
+            ctx.result_state.gas_counter.pay_per($bls12381_element, elements_count as u64)?;
+
+            let data = get_memory_or_register(
+                &mut ctx.result_state.gas_counter,
+                memory,
+                &ctx.registers,
+                value_ptr,
+                value_len,
+            )?;
+            let res_option = bls12381::$impl_fn_name(&data)?;
+
+            if let Some(res) = res_option {
+                ctx.registers.set(
+                    &mut ctx.result_state.gas_counter,
+                    &ctx.config.limit_config,
+                    register_id,
+                    res.as_slice(),
+                )?;
+
+                Ok(0)
+            } else {
+                Ok(1)
+            }
+        }
+    };
+}
+
+fn read_memory_for_free<'a>(memory: &'a [u8], ptr: u64, len: u64) -> Result<&'a [u8]> {
+    let start = usize::try_from(ptr).or(Err(HostError::MemoryAccessViolation))?;
+    let len = usize::try_from(len).or(Err(HostError::MemoryAccessViolation))?;
+    let end = start.checked_add(len).ok_or(HostError::MemoryAccessViolation)?;
+    let memory = memory.get(start..end).ok_or(HostError::MemoryAccessViolation)?;
+    Ok(memory)
+}
+
+fn read_memory<'a>(
+    gas_counter: &mut GasCounter,
+    memory: &'a [u8],
+    ptr: u64,
+    len: u64,
+) -> Result<&'a [u8]> {
+    gas_counter.pay_base(read_memory_base)?;
+    gas_counter.pay_per(read_memory_byte, len)?;
+    read_memory_for_free(memory, ptr, len)
+}
+
+fn write_memory_for_free(memory: &mut [u8], ptr: u64, buf: &[u8]) -> Result<()> {
+    let start = usize::try_from(ptr).or(Err(HostError::MemoryAccessViolation))?;
+    let end = start.checked_add(buf.len()).ok_or(HostError::MemoryAccessViolation)?;
+    let memory = memory.get_mut(start..end).ok_or(HostError::MemoryAccessViolation)?;
+    memory.copy_from_slice(buf);
+    Ok(())
+}
+
+fn write_memory(
+    gas_counter: &mut GasCounter,
+    memory: &mut [u8],
+    ptr: u64,
+    buf: &[u8],
+) -> Result<()> {
+    gas_counter.pay_base(write_memory_base)?;
+    gas_counter.pay_per(write_memory_byte, buf.len() as _)?;
+    write_memory_for_free(memory, ptr, buf)
+}
+
+/// Reads data from guest memory or register.
+///
+/// If `len` is `u64::MAX` read register with index `ptr`.  Otherwise, reads
+/// `len` bytes of guest memory starting at given offset.  Returns error if
+/// there’s insufficient gas, memory interval is out of bounds or given register
+/// isn’t set.
+///
+/// This is not a method on `VMLogic` so that the compiler can track borrowing
+/// of gas counter, memory and registers separately.  This allows `VMLogic` to
+/// borrow value from a register and then continue constructing mutable
+/// references to other fields in the structure..
+fn get_memory_or_register<'a>(
+    gas_counter: &mut GasCounter,
+    memory: &'a [u8],
+    registers: &'a Registers,
+    ptr: u64,
+    len: u64,
+) -> Result<&'a [u8]> {
+    if len == u64::MAX {
+        registers.get(gas_counter, ptr)
+    } else {
+        read_memory(gas_counter, memory, ptr, len)
+    }
+}
+
+fn get_u8(gas_counter: &mut GasCounter, memory: &[u8], ptr: u64) -> Result<u8> {
+    gas_counter.pay_base(read_memory_base)?;
+    gas_counter.pay_per(read_memory_byte, 1)?;
+    let ptr = usize::try_from(ptr).or(Err(HostError::MemoryAccessViolation))?;
+    let v = memory.get(ptr).ok_or(HostError::MemoryAccessViolation)?;
+    Ok(*v)
+}
+
+fn get_u16(gas_counter: &mut GasCounter, memory: &[u8], ptr: u64) -> Result<u16> {
+    let buf = read_memory(gas_counter, memory, ptr, 2)?;
+    let buf = buf.try_into().or(Err(HostError::MemoryAccessViolation))?;
+    Ok(u16::from_le_bytes(buf))
+}
+
+fn get_u32(gas_counter: &mut GasCounter, memory: &[u8], ptr: u64) -> Result<u32> {
+    let buf = read_memory(gas_counter, memory, ptr, 4)?;
+    let buf = buf.try_into().or(Err(HostError::MemoryAccessViolation))?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn get_u128(gas_counter: &mut GasCounter, memory: &[u8], ptr: u64) -> Result<u128> {
+    let buf = read_memory(gas_counter, memory, ptr, 16)?;
+    let buf = buf.try_into().or(Err(HostError::MemoryAccessViolation))?;
+    Ok(u128::from_le_bytes(buf))
+}
+
+fn set_u128(gas_counter: &mut GasCounter, memory: &mut [u8], ptr: u64, value: u128) -> Result<()> {
+    write_memory(gas_counter, memory, ptr, &u128::to_le_bytes(value))?;
+    Ok(())
+}
+
+// #########################
+// # Finite-wasm internals #
+// #########################
+pub fn finite_wasm_gas(ctx: &mut Ctx, _memory: &mut [u8], gas: u64) -> Result<()> {
+    consume_gas(&mut ctx.result_state.gas_counter, gas)
+}
+
+fn linear_gas(ctx: &mut Ctx, count: u32, linear: u64, constant: u64) -> Result<u32> {
+    let linear = u64::from(count).checked_mul(linear).ok_or(HostError::IntegerOverflow)?;
+    let gas = constant.checked_add(linear).ok_or(HostError::IntegerOverflow)?;
+    consume_gas(&mut ctx.result_state.gas_counter, gas)?;
+    Ok(count)
+}
+
+pub fn finite_wasm_memory_copy(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    count: u32,
+    linear: u64,
+    constant: u64,
+) -> Result<u32> {
+    linear_gas(ctx, count, linear, constant)
+}
+
+pub fn finite_wasm_memory_fill(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    count: u32,
+    linear: u64,
+    constant: u64,
+) -> Result<u32> {
+    linear_gas(ctx, count, linear, constant)
+}
+
+pub fn finite_wasm_memory_init(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    count: u32,
+    linear: u64,
+    constant: u64,
+) -> Result<u32> {
+    linear_gas(ctx, count, linear, constant)
+}
+
+pub fn finite_wasm_table_copy(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    count: u32,
+    linear: u64,
+    constant: u64,
+) -> Result<u32> {
+    linear_gas(ctx, count, linear, constant)
+}
+
+pub fn finite_wasm_table_fill(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    count: u32,
+    linear: u64,
+    constant: u64,
+) -> Result<u32> {
+    linear_gas(ctx, count, linear, constant)
+}
+
+pub fn finite_wasm_table_init(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    count: u32,
+    linear: u64,
+    constant: u64,
+) -> Result<u32> {
+    linear_gas(ctx, count, linear, constant)
+}
+
+pub fn finite_wasm_stack(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    operand_size: u64,
+    frame_size: u64,
+) -> Result<()> {
+    ctx.remaining_stack =
+        match ctx.remaining_stack.checked_sub(operand_size.saturating_add(frame_size)) {
+            Some(s) => s,
+            None => return Err(VMLogicError::HostError(HostError::MemoryAccessViolation)),
+        };
+    let gas = ((frame_size + 7) / 8) * u64::from(ctx.config.regular_op_cost);
+    consume_gas(&mut ctx.result_state.gas_counter, gas)?;
+    Ok(())
+}
+
+pub fn finite_wasm_unstack(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    operand_size: u64,
+    frame_size: u64,
+) -> Result<()> {
+    ctx.remaining_stack = ctx
+        .remaining_stack
+        .checked_add(operand_size.saturating_add(frame_size))
+        .expect("remaining stack integer overflow");
+    Ok(())
+}
+
+pub fn finite_wasm_gas_exhausted(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<()> {
+    // Burn all remaining gas
+    ctx.result_state.gas_counter.burn_gas(ctx.result_state.gas_counter.remaining_gas())?;
+    // This function will only ever be called by instrumentation on overflow, otherwise
+    // `finite_wasm_gas` will be called with the out-of-budget charge
+    Err(VMLogicError::HostError(HostError::IntegerOverflow))
+}
+
+pub fn finite_wasm_stack_exhausted(_ctx: &mut Ctx, _memory: &mut [u8]) -> Result<()> {
+    Err(VMLogicError::HostError(HostError::MemoryAccessViolation))
+}
+
+// #################
+// # Registers API #
+// #################
+
+/// Writes the entire content from the register `register_id` into the memory of the guest starting with `ptr`.
+///
+/// # Arguments
+///
+/// * `register_id` -- a register id from where to read the data;
+/// * `ptr` -- location on guest memory where to copy the data.
+///
+/// # Errors
+///
+/// * If the content extends outside the memory allocated to the guest. In Wasmer, it returns `MemoryAccessViolation` error message;
+/// * If `register_id` is pointing to unused register returns `InvalidRegisterId` error message.
+///
+/// # Undefined Behavior
+///
+/// If the content of register extends outside the preallocated memory on the host side, or the pointer points to a
+/// wrong location this function will overwrite memory that it is not supposed to overwrite causing an undefined behavior.
+///
+/// # Cost
+///
+/// `base + read_register_base + read_register_byte * num_bytes + write_memory_base + write_memory_byte * num_bytes`
+pub fn read_register(ctx: &mut Ctx, memory: &mut [u8], register_id: u64, ptr: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    let buf = ctx.registers.get(&mut ctx.result_state.gas_counter, register_id)?;
+    write_memory(&mut ctx.result_state.gas_counter, memory, ptr, buf)?;
+    Ok(())
+}
+
+/// Returns the size of the blob stored in the given register.
+/// * If register is used, then returns the size, which can potentially be zero;
+/// * If register is not used, returns `u64::MAX`
+///
+/// # Arguments
+///
+/// * `register_id` -- a register id from where to read the data;
+///
+/// # Cost
+///
+/// `base`
+pub fn register_len(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    Ok(ctx.registers.get_len(register_id).unwrap_or(u64::MAX))
+}
+
+/// Copies `data` from the guest memory into the register. If register is unused will initialize
+/// it. If register has larger capacity than needed for `data` will not re-allocate it. The
+/// register will lose the pre-existing data if any.
+///
+/// # Arguments
+///
+/// * `register_id` -- a register id where to write the data;
+/// * `data_len` -- length of the data in bytes;
+/// * `data_ptr` -- pointer in the guest memory where to read the data from.
+///
+/// # Cost
+///
+/// `base + read_memory_base + read_memory_bytes * num_bytes + write_register_base + write_register_bytes * num_bytes`
+pub fn write_register(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    register_id: u64,
+    data_len: u64,
+    data_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    let memory = read_memory(&mut ctx.result_state.gas_counter, memory, data_ptr, data_len)?;
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        memory,
+    )
+}
+
+// ###################################
+// # String reading helper functions #
+// ###################################
+
+/// Helper function to read and return utf8-encoding string.
+/// If `len == u64::MAX` then treats the string as null-terminated with character `'\0'`.
+///
+/// # Errors
+///
+/// * If string extends outside the memory of the guest with `MemoryAccessViolation`;
+/// * If string is not UTF-8 returns `BadUtf8`.
+/// * If number of bytes read + `total_log_length` exceeds the `max_total_log_length` returns
+///   `TotalLogLengthExceeded`.
+///
+/// # Cost
+///
+/// For not nul-terminated string:
+/// `read_memory_base + read_memory_byte * num_bytes + utf8_decoding_base + utf8_decoding_byte * num_bytes`
+///
+/// For nul-terminated string:
+/// `(read_memory_base + read_memory_byte) * num_bytes + utf8_decoding_base + utf8_decoding_byte * num_bytes`
+fn get_utf8_string(
+    result_state: &mut ExecutionResultState,
+    memory: &[u8],
+    len: u64,
+    ptr: u64,
+) -> Result<String> {
+    result_state.gas_counter.pay_base(utf8_decoding_base)?;
+    let mut buf;
+    let max_len = result_state
+        .config
+        .limit_config
+        .max_total_log_length
+        .saturating_sub(result_state.total_log_length);
+    if len != u64::MAX {
+        if len > max_len {
+            return result_state.total_log_length_exceeded(len);
+        }
+
+        buf = read_memory(&mut result_state.gas_counter, memory, ptr, len)?.into();
+    } else {
+        buf = vec![];
+        for i in 0..=max_len {
+            let ptr = ptr.checked_add(i).ok_or(HostError::MemoryAccessViolation)?;
+            let el = get_u8(&mut result_state.gas_counter, memory, ptr)?;
+            if el == 0 {
+                break;
+            }
+            if i == max_len {
+                return result_state.total_log_length_exceeded(max_len.saturating_add(1));
+            }
+            buf.push(el);
+        }
+    }
+    result_state.gas_counter.pay_per(utf8_decoding_byte, buf.len() as _)?;
+    String::from_utf8(buf).map_err(|_| HostError::BadUTF8.into())
+}
+
+/// Helper function to get utf8 string, for sandbox debug log. The difference with `get_utf8_string`:
+/// * It's only available on sandbox node
+/// * The cost is 0
+/// * It's up to the caller to set correct len
+#[cfg(feature = "sandbox")]
+fn sandbox_get_utf8_string(memory: &[u8], len: u64, ptr: u64) -> Result<String> {
+    let buf = read_memory_for_free(memory, ptr, len)?;
+    String::from_utf8(buf.into()).map_err(|_| HostError::BadUTF8.into())
+}
+
+/// Helper function to read UTF-16 formatted string from guest memory.
+/// # Errors
+///
+/// * If string extends outside the memory of the guest with `MemoryAccessViolation`;
+/// * If string is not UTF-16 returns `BadUtf16`.
+/// * If number of bytes read + `total_log_length` exceeds the `max_total_log_length` returns
+///   `TotalLogLengthExceeded`.
+///
+/// # Cost
+///
+/// For not nul-terminated string:
+/// `read_memory_base + read_memory_byte * num_bytes + utf16_decoding_base + utf16_decoding_byte * num_bytes`
+///
+/// For nul-terminated string:
+/// `read_memory_base * num_bytes / 2 + read_memory_byte * num_bytes + utf16_decoding_base + utf16_decoding_byte * num_bytes`
+fn get_utf16_string(
+    result_state: &mut ExecutionResultState,
+    memory: &[u8],
+    mut len: u64,
+    ptr: u64,
+) -> Result<String> {
+    result_state.gas_counter.pay_base(utf16_decoding_base)?;
+    let max_len = result_state
+        .config
+        .limit_config
+        .max_total_log_length
+        .saturating_sub(result_state.total_log_length);
+
+    let mem_view = if len == u64::MAX {
+        len = get_nul_terminated_utf16_len(result_state, memory, ptr, max_len)?;
+        read_memory_for_free(memory, ptr, len)
+    } else {
+        read_memory(&mut result_state.gas_counter, memory, ptr, len)
+    }?;
+
+    let input = stdx::as_chunks_exact(&mem_view).map_err(|_| HostError::BadUTF16)?;
+    if len > max_len {
+        return result_state.total_log_length_exceeded(len);
+    }
+
+    result_state.gas_counter.pay_per(utf16_decoding_byte, len)?;
+    char::decode_utf16(input.into_iter().copied().map(u16::from_le_bytes))
+        .collect::<Result<String, _>>()
+        .map_err(|_| HostError::BadUTF16.into())
+}
+
+/// Helper function to get length of NUL-terminated UTF-16 formatted string
+/// in guest memory.
+///
+/// In other words, counts how many bytes are there to first pair of NUL
+/// bytes.
+fn get_nul_terminated_utf16_len(
+    result_state: &mut ExecutionResultState,
+    memory: &[u8],
+    ptr: u64,
+    max_len: u64,
+) -> Result<u64> {
+    let mut len = 0;
+    loop {
+        let ptr = ptr.checked_add(len).ok_or(HostError::MemoryAccessViolation)?;
+        if get_u16(&mut result_state.gas_counter, memory, ptr)? == 0 {
+            return Ok(len);
+        }
+        len = match len.checked_add(2) {
+            Some(len) if len <= max_len => len,
+            Some(len) => return result_state.total_log_length_exceeded(len),
+            None => return result_state.total_log_length_exceeded(u64::MAX),
+        };
+    }
+}
+
+// ####################################################
+// # Helper functions to prevent code duplication API #
+// ####################################################
+
+/// Adds a given promise to the vector of promises and returns a new promise index.
+/// Throws `NumberPromisesExceeded` if the total number of promises exceeded the limit.
+fn checked_push_promise(ctx: &mut Ctx, promise: Promise) -> Result<PromiseIndex> {
+    let new_promise_idx = ctx.promises.len() as PromiseIndex;
+    ctx.promises.push(promise);
+    if ctx.promises.len() as u64 > ctx.config.limit_config.max_promises_per_function_call_action {
+        Err(HostError::NumberPromisesExceeded {
+            number_of_promises: ctx.promises.len() as u64,
+            limit: ctx.config.limit_config.max_promises_per_function_call_action,
+        }
+        .into())
+    } else {
+        Ok(new_promise_idx)
+    }
+}
+
+fn get_public_key(
+    gas_counter: &mut GasCounter,
+    memory: &[u8],
+    registers: &Registers,
+    ptr: u64,
+    len: u64,
+) -> Result<PublicKeyBuffer> {
+    Ok(PublicKeyBuffer::new(get_memory_or_register(gas_counter, memory, registers, ptr, len)?))
+}
+
+// ###############
+// # Context API #
+// ###############
+
+/// Saves the account id of the current contract that we execute into the register.
+///
+/// # Errors
+///
+/// If the registers exceed the memory limit returns `MemoryAccessViolation`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes`
+pub fn current_account_id(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        ctx.context.current_account_id.as_bytes(),
+    )
+}
+
+/// All contract calls are a result of some transaction that was signed by some account using
+/// some access key and submitted into a memory pool (either through the wallet using RPC or by
+/// a node itself). This function returns the id of that account. Saves the bytes of the signer
+/// account id into the register.
+///
+/// # Errors
+///
+/// * If the registers exceed the memory limit returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes`
+pub fn signer_account_id(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+
+    if ctx.context.is_view() {
+        return Err(
+            HostError::ProhibitedInView { method_name: "signer_account_id".to_string() }.into()
+        );
+    }
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        ctx.context.signer_account_id.as_bytes(),
+    )
+}
+
+/// Saves the public key fo the access key that was used by the signer into the register. In
+/// rare situations smart contract might want to know the exact access key that was used to send
+/// the original transaction, e.g. to increase the allowance or manipulate with the public key.
+///
+/// # Errors
+///
+/// * If the registers exceed the memory limit returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes`
+pub fn signer_account_pk(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+
+    if ctx.context.is_view() {
+        return Err(
+            HostError::ProhibitedInView { method_name: "signer_account_pk".to_string() }.into()
+        );
+    }
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        ctx.context.signer_account_pk.as_slice(),
+    )
+}
+
+/// All contract calls are a result of a receipt, this receipt might be created by a transaction
+/// that does function invocation on the contract or another contract as a result of
+/// cross-contract call. Saves the bytes of the predecessor account id into the register.
+///
+/// # Errors
+///
+/// * If the registers exceed the memory limit returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes`
+pub fn predecessor_account_id(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "predecessor_account_id".to_string(),
+        }
+        .into());
+    }
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        ctx.context.predecessor_account_id.as_bytes(),
+    )
+}
+
+/// Populates a register with the ID of an account which would receive a refund.
+///
+/// This is the ID of an account set for the current receipt by its
+/// predecessor via [`Self::promise_set_refund_to()`], or
+/// [`Self::predecessor_account_id()`] otherwise.
+///
+/// # Errors
+///
+/// If the registers exceed the memory limit returns `MemoryAccessViolation`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes`
+pub fn refund_to_account_id(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "refund_to_account_id".to_string(),
+        }
+        .into());
+    }
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        ctx.context.refund_to_account_id.as_bytes(),
+    )
+}
+
+/// Reads input to the contract call into the register. Input is expected to be in JSON-format.
+/// If input is provided saves the bytes (potentially zero) of input into register. If input is
+/// not provided writes 0 bytes into the register.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes`
+pub fn input(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+
+    let charge_bytes_gas = !ctx.config.deterministic_account_ids;
+    ctx.registers.set_rc_data(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        Rc::clone(&ctx.context.input),
+        charge_bytes_gas,
+    )
+}
+
+/// Returns the current block height.
+///
+/// It’s only due to historical reasons, this host function is called
+/// `block_index` rather than `block_height`.
+///
+/// # Cost
+///
+/// `base`
+pub fn block_index(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    Ok(ctx.context.block_height)
+}
+
+/// Returns the current block timestamp (number of non-leap-nanoseconds since January 1, 1970 0:00:00 UTC).
+///
+/// # Cost
+///
+/// `base`
+pub fn block_timestamp(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    Ok(ctx.context.block_timestamp)
+}
+
+/// Returns the current epoch height.
+///
+/// # Cost
+///
+/// `base`
+pub fn epoch_height(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<EpochHeight> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    Ok(ctx.context.epoch_height)
+}
+
+/// Get the stake of an account, if the account is currently a validator. Otherwise returns 0.
+/// writes the value into the` u128` variable pointed by `stake_ptr`.
+///
+/// # Cost
+///
+/// `base + memory_write_base + memory_write_size * 16 + utf8_decoding_base + utf8_decoding_byte * account_id_len + validator_stake_base`.
+pub fn validator_stake(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    account_id_len: u64,
+    account_id_ptr: u64,
+    stake_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    let account_id = read_and_parse_account_id(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        &ctx.config,
+        account_id_ptr,
+        account_id_len,
+    )?;
+    ctx.result_state.gas_counter.pay_base(validator_stake_base)?;
+    let balance = ctx.ext.validator_stake(&account_id)?.unwrap_or_default();
+    set_u128(&mut ctx.result_state.gas_counter, memory, stake_ptr, balance.as_yoctonear())
+}
+
+/// Get the total validator stake of the current epoch.
+/// Write the u128 value into `stake_ptr`.
+/// writes the value into the` u128` variable pointed by `stake_ptr`.
+///
+/// # Cost
+///
+/// `base + memory_write_base + memory_write_size * 16 + validator_total_stake_base`
+pub fn validator_total_stake(ctx: &mut Ctx, memory: &mut [u8], stake_ptr: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    ctx.result_state.gas_counter.pay_base(validator_total_stake_base)?;
+    let total_stake = ctx.ext.validator_total_stake()?;
+    set_u128(&mut ctx.result_state.gas_counter, memory, stake_ptr, total_stake.as_yoctonear())
+}
+
+/// Returns the number of bytes used by the contract if it was saved to the trie as of the
+/// invocation. This includes:
+/// * The data written with storage_* functions during current and previous execution;
+/// * The bytes needed to store the access keys of the given account.
+/// * The contract code size
+/// * A small fixed overhead for account metadata.
+///
+/// # Cost
+///
+/// `base`
+pub fn storage_usage(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<StorageUsage> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    Ok(ctx.result_state.current_storage_usage)
+}
+
+// #################
+// # Economics API #
+// #################
+
+/// The current balance of the given account. This includes the attached_deposit that was
+/// attached to the transaction.
+///
+/// # Cost
+///
+/// `base + memory_write_base + memory_write_size * 16`
+pub fn account_balance(ctx: &mut Ctx, memory: &mut [u8], balance_ptr: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    set_u128(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        balance_ptr,
+        ctx.result_state.current_account_balance.as_yoctonear(),
+    )
+}
+
+/// The current amount of tokens locked due to staking.
+///
+/// # Cost
+///
+/// `base + memory_write_base + memory_write_size * 16`
+pub fn account_locked_balance(ctx: &mut Ctx, memory: &mut [u8], balance_ptr: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    set_u128(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        balance_ptr,
+        ctx.current_account_locked_balance.as_yoctonear(),
+    )
+}
+
+/// The balance that was attached to the call that will be immediately deposited before the
+/// contract execution starts.
+///
+/// # Errors
+///
+/// If called as view function returns `ProhibitedInView``.
+///
+/// # Cost
+///
+/// `base + memory_write_base + memory_write_size * 16`
+pub fn attached_deposit(ctx: &mut Ctx, memory: &mut [u8], balance_ptr: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    set_u128(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        balance_ptr,
+        ctx.context.attached_deposit.as_yoctonear(),
+    )
+}
+
+/// The amount of gas attached to the call that can be used to pay for the gas fees.
+///
+/// # Errors
+///
+/// If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `base`
+pub fn prepaid_gas(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView { method_name: "prepaid_gas".to_string() }.into());
+    }
+    Ok(ctx.context.prepaid_gas.as_gas())
+}
+
+/// The gas that was already burnt during the contract execution (cannot exceed `prepaid_gas`)
+///
+/// # Errors
+///
+/// If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `base`
+pub fn used_gas(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView { method_name: "used_gas".to_string() }.into());
+    }
+    Ok(ctx.result_state.gas_counter.used_gas().as_gas())
+}
+
+// ############
+// # Math API #
+// ############
+
+/// Computes multiexp on alt_bn128 curve using Pippenger's algorithm \sum_i
+/// mul_i g_{1 i} should be equal result.
+///
+/// # Arguments
+///
+/// * `value` - sequence of (g1:G1, fr:Fr), where
+///    G1 is point (x:Fq, y:Fq) on alt_bn128,
+///   alt_bn128 is Y^2 = X^3 + 3 curve over Fq.
+///
+///   `value` is encoded as packed, little-endian
+///   `[((u256, u256), u256)]` slice.
+///
+/// # Errors
+///
+/// If `value_len + value_ptr` points outside the memory or the registers
+/// use more memory than the limit, the function returns
+/// `MemoryAccessViolation`.
+///
+/// If point coordinates are not on curve, point is not in the subgroup,
+/// scalar is not in the field or  `value.len()%96!=0`, the function returns
+/// `AltBn128InvalidInput`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes +
+///  alt_bn128_g1_multiexp_base +
+///  alt_bn128_g1_multiexp_element * num_elements`
+///
+/// cspell:words Pippenger
+pub fn alt_bn128_g1_multiexp(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+    register_id: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(alt_bn128_g1_multiexp_base)?;
+    let data = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+
+    let elements = alt_bn128::split_elements(&data)?;
+    ctx.result_state.gas_counter.pay_per(alt_bn128_g1_multiexp_element, elements.len() as u64)?;
+
+    let res = alt_bn128::g1_multiexp(elements)?;
+
+    ctx.registers.set(&mut ctx.result_state.gas_counter, &ctx.config.limit_config, register_id, res)
+}
+
+/// Computes sum for signed g1 group elements on alt_bn128 curve \sum_i
+/// (-1)^{sign_i} g_{1 i} should be equal result.
+///
+/// # Arguments
+///
+/// * `value` - sequence of (sign:bool, g1:G1), where
+///    G1 is point (x:Fq, y:Fq) on alt_bn128,
+///    alt_bn128 is Y^2 = X^3 + 3 curve over Fq.
+///
+///   `value` is encoded as packed, little-endian
+///   `[(u8, (u256, u256))]` slice. `0u8` is positive sign,
+///   `1u8` -- negative.
+///
+/// # Errors
+///
+/// If `value_len + value_ptr` points outside the memory or the registers
+/// use more memory than the limit, the function returns `MemoryAccessViolation`.
+///
+/// If point coordinates are not on curve, point is not in the subgroup,
+/// scalar is not in the field, sign is not 0 or 1, or `value.len()%65!=0`,
+/// the function returns `AltBn128InvalidInput`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes +
+/// alt_bn128_g1_sum_base + alt_bn128_g1_sum_element * num_elements`
+pub fn alt_bn128_g1_sum(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+    register_id: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(alt_bn128_g1_sum_base)?;
+    let data = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+
+    let elements = alt_bn128::split_elements(&data)?;
+    ctx.result_state.gas_counter.pay_per(alt_bn128_g1_sum_element, elements.len() as u64)?;
+
+    let res = alt_bn128::g1_sum(elements)?;
+
+    ctx.registers.set(&mut ctx.result_state.gas_counter, &ctx.config.limit_config, register_id, res)
+}
+
+/// Computes pairing check on alt_bn128 curve.
+/// \sum_i e(g_{1 i}, g_{2 i}) should be equal one (in additive notation), e(g1, g2) is Ate pairing
+///
+/// # Arguments
+///
+/// * `value` - sequence of (g1:G1, g2:G2), where
+///   G2 is Fr-ordered subgroup point (x:Fq2, y:Fq2) on alt_bn128 twist,
+///   alt_bn128 twist is Y^2 = X^3 + 3/(i+9) curve over Fq2
+///   Fq2 is complex field element (re: Fq, im: Fq)
+///   G1 is point (x:Fq, y:Fq) on alt_bn128,
+///   alt_bn128 is Y^2 = X^3 + 3 curve over Fq
+///
+///   `value` is encoded a as packed, little-endian
+///   `[((u256, u256), ((u256, u256), (u256, u256)))]` slice.
+///
+/// # Errors
+///
+/// If `value_len + value_ptr` points outside the memory or the registers
+/// use more memory than the limit the function returns `MemoryAccessViolation`.
+///
+/// If point coordinates are not on curve, point is not in the subgroup, scalar
+/// is not in the field or data are wrong serialized, for example,
+/// `value.len()%192!=0`, the function returns `AltBn128InvalidInput`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes + alt_bn128_pairing_base + alt_bn128_pairing_element * num_elements`
+pub fn alt_bn128_pairing_check(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(alt_bn128_pairing_check_base)?;
+    let data = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+
+    let elements = alt_bn128::split_elements(&data)?;
+    ctx.result_state.gas_counter.pay_per(alt_bn128_pairing_check_element, elements.len() as u64)?;
+
+    let res = alt_bn128::pairing_check(elements)?;
+
+    Ok(res as u64)
+}
+
+bls12381_impl!(
+    r"Calculates the sum of signed elements on the BLS12-381 curve.
+It accepts an arbitrary number of pairs (sign_i, p_i),
+where p_i from E(Fp) and sign_i is 0 or 1.
+It calculates sum_i (-1)^{sign_i} * p_i
+
+# Arguments
+
+* `value` -  sequence of (sign:bool, p:E(Fp)), where
+  p is point (x:Fp, y:Fp) on BLS12-381,
+  BLS12-381 is Y^2 = X^3 + 4 curve over Fp.
+
+  `value` is encoded as packed `[(u8, ([u8;48], [u8;48]))]` slice.
+  `0u8` is positive sign, `1u8` -- negative.
+  Elements from Fp encoded as big-endian [u8;48].
+
+# Output
+
+If the input data is correct returns 0 and the 96 bytes represent
+the resulting points from E(Fp) which will be written to the register with
+the register_id identifier
+
+If one of the points not on the curve,
+the sign or points are incorrectly encoded then 1 will be returned
+and nothing will be written to the register.
+
+# Errors
+
+If `value_len + value_ptr` points outside the memory or the registers
+use more memory than the limit the function returns `MemoryAccessViolation`.
+
+If `value_len % 97 != 0`, the function returns `BLS12381InvalidInput`.
+
+# Cost
+
+`base + write_register_base + write_register_byte * num_bytes +
+bls12381_p1_sum_base + bls12381_p1_sum_element * num_elements`
+",
+    bls12381_p1_sum,
+    97,
+    bls12381_p1_sum_base,
+    bls12381_p1_sum_element,
+    p1_sum
+);
+
+bls12381_impl!(
+    r"Calculates the sum of signed elements on the twisted BLS12-381 curve.
+It accepts an arbitrary number of pairs (sign_i, p_i),
+where p_i from E'(Fp^2) and sign_i is 0 or 1.
+It calculates sum_i (-1)^{sign_i} * p_i
+
+# Arguments
+
+* `value` -  sequence of (sign:bool, p:E'(Fp^2)), where
+  p is point (x:Fp^2, y:Fp^2) on twisted BLS12-381,
+  twisted BLS12-381 is Y^2 = X^3 + 4(u + 1) curve over Fp^2.
+
+`value` is encoded as packed `[(u8, ([u8;96], [u8;96]))]` slice.
+`0u8` is positive, `1u8` is negative.
+Elements q = c0 + c1 * u from Fp^2 encoded as concatenation of c1 and c0,
+where c1 and c0 from Fp and encoded as big-endian [u8;48].
+
+# Output
+
+If the input data is correct returns 0 and the 192 bytes represent
+the resulting points from E'(Fp^2) which will be written to the register with
+the register_id identifier
+
+If one of the points not on the curve,
+the sign or points are incorrectly encoded then 1 will be returned
+and nothing will be written to the register.
+
+# Errors
+
+If `value_len + value_ptr` points outside the memory or the registers
+use more memory than the limit the function returns `MemoryAccessViolation`.
+
+If `value_len % 193 != 0`, the function returns `BLS12381InvalidInput`.
+
+# Cost
+
+`base + write_register_base + write_register_byte * num_bytes +
+bls12381_p2_sum_base + bls12381_p2_sum_element * num_elements`
+",
+    bls12381_p2_sum,
+    193,
+    bls12381_p2_sum_base,
+    bls12381_p2_sum_element,
+    p2_sum
+);
+
+bls12381_impl!(
+    r"Calculates multiexp on BLS12-381 curve:
+accepts an arbitrary number of pairs (p_i, s_i),
+where p_i from G1 and s_i is a scalar and
+calculates sum_i s_i*p_i
+
+# Arguments
+
+* `value` -  sequence of (p:E(Fp), s:u256), where
+   p is point (x:Fp, y:Fp) on BLS12-381,
+   BLS12-381 is Y^2 = X^3 + 4 curve over Fp.
+
+   `value` is encoded as packed `[(([u8;48], [u8;48]), [u8;32])]` slice.
+   Elements from Fp encoded as big-endian [u8;48].
+   Scalars encoded as little-endian [u8;32].
+
+# Output
+
+If the input data is correct returns 0 and the 96 bytes represent
+the resulting points from G1 which will be written to the register with
+the register_id identifier
+
+If one of the points not from G1 subgroup
+or points are incorrectly encoded then 1 will be returned
+and nothing will be written to the register.
+
+# Errors
+
+If `value_len + value_ptr` points outside the memory or the registers
+use more memory than the limit the function returns `MemoryAccessViolation`.
+
+If `value_len % 128 != 0`, the function returns `BLS12381InvalidInput`.
+
+# Cost
+
+`base + write_register_base + write_register_byte * num_bytes +
+bls12381_g1_multiexp_base + bls12381_g1_multiexp_element * num_elements`
+",
+    bls12381_g1_multiexp,
+    128,
+    bls12381_g1_multiexp_base,
+    bls12381_g1_multiexp_element,
+    g1_multiexp
+);
+
+bls12381_impl!(
+    r"Calculates multiexp on twisted BLS12-381 curve:
+accepts an arbitrary number of pairs (p_i, s_i),
+where p_i from G2 and s_i is a scalar and
+calculates sum_i s_i*p_i
+
+# Arguments
+
+* `value` -  sequence of (p:E'(Fp^2), s:u256), where
+  p is point (x:Fp^2, y:Fp^2) on twisted BLS12-381,
+  BLS12-381 is Y^2 = X^3 + 4(u + 1) curve over Fp^2.
+
+`value` is encoded as packed `[(([u8;96], [u8;96]), [u8;32])]` slice.
+Elements q = c0 + c1 * u from Fp^2 encoded as concatenation of c1 and c0,
+where c1 and c0 from Fp and encoded as big-endian [u8;48].
+Scalars encoded as little-endian [u8;32].
+
+# Output
+
+If the input data is correct returns 0 and the 192 bytes represent
+the resulting points from G2 which will be written to the register with
+the register_id identifier
+
+If one of the points not from G2 subgroup
+or points are incorrectly encoded then 1 will be returned
+and nothing will be written to the register.
+
+# Errors
+
+If `value_len + value_ptr` points outside the memory or the registers
+use more memory than the limit the function returns `MemoryAccessViolation`.
+
+If `value_len % 224 != 0`, the function returns `BLS12381InvalidInput`.
+
+# Cost
+
+`base + write_register_base + write_register_byte * num_bytes +
+bls12381_g2_multiexp_base + bls12381_g2_multiexp_element * num_elements`
+",
+    bls12381_g2_multiexp,
+    224,
+    bls12381_g2_multiexp_base,
+    bls12381_g2_multiexp_element,
+    g2_multiexp
+);
+
+bls12381_impl!(
+    r"Maps elements from Fp to the G1 subgroup of BLS12-381 curve.
+
+# Arguments
+
+* `value` -  sequence of p from Fp.
+
+   `value` is encoded as packed `[[u8;48]]` slice.
+   Elements from Fp encoded as big-endian [u8;48].
+
+# Output
+
+If the input data is correct returns 0 and the 96*num_elements bytes represent
+the resulting points from G1 which will be written to the register with
+the register_id identifier
+
+If one of the element >= p, then 1 will be returned
+and nothing will be written to the register.
+
+# Errors
+
+If `value_len + value_ptr` points outside the memory or the registers
+use more memory than the limit the function returns `MemoryAccessViolation`.
+
+If `value_len % 48 != 0`, the function returns `BLS12381InvalidInput`.
+
+# Cost
+
+`base + write_register_base + write_register_byte * num_bytes +
+bls12381_map_fp_to_g1_base + bls12381_map_fp_to_g1_element * num_elements`
+",
+    bls12381_map_fp_to_g1,
+    48,
+    bls12381_map_fp_to_g1_base,
+    bls12381_map_fp_to_g1_element,
+    map_fp_to_g1
+);
+
+bls12381_impl!(
+    r"Maps elements from Fp^2 to the G2 subgroup of twisted BLS12-381 curve.
+
+# Arguments
+
+* `value` -  sequence of p from Fp^2.
+
+`value` is encoded as packed `[[u8;96]]` slice.
+Elements q = c0 + c1 * u from Fp^2 encoded as concatenation of c1 and c0,
+where c1 and c0 from Fp and encoded as big-endian [u8;48].
+
+# Output
+
+If the input data is correct returns 0 and the 192*num_elements bytes represent
+the resulting points from G2 which will be written to the register with
+the register_id identifier
+
+If one of the element not valid Fp^2, then 1 will be returned
+and nothing will be written to the register.
+
+# Errors
+
+If `value_len + value_ptr` points outside the memory or the registers
+use more memory than the limit the function returns `MemoryAccessViolation`.
+
+If `value_len % 96 != 0`, the function returns `BLS12381InvalidInput`.
+
+# Cost
+`base + write_register_base + write_register_byte * num_bytes +
+bls12381_map_fp2_to_g2_base + bls12381_map_fp2_to_g2_element * num_elements`
+",
+    bls12381_map_fp2_to_g2,
+    96,
+    bls12381_map_fp2_to_g2_base,
+    bls12381_map_fp2_to_g2_element,
+    map_fp2_to_g2
+);
+
+/// Computes pairing check on BLS12-381 curve.
+/// In other words, computes whether \sum_i e(g_{1 i}, g_{2 i})
+/// is equal to one (in additive notation), where e(g1, g2) is the pairing function
+///
+/// # Arguments
+///
+/// * `value` -  sequence of (g1:G1, g2:G2), where
+///    g1 is point (x:Fp, y:Fp) on BLS12-381,
+///    BLS12-381 is Y^2 = X^3 + 4 curve over Fp.
+///    g2 is point (x:Fp^2, y:Fp^2) on twisted BLS12-381,
+///    twisted BLS12-381 is Y^2 = X^3 + 4(u + 1) curve over Fp^2.
+///
+///   `value` is encoded as packed `[(([u8;48], [u8;48]), ([u8;96], [u8;96]))]` slice.
+///    Elements from Fp encoded as big-endian [u8;48].
+///    Elements q = c0 + c1 * u from Fp^2 encoded as concatenation of c1 and c0,
+///    where c1 and c0 from Fp.
+///
+/// # Output
+///
+/// If the input data is correct and
+/// the pairing result equals the multiplicative identity returns 0.
+///
+/// If one of the points not on the curve, not from G1/G2 or
+/// incorrectly encoded then 1 will be returned
+///
+/// If the input data is correct and
+/// the pairing result does NOT equal the multiplicative identity returns 2.
+///
+/// # Errors
+///
+/// If `value_len + value_ptr` points outside the memory or the registers
+/// use more memory than the limit the function returns `MemoryAccessViolation`.
+///
+/// If `value_len % 288 != 0`, the function returns `BLS12381InvalidInput`.
+///
+/// # Cost
+/// `base + write_register_base + write_register_byte * num_bytes +
+///   bls12381_pairing_base + bls12381_pairing_element * num_elements`
+pub fn bls12381_pairing_check(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(bls12381_pairing_base)?;
+
+    const BLS_P1_SIZE: usize = 96;
+    const BLS_P2_SIZE: usize = 192;
+    const ITEM_SIZE: usize = BLS_P1_SIZE + BLS_P2_SIZE;
+
+    let data = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+    let elements_count = data.len() / ITEM_SIZE;
+
+    ctx.result_state.gas_counter.pay_per(bls12381_pairing_element, elements_count as u64)?;
+
+    bls12381::pairing_check(&data)
+}
+
+bls12381_impl!(
+    r"Decompress points from BLS12-381 curve.
+
+# Arguments
+
+* `value` -  sequence of p:E(Fp), where
+   p is point in compressed format on BLS12-381,
+   BLS12-381 is Y^2 = X^3 + 4 curve over Fp.
+
+   `value` is encoded as packed `[[u8;48]]` slice.
+   Where points (x: Fp, y: Fp) from E(Fp) encoded as
+   [u8; 48] -- big-endian x: Fp. y determined by the formula y=+-sqrt(x^3 + 4)
+
+   The highest bit should be set as 1, the second-highest bit marks the point at infinity,
+   The third-highest bit represent the sign of y (0 for positive).
+
+# Output
+
+If the input data is correct returns 0 and the 96*num_elements bytes represent
+the resulting uncompressed points from E(Fp) which will be written to the register with
+the register_id identifier
+
+If one of the points not on the curve
+or points are incorrectly encoded then 1 will be returned
+and nothing will be written to the register.
+
+# Errors
+
+If `value_len + value_ptr` points outside the memory or the registers
+use more memory than the limit the function returns `MemoryAccessViolation`.
+
+If `value_len % 48 != 0`, the function returns `BLS12381InvalidInput`.
+
+# Cost
+`base + write_register_base + write_register_byte * num_bytes +
+bls12381_p1_decompress_base + bls12381_p1_decompress_element * num_elements`
+",
+    bls12381_p1_decompress,
+    48,
+    bls12381_p1_decompress_base,
+    bls12381_p1_decompress_element,
+    p1_decompress
+);
+
+bls12381_impl!(
+    r"Decompress points from twisted BLS12-381 curve.
+
+# Arguments
+
+* `value` -  sequence of p:E'(Fp^2), where
+   p is point in compressed format on twisted BLS12-381,
+   twisted BLS12-381 is Y^2 = X^3 + 4(u + 1) curve over Fp^2.
+
+   `value` is encoded as packed `[[u8;96]]` slice.
+   Where points (x: Fp^2, y: Fp^2) from E'(Fp^2) encoded as
+   [u8; 96] -- x: Fp^2. y determined by the formula y=+-sqrt(x^3 + 4(u + 1))
+
+   Elements q = c0 + c1 * u from Fp^2 encoded as concatenation of c1 and c0,
+   where c1 and c0 from Fp and encoded as big-endian [u8;48].
+
+   The highest bit should be set as 1, the second-highest bit marks the point at infinity,
+   The third-highest bit represent the sign of y (0 for positive).
+
+# Output
+
+If the input data is correct returns 0 and the 192*num_elements bytes represent
+the resulting uncompressed points from E'(Fp^2) which will be written to the register with
+the register_id identifier
+
+If one of the points not on the curve
+or points are incorrectly encoded then 1 will be returned
+and nothing will be written to the register.
+
+# Errors
+
+If `value_len + value_ptr` points outside the memory or the registers
+use more memory than the limit the function returns `MemoryAccessViolation`.
+
+If `value_len % 96 != 0`, the function returns `BLS12381InvalidInput`.
+
+# Cost
+
+`base + write_register_base + write_register_byte * num_bytes +
+bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
+        ",
+    bls12381_p2_decompress,
+    96,
+    bls12381_p2_decompress_base,
+    bls12381_p2_decompress_element,
+    p2_decompress
+);
+
+/// Writes random seed into the register.
+///
+/// # Errors
+///
+/// If the size of the registers exceed the set limit `MemoryAccessViolation`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes`.
+pub fn random_seed(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        ctx.context.random_seed.as_slice(),
+    )
+}
+
+/// Hashes the given value using sha256 and returns it into `register_id`.
+///
+/// # Errors
+///
+/// If `value_len + value_ptr` points outside the memory or the registers use more memory than
+/// the limit with `MemoryAccessViolation`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes + sha256_base + sha256_byte * num_bytes`
+pub fn sha256(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+    register_id: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(sha256_base)?;
+    let value = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+    ctx.result_state.gas_counter.pay_per(sha256_byte, value.len() as u64)?;
+
+    use sha2::Digest;
+
+    let value_hash = sha2::Sha256::digest(&value);
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        value_hash.as_slice(),
+    )
+}
+
+/// Hashes the given value using keccak256 and returns it into `register_id`.
+///
+/// # Errors
+///
+/// If `value_len + value_ptr` points outside the memory or the registers use more memory than
+/// the limit with `MemoryAccessViolation`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes + keccak256_base + keccak256_byte * num_bytes`
+pub fn keccak256(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+    register_id: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(keccak256_base)?;
+    let value = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+    ctx.result_state.gas_counter.pay_per(keccak256_byte, value.len() as u64)?;
+
+    use sha3::Digest;
+
+    let value_hash = sha3::Keccak256::digest(&value);
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        value_hash.as_slice(),
+    )
+}
+
+/// Hashes the given value using keccak512 and returns it into `register_id`.
+///
+/// # Errors
+///
+/// If `value_len + value_ptr` points outside the memory or the registers use more memory than
+/// the limit with `MemoryAccessViolation`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes + keccak512_base + keccak512_byte * num_bytes`
+pub fn keccak512(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+    register_id: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(keccak512_base)?;
+    let value = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+    ctx.result_state.gas_counter.pay_per(keccak512_byte, value.len() as u64)?;
+
+    use sha3::Digest;
+
+    let value_hash = sha3::Keccak512::digest(&value);
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        value_hash.as_slice(),
+    )
+}
+
+/// Hashes the given value using RIPEMD-160 and returns it into `register_id`.
+///
+/// # Errors
+///
+/// If `value_len + value_ptr` points outside the memory or the registers use more memory than
+/// the limit with `MemoryAccessViolation`.
+///
+/// # Cost
+///
+///  Where `message_blocks` is `(value_len + 9).div_ceil(64)`.
+///
+/// `base + write_register_base + write_register_byte * num_bytes + ripemd160_base + ripemd160_block * message_blocks`
+pub fn ripemd160(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+    register_id: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(ripemd160_base)?;
+    let value = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+
+    let message_blocks =
+        value.len().checked_add(8).ok_or(VMLogicError::HostError(HostError::IntegerOverflow))? / 64
+            + 1;
+
+    ctx.result_state.gas_counter.pay_per(ripemd160_block, message_blocks as u64)?;
+
+    use ripemd::Digest;
+
+    let value_hash = ripemd::Ripemd160::digest(&value);
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        value_hash.as_slice(),
+    )
+}
+
+/// Recovers an ECDSA signer address and returns it into `register_id`.
+///
+/// Takes in an additional flag to check for malleability of the signature
+/// which is generally only ideal for transactions.
+///
+/// Returns a bool indicating success or failure as a `u64`.
+///
+/// # Malleability Flags
+///
+/// 0 - No extra checks.
+/// 1 - Rejecting upper range.
+///
+/// # Errors
+///
+/// * If `hash_ptr`, `r_ptr`, or `s_ptr` point outside the memory or the registers use more
+///   memory than the limit, then returns `MemoryAccessViolation`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * 64 + ecrecover_base`
+pub fn ecrecover(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    hash_len: u64,
+    hash_ptr: u64,
+    sig_len: u64,
+    sig_ptr: u64,
+    v: u64,
+    malleability_flag: u64,
+    register_id: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(ecrecover_base)?;
+
+    let signature = {
+        let vec = get_memory_or_register(
+            &mut ctx.result_state.gas_counter,
+            memory,
+            &ctx.registers,
+            sig_ptr,
+            sig_len,
+        )?;
+        if vec.len() != 64 {
+            return Err(VMLogicError::HostError(HostError::ECRecoverError {
+                msg: format!(
+                    "The length of the signature: {}, exceeds the limit of 64 bytes",
+                    vec.len()
+                ),
+            }));
+        }
+
+        let mut bytes = [0u8; 65];
+        bytes[0..64].copy_from_slice(&vec);
+
+        if v < 4 {
+            bytes[64] = v as u8;
+            Secp256K1Signature::from(bytes)
+        } else {
+            return Err(VMLogicError::HostError(HostError::ECRecoverError {
+                msg: format!("V recovery byte 0 through 3 are valid but was provided {}", v),
+            }));
+        }
+    };
+
+    let hash = {
+        let vec = get_memory_or_register(
+            &mut ctx.result_state.gas_counter,
+            memory,
+            &ctx.registers,
+            hash_ptr,
+            hash_len,
+        )?;
+        if vec.len() != 32 {
+            return Err(VMLogicError::HostError(HostError::ECRecoverError {
+                msg: format!(
+                    "The length of the hash: {}, exceeds the limit of 32 bytes",
+                    vec.len()
+                ),
+            }));
+        }
+
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(&vec);
+        bytes
+    };
+
+    if malleability_flag != 0 && malleability_flag != 1 {
+        return Err(VMLogicError::HostError(HostError::ECRecoverError {
+            msg: format!(
+                "Malleability flag needs to be 0 or 1, but is instead {}",
+                malleability_flag
+            ),
+        }));
+    }
+
+    if !signature.check_signature_values(malleability_flag != 0) {
+        return Ok(false as u64);
+    }
+
+    if let Ok(pk) = signature.recover(hash) {
+        ctx.registers.set(
+            &mut ctx.result_state.gas_counter,
+            &ctx.config.limit_config,
+            register_id,
+            pk.as_ref(),
+        )?;
+        return Ok(true as u64);
+    };
+
+    Ok(false as u64)
+}
+
+/// Verify an ED25519 signature given a message and a public key.
+///
+/// Returns a bool indicating success (1) or failure (0) as a `u64`.
+///
+/// # Errors
+///
+/// * If the public key's size is not equal to 32, or signature size is not
+///   equal to 64, returns [HostError::Ed25519VerifyInvalidInput].
+/// * If any of the signature, message or public key arguments are out of
+///   memory bounds, returns [`HostError::MemoryAccessViolation`]
+///
+/// # Cost
+///
+/// Each input can either be in memory or in a register. Set the length of
+/// the input to `u64::MAX` to declare that the input is a register number
+/// and not a pointer. Each input has a gas cost input_cost(num_bytes) that
+/// depends on whether it is from memory or from a register. It is either
+/// read_memory_base + num_bytes * read_memory_byte in the former case or
+/// read_register_base + num_bytes * read_register_byte in the latter. This
+/// function is labeled as `input_cost` below.
+///
+/// `input_cost(num_bytes_signature) + input_cost(num_bytes_message) +
+///  input_cost(num_bytes_public_key) + ed25519_verify_base +
+///  ed25519_verify_byte * num_bytes_message`
+pub fn ed25519_verify(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    signature_len: u64,
+    signature_ptr: u64,
+    message_len: u64,
+    message_ptr: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+) -> Result<u64> {
+    use ed25519_dalek::Verifier;
+
+    ctx.result_state.gas_counter.pay_base(ed25519_verify_base)?;
+
+    let signature: ed25519_dalek::Signature = {
+        let vec = get_memory_or_register(
+            &mut ctx.result_state.gas_counter,
+            memory,
+            &ctx.registers,
+            signature_ptr,
+            signature_len,
+        )?;
+        let b = <&[u8; ed25519_dalek::SIGNATURE_LENGTH]>::try_from(&vec[..]).map_err(|_| {
+            VMLogicError::HostError(HostError::Ed25519VerifyInvalidInput {
+                msg: "invalid signature length".to_string(),
+            })
+        })?;
+        // Sanity-check that was performed by ed25519-dalek in from_bytes before version 2,
+        // but was removed with version 2. It is not actually any good a check, but we need
+        // it to avoid costs changing.
+        if b[ed25519_dalek::SIGNATURE_LENGTH - 1] & 0b1110_0000 != 0 {
+            return Ok(false as u64);
+        }
+        ed25519_dalek::Signature::from_bytes(b)
+    };
+
+    let message = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        message_ptr,
+        message_len,
+    )?;
+    ctx.result_state.gas_counter.pay_per(ed25519_verify_byte, message.len() as u64)?;
+
+    let public_key: ed25519_dalek::VerifyingKey = {
+        let vec = get_memory_or_register(
+            &mut ctx.result_state.gas_counter,
+            memory,
+            &ctx.registers,
+            public_key_ptr,
+            public_key_len,
+        )?;
+        let b = <&[u8; ed25519_dalek::PUBLIC_KEY_LENGTH]>::try_from(&vec[..]).map_err(|_| {
+            VMLogicError::HostError(HostError::Ed25519VerifyInvalidInput {
+                msg: "invalid public key length".to_string(),
+            })
+        })?;
+        match ed25519_dalek::VerifyingKey::from_bytes(b) {
+            Ok(public_key) => public_key,
+            Err(_) => return Ok(false as u64),
+        }
+    };
+
+    match public_key.verify(&message, &signature) {
+        Err(_) => Ok(false as u64),
+        Ok(()) => Ok(true as u64),
+    }
+}
+
+/// Consume gas. Counts both towards `burnt_gas` and `used_gas`.
+///
+/// # Errors
+///
+/// * If passed gas amount somehow overflows internal gas counters returns `IntegerOverflow`;
+/// * If we exceed usage limit imposed on burnt gas returns `GasLimitExceeded`;
+/// * If we exceed the `prepaid_gas` then returns `GasExceeded`.
+pub fn consume_gas(gas_counter: &mut GasCounter, gas: u64) -> Result<()> {
+    gas_counter.burn_gas(Gas::from_gas(gas))
+}
+
+pub fn gas_opcodes(result_state: &mut ExecutionResultState, opcodes: u32) -> Result<()> {
+    consume_gas(
+        &mut result_state.gas_counter,
+        opcodes as u64 * result_state.config.regular_op_cost as u64,
+    )
+}
+
+/// An alias for [`consume_gas`].
+#[cfg(feature = "test_features")]
+pub fn burn_gas(ctx: &mut Ctx, _memory: &mut [u8], gas: u64) -> Result<()> {
+    consume_gas(&mut ctx.result_state.gas_counter, gas)
+}
+
+/// This is the function that is exposed to WASM contracts under the name `gas`.
+///
+/// For now it is consuming the gas for `gas` opcodes. When we switch to finite-wasm it’ll
+/// be made to be a no-op.
+///
+/// This function might be intrinsified.
+pub fn gas_seen_from_wasm(ctx: &mut Ctx, _memory: &mut [u8], opcodes: u32) -> Result<()> {
+    gas_opcodes(&mut ctx.result_state, opcodes)
+}
+
+#[cfg(feature = "test_features")]
+pub fn sleep_nanos(_ctx: &mut Ctx, _memory: &mut [u8], nanos: u64) -> Result<()> {
+    let duration = std::time::Duration::from_nanos(nanos);
+    std::thread::sleep(duration);
+    Ok(())
+}
+
+// ################
+// # Promises API #
+// ################
+
+/// A helper function to pay gas fee for creating a new receipt without actions.
+/// # Args:
+/// * `sir`: whether contract call is addressed to itself;
+/// * `data_dependencies`: other contracts that this execution will be waiting on (or rather
+///   their data receipts), where bool indicates whether this is sender=receiver communication.
+///
+/// # Cost
+///
+/// This is a convenience function that encapsulates several costs:
+/// `burnt_gas := dispatch cost of the receipt + base dispatch cost of the data receipt`
+/// `used_gas := burnt_gas + exec cost of the receipt + base exec cost of the data receipt`
+/// Notice that we prepay all base cost upon the creation of the data dependency, we are going to
+/// pay for the content transmitted through the dependency upon the actual creation of the
+/// DataReceipt.
+fn pay_gas_for_new_receipt(
+    gas_counter: &mut GasCounter,
+    fees_config: &RuntimeFeesConfig,
+    sir: bool,
+    data_dependencies: &[bool],
+) -> Result<()> {
+    let mut burn_gas = fees_config.fee(ActionCosts::new_action_receipt).send_fee(sir);
+    let mut use_gas = fees_config.fee(ActionCosts::new_action_receipt).exec_fee();
+    for dep in data_dependencies {
+        // Both creation and execution for data receipts are considered burnt gas.
+        burn_gas = burn_gas
+            .checked_add(fees_config.fee(ActionCosts::new_data_receipt_base).send_fee(*dep))
+            .ok_or(HostError::IntegerOverflow)?
+            .checked_add(fees_config.fee(ActionCosts::new_data_receipt_base).exec_fee())
+            .ok_or(HostError::IntegerOverflow)?;
+    }
+    use_gas = use_gas.checked_add(burn_gas).ok_or(HostError::IntegerOverflow)?;
+    // This should go to `new_data_receipt_base` and `new_action_receipt` in parts.
+    // But we have to keep charing these two together unless we make a protocol change.
+    gas_counter.pay_action_accumulated(burn_gas, use_gas, ActionCosts::new_action_receipt)
+}
+
+/// Creates a promise that will execute a method on account with given arguments and attaches
+/// the given amount and gas. `amount_ptr` point to slices of bytes representing `u128`.
+///
+/// # Errors
+///
+/// * If `account_id_len + account_id_ptr` or `method_name_len + method_name_ptr` or
+/// `arguments_len + arguments_ptr` or `amount_ptr + 16` points outside the memory of the guest
+/// or host returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Returns
+///
+/// Index of the new promise that uniquely identifies it within the current execution of the
+/// method.
+///
+/// # Cost
+///
+/// `promise_create` is a convenience wrapper around `promise_batch_create` and
+/// `promise_batch_action_function_call`. This means it charges the `base` cost twice.
+pub fn promise_create(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    account_id_len: u64,
+    account_id_ptr: u64,
+    method_name_len: u64,
+    method_name_ptr: u64,
+    arguments_len: u64,
+    arguments_ptr: u64,
+    amount_ptr: u64,
+    gas: u64,
+) -> Result<u64> {
+    let new_promise_idx = promise_batch_create(ctx, memory, account_id_len, account_id_ptr)?;
+    promise_batch_action_function_call(
+        ctx,
+        memory,
+        new_promise_idx,
+        method_name_len,
+        method_name_ptr,
+        arguments_len,
+        arguments_ptr,
+        amount_ptr,
+        gas,
+    )?;
+    Ok(new_promise_idx)
+}
+
+/// Attaches the callback that is executed after promise pointed by `promise_idx` is complete.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`;
+/// * If `account_id_len + account_id_ptr` or `method_name_len + method_name_ptr` or
+///   `arguments_len + arguments_ptr` or `amount_ptr + 16` points outside the memory of the
+///   guest or host returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Returns
+///
+/// Index of the new promise that uniquely identifies it within the current execution of the
+/// method.
+///
+/// # Cost
+///
+/// `promise_then` is a convenience wrapper around `promise_batch_then` and
+/// `promise_batch_action_function_call`. This means it charges the `base` cost twice.
+pub fn promise_then(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    account_id_len: u64,
+    account_id_ptr: u64,
+    method_name_len: u64,
+    method_name_ptr: u64,
+    arguments_len: u64,
+    arguments_ptr: u64,
+    amount_ptr: u64,
+    gas: u64,
+) -> Result<u64> {
+    let new_promise_idx =
+        promise_batch_then(ctx, memory, promise_idx, account_id_len, account_id_ptr)?;
+    promise_batch_action_function_call(
+        ctx,
+        memory,
+        new_promise_idx,
+        method_name_len,
+        method_name_ptr,
+        arguments_len,
+        arguments_ptr,
+        amount_ptr,
+        gas,
+    )?;
+    Ok(new_promise_idx)
+}
+
+/// Creates a new promise which completes when time all promises passed as arguments complete.
+/// Cannot be used with registers. `promise_idx_ptr` points to an array of `u64` elements, with
+/// `promise_idx_count` denoting the number of elements. The array contains indices of promises
+/// that need to be waited on jointly.
+///
+/// # Errors
+///
+/// * If `promise_ids_ptr + 8 * promise_idx_count` extend outside the guest memory returns
+///   `MemoryAccessViolation`;
+/// * If any of the promises in the array do not correspond to existing promises returns
+///   `InvalidPromiseIndex`.
+/// * If called as view function returns `ProhibitedInView`.
+/// * If the total number of receipt dependencies exceeds `max_number_input_data_dependencies`
+///   limit returns `NumInputDataDependenciesExceeded`.
+/// * If the total number of promises exceeds `max_promises_per_function_call_action` limit
+///   returns `NumPromisesExceeded`.
+///
+/// # Returns
+///
+/// Index of the new promise that uniquely identifies it within the current execution of the
+/// method.
+///
+/// # Cost
+///
+/// `base + promise_and_base + promise_and_per_promise * num_promises + cost of reading promise ids from memory`.
+pub fn promise_and(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx_ptr: u64,
+    promise_idx_count: u64,
+) -> Result<PromiseIndex> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView { method_name: "promise_and".to_string() }.into());
+    }
+    ctx.result_state.gas_counter.pay_base(promise_and_base)?;
+    let memory_len =
+        promise_idx_count.checked_mul(size_of::<u64>() as u64).ok_or(HostError::IntegerOverflow)?;
+    ctx.result_state.gas_counter.pay_per(promise_and_per_promise, memory_len)?;
+
+    // Read indices as little endian u64.
+    let promise_indices =
+        read_memory(&mut ctx.result_state.gas_counter, memory, promise_idx_ptr, memory_len)?;
+    let promise_indices = stdx::as_chunks_exact::<{ size_of::<u64>() }, u8>(&promise_indices)
+        .unwrap()
+        .into_iter()
+        .map(|bytes| u64::from_le_bytes(*bytes));
+
+    let mut receipt_dependencies = vec![];
+    for promise_idx in promise_indices {
+        let promise = ctx
+            .promises
+            .get(promise_idx as usize)
+            .ok_or(HostError::InvalidPromiseIndex { promise_idx })?;
+        match &promise {
+            Promise::Receipt(receipt_idx) => {
+                receipt_dependencies.push(*receipt_idx);
+            }
+            Promise::NotReceipt(receipt_indices) => {
+                receipt_dependencies.extend(receipt_indices.clone());
+            }
+        }
+        // Checking this in the loop to prevent abuse of too many joined vectors.
+        if receipt_dependencies.len() as u64
+            > ctx.config.limit_config.max_number_input_data_dependencies
+        {
+            return Err(HostError::NumberInputDataDependenciesExceeded {
+                number_of_input_data_dependencies: receipt_dependencies.len() as u64,
+                limit: ctx.config.limit_config.max_number_input_data_dependencies,
+            }
+            .into());
+        }
+    }
+    checked_push_promise(ctx, Promise::NotReceipt(receipt_dependencies))
+}
+
+/// Creates a new promise towards given `account_id` without any actions attached to it.
+///
+/// # Errors
+///
+/// * If `account_id_len + account_id_ptr` points outside the memory of the guest or host
+/// returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+/// * If the total number of promises exceeds `max_promises_per_function_call_action` limit
+///   returns `NumPromisesExceeded`.
+///
+/// # Returns
+///
+/// Index of the new promise that uniquely identifies it within the current execution of the
+/// method.
+///
+/// # Cost
+///
+/// `burnt_gas := base + cost of reading and decoding the account id + dispatch cost of the receipt`.
+/// `used_gas := burnt_gas + exec cost of the receipt`.
+pub fn promise_batch_create(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    account_id_len: u64,
+    account_id_ptr: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_create".to_string(),
+        }
+        .into());
+    }
+    let account_id = read_and_parse_account_id(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        &ctx.config,
+        account_id_ptr,
+        account_id_len,
+    )?;
+    let sir = account_id == ctx.context.current_account_id;
+    pay_gas_for_new_receipt(&mut ctx.result_state.gas_counter, &ctx.fees_config, sir, &[])?;
+    let new_receipt_idx = ctx.ext.create_action_receipt(vec![], account_id)?;
+
+    checked_push_promise(ctx, Promise::Receipt(new_receipt_idx))
+}
+
+/// Creates a new promise towards given `account_id` without any actions attached, that is
+/// executed after promise pointed by `promise_idx` is complete.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`;
+/// * If `account_id_len + account_id_ptr` points outside the memory of the guest or host
+/// returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+/// * If the total number of promises exceeds `max_promises_per_function_call_action` limit
+///   returns `NumPromisesExceeded`.
+///
+/// # Returns
+///
+/// Index of the new promise that uniquely identifies it within the current execution of the
+/// method.
+///
+/// # Cost
+///
+/// `base + cost of reading and decoding the account id + dispatch&execution cost of the receipt
+///  + dispatch&execution base cost for each data dependency`
+pub fn promise_batch_then(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    account_id_len: u64,
+    account_id_ptr: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(
+            HostError::ProhibitedInView { method_name: "promise_batch_then".to_string() }.into()
+        );
+    }
+    let account_id = read_and_parse_account_id(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        &ctx.config,
+        account_id_ptr,
+        account_id_len,
+    )?;
+    // Update the DAG and return new promise idx.
+    let promise = ctx
+        .promises
+        .get(promise_idx as usize)
+        .ok_or(HostError::InvalidPromiseIndex { promise_idx })?;
+    let receipt_dependencies = match &promise {
+        Promise::Receipt(receipt_idx) => vec![*receipt_idx],
+        Promise::NotReceipt(receipt_indices) => receipt_indices.clone(),
+    };
+
+    let sir = account_id == ctx.context.current_account_id;
+    let deps: Vec<_> = receipt_dependencies
+        .iter()
+        .map(|&receipt_idx| ctx.ext.get_receipt_receiver(receipt_idx) == &account_id)
+        .collect();
+    pay_gas_for_new_receipt(&mut ctx.result_state.gas_counter, &ctx.fees_config, sir, &deps)?;
+
+    let new_receipt_idx = ctx.ext.create_action_receipt(receipt_dependencies, account_id)?;
+
+    checked_push_promise(ctx, Promise::Receipt(new_receipt_idx))
+}
+
+/// Sets the `refund_to` field on the promise
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`;
+/// * If `account_id_len + account_id_ptr` points outside the memory of the guest or host
+/// returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `base + cost of reading and decoding the account id`
+pub fn promise_set_refund_to(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    account_id_len: u64,
+    account_id_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_set_refund_to".to_string(),
+        }
+        .into());
+    }
+    let refund_to = read_and_parse_account_id(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        &ctx.config,
+        account_id_ptr,
+        account_id_len,
+    )?;
+    let promise = ctx
+        .promises
+        .get(promise_idx as usize)
+        .ok_or(HostError::InvalidPromiseIndex { promise_idx })?;
+
+    let receipt_idx = match &promise {
+        Promise::Receipt(receipt_idx) => Ok(*receipt_idx),
+        Promise::NotReceipt(_) => Err(HostError::CannotSetRefundToOnJointPromise),
+    }?;
+
+    ctx.ext.set_refund_to(receipt_idx, refund_to);
+    Ok(())
+}
+
+/// Helper function to return the receipt index corresponding to the given promise index.
+/// It also pulls account ID for the given receipt and compares it with the current account ID
+/// to return whether the receipt's account ID is the same.
+fn promise_idx_to_receipt_idx_with_sir(
+    ctx: &Ctx,
+    promise_idx: u64,
+) -> Result<(ReceiptIndex, bool)> {
+    let promise = ctx
+        .promises
+        .get(promise_idx as usize)
+        .ok_or(HostError::InvalidPromiseIndex { promise_idx })?;
+    let receipt_idx = match &promise {
+        Promise::Receipt(receipt_idx) => Ok(*receipt_idx),
+        Promise::NotReceipt(_) => Err(HostError::CannotAppendActionToJointPromise),
+    }?;
+
+    let account_id = ctx.ext.get_receipt_receiver(receipt_idx);
+    let sir = account_id == &ctx.context.current_account_id;
+    Ok((receipt_idx, sir))
+}
+
+/// Appends `CreateAccount` action to the batch of actions for the given promise pointed by
+/// `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action fee`
+/// `used_gas := burnt_gas + exec action fee`
+pub fn promise_batch_action_create_account(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    promise_idx: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_create_account".to_string(),
+        }
+        .into());
+    }
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::create_account,
+        sir,
+    )?;
+
+    ctx.ext.append_action_create_account(receipt_idx);
+    Ok(())
+}
+
+/// Appends `DeployContract` action to the batch of actions for the given promise pointed by
+/// `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If `code_len + code_ptr` points outside the memory of the guest or host returns
+/// `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+/// * If the contract code length exceeds `max_contract_size` returns `ContractSizeExceeded`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_deploy_contract(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    code_len: u64,
+    code_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_deploy_contract".to_string(),
+        }
+        .into());
+    }
+    let code = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        code_ptr,
+        code_len,
+    )?;
+    let code_len = code.len() as u64;
+    let limit = ctx.config.limit_config.max_contract_size;
+    if code_len > limit {
+        return Err(HostError::ContractSizeExceeded { size: code_len, limit }.into());
+    }
+    let code = code.into();
+
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::deploy_contract_base,
+        sir,
+    )?;
+    pay_action_per_byte(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::deploy_contract_byte,
+        code_len,
+        sir,
+    )?;
+
+    ctx.ext.append_action_deploy_contract(receipt_idx, code);
+    Ok(())
+}
+
+/// Appends `DeployGlobalContract` action to the batch of actions for the given promise
+/// pointed by `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If `code_len + code_ptr` points outside the memory of the guest or host returns
+/// `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+/// * If the contract code length exceeds `max_contract_size` returns `ContractSizeExceeded`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_deploy_global_contract(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    code_len: u64,
+    code_ptr: u64,
+) -> Result<()> {
+    promise_batch_action_deploy_global_contract_impl(
+        ctx,
+        memory,
+        promise_idx,
+        code_len,
+        code_ptr,
+        GlobalContractDeployMode::CodeHash,
+        "promise_batch_action_deploy_global_contract",
+    )
+}
+
+/// Appends `DeployGlobalContractByAccountId` action to the batch of actions for the given
+/// promise pointed by `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If `code_len + code_ptr` points outside the memory of the guest or host returns
+/// `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+/// * If the contract code length exceeds `max_contract_size` returns `ContractSizeExceeded`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_deploy_global_contract_by_account_id(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    code_len: u64,
+    code_ptr: u64,
+) -> Result<()> {
+    promise_batch_action_deploy_global_contract_impl(
+        ctx,
+        memory,
+        promise_idx,
+        code_len,
+        code_ptr,
+        GlobalContractDeployMode::AccountId,
+        "promise_batch_action_deploy_global_contract_by_account_id",
+    )
+}
+
+fn promise_batch_action_deploy_global_contract_impl(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    code_len: u64,
+    code_ptr: u64,
+    mode: GlobalContractDeployMode,
+    method_name: &str,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView { method_name: method_name.to_owned() }.into());
+    }
+    let code = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        code_ptr,
+        code_len,
+    )?;
+    let code_len = code.len() as u64;
+    let limit = ctx.config.limit_config.max_contract_size;
+    if code_len > limit {
+        return Err(HostError::ContractSizeExceeded { size: code_len, limit }.into());
+    }
+    let code = code.into();
+
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::deploy_global_contract_base,
+        sir,
+    )?;
+    pay_action_per_byte(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::deploy_global_contract_byte,
+        code_len,
+        sir,
+    )?;
+
+    ctx.ext.append_action_deploy_global_contract(receipt_idx, code, mode);
+    Ok(())
+}
+
+/// Appends `UseGlobalContract` action to the batch of actions for the given promise
+/// pointed by `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If called as view function returns `ProhibitedInView`.
+/// * If `code_hash_len + code_hash_ptr` points outside the memory of the guest or host returns
+/// `MemoryAccessViolation`.
+/// * If a malformed code hash is passed, returns `ContractCodeHashMalformed`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_use_global_contract(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    code_hash_len: u64,
+    code_hash_ptr: u64,
+) -> Result<()> {
+    promise_batch_action_use_global_contract_impl(
+        ctx,
+        memory,
+        promise_idx,
+        GlobalContractIdentifierPtrData::CodeHash { code_hash_len, code_hash_ptr },
+        "promise_batch_action_use_global_contract",
+    )
+}
+
+/// Appends `UseGlobalContract` action to the batch of actions for the given promise
+/// pointed by `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If called as view function returns `ProhibitedInView`.
+/// * If `account_id_len + account_id_ptr` points outside the memory of the guest or host returns
+/// `MemoryAccessViolation`.
+/// * If account_id string is not UTF-8 returns `BadUtf8`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes
+/// + cost of reading vector from memory + cost of reading and parsing account name`
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_use_global_contract_by_account_id(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    account_id_len: u64,
+    account_id_ptr: u64,
+) -> Result<()> {
+    promise_batch_action_use_global_contract_impl(
+        ctx,
+        memory,
+        promise_idx,
+        GlobalContractIdentifierPtrData::AccountId { account_id_len, account_id_ptr },
+        "promise_batch_action_use_global_contract_by_account_id",
+    )
+}
+
+fn promise_batch_action_use_global_contract_impl(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    contract_id_ptr: GlobalContractIdentifierPtrData,
+    method_name: &str,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView { method_name: method_name.to_owned() }.into());
+    }
+    let contract_id = read_contract_id(contract_id_ptr, memory, ctx)?;
+
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::use_global_contract_base,
+        sir,
+    )?;
+    let len = contract_id.len() as u64;
+    pay_action_per_byte(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::use_global_contract_byte,
+        len,
+        sir,
+    )?;
+
+    ctx.ext.append_action_use_global_contract(receipt_idx, contract_id);
+    Ok(())
+}
+
+fn read_contract_id(
+    contract_id_ptr: GlobalContractIdentifierPtrData,
+    memory: &[u8],
+    ctx: &mut Ctx,
+) -> Result<GlobalContractIdentifier, VMLogicError> {
+    match contract_id_ptr {
+        GlobalContractIdentifierPtrData::CodeHash { code_hash_len, code_hash_ptr } => {
+            let code_hash_bytes = get_memory_or_register(
+                &mut ctx.result_state.gas_counter,
+                memory,
+                &ctx.registers,
+                code_hash_ptr,
+                code_hash_len,
+            )?;
+            let code_hash: [_; CryptoHash::LENGTH] =
+                (&*code_hash_bytes).try_into().map_err(|_| HostError::ContractCodeHashMalformed)?;
+            Ok(GlobalContractIdentifier::CodeHash(CryptoHash(code_hash)))
+        }
+        GlobalContractIdentifierPtrData::AccountId { account_id_len, account_id_ptr } => {
+            let account_id = read_and_parse_account_id(
+                &mut ctx.result_state.gas_counter,
+                memory,
+                &ctx.registers,
+                &ctx.config,
+                account_id_ptr,
+                account_id_len,
+            )?;
+            Ok(GlobalContractIdentifier::AccountId(account_id))
+        }
+    }
+}
+
+/// Appends `DeterministicStateInit` action to the batch of actions for the given promise
+/// pointed by `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns
+///   [`HostError::InvalidPromiseIndex`].
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns [`HostError::CannotAppendActionToJointPromise`].
+/// * If called as view function returns [`HostError::ProhibitedInView`].
+/// * If `code_hash_len + code_hash_ptr` or `amount_ptr + 16` points outside the memory of the
+/// guest or host returns [`HostError::MemoryAccessViolation`].
+///
+/// # Cost
+///
+/// `burnt_gas` := base + dispatch action base fee
+///             + cost of reading code from memory
+///             + cost of reading amount from memory
+///
+/// `used_gas`  := burnt_gas + exec action base fee
+pub fn promise_batch_action_state_init(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    code_hash_len: u64,
+    code_hash_ptr: u64,
+    amount_ptr: u64,
+) -> Result<u64> {
+    promise_batch_action_state_init_impl(
+        ctx,
+        memory,
+        promise_idx,
+        GlobalContractIdentifierPtrData::CodeHash { code_hash_len, code_hash_ptr },
+        amount_ptr,
+        "promise_batch_action_state_init",
+    )
+}
+
+/// Appends `DeterministicStateInit` action to the batch of actions for the given promise
+/// pointed by `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns
+///   [`HostError::InvalidPromiseIndex`].
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns [`HostError::CannotAppendActionToJointPromise`].
+/// * If called as view function returns [`HostError::ProhibitedInView`].
+/// * If `account_id_len + account_id_ptr` or `amount_ptr + 16` points outside the memory of the
+/// guest or host returns [`HostError::MemoryAccessViolation`].
+/// * If account_id string is not UTF-8 returns `BadUtf8`.
+///
+/// # Cost
+///
+/// `burnt_gas` := base + dispatch action base fee
+///             + cost of reading account id from memory
+///             + cost of decoding account_id as UTF-8
+///             + cost of reading amount from memory
+///
+/// `used_gas`  := burnt_gas + exec action base fee
+pub fn promise_batch_action_state_init_by_account_id(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    account_id_len: u64,
+    account_id_ptr: u64,
+    amount_ptr: u64,
+) -> Result<u64> {
+    promise_batch_action_state_init_impl(
+        ctx,
+        memory,
+        promise_idx,
+        GlobalContractIdentifierPtrData::AccountId { account_id_len, account_id_ptr },
+        amount_ptr,
+        "promise_batch_action_state_init_by_account_id",
+    )
+}
+
+fn promise_batch_action_state_init_impl(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    contract_id_ptr: GlobalContractIdentifierPtrData,
+    amount_ptr: u64,
+    method_name: &str,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView { method_name: method_name.to_owned() }.into());
+    }
+    let code = read_contract_id(contract_id_ptr, memory, ctx)?;
+    let amount =
+        Balance::from_yoctonear(get_u128(&mut ctx.result_state.gas_counter, memory, amount_ptr)?);
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::deterministic_state_init_base,
+        sir,
+    )?;
+    ctx.result_state.deduct_balance(amount)?;
+    Ok(ctx.ext.append_action_deterministic_state_init(receipt_idx, code, amount))
+}
+
+/// Appends a data entry to an existing `DeterministicStateInit` action.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns
+///   [`HostError::InvalidPromiseIndex`].
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+///   `promise_and` returns [`HostError::CannotAppendActionToJointPromise`].
+/// * If `action_idx` does not correspond to an existing action within the promise,
+///   returns [`HostError::InvalidActionIndex`].
+/// * If `key` has already been set returns [`HostError::DataEntryAlreadyExists`].
+/// * If called as view function returns [`HostError::ProhibitedInView`].
+///
+/// # Cost
+///
+/// `burnt_gas` := base +
+///             + deterministic_state_init_entry send fee
+///             + deterministic_state_init_byte send fee * (key_len + value_len)
+///             + cost of reading account id from memory
+///             + cost of decoding account_id as UTF-8
+///             + cost of reading amount from memory
+///
+/// `used_gas`  := burnt_gas +
+///             + deterministic_state_init_entry exec fee
+///             + deterministic_state_init_byte exec fee * (key_len + value_len)
+pub fn set_state_init_data_entry(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    action_index: u64,
+    key_len: u64,
+    key_ptr: u64,
+    value_len: u64,
+    value_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "set_state_init_data_entry".to_string(),
+        }
+        .into());
+    }
+
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+    let key = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        key_ptr,
+        key_len,
+    )?;
+    let key = key.to_vec();
+    let value = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+    let value = value.to_vec();
+
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::deterministic_state_init_entry,
+        sir,
+    )?;
+    let bytes =
+        (key.len() as u64).checked_add(value.len() as u64).ok_or(HostError::IntegerOverflow)?;
+    pay_action_per_byte(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::deterministic_state_init_byte,
+        bytes,
+        sir,
+    )?;
+
+    ctx.ext.set_deterministic_state_init_data_entry(receipt_idx, action_index, key, value)?;
+
+    Ok(())
+}
+
+/// Appends `FunctionCall` action to the batch of actions for the given promise pointed by
+/// `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If `method_name_len + method_name_ptr` or `arguments_len + arguments_ptr` or
+/// `amount_ptr + 16` points outside the memory of the guest or host returns
+/// `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory
+///  + cost of reading u128, method_name and arguments from the memory`
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_function_call(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    method_name_len: u64,
+    method_name_ptr: u64,
+    arguments_len: u64,
+    arguments_ptr: u64,
+    amount_ptr: u64,
+    gas: u64,
+) -> Result<()> {
+    promise_batch_action_function_call_weight(
+        ctx,
+        memory,
+        promise_idx,
+        method_name_len,
+        method_name_ptr,
+        arguments_len,
+        arguments_ptr,
+        amount_ptr,
+        gas,
+        0,
+    )
+}
+
+/// Appends `FunctionCall` action to the batch of actions for the given promise pointed by
+/// `promise_idx`. This function allows not specifying a specific gas value and allowing the
+/// runtime to assign remaining gas based on a weight.
+///
+/// # Gas
+///
+/// Gas can be specified using a static amount, a weight of remaining prepaid gas, or a mixture
+/// of both. To omit a static gas amount, `0` can be passed for the `gas` parameter.
+/// To omit assigning remaining gas, `0` can be passed as the `gas_weight` parameter.
+///
+/// The gas weight parameter works as the following:
+///
+/// All unused prepaid gas from the current function call is split among all function calls
+/// which supply this gas weight. The amount attached to each respective call depends on the
+/// value of the weight.
+///
+/// For example, if 40 gas is leftover from the current method call and three functions specify
+/// the weights 1, 5, 2 then 5, 25, 10 gas will be added to each function call respectively,
+/// using up all remaining available gas.
+///
+/// If the `gas_weight` parameter is set as a large value, the amount of distributed gas
+/// to each action can be 0 or a very low value because the amount of gas per weight is
+/// based on the floor division of the amount of gas by the sum of weights.
+///
+/// Any remaining gas will be distributed to the last scheduled function call with a weight
+/// specified.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If `method_name_len + method_name_ptr` or `arguments_len + arguments_ptr` or
+/// `amount_ptr + 16` points outside the memory of the guest or host returns
+/// `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+pub fn promise_batch_action_function_call_weight(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    method_name_len: u64,
+    method_name_ptr: u64,
+    arguments_len: u64,
+    arguments_ptr: u64,
+    amount_ptr: u64,
+    gas: u64,
+    gas_weight: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_function_call".to_string(),
+        }
+        .into());
+    }
+    let amount =
+        Balance::from_yoctonear(get_u128(&mut ctx.result_state.gas_counter, memory, amount_ptr)?);
+    let method_name = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        method_name_ptr,
+        method_name_len,
+    )?;
+    if method_name.is_empty() {
+        return Err(HostError::EmptyMethodName.into());
+    }
+    let arguments = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        arguments_ptr,
+        arguments_len,
+    )?;
+
+    let method_name = method_name.to_owned();
+    let arguments = arguments.to_owned();
+
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    // Input can't be large enough to overflow
+    let num_bytes = method_name.len() as u64 + arguments.len() as u64;
+
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::function_call_base,
+        sir,
+    )?;
+    pay_action_per_byte(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::function_call_byte,
+        num_bytes,
+        sir,
+    )?;
+    // Prepaid gas
+    ctx.result_state.gas_counter.prepay_gas(Gas::from_gas(gas))?;
+    // Allow attaching exactly 1 yoctoNEAR to a promise function call
+    // when the contract has zero balance. This lets deterministic accounts
+    // call functions like ft_transfer_call that require an attached deposit
+    // without needing to be seeded with balance first.
+    let skip_deduct = amount == Balance::from_yoctonear(1)
+        && ctx.config.one_yocto_on_promise
+        && ctx.result_state.current_account_balance.is_zero();
+    if skip_deduct {
+        ctx.result_state.subsidized_amount = ctx
+            .result_state
+            .subsidized_amount
+            .checked_add(amount)
+            .expect("subsidized_amount overflow");
+    } else {
+        ctx.result_state.deduct_balance(amount)?;
+    }
+    ctx.ext.append_action_function_call_weight(
+        receipt_idx,
+        method_name,
+        arguments,
+        amount,
+        Gas::from_gas(gas),
+        GasWeight(gas_weight),
+    )
+}
+
+/// Appends `Transfer` action to the batch of actions for the given promise pointed by
+/// `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If `amount_ptr + 16` points outside the memory of the guest or host returns
+/// `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading u128 from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_transfer(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    amount_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_transfer".to_string(),
+        }
+        .into());
+    }
+    let amount =
+        Balance::from_yoctonear(get_u128(&mut ctx.result_state.gas_counter, memory, amount_ptr)?);
+
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+    let receiver_id = ctx.ext.get_receipt_receiver(receipt_idx);
+    let send_fee = transfer_send_fee(
+        &ctx.fees_config,
+        sir,
+        ctx.config.eth_implicit_accounts,
+        receiver_id.get_account_type(),
+    );
+    let exec_fee = transfer_exec_fee(
+        &ctx.fees_config,
+        ctx.config.eth_implicit_accounts,
+        receiver_id.get_account_type(),
+    );
+    let burn_gas = send_fee;
+    let use_gas = burn_gas.checked_add(exec_fee).ok_or(HostError::IntegerOverflow)?;
+    ctx.result_state.gas_counter.pay_action_accumulated(
+        burn_gas,
+        use_gas,
+        ActionCosts::transfer,
+    )?;
+    ctx.result_state.deduct_balance(amount)?;
+    ctx.ext.append_action_transfer(receipt_idx, amount);
+    Ok(())
+}
+
+/// Appends `TransferToGasKey` action to the batch of actions for the given promise pointed by
+/// `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If the given public key is not a valid (e.g. wrong length) returns `InvalidPublicKey`.
+/// * If `amount_ptr + 16` or `public_key_len + public_key_ptr` points outside the memory of the
+/// guest or host returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key and u128 from memory`
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_transfer_to_gas_key(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+    amount_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_transfer_to_gas_key".to_string(),
+        }
+        .into());
+    }
+    let public_key = get_public_key(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        public_key_ptr,
+        public_key_len,
+    )?;
+    let amount =
+        Balance::from_yoctonear(get_u128(&mut ctx.result_state.gas_counter, memory, amount_ptr)?);
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+    let receiver_id = ctx.ext.get_receipt_receiver(receipt_idx);
+    let send = gas_key_transfer_send_fee(&ctx.fees_config, sir, public_key_len as usize);
+    let exec =
+        gas_key_transfer_exec_fee(&ctx.fees_config, receiver_id.len(), public_key_len as usize);
+    let burn_base = send.base;
+    let use_base = burn_base.checked_add(exec.base).ok_or(HostError::IntegerOverflow)?;
+    ctx.result_state.gas_counter.pay_action_accumulated(
+        burn_base,
+        use_base,
+        ActionCosts::gas_key_transfer_base,
+    )?;
+    let burn_byte = send.per_byte;
+    let use_byte = burn_byte.checked_add(exec.per_byte).ok_or(HostError::IntegerOverflow)?;
+    ctx.result_state.gas_counter.pay_action_accumulated(
+        burn_byte,
+        use_byte,
+        ActionCosts::gas_key_byte,
+    )?;
+    ctx.result_state.deduct_balance(amount)?;
+    ctx.ext.append_action_transfer_to_gas_key(receipt_idx, public_key.decode()?, amount);
+    Ok(())
+}
+
+/// Appends `AddKey` action to the batch of actions for the given promise pointed by
+/// `promise_idx`. The access key will have `GasKeyFullAccess` permission.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If the given public key is not a valid (e.g. wrong length) returns `InvalidPublicKey`.
+/// * If `public_key_len + public_key_ptr` points outside the memory of the guest or host
+/// returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key from memory + gas key send fee`
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes + gas key exec fee`
+pub fn promise_batch_action_add_gas_key_with_full_access(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+    num_nonces: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_add_gas_key_with_full_access".to_string(),
+        }
+        .into());
+    }
+    let public_key = get_public_key(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        public_key_ptr,
+        public_key_len,
+    )?;
+    let num_nonces = u16::try_from(num_nonces).map_err(|_| HostError::IntegerOverflow)?;
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::add_full_access_key,
+        sir,
+    )?;
+    let receiver_id = ctx.ext.get_receipt_receiver(receipt_idx);
+    let send_fee = gas_key_add_key_send_fee(&ctx.fees_config, sir);
+    let exec_fee = gas_key_add_key_exec_fee(
+        &ctx.fees_config,
+        receiver_id.len(),
+        public_key_len as usize,
+        num_nonces,
+    );
+    ctx.result_state.gas_counter.pay_gas_key_add_key_fees(send_fee, &exec_fee)?;
+    ctx.ext.append_action_add_gas_key_with_full_access(
+        receipt_idx,
+        public_key.decode()?,
+        num_nonces,
+    );
+    Ok(())
+}
+
+/// Appends `AddKey` action to the batch of actions for the given promise pointed by
+/// `promise_idx`. The access key will have `GasKeyFunctionCall` permission.
+///
+/// The `method_names` parameter is a comma-separated list of method names that the gas key
+/// is allowed to call.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If the given public key is not a valid (e.g. wrong length) returns `InvalidPublicKey`.
+/// * If `public_key_len + public_key_ptr`, `allowance_ptr + 16`,
+/// `receiver_id_len + receiver_id_ptr` or `method_names_len + method_names_ptr` points outside
+/// the memory of the guest or host returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory
+///  + cost of reading u128, method_names and public key from the memory + cost of reading and parsing account name + gas key send fee`
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes + gas key exec fee`
+pub fn promise_batch_action_add_gas_key_with_function_call(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+    num_nonces: u64,
+    allowance_ptr: u64,
+    receiver_id_len: u64,
+    receiver_id_ptr: u64,
+    method_names_len: u64,
+    method_names_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_add_gas_key_with_function_call".to_string(),
+        }
+        .into());
+    }
+    let public_key = get_public_key(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        public_key_ptr,
+        public_key_len,
+    )?;
+    let num_nonces = u16::try_from(num_nonces).map_err(|_| HostError::IntegerOverflow)?;
+    let allowance = Balance::from_yoctonear(get_u128(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        allowance_ptr,
+    )?);
+    let allowance = if allowance > Balance::ZERO { Some(allowance) } else { None };
+    let receiver_id = read_and_parse_account_id(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        &ctx.config,
+        receiver_id_ptr,
+        receiver_id_len,
+    )?;
+    let raw_method_names = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        method_names_ptr,
+        method_names_len,
+    )?;
+    let method_names = split_method_names(&raw_method_names)?;
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+    let num_bytes = null_terminated_method_names_len(&method_names);
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::add_function_call_key_base,
+        sir,
+    )?;
+    pay_action_per_byte(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::add_function_call_key_byte,
+        num_bytes,
+        sir,
+    )?;
+    let receipt_receiver_id = ctx.ext.get_receipt_receiver(receipt_idx);
+    let send_fee = gas_key_add_key_send_fee(&ctx.fees_config, sir);
+    let exec_fee = gas_key_add_key_exec_fee(
+        &ctx.fees_config,
+        receipt_receiver_id.len(),
+        public_key_len as usize,
+        num_nonces,
+    );
+    ctx.result_state.gas_counter.pay_gas_key_add_key_fees(send_fee, &exec_fee)?;
+    ctx.ext.append_action_add_gas_key_with_function_call(
+        receipt_idx,
+        public_key.decode()?,
+        num_nonces,
+        allowance,
+        receiver_id,
+        method_names,
+    )?;
+    Ok(())
+}
+
+/// Appends `Stake` action to the batch of actions for the given promise pointed by
+/// `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If the given public key is not a valid (e.g. wrong length) returns `InvalidPublicKey`.
+/// * If `amount_ptr + 16` or `public_key_len + public_key_ptr` points outside the memory of the
+/// guest or host returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_stake(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    amount_ptr: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_stake".to_string(),
+        }
+        .into());
+    }
+    let amount =
+        Balance::from_yoctonear(get_u128(&mut ctx.result_state.gas_counter, memory, amount_ptr)?);
+    let public_key = get_public_key(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        public_key_ptr,
+        public_key_len,
+    )?;
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    pay_action_base(&mut ctx.result_state.gas_counter, &ctx.fees_config, ActionCosts::stake, sir)?;
+    ctx.ext.append_action_stake(receipt_idx, amount, public_key.decode()?);
+    Ok(())
+}
+
+/// Appends `AddKey` action to the batch of actions for the given promise pointed by
+/// `promise_idx`. The access key will have `FullAccess` permission.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If the given public key is not a valid (e.g. wrong length) returns `InvalidPublicKey`.
+/// * If `public_key_len + public_key_ptr` points outside the memory of the guest or host
+/// returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_add_key_with_full_access(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+    nonce: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_add_key_with_full_access".to_string(),
+        }
+        .into());
+    }
+    let public_key = get_public_key(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        public_key_ptr,
+        public_key_len,
+    )?;
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::add_full_access_key,
+        sir,
+    )?;
+    ctx.ext.append_action_add_key_with_full_access(receipt_idx, public_key.decode()?, nonce);
+    Ok(())
+}
+
+/// Appends `AddKey` action to the batch of actions for the given promise pointed by
+/// `promise_idx`. The access key will have `FunctionCall` permission.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If the given public key is not a valid (e.g. wrong length) returns `InvalidPublicKey`.
+/// * If `public_key_len + public_key_ptr`, `allowance_ptr + 16`,
+/// `receiver_id_len + receiver_id_ptr` or `method_names_len + method_names_ptr` points outside
+/// the memory of the guest or host returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading vector from memory
+///  + cost of reading u128, method_names and public key from the memory + cost of reading and parsing account name`
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_add_key_with_function_call(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+    nonce: u64,
+    allowance_ptr: u64,
+    receiver_id_len: u64,
+    receiver_id_ptr: u64,
+    method_names_len: u64,
+    method_names_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_add_key_with_function_call".to_string(),
+        }
+        .into());
+    }
+    let public_key = get_public_key(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        public_key_ptr,
+        public_key_len,
+    )?;
+    let allowance = Balance::from_yoctonear(get_u128(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        allowance_ptr,
+    )?);
+    let allowance = if allowance > Balance::ZERO { Some(allowance) } else { None };
+    let receiver_id = read_and_parse_account_id(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        &ctx.config,
+        receiver_id_ptr,
+        receiver_id_len,
+    )?;
+    let raw_method_names = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        method_names_ptr,
+        method_names_len,
+    )?;
+    let method_names = split_method_names(&raw_method_names)?;
+
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    let num_bytes = null_terminated_method_names_len(&method_names);
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::add_function_call_key_base,
+        sir,
+    )?;
+    pay_action_per_byte(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::add_function_call_key_byte,
+        num_bytes,
+        sir,
+    )?;
+
+    ctx.ext.append_action_add_key_with_function_call(
+        receipt_idx,
+        public_key.decode()?,
+        nonce,
+        allowance,
+        receiver_id,
+        method_names,
+    )?;
+    Ok(())
+}
+
+/// Appends `DeleteKey` action to the batch of actions for the given promise pointed by
+/// `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If the given public key is not a valid (e.g. wrong length) returns `InvalidPublicKey`.
+/// * If `public_key_len + public_key_ptr` points outside the memory of the guest or host
+/// returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading public key from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes`
+pub fn promise_batch_action_delete_key(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_delete_key".to_string(),
+        }
+        .into());
+    }
+    let public_key = get_public_key(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        public_key_ptr,
+        public_key_len,
+    )?;
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::delete_key,
+        sir,
+    )?;
+    ctx.ext.append_action_delete_key(receipt_idx, public_key.decode()?);
+    Ok(())
+}
+
+/// Appends `DeleteAccount` action to the batch of actions for the given promise pointed by
+/// `promise_idx`.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If the promise pointed by the `promise_idx` is an ephemeral promise created by
+/// `promise_and` returns `CannotAppendActionToJointPromise`.
+/// * If `beneficiary_id_len + beneficiary_id_ptr` points outside the memory of the guest or
+/// host returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `burnt_gas := base + dispatch action base fee + dispatch action per byte fee * num bytes + cost of reading and parsing account id from memory `
+/// `used_gas := burnt_gas + exec action base fee + exec action per byte fee * num bytes + fees for transferring funds to the beneficiary`
+pub fn promise_batch_action_delete_account(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    promise_idx: u64,
+    beneficiary_id_len: u64,
+    beneficiary_id_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_batch_action_delete_account".to_string(),
+        }
+        .into());
+    }
+    let beneficiary_id = read_and_parse_account_id(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        &ctx.config,
+        beneficiary_id_ptr,
+        beneficiary_id_len,
+    )?;
+
+    let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
+
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::delete_account,
+        sir,
+    )?;
+
+    ctx.ext.append_action_delete_account(receipt_idx, beneficiary_id);
+    Ok(())
+}
+
+/// Creates a promise that will execute a method on the current account with given arguments
+/// and gas. The created promise will have a special input data dependency.
+///
+/// A resumption token is written by this function into the register denoted by `register_id`.
+/// To satisfy the data dependency, call `promise_yield_resume` with the resumption token
+/// and a payload. The provided method will then be executed with input
+/// `PromiseResult::Successful(payload)`.
+///
+/// The resumption token is portable across transactions, but only the current account
+/// is allowed to resolve this data dependency.
+///
+/// If `promise_yield_resume` has not been called after a certain protocol-defined number of
+/// of blocks (as defined by the `yield_timeout_length_in_blocks` parameter) the created
+/// promise will instead be executed with input `PromiseResult::Failed`.
+///
+/// # Errors
+///
+/// * If `method_name_len + method_name_ptr` or `arguments_len + arguments_ptr` point outside
+/// the memory of the guest or host returns `MemoryAccessViolation`;
+/// * If called as view function returns `ProhibitedInView`;
+/// * Gas is insufficient;
+/// * Too many promises have been created already;
+/// * Resumption token cannot be written to the register `register_id`.
+///
+/// # Returns
+///
+/// Index of the new promise that uniquely identifies it within the current execution of the
+/// method.
+///
+/// # Cost
+///
+/// The following fees are charged:
+///
+/// * `base` fee;
+/// * `yield_create_base` fee;
+/// * `yield_create_byte` for each byte of `method_name` and `arguments`;
+/// * Fees for reading the `method_name` and `arguments`;
+/// * Fees for writing the Data ID to the output register;
+/// * Fees for setting up the receipt and the eventual function call of the method.
+pub fn promise_yield_create(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    method_name_len: u64,
+    method_name_ptr: u64,
+    arguments_len: u64,
+    arguments_ptr: u64,
+    gas: u64,
+    gas_weight: u64,
+    register_id: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_yield_create".to_string(),
+        }
+        .into());
+    }
+    ctx.result_state.gas_counter.pay_base(yield_create_base)?;
+
+    let method_name = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        method_name_ptr,
+        method_name_len,
+    )?;
+    if method_name.is_empty() {
+        return Err(HostError::EmptyMethodName.into());
+    }
+    let arguments = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        arguments_ptr,
+        arguments_len,
+    )?;
+    let method_name = method_name.to_owned();
+    let arguments = arguments.to_owned();
+
+    // Input can't be large enough to overflow, WebAssembly address space is 32-bits.
+    let num_bytes = method_name.len() as u64 + arguments.len() as u64;
+    ctx.result_state.gas_counter.pay_per(yield_create_byte, num_bytes)?;
+    // Prepay gas for the callback so that it cannot be used for this execution any longer.
+    ctx.result_state.gas_counter.prepay_gas(Gas::from_gas(gas))?;
+
+    // Here we are creating a receipt with a single data dependency which will then be
+    // resolved by the resume call.
+    pay_gas_for_new_receipt(&mut ctx.result_state.gas_counter, &ctx.fees_config, true, &[true])?;
+    let (new_receipt_idx, data_id) =
+        ctx.ext.create_promise_yield_receipt(ctx.context.current_account_id.clone())?;
+
+    let new_promise_idx = checked_push_promise(ctx, Promise::Receipt(new_receipt_idx))?;
+    pay_action_base(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::function_call_base,
+        true,
+    )?;
+    pay_action_per_byte(
+        &mut ctx.result_state.gas_counter,
+        &ctx.fees_config,
+        ActionCosts::function_call_byte,
+        num_bytes,
+        true,
+    )?;
+    ctx.ext.append_action_function_call_weight(
+        new_receipt_idx,
+        method_name,
+        arguments,
+        Balance::ZERO,
+        Gas::from_gas(gas),
+        GasWeight(gas_weight),
+    )?;
+
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        *data_id.as_bytes(),
+    )?;
+    Ok(new_promise_idx)
+}
+
+/// Submits the data for a yield promise which is awaiting its value.
+///
+/// The `data_id` pair of parameters must refer to a resumption token generated by a call to
+/// the [`promise_yield_create`] made by the same account.
+///
+/// Returns `1` if submitting the payload for the data dependency was successful. This
+/// guarantees that the yield callback function will be executed with a payload. Otherwise a
+/// `0` is returned.
+///
+/// # Errors
+///
+/// * If `data_id_ptr + data_id_ptr` points outside the memory of the guest or host
+/// returns `MemoryAccessViolation`;
+/// * If a malformed data id is passed, returns `DataIdMalformed`;
+/// * If `payload_len` exceeds the maximum permitted returns `YieldPayloadLength`;
+/// * If called as view function returns `ProhibitedInView`;
+/// * Runs out of gas.
+///
+/// # Cost
+///
+/// The following fees are charged:
+///
+/// * `base` fee;
+/// * `yield_resume_base` fee;
+/// * `yield_resume_byte` for each byte of `payload`;
+/// * Fees for reading the `data_id` and `payload`.
+pub fn promise_yield_resume(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    data_id_len: u64,
+    data_id_ptr: u64,
+    payload_len: u64,
+    payload_ptr: u64,
+) -> Result<u32, VMLogicError> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_yield_resume".to_string(),
+        }
+        .into());
+    }
+    ctx.result_state.gas_counter.pay_base(yield_resume_base)?;
+    ctx.result_state.gas_counter.pay_per(yield_resume_byte, payload_len)?;
+    let data_id = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        data_id_ptr,
+        data_id_len,
+    )?;
+    let payload = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        payload_ptr,
+        payload_len,
+    )?;
+    let payload_len = payload.len() as u64;
+    if payload_len > ctx.config.limit_config.max_yield_payload_size {
+        return Err(HostError::YieldPayloadLength {
+            length: payload_len,
+            limit: ctx.config.limit_config.max_yield_payload_size,
+        }
+        .into());
+    }
+
+    let data_id: [_; CryptoHash::LENGTH] =
+        (&*data_id).try_into().map_err(|_| HostError::DataIdMalformed)?;
+    let data_id = CryptoHash(data_id);
+    let payload = payload.into();
+    ctx.ext.submit_promise_resume_data(data_id, payload).map(u32::from)
+}
+
+/// If the current function is invoked by a callback we can access the execution results of the
+/// promises that caused the callback. This function returns the number of complete and
+/// incomplete callbacks.
+///
+/// Note, we are only going to have incomplete callbacks once we have promise_or combinator.
+///
+///
+/// * If there is only one callback returns `1`;
+/// * If there are multiple callbacks (e.g. created through `promise_and`) returns their number;
+/// * If the function was called not through the callback returns `0`.
+///
+/// # Cost
+///
+/// `base`
+pub fn promise_results_count(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_results_count".to_string(),
+        }
+        .into());
+    }
+    Ok(ctx.context.promise_results.len() as _)
+}
+
+/// If the current function is invoked by a callback we can access the execution results of the
+/// promises that caused the callback. This function returns the result in blob format and
+/// places it into the register.
+///
+/// * If promise result is complete and successful copies its blob into the register;
+/// * If promise result is complete and failed or incomplete keeps register unused;
+///
+/// # Returns
+///
+/// * If promise result is not complete returns `0`;
+/// * If promise result is complete and successful returns `1`;
+/// * If promise result is complete and failed returns `2`.
+///
+/// # Errors
+///
+/// * If `result_id` does not correspond to an existing result returns `InvalidPromiseResultIndex`;
+/// * If copying the blob exhausts the memory limit it returns `MemoryAccessViolation`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `base + cost of writing data into a register`
+pub fn promise_result(
+    ctx: &mut Ctx,
+    _memory: &mut [u8],
+    result_idx: u64,
+    register_id: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(
+            HostError::ProhibitedInView { method_name: "promise_result".to_string() }.into()
+        );
+    }
+    match ctx
+        .context
+        .promise_results
+        .get(result_idx as usize)
+        .ok_or(HostError::InvalidPromiseResultIndex { result_idx })?
+    {
+        PromiseResult::NotReady => Ok(0),
+        PromiseResult::Successful(data) => {
+            let charge_bytes_gas = !ctx.config.deterministic_account_ids;
+            ctx.registers.set_rc_data(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                Rc::clone(data),
+                charge_bytes_gas,
+            )?;
+            Ok(1)
+        }
+        PromiseResult::Failed => Ok(2),
+    }
+}
+
+/// When promise `promise_idx` finishes executing its result is considered to be the result of
+/// the current function.
+///
+/// # Errors
+///
+/// * If `promise_idx` does not correspond to an existing promise returns `InvalidPromiseIndex`.
+/// * If called as view function returns `ProhibitedInView`.
+///
+/// # Cost
+///
+/// `base + promise_return`
+pub fn promise_return(ctx: &mut Ctx, _memory: &mut [u8], promise_idx: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    ctx.result_state.gas_counter.pay_base(ExtCosts::promise_return)?;
+    if ctx.context.is_view() {
+        return Err(
+            HostError::ProhibitedInView { method_name: "promise_return".to_string() }.into()
+        );
+    }
+    match ctx
+        .promises
+        .get(promise_idx as usize)
+        .ok_or(HostError::InvalidPromiseIndex { promise_idx })?
+    {
+        Promise::Receipt(receipt_idx) => {
+            ctx.result_state.return_data = ReturnData::ReceiptIndex(*receipt_idx);
+            Ok(())
+        }
+        Promise::NotReceipt(_) => Err(HostError::CannotReturnJointPromise.into()),
+    }
+}
+
+// #####################
+// # Miscellaneous API #
+// #####################
+
+/// Sets the blob of data as the return value of the contract.
+///
+/// # Errors
+///
+/// * If `value_len + value_ptr` exceeds the memory container or points to an unused register it
+///   returns `MemoryAccessViolation`.
+/// * if the length of the returned data exceeds `max_length_returned_data` returns
+///   `ReturnedValueLengthExceeded`.
+///
+/// # Cost
+/// `base + cost of reading return value from memory or register + dispatch&exec cost per byte of the data sent * num data receivers`
+pub fn value_return(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    value_len: u64,
+    value_ptr: u64,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    let return_val = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+    let mut burn_gas: Gas = Gas::ZERO;
+    let num_bytes = return_val.len() as u64;
+    if num_bytes > ctx.config.limit_config.max_length_returned_data {
+        return Err(HostError::ReturnedValueLengthExceeded {
+            length: num_bytes,
+            limit: ctx.config.limit_config.max_length_returned_data,
+        }
+        .into());
+    }
+    for data_receiver in &ctx.context.output_data_receivers {
+        let sir = data_receiver == &ctx.context.current_account_id;
+        // We deduct for execution here too, because if we later have an OR combinator
+        // for promises then we might have some valid data receipts that arrive too late
+        // to be picked up by the execution that waits on them (because it has started
+        // after it receives the first data receipt) and then we need to issue a special
+        // refund in this situation. Which we avoid by just paying for execution of
+        // data receipt that might not be performed.
+        // The gas here is considered burnt, cause we'll prepay for it upfront.
+        burn_gas = burn_gas
+            .checked_add(
+                ctx.fees_config
+                    .fee(ActionCosts::new_data_receipt_byte)
+                    .send_fee(sir)
+                    .checked_add(ctx.fees_config.fee(ActionCosts::new_data_receipt_byte).exec_fee())
+                    .ok_or(HostError::IntegerOverflow)?
+                    .checked_mul(num_bytes)
+                    .ok_or(HostError::IntegerOverflow)?,
+            )
+            .ok_or(HostError::IntegerOverflow)?;
+    }
+    ctx.result_state.gas_counter.pay_action_accumulated(
+        burn_gas,
+        burn_gas,
+        ActionCosts::new_data_receipt_byte,
+    )?;
+    ctx.result_state.return_data = ReturnData::Value(return_val.into());
+    Ok(())
+}
+
+/// Terminates the execution of the program with panic `GuestPanic`.
+///
+/// # Cost
+///
+/// `base`
+pub fn panic(ctx: &mut Ctx, _memory: &mut [u8]) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    Err(HostError::GuestPanic { panic_msg: "explicit guest panic".to_string() }.into())
+}
+
+/// Guest panics with the UTF-8 encoded string.
+/// If `len == u64::MAX` then treats the string as null-terminated with character `'\0'`.
+///
+/// # Errors
+///
+/// * If string extends outside the memory of the guest with `MemoryAccessViolation`;
+/// * If string is not UTF-8 returns `BadUtf8`.
+/// * If string is longer than `max_log_len` returns `TotalLogLengthExceeded`.
+///
+/// # Cost
+/// `base + cost of reading and decoding a utf8 string`
+pub fn panic_utf8(ctx: &mut Ctx, memory: &mut [u8], len: u64, ptr: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    Err(HostError::GuestPanic {
+        panic_msg: get_utf8_string(&mut ctx.result_state, memory, len, ptr)?,
+    }
+    .into())
+}
+
+/// Logs the UTF-8 encoded string.
+/// If `len == u64::MAX` then treats the string as null-terminated with character `'\0'`.
+///
+/// # Errors
+///
+/// * If string extends outside the memory of the guest with `MemoryAccessViolation`;
+/// * If string is not UTF-8 returns `BadUtf8`.
+/// * If number of bytes read + `total_log_length` exceeds the `max_total_log_length` returns
+///   `TotalLogLengthExceeded`.
+/// * If the total number of logs will exceed the `max_number_logs` returns
+///   `NumberOfLogsExceeded`.
+///
+/// # Cost
+///
+/// `base + log_base + log_byte + num_bytes + utf8 decoding cost`
+pub fn log_utf8(ctx: &mut Ctx, memory: &mut [u8], len: u64, ptr: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    ctx.result_state.check_can_add_a_log_message()?;
+    let message = get_utf8_string(&mut ctx.result_state, memory, len, ptr)?;
+    ctx.result_state.gas_counter.pay_base(log_base)?;
+    ctx.result_state.gas_counter.pay_per(log_byte, message.len() as u64)?;
+    ctx.result_state.checked_push_log(message)
+}
+
+/// Logs the UTF-16 encoded string. If `len == u64::MAX` then treats the string as
+/// null-terminated with two-byte sequence of `0x00 0x00`.
+///
+/// # Errors
+///
+/// * If string extends outside the memory of the guest with `MemoryAccessViolation`;
+/// * If string is not UTF-16 returns `BadUtf16`.
+/// * If number of bytes read + `total_log_length` exceeds the `max_total_log_length` returns
+///   `TotalLogLengthExceeded`.
+/// * If the total number of logs will exceed the `max_number_logs` returns
+///   `NumberOfLogsExceeded`.
+///
+/// # Cost
+///
+/// `base + log_base + log_byte * num_bytes + utf16 decoding cost`
+pub fn log_utf16(ctx: &mut Ctx, memory: &mut [u8], len: u64, ptr: u64) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    ctx.result_state.check_can_add_a_log_message()?;
+    let message = get_utf16_string(&mut ctx.result_state, memory, len, ptr)?;
+    ctx.result_state.gas_counter.pay_base(log_base)?;
+    // Let's not use `encode_utf16` for gas per byte here, since it's a lot of compute.
+    ctx.result_state.gas_counter.pay_per(log_byte, message.len() as u64)?;
+    ctx.result_state.checked_push_log(message)
+}
+
+/// Special import kept for compatibility with AssemblyScript contracts. Not called by smart
+/// contracts directly, but instead called by the code generated by AssemblyScript.
+///
+/// # Errors
+///
+/// * If string extends outside the memory of the guest with `MemoryAccessViolation`;
+/// * If string is not UTF-8 returns `BadUtf8`.
+/// * If number of bytes read + `total_log_length` exceeds the `max_total_log_length` returns
+///   `TotalLogLengthExceeded`.
+/// * If the total number of logs will exceed the `max_number_logs` returns
+///   `NumberOfLogsExceeded`.
+///
+/// # Cost
+///
+/// `base +  log_base + log_byte * num_bytes + utf16 decoding cost`
+pub fn abort(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    msg_ptr: u32,
+    filename_ptr: u32,
+    line: u32,
+    col: u32,
+) -> Result<()> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if msg_ptr < 4 || filename_ptr < 4 {
+        return Err(HostError::BadUTF16.into());
+    }
+    ctx.result_state.check_can_add_a_log_message()?;
+
+    // Underflow checked above.
+    let msg_len = get_u32(&mut ctx.result_state.gas_counter, memory, (msg_ptr - 4) as u64)?;
+    let filename_len =
+        get_u32(&mut ctx.result_state.gas_counter, memory, (filename_ptr - 4) as u64)?;
+
+    let msg = get_utf16_string(&mut ctx.result_state, memory, msg_len as u64, msg_ptr as u64)?;
+    let filename =
+        get_utf16_string(&mut ctx.result_state, memory, filename_len as u64, filename_ptr as u64)?;
+
+    let message = format!("{}, filename: \"{}\" line: {} col: {}", msg, filename, line, col);
+    ctx.result_state.gas_counter.pay_base(log_base)?;
+    ctx.result_state.gas_counter.pay_per(log_byte, message.as_bytes().len() as u64)?;
+    ctx.result_state.checked_push_log(format!("ABORT: {}", message))?;
+
+    Err(HostError::GuestPanic { panic_msg: message }.into())
+}
+
+/// Writes the code deployed on current contract being executed to the register.
+///
+/// The output data in the register will either be empty, `CryptoHash`, or `AccountId`,
+/// depending on the return value.
+///
+/// # Returns
+///
+/// Returns a different number depending on the type of contract that is stored on the account
+///  (and has been written to the register).
+///
+/// * 0 if the contract code is None
+/// * 1 if the contract code is Local(CryptoHash)
+/// * 2 if the contract code is Global(CryptoHash)
+/// * 3 if the contract code is GlobalByAccount(AccountId)
+///
+/// # Cost
+///
+/// `base` - the base cost for a simple host function call `write_memory_base` + 16 *
+/// `write_memory_byte` - the cost of writing the data to the register
+pub fn current_contract_code(ctx: &mut Ctx, _memory: &mut [u8], register_id: u64) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    match &ctx.context.account_contract {
+        AccountContract::None => Ok(0),
+        AccountContract::Local(crypto_hash) => {
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                crypto_hash.0,
+            )?;
+            Ok(1)
+        }
+        AccountContract::Global(crypto_hash) => {
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                crypto_hash.0,
+            )?;
+            Ok(2)
+        }
+        AccountContract::GlobalByAccount(account_id) => {
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                account_id.as_bytes(),
+            )?;
+            Ok(3)
+        }
+    }
+}
+
+// ###############
+// # Storage API #
+// ###############
+
+/// Reads account id from the given location in memory.
+///
+/// # Errors
+///
+/// * If account is not UTF-8 encoded then returns `BadUtf8`;
+/// * If account is not valid then returns `InvalidAccountId`.
+///
+/// # Cost
+///
+/// This is a helper function that encapsulates the following costs:
+/// cost of reading buffer from register or memory,
+/// `utf8_decoding_base + utf8_decoding_byte * num_bytes`.
+fn read_and_parse_account_id(
+    gas_counter: &mut GasCounter,
+    memory: &[u8],
+    registers: &Registers,
+    config: &Config,
+    ptr: u64,
+    len: u64,
+) -> Result<AccountId> {
+    let buf = get_memory_or_register(gas_counter, memory, registers, ptr, len)?;
+    gas_counter.pay_base(utf8_decoding_base)?;
+    gas_counter.pay_per(utf8_decoding_byte, buf.len() as u64)?;
+
+    let account_id_str = String::from_utf8(buf.into()).map_err(|_| HostError::BadUTF8)?;
+
+    match config.limit_config.account_id_validity_rules_version {
+        near_primitives_core::config::AccountIdValidityRulesVersion::V0
+        | near_primitives_core::config::AccountIdValidityRulesVersion::V1 =>
+        {
+            #[allow(deprecated)]
+            Ok(AccountId::new_unvalidated(account_id_str))
+        }
+        near_primitives_core::config::AccountIdValidityRulesVersion::V2 => {
+            account_id_str.parse().map_err(|_| VMLogicError::HostError(HostError::InvalidAccountId))
+        }
+    }
+}
+
+/// Writes key-value into storage.
+/// * If key is not in use it inserts the key-value pair and does not modify the register. Returns `0`;
+/// * If key is in use it inserts the key-value and copies the old value into the `register_id`. Returns `1`.
+///
+/// # Errors
+///
+/// * If `key_len + key_ptr` or `value_len + value_ptr` exceeds the memory container or points
+///   to an unused register it returns `MemoryAccessViolation`;
+/// * If returning the preempted value into the registers exceed the memory container it returns
+///   `MemoryAccessViolation`.
+/// * If the length of the key exceeds `max_length_storage_key` returns `KeyLengthExceeded`.
+/// * If the length of the value exceeds `max_length_storage_value` returns
+///   `ValueLengthExceeded`.
+/// * If called as view function returns `ProhibitedInView``.
+///
+/// # Cost
+///
+/// `base + storage_write_base + storage_write_key_byte * num_key_bytes + storage_write_value_byte * num_value_bytes
+/// + get_vec_from_memory_or_register_cost x 2`.
+///
+/// If a value was evicted it costs additional `storage_write_value_evicted_byte * num_evicted_bytes + internal_write_register_cost`.
+pub fn storage_write(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    key_len: u64,
+    key_ptr: u64,
+    value_len: u64,
+    value_ptr: u64,
+    register_id: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView { method_name: "storage_write".to_string() }.into());
+    }
+    ctx.result_state.gas_counter.pay_base(storage_write_base)?;
+    let key = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        key_ptr,
+        key_len,
+    )?;
+    if key.len() as u64 > ctx.config.limit_config.max_length_storage_key {
+        return Err(HostError::KeyLengthExceeded {
+            length: key.len() as u64,
+            limit: ctx.config.limit_config.max_length_storage_key,
+        }
+        .into());
+    }
+    let value = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        value_ptr,
+        value_len,
+    )?;
+    if value.len() as u64 > ctx.config.limit_config.max_length_storage_value {
+        return Err(HostError::ValueLengthExceeded {
+            length: value.len() as u64,
+            limit: ctx.config.limit_config.max_length_storage_value,
+        }
+        .into());
+    }
+    ctx.result_state.gas_counter.pay_per(storage_write_key_byte, key.len() as u64)?;
+    ctx.result_state.gas_counter.pay_per(storage_write_value_byte, value.len() as u64)?;
+    let evicted = ctx.ext.storage_set(&mut ctx.result_state.gas_counter, &key, &value)?;
+    let storage_config = &ctx.fees_config.storage_usage_config;
+    ctx.recorded_storage_counter.observe_size(ctx.ext.get_recorded_storage_size())?;
+    match evicted {
+        Some(old_value) => {
+            // Inner value can't overflow, because the value length is limited.
+            ctx.result_state.current_storage_usage = ctx
+                .result_state
+                .current_storage_usage
+                .checked_sub(old_value.len() as u64)
+                .ok_or(InconsistentStateError::IntegerOverflow)?;
+            // Inner value can't overflow, because the value length is limited.
+            ctx.result_state.current_storage_usage = ctx
+                .result_state
+                .current_storage_usage
+                .checked_add(value.len() as u64)
+                .ok_or(InconsistentStateError::IntegerOverflow)?;
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                old_value,
+            )?;
+            Ok(1)
+        }
+        None => {
+            // Inner value can't overflow, because the key/value length is limited.
+            ctx.result_state.current_storage_usage = ctx
+                .result_state
+                .current_storage_usage
+                .checked_add(
+                    value.len() as u64 + key.len() as u64 + storage_config.num_extra_bytes_record,
+                )
+                .ok_or(InconsistentStateError::IntegerOverflow)?;
+            Ok(0)
+        }
+    }
+}
+
+/// Reads the value stored under the given key.
+/// * If key is used copies the content of the value into the `register_id`, even if the content
+///   is zero bytes. Returns `1`;
+/// * If key is not present then does not modify the register. Returns `0`;
+///
+/// # Errors
+///
+/// * If `key_len + key_ptr` exceeds the memory container or points to an unused register it
+///   returns `MemoryAccessViolation`;
+/// * If returning the preempted value into the registers exceed the memory container it returns
+///   `MemoryAccessViolation`.
+/// * If the length of the key exceeds `max_length_storage_key` returns `KeyLengthExceeded`.
+///
+/// # Cost
+///
+/// `base + storage_read_base + storage_read_key_byte * num_key_bytes + storage_read_value_byte + num_value_bytes
+///  cost to read key from register + cost to write value into register`.
+pub fn storage_read(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    key_len: u64,
+    key_ptr: u64,
+    register_id: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    ctx.result_state.gas_counter.pay_base(storage_read_base)?;
+    let key = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        key_ptr,
+        key_len,
+    )?;
+    if key.len() as u64 > ctx.config.limit_config.max_length_storage_key {
+        return Err(HostError::KeyLengthExceeded {
+            length: key.len() as u64,
+            limit: ctx.config.limit_config.max_length_storage_key,
+        }
+        .into());
+    }
+    ctx.result_state.gas_counter.pay_per(storage_read_key_byte, key.len() as u64)?;
+    let read = ctx.ext.storage_get(&mut ctx.result_state.gas_counter, &key);
+    let read = match read? {
+        Some(read) => {
+            // Here we'll do u32 -> usize -> u64, which is always infallible
+            let read_len = read.len() as usize;
+            ctx.result_state.gas_counter.pay_per(storage_read_value_byte, read_len as u64)?;
+            if read_len > INLINE_DISK_VALUE_THRESHOLD {
+                ctx.result_state.gas_counter.pay_base(storage_large_read_overhead_base)?;
+                ctx.result_state
+                    .gas_counter
+                    .pay_per(storage_large_read_overhead_byte, read_len as u64)?;
+            }
+            Some(read.deref(&mut FreeGasCounter)?)
+        }
+        None => None,
+    };
+
+    ctx.recorded_storage_counter.observe_size(ctx.ext.get_recorded_storage_size())?;
+    match read {
+        Some(value) => {
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                value,
+            )?;
+            Ok(1)
+        }
+        None => Ok(0),
+    }
+}
+
+/// Removes the value stored under the given key.
+/// * If key is used, removes the key-value from the trie and copies the content of the value
+///   into the `register_id`, even if the content is zero bytes. Returns `1`;
+/// * If key is not present then does not modify the register. Returns `0`.
+///
+/// # Errors
+///
+/// * If `key_len + key_ptr` exceeds the memory container or points to an unused register it
+///   returns `MemoryAccessViolation`;
+/// * If the registers exceed the memory limit returns `MemoryAccessViolation`;
+/// * If returning the preempted value into the registers exceed the memory container it returns
+///   `MemoryAccessViolation`.
+/// * If the length of the key exceeds `max_length_storage_key` returns `KeyLengthExceeded`.
+/// * If called as view function returns `ProhibitedInView``.
+///
+/// # Cost
+///
+/// `base + storage_remove_base + storage_remove_key_byte * num_key_bytes + storage_remove_ret_value_byte * num_value_bytes
+/// + cost to read the key + cost to write the value`.
+pub fn storage_remove(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    key_len: u64,
+    key_ptr: u64,
+    register_id: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(
+            HostError::ProhibitedInView { method_name: "storage_remove".to_string() }.into()
+        );
+    }
+    ctx.result_state.gas_counter.pay_base(storage_remove_base)?;
+    let key = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        key_ptr,
+        key_len,
+    )?;
+    if key.len() as u64 > ctx.config.limit_config.max_length_storage_key {
+        return Err(HostError::KeyLengthExceeded {
+            length: key.len() as u64,
+            limit: ctx.config.limit_config.max_length_storage_key,
+        }
+        .into());
+    }
+    ctx.result_state.gas_counter.pay_per(storage_remove_key_byte, key.len() as u64)?;
+    let removed = ctx.ext.storage_remove(&mut ctx.result_state.gas_counter, &key)?;
+    let storage_config = &ctx.fees_config.storage_usage_config;
+    ctx.recorded_storage_counter.observe_size(ctx.ext.get_recorded_storage_size())?;
+    match removed {
+        Some(value) => {
+            // Inner value can't overflow, because the key/value length is limited.
+            ctx.result_state.current_storage_usage = ctx
+                .result_state
+                .current_storage_usage
+                .checked_sub(
+                    value.len() as u64 + key.len() as u64 + storage_config.num_extra_bytes_record,
+                )
+                .ok_or(InconsistentStateError::IntegerOverflow)?;
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                value,
+            )?;
+            Ok(1)
+        }
+        None => Ok(0),
+    }
+}
+
+/// Checks if there is a key-value pair.
+/// * If key is used returns `1`, even if the value is zero bytes;
+/// * Otherwise returns `0`.
+///
+/// # Errors
+///
+/// * If `key_len + key_ptr` exceeds the memory container it returns `MemoryAccessViolation`.
+/// * If the length of the key exceeds `max_length_storage_key` returns `KeyLengthExceeded`.
+///
+/// # Cost
+///
+/// `base + storage_has_key_base + storage_has_key_byte * num_bytes + cost of reading key`
+pub fn storage_has_key(
+    ctx: &mut Ctx,
+    memory: &mut [u8],
+    key_len: u64,
+    key_ptr: u64,
+) -> Result<u64> {
+    ctx.result_state.gas_counter.pay_base(base)?;
+    ctx.result_state.gas_counter.pay_base(storage_has_key_base)?;
+    let key = get_memory_or_register(
+        &mut ctx.result_state.gas_counter,
+        memory,
+        &ctx.registers,
+        key_ptr,
+        key_len,
+    )?;
+    if key.len() as u64 > ctx.config.limit_config.max_length_storage_key {
+        return Err(HostError::KeyLengthExceeded {
+            length: key.len() as u64,
+            limit: ctx.config.limit_config.max_length_storage_key,
+        }
+        .into());
+    }
+    ctx.result_state.gas_counter.pay_per(storage_has_key_byte, key.len() as u64)?;
+    let res = ctx.ext.storage_has_key(&mut ctx.result_state.gas_counter, &key);
+
+    ctx.recorded_storage_counter.observe_size(ctx.ext.get_recorded_storage_size())?;
+    Ok(res? as u64)
+}
+
+/// Debug print given utf-8 string to node log. It's only available in Sandbox node
+///
+/// # Errors
+///
+/// * If string is not UTF-8 returns `BadUtf8`
+/// * If the log is over available memory in wasm runner, returns `MemoryAccessViolation`
+///
+/// # Cost
+///
+/// 0
+#[cfg(feature = "sandbox")]
+pub fn sandbox_debug_log(_ctx: &mut Ctx, memory: &mut [u8], len: u64, ptr: u64) -> Result<()> {
+    let message = sandbox_get_utf8_string(memory, len, ptr)?;
+    tracing::debug!(target: "sandbox", message = &message[..]);
+    Ok(())
+}
+
+/// DEPRECATED
+/// Creates an iterator object inside the host. Returns the identifier that uniquely
+/// differentiates the given iterator from other iterators that can be simultaneously created.
+/// * It iterates over the keys that have the provided prefix. The order of iteration is defined
+///   by the lexicographic order of the bytes in the keys;
+/// * If there are no keys, it creates an empty iterator, see below on empty iterators.
+///
+/// # Errors
+///
+/// * If `prefix_len + prefix_ptr` exceeds the memory container it returns
+///   `MemoryAccessViolation`.
+/// * If the length of the prefix exceeds `max_length_storage_key` returns `KeyLengthExceeded`.
+///
+/// # Cost
+///
+/// `base + storage_iter_create_prefix_base + storage_iter_create_key_byte * num_prefix_bytes
+///  cost of reading the prefix`.
+pub fn storage_iter_prefix(
+    _ctx: &mut Ctx,
+    _memory: &mut [u8],
+    _prefix_len: u64,
+    _prefix_ptr: u64,
+) -> Result<u64> {
+    Err(VMLogicError::HostError(HostError::Deprecated {
+        method_name: "storage_iter_prefix".to_string(),
+    }))
+}
+
+/// DEPRECATED
+/// Iterates over all key-values such that keys are between `start` and `end`, where `start` is
+/// inclusive and `end` is exclusive. Unless lexicographically `start < end`, it creates an
+/// empty iterator. Note, this definition allows for `start` or `end` keys to not actually exist
+/// on the given trie.
+///
+/// # Errors
+///
+/// * If `start_len + start_ptr` or `end_len + end_ptr` exceeds the memory container or points to
+///   an unused register it returns `MemoryAccessViolation`.
+/// * If the length of the `start` exceeds `max_length_storage_key` returns `KeyLengthExceeded`.
+/// * If the length of the `end` exceeds `max_length_storage_key` returns `KeyLengthExceeded`.
+///
+/// # Cost
+///
+/// `base + storage_iter_create_range_base + storage_iter_create_from_byte * num_from_bytes
+///  + storage_iter_create_to_byte * num_to_bytes + reading from prefix + reading to prefix`.
+pub fn storage_iter_range(
+    _ctx: &mut Ctx,
+    _memory: &mut [u8],
+    _start_len: u64,
+    _start_ptr: u64,
+    _end_len: u64,
+    _end_ptr: u64,
+) -> Result<u64> {
+    Err(VMLogicError::HostError(HostError::Deprecated {
+        method_name: "storage_iter_range".to_string(),
+    }))
+}
+
+/// DEPRECATED
+/// Advances iterator and saves the next key and value in the register.
+/// * If iterator is not empty (after calling next it points to a key-value), copies the key
+///   into `key_register_id` and value into `value_register_id` and returns `1`;
+/// * If iterator is empty returns `0`;
+/// This allows us to iterate over the keys that have zero bytes stored in values.
+///
+/// # Errors
+///
+/// * If `key_register_id == value_register_id` returns `MemoryAccessViolation`;
+/// * If the registers exceed the memory limit returns `MemoryAccessViolation`;
+/// * If `iterator_id` does not correspond to an existing iterator returns `InvalidIteratorId`;
+/// * If between the creation of the iterator and calling `storage_iter_next` the range over
+///   which it iterates was modified returns `IteratorWasInvalidated`. Specifically, if
+///   `storage_write` or `storage_remove` was invoked on the key such that:
+///   * in case of `storage_iter_prefix`. `key` has the given prefix and:
+///     * Iterator was not called next yet.
+///     * `next` was already called on the iterator and it is currently pointing at the `key`
+///       `curr` such that `curr <= key`.
+///   * in case of `storage_iter_range`. `start<=key<end` and:
+///     * Iterator was not called `next` yet.
+///     * `next` was already called on the iterator and it is currently pointing at the key
+///       `curr` such that `curr<=key<end`.
+///
+/// # Cost
+///
+/// `base + storage_iter_next_base + storage_iter_next_key_byte * num_key_bytes + storage_iter_next_value_byte * num_value_bytes
+///  + writing key to register + writing value to register`.
+pub fn storage_iter_next(
+    _ctx: &mut Ctx,
+    _memory: &mut [u8],
+    _iterator_id: u64,
+    _key_register_id: u64,
+    _value_register_id: u64,
+) -> Result<u64> {
+    Err(VMLogicError::HostError(HostError::Deprecated {
+        method_name: "storage_iter_next".to_string(),
+    }))
+}
+
+/// A helper function to pay base cost gas fee for batching an action.
+pub fn pay_action_base(
+    gas_counter: &mut GasCounter,
+    fees_config: &RuntimeFeesConfig,
+    action: ActionCosts,
+    sir: bool,
+) -> Result<()> {
+    let base_fee = fees_config.fee(action);
+    let burn_gas = base_fee.send_fee(sir);
+    let use_gas = burn_gas.checked_add(base_fee.exec_fee()).ok_or(HostError::IntegerOverflow)?;
+    gas_counter.pay_action_accumulated(burn_gas, use_gas, action)
+}
+
+/// A helper function to pay per byte gas fee for batching an action.
+pub fn pay_action_per_byte(
+    gas_counter: &mut GasCounter,
+    fees_config: &RuntimeFeesConfig,
+    action: ActionCosts,
+    num_bytes: u64,
+    sir: bool,
+) -> Result<()> {
+    let per_byte_fee = fees_config.fee(action);
+    let burn_gas =
+        per_byte_fee.send_fee(sir).checked_mul(num_bytes).ok_or(HostError::IntegerOverflow)?;
+    let use_gas = burn_gas
+        .checked_add(
+            per_byte_fee.exec_fee().checked_mul(num_bytes).ok_or(HostError::IntegerOverflow)?,
+        )
+        .ok_or(HostError::IntegerOverflow)?;
+    gas_counter.pay_action_accumulated(burn_gas, use_gas, action)
+}

--- a/runtime/near-vm-runner/src/wasmtime42_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime42_runner/mod.rs
@@ -1,0 +1,1058 @@
+use crate::cache::get_contract_cache_key;
+use crate::errors::ContractPrecompilatonResult;
+use crate::logic::errors::{
+    CacheError, CompilationError, FunctionCallError, MethodResolveError, VMLogicError,
+    VMRunnerError, WasmTrap,
+};
+use crate::logic::logic::Promise;
+use crate::logic::recorded_storage_counter::RecordedStorageCounter;
+use crate::logic::vmstate::Registers;
+use crate::logic::{Config, ExecutionResultState, External, GasCounter, VMContext, VMOutcome};
+use crate::runner::VMResult;
+use crate::{
+    CompiledContract, CompiledContractInfo, Contract, ContractCode, ContractRuntimeCache,
+    EXPORT_PREFIX, MEMORY_EXPORT, NoContractRuntimeCache, REMAINING_GAS_EXPORT, START_EXPORT,
+    imports, prepare,
+};
+use core::mem::transmute;
+use core::ops::Deref;
+use core::sync::atomic::{AtomicU64, Ordering};
+use near_parameters::RuntimeFeesConfig;
+use near_parameters::vm::{LimitConfig, VMKind};
+use near_primitives_core::gas::Gas;
+use near_primitives_core::types::Balance;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, LazyLock};
+use wasmtime42::{
+    CallHook, Engine, Extern, ExternType, Instance, InstanceAllocationStrategy, InstancePre,
+    Linker, Memory, Module, ModuleExport, PoolingAllocationConfig, ResourcesRequired, Store,
+    StoreLimits, StoreLimitsBuilder, Strategy, Val, WasmBacktraceDetails,
+};
+
+mod logic;
+
+/// The maximum amount of concurrent calls this engine can handle.
+/// If this limit is reached, invocations will block until an execution slot is available.
+///
+/// Wasmtime will use this value to pre-allocate and pool resources internally.
+/// Wasmtime defaults to `1_000`
+const MAX_CONCURRENCY: u32 = 1_000;
+
+/// Value used for [PoolingAllocationConfig::decommit_batch_size]
+///
+/// Wasmtime defaults to `1`
+const DECOMMIT_BATCH_SIZE: usize = MAX_CONCURRENCY as usize / 2;
+
+/// The default maximum amount of tables per module.
+///
+/// This value is used if `max_tables_per_contract` is not set.
+///
+/// Wasmtime defaults to `1`
+const DEFAULT_MAX_TABLES_PER_MODULE: u32 = 1;
+
+/// The default maximum amount of elements in a single table.
+///
+/// This value is used if `max_elements_per_contract_table` is not set.
+///
+/// Wasmtime defaults to `20_000`
+const DEFAULT_MAX_ELEMENTS_PER_TABLE: usize = 10_000;
+
+/// Guest page size, in bytes
+const GUEST_PAGE_SIZE: usize = 1 << 16;
+
+#[derive(Hash, PartialEq, Eq)]
+struct VMKey {
+    config: Arc<Config>,
+    target: Option<String>,
+}
+
+static VMS: LazyLock<parking_lot::RwLock<HashMap<VMKey, Wasmtime42VM>>> =
+    LazyLock::new(parking_lot::RwLock::default);
+
+fn guest_memory_size(pages: u32) -> Option<usize> {
+    let pages = usize::try_from(pages).ok()?;
+    pages.checked_mul(GUEST_PAGE_SIZE)
+}
+
+struct InstancePermit<'a> {
+    instances: &'a AtomicU64,
+    tables: &'a AtomicU64,
+    num_tables: u32,
+    release_notify: &'a parking_lot::Condvar,
+    release_mutex: &'a parking_lot::Mutex<()>,
+}
+
+impl Drop for InstancePermit<'_> {
+    fn drop(&mut self) {
+        self.instances.fetch_sub(1, Ordering::Release);
+        if self.num_tables != 0 {
+            self.tables.fetch_sub(self.num_tables.into(), Ordering::Release);
+        }
+        let _guard = self.release_mutex.lock();
+        self.release_notify.notify_all();
+    }
+}
+
+/// State stored in [ConcurrencySemaphore]
+struct ConcurrencySemaphoreState {
+    max_tables: u32,
+    instances: AtomicU64,
+    tables: AtomicU64,
+    release_notify: parking_lot::Condvar,
+    release_mutex: parking_lot::Mutex<()>,
+}
+
+/// A simple semaphore, which is not expected to be contended often.
+#[derive(Clone)]
+struct ConcurrencySemaphore(Arc<ConcurrencySemaphoreState>);
+
+impl ConcurrencySemaphore {
+    /// Constructs a new [ConcurrencySemaphore].
+    ///
+    /// `max_tables` is the maximum amount of tables that can concurrently exist.
+    pub fn new(max_tables: u32) -> Self {
+        Self(Arc::new(ConcurrencySemaphoreState {
+            max_tables,
+            instances: AtomicU64::default(),
+            tables: AtomicU64::default(),
+            release_notify: parking_lot::Condvar::default(),
+            release_mutex: parking_lot::Mutex::default(),
+        }))
+    }
+}
+
+impl Deref for ConcurrencySemaphore {
+    type Target = ConcurrencySemaphoreState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ConcurrencySemaphore {
+    /// Attempts to reserve a single instance slot, returns `true` on success
+    fn try_reserve_instance(&self) -> bool {
+        let prev = self.instances.fetch_add(1, Ordering::Acquire);
+        prev.checked_add(1).is_some_and(|n| n <= MAX_CONCURRENCY.into())
+    }
+
+    /// Attempts to reserve `n` table slots, returns `true` on success
+    fn try_reserve_tables(&self, n: u32) -> bool {
+        let prev = self.tables.fetch_add(n.into(), Ordering::Acquire);
+        prev.checked_add(n.into()).is_some_and(|n| n <= self.max_tables.into())
+    }
+
+    /// Releases a single instance slot returning the amount of previously active instances
+    fn release_instance(&self) -> u64 {
+        self.instances.fetch_sub(1, Ordering::Release)
+    }
+
+    /// Releases `n` table slots returning the amount of previously active tables
+    fn release_tables(&self, n: u32) -> u64 {
+        self.tables.fetch_sub(n.into(), Ordering::Release)
+    }
+
+    /// Attempt to acquire the semaphore using the specified number of tables
+    fn try_acquire(&self, num_tables: u32) -> Option<InstancePermit<'_>> {
+        debug_assert!(num_tables <= self.max_tables);
+
+        // At most [`u16::MAX`] iterations per lock
+        let mut iterations: u16 = 0;
+
+        if num_tables != 0 {
+            if !self.try_reserve_tables(num_tables) {
+                let active = self.release_tables(num_tables).checked_sub(num_tables.into())?;
+                tracing::warn!(active, requested = num_tables, "table lock contended");
+                let mut guard = self.release_mutex.lock();
+                while !self.try_reserve_tables(num_tables) {
+                    iterations = iterations.checked_add(1)?;
+                    if self.release_tables(num_tables) <= self.max_tables.into() {
+                        continue;
+                    }
+                    self.release_notify.wait(&mut guard);
+                }
+            }
+        }
+
+        // reset iteration counter
+        iterations = 0;
+        if !self.try_reserve_instance() {
+            let active = self.release_instance().checked_sub(1)?;
+            tracing::warn!(active, "instance lock contended");
+            let mut guard = self.release_mutex.lock();
+            while !self.try_reserve_instance() {
+                iterations = iterations.checked_add(1)?;
+                if self.release_instance() <= MAX_CONCURRENCY.into() {
+                    continue;
+                }
+                self.release_notify.wait(&mut guard);
+            }
+        }
+        return Some(InstancePermit {
+            instances: &self.instances,
+            tables: &self.tables,
+            num_tables,
+            release_notify: &self.release_notify,
+            release_mutex: &self.release_mutex,
+        });
+    }
+}
+
+enum Export<T> {
+    Unresolved(ModuleExport),
+    Resolved(T),
+}
+
+pub struct Ctx {
+    memory: Export<Memory>,
+    limits: StoreLimits,
+    /// Provides access to the components outside the Wasm runtime for operations on the trie and
+    /// receipts creation.
+    ext: &'static mut dyn External,
+    /// Part of Context API and Economics API that was extracted from the receipt.
+    context: &'static VMContext,
+
+    /// All gas and economic parameters required during contract execution.
+    config: Arc<Config>,
+    /// Fees charged for various operations that contract may execute.
+    fees_config: Arc<RuntimeFeesConfig>,
+
+    /// Current amount of locked tokens, does not automatically change when staking transaction is
+    /// issued.
+    current_account_locked_balance: Balance,
+    /// Registers can be used by the guest to store blobs of data without moving them across
+    /// host-guest boundary.
+    registers: Registers,
+    /// The DAG of promises, indexed by promise id.
+    promises: Vec<Promise>,
+
+    /// Stores the amount of stack space remaining
+    remaining_stack: u64,
+
+    /// Tracks size of the recorded trie storage proof.
+    recorded_storage_counter: RecordedStorageCounter,
+
+    result_state: ExecutionResultState,
+}
+
+impl Ctx {
+    fn new(
+        ext: &'static mut dyn External,
+        context: &'static VMContext,
+        fees_config: Arc<RuntimeFeesConfig>,
+        result_state: ExecutionResultState,
+        memory: ModuleExport,
+    ) -> Self {
+        let LimitConfig {
+            max_memory_pages,
+            max_tables_per_contract,
+            max_elements_per_contract_table,
+            ..
+        } = result_state.config.limit_config;
+        let max_tables_per_contract =
+            max_tables_per_contract.unwrap_or(DEFAULT_MAX_TABLES_PER_MODULE);
+        let max_elements_per_contract_table =
+            max_elements_per_contract_table.unwrap_or(DEFAULT_MAX_ELEMENTS_PER_TABLE);
+        let max_memory_size = guest_memory_size(max_memory_pages).unwrap_or(usize::MAX);
+
+        let limits = StoreLimitsBuilder::new()
+            .instances(1)
+            .memories(1)
+            .memory_size(max_memory_size)
+            .tables(max_tables_per_contract.try_into().unwrap_or(usize::MAX))
+            .table_elements(max_elements_per_contract_table)
+            .build();
+
+        let current_account_locked_balance = context.account_locked_balance;
+        let config = Arc::clone(&result_state.config);
+        let recorded_storage_counter = RecordedStorageCounter::new(
+            ext.get_recorded_storage_size(),
+            result_state.config.limit_config.per_receipt_storage_proof_size_limit,
+        );
+        let remaining_stack = u64::from(result_state.config.limit_config.max_stack_height);
+        Self {
+            memory: Export::Unresolved(memory),
+            limits,
+            ext,
+            context,
+            config,
+            fees_config,
+            current_account_locked_balance,
+            recorded_storage_counter,
+            registers: Default::default(),
+            promises: vec![],
+            remaining_stack,
+            result_state,
+        }
+    }
+}
+
+trait IntoVMError {
+    fn into_vm_error(self) -> Result<FunctionCallError, VMRunnerError>;
+}
+
+impl IntoVMError for wasmtime42::Error {
+    fn into_vm_error(self) -> Result<FunctionCallError, VMRunnerError> {
+        let cause = self.root_cause();
+        if let Some(container) = cause.downcast_ref::<ErrorContainer>() {
+            use {VMLogicError as LE, VMRunnerError as RE};
+            return match container.take() {
+                Some(LE::HostError(h)) => Ok(FunctionCallError::HostError(h)),
+                Some(LE::ExternalError(s)) => Err(RE::ExternalError(s)),
+                Some(LE::InconsistentStateError(e)) => Err(RE::InconsistentStateError(e)),
+                None => panic!("error has already been taken out of the container?!"),
+            };
+        }
+        if let Some(trap) = cause.downcast_ref::<wasmtime42::Trap>() {
+            use wasmtime42::Trap as T;
+            let nondeterministic_message = 'nondet: {
+                return Ok(FunctionCallError::WasmTrap(match *trap {
+                    T::StackOverflow => WasmTrap::StackOverflow,
+                    T::MemoryOutOfBounds => WasmTrap::MemoryOutOfBounds,
+                    T::TableOutOfBounds => WasmTrap::MemoryOutOfBounds,
+                    T::IndirectCallToNull => WasmTrap::IndirectCallToNull,
+                    T::BadSignature => WasmTrap::IncorrectCallIndirectSignature,
+                    T::IntegerOverflow => WasmTrap::IllegalArithmetic,
+                    T::IntegerDivisionByZero => WasmTrap::IllegalArithmetic,
+                    T::BadConversionToInteger => WasmTrap::IllegalArithmetic,
+                    T::UnreachableCodeReached => WasmTrap::Unreachable,
+                    T::Interrupt => break 'nondet "interrupt",
+                    T::HeapMisaligned => break 'nondet "heap misaligned",
+                    t => {
+                        return Err(VMRunnerError::WasmUnknownError {
+                            debug_message: format!("unhandled trap type: {:?}", t),
+                        });
+                    }
+                }));
+            };
+            return Err(VMRunnerError::Nondeterministic(nondeterministic_message.into()));
+        }
+        let description = if cause.is::<wasmtime42::UnknownImportError>() {
+            "unknown or invalid import".to_string()
+        } else {
+            cause.to_string()
+        };
+        Ok(FunctionCallError::LinkError { msg: description })
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Wasmtime42VM {
+    config: Arc<Config>,
+    engine: Engine,
+    concurrency: ConcurrencySemaphore,
+}
+
+#[derive(Clone)]
+struct PreparedModule {
+    pre: InstancePre<Ctx>,
+    memory: ModuleExport,
+    remaining_gas: Option<ModuleExport>,
+    start: Option<ModuleExport>,
+    num_tables: u32,
+}
+
+impl Wasmtime42VM {
+    pub(crate) fn new(config: Arc<Config>) -> Self {
+        Self::new_for_target(config, None)
+            .expect("construction without target specified cannot fail")
+    }
+
+    pub(crate) fn new_for_target(
+        config: Arc<Config>,
+        target: Option<String>,
+    ) -> wasmtime42::Result<Self> {
+        let vm_key = VMKey { config: Arc::clone(&config), target: target.clone() };
+        {
+            if let Some(vm) = VMS.read().get(&vm_key) {
+                return Ok(vm.clone());
+            }
+        }
+
+        let features = crate::features::WasmFeatures::new(&config);
+        let mut engine_config = wasmtime42::Config::from(features);
+        if let Some(target) = &target {
+            engine_config.target(&target)?;
+        }
+        let mut guard = VMS.write();
+        let vm = guard.entry(vm_key).or_insert_with_key(|vm_key| {
+            // NOTE: Configuration values are based on:
+            // - https://docs.wasmtime.dev/examples-fast-execution.html
+            // - https://docs.wasmtime.dev/examples-fast-instantiation.html
+
+            let LimitConfig {
+                max_memory_pages,
+                max_tables_per_contract,
+                max_elements_per_contract_table,
+                ..
+            } = config.limit_config;
+
+            let max_memory_size = guest_memory_size(max_memory_pages).unwrap_or(usize::MAX);
+            let max_tables_per_contract =
+                max_tables_per_contract.unwrap_or(DEFAULT_MAX_TABLES_PER_MODULE);
+            let max_elements_per_contract_table =
+                max_elements_per_contract_table.unwrap_or(DEFAULT_MAX_ELEMENTS_PER_TABLE);
+            let max_tables = MAX_CONCURRENCY.saturating_mul(max_tables_per_contract);
+
+            let mut pooling_config = PoolingAllocationConfig::default();
+            pooling_config
+                .decommit_batch_size(DECOMMIT_BATCH_SIZE)
+                .max_memory_size(max_memory_size)
+                .table_elements(max_elements_per_contract_table)
+                .total_component_instances(0)
+                .total_core_instances(MAX_CONCURRENCY)
+                .total_memories(MAX_CONCURRENCY)
+                .total_tables(max_tables)
+                .max_memories_per_module(1)
+                .max_tables_per_module(max_tables_per_contract)
+                .table_keep_resident(max_elements_per_contract_table);
+
+            engine_config
+                .allocation_strategy(InstanceAllocationStrategy::Pooling(pooling_config))
+                // From official documentation:
+                // > Note that systems loading many modules may wish to disable this
+                // > configuration option instead of leaving it on-by-default.
+                // > Some platforms exhibit quadratic behavior when registering/unregistering
+                // > unwinding information which can greatly slow down the module loading/unloading process.
+                // https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.native_unwind_info
+                .native_unwind_info(false)
+                .wasm_backtrace(false)
+                .wasm_backtrace_details(WasmBacktraceDetails::Disable)
+                // Enable copy-on-write heap images.
+                .memory_init_cow(true)
+                // Wasm stack metering is implemented by instrumentation, we don't want wasmtime to trap before that
+                .max_wasm_stack(1024 * 1024 * 1024)
+                // Enable the Cranelift optimizing compiler.
+                .strategy(Strategy::Cranelift)
+                // Enable signals-based traps. This is required to elide explicit bounds-checking.
+                .signals_based_traps(true)
+                // Configure linear memories such that explicit bounds-checking can be elided.
+                .force_memory_init_memfd(true)
+                .memory_guaranteed_dense_image_size(max_memory_size.try_into().unwrap_or(u64::MAX))
+                .guard_before_linear_memory(false)
+                .memory_guard_size(0)
+                .memory_may_move(false)
+                .memory_reservation(max_memory_size.try_into().unwrap_or(u64::MAX))
+                .memory_reservation_for_growth(0)
+                .compiler_inlining(true)
+                .cranelift_nan_canonicalization(true)
+                .wasm_wide_arithmetic(true);
+
+            let config = Arc::clone(&vm_key.config);
+            let engine = Engine::new(&engine_config).expect("failed to construct Wasmtime engine");
+            let concurrency = ConcurrencySemaphore::new(max_tables);
+            Self { config, engine, concurrency }
+        });
+        Ok(vm.clone())
+    }
+
+    pub(crate) fn vm_hash(&self) -> u64 {
+        // increment the `version` when making modifications that affect the
+        // artifact compatibility.
+        let version = 1;
+
+        let mut hasher = std::hash::DefaultHasher::new();
+        self.engine.precompile_compatibility_hash().hash(&mut hasher);
+        hasher.write_u16(version);
+        hasher.finish()
+    }
+
+    #[tracing::instrument(
+        target = "vm",
+        level = "debug",
+        "Wasmtime42VM::compile_uncached",
+        skip_all
+    )]
+    pub(crate) fn compile_uncached(
+        &self,
+        code: &ContractCode,
+    ) -> Result<Vec<u8>, CompilationError> {
+        let start = std::time::Instant::now();
+        let prepared_code =
+            prepare::prepare_contract(code.code(), &self.config, VMKind::Wasmtime42)
+                .map_err(CompilationError::PrepareError)?;
+        let serialized = self.engine.precompile_module(&prepared_code).map_err(|err| {
+            tracing::debug!(
+                target: "vm",
+                ?err,
+                code_hash = %code.hash(),
+                code_size = code.code().len(),
+                "wasmtime42 contract compilation failed",
+            );
+            CompilationError::WasmtimeCompileError { msg: err.to_string() }
+        })?;
+
+        tracing::debug!(
+            target: "vm",
+            original_size = %code.code().len(),
+            prepared_size = %prepared_code.len(),
+            compiled_size = %serialized.len(),
+            "wasmtime42 compiled contract",
+        );
+
+        crate::metrics::compilation_duration(VMKind::Wasmtime42, start.elapsed());
+        Ok(serialized)
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        target = "vm",
+        name = "Wasmtime42::compile_and_cache",
+        skip_all
+    )]
+    fn compile_and_cache(
+        &self,
+        code: &ContractCode,
+        cache: &dyn ContractRuntimeCache,
+    ) -> Result<Result<Vec<u8>, CompilationError>, CacheError> {
+        let serialized_or_error = self.compile_uncached(code);
+        let key = get_contract_cache_key(*code.hash(), &self.config, self.vm_hash());
+        let record = CompiledContractInfo {
+            wasm_bytes: code.code().len() as u64,
+            compiled: match &serialized_or_error {
+                Ok(serialized) => CompiledContract::Code(serialized.clone()),
+                Err(err) => CompiledContract::CompileModuleError(err.clone()),
+            },
+        };
+        cache.put(&key, record).map_err(CacheError::WriteError)?;
+        Ok(serialized_or_error)
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        target = "vm",
+        name = "Wasmtime42::with_compiled_and_loaded",
+        skip_all
+    )]
+    fn with_compiled_and_loaded(
+        &self,
+        cache: &dyn ContractRuntimeCache,
+        contract: &dyn Contract,
+        mut gas_counter: GasCounter,
+        method: &str,
+        closure: impl FnOnce(
+            GasCounter,
+            Result<PreparedModule, FunctionCallError>,
+        ) -> VMResult<PreparedContract>,
+    ) -> VMResult<PreparedContract> {
+        type MemoryCacheType =
+            (u64, Result<Result<PreparedModule, FunctionCallError>, CompilationError>);
+        let to_any = |v: MemoryCacheType| -> Box<dyn std::any::Any + Send> { Box::new(v) };
+        let key = get_contract_cache_key(contract.hash(), &self.config, self.vm_hash());
+        let (wasm_bytes, pre_result) = cache.memory_cache().try_lookup(
+            key,
+            || {
+                let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
+                let (wasm_bytes, module) =
+                    if let Some(CompiledContractInfo { wasm_bytes, compiled }) = cache_record {
+                        match compiled {
+                            CompiledContract::CompileModuleError(err) => {
+                                return Ok((
+                                    err.size_bytes_approximate() as u64,
+                                    to_any((wasm_bytes, Err(err))),
+                                ));
+                            }
+                            CompiledContract::Code(module) => (wasm_bytes, module),
+                        }
+                    } else {
+                        let Some(code) = contract.get_code() else {
+                            return Err(VMRunnerError::ContractCodeNotPresent);
+                        };
+                        let wasm_bytes = code.code().len() as u64;
+                        match self.compile_and_cache(&code, cache)? {
+                            Err(err) => {
+                                return Ok((
+                                    err.size_bytes_approximate() as u64,
+                                    to_any((wasm_bytes, Err(err))),
+                                ));
+                            }
+                            Ok(module) => (wasm_bytes, module),
+                        }
+                    };
+                // (UN-)SAFETY: the `module` must have been produced by
+                // a prior call to `serialize`.
+                //
+                // In practice this is not necessarily true. One could have
+                // forgotten to change the cache key when upgrading the version of
+                // the near_vm library or the database could have had its data
+                // corrupted while at rest.
+                //
+                // There should definitely be some validation in near_vm to ensure
+                // we load what we think we load.
+                let compiled_size = module.len();
+                let module = unsafe { Module::deserialize(&self.engine, &module) }
+                    .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
+                let Some(memory) = module.get_export_index(MEMORY_EXPORT) else {
+                    let err = FunctionCallError::LinkError { msg: "memory export missing".into() };
+                    return Ok((
+                        err.size_bytes_approximate() as u64,
+                        to_any((wasm_bytes, Ok(Err(err)))),
+                    ));
+                };
+                let remaining_gas = module.get_export_index(REMAINING_GAS_EXPORT);
+                let start = module.get_export_index(START_EXPORT);
+                let mut linker = Linker::new(&self.engine);
+                link(&mut linker, &self.config);
+                match linker.instantiate_pre(&module) {
+                    Err(err) => {
+                        let err = err.into_vm_error()?;
+                        Ok((
+                            err.size_bytes_approximate() as u64,
+                            to_any((wasm_bytes, Ok(Err(err)))),
+                        ))
+                    }
+                    Ok(pre) => {
+                        let ResourcesRequired { num_tables, .. } = module.resources_required();
+                        // The module `weight` is estimated as its serialized size. This is a
+                        // rough approximation as the runtime metadata size is not included.
+                        // Should be sufficient for our purposes.
+                        Ok((
+                            compiled_size as u64,
+                            to_any((
+                                wasm_bytes,
+                                Ok(Ok(PreparedModule {
+                                    pre,
+                                    memory,
+                                    remaining_gas,
+                                    start,
+                                    num_tables,
+                                })),
+                            )),
+                        ))
+                    }
+                }
+            },
+            move |value| {
+                let &(wasm_bytes, ref downcast) = value
+                    .downcast_ref::<MemoryCacheType>()
+                    .expect("downcast should always succeed");
+
+                (wasm_bytes, downcast.clone())
+            },
+        )?;
+
+        let config = Arc::clone(&self.config);
+        let result = gas_counter.before_loading_executable(&config, &method, wasm_bytes);
+        if let Err(e) = result {
+            let result = PreparationResult::OutcomeAbort(e);
+            return Ok(PreparedContract { config, gas_counter, result });
+        }
+        match pre_result {
+            Ok(res) => {
+                let result = gas_counter.after_loading_executable(&config, wasm_bytes);
+                if let Err(e) = result {
+                    let result = PreparationResult::OutcomeAbort(e);
+                    return Ok(PreparedContract { config, gas_counter, result });
+                }
+                closure(gas_counter, res)
+            }
+            Err(e) => {
+                let result =
+                    PreparationResult::OutcomeAbort(FunctionCallError::CompilationError(e));
+                return Ok(PreparedContract { config, gas_counter, result });
+            }
+        }
+    }
+}
+
+impl crate::runner::VM for Wasmtime42VM {
+    fn contract_cached(
+        &self,
+        cache: &dyn ContractRuntimeCache,
+        hash: near_primitives_core::hash::CryptoHash,
+    ) -> Result<bool, crate::logic::errors::CacheError> {
+        let key = get_contract_cache_key(hash, &self.config, self.vm_hash());
+        // Check if we already cached with such a key.
+        cache.has(&key).map_err(CacheError::ReadError)
+    }
+
+    fn precompile(
+        &self,
+        code: &ContractCode,
+        cache: &dyn ContractRuntimeCache,
+    ) -> Result<
+        Result<ContractPrecompilatonResult, CompilationError>,
+        crate::logic::errors::CacheError,
+    > {
+        if self.contract_cached(cache, *code.hash())? {
+            return Ok(Ok(ContractPrecompilatonResult::ContractAlreadyInCache));
+        }
+        Ok(self
+            .compile_and_cache(code, cache)?
+            .map(|_| ContractPrecompilatonResult::ContractCompiled))
+    }
+
+    fn prepare(
+        self: Box<Self>,
+        code: &dyn Contract,
+        cache: Option<&dyn ContractRuntimeCache>,
+        gas_counter: GasCounter,
+        method: &str,
+    ) -> Box<dyn crate::PreparedContract> {
+        let cache = cache.unwrap_or(&NoContractRuntimeCache);
+        let prepd =
+            self.with_compiled_and_loaded(cache, code, gas_counter, method, |gas_counter, pre| {
+                let config = Arc::clone(&self.config);
+                match pre {
+                    Ok(PreparedModule { pre, memory, remaining_gas, start, num_tables }) => {
+                        let method = format!("{EXPORT_PREFIX}{method}");
+                        let Some(ExternType::Func(func_type)) = pre.module().get_export(&method)
+                        else {
+                            let e = FunctionCallError::MethodResolveError(
+                                MethodResolveError::MethodNotFound,
+                            );
+                            let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
+                            return Ok(PreparedContract { config, gas_counter, result });
+                        };
+                        if func_type.params().len() != 0 || func_type.results().len() != 0 {
+                            let e = FunctionCallError::MethodResolveError(
+                                MethodResolveError::MethodInvalidSignature,
+                            );
+                            let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
+                            return Ok(PreparedContract { config, gas_counter, result });
+                        }
+
+                        let result = PreparationResult::Ready(ReadyContract {
+                            pre,
+                            memory,
+                            remaining_gas,
+                            start,
+                            num_tables,
+                            method: method.into(),
+                            concurrency: self.concurrency.clone(),
+                        });
+                        Ok(PreparedContract { config, gas_counter, result })
+                    }
+                    Err(err) => {
+                        let result = PreparationResult::OutcomeAbort(err);
+                        Ok(PreparedContract { config, gas_counter, result })
+                    }
+                }
+            });
+        Box::new(prepd)
+    }
+}
+
+struct ReadyContract {
+    pre: InstancePre<Ctx>,
+    memory: ModuleExport,
+    remaining_gas: Option<ModuleExport>,
+    start: Option<ModuleExport>,
+    method: Box<str>,
+    num_tables: u32,
+    concurrency: ConcurrencySemaphore,
+}
+
+struct PreparedContract {
+    config: Arc<Config>,
+    gas_counter: GasCounter,
+    result: PreparationResult,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum PreparationResult {
+    OutcomeAbortButNopInOldProtocol(FunctionCallError),
+    OutcomeAbort(FunctionCallError),
+    Ready(ReadyContract),
+}
+
+/// This enum allows us to replicate the various [`VMOutcome`] states without moving [`VMLogic`]
+///
+/// If function like [`call`] where to rely on [`VMOutcome::ok`], for example, it would require
+/// ownership of [`VMLogic`], to acquire the inner [`ExecutionResultState`].
+/// `run`, however, owns [`VMLogic`] and creates a mutable borrow,
+/// which is then stored in a thread-local static as a raw pointer.
+/// This means that we need to be very careful to ensure that the reference created is only dropped
+/// after the module method call has returned.
+/// Moving the [`VMLogic`] would break this assertion.
+enum RunOutcome {
+    Ok,
+    AbortNop(FunctionCallError),
+    Abort(FunctionCallError),
+}
+
+fn call(
+    mut store: &mut Store<Ctx>,
+    instance: Instance,
+    method: &str,
+) -> Result<RunOutcome, VMRunnerError> {
+    let Some(func) = instance.get_func(&mut store, method) else {
+        return Ok(RunOutcome::AbortNop(FunctionCallError::MethodResolveError(
+            MethodResolveError::MethodNotFound,
+        )));
+    };
+    match func.typed(&mut store) {
+        Ok(run) => match run.call(store, ()) {
+            Ok(()) => Ok(RunOutcome::Ok),
+            Err(err) => err.into_vm_error().map(RunOutcome::Abort),
+        },
+        Err(err) => err.into_vm_error().map(RunOutcome::Abort),
+    }
+}
+
+impl crate::PreparedContract for VMResult<PreparedContract> {
+    fn run(
+        self: Box<Self>,
+        ext: &mut dyn External,
+        context: &VMContext,
+        fees_config: Arc<RuntimeFeesConfig>,
+    ) -> VMResult {
+        let PreparedContract { config, gas_counter, result } = (*self)?;
+        let result_state = ExecutionResultState::new(&context, gas_counter, config);
+        let ReadyContract { pre, memory, remaining_gas, start, method, num_tables, concurrency } =
+            match result {
+                PreparationResult::Ready(r) => r,
+                PreparationResult::OutcomeAbortButNopInOldProtocol(e) => {
+                    return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(result_state, e));
+                }
+                PreparationResult::OutcomeAbort(e) => {
+                    return Ok(VMOutcome::abort(result_state, e));
+                }
+            };
+
+        // SAFETY:
+        // Although the 'static here is a lie, we are pretty confident that the `External` and
+        // VMContext here only live for the duration of the contract method call
+        // (which is covered by the original lifetime).
+        let ext = unsafe { transmute::<&mut dyn External, &'static mut dyn External>(ext) };
+        let context = unsafe { transmute::<&VMContext, &'static VMContext>(context) };
+        let ctx = Ctx::new(ext, context, fees_config, result_state, memory);
+
+        let mut store = Store::<Ctx>::new(pre.module().engine(), ctx);
+        store.limiter(|ctx| &mut ctx.limits);
+        let Some(_permit) = concurrency.try_acquire(num_tables) else {
+            let Ctx { result_state, .. } = store.into_data();
+            return Ok(VMOutcome::abort(
+                result_state,
+                FunctionCallError::LinkError { msg: "failed to acquire execution slot".into() },
+            ));
+        };
+        let instance = match pre.instantiate(&mut store) {
+            Ok(instance) => instance,
+            Err(err) => {
+                let err = err.into_vm_error()?;
+                let Ctx { result_state, .. } = store.into_data();
+                return Ok(VMOutcome::abort(result_state, err));
+            }
+        };
+        // Pre-resolve the memory export so that host functions don't need to
+        // resolve it lazily via Caller::get_module_export (which can fail when
+        // the Caller's instance is a host-side trampoline for re-exported
+        // host functions). It may already be resolved if a start function
+        // triggered a host import during instantiation.
+        //
+        // Uses string-based instance.get_memory instead of
+        // instance.get_module_export due to a wasmtime issue: for modules
+        // whose only compiled functions are trampolines (no user-defined
+        // function bodies), LoadedCode::push_module stores the module in
+        // modules_with_only_trampolines, but LoadedCode::module() only
+        // searches self.modules, causing module_for_instance to panic.
+        if let Export::Unresolved(_) = store.data().memory {
+            if let Some(memory) = instance.get_memory(&mut store, MEMORY_EXPORT) {
+                store.data_mut().memory = Export::Resolved(memory);
+            }
+        }
+        if let Some(global) = remaining_gas {
+            let Some(Extern::Global(global)) = instance.get_module_export(&mut store, &global)
+            else {
+                panic!("gas global export was present on the module, but not on the instance");
+            };
+            store.call_hook(move |mut store, hook| {
+                match hook {
+                    CallHook::CallingHost | CallHook::ReturningFromWasm => {
+                        let Val::I64(remaining_gas) = global.get(&mut store) else {
+                            panic!("gas global export is not i64");
+                        };
+                        let ctx = store.data_mut();
+                        let burned = ctx
+                            .result_state
+                            .gas_counter
+                            .remaining_gas()
+                            .saturating_sub(Gas::from_gas(remaining_gas as _));
+                        if burned.as_gas() > 0 {
+                            ctx.result_state.gas_counter.burn_gas(burned).map_err(|e| {
+                                wasmtime42::Error::new(ErrorContainer(parking_lot::Mutex::new(
+                                    Some(e),
+                                )))
+                            })?;
+                        }
+                    }
+                    CallHook::ReturningFromHost | CallHook::CallingWasm => {
+                        let remaining_gas = store.data().result_state.gas_counter.remaining_gas();
+                        global
+                            .set(&mut store, Val::I64(remaining_gas.as_gas() as _))
+                            .expect("failed to set gas global export")
+                    }
+                }
+                Ok(())
+            });
+        }
+        if let Some(start) = start {
+            let Some(Extern::Func(start)) = instance.get_module_export(&mut store, &start) else {
+                panic!("start function export was present on the module, but not on the instance");
+            };
+            if let Err(err) = start.call(&mut store, &[], &mut []) {
+                let err = err.into_vm_error()?;
+                let Ctx { result_state, .. } = store.into_data();
+                return Ok(VMOutcome::abort(result_state, err));
+            }
+        }
+
+        let res = call(&mut store, instance, &method);
+        let Ctx { result_state, .. } = store.into_data();
+        match res? {
+            RunOutcome::Ok => Ok(VMOutcome::ok(result_state)),
+            RunOutcome::AbortNop(error) => {
+                Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(result_state, error))
+            }
+            RunOutcome::Abort(error) => Ok(VMOutcome::abort(result_state, error)),
+        }
+    }
+}
+
+/// This is a container from which an error can be taken out by value. This is necessary as
+/// the VM Logic errors end up a couple layers deep in a causal chain.
+#[derive(Debug)]
+pub(crate) struct ErrorContainer(parking_lot::Mutex<Option<VMLogicError>>);
+impl ErrorContainer {
+    pub(crate) fn take(&self) -> Option<VMLogicError> {
+        self.0.lock().take()
+    }
+}
+impl std::error::Error for ErrorContainer {}
+impl std::fmt::Display for ErrorContainer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("VMLogic error occurred and is now stored in an opaque storage container")
+    }
+}
+
+fn get_memory(caller: &mut wasmtime42::Caller<'_, Ctx>) -> Result<Memory, VMLogicError> {
+    use crate::logic::HostError;
+    match caller.data().memory {
+        Export::Unresolved(memory) => {
+            let Some(Extern::Memory(memory)) = caller.get_module_export(&memory) else {
+                return Err(HostError::MemoryAccessViolation.into());
+            };
+            caller.data_mut().memory = Export::Resolved(memory);
+            Ok(memory)
+        }
+        Export::Resolved(memory) => Ok(memory),
+    }
+}
+
+fn link(linker: &mut Linker<Ctx>, config: &Config) {
+    macro_rules! add_import {
+        (
+          $mod:ident / $name:ident : $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >
+        ) => {
+            #[allow(unused_parens)]
+            fn $name(mut caller: wasmtime42::Caller<'_, Ctx>, $( $arg_name: $arg_type ),* ) -> wasmtime42::Result<($( $returns ),*)> {
+                const TRACE: bool = imports::should_trace_host_function(stringify!($name));
+                let _span = TRACE.then(|| {
+                    tracing::trace_span!(target: "vm::host_function", stringify!($name)).entered()
+                });
+                let memory = match get_memory(&mut caller) {
+                    Ok(m) => m,
+                    Err(err) => return Err(wasmtime42::Error::new(ErrorContainer(parking_lot::Mutex::new(Some(err))))),
+                };
+                let (memory, ctx) = memory.data_and_store_mut(&mut caller);
+                match logic::$func(ctx, memory, $( $arg_name as $arg_type, )*) {
+                    Ok(result) => Ok(result as ($( $returns ),* ) ),
+                    Err(err) => {
+                        Err(wasmtime42::Error::new(ErrorContainer(parking_lot::Mutex::new(Some(err)))))
+                    }
+                }
+            }
+
+            linker.func_wrap(stringify!($mod), stringify!($name), $name).expect("cannot link external");
+        };
+    }
+    imports::for_each_available_import!(config, add_import);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::array;
+    use std::thread::{scope, spawn, yield_now};
+
+    #[test]
+    fn test_semaphore() {
+        const MAX_TABLES: u32 = 5 * MAX_CONCURRENCY;
+
+        let concurrency = ConcurrencySemaphore::new(MAX_TABLES);
+        let permit = concurrency.try_acquire(MAX_TABLES).expect("failed to acquire permit");
+        let thread = spawn({
+            let concurrency = concurrency.clone();
+            move || concurrency.try_acquire(1).is_some()
+        });
+        yield_now();
+        assert!(!thread.is_finished());
+        drop(permit);
+        let acquired = thread.join().expect("failed to join thread");
+        assert!(acquired);
+
+        assert!(concurrency.try_reserve_tables(MAX_TABLES));
+        assert!(!concurrency.try_reserve_tables(1));
+        assert_eq!(concurrency.release_tables(MAX_TABLES), u64::from(MAX_TABLES + 1));
+        assert_eq!(concurrency.release_tables(1), 1);
+        assert!(concurrency.try_reserve_tables(2));
+        assert_eq!(concurrency.release_tables(1), 2);
+        assert_eq!(concurrency.release_tables(1), 1);
+
+        #[expect(clippy::large_stack_frames)]
+        scope(|scope| {
+            let permits: [_; MAX_CONCURRENCY as _] = array::from_fn(|_| {
+                scope.spawn(|| concurrency.try_acquire(MAX_TABLES / MAX_CONCURRENCY))
+            });
+            let permits = permits.map(|thread| {
+                thread.join().expect("failed to join thread").expect("failed to acquire permit")
+            });
+            assert!(!concurrency.try_reserve_instance());
+            assert_eq!(concurrency.release_instance(), u64::from(MAX_CONCURRENCY + 1));
+
+            let thread = spawn({
+                let concurrency = concurrency.clone();
+                move || concurrency.try_acquire(MAX_TABLES).is_some()
+            });
+            let mut permits = Vec::from(permits);
+            let permit = permits.pop().expect("last permit missing");
+            for permit in permits {
+                drop(permit);
+                yield_now();
+                assert!(!thread.is_finished());
+            }
+
+            yield_now();
+            assert!(!thread.is_finished());
+            drop(permit);
+
+            let acquired = thread.join().expect("failed to join thread");
+            assert!(acquired);
+        });
+
+        #[expect(clippy::large_stack_frames)]
+        scope(|scope| {
+            let permits: [_; MAX_CONCURRENCY as _] =
+                array::from_fn(|_| scope.spawn(|| concurrency.try_acquire(0)));
+            let permits = permits.map(|thread| {
+                thread.join().expect("failed to join thread").expect("failed to acquire permit")
+            });
+            assert!(!concurrency.try_reserve_instance());
+            assert_eq!(concurrency.release_instance(), u64::from(MAX_CONCURRENCY + 1));
+
+            let thread = spawn({
+                let concurrency = concurrency.clone();
+                move || concurrency.try_acquire(0).is_some()
+            });
+
+            yield_now();
+            assert!(!thread.is_finished());
+            drop(permits);
+
+            let acquired = thread.join().expect("failed to join thread");
+            assert!(acquired);
+        });
+    }
+}

--- a/runtime/near-vm/vm/src/probestack.rs
+++ b/runtime/near-vm/vm/src/probestack.rs
@@ -55,10 +55,12 @@ cfg_if::cfg_if! {
         /// A default probestack for other architectures
         pub const PROBESTACK: unsafe extern "C" fn() = empty_probestack;
     } else {
-        unsafe extern "C" {
-            pub fn __rust_probestack();
-        }
-        /// The probestack based on the Rust probestack
-        pub static PROBESTACK: unsafe extern "C" fn() = __rust_probestack;
+        // Starting with Rust 1.89, LLVM emits inline stack probes on x86/x86_64
+        // and __rust_probestack is no longer provided by compiler-builtins.
+        // NearVM is a legacy VM used only for replaying pre-protocol-84 blocks,
+        // so an empty probestack is sufficient here.
+        unsafe extern "C" fn empty_probestack() {}
+        /// The probestack for x86/x86_64 Linux (noop, inline probes used instead)
+        pub const PROBESTACK: unsafe extern "C" fn() = empty_probestack;
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,13 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-
-# XXX: Do not bump this version yet.  1.87 adds supports for bulk memory in wasm
-# and we do not support contracts with bulk memory yet.  Increasing the version
-# number here will make it harder for contract developers to build and test
-# their contracts.  See
-# https://near.zulipchat.com/#narrow/channel/295306-contract-runtime/topic/bulk.20memory.20support
-# for more details.
-channel = "1.86.0"
+channel = "1.91.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION

1. Bump rust-toolchain.toml to the new wasmtime's MSRV (1.91 for wasmtime 42) . Verify the existing wasmtime 36 still compiles with the new toolchain. This would normally be a separate step before the wasmtime upgrade.
2. Add new wasmtime version as a separate workspace dependency (e.g., wasmtime42 = { package = "wasmtime", version = "42" }). This only works for the major wasmtime version upgrades - semver compatible versions are resolved to one version.
3. Copy wasmtime_runner/ → wasmtime42_runner/ and port to the new API
4. Add Wasmtime42 to the VMKind enum in core/parameters/src/vm.rs
5. Add a new ProtocolFeature variant and map it to a future protocol version
6. Wire up the dispatch in runner.rs (is_available + runtime)
7. Add a feature flag (e.g., wasmtime42_vm) in near-vm-runner/Cargo.toml
8. Update runtime config to switch vm_kind at the new protocol version
9. Run the full test suite, especially the VM-specific tests and any contract compatibility tests


Main breaking change: wasmtime 42 replaced anyhow with its own error type `anyhow::Result → wasmtime::Result / wasmtime::Error`. 