### PR TITLE
refactor(network): extract handle_peer_message from PeerActor (1/n)

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1,17 +1,12 @@
 use crate::accounts_data::AccountDataError;
-use crate::client::{
-    AnnounceAccountRequest, BlockHeadersRequest, BlockHeadersResponse, BlockRequest, BlockResponse,
-    EpochSyncRequestMessage, EpochSyncResponseMessage, OptimisticBlockMessage, ProcessTxRequest,
-    StateRequestHeader, StateRequestPart, StateResponse, StateResponseReceived,
-};
+use crate::client::AnnounceAccountRequest;
 use crate::concurrency::atomic_cell::AtomicCell;
 use crate::concurrency::demux;
 use crate::config::PEERS_RESPONSE_MAX_PEERS;
 use crate::network_protocol::{
     Edge, EdgeState, OwnedAccount, PartialEdgeInfo, PeerChainInfoV2, PeerIdOrHash, PeerInfo,
-    PeersRequest, PeersResponse, RawRoutedMessage, RoutingTableUpdate,
-    SnapshotHostInfoVerificationError, SyncAccountsData, SyncSnapshotHosts, T2MessageBody,
-    TieredMessageBody,
+    PeersRequest, PeersResponse, RoutingTableUpdate, SnapshotHostInfoVerificationError,
+    SyncAccountsData, SyncSnapshotHosts, T2MessageBody, TieredMessageBody,
 };
 use crate::peer::stream;
 use crate::peer::tracker::Tracker;
@@ -32,12 +27,12 @@ use crate::types::{
 use ::time::Duration;
 use lru::LruCache;
 use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt, FutureSpawnerExt};
-use near_async::messaging::{self, CanSend, CanSendAsync, IntoAsyncSender, IntoSender};
+use near_async::messaging::{self, CanSendAsync, IntoAsyncSender, IntoSender};
 use near_async::tokio::TokioRuntimeHandle;
 use near_async::{ActorSystem, time};
 use near_crypto::Signature;
 use near_o11y::log_assert;
-use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
+use near_o11y::span_wrapped_msg::SpanWrapped;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::types::EpochId;
@@ -950,24 +945,6 @@ impl PeerActor {
         }
     }
 
-    #[tracing::instrument(
-        level = "trace",
-        target = "network",
-        "receive_routed_message",
-        skip_all,
-        fields(body_type = body.variant()),
-    )]
-    async fn receive_routed_message(
-        clock: &time::Clock,
-        network_state: &Arc<NetworkState>,
-        msg_author: PeerId,
-        prev_hop: PeerId,
-        msg_hash: CryptoHash,
-        body: TieredMessageBody,
-    ) -> Result<Option<TieredMessageBody>, ReasonForBan> {
-        Ok(network_state.receive_routed_message(clock, msg_author, prev_hop, msg_hash, body).await)
-    }
-
     fn receive_message(&self, conn: &connection::Connection, msg: PeerMessage) {
         let _span = tracing::trace_span!(target: "network", "receive_message").entered();
         #[cfg(test)]
@@ -1000,128 +977,13 @@ impl PeerActor {
         let clock = self.clock.clone();
         let network_state = self.network_state.clone();
         let peer_id = conn.peer_info.id.clone();
-        let handling_future = async move {
-            Ok(match msg {
-                PeerMessage::Routed(msg) => {
-                    let msg_hash = msg.hash();
-                    Self::receive_routed_message(
-                        &clock,
-                        &network_state,
-                        msg.author().clone(),
-                        peer_id.clone(),
-                        msg_hash,
-                        msg.body_owned(),
-                    )
-                    .await?
-                    .map(|body| {
-                        PeerMessage::Routed(network_state.sign_message(
-                            &clock,
-                            RawRoutedMessage { target: PeerIdOrHash::Hash(msg_hash), body },
-                        ))
-                    })
-                }
-                PeerMessage::BlockRequest(hash) => network_state
-                    .client
-                    .send_async(BlockRequest(hash))
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(|block| PeerMessage::Block(block)),
-                PeerMessage::BlockHeadersRequest(hashes) => network_state
-                    .client
-                    .send_async(BlockHeadersRequest(hashes))
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(PeerMessage::BlockHeaders),
-                PeerMessage::Block(block) => {
-                    network_state
-                        .client
-                        .send_async(BlockResponse { block, peer_id, was_requested }.span_wrap())
-                        .await
-                        .ok();
-                    None
-                }
-                PeerMessage::Transaction(transaction) => {
-                    network_state
-                        .client
-                        .send_async(ProcessTxRequest {
-                            transaction,
-                            is_forwarded: false,
-                            check_only: false,
-                        })
-                        .await
-                        .ok();
-                    None
-                }
-                PeerMessage::BlockHeaders(headers) => {
-                    if let Ok(Err(ban_reason)) = network_state
-                        .client
-                        .send_async(BlockHeadersResponse(headers, peer_id).span_wrap())
-                        .await
-                    {
-                        return Err(ban_reason);
-                    }
-                    None
-                }
-                PeerMessage::Challenge(_) => None,
-                PeerMessage::StateRequestHeader(shard_id, sync_hash) => network_state
-                    .state_request_adapter
-                    .send_async(StateRequestHeader { shard_id, sync_hash })
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(|response| PeerMessage::VersionedStateResponse(*response.0)),
-                PeerMessage::StateRequestPart(shard_id, sync_hash, part_id) => network_state
-                    .state_request_adapter
-                    .send_async(StateRequestPart { shard_id, sync_hash, part_id })
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(|response| PeerMessage::VersionedStateResponse(*response.0)),
-                PeerMessage::VersionedStateResponse(info) => {
-                    network_state
-                        .client
-                        .send_async(
-                            StateResponseReceived {
-                                peer_id,
-                                state_response: StateResponse::State(info.into()),
-                            }
-                            .span_wrap(),
-                        )
-                        .await
-                        .ok();
-                    None
-                }
-                PeerMessage::EpochSyncRequest => {
-                    network_state.client.send(EpochSyncRequestMessage { from_peer: peer_id });
-                    None
-                }
-                PeerMessage::EpochSyncResponse(proof) => {
-                    network_state
-                        .client
-                        .send(EpochSyncResponseMessage { from_peer: peer_id, proof });
-                    None
-                }
-                PeerMessage::OptimisticBlock(ob) => {
-                    network_state.client.send(
-                        OptimisticBlockMessage { from_peer: peer_id, optimistic_block: ob }
-                            .span_wrap(),
-                    );
-                    None
-                }
-                msg => {
-                    tracing::error!(target: "network", ?msg, "peer received unexpected type");
-                    None
-                }
-            })
-        };
 
         let mut handle = self.handle.clone();
         self.handle.spawn(
             "handle message",
             async move {
-                let result = handling_future.await;
+                let result =
+                    network_state.handle_peer_message(&clock, peer_id, msg, was_requested).await;
                 handle.run_later("message handle result", Duration::ZERO, |act, _| {
                     match result {
                         // TODO(gprusak): make sure that for routed messages we drop routeback info correctly.

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1,9 +1,11 @@
 use crate::accounts_data::{AccountDataCache, AccountDataError};
 use crate::announce_accounts::AnnounceAccountCache;
 use crate::client::{
-    BlockApproval, ChunkEndorsementMessage, ClientSenderForNetwork, ProcessTxRequest,
-    SpiceChunkEndorsementMessage, StateResponse, StateResponseReceived, TxStatusRequest,
-    TxStatusResponse,
+    BlockApproval, BlockHeadersRequest, BlockHeadersResponse, BlockRequest, BlockResponse,
+    ChunkEndorsementMessage, ClientSenderForNetwork, EpochSyncRequestMessage,
+    EpochSyncResponseMessage, OptimisticBlockMessage, ProcessTxRequest,
+    SpiceChunkEndorsementMessage, StateRequestHeader, StateRequestPart, StateResponse,
+    StateResponseReceived, TxStatusRequest, TxStatusResponse,
 };
 use crate::concurrency::demux;
 use crate::config;
@@ -908,6 +910,124 @@ impl NetworkState {
                 }
             },
         }
+    }
+
+    /// Dispatches an inbound peer message to the appropriate handler.
+    ///
+    /// Messages handled here are "business logic" messages — TCP-protocol
+    /// messages (handshake, peers, gossip, routed forwarding) are handled
+    /// by PeerActor directly.
+    ///
+    /// Returns:
+    /// - `Ok(Some(response))` — caller should send response back to peer
+    /// - `Ok(None)` — message consumed, no response needed
+    /// - `Err(ban_reason)` — caller should ban the peer
+    pub async fn handle_peer_message(
+        self: &Arc<Self>,
+        clock: &time::Clock,
+        peer_id: PeerId,
+        msg: PeerMessage,
+        was_requested: bool,
+    ) -> Result<Option<PeerMessage>, ReasonForBan> {
+        Ok(match msg {
+            PeerMessage::Routed(msg) => {
+                let msg_hash = msg.hash();
+                self.receive_routed_message(
+                    clock,
+                    msg.author().clone(),
+                    peer_id.clone(),
+                    msg_hash,
+                    msg.body_owned(),
+                )
+                .await
+                .map(|body| {
+                    PeerMessage::Routed(self.sign_message(
+                        clock,
+                        RawRoutedMessage { target: PeerIdOrHash::Hash(msg_hash), body },
+                    ))
+                })
+            }
+            PeerMessage::BlockRequest(hash) => {
+                let response = self.client.send_async(BlockRequest(hash)).await;
+                response.ok().flatten().map(|block| PeerMessage::Block(block))
+            }
+            PeerMessage::BlockHeadersRequest(hashes) => {
+                let response = self.client.send_async(BlockHeadersRequest(hashes)).await;
+                response.ok().flatten().map(PeerMessage::BlockHeaders)
+            }
+            PeerMessage::Block(block) => {
+                self.client
+                    .send_async(BlockResponse { block, peer_id, was_requested }.span_wrap())
+                    .await
+                    .ok();
+                None
+            }
+            PeerMessage::Transaction(transaction) => {
+                self.client
+                    .send_async(ProcessTxRequest {
+                        transaction,
+                        is_forwarded: false,
+                        check_only: false,
+                    })
+                    .await
+                    .ok();
+                None
+            }
+            PeerMessage::BlockHeaders(headers) => {
+                if let Ok(Err(ban_reason)) =
+                    self.client.send_async(BlockHeadersResponse(headers, peer_id).span_wrap()).await
+                {
+                    return Err(ban_reason);
+                }
+                None
+            }
+            PeerMessage::Challenge(_) => None,
+            PeerMessage::StateRequestHeader(shard_id, sync_hash) => {
+                let response = self
+                    .state_request_adapter
+                    .send_async(StateRequestHeader { shard_id, sync_hash })
+                    .await;
+                response.ok().flatten().map(|r| PeerMessage::VersionedStateResponse(*r.0))
+            }
+            PeerMessage::StateRequestPart(shard_id, sync_hash, part_id) => {
+                let response = self
+                    .state_request_adapter
+                    .send_async(StateRequestPart { shard_id, sync_hash, part_id })
+                    .await;
+                response.ok().flatten().map(|r| PeerMessage::VersionedStateResponse(*r.0))
+            }
+            PeerMessage::VersionedStateResponse(info) => {
+                self.client
+                    .send_async(
+                        StateResponseReceived {
+                            peer_id,
+                            state_response: StateResponse::State(info.into()),
+                        }
+                        .span_wrap(),
+                    )
+                    .await
+                    .ok();
+                None
+            }
+            PeerMessage::EpochSyncRequest => {
+                self.client.send(EpochSyncRequestMessage { from_peer: peer_id });
+                None
+            }
+            PeerMessage::EpochSyncResponse(proof) => {
+                self.client.send(EpochSyncResponseMessage { from_peer: peer_id, proof });
+                None
+            }
+            PeerMessage::OptimisticBlock(ob) => {
+                self.client.send(
+                    OptimisticBlockMessage { from_peer: peer_id, optimistic_block: ob }.span_wrap(),
+                );
+                None
+            }
+            msg => {
+                tracing::error!(target: "network", ?msg, "peer received unexpected type");
+                None
+            }
+        })
     }
 
     pub async fn add_accounts_data(


### PR DESCRIPTION
First PR in a series to separate TCP transport from business logic in the
network layer, enabling the real `PeerManagerActor` to run in testloop.

- Extract shared message dispatch from `PeerActor::receive_message` into `NetworkState::handle_peer_message`
- Covers business-logic messages: Block, Transaction, BlockHeaders, StateRequest, EpochSync, etc.
- `PeerActor::receive_message` becomes a thin wrapper handling per-connection concerns (`conn.last_block`, `was_requested` tracker) then delegating
- TCP-protocol messages (handshake, peers, gossip, routed forwarding/dedup) remain in `PeerActor::handle_msg_ready`