### PR TITLE
poc(network): run real PeerManagerActor in testloop (prototype-v3)

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1,17 +1,12 @@
 use crate::accounts_data::AccountDataError;
-use crate::client::{
-    AnnounceAccountRequest, BlockHeadersRequest, BlockHeadersResponse, BlockRequest, BlockResponse,
-    EpochSyncRequestMessage, EpochSyncResponseMessage, OptimisticBlockMessage, ProcessTxRequest,
-    StateRequestHeader, StateRequestPart, StateResponse, StateResponseReceived,
-};
+use crate::client::AnnounceAccountRequest;
 use crate::concurrency::atomic_cell::AtomicCell;
 use crate::concurrency::demux;
 use crate::config::PEERS_RESPONSE_MAX_PEERS;
 use crate::network_protocol::{
     Edge, EdgeState, OwnedAccount, PartialEdgeInfo, PeerChainInfoV2, PeerIdOrHash, PeerInfo,
-    PeersRequest, PeersResponse, RawRoutedMessage, RoutingTableUpdate,
-    SnapshotHostInfoVerificationError, SyncAccountsData, SyncSnapshotHosts, T2MessageBody,
-    TieredMessageBody,
+    PeersRequest, PeersResponse, RoutingTableUpdate, SnapshotHostInfoVerificationError,
+    SyncAccountsData, SyncSnapshotHosts, T2MessageBody, TieredMessageBody,
 };
 use crate::peer::stream;
 use crate::peer::tracker::Tracker;
@@ -32,12 +27,12 @@ use crate::types::{
 use ::time::Duration;
 use lru::LruCache;
 use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt, FutureSpawnerExt};
-use near_async::messaging::{self, CanSend, CanSendAsync, IntoAsyncSender, IntoSender};
+use near_async::messaging::{self, CanSendAsync, IntoAsyncSender, IntoSender};
 use near_async::tokio::TokioRuntimeHandle;
 use near_async::{ActorSystem, time};
 use near_crypto::Signature;
 use near_o11y::log_assert;
-use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
+use near_o11y::span_wrapped_msg::SpanWrapped;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::types::EpochId;
@@ -950,24 +945,6 @@ impl PeerActor {
         }
     }
 
-    #[tracing::instrument(
-        level = "trace",
-        target = "network",
-        "receive_routed_message",
-        skip_all,
-        fields(body_type = body.variant()),
-    )]
-    async fn receive_routed_message(
-        clock: &time::Clock,
-        network_state: &Arc<NetworkState>,
-        msg_author: PeerId,
-        prev_hop: PeerId,
-        msg_hash: CryptoHash,
-        body: TieredMessageBody,
-    ) -> Result<Option<TieredMessageBody>, ReasonForBan> {
-        Ok(network_state.receive_routed_message(clock, msg_author, prev_hop, msg_hash, body).await)
-    }
-
     fn receive_message(&self, conn: &connection::Connection, msg: PeerMessage) {
         let _span = tracing::trace_span!(target: "network", "receive_message").entered();
         #[cfg(test)]
@@ -1001,120 +978,7 @@ impl PeerActor {
         let network_state = self.network_state.clone();
         let peer_id = conn.peer_info.id.clone();
         let handling_future = async move {
-            Ok(match msg {
-                PeerMessage::Routed(msg) => {
-                    let msg_hash = msg.hash();
-                    Self::receive_routed_message(
-                        &clock,
-                        &network_state,
-                        msg.author().clone(),
-                        peer_id.clone(),
-                        msg_hash,
-                        msg.body_owned(),
-                    )
-                    .await?
-                    .map(|body| {
-                        PeerMessage::Routed(network_state.sign_message(
-                            &clock,
-                            RawRoutedMessage { target: PeerIdOrHash::Hash(msg_hash), body },
-                        ))
-                    })
-                }
-                PeerMessage::BlockRequest(hash) => network_state
-                    .client
-                    .send_async(BlockRequest(hash))
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(|block| PeerMessage::Block(block)),
-                PeerMessage::BlockHeadersRequest(hashes) => network_state
-                    .client
-                    .send_async(BlockHeadersRequest(hashes))
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(PeerMessage::BlockHeaders),
-                PeerMessage::Block(block) => {
-                    network_state
-                        .client
-                        .send_async(BlockResponse { block, peer_id, was_requested }.span_wrap())
-                        .await
-                        .ok();
-                    None
-                }
-                PeerMessage::Transaction(transaction) => {
-                    network_state
-                        .client
-                        .send_async(ProcessTxRequest {
-                            transaction,
-                            is_forwarded: false,
-                            check_only: false,
-                        })
-                        .await
-                        .ok();
-                    None
-                }
-                PeerMessage::BlockHeaders(headers) => {
-                    if let Ok(Err(ban_reason)) = network_state
-                        .client
-                        .send_async(BlockHeadersResponse(headers, peer_id).span_wrap())
-                        .await
-                    {
-                        return Err(ban_reason);
-                    }
-                    None
-                }
-                PeerMessage::Challenge(_) => None,
-                PeerMessage::StateRequestHeader(shard_id, sync_hash) => network_state
-                    .state_request_adapter
-                    .send_async(StateRequestHeader { shard_id, sync_hash })
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(|response| PeerMessage::VersionedStateResponse(*response.0)),
-                PeerMessage::StateRequestPart(shard_id, sync_hash, part_id) => network_state
-                    .state_request_adapter
-                    .send_async(StateRequestPart { shard_id, sync_hash, part_id })
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(|response| PeerMessage::VersionedStateResponse(*response.0)),
-                PeerMessage::VersionedStateResponse(info) => {
-                    network_state
-                        .client
-                        .send_async(
-                            StateResponseReceived {
-                                peer_id,
-                                state_response: StateResponse::State(info.into()),
-                            }
-                            .span_wrap(),
-                        )
-                        .await
-                        .ok();
-                    None
-                }
-                PeerMessage::EpochSyncRequest => {
-                    network_state.client.send(EpochSyncRequestMessage { from_peer: peer_id });
-                    None
-                }
-                PeerMessage::EpochSyncResponse(proof) => {
-                    network_state
-                        .client
-                        .send(EpochSyncResponseMessage { from_peer: peer_id, proof });
-                    None
-                }
-                PeerMessage::OptimisticBlock(ob) => {
-                    network_state.client.send(
-                        OptimisticBlockMessage { from_peer: peer_id, optimistic_block: ob }
-                            .span_wrap(),
-                    );
-                    None
-                }
-                msg => {
-                    tracing::error!(target: "network", ?msg, "peer received unexpected type");
-                    None
-                }
-            })
+            network_state.handle_peer_message(&clock, peer_id, msg, was_requested).await
         };
 
         let mut handle = self.handle.clone();

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1427,11 +1427,13 @@ impl PeerActor {
                     match msg.body() {
                         TieredMessageBody::T2(t2) => match t2.as_ref() {
                             T2MessageBody::Ping(ping) => {
+                                let transport = self.network_state.pool_transport(conn.tier);
                                 self.network_state.send_pong(
                                     &self.clock,
                                     conn.tier,
                                     ping.nonce,
                                     msg.hash(),
+                                    &transport,
                                 );
                                 // TODO(gprusak): deprecate Event::Ping/Pong in favor of
                                 // MessageProcessed.
@@ -1460,7 +1462,13 @@ impl PeerActor {
                     if msg.decrease_ttl() {
                         let num_hops = msg.num_hops_mut();
                         *num_hops = num_hops.saturating_add(1);
-                        self.network_state.send_message_to_peer(&self.clock, conn.tier, msg);
+                        let transport = self.network_state.pool_transport(conn.tier);
+                        self.network_state.send_message_to_peer(
+                            &self.clock,
+                            conn.tier,
+                            msg,
+                            &transport,
+                        );
                     } else {
                         #[cfg(test)]
                         self.network_state.config.event_sink.send(Event::RoutedMessageDropped);

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -168,10 +168,11 @@ pub struct NetworkState {
     /// TODO(gprusak): make it use synchronization primitives in some more canonical way.
     set_chain_info_mutex: Mutex<()>,
 
-    /// Testloop-only: block info per peer, populated by TestLoopTransport when
-    /// dispatching Block messages. Empty in production (zero-cost).
-    /// Used by PeerManagerActor::highest_height_peers() to provide sync info.
-    pub testloop_peer_block_info:
+    /// Block info per peer, populated by dispatch_incoming_message when
+    /// processing Block messages. Used by highest_height_peers() to provide
+    /// sync info. In production this supplements Pool-based peer info;
+    /// in testloop (where Pools are empty) this is the sole source.
+    pub peer_block_info:
         Mutex<std::collections::HashMap<PeerId, (crate::types::PeerInfo, crate::types::BlockInfo)>>,
 }
 
@@ -261,7 +262,7 @@ impl NetworkState {
                 future_spawner,
             ),
             set_chain_info_mutex: Mutex::new(()),
-            testloop_peer_block_info: Mutex::new(std::collections::HashMap::new()),
+            peer_block_info: Mutex::new(std::collections::HashMap::new()),
             config,
             created_at: clock.now(),
             tier1_advertise_proxies_mutex: tokio::sync::Mutex::new(()),
@@ -330,7 +331,7 @@ impl NetworkState {
                 &*ops_spawner,
             ),
             set_chain_info_mutex: Mutex::new(()),
-            testloop_peer_block_info: Mutex::new(std::collections::HashMap::new()),
+            peer_block_info: Mutex::new(std::collections::HashMap::new()),
             config,
             created_at: clock.now(),
             tier1_advertise_proxies_mutex: tokio::sync::Mutex::new(()),
@@ -987,7 +988,7 @@ impl NetworkState {
                 self.txns_since_last_block.store(0, Ordering::Release);
                 let height = block.header().height();
                 let hash = *block.hash();
-                self.testloop_peer_block_info.lock().insert(
+                self.peer_block_info.lock().insert(
                     from_peer.clone(),
                     (
                         PeerInfo { id: from_peer.clone(), addr: None, account_id: None },

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1,9 +1,10 @@
 use crate::accounts_data::{AccountDataCache, AccountDataError};
 use crate::announce_accounts::AnnounceAccountCache;
 use crate::client::{
-    BlockApproval, BlockHeadersResponse, BlockResponse, ChunkEndorsementMessage,
-    ClientSenderForNetwork, EpochSyncRequestMessage, EpochSyncResponseMessage,
-    OptimisticBlockMessage, ProcessTxRequest, SpiceChunkEndorsementMessage, StateResponse,
+    BlockApproval, BlockHeadersRequest, BlockHeadersResponse, BlockRequest, BlockResponse,
+    ChunkEndorsementMessage, ClientSenderForNetwork, EpochSyncRequestMessage,
+    EpochSyncResponseMessage, OptimisticBlockMessage, ProcessTxRequest,
+    SpiceChunkEndorsementMessage, StateRequestHeader, StateRequestPart, StateResponse,
     StateResponseReceived, TxStatusRequest, TxStatusResponse,
 };
 use crate::concurrency::demux;
@@ -972,80 +973,142 @@ impl NetworkState {
         }
     }
 
-    /// Dispatch a non-routed incoming message to the appropriate actor sender.
-    /// Fire-and-forget -- no response expected. Returns true if handled.
+    /// Dispatch an incoming peer message to the appropriate actor sender.
     ///
-    /// For request-response messages (BlockRequest, BlockHeadersRequest,
-    /// StateRequest*), returns false -- the caller handles these separately
-    /// (PeerActor awaits response via TCP, TestLoopTransport spawns async).
+    /// Handles both fire-and-forget messages (Block, Transaction, etc.) and
+    /// request-response messages (BlockRequest, StateRequest*, etc.).
+    /// Returns `Ok(Some(response))` for request-response messages,
+    /// `Ok(None)` for fire-and-forget, `Err(ban)` for protocol violations.
     ///
-    /// For routed messages, the caller should use process_incoming_routed
-    /// or dispatch_routed_body_sync instead.
-    #[allow(unused_must_use)]
-    pub fn dispatch_incoming_message(&self, from_peer: PeerId, msg: PeerMessage) -> bool {
-        match msg {
+    /// Shared between PeerActor (production) and TestLoopTransport (testloop).
+    /// PeerActor sends `Ok(Some(response))` back over TCP.
+    /// TestLoopTransport routes it back via in-memory dispatch.
+    ///
+    /// Routed messages are also handled here via `receive_routed_message`.
+    /// In testloop, routed messages go through multi-hop routing instead
+    /// and don't reach this function.
+    pub async fn handle_peer_message(
+        self: &Arc<Self>,
+        clock: &time::Clock,
+        peer_id: PeerId,
+        msg: PeerMessage,
+        was_requested: bool,
+    ) -> Result<Option<PeerMessage>, ReasonForBan> {
+        Ok(match msg {
+            PeerMessage::Routed(msg) => {
+                let msg_hash = msg.hash();
+                self.receive_routed_message(
+                    clock,
+                    msg.author().clone(),
+                    peer_id.clone(),
+                    msg_hash,
+                    msg.body_owned(),
+                )
+                .await
+                .map(|body| {
+                    PeerMessage::Routed(self.sign_message(
+                        clock,
+                        RawRoutedMessage { target: PeerIdOrHash::Hash(msg_hash), body },
+                    ))
+                })
+            }
+            PeerMessage::BlockRequest(hash) => self
+                .client
+                .send_async(BlockRequest(hash))
+                .await
+                .ok()
+                .flatten()
+                .map(|block| PeerMessage::Block(block)),
+            PeerMessage::BlockHeadersRequest(hashes) => self
+                .client
+                .send_async(BlockHeadersRequest(hashes))
+                .await
+                .ok()
+                .flatten()
+                .map(PeerMessage::BlockHeaders),
             PeerMessage::Block(block) => {
                 self.txns_since_last_block.store(0, Ordering::Release);
                 let height = block.header().height();
                 let hash = *block.hash();
                 self.peer_block_info.lock().insert(
-                    from_peer.clone(),
+                    peer_id.clone(),
                     (
-                        PeerInfo { id: from_peer.clone(), addr: None, account_id: None },
+                        PeerInfo { id: peer_id.clone(), addr: None, account_id: None },
                         BlockInfo { height, hash },
                     ),
                 );
-                self.client.send_async(
-                    BlockResponse { block, peer_id: from_peer, was_requested: false }.span_wrap(),
-                );
-                true
+                self.client
+                    .send_async(BlockResponse { block, peer_id, was_requested }.span_wrap())
+                    .await
+                    .ok();
+                None
             }
             PeerMessage::Transaction(transaction) => {
-                self.client.send_async(ProcessTxRequest {
-                    transaction,
-                    is_forwarded: false,
-                    check_only: false,
-                });
-                true
+                self.client
+                    .send_async(ProcessTxRequest {
+                        transaction,
+                        is_forwarded: false,
+                        check_only: false,
+                    })
+                    .await
+                    .ok();
+                None
             }
             PeerMessage::BlockHeaders(headers) => {
-                self.client.send_async(BlockHeadersResponse(headers, from_peer).span_wrap());
-                true
+                if let Ok(Err(ban_reason)) =
+                    self.client.send_async(BlockHeadersResponse(headers, peer_id).span_wrap()).await
+                {
+                    return Err(ban_reason);
+                }
+                None
             }
+            PeerMessage::Challenge(_) => None,
+            PeerMessage::StateRequestHeader(shard_id, sync_hash) => self
+                .state_request_adapter
+                .send_async(StateRequestHeader { shard_id, sync_hash })
+                .await
+                .ok()
+                .flatten()
+                .map(|response| PeerMessage::VersionedStateResponse(*response.0)),
+            PeerMessage::StateRequestPart(shard_id, sync_hash, part_id) => self
+                .state_request_adapter
+                .send_async(StateRequestPart { shard_id, sync_hash, part_id })
+                .await
+                .ok()
+                .flatten()
+                .map(|response| PeerMessage::VersionedStateResponse(*response.0)),
             PeerMessage::VersionedStateResponse(info) => {
-                self.client.send_async(
-                    StateResponseReceived {
-                        peer_id: from_peer,
-                        state_response: StateResponse::State(info.into()),
-                    }
-                    .span_wrap(),
-                );
-                true
+                self.client
+                    .send_async(
+                        StateResponseReceived {
+                            peer_id,
+                            state_response: StateResponse::State(info.into()),
+                        }
+                        .span_wrap(),
+                    )
+                    .await
+                    .ok();
+                None
             }
             PeerMessage::EpochSyncRequest => {
-                self.client.send(EpochSyncRequestMessage { from_peer });
-                true
+                self.client.send(EpochSyncRequestMessage { from_peer: peer_id });
+                None
             }
             PeerMessage::EpochSyncResponse(proof) => {
-                self.client.send(EpochSyncResponseMessage { from_peer, proof });
-                true
+                self.client.send(EpochSyncResponseMessage { from_peer: peer_id, proof });
+                None
             }
             PeerMessage::OptimisticBlock(ob) => {
-                self.client
-                    .send(OptimisticBlockMessage { from_peer, optimistic_block: ob }.span_wrap());
-                true
+                self.client.send(
+                    OptimisticBlockMessage { from_peer: peer_id, optimistic_block: ob }.span_wrap(),
+                );
+                None
             }
-            PeerMessage::Challenge(_) => true, // ignored
-            // Request-response messages -- caller handles these
-            PeerMessage::BlockRequest(_)
-            | PeerMessage::BlockHeadersRequest(_)
-            | PeerMessage::StateRequestHeader(..)
-            | PeerMessage::StateRequestPart(..) => false,
-            // Routed messages -- caller should use process_incoming_routed
-            PeerMessage::Routed(_) => false,
-            // Connection-level messages -- not dispatched here
-            _ => false,
-        }
+            msg => {
+                tracing::error!(target: "network", ?msg, "unexpected peer message type");
+                None
+            }
+        })
     }
 
     pub async fn receive_routed_message(

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1,9 +1,10 @@
 use crate::accounts_data::{AccountDataCache, AccountDataError};
 use crate::announce_accounts::AnnounceAccountCache;
 use crate::client::{
-    BlockApproval, ChunkEndorsementMessage, ClientSenderForNetwork, ProcessTxRequest,
-    SpiceChunkEndorsementMessage, StateResponse, StateResponseReceived, TxStatusRequest,
-    TxStatusResponse,
+    BlockApproval, BlockHeadersResponse, BlockResponse, ChunkEndorsementMessage,
+    ClientSenderForNetwork, EpochSyncRequestMessage, EpochSyncResponseMessage,
+    OptimisticBlockMessage, ProcessTxRequest, SpiceChunkEndorsementMessage, StateResponse,
+    StateResponseReceived, TxStatusRequest, TxStatusResponse,
 };
 use crate::concurrency::demux;
 use crate::config;
@@ -37,8 +38,9 @@ use crate::stats::metrics;
 use crate::store;
 use crate::tcp;
 use crate::types::{
-    ChainInfo, PeerManagerSenderForNetwork, PeerType, ReasonForBan, StateHeaderRequestBody,
-    StatePartRequestBody, StateRequestSenderForNetwork, Tier3Request, Tier3RequestBody,
+    BlockInfo, ChainInfo, PeerManagerSenderForNetwork, PeerType, ReasonForBan,
+    StateHeaderRequestBody, StatePartRequestBody, StateRequestSenderForNetwork, Tier3Request,
+    Tier3RequestBody,
 };
 use anyhow::Context;
 use arc_swap::ArcSwap;
@@ -54,7 +56,7 @@ use parking_lot::{Mutex, RwLock};
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 mod routing;
 mod tier1;
@@ -960,6 +962,82 @@ impl NetworkState {
                     );
                 }
             },
+        }
+    }
+
+    /// Dispatch a non-routed incoming message to the appropriate actor sender.
+    /// Fire-and-forget -- no response expected. Returns true if handled.
+    ///
+    /// For request-response messages (BlockRequest, BlockHeadersRequest,
+    /// StateRequest*), returns false -- the caller handles these separately
+    /// (PeerActor awaits response via TCP, TestLoopTransport spawns async).
+    ///
+    /// For routed messages, the caller should use process_incoming_routed
+    /// or dispatch_routed_body_sync instead.
+    #[allow(unused_must_use)]
+    pub fn dispatch_incoming_message(&self, from_peer: PeerId, msg: PeerMessage) -> bool {
+        match msg {
+            PeerMessage::Block(block) => {
+                self.txns_since_last_block.store(0, Ordering::Release);
+                let height = block.header().height();
+                let hash = *block.hash();
+                self.testloop_peer_block_info.lock().insert(
+                    from_peer.clone(),
+                    (
+                        PeerInfo { id: from_peer.clone(), addr: None, account_id: None },
+                        BlockInfo { height, hash },
+                    ),
+                );
+                self.client.send_async(
+                    BlockResponse { block, peer_id: from_peer, was_requested: false }.span_wrap(),
+                );
+                true
+            }
+            PeerMessage::Transaction(transaction) => {
+                self.client.send_async(ProcessTxRequest {
+                    transaction,
+                    is_forwarded: false,
+                    check_only: false,
+                });
+                true
+            }
+            PeerMessage::BlockHeaders(headers) => {
+                self.client.send_async(BlockHeadersResponse(headers, from_peer).span_wrap());
+                true
+            }
+            PeerMessage::VersionedStateResponse(info) => {
+                self.client.send_async(
+                    StateResponseReceived {
+                        peer_id: from_peer,
+                        state_response: StateResponse::State(info.into()),
+                    }
+                    .span_wrap(),
+                );
+                true
+            }
+            PeerMessage::EpochSyncRequest => {
+                self.client.send(EpochSyncRequestMessage { from_peer });
+                true
+            }
+            PeerMessage::EpochSyncResponse(proof) => {
+                self.client.send(EpochSyncResponseMessage { from_peer, proof });
+                true
+            }
+            PeerMessage::OptimisticBlock(ob) => {
+                self.client
+                    .send(OptimisticBlockMessage { from_peer, optimistic_block: ob }.span_wrap());
+                true
+            }
+            PeerMessage::Challenge(_) => true, // ignored
+            // Request-response messages -- caller handles these
+            PeerMessage::BlockRequest(_)
+            | PeerMessage::BlockHeadersRequest(_)
+            | PeerMessage::StateRequestHeader(..)
+            | PeerMessage::StateRequestPart(..) => false,
+            // Routed messages -- caller should use process_incoming_routed
+            PeerMessage::Routed(_) => false,
+            // Connection-level messages -- not dispatched here
+            _ => false,
         }
     }
 

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -126,12 +126,6 @@ pub struct NetworkState {
     pub tier2: connection::Pool,
     pub tier1: connection::Pool,
     pub tier3: connection::Pool,
-    /// Transport layer for sending messages to peers.
-    /// In production, these are PoolTransport wrapping the connection pools.
-    /// In testloop, these will be replaced with TestLoopTransport.
-    pub tier1_transport: Arc<dyn NetworkTransport>,
-    pub tier2_transport: Arc<dyn NetworkTransport>,
-    pub tier3_transport: Arc<dyn NetworkTransport>,
     /// Semaphore limiting inflight inbound handshakes.
     pub inbound_handshake_permits: Arc<tokio::sync::Semaphore>,
     /// The public IP of this node; available after connecting to any one peer.
@@ -244,9 +238,6 @@ impl NetworkState {
             shards_manager_adapter,
             partial_witness_adapter,
             chain_info: Default::default(),
-            tier1_transport: Arc::new(PoolTransport::new(tier1.clone())),
-            tier2_transport: Arc::new(PoolTransport::new(tier2.clone())),
-            tier3_transport: Arc::new(PoolTransport::new(tier3.clone())),
             tier1,
             tier2,
             tier3,
@@ -296,9 +287,6 @@ impl NetworkState {
         partial_witness_adapter: PartialWitnessSenderForNetwork,
         spice_data_distributor_adapter: SpiceDataDistributorSenderForNetwork,
         spice_core_writer_adapter: Sender<SpiceChunkEndorsementMessage>,
-        tier1_transport: Arc<dyn NetworkTransport>,
-        tier2_transport: Arc<dyn NetworkTransport>,
-        tier3_transport: Arc<dyn NetworkTransport>,
     ) -> Self {
         let tier1 = connection::Pool::new(config.node_id());
         let tier2 = connection::Pool::new(config.node_id());
@@ -319,9 +307,6 @@ impl NetworkState {
             shards_manager_adapter,
             partial_witness_adapter,
             chain_info: Default::default(),
-            tier1_transport,
-            tier2_transport,
-            tier3_transport,
             tier1,
             tier2,
             tier3,
@@ -352,6 +337,16 @@ impl NetworkState {
             ops_spawner,
             spice_data_distributor_adapter,
             spice_core_writer_adapter,
+        }
+    }
+
+    /// Create a PoolTransport for the given tier from the connection pool.
+    /// Used by PeerActor (production-only) to create transports on-the-fly.
+    pub fn pool_transport(&self, tier: tcp::Tier) -> PoolTransport {
+        match tier {
+            tcp::Tier::T1 => PoolTransport::new(self.tier1.clone()),
+            tcp::Tier::T2 => PoolTransport::new(self.tier2.clone()),
+            tcp::Tier::T3 => PoolTransport::new(self.tier3.clone()),
         }
     }
 
@@ -633,24 +628,38 @@ impl NetworkState {
     }
 
     #[cfg(test)]
-    pub fn send_ping(&self, clock: &time::Clock, tier: tcp::Tier, nonce: u64, target: PeerId) {
+    pub fn send_ping(
+        &self,
+        clock: &time::Clock,
+        tier: tcp::Tier,
+        nonce: u64,
+        target: PeerId,
+        transport: &dyn NetworkTransport,
+    ) {
         let body = T2MessageBody::Ping(crate::network_protocol::Ping {
             nonce,
             source: self.config.node_id(),
         })
         .into();
         let msg = RawRoutedMessage { target: PeerIdOrHash::PeerId(target), body };
-        self.send_message_to_peer(clock, tier, self.sign_message(clock, msg));
+        self.send_message_to_peer(clock, tier, self.sign_message(clock, msg), transport);
     }
 
-    pub fn send_pong(&self, clock: &time::Clock, tier: tcp::Tier, nonce: u64, target: CryptoHash) {
+    pub fn send_pong(
+        &self,
+        clock: &time::Clock,
+        tier: tcp::Tier,
+        nonce: u64,
+        target: CryptoHash,
+        transport: &dyn NetworkTransport,
+    ) {
         let body = T2MessageBody::Pong(crate::network_protocol::Pong {
             nonce,
             source: self.config.node_id(),
         })
         .into();
         let msg = RawRoutedMessage { target: PeerIdOrHash::Hash(target), body };
-        self.send_message_to_peer(clock, tier, self.sign_message(clock, msg));
+        self.send_message_to_peer(clock, tier, self.sign_message(clock, msg), transport);
     }
 
     pub fn sign_message(&self, clock: &time::Clock, msg: RawRoutedMessage) -> Box<RoutedMessage> {
@@ -668,6 +677,7 @@ impl NetworkState {
         clock: &time::Clock,
         tier: tcp::Tier,
         msg: Box<RoutedMessage>,
+        transport: &dyn NetworkTransport,
     ) -> bool {
         let my_peer_id = self.config.node_id();
 
@@ -692,9 +702,7 @@ impl NetworkState {
                     }
                     PeerIdOrHash::PeerId(peer_id) => peer_id.clone(),
                 };
-                return self
-                    .tier1_transport
-                    .send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
+                return transport.send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
             }
             tcp::Tier::T2 => {
                 match self.tier2_find_route(&clock, msg.target()) {
@@ -704,9 +712,7 @@ impl NetworkState {
                             tracing::trace!(target: "network", ?msg, "initiate route back");
                             self.tier2_route_back.lock().insert(clock, msg.hash(), my_peer_id);
                         }
-                        return self
-                            .tier2_transport
-                            .send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
+                        return transport.send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
                     }
                     Err(find_route_error) => {
                         // TODO(MarX, #1369): Message is dropped here. Define policy for this case.
@@ -733,9 +739,7 @@ impl NetworkState {
                     }
                     PeerIdOrHash::PeerId(peer_id) => peer_id.clone(),
                 };
-                return self
-                    .tier3_transport
-                    .send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
+                return transport.send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
             }
         }
     }
@@ -748,6 +752,7 @@ impl NetworkState {
         clock: &time::Clock,
         account_id: &AccountId,
         msg: TieredMessageBody,
+        tier2_transport: &dyn NetworkTransport,
     ) -> bool {
         // If the message is allowed to be sent to self, we handle it directly.
         // If the message is allowed to be sent to self, we handle it directly.
@@ -834,7 +839,8 @@ impl NetworkState {
         let msg = RawRoutedMessage { target: PeerIdOrHash::PeerId(target), body: msg };
         let msg = self.sign_message(clock, msg);
         for _ in 0..msg.body().message_resend_count() {
-            success |= self.send_message_to_peer(clock, tcp::Tier::T2, msg.clone());
+            success |=
+                self.send_message_to_peer(clock, tcp::Tier::T2, msg.clone(), tier2_transport);
         }
         success
     }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -12,6 +12,7 @@ use crate::network_protocol::{
 use crate::network_protocol::{SyncSnapshotHosts, T1MessageBody};
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::connection;
+use crate::peer_manager::connection::transport::{NetworkTransport, PoolTransport};
 use crate::peer_manager::network_state::{NetworkState, WhitelistNode};
 use crate::peer_manager::peer_store;
 use crate::shards_manager::ShardsManagerRequestFromNetwork;
@@ -111,6 +112,14 @@ pub struct PeerManagerActor {
 
     /// State that is shared between multiple threads (including PeerActors).
     pub(crate) state: Arc<NetworkState>,
+
+    /// Transport layer for sending messages to peers.
+    /// In production, these are PoolTransport wrapping the connection pools.
+    /// In testloop, these are TestLoopTransport using in-memory dispatch.
+    #[allow(dead_code)]
+    pub(crate) tier1_transport: Arc<dyn NetworkTransport>,
+    pub(crate) tier2_transport: Arc<dyn NetworkTransport>,
+    pub(crate) tier3_transport: Arc<dyn NetworkTransport>,
 }
 
 /// TEST-ONLY
@@ -212,15 +221,21 @@ impl messaging::Actor for PeerManagerActor {
     /// Try to gracefully disconnect from connected peers.
     fn stop_actor(&mut self) {
         tracing::debug!(target: "network", "peer manager stopping");
-        self.state.tier2_transport.broadcast_message(Arc::new(PeerMessage::Disconnect(
-            Disconnect { remove_from_connection_store: false },
-        )));
+        self.tier2_transport.broadcast_message(Arc::new(PeerMessage::Disconnect(Disconnect {
+            remove_from_connection_store: false,
+        })));
     }
 }
 
 impl PeerManagerActor {
     /// Testloop constructor. Creates a PeerManagerActor without TCP infrastructure.
-    pub fn new_for_testloop(clock: time::Clock, state: Arc<NetworkState>) -> Self {
+    pub fn new_for_testloop(
+        clock: time::Clock,
+        state: Arc<NetworkState>,
+        tier1_transport: Arc<dyn NetworkTransport>,
+        tier2_transport: Arc<dyn NetworkTransport>,
+        tier3_transport: Arc<dyn NetworkTransport>,
+    ) -> Self {
         let my_peer_id = state.config.node_id();
         Self {
             clock,
@@ -229,6 +244,9 @@ impl PeerManagerActor {
             my_peer_id,
             started_connect_attempts: false,
             state,
+            tier1_transport,
+            tier2_transport,
+            tier3_transport,
         }
     }
 
@@ -394,6 +412,12 @@ impl PeerManagerActor {
                 });
             }
         });
+        let tier1_transport: Arc<dyn NetworkTransport> =
+            Arc::new(PoolTransport::new(state.tier1.clone()));
+        let tier2_transport: Arc<dyn NetworkTransport> =
+            Arc::new(PoolTransport::new(state.tier2.clone()));
+        let tier3_transport: Arc<dyn NetworkTransport> =
+            Arc::new(PoolTransport::new(state.tier3.clone()));
         builder.spawn_tokio_actor(Self {
             my_peer_id,
             started_connect_attempts: false,
@@ -401,6 +425,9 @@ impl PeerManagerActor {
             clock,
             actor_system: Some(actor_system),
             handle: Some(handle.clone()),
+            tier1_transport,
+            tier2_transport,
+            tier3_transport,
         });
         Ok(handle)
     }
@@ -843,7 +870,7 @@ impl PeerManagerActor {
         metrics::REQUEST_COUNT_BY_TYPE_TOTAL.with_label_values(&[msg.as_ref()]).inc();
         match msg {
             NetworkRequests::Block { block } => {
-                self.state.tier2_transport.broadcast_message(Arc::new(PeerMessage::Block(block)));
+                self.tier2_transport.broadcast_message(Arc::new(PeerMessage::Block(block)));
                 NetworkResponses::NoResponse
             }
             NetworkRequests::OptimisticBlock { chunk_producers, optimistic_block } => {
@@ -860,7 +887,7 @@ impl PeerManagerActor {
                         if let Some(peer_id) =
                             self.state.account_announcements.get_account_owner(&target_account)
                         {
-                            self.state.tier2_transport.send_message(peer_id, msg.clone());
+                            self.tier2_transport.send_message(peer_id, msg.clone());
                         }
                     }
                 }
@@ -871,12 +898,12 @@ impl PeerManagerActor {
                     &self.clock,
                     &approval_message.target,
                     T1MessageBody::BlockApproval(approval_message.approval).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
             NetworkRequests::BlockRequest { hash, peer_id } => {
                 if self
-                    .state
                     .tier2_transport
                     .send_message(peer_id, Arc::new(PeerMessage::BlockRequest(hash)))
                 {
@@ -887,7 +914,6 @@ impl PeerManagerActor {
             }
             NetworkRequests::BlockHeadersRequest { hashes, peer_id } => {
                 if self
-                    .state
                     .tier2_transport
                     .send_message(peer_id, Arc::new(PeerMessage::BlockHeadersRequest(hashes)))
                 {
@@ -927,7 +953,12 @@ impl PeerManagerActor {
                     },
                 );
 
-                if !self.state.send_message_to_peer(&self.clock, tcp::Tier::T2, routed_message) {
+                if !self.state.send_message_to_peer(
+                    &self.clock,
+                    tcp::Tier::T2,
+                    routed_message,
+                    &*self.tier2_transport,
+                ) {
                     return NetworkResponses::RouteNotFound;
                 }
 
@@ -971,7 +1002,12 @@ impl PeerManagerActor {
                     },
                 );
 
-                if !self.state.send_message_to_peer(&self.clock, tcp::Tier::T2, routed_message) {
+                if !self.state.send_message_to_peer(
+                    &self.clock,
+                    tcp::Tier::T2,
+                    routed_message,
+                    &*self.tier2_transport,
+                ) {
                     return NetworkResponses::RouteNotFound;
                 }
 
@@ -999,7 +1035,12 @@ impl PeerManagerActor {
                     },
                 );
 
-                if !self.state.send_message_to_peer(&self.clock, tcp::Tier::T2, routed_message) {
+                if !self.state.send_message_to_peer(
+                    &self.clock,
+                    tcp::Tier::T2,
+                    routed_message,
+                    &*self.tier2_transport,
+                ) {
                     return NetworkResponses::RouteNotFound;
                 }
 
@@ -1070,11 +1111,9 @@ impl PeerManagerActor {
                 // Insert our info to our own cache.
                 self.state.snapshot_hosts.insert_skip_verify(snapshot_host_info.clone());
 
-                self.state.tier2_transport.broadcast_message(Arc::new(
-                    PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts {
-                        hosts: vec![snapshot_host_info],
-                    }),
-                ));
+                self.tier2_transport.broadcast_message(Arc::new(PeerMessage::SyncSnapshotHosts(
+                    SyncSnapshotHosts { hosts: vec![snapshot_host_info] },
+                )));
                 NetworkResponses::NoResponse
             }
             NetworkRequests::BanPeer { peer_id, ban_reason } => {
@@ -1103,6 +1142,7 @@ impl PeerManagerActor {
                                 &self.clock,
                                 account_id,
                                 T2MessageBody::PartialEncodedChunkRequest(request.clone()).into(),
+                                &*self.tier2_transport,
                             ) {
                                 success = true;
                                 break;
@@ -1136,6 +1176,7 @@ impl PeerManagerActor {
                                         .into(),
                                     },
                                 ),
+                                &*self.tier2_transport,
                             ) {
                                 success = true;
                                 break;
@@ -1164,6 +1205,7 @@ impl PeerManagerActor {
                             body: T2MessageBody::PartialEncodedChunkResponse(response).into(),
                         },
                     ),
+                    &*self.tier2_transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1178,6 +1220,7 @@ impl PeerManagerActor {
                         partial_encoded_chunk.into(),
                     ))
                     .into(),
+                    &*self.tier2_transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1189,6 +1232,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &account_id,
                     T1MessageBody::PartialEncodedChunkForward(forward).into(),
+                    &*self.tier2_transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1200,6 +1244,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &account_id,
                     T2MessageBody::ForwardTx(tx).into(),
+                    &*self.tier2_transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1211,6 +1256,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &account_id,
                     T2MessageBody::TxStatusRequest(signer_account_id, tx_hash).into(),
+                    &*self.tier2_transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1222,6 +1268,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T2MessageBody::ChunkStateWitnessAck(ack).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1230,6 +1277,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::VersionedChunkEndorsement(endorsement).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1252,6 +1300,7 @@ impl PeerManagerActor {
                         &self.clock,
                         &chunk_validator,
                         T1MessageBody::PartialEncodedStateWitness(partial_witness).into(),
+                        &*self.tier2_transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1274,15 +1323,13 @@ impl PeerManagerActor {
                         &chunk_validator,
                         T1MessageBody::PartialEncodedStateWitnessForward(partial_witness.clone())
                             .into(),
+                        &*self.tier2_transport,
                     );
                 }
                 NetworkResponses::NoResponse
             }
             NetworkRequests::EpochSyncRequest { peer_id } => {
-                if self
-                    .state
-                    .tier2_transport
-                    .send_message(peer_id, PeerMessage::EpochSyncRequest.into())
+                if self.tier2_transport.send_message(peer_id, PeerMessage::EpochSyncRequest.into())
                 {
                     NetworkResponses::NoResponse
                 } else {
@@ -1291,7 +1338,6 @@ impl PeerManagerActor {
             }
             NetworkRequests::EpochSyncResponse { peer_id, proof } => {
                 if self
-                    .state
                     .tier2_transport
                     .send_message(peer_id, PeerMessage::EpochSyncResponse(proof).into())
                 {
@@ -1306,6 +1352,7 @@ impl PeerManagerActor {
                         &self.clock,
                         &validator,
                         T1MessageBody::ChunkContractAccesses(accesses.clone()).into(),
+                        &*self.tier2_transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1315,6 +1362,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::ContractCodeRequest(request).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1323,6 +1371,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::ContractCodeResponse(response).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1334,12 +1383,14 @@ impl PeerManagerActor {
                         &self.clock,
                         &account,
                         T2MessageBody::PartialEncodedContractDeploys(deploys.clone()).into(),
+                        &*self.tier2_transport,
                     );
                 }
                 self.state.send_message_to_account(
                     &self.clock,
                     &last_account,
                     T2MessageBody::PartialEncodedContractDeploys(deploys).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1353,6 +1404,7 @@ impl PeerManagerActor {
                         // TODO(spice): Once spice data distribution retries are implemented
                         // reconsider if sending data over T1 still makes sense.
                         T1MessageBody::SpicePartialData(partial_data).into(),
+                        &*self.tier2_transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1362,6 +1414,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::SpiceChunkEndorsement(endorsement).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1370,6 +1423,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &producer,
                     T1MessageBody::SpicePartialDataRequest(request).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1379,6 +1433,7 @@ impl PeerManagerActor {
                         &self.clock,
                         &target,
                         T1MessageBody::SpiceChunkContractAccesses(accesses.clone()).into(),
+                        &*self.tier2_transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1388,6 +1443,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::SpiceContractCodeRequest(request).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1396,6 +1452,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::SpiceContractCodeResponse(response).into(),
+                    &*self.tier2_transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1510,6 +1567,8 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
         let state = self.state.clone();
         let clock = self.clock.clone();
         let actor_system = self.actor_system.clone().unwrap();
+        let tier2_transport = self.tier2_transport.clone();
+        let tier3_transport = self.tier3_transport.clone();
         handle.spawn("handle tier3 request",
             async move {
                 // Process the request.
@@ -1579,7 +1638,7 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                         body: tier2_ack,
                     },
                 );
-                if !state.send_message_to_peer(&clock, tcp::Tier::T2, routed_message) {
+                if !state.send_message_to_peer(&clock, tcp::Tier::T2, routed_message, &*tier2_transport) {
                     tracing::debug!(target: "network", sender = %sender, "failed to route ack");
                 }
 
@@ -1604,7 +1663,7 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                     }
                 }
 
-                state.tier3_transport.send_message(sender, Arc::new(tier3_response));
+                tier3_transport.send_message(sender, Arc::new(tier3_response));
             }
         );
     }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -495,10 +495,11 @@ impl PeerManagerActor {
             .filter_map(|p| p.full_peer_info().into())
             .collect();
 
-        // In testloop, connection pools are empty. Use block info from transport dispatch.
+        // Supplement with block info from dispatch_incoming_message.
+        // In testloop (no Pools), this is the sole source of peer height info.
         {
-            let testloop_info = self.state.testloop_peer_block_info.lock();
-            for (_peer_id, (peer_info, block_info)) in testloop_info.iter() {
+            let dispatch_info = self.state.peer_block_info.lock();
+            for (_peer_id, (peer_info, block_info)) in dispatch_info.iter() {
                 infos.push(HighestHeightPeerInfo {
                     peer_info: peer_info.clone(),
                     genesis_id: self.state.genesis_id.clone(),

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -165,54 +165,51 @@ impl messaging::Actor for PeerManagerActor {
         self.push_network_info_trigger(ctx, self.state.config.push_info_period);
 
         // TCP-only infrastructure (skipped in testloop mode where handle is None).
-        if self.handle.is_none() {
-            #[cfg(test)]
-            self.state.config.event_sink.send(Event::PeerManagerStarted);
-            return;
-        }
-
-        // Attempt to reconnect to recent outbound connections from storage
-        if self.state.config.connect_to_reliable_peers_on_startup {
-            tracing::debug!(target: "network", "reconnecting to reliable peers from storage");
-            self.bootstrap_outbound_from_recent_connections();
-        } else {
-            tracing::debug!(target: "network", "skipping reconnection to reliable peers");
-        }
-
-        // Periodically starts peer monitoring.
-        tracing::debug!(target: "network",
-               max_period=?self.state.config.monitor_peers_max_period,
-               "monitor_peers_trigger");
-        self.monitor_peers_trigger(
-            MONITOR_PEERS_INITIAL_DURATION,
-            (MONITOR_PEERS_INITIAL_DURATION, self.state.config.monitor_peers_max_period),
-        );
-
-        // Periodically fix local edges.
-        let clock = self.clock.clone();
-        let state = self.state.clone();
-        let handle = self.handle.as_ref().unwrap();
-        handle.spawn("fix_local_edges loop", async move {
-            let mut interval = time::Interval::new(clock.now(), FIX_LOCAL_EDGES_INTERVAL);
-            loop {
-                interval.tick(&clock).await;
-                state.fix_local_edges(&clock, FIX_LOCAL_EDGES_TIMEOUT).await;
+        if self.handle.is_some() {
+            // Attempt to reconnect to recent outbound connections from storage
+            if self.state.config.connect_to_reliable_peers_on_startup {
+                tracing::debug!(target: "network", "reconnecting to reliable peers from storage");
+                self.bootstrap_outbound_from_recent_connections();
+            } else {
+                tracing::debug!(target: "network", "skipping reconnection to reliable peers");
             }
-        });
 
-        // Periodically update the connection store.
-        let clock = self.clock.clone();
-        let state = self.state.clone();
-        handle.spawn("update_connection_store loop", async move {
-            let mut interval = time::Interval::new(clock.now(), UPDATE_CONNECTION_STORE_INTERVAL);
-            loop {
-                interval.tick(&clock).await;
-                state.update_connection_store(&clock);
-            }
-        });
+            // Periodically starts peer monitoring.
+            tracing::debug!(target: "network",
+                   max_period=?self.state.config.monitor_peers_max_period,
+                   "monitor_peers_trigger");
+            self.monitor_peers_trigger(
+                MONITOR_PEERS_INITIAL_DURATION,
+                (MONITOR_PEERS_INITIAL_DURATION, self.state.config.monitor_peers_max_period),
+            );
 
-        // Periodically prints bandwidth stats for each peer.
-        self.report_bandwidth_stats_trigger(ctx, REPORT_BANDWIDTH_STATS_TRIGGER_INTERVAL);
+            // Periodically fix local edges.
+            let clock = self.clock.clone();
+            let state = self.state.clone();
+            let handle = self.handle.as_ref().unwrap();
+            handle.spawn("fix_local_edges loop", async move {
+                let mut interval = time::Interval::new(clock.now(), FIX_LOCAL_EDGES_INTERVAL);
+                loop {
+                    interval.tick(&clock).await;
+                    state.fix_local_edges(&clock, FIX_LOCAL_EDGES_TIMEOUT).await;
+                }
+            });
+
+            // Periodically update the connection store.
+            let clock = self.clock.clone();
+            let state = self.state.clone();
+            handle.spawn("update_connection_store loop", async move {
+                let mut interval =
+                    time::Interval::new(clock.now(), UPDATE_CONNECTION_STORE_INTERVAL);
+                loop {
+                    interval.tick(&clock).await;
+                    state.update_connection_store(&clock);
+                }
+            });
+
+            // Periodically prints bandwidth stats for each peer.
+            self.report_bandwidth_stats_trigger(ctx, REPORT_BANDWIDTH_STATS_TRIGGER_INTERVAL);
+        }
 
         #[cfg(test)]
         self.state.config.event_sink.send(Event::PeerManagerStarted);
@@ -228,19 +225,20 @@ impl messaging::Actor for PeerManagerActor {
 }
 
 impl PeerManagerActor {
-    /// Testloop constructor. Creates a PeerManagerActor without TCP infrastructure.
-    pub fn new_for_testloop(
+    pub fn new(
         clock: time::Clock,
         state: Arc<NetworkState>,
         tier1_transport: Arc<dyn NetworkTransport>,
         tier2_transport: Arc<dyn NetworkTransport>,
         tier3_transport: Arc<dyn NetworkTransport>,
+        handle: Option<TokioRuntimeHandle<Self>>,
+        actor_system: Option<ActorSystem>,
     ) -> Self {
         let my_peer_id = state.config.node_id();
         Self {
             clock,
-            actor_system: None,
-            handle: None,
+            actor_system,
+            handle,
             my_peer_id,
             started_connect_attempts: false,
             state,
@@ -281,7 +279,6 @@ impl PeerManagerActor {
             }
             v
         };
-        let my_peer_id = config.node_id();
         let builder = actor_system.new_tokio_builder();
         let handle = builder.handle();
         let clock = clock;
@@ -418,17 +415,15 @@ impl PeerManagerActor {
             Arc::new(PoolTransport::new(state.tier2.clone()));
         let tier3_transport: Arc<dyn NetworkTransport> =
             Arc::new(PoolTransport::new(state.tier3.clone()));
-        builder.spawn_tokio_actor(Self {
-            my_peer_id,
-            started_connect_attempts: false,
-            state,
+        builder.spawn_tokio_actor(Self::new(
             clock,
-            actor_system: Some(actor_system),
-            handle: Some(handle.clone()),
+            state,
             tier1_transport,
             tier2_transport,
             tier3_transport,
-        });
+            Some(handle.clone()),
+            Some(actor_system),
+        ));
         Ok(handle)
     }
 

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -380,7 +380,8 @@ impl ActorHandler {
     pub async fn send_ping(&self, clock: &time::Clock, nonce: u64, target: PeerId) {
         let clock = clock.clone();
         self.with_state(move |s| async move {
-            s.send_ping(&clock, tcp::Tier::T2, nonce, target);
+            let transport = s.pool_transport(tcp::Tier::T2);
+            s.send_ping(&clock, tcp::Tier::T2, nonce, target, &transport);
         })
         .await;
     }

--- a/chain/network/src/peer_manager/tests/tier1.rs
+++ b/chain/network/src/peer_manager/tests/tier1.rs
@@ -61,7 +61,12 @@ async fn send_tier1_message(
         T1MessageBody::BlockApproval(make_block_approval(rng, from_signer.as_ref())).into();
     let clock = clock.clone();
     from.with_state(move |s| async move {
-        if s.send_message_to_account(&clock, &target, want.clone()) { Some(want) } else { None }
+        let transport = s.pool_transport(tcp::Tier::T2);
+        if s.send_message_to_account(&clock, &target, want.clone(), &transport) {
+            Some(want)
+        } else {
+            None
+        }
     })
     .await
 }

--- a/test-loop-tests/src/setup/network_dispatch.rs
+++ b/test-loop-tests/src/setup/network_dispatch.rs
@@ -1,16 +1,11 @@
 #![allow(dead_code, unused_must_use, unused_variables)]
 
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
-use near_async::messaging::CanSendAsync;
 use near_async::time::Clock;
-use near_network::client::{
-    BlockHeadersRequest, BlockHeadersResponse, BlockRequest, BlockResponse,
-};
 use near_network::peer_manager_exports::connection::transport::NetworkTransport;
 use near_network::peer_manager_exports::network_state::{NetworkState, RoutedAction};
 use near_network::types::PeerMessage;
 use near_network::{PeerIdOrHash, RawRoutedMessage};
-use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_primitives::network::PeerId;
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -87,84 +82,43 @@ impl TestLoopTransport {
                     unreachable!()
                 }
             }
-            PeerMessage::BlockRequest(_) | PeerMessage::BlockHeadersRequest(_) => {
-                // Request-response messages need async handling.
-                match msg {
-                    PeerMessage::BlockRequest(hash) => {
-                        let target = target_state;
-                        let my_id = my_peer_id;
-                        let node_states = self.node_network_states.clone();
-                        self.future_spawner.spawn("testloop_block_request", async move {
-                            if let Ok(Some(block)) =
-                                target.client.send_async(BlockRequest(hash)).await
-                            {
-                                let requester_state = {
-                                    let states = node_states.lock();
-                                    states.get(&my_id).cloned()
-                                };
-                                if let Some(requester) = requester_state {
-                                    requester.client.send_async(
-                                        BlockResponse {
-                                            block,
-                                            peer_id: target.config.node_id(),
-                                            was_requested: true,
-                                        }
-                                        .span_wrap(),
-                                    );
-                                }
-                            }
-                        });
-                        true
-                    }
-                    PeerMessage::BlockHeadersRequest(hashes) => {
-                        let target = target_state;
-                        let my_id = my_peer_id;
-                        let shared_state = self.shared_state.clone();
-                        let node_states = self.node_network_states.clone();
-                        self.future_spawner.spawn("testloop_block_headers_request", async move {
-                            if let Ok(Some(headers)) =
-                                target.client.send_async(BlockHeadersRequest(hashes)).await
-                            {
-                                let response = PeerMessage::BlockHeaders(headers);
-                                let target_node_id = target.config.node_id();
-                                let response = match shared_state.apply_message_filters(
-                                    &target_node_id,
-                                    &my_id,
-                                    response,
-                                ) {
-                                    Some(msg) => msg,
-                                    None => return,
-                                };
-                                if let PeerMessage::BlockHeaders(headers) = response {
-                                    let requester_state = {
-                                        let states = node_states.lock();
-                                        states.get(&my_id).cloned()
-                                    };
-                                    if let Some(requester) = requester_state {
-                                        requester.client.send_async(
-                                            BlockHeadersResponse(headers, target_node_id)
-                                                .span_wrap(),
-                                        );
-                                    }
-                                }
-                            }
-                        });
-                        true
-                    }
-                    _ => unreachable!(),
-                }
-            }
             _ => {
-                // Fire-and-forget messages: use shared dispatch on NetworkState.
-                if target_state.dispatch_incoming_message(my_peer_id, msg) {
-                    true
-                } else {
-                    tracing::warn!(
-                        target: "network",
-                        "testloop transport: unhandled non-routed message type, dropping"
-                    );
-                    false
-                }
+                // All non-routed messages: use shared async dispatch.
+                // Returns Ok(Some(response)) for request-response messages,
+                // Ok(None) for fire-and-forget.
+                let target = target_state;
+                let my_id = my_peer_id;
+                let shared_state = self.shared_state.clone();
+                let node_states = self.node_network_states.clone();
+                let clock = self.clock.clone();
+                self.future_spawner.spawn("testloop_handle_peer_message", async move {
+                    let target_node_id = target.config.node_id();
+                    let result =
+                        target.handle_peer_message(&clock, my_id.clone(), msg, false).await;
+                    if let Ok(Some(response)) = result {
+                        // Route response back to requester, applying filters.
+                        let response = match shared_state.apply_message_filters(
+                            &target_node_id,
+                            &my_id,
+                            response,
+                        ) {
+                            Some(msg) => msg,
+                            None => return,
+                        };
+                        let requester_state = {
+                            let states = node_states.lock();
+                            states.get(&my_id).cloned()
+                        };
+                        if let Some(requester) = requester_state {
+                            // Dispatch the response at the requester (fire-and-forget).
+                            requester
+                                .handle_peer_message(&clock, target_node_id, response, true)
+                                .await
+                                .ok();
+                        }
+                    }
+                });
+                true
             }
         }
     }

--- a/test-loop-tests/src/setup/network_dispatch.rs
+++ b/test-loop-tests/src/setup/network_dispatch.rs
@@ -1,12 +1,10 @@
 #![allow(dead_code, unused_must_use, unused_variables)]
 
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
-use near_async::messaging::{CanSend, CanSendAsync};
+use near_async::messaging::CanSendAsync;
 use near_async::time::Clock;
 use near_network::client::{
     BlockHeadersRequest, BlockHeadersResponse, BlockRequest, BlockResponse,
-    EpochSyncRequestMessage, EpochSyncResponseMessage, OptimisticBlockMessage, ProcessTxRequest,
-    StateResponse, StateResponseReceived,
 };
 use near_network::peer_manager_exports::connection::transport::NetworkTransport;
 use near_network::peer_manager_exports::network_state::{NetworkState, RoutedAction};
@@ -80,151 +78,93 @@ impl TestLoopTransport {
         };
 
         let my_peer_id = self.my_peer_id.clone();
-        let clock = self.clock.clone();
 
-        match msg {
-            PeerMessage::Routed(routed_msg) => {
-                self.dispatch_routed_with_hops(target_peer_id.clone(), target_state, routed_msg)
+        match &msg {
+            PeerMessage::Routed(_) => {
+                if let PeerMessage::Routed(routed_msg) = msg {
+                    self.dispatch_routed_with_hops(target_peer_id.clone(), target_state, routed_msg)
+                } else {
+                    unreachable!()
+                }
             }
-
-            PeerMessage::Block(block) => {
-                // Record sender's block info so highest_height_peers is populated for sync.
-                let height = block.header().height();
-                let hash = *block.hash();
-                target_state.testloop_peer_block_info.lock().insert(
-                    my_peer_id.clone(),
-                    (
-                        near_network::types::PeerInfo {
-                            id: my_peer_id.clone(),
-                            addr: None,
-                            account_id: None,
-                        },
-                        near_network::types::BlockInfo { height, hash },
-                    ),
-                );
-                target_state.client.send_async(
-                    BlockResponse { block, peer_id: my_peer_id, was_requested: false }.span_wrap(),
-                );
-                true
-            }
-
-            PeerMessage::Transaction(tx) => {
-                target_state.client.send_async(ProcessTxRequest {
-                    transaction: tx,
-                    is_forwarded: false,
-                    check_only: false,
-                });
-                true
-            }
-
-            PeerMessage::BlockRequest(hash) => {
-                let target = target_state;
-                let my_id = my_peer_id;
-                let node_states = self.node_network_states.clone();
-                self.future_spawner.spawn("testloop_block_request", async move {
-                    if let Ok(Some(block)) = target.client.send_async(BlockRequest(hash)).await {
-                        // Send block back to requester.
-                        let requester_state = {
-                            let states = node_states.lock();
-                            states.get(&my_id).cloned()
-                        };
-                        if let Some(requester) = requester_state {
-                            requester.client.send_async(
-                                BlockResponse {
-                                    block,
-                                    peer_id: target.config.node_id(),
-                                    was_requested: true,
+            PeerMessage::BlockRequest(_) | PeerMessage::BlockHeadersRequest(_) => {
+                // Request-response messages need async handling.
+                match msg {
+                    PeerMessage::BlockRequest(hash) => {
+                        let target = target_state;
+                        let my_id = my_peer_id;
+                        let node_states = self.node_network_states.clone();
+                        self.future_spawner.spawn("testloop_block_request", async move {
+                            if let Ok(Some(block)) =
+                                target.client.send_async(BlockRequest(hash)).await
+                            {
+                                let requester_state = {
+                                    let states = node_states.lock();
+                                    states.get(&my_id).cloned()
+                                };
+                                if let Some(requester) = requester_state {
+                                    requester.client.send_async(
+                                        BlockResponse {
+                                            block,
+                                            peer_id: target.config.node_id(),
+                                            was_requested: true,
+                                        }
+                                        .span_wrap(),
+                                    );
                                 }
-                                .span_wrap(),
-                            );
-                        }
-                    }
-                });
-                true
-            }
-
-            PeerMessage::BlockHeadersRequest(hashes) => {
-                let target = target_state;
-                let my_id = my_peer_id;
-                let shared_state = self.shared_state.clone();
-                let node_states = self.node_network_states.clone();
-                self.future_spawner.spawn("testloop_block_headers_request", async move {
-                    if let Ok(Some(headers)) =
-                        target.client.send_async(BlockHeadersRequest(hashes)).await
-                    {
-                        // Send response as PeerMessage::BlockHeaders through the
-                        // filter chain (apply_message_filters) so transport filters
-                        // like throttle_header_sync can intercept it.
-                        let response = PeerMessage::BlockHeaders(headers);
-                        let target_node_id = target.config.node_id();
-                        let response = match shared_state.apply_message_filters(
-                            &target_node_id,
-                            &my_id,
-                            response,
-                        ) {
-                            Some(msg) => msg,
-                            None => return, // dropped by filter
-                        };
-                        // Dispatch the (possibly filtered) response to the requester.
-                        if let PeerMessage::BlockHeaders(headers) = response {
-                            let requester_state = {
-                                let states = node_states.lock();
-                                states.get(&my_id).cloned()
-                            };
-                            if let Some(requester) = requester_state {
-                                requester.client.send_async(
-                                    BlockHeadersResponse(headers, target_node_id).span_wrap(),
-                                );
                             }
-                        }
+                        });
+                        true
                     }
-                });
-                true
-            }
-
-            PeerMessage::BlockHeaders(headers) => {
-                target_state
-                    .client
-                    .send_async(BlockHeadersResponse(headers, my_peer_id).span_wrap());
-                true
-            }
-
-            PeerMessage::VersionedStateResponse(info) => {
-                target_state.client.send_async(
-                    StateResponseReceived {
-                        peer_id: my_peer_id,
-                        state_response: StateResponse::State(info.into()),
+                    PeerMessage::BlockHeadersRequest(hashes) => {
+                        let target = target_state;
+                        let my_id = my_peer_id;
+                        let shared_state = self.shared_state.clone();
+                        let node_states = self.node_network_states.clone();
+                        self.future_spawner.spawn("testloop_block_headers_request", async move {
+                            if let Ok(Some(headers)) =
+                                target.client.send_async(BlockHeadersRequest(hashes)).await
+                            {
+                                let response = PeerMessage::BlockHeaders(headers);
+                                let target_node_id = target.config.node_id();
+                                let response = match shared_state.apply_message_filters(
+                                    &target_node_id,
+                                    &my_id,
+                                    response,
+                                ) {
+                                    Some(msg) => msg,
+                                    None => return,
+                                };
+                                if let PeerMessage::BlockHeaders(headers) = response {
+                                    let requester_state = {
+                                        let states = node_states.lock();
+                                        states.get(&my_id).cloned()
+                                    };
+                                    if let Some(requester) = requester_state {
+                                        requester.client.send_async(
+                                            BlockHeadersResponse(headers, target_node_id)
+                                                .span_wrap(),
+                                        );
+                                    }
+                                }
+                            }
+                        });
+                        true
                     }
-                    .span_wrap(),
-                );
-                true
+                    _ => unreachable!(),
+                }
             }
-
-            PeerMessage::EpochSyncRequest => {
-                target_state.client.send(EpochSyncRequestMessage { from_peer: my_peer_id });
-                true
-            }
-
-            PeerMessage::EpochSyncResponse(proof) => {
-                target_state.client.send(EpochSyncResponseMessage { from_peer: my_peer_id, proof });
-                true
-            }
-
-            PeerMessage::OptimisticBlock(ob) => {
-                target_state.client.send(
-                    OptimisticBlockMessage { from_peer: my_peer_id, optimistic_block: ob }
-                        .span_wrap(),
-                );
-                true
-            }
-
-            other => {
-                tracing::warn!(
-                    target: "network",
-                    msg = ?format!("{:?}", std::mem::discriminant(&other)),
-                    "testloop transport: unhandled non-routed message type, dropping"
-                );
-                false
+            _ => {
+                // Fire-and-forget messages: use shared dispatch on NetworkState.
+                if target_state.dispatch_incoming_message(my_peer_id, msg) {
+                    true
+                } else {
+                    tracing::warn!(
+                        target: "network",
+                        "testloop transport: unhandled non-routed message type, dropping"
+                    );
+                    false
+                }
             }
         }
     }

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -631,12 +631,14 @@ pub fn setup_client(
     // Register in shared state for other nodes' transports.
     shared_state.node_network_states.lock().insert(peer_id.clone(), network_state.clone());
 
-    let peer_manager_actor = PeerManagerActor::new_for_testloop(
+    let peer_manager_actor = PeerManagerActor::new(
         test_loop.clock(),
         network_state,
         transport.clone(),
         transport.clone(),
         transport,
+        None,
+        None,
     );
     let peer_manager_sender =
         test_loop.data.register_actor(identifier, peer_manager_actor, Some(network_adapter));

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -626,15 +626,18 @@ pub fn setup_client(
         partial_witness_sender.clone().with_delay(NETWORK_DELAY).into_multi_sender(),
         spice_data_distributor_sender.clone().with_delay(NETWORK_DELAY).into_multi_sender(),
         spice_core_writer_sender.clone().with_delay(NETWORK_DELAY).into_sender(),
-        transport.clone(),
-        transport.clone(),
-        transport,
     ));
 
     // Register in shared state for other nodes' transports.
     shared_state.node_network_states.lock().insert(peer_id.clone(), network_state.clone());
 
-    let peer_manager_actor = PeerManagerActor::new_for_testloop(test_loop.clock(), network_state);
+    let peer_manager_actor = PeerManagerActor::new_for_testloop(
+        test_loop.clock(),
+        network_state,
+        transport.clone(),
+        transport.clone(),
+        transport,
+    );
     let peer_manager_sender =
         test_loop.data.register_actor(identifier, peer_manager_actor, Some(network_adapter));
 


### PR DESCRIPTION
## Summary

Prototype-v3: Clean separation of TCP transport from business logic in the network layer.

Based on prototype-v2 (working testloop transport, 0 CI failures, multi-hop routing). This prototype refactors the internals to achieve:

- **NetworkState** = pure business logic (routing, dispatch, state). No transport fields.
- **TcpTransport** = all TCP infrastructure (Pool, PeerActor, connections, background tasks). Internal to production.
- **TestLoopTransport** = in-memory dispatch with filters. Internal to testloop.
- **Transport trait** = the ONLY separation point between production and testloop.

Design doc: `tmp/projects/peer-testloop/prototype-v3/de-entanglement.md`