### PR TITLE
feat(vm-runner): add compile and cache metrics

### DIFF
--- a/runtime/near-vm-runner/src/metrics.rs
+++ b/runtime/near-vm-runner/src/metrics.rs
@@ -24,6 +24,20 @@ static COMPILATION_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+/// Per-compile histogram, observed directly at the (uncached) compile site.
+/// Unlike `near_vm_runner_compilation_seconds`, this metric counts every
+/// compile regardless of the invoking path (function-call `run`, precompile
+/// on a dedicated rayon pool, view calls, etc.).
+static COMPILE_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec(
+        "near_vm_runner_compile_seconds",
+        "Time to compile a single contract, measured at the compile site",
+        &["vm_kind"],
+        Some(vec![0.010, 0.025, 0.050, 0.1, 0.25, 0.5, 1.0, 2.0]),
+    )
+    .unwrap()
+});
+
 static COMPILED_CONTRACT_CACHE_LOOKUPS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     try_create_int_counter_vec(
         "near_vm_compiled_contract_cache_lookups_total",
@@ -75,6 +89,18 @@ pub(crate) fn compilation_duration(kind: near_parameters::vm::VMKind, duration: 
         VMKind::Wasmer2 => unreachable!(),
         VMKind::NearVm => m.near_vm_compilation_time += duration,
     });
+    observe_compile_seconds(kind, duration);
+}
+
+#[cfg(any(feature = "near_vm", feature = "wasmtime_vm"))]
+fn observe_compile_seconds(kind: near_parameters::vm::VMKind, duration: Duration) {
+    use near_parameters::vm::VMKind;
+    let label = match kind {
+        VMKind::NearVm => "near_vm",
+        VMKind::Wasmtime => "wasmtime",
+        VMKind::Wasmer0 | VMKind::Wasmer2 => return,
+    };
+    COMPILE_SECONDS.with_label_values(&[label]).observe(duration.as_secs_f64());
 }
 
 /// Updates metrics to record a compiled-contract cache lookup,

--- a/runtime/near-vm-runner/src/metrics.rs
+++ b/runtime/near-vm-runner/src/metrics.rs
@@ -11,6 +11,8 @@ thread_local! {
         wasmtime_compilation_time: Duration::new(0, 0),
         compiled_contract_cache_lookups: 0,
         compiled_contract_cache_hits: 0,
+        persisted_contract_cache_lookups: 0,
+        persisted_contract_cache_hits: 0,
     }) };
 }
 
@@ -70,6 +72,24 @@ static COMPILED_CONTRACT_CACHE_HITS_TOTAL: LazyLock<IntCounterVec> = LazyLock::n
     .unwrap()
 });
 
+static PERSISTED_CONTRACT_CACHE_LOOKUPS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_vm_persisted_contract_cache_lookups_total",
+        "The number of times the runtime looks up an entry in the persisted (on-disk) compiled-contract cache, after missing the in-memory cache, for the given caller context and shard_id",
+        &["context", "shard_id"],
+    )
+    .unwrap()
+});
+
+static PERSISTED_CONTRACT_CACHE_HITS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_vm_persisted_contract_cache_hits_total",
+        "The number of times the runtime finds an entry in the persisted (on-disk) compiled-contract cache, after missing the in-memory cache, for the given caller context and shard_id",
+        &["context", "shard_id"],
+    )
+    .unwrap()
+});
+
 #[derive(Default, Copy, Clone)]
 struct Metrics {
     near_vm_compilation_time: Duration,
@@ -78,6 +98,11 @@ struct Metrics {
     compiled_contract_cache_lookups: u64,
     /// Number of times the lookup from the compiled contract cache finds a match.
     compiled_contract_cache_hits: u64,
+    /// Number of lookups from the persisted (on-disk) compiled contract cache,
+    /// after an in-memory cache miss.
+    persisted_contract_cache_lookups: u64,
+    /// Number of times the persisted-cache lookup finds a match.
+    persisted_contract_cache_hits: u64,
 }
 
 #[cfg(any(feature = "near_vm", feature = "wasmtime_vm"))]
@@ -115,6 +140,19 @@ pub(crate) fn record_compiled_contract_cache_lookup(is_hit: bool) {
     });
 }
 
+/// Updates metrics to record a persisted (on-disk) compiled-contract cache
+/// lookup, where is_hit=true indicates that we found an entry. This is only
+/// called when the in-memory cache missed and we fell back to disk.
+#[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
+pub(crate) fn record_persisted_contract_cache_lookup(is_hit: bool) {
+    METRICS.with_borrow_mut(|m| {
+        m.persisted_contract_cache_lookups += 1;
+        if is_hit {
+            m.persisted_contract_cache_hits += 1;
+        }
+    });
+}
+
 pub fn reset_metrics() {
     METRICS.with_borrow_mut(|m| *m = Metrics::default());
 }
@@ -146,6 +184,16 @@ pub fn report_metrics(shard_id: &str, caller_context: &str) {
             COMPILED_CONTRACT_CACHE_HITS_TOTAL
                 .with_label_values(&[caller_context, shard_id])
                 .inc_by(m.compiled_contract_cache_hits);
+        }
+        if m.persisted_contract_cache_lookups > 0 {
+            PERSISTED_CONTRACT_CACHE_LOOKUPS_TOTAL
+                .with_label_values(&[caller_context, shard_id])
+                .inc_by(m.persisted_contract_cache_lookups);
+        }
+        if m.persisted_contract_cache_hits > 0 {
+            PERSISTED_CONTRACT_CACHE_HITS_TOTAL
+                .with_label_values(&[caller_context, shard_id])
+                .inc_by(m.persisted_contract_cache_hits);
         }
 
         *m = Metrics::default();

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -262,6 +262,7 @@ impl NearVM {
                 let _span =
                     tracing::debug_span!(target: "vm", "NearVM::fetch_from_cache").entered();
                 let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
+                crate::metrics::record_persisted_contract_cache_lookup(cache_record.is_some());
                 let Some(compiled_contract_info) = cache_record else {
                     let Some(code) = contract.get_code() else {
                         return Err(VMRunnerError::ContractCodeNotPresent);


### PR DESCRIPTION
Adds two metrics for contract compilation observability.

- `near_vm_runner_compile_seconds`: per-compile time histogram, observed directly at the uncached compile site. Unlike the existing `near_vm_runner_compilation_seconds` (which is flushed via a thread-local only on the function-call path), this captures compiles from every caller — function-call `run`, the precompile path, and view calls.
- `near_vm_persisted_contract_cache_{lookups,hits}_total`: counters for the persisted (on-disk) contract cache, split out from the combined in-memory + persisted counters. Incremented only when the in-memory cache missed, so `hits/lookups` answers "when we had to go to disk, how often was the compiled artifact there?".