### PR TITLE
revert(deterministic-account-id): allow account creation by transfers

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -359,11 +359,6 @@ pub enum ProtocolFeature {
     /// Includes tokens burnt as part of global contract deploys into corresponding
     /// execution outcome's `tokens_burnt`.
     IncludeDeployGlobalContractOutcomeBurntStorage,
-    /// Fix deterministic account ID creation to allow creation by any incoming transfer
-    /// (unless it's a refund) and fix `account_is_implicit()` to correctly check if
-    /// deterministic account IDs are enabled.
-    /// NEP: https://github.com/near/NEPs/pull/616
-    FixDeterministicAccountIdCreation,
     /// Nonce-based idempotency for global contract distribution receipts. Each
     /// distribution carries an auto-incremented nonce. Any distribution receipt
     /// with a nonce less than the one already stored will be dropped. This
@@ -483,7 +478,6 @@ impl ProtocolFeature {
             | ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen
             | ProtocolFeature::FixAccessKeyAllowanceCharging
             | ProtocolFeature::IncludeDeployGlobalContractOutcomeBurntStorage
-            | ProtocolFeature::FixDeterministicAccountIdCreation
             | ProtocolFeature::GlobalContractDistributionNonce
             | ProtocolFeature::InstantPromiseYield
             | ProtocolFeature::YieldResumeImprovements

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -440,18 +440,14 @@ where
     Serializable(object)
 }
 
+/// From `near-account-id` version `1.0.0-alpha.2`, `is_implicit` returns true for ETH-implicit accounts.
 /// This function is a wrapper for `is_implicit` method so that we can easily differentiate its behavior
-/// based on whether specific implicit accounts are enabled.
-pub fn account_is_implicit(
-    account_id: &AccountId,
-    eth_implicit_accounts_enabled: bool,
-    deterministic_account_ids_enabled: bool,
-) -> bool {
-    match account_id.get_account_type() {
-        AccountType::NamedAccount => false,
-        AccountType::NearImplicitAccount => true,
-        AccountType::EthImplicitAccount => eth_implicit_accounts_enabled,
-        AccountType::NearDeterministicAccount => deterministic_account_ids_enabled,
+/// based on whether ETH-implicit accounts are enabled.
+pub fn account_is_implicit(account_id: &AccountId, eth_implicit_accounts_enabled: bool) -> bool {
+    if eth_implicit_accounts_enabled {
+        account_id.get_account_type().is_implicit()
+    } else {
+        account_id.get_account_type() == AccountType::NearImplicitAccount
     }
 }
 
@@ -524,39 +520,6 @@ mod tests {
         let expected: AccountId = "0x96791e923f8cf697ad9c3290f2c9059f0231b24c".parse().unwrap();
         let account_id = derive_eth_implicit_account_id(public_key.unwrap_as_secp256k1());
         assert_eq!(account_id, expected);
-    }
-
-    #[test]
-    fn test_account_is_implicit() {
-        // Named accounts are never implicit
-        let named: AccountId = "alice.near".parse().unwrap();
-        assert!(!account_is_implicit(&named, false, false));
-        assert!(!account_is_implicit(&named, true, false));
-        assert!(!account_is_implicit(&named, false, true));
-        assert!(!account_is_implicit(&named, true, true));
-
-        // NEAR implicit accounts are always implicit (64 hex chars)
-        let near_implicit: AccountId =
-            "bb4dc639b212e075a751685b26bdcea5920a504181ff2910e8549742127092a0".parse().unwrap();
-        assert!(account_is_implicit(&near_implicit, false, false));
-        assert!(account_is_implicit(&near_implicit, true, false));
-        assert!(account_is_implicit(&near_implicit, false, true));
-        assert!(account_is_implicit(&near_implicit, true, true));
-
-        // ETH implicit accounts depend on eth_implicit_accounts_enabled flag
-        let eth_implicit: AccountId = "0x96791e923f8cf697ad9c3290f2c9059f0231b24c".parse().unwrap();
-        assert!(!account_is_implicit(&eth_implicit, false, false));
-        assert!(account_is_implicit(&eth_implicit, true, false));
-        assert!(!account_is_implicit(&eth_implicit, false, true));
-        assert!(account_is_implicit(&eth_implicit, true, true));
-
-        // Deterministic accounts depend on deterministic_account_ids_enabled flag (0s prefix)
-        let deterministic: AccountId =
-            "0s1234567890123456789012345678901234567890".parse().unwrap();
-        assert!(!account_is_implicit(&deterministic, false, false));
-        assert!(!account_is_implicit(&deterministic, true, false));
-        assert!(account_is_implicit(&deterministic, false, true));
-        assert!(account_is_implicit(&deterministic, true, true));
     }
 
     #[test]

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -99,6 +99,12 @@ extern "C" {
         account_id_len: u64,
         account_id_ptr: u64,
     );
+    fn promise_batch_action_state_init_by_account_id(
+        promise_idx: u64,
+        account_id_len: u64,
+        account_id_ptr: u64,
+        amount_ptr: u64,
+    ) -> u64;
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,
@@ -969,6 +975,17 @@ fn call_promise() {
                     promise_index,
                     beneficiary_id.len() as u64,
                     beneficiary_id.as_ptr() as u64,
+                );
+                promise_index
+            } else if let Some(action) = arg.get("action_state_init_by_account_id") {
+                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
+                let account_id = action["account_id"].as_str().unwrap().as_bytes();
+                let amount = action["amount"].as_str().unwrap().parse::<u128>().unwrap();
+                let _action_index = promise_batch_action_state_init_by_account_id(
+                    promise_index,
+                    account_id.len() as u64,
+                    account_id.as_ptr() as u64,
+                    &amount as *const u128 as *const u64 as u64,
                 );
                 promise_index
             } else if let Some(action) = arg.get("action_add_gas_key_with_full_access") {

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -743,11 +743,7 @@ pub(crate) fn check_account_existence(
                 }
                 .into());
             } else {
-                if account_is_implicit(
-                    account_id,
-                    config.wasm_config.eth_implicit_accounts,
-                    config.wasm_config.deterministic_account_ids,
-                ) {
+                if account_is_implicit(account_id, config.wasm_config.eth_implicit_accounts) {
                     // If the account doesn't exist and it's implicit, then you
                     // should only be able to create it using single transfer action.
                     // Because you should not be able to add another access key to the account in
@@ -807,11 +803,7 @@ fn check_transfer_to_nonexisting_account(
     implicit_account_creation_eligible: bool,
 ) -> Result<(), ActionError> {
     if implicit_account_creation_eligible
-        && account_is_implicit(
-            account_id,
-            config.wasm_config.eth_implicit_accounts,
-            config.wasm_config.deterministic_account_ids,
-        )
+        && account_is_implicit(account_id, config.wasm_config.eth_implicit_accounts)
     {
         // OK. It's implicit account creation.
         // Notes:

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -39,7 +39,6 @@ pub use near_crypto;
 use near_crypto::{PublicKey, Signature};
 use near_parameters::{ActionCosts, RuntimeConfig};
 pub use near_primitives;
-use near_primitives::account::id::AccountType;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::bandwidth_scheduler::{BandwidthRequests, BlockBandwidthRequests};
 use near_primitives::chunk_apply_stats::ChunkApplyStatsV0;
@@ -461,20 +460,7 @@ impl Runtime {
         let account_id = receipt.receiver_id();
         let is_refund = receipt.predecessor_id().is_system();
         let is_the_only_action = actions.len() == 1;
-        // Deterministic AccountIds can be created by incoming transfers regardless
-        // of number of actions in the current receipt. For instance, this sequence
-        // of actions within a single receipt is considered valid:
-        // 1. Transfer
-        // 2. DeterministicStateInit
-        // 3. FunctionCall
-        // 4. etc...
-        let is_deterministic_account_multi_action_eligible =
-            ProtocolFeature::FixDeterministicAccountIdCreation
-                .enabled(apply_state.current_protocol_version)
-                && apply_state.config.wasm_config.deterministic_account_ids
-                && account_id.get_account_type() == AccountType::NearDeterministicAccount;
-        let implicit_account_creation_eligible =
-            !is_refund && (is_the_only_action || is_deterministic_account_multi_action_eligible);
+        let implicit_account_creation_eligible = is_the_only_action && !is_refund;
 
         // Account validation
         if let Err(e) = check_account_existence(

--- a/test-loop-tests/src/tests/deterministic_account_id.rs
+++ b/test-loop-tests/src/tests/deterministic_account_id.rs
@@ -32,9 +32,7 @@ use assert_matches::assert_matches;
 use near_async::time::Duration;
 use near_o11y::testonly::init_test_logger;
 use near_parameters::RuntimeConfigStore;
-use near_primitives::action::{
-    DeterministicStateInitAction, GlobalContractDeployMode, GlobalContractIdentifier,
-};
+use near_primitives::action::{GlobalContractDeployMode, GlobalContractIdentifier};
 use near_primitives::deterministic_account_id::{
     DeterministicAccountStateInit, DeterministicAccountStateInitV1,
 };
@@ -45,12 +43,10 @@ use near_primitives::errors::{
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_user_test_signer;
-use near_primitives::transaction::Action;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::Gas;
 use near_primitives::types::{AccountId, Balance};
 use near_primitives::utils::derive_near_deterministic_account_id;
-use near_primitives::version::ProtocolVersion;
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::AccountView;
 use near_primitives::views::{FinalExecutionOutcomeView, FinalExecutionStatus};
@@ -374,54 +370,6 @@ fn test_deterministic_state_init_prepay_for_storage() {
     env.assert_test_contract_usable_on_account(det_account);
 }
 
-/// Test that multi-action receipts fail to create deterministic accounts before
-/// `FixDeterministicAccountIdCreation` is enabled.
-#[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
-fn test_deterministic_state_init_multi_action_before_fix() {
-    let version_before_fix =
-        ProtocolFeature::FixDeterministicAccountIdCreation.protocol_version() - 1;
-    assert!(
-        ProtocolFeature::DeterministicAccountIds.enabled(version_before_fix),
-        "DeterministicAccountIds must be enabled before FixDeterministicAccountIdCreation"
-    );
-
-    let mut env = TestEnv::setup_with_protocol_version(Balance::from_near(100), version_before_fix);
-    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
-
-    let tx = env.multi_action_deterministic_account_tx(Balance::from_near(5));
-    let outcome = env.try_execute_tx(tx).expect("tx should be submitted");
-
-    assert_matches!(
-        outcome.status,
-        FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
-            kind: ActionErrorKind::AccountDoesNotExist { .. },
-            ..
-        }))
-    );
-}
-
-/// Test that multi-action receipts can create deterministic accounts after
-/// `FixDeterministicAccountIdCreation` is enabled.
-#[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
-fn test_deterministic_state_init_multi_action_after_fix() {
-    let version_with_fix = ProtocolFeature::FixDeterministicAccountIdCreation.protocol_version();
-    let mut env = TestEnv::setup_with_protocol_version(Balance::from_near(100), version_with_fix);
-    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
-
-    let balance = Balance::from_near(5);
-    let tx = env.multi_action_deterministic_account_tx(balance);
-    let det_account = tx.transaction.receiver_id().clone();
-
-    env.try_execute_tx(tx).expect("tx should be submitted").assert_success();
-
-    assert!(env.get_account_state(det_account.clone()).amount >= balance);
-    env.assert_test_contract_usable_on_account(det_account);
-}
-
 /// Deploy a sharded toy-contract and check it can do a "predecessor is owner"
 /// check as intended by NEP-616.
 #[test]
@@ -650,13 +598,6 @@ struct TestEnv {
 
 impl TestEnv {
     fn setup(initial_balance: Balance) -> Self {
-        Self::setup_with_protocol_version(initial_balance, PROTOCOL_VERSION)
-    }
-
-    fn setup_with_protocol_version(
-        initial_balance: Balance,
-        protocol_version: ProtocolVersion,
-    ) -> Self {
         init_test_logger();
 
         let [user_account, independent_account, global_contract_account] =
@@ -668,7 +609,6 @@ impl TestEnv {
         let clients = validators_spec_clients_with_rpc(&validators_spec);
 
         let genesis = TestLoopBuilder::new_genesis_builder()
-            .protocol_version(protocol_version)
             .validators_spec(validators_spec)
             .shard_layout(shard_layout)
             .add_user_accounts_simple(
@@ -786,33 +726,6 @@ impl TestEnv {
             balance,
         );
         self.try_execute_tx(create_deterministic_account_tx)
-    }
-
-    /// Creates a multi-action transaction: Transfer + DeterministicStateInit + FunctionCall.
-    fn multi_action_deterministic_account_tx(&mut self, balance: Balance) -> SignedTransaction {
-        let (state_init, det_account) = self.new_deterministic_account_with_data(small());
-        let signer = create_user_test_signer(&self.user_account());
-        let actions = vec![
-            Action::Transfer(near_primitives::transaction::TransferAction { deposit: balance }),
-            Action::DeterministicStateInit(Box::new(DeterministicStateInitAction {
-                state_init,
-                deposit: Balance::ZERO,
-            })),
-            Action::FunctionCall(Box::new(near_primitives::action::FunctionCallAction {
-                method_name: "log_something".to_owned(),
-                args: vec![],
-                gas: Gas::from_teragas(50),
-                deposit: Balance::ZERO,
-            })),
-        ];
-        SignedTransaction::from_actions(
-            self.next_nonce(),
-            self.user_account(),
-            det_account,
-            &signer,
-            actions,
-            self.get_tx_block_hash(),
-        )
     }
 
     /// Creates, on-chain, a deterministic account id owned by `user`.

--- a/test-loop-tests/src/tests/deterministic_account_id.rs
+++ b/test-loop-tests/src/tests/deterministic_account_id.rs
@@ -30,9 +30,14 @@ use crate::utils::account::{
 use crate::utils::transactions;
 use assert_matches::assert_matches;
 use near_async::time::Duration;
+use near_crypto::{KeyType, PublicKey};
 use near_o11y::testonly::init_test_logger;
 use near_parameters::RuntimeConfigStore;
-use near_primitives::action::{GlobalContractDeployMode, GlobalContractIdentifier};
+use near_primitives::account::AccessKey;
+use near_primitives::action::{
+    Action, AddKeyAction, DeployContractAction, DeterministicStateInitAction,
+    GlobalContractDeployMode, GlobalContractIdentifier, TransferAction,
+};
 use near_primitives::deterministic_account_id::{
     DeterministicAccountStateInit, DeterministicAccountStateInitV1,
 };
@@ -370,6 +375,252 @@ fn test_deterministic_state_init_prepay_for_storage() {
     env.assert_test_contract_usable_on_account(det_account);
 }
 
+/// Try to do Transfer and AddKey in a single transaction targeting a
+/// deterministic account. A single Transfer can create a deterministic
+/// account, but multiple actions are disallowed in that case.
+#[test]
+fn test_transfer_and_add_key_to_deterministic_account() {
+    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut env = TestEnv::setup(Balance::from_near(100));
+    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
+
+    let data = empty();
+    let (_state_init, det_account) = env.new_deterministic_account_with_data(data);
+
+    let user_signer = create_user_test_signer(&env.user_account());
+    let public_key = PublicKey::from_seed(KeyType::ED25519, "test");
+
+    let tx = SignedTransaction::from_actions(
+        env.next_nonce(),
+        env.user_account(),
+        det_account.clone(),
+        &user_signer,
+        vec![
+            Action::Transfer(TransferAction { deposit: Balance::from_near(1) }),
+            Action::AddKey(Box::new(AddKeyAction {
+                public_key,
+                access_key: AccessKey::full_access(),
+            })),
+        ],
+        env.get_tx_block_hash(),
+    );
+
+    let outcome = env.try_execute_tx(tx).expect("should be able to send transaction");
+    assert_matches!(
+        outcome.status,
+        FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+            kind: ActionErrorKind::AccountDoesNotExist { .. },
+            index: Some(0)
+        }))
+    );
+}
+
+/// Try to do Transfer and DeployContract in a single transaction targeting a
+/// deterministic account. Should fail the same way as Transfer + AddKey:
+/// multiple actions are disallowed when creating a deterministic account
+/// via transfer.
+#[test]
+fn test_transfer_and_deploy_contract_to_deterministic_account() {
+    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut env = TestEnv::setup(Balance::from_near(100));
+    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
+
+    let data = empty();
+    let (_state_init, det_account) = env.new_deterministic_account_with_data(data);
+
+    let user_signer = create_user_test_signer(&env.user_account());
+
+    let tx = SignedTransaction::from_actions(
+        env.next_nonce(),
+        env.user_account(),
+        det_account.clone(),
+        &user_signer,
+        vec![
+            Action::Transfer(TransferAction { deposit: Balance::from_near(1) }),
+            Action::DeployContract(DeployContractAction {
+                code: near_test_contracts::rs_contract().to_vec(),
+            }),
+        ],
+        env.get_tx_block_hash(),
+    );
+
+    let outcome = env.try_execute_tx(tx).expect("should be able to send transaction");
+    assert_matches!(
+        outcome.status,
+        FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+            kind: ActionErrorKind::AccountDoesNotExist { .. },
+            index: Some(0)
+        }))
+    );
+}
+
+/// Try to do Transfer and DeterministicStateInit in a single transaction
+/// targeting a deterministic account. Should fail the same way: multiple
+/// actions are disallowed when creating a deterministic account via
+/// transfer.
+#[test]
+fn test_transfer_and_state_init_to_deterministic_account() {
+    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut env = TestEnv::setup(Balance::from_near(100));
+    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
+
+    let data = empty();
+    let (state_init, det_account) = env.new_deterministic_account_with_data(data);
+
+    let user_signer = create_user_test_signer(&env.user_account());
+
+    let tx = SignedTransaction::from_actions(
+        env.next_nonce(),
+        env.user_account(),
+        det_account.clone(),
+        &user_signer,
+        vec![
+            Action::Transfer(TransferAction { deposit: Balance::from_near(1) }),
+            Action::DeterministicStateInit(Box::new(DeterministicStateInitAction {
+                state_init,
+                deposit: Balance::ZERO,
+            })),
+        ],
+        env.get_tx_block_hash(),
+    );
+
+    let outcome = env.try_execute_tx(tx).expect("should be able to send transaction");
+    assert_matches!(
+        outcome.status,
+        FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+            kind: ActionErrorKind::AccountDoesNotExist { .. },
+            index: Some(0)
+        }))
+    );
+}
+
+/// Like test_transfer_and_add_key_to_deterministic_account but the
+/// actions are created by a contract via `call_promise`.
+#[test]
+fn test_contract_transfer_and_add_key_to_deterministic_account() {
+    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut env = TestEnv::setup(Balance::from_near(100));
+    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
+    env.deploy_test_contract();
+
+    let det_account = env.new_deterministic_account_with_data(empty()).1;
+
+    let public_key = PublicKey::from_seed(KeyType::ED25519, "test");
+    let public_key_base64 =
+        near_primitives_core::serialize::to_base64(&borsh::to_vec(&public_key).unwrap());
+    let call_promise_args = serde_json::json!([
+        {
+            "batch_create": { "account_id": det_account.as_str() },
+            "id": 0
+        },
+        {
+            "action_transfer": {
+                "promise_index": 0,
+                "amount": Balance::from_near(1).as_yoctonear().to_string()
+            },
+            "id": 0
+        },
+        {
+            "action_add_key_with_full_access": {
+                "promise_index": 0,
+                "public_key": public_key_base64,
+                "nonce": 0
+            },
+            "id": 0,
+            "return": true
+        }
+    ]);
+
+    env.assert_call_promise_creates_failing_receipt(call_promise_args);
+}
+
+/// Like test_transfer_and_deploy_contract_to_deterministic_account but
+/// the actions are created by a contract via `call_promise`.
+#[test]
+fn test_contract_transfer_and_deploy_contract_to_deterministic_account() {
+    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut env = TestEnv::setup(Balance::from_near(100));
+    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
+    env.deploy_test_contract();
+
+    let det_account = env.new_deterministic_account_with_data(empty()).1;
+
+    let code_base64 =
+        near_primitives_core::serialize::to_base64(near_test_contracts::rs_contract());
+    let call_promise_args = serde_json::json!([
+        {
+            "batch_create": { "account_id": det_account.as_str() },
+            "id": 0
+        },
+        {
+            "action_transfer": {
+                "promise_index": 0,
+                "amount": Balance::from_near(1).as_yoctonear().to_string()
+            },
+            "id": 0
+        },
+        {
+            "action_deploy_contract": {
+                "promise_index": 0,
+                "code": code_base64
+            },
+            "id": 0,
+            "return": true
+        }
+    ]);
+
+    env.assert_call_promise_creates_failing_receipt(call_promise_args);
+}
+
+/// Like test_transfer_and_state_init_to_deterministic_account but the
+/// actions are created by a contract via `call_promise`.
+#[test]
+fn test_contract_transfer_and_state_init_to_deterministic_account() {
+    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut env = TestEnv::setup(Balance::from_near(100));
+    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
+    env.deploy_test_contract();
+
+    let det_account = env.new_deterministic_account_with_data(empty()).1;
+
+    let call_promise_args = serde_json::json!([
+        {
+            "batch_create": { "account_id": det_account.as_str() },
+            "id": 0
+        },
+        {
+            "action_transfer": {
+                "promise_index": 0,
+                "amount": Balance::from_near(1).as_yoctonear().to_string()
+            },
+            "id": 0
+        },
+        {
+            "action_state_init_by_account_id": {
+                "promise_index": 0,
+                "account_id": env.global_contract_account().as_str(),
+                "amount": "0"
+            },
+            "id": 0,
+            "return": true
+        }
+    ]);
+
+    env.assert_call_promise_creates_failing_receipt(call_promise_args);
+}
+
 /// Deploy a sharded toy-contract and check it can do a "predecessor is owner"
 /// check as intended by NEP-616.
 #[test]
@@ -678,6 +929,47 @@ impl TestEnv {
     fn deploy_global_contract(&mut self, deploy_mode: GlobalContractDeployMode) {
         let tx = self.deploy_global_contract_tx(deploy_mode);
         self.run_tx(tx);
+    }
+
+    /// Deploy the standard test contract on the user account.
+    fn deploy_test_contract(&mut self) {
+        let user_account = self.user_account();
+        let user_signer = create_user_test_signer(&user_account);
+        let deploy_tx = SignedTransaction::deploy_contract(
+            self.next_nonce(),
+            &user_account,
+            near_test_contracts::rs_contract().to_vec(),
+            &user_signer,
+            self.get_tx_block_hash(),
+        );
+        self.run_tx(deploy_tx);
+    }
+
+    /// Call `call_promise` on the user account's test contract and assert
+    /// that the resulting promise receipt fails.
+    fn assert_call_promise_creates_failing_receipt(
+        &mut self,
+        call_promise_args: serde_json::Value,
+    ) {
+        let user_account = self.user_account();
+        let user_signer = create_user_test_signer(&user_account);
+        let tx = SignedTransaction::call(
+            self.next_nonce(),
+            user_account.clone(),
+            user_account,
+            &user_signer,
+            Balance::from_near(2),
+            "call_promise".to_owned(),
+            serde_json::to_vec(&call_promise_args).unwrap(),
+            Gas::from_teragas(300),
+            self.get_tx_block_hash(),
+        );
+
+        let outcome = self.try_execute_tx(tx).expect("should be able to send transaction");
+        let promise_outcome = outcome.receipts_outcome.iter().find(|o| {
+            matches!(&o.outcome.status, near_primitives::views::ExecutionStatusView::Failure(_))
+        });
+        assert!(promise_outcome.is_some(), "expected a failing receipt outcome");
     }
 
     /// Assumes to use global_contract_account by account id as code.

--- a/test-loop-tests/src/tests/deterministic_account_id.rs
+++ b/test-loop-tests/src/tests/deterministic_account_id.rs
@@ -53,7 +53,7 @@ use near_primitives::types::Gas;
 use near_primitives::types::{AccountId, Balance};
 use near_primitives::utils::derive_near_deterministic_account_id;
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
-use near_primitives::views::AccountView;
+use near_primitives::views::{AccountView, ExecutionStatusView};
 use near_primitives::views::{FinalExecutionOutcomeView, FinalExecutionStatus};
 use near_vm_runner::ContractCode;
 use std::collections::BTreeMap;
@@ -377,12 +377,11 @@ fn test_deterministic_state_init_prepay_for_storage() {
 
 /// Try to do Transfer and AddKey in a single transaction targeting a
 /// deterministic account. A single Transfer can create a deterministic
-/// account, but multiple actions are disallowed in that case.
+/// account, but multiple actions are disallowed.
+/// It should not be possible to add an access key to a deterministic account this way, as it would
+/// give the creator control over the account before StateInit.
 #[test]
 fn test_transfer_and_add_key_to_deterministic_account() {
-    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
-        return;
-    }
     let mut env = TestEnv::setup(Balance::from_near(100));
     env.deploy_global_contract(GlobalContractDeployMode::AccountId);
 
@@ -421,11 +420,10 @@ fn test_transfer_and_add_key_to_deterministic_account() {
 /// deterministic account. Should fail the same way as Transfer + AddKey:
 /// multiple actions are disallowed when creating a deterministic account
 /// via transfer.
+/// It should not be possible to deploy a contract to a deterministic account this way, as it would
+/// give the creator control over the account before StateInit.
 #[test]
 fn test_transfer_and_deploy_contract_to_deterministic_account() {
-    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
-        return;
-    }
     let mut env = TestEnv::setup(Balance::from_near(100));
     env.deploy_global_contract(GlobalContractDeployMode::AccountId);
 
@@ -464,9 +462,6 @@ fn test_transfer_and_deploy_contract_to_deterministic_account() {
 /// transfer.
 #[test]
 fn test_transfer_and_state_init_to_deterministic_account() {
-    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
-        return;
-    }
     let mut env = TestEnv::setup(Balance::from_near(100));
     env.deploy_global_contract(GlobalContractDeployMode::AccountId);
 
@@ -504,9 +499,6 @@ fn test_transfer_and_state_init_to_deterministic_account() {
 /// actions are created by a contract via `call_promise`.
 #[test]
 fn test_contract_transfer_and_add_key_to_deterministic_account() {
-    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
-        return;
-    }
     let mut env = TestEnv::setup(Balance::from_near(100));
     env.deploy_global_contract(GlobalContractDeployMode::AccountId);
     env.deploy_test_contract();
@@ -546,9 +538,6 @@ fn test_contract_transfer_and_add_key_to_deterministic_account() {
 /// the actions are created by a contract via `call_promise`.
 #[test]
 fn test_contract_transfer_and_deploy_contract_to_deterministic_account() {
-    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
-        return;
-    }
     let mut env = TestEnv::setup(Balance::from_near(100));
     env.deploy_global_contract(GlobalContractDeployMode::AccountId);
     env.deploy_test_contract();
@@ -586,9 +575,6 @@ fn test_contract_transfer_and_deploy_contract_to_deterministic_account() {
 /// actions are created by a contract via `call_promise`.
 #[test]
 fn test_contract_transfer_and_state_init_to_deterministic_account() {
-    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
-        return;
-    }
     let mut env = TestEnv::setup(Balance::from_near(100));
     env.deploy_global_contract(GlobalContractDeployMode::AccountId);
     env.deploy_test_contract();
@@ -946,7 +932,8 @@ impl TestEnv {
     }
 
     /// Call `call_promise` on the user account's test contract and assert
-    /// that the resulting promise receipt fails.
+    /// that the child receipt (the promise batch) fails with
+    /// AccountDoesNotExist.
     fn assert_call_promise_creates_failing_receipt(
         &mut self,
         call_promise_args: serde_json::Value,
@@ -966,10 +953,33 @@ impl TestEnv {
         );
 
         let outcome = self.try_execute_tx(tx).expect("should be able to send transaction");
-        let promise_outcome = outcome.receipts_outcome.iter().find(|o| {
-            matches!(&o.outcome.status, near_primitives::views::ExecutionStatusView::Failure(_))
-        });
-        assert!(promise_outcome.is_some(), "expected a failing receipt outcome");
+
+        // The first receipt is the call_promise FunctionCall itself.
+        let call_promise_outcome = &outcome.receipts_outcome[0];
+        assert!(
+            matches!(
+                call_promise_outcome.outcome.status,
+                near_primitives::views::ExecutionStatusView::SuccessReceiptId(_)
+            ),
+            "call_promise should succeed, got: {:?}",
+            call_promise_outcome.outcome.status
+        );
+
+        // Find the child receipt produced by call_promise (the batch with
+        // Transfer + second action) and assert it fails.
+        let child_id = &call_promise_outcome.outcome.receipt_ids[0];
+        let child_outcome = outcome
+            .receipts_outcome
+            .iter()
+            .find(|o| o.id == *child_id)
+            .expect("child receipt outcome not found");
+        assert_matches!(
+            child_outcome.outcome.status,
+            ExecutionStatusView::Failure(TxExecutionError::ActionError(ActionError {
+                kind: ActionErrorKind::AccountDoesNotExist { .. },
+                index: Some(0)
+            }))
+        );
     }
 
     /// Assumes to use global_contract_account by account id as code.

--- a/test-loop-tests/src/tests/deterministic_account_id.rs
+++ b/test-loop-tests/src/tests/deterministic_account_id.rs
@@ -394,7 +394,7 @@ fn test_transfer_and_add_key_to_deterministic_account() {
     let tx = SignedTransaction::from_actions(
         env.next_nonce(),
         env.user_account(),
-        det_account.clone(),
+        det_account,
         &user_signer,
         vec![
             Action::Transfer(TransferAction { deposit: Balance::from_near(1) }),
@@ -435,7 +435,7 @@ fn test_transfer_and_deploy_contract_to_deterministic_account() {
     let tx = SignedTransaction::from_actions(
         env.next_nonce(),
         env.user_account(),
-        det_account.clone(),
+        det_account,
         &user_signer,
         vec![
             Action::Transfer(TransferAction { deposit: Balance::from_near(1) }),
@@ -473,7 +473,7 @@ fn test_transfer_and_state_init_to_deterministic_account() {
     let tx = SignedTransaction::from_actions(
         env.next_nonce(),
         env.user_account(),
-        det_account.clone(),
+        det_account,
         &user_signer,
         vec![
             Action::Transfer(TransferAction { deposit: Balance::from_near(1) }),


### PR DESCRIPTION
This reverts commit 122ef2d210426d646fdb2d6a8bf59ae5762852eb.

The change has the be reverted because it allowed to add access keys to a deterministic account at creation time.

It's already included in the 2.11 release: https://github.com/near/nearcore/commit/56620c11db93e62b60c1f55078b4cab1142e065e
