### PR TITLE
feat(vm-runner): disable address map

### DIFF
--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -239,13 +239,13 @@ fn test_wasmtime_artifact_output_stability() {
     ];
     let compiled_hashes = [
         // See the above comment if you want to change this
-        15357622861946059213,
-        16638481262920523869,
-        3943469136926844948,
-        16440063152199940029,
-        17421217776167824235,
-        12368027928383938722,
-        18372661511647223039,
+        17467356520024489490,
+        14729060831070184139,
+        11041498883632407283,
+        12049699321754363033,
+        9906436427985886682,
+        15560032392659795845,
+        11171783944424554209,
     ];
     let mut got_prepared_hashes = Vec::with_capacity(seeds.len());
     let mut got_compiled_hashes = Vec::with_capacity(seeds.len());

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -390,7 +390,6 @@ impl WasmtimeVM {
         if let Some(target) = &target {
             engine_config.target(&target)?;
         }
-
         let mut guard = VMS.write();
         let vm = guard.entry(vm_key).or_insert_with_key(|vm_key| {
             // NOTE: Configuration values are based on:

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -390,6 +390,10 @@ impl WasmtimeVM {
         if let Some(target) = &target {
             engine_config.target(&target)?;
         }
+        // Disable native -> wasm code address mappings to reduce the generated code size.
+        // This saves around 40% of total size for contracts on mainnet.
+        engine_config.generate_address_map(false);
+
         let mut guard = VMS.write();
         let vm = guard.entry(vm_key).or_insert_with_key(|vm_key| {
             // NOTE: Configuration values are based on:

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -390,9 +390,6 @@ impl WasmtimeVM {
         if let Some(target) = &target {
             engine_config.target(&target)?;
         }
-        // Disable native -> wasm code address mappings to reduce the generated code size.
-        // This saves around 40% of total size for contracts on mainnet.
-        engine_config.generate_address_map(false);
 
         let mut guard = VMS.write();
         let vm = guard.entry(vm_key).or_insert_with_key(|vm_key| {
@@ -438,6 +435,9 @@ impl WasmtimeVM {
                 .native_unwind_info(false)
                 .wasm_backtrace(false)
                 .wasm_backtrace_details(WasmBacktraceDetails::Disable)
+                // Disable native -> wasm code address mappings to reduce the generated code size.
+                // This saves around 40% of total size for contracts on mainnet.
+                .generate_address_map(false)
                 // Enable copy-on-write heap images.
                 .memory_init_cow(true)
                 // Wasm stack metering is implemented by instrumentation, we don't want wasmtime to trap before that

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -469,7 +469,7 @@ impl WasmtimeVM {
     pub(crate) fn vm_hash(&self) -> u64 {
         // increment the `version` when making modifications that affect the
         // artifact compatibility.
-        let version = 70;
+        let version = 71;
 
         let mut hasher = std::hash::DefaultHasher::new();
         self.engine.precompile_compatibility_hash().hash(&mut hasher);


### PR DESCRIPTION
Disable address maps for wasmtime generated code.

The map allows showing the WASM source line in backtraces. In normal operation, nobody sees these backtraces anyway.

If someone needs address maps in a debugging setup, we could enable them conditionally. But I refrained from adding it in this PR, I suspect we won't need it.

The effect on generated code size is substantial.
For all contract currently on mainnet, it would be -42.57% total compiled size, just by disabling this flag.

| | Sum of all mainnet contracts [Byte] | Relative to NearVM | Relative to default Wasmtime
-- | -- | -- | --
NearVm | 12118601120 | 100.00% | 68.53%
Wasmtime | 17683515200 | 145.92% | 100.00%
Wasmtime -address_map | 10155668352 | 83.80% | 57.43%