### PR TITLE
feat(rpc): add sharded routing for chunk RPC method

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1297,8 +1297,20 @@ impl JsonRpcHandler {
                 let block_hint = BlockReference::BlockId(block_id.clone()).into();
                 (block_hint, ShardHint::Id(*shard_id), CoordinatorRequestStrategy::Sequential)
             }
-            ChunkReference::ChunkHash { .. } => {
-                (BlockHint::None, ShardHint::None, CoordinatorRequestStrategy::ParallelTakeFirst)
+            ChunkReference::ChunkHash { chunk_id } => {
+                let chunk_hash = ChunkHash::from(*chunk_id);
+                match self.pool.read().try_resolve_chunk_shard(&chunk_hash) {
+                    Some(shard_id) => (
+                        BlockHint::None,
+                        ShardHint::Id(shard_id),
+                        CoordinatorRequestStrategy::Sequential,
+                    ),
+                    None => (
+                        BlockHint::None,
+                        ShardHint::None,
+                        CoordinatorRequestStrategy::ParallelTakeFirst,
+                    ),
+                }
             }
         };
         self.run_coordinator_request(

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1299,9 +1299,9 @@ impl JsonRpcHandler {
             }
             ChunkReference::ChunkHash { chunk_id } => {
                 let chunk_hash = ChunkHash::from(*chunk_id);
-                match self.pool.read().try_resolve_chunk_shard(&chunk_hash) {
-                    Some(shard_id) => (
-                        BlockHint::None,
+                match self.pool.read().try_resolve_chunk_block_and_shard(&chunk_hash) {
+                    Some((height, shard_id)) => (
+                        BlockHint::Height(height),
                         ShardHint::Id(shard_id),
                         CoordinatorRequestStrategy::Sequential,
                     ),
@@ -1719,9 +1719,9 @@ impl JsonRpcHandler {
             }
             ChunkReference::ChunkHash { chunk_id } => {
                 let chunk_hash = ChunkHash::from(*chunk_id);
-                match self.pool.read().try_resolve_chunk_shard(&chunk_hash) {
-                    Some(shard_id) => (
-                        BlockHint::None,
+                match self.pool.read().try_resolve_chunk_block_and_shard(&chunk_hash) {
+                    Some((height, shard_id)) => (
+                        BlockHint::Height(height),
                         ShardHint::Id(shard_id),
                         CoordinatorRequestStrategy::Sequential,
                     ),

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -77,6 +77,7 @@ use near_network::tcp::{self, ListenerAddr};
 use near_o11y::metrics::{Encoder, TextEncoder, prometheus};
 use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
 use near_primitives::hash::CryptoHash;
+use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockId, BlockReference, ShardId};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
@@ -509,7 +510,15 @@ impl JsonRpcHandler {
             "changes" | "EXPERIMENTAL_changes" => {
                 process_method_call(request, |params| self.changes_in_block_by_type(params)).await
             }
-            "chunk" => process_method_call(request, |params| self.chunk(params)).await,
+            "chunk" => {
+                process_sharded_method_call(
+                    request,
+                    source,
+                    |params| self.chunk_sharded(params),
+                    |params| self.chunk_local(params),
+                )
+                .await
+            }
             "gas_price" => process_method_call(request, |params| self.gas_price(params)).await,
 
             "genesis_config" | "EXPERIMENTAL_genesis_config" => {
@@ -1687,7 +1696,35 @@ impl JsonRpcHandler {
         Ok(near_jsonrpc_primitives::types::blocks::RpcBlockResponse { block_view })
     }
 
-    async fn chunk(
+    async fn chunk_sharded(
+        &self,
+        request_data: near_jsonrpc_primitives::types::chunks::RpcChunkRequest,
+    ) -> Result<Value, RpcError> {
+        let (block_hint, shard_hint, strategy) = match &request_data.chunk_reference {
+            ChunkReference::BlockShardId { block_id, shard_id } => {
+                let block_hint = BlockReference::BlockId(block_id.clone()).into();
+                (block_hint, ShardHint::Id(*shard_id), CoordinatorRequestStrategy::Sequential)
+            }
+            ChunkReference::ChunkHash { chunk_id } => {
+                let chunk_hash = ChunkHash::from(*chunk_id);
+                match self.pool.read().try_resolve_chunk_shard(&chunk_hash) {
+                    Some(shard_id) => (
+                        BlockHint::None,
+                        ShardHint::Id(shard_id),
+                        CoordinatorRequestStrategy::Sequential,
+                    ),
+                    None => (
+                        BlockHint::None,
+                        ShardHint::None,
+                        CoordinatorRequestStrategy::ParallelTakeFirst,
+                    ),
+                }
+            }
+        };
+        self.run_coordinator_request("chunk", request_data, block_hint, shard_hint, strategy).await
+    }
+
+    async fn chunk_local(
         &self,
         request_data: near_jsonrpc_primitives::types::chunks::RpcChunkRequest,
     ) -> Result<

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -283,7 +283,7 @@ impl ShardedRpcPool {
     /// (header-only for untracked shards), so this works regardless of which
     /// shards the local node tracks.
     pub fn try_resolve_chunk_shard(&self, chunk_hash: &ChunkHash) -> Option<ShardId> {
-        let chunk_store = ChunkStoreAdapter::new(self.chain_store.store_ref().clone());
+        let chunk_store = ChunkStoreAdapter::new(self.chain_store.store());
         let partial_chunk = chunk_store.get_partial_chunk(chunk_hash).ok()?;
         Some(partial_chunk.shard_id())
     }

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -207,6 +207,7 @@ impl ShardedRpcPool {
 
                 self.nodes_for_account_in_epochs(possible_epochs, account_id)?
             }
+            (_, ShardHint::Id(shard_id)) => self.nodes_for_shard(*shard_id),
             _ => self.all_nodes(),
         };
 
@@ -278,14 +279,44 @@ impl ShardedRpcPool {
         Ok(result)
     }
 
+    /// Returns nodes that track the given shard.
+    fn nodes_for_shard(&self, shard_id: ShardId) -> Vec<RpcNodeHandle> {
+        let mut result = Vec::new();
+
+        // Check if the local node tracks this shard (using head epoch).
+        if let Ok(tip) = self.chain_store.head() {
+            if self
+                .shard_tracker
+                .rpc_tracks_shard_at_epoch(shard_id, &tip.epoch_id)
+                .unwrap_or(false)
+            {
+                result.push(RpcNodeHandle::LocalNode);
+            }
+        }
+
+        // Check remote nodes.
+        for node in &self.nodes {
+            if node.tracked_shards.contains(&shard_id) {
+                result.push(RpcNodeHandle::RemoteNode(node.client.clone()));
+            }
+        }
+
+        result
+    }
+
     /// Try to resolve a chunk hash to its shard_id by looking up the partial
     /// chunk in the store. All nodes persist partial chunks for all shards
     /// (header-only for untracked shards), so this works regardless of which
     /// shards the local node tracks.
     pub fn try_resolve_chunk_shard(&self, chunk_hash: &ChunkHash) -> Option<ShardId> {
         let chunk_store = ChunkStoreAdapter::new(self.chain_store.store());
-        let partial_chunk = chunk_store.get_partial_chunk(chunk_hash).ok()?;
-        Some(partial_chunk.shard_id())
+        match chunk_store.get_partial_chunk(chunk_hash) {
+            Ok(partial_chunk) => Some(partial_chunk.shard_id()),
+            Err(err) => {
+                tracing::debug!(target: "jsonrpc", ?chunk_hash, ?err, "failed to resolve chunk shard from partial chunk store");
+                None
+            }
+        }
     }
 }
 

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -5,8 +5,11 @@ use near_jsonrpc_client_internal::JsonRpcClient;
 use near_jsonrpc_primitives::errors::RpcError;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
+use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{AccountId, BlockHeight, BlockId, BlockReference, EpochId, ShardId};
+use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use near_store::adapter::chunk_store::ChunkStoreAdapter;
 use std::net::{IpAddr, SocketAddr, UdpSocket};
 use std::sync::Arc;
 use url::Url;
@@ -273,6 +276,16 @@ impl ShardedRpcPool {
         }
 
         Ok(result)
+    }
+
+    /// Try to resolve a chunk hash to its shard_id by looking up the partial
+    /// chunk in the store. All nodes persist partial chunks for all shards
+    /// (header-only for untracked shards), so this works regardless of which
+    /// shards the local node tracks.
+    pub fn try_resolve_chunk_shard(&self, chunk_hash: &ChunkHash) -> Option<ShardId> {
+        let chunk_store = ChunkStoreAdapter::new(self.chain_store.store_ref().clone());
+        let partial_chunk = chunk_store.get_partial_chunk(chunk_hash).ok()?;
+        Some(partial_chunk.shard_id())
     }
 }
 

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -9,7 +9,6 @@ use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{AccountId, BlockHeight, BlockId, BlockReference, EpochId, ShardId};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
-use near_store::adapter::chunk_store::ChunkStoreAdapter;
 use std::net::{IpAddr, SocketAddr, UdpSocket};
 use std::sync::Arc;
 use url::Url;
@@ -207,7 +206,35 @@ impl ShardedRpcPool {
 
                 self.nodes_for_account_in_epochs(possible_epochs, account_id)?
             }
-            (_, ShardHint::Id(shard_id)) => self.nodes_for_shard(*shard_id),
+            (BlockHint::Hash(block_hash), ShardHint::Id(shard_id)) => {
+                let epoch_id = match self.chain_store.get_block_header(block_hash) {
+                    Ok(header) => *header.epoch_id(),
+                    Err(Error::DBNotFoundErr(_)) => return Ok(self.all_nodes()), // Unknown block, try all nodes
+                    Err(e) => return Err(make_rpc_error(e)),
+                };
+                self.nodes_for_shard_in_epochs(vec![epoch_id], *shard_id)?
+            }
+            (BlockHint::Height(height), ShardHint::Id(shard_id)) => {
+                let epoch_ids: Vec<_> = self
+                    .chain_store
+                    .get_all_block_hashes_by_height(*height)
+                    .keys()
+                    .cloned()
+                    .collect();
+                if epoch_ids.is_empty() {
+                    return Ok(self.all_nodes()); // Unknown block, try all nodes
+                }
+                self.nodes_for_shard_in_epochs(epoch_ids, *shard_id)?
+            }
+            (BlockHint::Recent, ShardHint::Id(shard_id))
+            | (BlockHint::None, ShardHint::Id(shard_id)) => {
+                let head = match self.chain_store.head() {
+                    Ok(tip) => tip,
+                    Err(Error::DBNotFoundErr(_)) => return Ok(self.all_nodes()),
+                    Err(e) => return Err(make_rpc_error(e)),
+                };
+                self.nodes_for_shard_in_epochs(vec![head.epoch_id], *shard_id)?
+            }
             _ => self.all_nodes(),
         };
 
@@ -279,41 +306,50 @@ impl ShardedRpcPool {
         Ok(result)
     }
 
-    /// Returns nodes that track the given shard.
-    fn nodes_for_shard(&self, shard_id: ShardId) -> Vec<RpcNodeHandle> {
+    /// Returns nodes that track the given shard in any of the given epochs.
+    fn nodes_for_shard_in_epochs(
+        &self,
+        epoch_ids: Vec<EpochId>,
+        shard_id: ShardId,
+    ) -> Result<Vec<RpcNodeHandle>, RpcError> {
         let mut result = Vec::new();
 
-        // Check if the local node tracks this shard (using head epoch).
-        if let Ok(tip) = self.chain_store.head() {
-            if self
-                .shard_tracker
-                .rpc_tracks_shard_at_epoch(shard_id, &tip.epoch_id)
-                .unwrap_or(false)
-            {
-                result.push(RpcNodeHandle::LocalNode);
+        // Check if the local node tracks this shard in any of the given epochs.
+        for epoch_id in &epoch_ids {
+            match self.shard_tracker.rpc_tracks_shard_at_epoch(shard_id, epoch_id) {
+                Ok(true) => {
+                    result.push(RpcNodeHandle::LocalNode);
+                    break;
+                }
+                Ok(false) => {}
+                Err(EpochError::EpochOutOfBounds(_)) => return Ok(self.all_nodes()), // Unknown epoch, try all nodes
+                Err(e) => return Err(make_rpc_error(e)),
             }
         }
 
-        // Check remote nodes.
+        // Check remote nodes. Their `tracked_shards` is a static config and
+        // not epoch-dependent, so a single membership check is enough.
         for node in &self.nodes {
             if node.tracked_shards.contains(&shard_id) {
                 result.push(RpcNodeHandle::RemoteNode(node.client.clone()));
             }
         }
 
-        result
+        Ok(result)
     }
 
-    /// Try to resolve a chunk hash to its shard_id by looking up the partial
-    /// chunk in the store. All nodes persist partial chunks for all shards
-    /// (header-only for untracked shards), so this works regardless of which
-    /// shards the local node tracks.
-    pub fn try_resolve_chunk_shard(&self, chunk_hash: &ChunkHash) -> Option<ShardId> {
-        let chunk_store = ChunkStoreAdapter::new(self.chain_store.store());
-        match chunk_store.get_partial_chunk(chunk_hash) {
-            Ok(partial_chunk) => Some(partial_chunk.shard_id()),
+    /// Try to resolve a chunk hash to its (block_height, shard_id) by looking
+    /// up the partial chunk in the store. All nodes persist partial chunks for
+    /// all shards (header-only for untracked shards), so this works regardless
+    /// of which shards the local node tracks.
+    pub fn try_resolve_chunk_block_and_shard(
+        &self,
+        chunk_hash: &ChunkHash,
+    ) -> Option<(BlockHeight, ShardId)> {
+        match self.chain_store.chunk_store().get_partial_chunk(chunk_hash) {
+            Ok(partial_chunk) => Some((partial_chunk.height_included(), partial_chunk.shard_id())),
             Err(err) => {
-                tracing::debug!(target: "jsonrpc", ?chunk_hash, ?err, "failed to resolve chunk shard from partial chunk store");
+                tracing::debug!(target: "jsonrpc", ?chunk_hash, ?err, "failed to resolve chunk from partial chunk store");
                 None
             }
         }

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -1,5 +1,6 @@
 use crate::utils::sharded_rpc::{TwoShardHarness, assert_rpc_error};
 use near_async::time::Duration;
+use near_jsonrpc::client::ChunkId;
 use near_jsonrpc_primitives::errors::RpcError;
 use near_jsonrpc_primitives::message::Message;
 use near_jsonrpc_primitives::types::call_function::RpcCallFunctionRequest;
@@ -798,6 +799,101 @@ fn test_rpc_experimental_congestion_level_chunk_hash_forwarding() {
     let zoe_node = h.zoe_node.clone();
     run_congestion_level(&alice_node, chunk_hash).unwrap();
     run_congestion_level(&zoe_node, chunk_hash).unwrap();
+}
+
+/// chunk queries by BlockId::Height + ShardId should be forwarded across shards.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_rpc_chunk_block_height_shard_id_forwarding() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let shard_layout = ShardLayout::multi_shard(2, 1);
+    let shard_uids: Vec<ShardUId> = shard_layout.shard_uids().collect();
+    let head_height = h.env.node_for_account(&h.validator).head().height;
+
+    let mut run_chunk = |node_id: &AccountId, shard_uid: ShardUId| -> Result<(), RpcError> {
+        let result = h.env.runner_for_account(node_id).run_with_jsonrpc_client(
+            |client| {
+                client.chunk(ChunkId::BlockShardId(
+                    BlockId::Height(head_height),
+                    shard_uid.shard_id(),
+                ))
+            },
+            Duration::seconds(5),
+        )?;
+        assert_eq!(result.header.shard_id, shard_uid.shard_id());
+        Ok(())
+    };
+
+    // Cross-shard: query shard 1 from shard 0's node and vice versa.
+    run_chunk(&h.alice_node, shard_uids[1]).unwrap();
+    run_chunk(&h.zoe_node, shard_uids[0]).unwrap();
+    // Local.
+    run_chunk(&h.alice_node, shard_uids[0]).unwrap();
+    run_chunk(&h.zoe_node, shard_uids[1]).unwrap();
+}
+
+/// chunk queries by BlockId::Hash + ShardId should be forwarded across shards.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_rpc_chunk_block_hash_shard_id_forwarding() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let shard_layout = ShardLayout::multi_shard(2, 1);
+    let shard_uids: Vec<ShardUId> = shard_layout.shard_uids().collect();
+    let validator = h.validator.clone();
+    let head = h.env.node_for_account(&validator).head();
+    let block_hash = head.last_block_hash;
+
+    let mut run_chunk = |node_id: &AccountId, shard_uid: ShardUId| -> Result<(), RpcError> {
+        let result = h.env.runner_for_account(node_id).run_with_jsonrpc_client(
+            |client| {
+                client.chunk(ChunkId::BlockShardId(BlockId::Hash(block_hash), shard_uid.shard_id()))
+            },
+            Duration::seconds(5),
+        )?;
+        assert_eq!(result.header.shard_id, shard_uid.shard_id());
+        Ok(())
+    };
+
+    // Cross-shard: query shard 1 from shard 0's node and vice versa.
+    run_chunk(&h.alice_node, shard_uids[1]).unwrap();
+    run_chunk(&h.zoe_node, shard_uids[0]).unwrap();
+    // Local.
+    run_chunk(&h.alice_node, shard_uids[0]).unwrap();
+    run_chunk(&h.zoe_node, shard_uids[1]).unwrap();
+}
+
+/// chunk queries by ChunkHash should be forwarded across shards.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_rpc_chunk_hash_forwarding() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    // Get a chunk hash from the head block.
+    let validator = h.validator.clone();
+    let head = h.env.node_for_account(&validator).head();
+    let head_block =
+        h.env.node_for_account(&validator).client().chain.get_block(&head.last_block_hash).unwrap();
+    let chunk_hash = head_block.chunks()[0].chunk_hash().0;
+
+    let mut run_chunk = |node_id: &AccountId, chunk_id: CryptoHash| -> Result<(), RpcError> {
+        let result = h.env.runner_for_account(node_id).run_with_jsonrpc_client(
+            |client| client.chunk(ChunkId::Hash(chunk_id)),
+            Duration::seconds(5),
+        )?;
+        assert_eq!(CryptoHash(result.header.chunk_hash.0), chunk_id);
+        Ok(())
+    };
+
+    // Both nodes should be able to serve a ChunkHash query (resolved via partial chunk store).
+    let alice_node = h.alice_node.clone();
+    let zoe_node = h.zoe_node.clone();
+    run_chunk(&alice_node, chunk_hash).unwrap();
+    run_chunk(&zoe_node, chunk_hash).unwrap();
 }
 
 /// Cross-shard EXPERIMENTAL_view_code for an account with no contract should return a proper error.

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -886,7 +886,7 @@ fn test_rpc_chunk_hash_forwarding() {
             |client| client.chunk(ChunkId::Hash(chunk_id)),
             Duration::seconds(5),
         )?;
-        assert_eq!(CryptoHash(result.header.chunk_hash.0), chunk_id);
+        assert_eq!(result.header.chunk_hash, chunk_id);
         Ok(())
     };
 

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -873,12 +873,13 @@ fn test_rpc_chunk_hash_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
 
-    // Get a chunk hash from the head block.
+    // Get chunk hashes from both shards in the head block.
     let validator = h.validator.clone();
     let head = h.env.node_for_account(&validator).head();
     let head_block =
         h.env.node_for_account(&validator).client().chain.get_block(&head.last_block_hash).unwrap();
-    let chunk_hash = head_block.chunks()[0].chunk_hash().0;
+    let chunk_hash_shard0 = head_block.chunks()[0].chunk_hash().0;
+    let chunk_hash_shard1 = head_block.chunks()[1].chunk_hash().0;
 
     let mut run_chunk = |node_id: &AccountId, chunk_id: CryptoHash| -> Result<(), RpcError> {
         let result = h.env.runner_for_account(node_id).run_with_jsonrpc_client(
@@ -889,11 +890,14 @@ fn test_rpc_chunk_hash_forwarding() {
         Ok(())
     };
 
-    // Both nodes should be able to serve a ChunkHash query (resolved via partial chunk store).
+    // Both nodes should be able to serve ChunkHash queries for both shards
+    // (resolved via partial chunk store).
     let alice_node = h.alice_node.clone();
     let zoe_node = h.zoe_node.clone();
-    run_chunk(&alice_node, chunk_hash).unwrap();
-    run_chunk(&zoe_node, chunk_hash).unwrap();
+    run_chunk(&alice_node, chunk_hash_shard0).unwrap();
+    run_chunk(&alice_node, chunk_hash_shard1).unwrap();
+    run_chunk(&zoe_node, chunk_hash_shard0).unwrap();
+    run_chunk(&zoe_node, chunk_hash_shard1).unwrap();
 }
 
 /// Cross-shard EXPERIMENTAL_view_code for an account with no contract should return a proper error.

--- a/test-loop-tests/src/tests/sharded_rpc_reliability.rs
+++ b/test-loop-tests/src/tests/sharded_rpc_reliability.rs
@@ -6,6 +6,7 @@ use near_jsonrpc_primitives::types::chunks::{ChunkReference, RpcChunkRequest};
 use near_jsonrpc_primitives::types::query::RpcQueryRequest;
 use near_jsonrpc_primitives::types::receipts::{ReceiptReference, RpcReceiptRequest};
 use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, Balance, BlockId, BlockReference, Finality};
 use near_primitives::views::QueryRequest;
@@ -153,6 +154,31 @@ fn test_rpc_chunk_coordinator_header_bypass() {
             assert_rpc_error(&err, "UNKNOWN_CHUNK");
         }
         other => panic!("expected Response, got: {other:?}"),
+    }
+}
+
+/// A chunk query by ChunkHash for a chunk that doesn't exist anywhere falls
+/// through the partial-chunk-store resolution and triggers the
+/// ParallelTakeFirst fallback. All nodes return UnknownChunk; the strategy
+/// must surface UNKNOWN_CHUNK rather than an unrelated error or a timeout.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_rpc_chunk_bogus_hash_parallel_fallback() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let bogus_chunk_hash = CryptoHash::hash_bytes(b"bogus chunk hash");
+
+    for node_id in [&h.alice_node.clone(), &h.zoe_node.clone()] {
+        let err = h
+            .env
+            .runner_for_account(node_id)
+            .run_with_jsonrpc_client(
+                |client| client.chunk(ChunkId::Hash(bogus_chunk_hash)),
+                Duration::seconds(5),
+            )
+            .unwrap_err();
+        assert_rpc_error(&err, "UNKNOWN_CHUNK");
     }
 }
 

--- a/test-loop-tests/src/tests/sharded_rpc_reliability.rs
+++ b/test-loop-tests/src/tests/sharded_rpc_reliability.rs
@@ -1,11 +1,15 @@
 use crate::utils::sharded_rpc::{TwoShardHarness, assert_rpc_error};
 use near_async::time::Duration;
+use near_jsonrpc::client::ChunkId;
 use near_jsonrpc_primitives::message::Message;
+use near_jsonrpc_primitives::types::chunks::{ChunkReference, RpcChunkRequest};
 use near_jsonrpc_primitives::types::query::RpcQueryRequest;
 use near_jsonrpc_primitives::types::receipts::{ReceiptReference, RpcReceiptRequest};
 use near_o11y::testonly::init_test_logger;
-use near_primitives::types::{AccountId, Balance, BlockReference, Finality};
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::types::{AccountId, Balance, BlockId, BlockReference, Finality};
 use near_primitives::views::QueryRequest;
+use near_store::ShardUId;
 
 /// A cross-shard query for a nonexistent account must return UNKNOWN_ACCOUNT,
 /// not UNAVAILABLE_SHARD. The latter would mean the coordinator gave up instead
@@ -86,6 +90,67 @@ fn test_rpc_coordinator_header_bypass() {
             let err =
                 resp.result.expect_err("coordinator request should fail locally (no forwarding)");
             assert_rpc_error(&err, "UNAVAILABLE_SHARD");
+        }
+        other => panic!("expected Response, got: {other:?}"),
+    }
+}
+
+/// Same as test_rpc_coordinator_header_bypass but for the chunk method.
+/// A coordinator chunk request sent to a node that doesn't track the shard
+/// must fail locally (UNKNOWN_CHUNK) instead of being forwarded again.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_rpc_chunk_coordinator_header_bypass() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let shard_layout = ShardLayout::multi_shard(2, 1);
+    let shard_uids: Vec<ShardUId> = shard_layout.shard_uids().collect();
+    let head_height = h.env.node_for_account(&h.validator).head().height;
+    let zoe_node = h.zoe_node.clone();
+
+    // Baseline: a normal chunk request for shard 0 from zoe's node succeeds
+    // because the pool coordinator forwards it to alice's node.
+    let normal_result = h.env.runner_for_account(&zoe_node).run_with_jsonrpc_client(
+        |client| {
+            client.chunk(ChunkId::BlockShardId(
+                BlockId::Height(head_height),
+                shard_uids[0].shard_id(),
+            ))
+        },
+        Duration::seconds(5),
+    );
+    assert!(
+        normal_result.is_ok(),
+        "baseline cross-shard chunk query should succeed via forwarding"
+    );
+
+    // Now send the same query with the coordinator header. Zoe's node doesn't
+    // track shard 0, so without forwarding it must fail.
+    let request = Message::request(
+        "chunk".to_string(),
+        serde_json::to_value(RpcChunkRequest {
+            chunk_reference: ChunkReference::BlockShardId {
+                block_id: BlockId::Height(head_height),
+                shard_id: shard_uids[0].shard_id(),
+            },
+        })
+        .unwrap(),
+    );
+
+    let response = h
+        .env
+        .runner_for_account(&zoe_node)
+        .run_with_jsonrpc_client(
+            |client| client.transport.send_jsonrpc_request(request, true),
+            Duration::seconds(5),
+        )
+        .unwrap();
+
+    match response {
+        Message::Response(resp) => {
+            let err = resp.result.expect_err("coordinator chunk request should fail locally");
+            assert_rpc_error(&err, "UNKNOWN_CHUNK");
         }
         other => panic!("expected Response, got: {other:?}"),
     }


### PR DESCRIPTION
Route chunk requests to shard-aware nodes via the ShardedRpcPool:
- BlockShardId: use the known shard_id for Sequential routing
- ChunkHash: resolve shard_id from DBCol::PartialChunks (all nodes persist partial chunk headers for all shards), then Sequential.
- Falls back to ParallelTakeFirst if resolution fails.