### PR TITLE
fix(runtime): use dedicated rayon pool for pipelining

### DIFF
--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -30,9 +30,10 @@ fn pipelining_pool() -> &'static rayon::ThreadPool {
     static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
     POOL.get_or_init(|| {
         rayon::ThreadPoolBuilder::new()
+            .num_threads(std::cmp::max(rayon::current_num_threads() / 2, 1))
             .thread_name(|index| format!("pipelining-{index}"))
             .build()
-            .unwrap()
+            .expect("failed to build pipelining thread pool")
     })
 }
 

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -21,8 +21,20 @@ use near_vm_runner::logic::GasCounter;
 use near_vm_runner::{ContractRuntimeCache, PreparedContract};
 use parking_lot::{Condvar, Mutex};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
+
+/// Dedicated thread pool for pipelining, to avoid sharing the global rayon pool
+/// with wasmtime's internal compilation which also uses rayon.
+fn pipelining_pool() -> &'static rayon::ThreadPool {
+    static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .thread_name(|index| format!("pipelining-{index}"))
+            .build()
+            .unwrap()
+    })
+}
 
 pub(crate) struct ReceiptPreparationPipeline {
     /// Mapping from a Receipt's ID to a parallel "task" to prepare the receipt's data.
@@ -212,7 +224,7 @@ impl ReceiptPreparationPipeline {
                     let task = Arc::new(PrepareTask { status, condvar: Condvar::new() });
                     entry.insert(Arc::clone(&task));
                     PIPELINING_ACTIONS_SUBMITTED.inc_by(1);
-                    rayon::spawn_fifo(move || {
+                    pipelining_pool().spawn_fifo(move || {
                         let task_status = {
                             let mut status = task.status.lock();
                             std::mem::replace(&mut *status, PrepareTaskStatus::Working)


### PR DESCRIPTION
Use a dedicated rayon thread pool for pipelining preparation tasks instead of the global rayon pool. Wasmtime's internal compilation also uses rayon, and when both share the same pool, work-stealing can cause a thread holding the per-contract compilation lock to steal another pipelining task for the same contract, resulting in a self-deadlock. 