### PR TITLE
chore(ci): remove stale cargo audit ignores

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,7 +6,7 @@ ignore = [
     # It cannot be a security liability in production, considering it is bindings to the OS X kernel.
     "RUSTSEC-2020-0168",
 
-    # older versions of parking-lot are vulnerable, but used by reed-solomon-erasure (dev-dep).
+    # older versions of parking-lot are vulnerable, but used by reed-solomon-erasure.
     "RUSTSEC-2020-0070",
 
     # proc-macro-error is unmaintained, but hard to replace right now (via dynasm).

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -21,8 +21,9 @@ ignore = [
     # because ark-poly depends on it.
     "RUSTSEC-2024-0388",
 
-    # paste is no longer maintained, but it's a transitive dependency via ark-ff.
-    # It is feature complete and poses no security risk.
+    # burntsushi says the crate is feature complete and needs no maintenance, nagisa also doesn't
+    # see any security risk whatsoever to keeping this crate, so we'll be letting it to upgrade out
+    # of existence naturally.
     "RUSTSEC-2024-0436",
 
     # rustls-pemfile is no longer maintained, but it's indirectly required by rust-s3,

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,47 +2,27 @@
 ignore = [
     # DO NOT ADD ANYTHING TO THIS LIST WITHOUT CAREFUL CONSIDERATION!
 
-    # dotenv being unmaintained is ignored because it is an indirect dependency of cloud-storage, which would be hard to replace.
-    # In addition, it is most likely not ever going to be on a security-critical path, considering it only parses trusted .env files.
-    # However, we should probably replace cloud-storage with tame-gcs as soon as possible to remove this ignore.
-    "RUSTSEC-2021-0141",
-
-    # mach is unmaintained, but seems to be required by wasmtime at its latest version, which we currently cannot do without.
-    # We should replace it with mach2 in our personal code, but will need to keep it there until wasmtime switches to it.
-    # Anyway, it cannot be a security liability in production, considering it is bindings to the OS X kernel.
+    # mach is unmaintained, but is required by near-vm (via region).
+    # It cannot be a security liability in production, considering it is bindings to the OS X kernel.
     "RUSTSEC-2020-0168",
 
-    # memmap is unmaintained, but is used by wasmer0, which we need to keep alive for replayability reasons.
-    # We should remove wasmer0 and this ignore as soon as we get limited replayability.
-    "RUSTSEC-2020-0077",
-
-    # parity-wasm is deprecated, but is used by our runtimes before near-vm, which we need to keep alive for replayability reasons.
-    # We should remove them all, as well as this ignore, as soon as we get limited replayability.
-    "RUSTSEC-2022-0061",
-
-    # borsh is vulnerable, but is used by wasmer0, which we need to keep alive for replayability reasons.
-    # We should remove it, as well as this ignore, as soon as we get limited replayability.
-    "RUSTSEC-2023-0033",
-
-    # older versions of parking-lot are vulnerable, but used by wasmer0, which we need to keep alive for replayability reasons.
-    # We should remove it, as well as this ignore, as soon as we get limited replayability.
+    # older versions of parking-lot are vulnerable, but used by reed-solomon-erasure (dev-dep).
     "RUSTSEC-2020-0070",
 
-    # proc-macro-error is unmaintained, but hard to replace right now.
+    # proc-macro-error is unmaintained, but hard to replace right now (via dynasm).
     # Follow https://github.com/Kyuuhachi/syn_derive/issues/4
     "RUSTSEC-2024-0370",
 
     # The instant package is unmaintained, but hard to replace right now because
-    # parking_lot depends on it.
+    # parking_lot 0.11 depends on it (via reed-solomon-erasure).
     "RUSTSEC-2024-0384",
 
     # The derivative package is unmaintained, but hard to replace right now
     # because ark-poly depends on it.
     "RUSTSEC-2024-0388",
 
-    # burntsushi says the crate is feature complete and needs no maintenance, nagisa also doesn't
-    # see any security risk whatsoever to keeping this crate, so we'll be letting it to upgrade out
-    # of existence naturally.
+    # paste is no longer maintained, but it's a transitive dependency via ark-ff.
+    # It is feature complete and poses no security risk.
     "RUSTSEC-2024-0436",
 
     # rustls-pemfile is no longer maintained, but it's indirectly required by rust-s3,

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,7 +3,7 @@ ignore = [
     # DO NOT ADD ANYTHING TO THIS LIST WITHOUT CAREFUL CONSIDERATION!
 
     # mach is unmaintained, but is required by near-vm-vm (via region).
-    # It cannot be a security liability in production, considering it is bindings to the OS X kernel.
+    # It cannot be a security liability in production, considering it only provides bindings to the OS X kernel.
     "RUSTSEC-2020-0168",
 
     # older versions of parking-lot are vulnerable, but used by reed-solomon-erasure.

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,7 +2,7 @@
 ignore = [
     # DO NOT ADD ANYTHING TO THIS LIST WITHOUT CAREFUL CONSIDERATION!
 
-    # mach is unmaintained, but is required by near-vm (via region).
+    # mach is unmaintained, but is required by near-vm-vm (via region).
     # It cannot be a security liability in production, considering it is bindings to the OS X kernel.
     "RUSTSEC-2020-0168",
 


### PR DESCRIPTION
Remove 4 cargo audit ignores for dependencies no longer in the tree: dotenv (RUSTSEC-2021-0141), memmap (RUSTSEC-2020-0077), parity-wasm (RUSTSEC-2022-0061), and borsh old versions (RUSTSEC-2023-0033). Update comments on remaining ignores to reflect current dependency chains.