### PR TITLE
chore(ci): ignore RUSTSEC-2026-0097 in cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -61,13 +61,10 @@ ignore = [
     # TODO(#15435): Update object_store once the maintainers release a version with reqwest 0.13+
     "RUSTSEC-2026-0049",
 
-    # RUSTSEC-2026-0097: rand unsoundness is only reachable when rand's `log` feature is enabled
-    # AND a custom `log::Log` logger calls `rand::rng()` during `ThreadRng` reseed. Verified not
-    # to apply here: none of rand 0.7.3 / 0.8.5 / 0.9.0 in Cargo.lock has the `log` feature enabled,
-    # and nearcore installs no custom `log::Log` implementation (logging goes through tracing).
-    # Fixed in rand >= 0.9.3 / >= 0.10.1, but rand 0.8.x has no patched release, and the 0.7.3
-    # (wiremock -> http-types) and 0.9.0 (object_store, opentelemetry_sdk, rust-multipart-rfc7578_2)
-    # copies come from upstream deps. Revisit once workspace rand is bumped to 0.9.3+ and those
-    # upstream crates update.
+    # RUSTSEC-2026-0097: rand unsoundness only triggers when rand's `log` feature is on and a
+    # custom `log::Log` logger calls `rand::rng()` on reseed. Neither applies here: the `log`
+    # feature is not enabled (check with `cargo tree -e features --workspace | grep 'rand feature'`)
+    # and nearcore has no custom `log::Log` impl (logging goes through tracing).
+    # Fixed in rand >= 0.9.3 / >= 0.10.1; 0.8.x has no patch and 0.7.3/0.9.0 are transitive.
     "RUSTSEC-2026-0097",
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -60,4 +60,14 @@ ignore = [
     # object_store 0.13.1 -> reqwest 0.12.4 -> tokio-rustls 0.25.0 -> rustls 0.22.4 -> rustls-webpki 0.102.8
     # TODO(#15435): Update object_store once the maintainers release a version with reqwest 0.13+
     "RUSTSEC-2026-0049",
+
+    # RUSTSEC-2026-0097: rand unsoundness is only reachable when rand's `log` feature is enabled
+    # AND a custom `log::Log` logger calls `rand::rng()` during `ThreadRng` reseed. Verified not
+    # to apply here: none of rand 0.7.3 / 0.8.5 / 0.9.0 in Cargo.lock has the `log` feature enabled,
+    # and nearcore installs no custom `log::Log` implementation (logging goes through tracing).
+    # Fixed in rand >= 0.9.3 / >= 0.10.1, but rand 0.8.x has no patched release, and the 0.7.3
+    # (wiremock -> http-types) and 0.9.0 (object_store, opentelemetry_sdk, rust-multipart-rfc7578_2)
+    # copies come from upstream deps. Revisit once workspace rand is bumped to 0.9.3+ and those
+    # upstream crates update.
+    "RUSTSEC-2026-0097",
 ]


### PR DESCRIPTION
`cargo audit -D warnings` started failing on master due to RUSTSEC-2026-0097, which flags `rand` 0.7.3 / 0.8.5 / 0.9.0 as unsound.

The unsoundness is only reachable when rand's `log` feature is enabled AND a custom `log::Log` logger calls `rand::rng()` during `ThreadRng` reseed. Neither precondition holds here.

Fixed in rand >= 0.9.3 / >= 0.10.1, but 0.8.x has no patched release, and the 0.7.3 (wiremock -> http-types) and 0.9.0 (object_store, opentelemetry_sdk, rust-multipart-rfc7578_2) copies are transitive from upstream deps. Add a TODO to revisit once workspace rand is bumped and those deps update.