### PR TITLE
feat(rpc): add sharded routing for light_client_proof

### DIFF
--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -333,8 +333,9 @@ impl JsonRpcClient {
     pub fn light_client_proof(
         &self,
         request: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofRequest,
-    ) -> RpcRequest<near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofResponse>
-    {
+    ) -> RpcRequest<
+        near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofResponse,
+    > {
         call_method(&self.transport, "light_client_proof", request)
     }
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -330,6 +330,14 @@ impl JsonRpcClient {
         call_method(&self.transport, "EXPERIMENTAL_receipt", request)
     }
 
+    pub fn light_client_proof(
+        &self,
+        request: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofRequest,
+    ) -> RpcRequest<near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofResponse>
+    {
+        call_method(&self.transport, "light_client_proof", request)
+    }
+
     #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_receipt_to_tx(
         &self,

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -532,7 +532,7 @@ impl JsonRpcHandler {
                 process_sharded_method_call(
                     request,
                     source,
-                    |params| self.light_client_proof_sharded(params),
+                    |params| self.light_client_proof_sharded("light_client_proof", params),
                     |params| self.light_client_proof_local(params),
                 )
                 .await
@@ -629,7 +629,9 @@ impl JsonRpcHandler {
                 process_sharded_method_call(
                     request,
                     source,
-                    |params| self.light_client_proof_sharded(params),
+                    |params| {
+                        self.light_client_proof_sharded("EXPERIMENTAL_light_client_proof", params)
+                    },
                     |params| self.light_client_proof_local(params),
                 )
                 .await
@@ -1875,6 +1877,7 @@ impl JsonRpcHandler {
 
     async fn light_client_proof_sharded(
         &self,
+        method_name: &str,
         request_data: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofRequest,
     ) -> Result<Value, RpcError> {
         let account_id = match &request_data.id {
@@ -1884,7 +1887,7 @@ impl JsonRpcHandler {
         let block_hint = BlockHint::Hash(request_data.light_client_head);
         let shard_hint = ShardHint::Account(account_id);
         self.run_coordinator_request(
-            "light_client_proof",
+            method_name,
             request_data,
             block_hint,
             shard_hint,

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -79,7 +79,7 @@ use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockId, BlockReference, ShardId};
+use near_primitives::types::{AccountId, BlockId, BlockReference, ShardId, TransactionOrReceiptId};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, GasPriceView, LightClientBlockView,
@@ -529,9 +529,12 @@ impl JsonRpcHandler {
             }
             "health" => process_method_call(request, |_params: ()| self.health()).await,
             "light_client_proof" => {
-                process_method_call(request, |params| {
-                    self.light_client_execution_outcome_proof(params)
-                })
+                process_sharded_method_call(
+                    request,
+                    source,
+                    |params| self.light_client_execution_outcome_proof_sharded(params),
+                    |params| self.light_client_execution_outcome_proof_local(params),
+                )
                 .await
             }
             "maintenance_windows" | "EXPERIMENTAL_maintenance_windows" => {
@@ -623,9 +626,12 @@ impl JsonRpcHandler {
                 .await
             }
             "EXPERIMENTAL_light_client_proof" => {
-                process_method_call(request, |params| {
-                    self.light_client_execution_outcome_proof(params)
-                })
+                process_sharded_method_call(
+                    request,
+                    source,
+                    |params| self.light_client_execution_outcome_proof_sharded(params),
+                    |params| self.light_client_execution_outcome_proof_local(params),
+                )
                 .await
             }
             "EXPERIMENTAL_light_client_block_proof" => {
@@ -1867,7 +1873,27 @@ impl JsonRpcHandler {
         Ok(response.rpc_into())
     }
 
-    async fn light_client_execution_outcome_proof(
+    async fn light_client_execution_outcome_proof_sharded(
+        &self,
+        request_data: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofRequest,
+    ) -> Result<Value, RpcError> {
+        let account_id = match &request_data.id {
+            TransactionOrReceiptId::Transaction { sender_id, .. } => sender_id.clone(),
+            TransactionOrReceiptId::Receipt { receiver_id, .. } => receiver_id.clone(),
+        };
+        let block_hint = BlockHint::Hash(request_data.light_client_head);
+        let shard_hint = ShardHint::Account(account_id);
+        self.run_coordinator_request(
+            "light_client_proof",
+            request_data,
+            block_hint,
+            shard_hint,
+            CoordinatorRequestStrategy::Sequential,
+        )
+        .await
+    }
+
+    async fn light_client_execution_outcome_proof_local(
         &self,
         request: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofRequest,
     ) -> Result<

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -532,8 +532,8 @@ impl JsonRpcHandler {
                 process_sharded_method_call(
                     request,
                     source,
-                    |params| self.light_client_execution_outcome_proof_sharded(params),
-                    |params| self.light_client_execution_outcome_proof_local(params),
+                    |params| self.light_client_proof_sharded(params),
+                    |params| self.light_client_proof_local(params),
                 )
                 .await
             }
@@ -629,8 +629,8 @@ impl JsonRpcHandler {
                 process_sharded_method_call(
                     request,
                     source,
-                    |params| self.light_client_execution_outcome_proof_sharded(params),
-                    |params| self.light_client_execution_outcome_proof_local(params),
+                    |params| self.light_client_proof_sharded(params),
+                    |params| self.light_client_proof_local(params),
                 )
                 .await
             }
@@ -1873,7 +1873,7 @@ impl JsonRpcHandler {
         Ok(response.rpc_into())
     }
 
-    async fn light_client_execution_outcome_proof_sharded(
+    async fn light_client_proof_sharded(
         &self,
         request_data: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofRequest,
     ) -> Result<Value, RpcError> {
@@ -1893,7 +1893,7 @@ impl JsonRpcHandler {
         .await
     }
 
-    async fn light_client_execution_outcome_proof_local(
+    async fn light_client_proof_local(
         &self,
         request: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofRequest,
     ) -> Result<

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -1358,7 +1358,7 @@ fn test_rpc_light_client_proof_unknown_outcome() {
     // Bogus transaction hash — routes by `sender_id` to alice's shard.
     let bogus_tx = TransactionOrReceiptId::Transaction {
         transaction_hash: CryptoHash::hash_bytes(b"bogus-tx"),
-        sender_id: alice.clone(),
+        sender_id: alice,
     };
     for node_id in [&alice_node, &zoe_node] {
         let err = run_proof_query(&mut h, node_id, bogus_tx.clone())
@@ -1369,7 +1369,7 @@ fn test_rpc_light_client_proof_unknown_outcome() {
     // Bogus receipt id — routes by `receiver_id` to zoe's shard.
     let bogus_receipt = TransactionOrReceiptId::Receipt {
         receipt_id: CryptoHash::hash_bytes(b"bogus-receipt"),
-        receiver_id: zoe.clone(),
+        receiver_id: zoe,
     };
     for node_id in [&alice_node, &zoe_node] {
         let err = run_proof_query(&mut h, node_id, bogus_receipt.clone())

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -1291,14 +1291,13 @@ fn test_rpc_light_client_proof_forwarding() {
         )
         .unwrap_or_else(|e| panic!("tx proof query from {node_id} failed: {e:?}"));
         assert_eq!(resp.outcome_proof.id, tx_hash);
-        // The block referenced by the proof must be final and match the block
-        // the header lite describes.
-        assert_eq!(resp.block_header_lite.inner_lite.height > 0, true);
-        // Every outcome produces a non-empty outcome merkle path because the
-        // outcome hash is not the only leaf in its chunk.
+        assert_ne!(resp.outcome_proof.block_hash, CryptoHash::default());
+        assert!(resp.block_header_lite.inner_lite.height > 0);
+        // With 2 shards, the per-shard outcome root must be lifted into the
+        // block-level outcome root via exactly one merkle step.
         assert!(
-            !resp.outcome_proof.proof.is_empty() || !resp.outcome_root_proof.is_empty(),
-            "expected non-empty outcome/outcome-root proof chain, got empty from {node_id}",
+            !resp.outcome_root_proof.is_empty(),
+            "expected non-empty outcome_root_proof from {node_id}",
         );
     }
 
@@ -1311,42 +1310,44 @@ fn test_rpc_light_client_proof_forwarding() {
         )
         .unwrap_or_else(|e| panic!("receipt proof query from {node_id} failed: {e:?}"));
         assert_eq!(resp.outcome_proof.id, receipt_id);
+        assert_ne!(resp.outcome_proof.block_hash, CryptoHash::default());
+        assert!(!resp.outcome_root_proof.is_empty());
     }
 }
 
-/// `light_client_proof` should return `UNKNOWN_TRANSACTION_OR_RECEIPT` from either RPC
-/// node when the outcome id does not exist, since the routing target tracks the
-/// shard but still cannot find the outcome.
+/// `light_client_proof` should surface `UNKNOWN_TRANSACTION_OR_RECEIPT` cleanly
+/// through the coordinator for bogus tx and receipt ids, exercised from both the
+/// local (target-shard node resolves directly) and the forwarded (other-shard
+/// node forwards via the coordinator) paths.
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_rpc_light_client_proof_unknown_outcome() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
 
-    // Run a few blocks so we have a final head to use as `light_client_head`.
-    let target_height = h.env.node_for_account(&h.validator.clone()).head().height + 5;
-    h.env.runner_for_account(&h.validator.clone()).run_until_executed_height(target_height);
-
     let validator = h.validator.clone();
     let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
     let alice_node = h.alice_node.clone();
     let zoe_node = h.zoe_node.clone();
 
-    let light_client_head =
-        h.env.node_for_account(&validator).client().chain.final_head().unwrap().last_block_hash;
+    // Run a few blocks so we have a final head to use as `light_client_head`.
+    let target_height = h.env.node_for_account(&validator).head().height + 5;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+    h.env.runner_for_account(&alice_node).run_until_executed_height(target_height);
+    h.env.runner_for_account(&zoe_node).run_until_executed_height(target_height);
 
-    let bogus_tx_hash = CryptoHash::hash_bytes(b"bogus-tx");
+    let light_client_head =
+        h.env.node_for_account(&alice_node).client().chain.final_head().unwrap().last_block_hash;
 
     let run_proof_query = |h: &mut TwoShardHarness,
-                           node_id: &AccountId|
+                           node_id: &AccountId,
+                           id: TransactionOrReceiptId|
      -> Result<RpcLightClientExecutionProofResponse, RpcError> {
         h.env.runner_for_account(node_id).run_with_jsonrpc_client(
             |client| {
                 client.light_client_proof(RpcLightClientExecutionProofRequest {
-                    id: TransactionOrReceiptId::Transaction {
-                        transaction_hash: bogus_tx_hash,
-                        sender_id: alice.clone(),
-                    },
+                    id: id.clone(),
                     light_client_head,
                 })
             },
@@ -1354,11 +1355,25 @@ fn test_rpc_light_client_proof_unknown_outcome() {
         )
     };
 
-    // Both RPC nodes should return UNKNOWN_TRANSACTION_OR_RECEIPT: alice_node resolves
-    // locally, zoe_node forwards to alice_node via the coordinator.
-    let err = run_proof_query(&mut h, &alice_node).unwrap_err();
-    assert_rpc_error(&err, "UNKNOWN_TRANSACTION_OR_RECEIPT");
+    // Bogus transaction hash — routes by `sender_id` to alice's shard.
+    let bogus_tx = TransactionOrReceiptId::Transaction {
+        transaction_hash: CryptoHash::hash_bytes(b"bogus-tx"),
+        sender_id: alice.clone(),
+    };
+    for node_id in [&alice_node, &zoe_node] {
+        let err = run_proof_query(&mut h, node_id, bogus_tx.clone())
+            .expect_err("expected UNKNOWN_TRANSACTION_OR_RECEIPT");
+        assert_rpc_error(&err, "UNKNOWN_TRANSACTION_OR_RECEIPT");
+    }
 
-    let err = run_proof_query(&mut h, &zoe_node).unwrap_err();
-    assert_rpc_error(&err, "UNKNOWN_TRANSACTION_OR_RECEIPT");
+    // Bogus receipt id — routes by `receiver_id` to zoe's shard.
+    let bogus_receipt = TransactionOrReceiptId::Receipt {
+        receipt_id: CryptoHash::hash_bytes(b"bogus-receipt"),
+        receiver_id: zoe.clone(),
+    };
+    for node_id in [&alice_node, &zoe_node] {
+        let err = run_proof_query(&mut h, node_id, bogus_receipt.clone())
+            .expect_err("expected UNKNOWN_TRANSACTION_OR_RECEIPT");
+        assert_rpc_error(&err, "UNKNOWN_TRANSACTION_OR_RECEIPT");
+    }
 }

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -6,6 +6,9 @@ use near_jsonrpc_primitives::message::Message;
 use near_jsonrpc_primitives::types::call_function::RpcCallFunctionRequest;
 use near_jsonrpc_primitives::types::chunks::ChunkReference;
 use near_jsonrpc_primitives::types::congestion::RpcCongestionLevelRequest;
+use near_jsonrpc_primitives::types::light_client::{
+    RpcLightClientExecutionProofRequest, RpcLightClientExecutionProofResponse,
+};
 use near_jsonrpc_primitives::types::query::{QueryResponseKind, RpcQueryRequest};
 use near_jsonrpc_primitives::types::receipts::{
     ReceiptReference, RpcReceiptRequest, RpcReceiptResponse,
@@ -21,6 +24,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{
     AccountId, Balance, BlockId, BlockReference, Finality, FunctionArgs, Gas, StoreKey,
+    TransactionOrReceiptId,
 };
 use near_primitives::views::QueryRequest;
 use near_store::ShardUId;
@@ -1212,4 +1216,149 @@ fn test_rpc_query_unknown_block_fallback() {
         )
         .unwrap_err();
     assert_rpc_error(&err, "UNKNOWN_BLOCK");
+}
+
+/// `light_client_proof` should be forwarded to the RPC node that tracks the shard
+/// derived from the account in `TransactionOrReceiptId` under the epoch of
+/// `light_client_head`, for both transaction and receipt variants.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_rpc_light_client_proof_forwarding() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    // Submit a cross-shard transfer so we have both a transaction outcome (alice's shard)
+    // and a receipt outcome (zoe's shard).
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+    let alice_node = h.alice_node.clone();
+    let zoe_node = h.zoe_node.clone();
+
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    // Wait for tx + receipt to execute and for several further blocks so the
+    // outcome's block is final and we have a final head ahead of it. Advance
+    // both RPC nodes so their canonical chain includes the chosen
+    // `light_client_head`.
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+    h.env.runner_for_account(&alice_node).run_until_executed_height(target_height);
+    h.env.runner_for_account(&zoe_node).run_until_executed_height(target_height);
+
+    let receipt_id = h
+        .env
+        .node_for_account(&validator)
+        .client()
+        .chain
+        .get_execution_outcome(&tx_hash)
+        .unwrap()
+        .outcome_with_id
+        .outcome
+        .receipt_ids[0];
+
+    // Pick the final head from an RPC node so the block is guaranteed to be
+    // canonical on the node that actually answers the request.
+    let light_client_head =
+        h.env.node_for_account(&alice_node).client().chain.final_head().unwrap().last_block_hash;
+
+    let run_proof_query = |h: &mut TwoShardHarness,
+                           node_id: &AccountId,
+                           id: TransactionOrReceiptId|
+     -> Result<RpcLightClientExecutionProofResponse, RpcError> {
+        h.env.runner_for_account(node_id).run_with_jsonrpc_client(
+            |client| {
+                client.light_client_proof(RpcLightClientExecutionProofRequest {
+                    id: id.clone(),
+                    light_client_head,
+                })
+            },
+            Duration::seconds(5),
+        )
+    };
+
+    // Transaction variant — routes to alice's shard via `sender_id`.
+    for node_id in [&alice_node, &zoe_node] {
+        let resp = run_proof_query(
+            &mut h,
+            node_id,
+            TransactionOrReceiptId::Transaction {
+                transaction_hash: tx_hash,
+                sender_id: alice.clone(),
+            },
+        )
+        .unwrap_or_else(|e| panic!("tx proof query from {node_id} failed: {e:?}"));
+        assert_eq!(resp.outcome_proof.id, tx_hash);
+        // The block referenced by the proof must be final and match the block
+        // the header lite describes.
+        assert_eq!(resp.block_header_lite.inner_lite.height > 0, true);
+        // Every outcome produces a non-empty outcome merkle path because the
+        // outcome hash is not the only leaf in its chunk.
+        assert!(
+            !resp.outcome_proof.proof.is_empty() || !resp.outcome_root_proof.is_empty(),
+            "expected non-empty outcome/outcome-root proof chain, got empty from {node_id}",
+        );
+    }
+
+    // Receipt variant — routes to zoe's shard via `receiver_id`.
+    for node_id in [&alice_node, &zoe_node] {
+        let resp = run_proof_query(
+            &mut h,
+            node_id,
+            TransactionOrReceiptId::Receipt { receipt_id, receiver_id: zoe.clone() },
+        )
+        .unwrap_or_else(|e| panic!("receipt proof query from {node_id} failed: {e:?}"));
+        assert_eq!(resp.outcome_proof.id, receipt_id);
+    }
+}
+
+/// `light_client_proof` should return `UNKNOWN_TRANSACTION_OR_RECEIPT` from either RPC
+/// node when the outcome id does not exist, since the routing target tracks the
+/// shard but still cannot find the outcome.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_rpc_light_client_proof_unknown_outcome() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    // Run a few blocks so we have a final head to use as `light_client_head`.
+    let target_height = h.env.node_for_account(&h.validator.clone()).head().height + 5;
+    h.env.runner_for_account(&h.validator.clone()).run_until_executed_height(target_height);
+
+    let validator = h.validator.clone();
+    let alice = h.alice.clone();
+    let alice_node = h.alice_node.clone();
+    let zoe_node = h.zoe_node.clone();
+
+    let light_client_head =
+        h.env.node_for_account(&validator).client().chain.final_head().unwrap().last_block_hash;
+
+    let bogus_tx_hash = CryptoHash::hash_bytes(b"bogus-tx");
+
+    let run_proof_query = |h: &mut TwoShardHarness,
+                           node_id: &AccountId|
+     -> Result<RpcLightClientExecutionProofResponse, RpcError> {
+        h.env.runner_for_account(node_id).run_with_jsonrpc_client(
+            |client| {
+                client.light_client_proof(RpcLightClientExecutionProofRequest {
+                    id: TransactionOrReceiptId::Transaction {
+                        transaction_hash: bogus_tx_hash,
+                        sender_id: alice.clone(),
+                    },
+                    light_client_head,
+                })
+            },
+            Duration::seconds(5),
+        )
+    };
+
+    // Both RPC nodes should return UNKNOWN_TRANSACTION_OR_RECEIPT: alice_node resolves
+    // locally, zoe_node forwards to alice_node via the coordinator.
+    let err = run_proof_query(&mut h, &alice_node).unwrap_err();
+    assert_rpc_error(&err, "UNKNOWN_TRANSACTION_OR_RECEIPT");
+
+    let err = run_proof_query(&mut h, &zoe_node).unwrap_err();
+    assert_rpc_error(&err, "UNKNOWN_TRANSACTION_OR_RECEIPT");
 }


### PR DESCRIPTION
 ## Summary
  - Route `light_client_proof` and `EXPERIMENTAL_light_client_proof` through the sharded-RPC coordinator so coordinator nodes no longer need to track every shard to answer these methods.
  - Shard is resolved from the `TransactionOrReceiptId` (`sender_id` for transactions, `receiver_id` for receipts) at the epoch of `light_client_head`; strategy is `Sequential` since each outcome lives on exactly one shard.
  - Preserve the original handler as `light_client_proof_local` (coordinator-forwarded leaf) and add `light_client_proof_sharded` as the user-facing entry, matching the pattern used by `chunk`, `query`, and the `view_*` methods.
  - Add a `light_client_proof` helper to the JSON-RPC client for test usage.
