### PR TITLE
refactor(network): extract process_incoming_routed + RoutedAction (2/n)

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -11,7 +11,9 @@ use crate::network_protocol::{
 use crate::peer::stream;
 use crate::peer::tracker::Tracker;
 use crate::peer_manager::connection;
-use crate::peer_manager::network_state::{EdgesWithSource, NetworkState, PRUNE_EDGES_AFTER};
+use crate::peer_manager::network_state::{
+    EdgesWithSource, NetworkState, PRUNE_EDGES_AFTER, RoutedAction,
+};
 #[cfg(test)]
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_manager_actor::MAX_TIER2_PEERS;
@@ -33,7 +35,6 @@ use near_async::{ActorSystem, time};
 use near_crypto::Signature;
 use near_o11y::log_assert;
 use near_o11y::span_wrapped_msg::SpanWrapped;
-use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::types::EpochId;
 use near_primitives::utils::DisplayOption;
@@ -1226,25 +1227,12 @@ impl PeerActor {
                     message_processed_event();
                 });
             }
-            PeerMessage::Routed(mut msg) => {
+            PeerMessage::Routed(msg) => {
                 tracing::trace!(
                     target: "network",
                     peer_info = %self.peer_info,
                     target = ?msg.target(),
                     "received routed message");
-                let for_me = self.network_state.message_for_me(msg.target());
-                if for_me {
-                    // Check if we have already received this message.
-                    let new_hash = CryptoHash::hash_borsh(msg.body());
-                    let fastest = self
-                        .network_state
-                        .recent_routed_messages
-                        .lock()
-                        .put(new_hash, ())
-                        .is_none();
-                    // Register that the message has been received.
-                    metrics::record_routed_msg_metrics(&self.clock, &msg, conn.tier, fastest);
-                }
 
                 // Drop duplicated messages routed within DROP_DUPLICATED_MESSAGES_PERIOD ms
                 if let Some(signature) = msg.signature() {
@@ -1261,6 +1249,7 @@ impl PeerActor {
                     }
                     self.routed_message_cache.put(key, now);
                 }
+
                 if let TieredMessageBody::T2(t2) = msg.body() {
                     if let T2MessageBody::ForwardTx(_) = t2.as_ref() {
                         // Check whenever we exceeded number of transactions we got since last block.
@@ -1282,56 +1271,52 @@ impl PeerActor {
                     self.stop(ClosingReason::Ban(ReasonForBan::InvalidSignature));
                     return;
                 }
-
-                self.network_state.add_route_back(&self.clock, &conn, msg.as_ref());
-                if for_me {
-                    // Handle Ping and Pong message if they are for us without sending to client.
-                    // i.e. Return false in case of Ping and Pong
-                    match msg.body() {
-                        TieredMessageBody::T2(t2) => match t2.as_ref() {
-                            T2MessageBody::Ping(ping) => {
-                                self.network_state.send_pong(
-                                    &self.clock,
-                                    conn.tier,
-                                    ping.nonce,
-                                    msg.hash(),
-                                );
-                                // TODO(gprusak): deprecate Event::Ping/Pong in favor of
-                                // MessageProcessed.
-                                #[cfg(test)]
-                                self.network_state
-                                    .config
-                                    .event_sink
-                                    .send(Event::Ping(ping.clone()));
-                                #[cfg(test)]
-                                message_processed_event();
-                            }
-                            T2MessageBody::Pong(_pong) => {
-                                #[cfg(test)]
-                                self.network_state
-                                    .config
-                                    .event_sink
-                                    .send(Event::Pong(_pong.clone()));
-                                #[cfg(test)]
-                                message_processed_event();
-                            }
+                match self.network_state.process_incoming_routed(
+                    &self.clock,
+                    &conn.peer_info.id,
+                    conn.tier,
+                    msg,
+                ) {
+                    RoutedAction::ForMe(msg) => {
+                        // Handle Ping and Pong message if they are for us without sending
+                        // to client. i.e. Return false in case of Ping and Pong
+                        match msg.body() {
+                            TieredMessageBody::T2(t2) => match t2.as_ref() {
+                                T2MessageBody::Ping(ping) => {
+                                    self.network_state.send_pong(
+                                        &self.clock,
+                                        conn.tier,
+                                        ping.nonce,
+                                        msg.hash(),
+                                    );
+                                    // TODO(gprusak): deprecate Event::Ping/Pong in favor of
+                                    // MessageProcessed.
+                                    #[cfg(test)]
+                                    self.network_state
+                                        .config
+                                        .event_sink
+                                        .send(Event::Ping(ping.clone()));
+                                    #[cfg(test)]
+                                    message_processed_event();
+                                }
+                                T2MessageBody::Pong(_pong) => {
+                                    #[cfg(test)]
+                                    self.network_state
+                                        .config
+                                        .event_sink
+                                        .send(Event::Pong(_pong.clone()));
+                                    #[cfg(test)]
+                                    message_processed_event();
+                                }
+                                _ => self.receive_message(&conn, PeerMessage::Routed(msg)),
+                            },
                             _ => self.receive_message(&conn, PeerMessage::Routed(msg)),
-                        },
-                        _ => self.receive_message(&conn, PeerMessage::Routed(msg)),
+                        }
                     }
-                } else {
-                    if msg.decrease_ttl() {
-                        let num_hops = msg.num_hops_mut();
-                        *num_hops = num_hops.saturating_add(1);
+                    RoutedAction::Forward(msg) => {
                         self.network_state.send_message_to_peer(&self.clock, conn.tier, msg);
-                    } else {
-                        #[cfg(test)]
-                        self.network_state.config.event_sink.send(Event::RoutedMessageDropped);
-                        tracing::debug!(target: "network", ?msg, from = ?conn.peer_info.id, "message dropped because ttl reached 0");
-                        metrics::ROUTED_MESSAGE_DROPPED
-                            .with_label_values(&[msg.body_variant()])
-                            .inc();
                     }
+                    RoutedAction::Dropped => {}
                 }
             }
             msg => self.receive_message(&conn, msg),

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -18,6 +18,8 @@ use crate::peer::peer_actor::ClosingReason;
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::connection;
 use crate::peer_manager::connection_store;
+#[cfg(test)]
+use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_store;
 use crate::private_messages::RegisterPeerError;
 use crate::routing::route_back_cache::RouteBackCache;
@@ -193,6 +195,20 @@ impl EdgesWithSource {
             EdgesWithSource::Local(edges) | EdgesWithSource::Remote(edges) => edges.is_empty(),
         }
     }
+}
+
+/// Action to take after processing an incoming routed message.
+/// Returned by `NetworkState::process_incoming_routed` for the caller
+/// (PeerActor or TestLoopTransport) to execute.
+pub(crate) enum RoutedAction {
+    /// Message is for us — caller should handle (Ping/Pong synchronously,
+    /// others via `handle_peer_message`).
+    ForMe(Box<RoutedMessage>),
+    /// Not for us — caller should forward via `send_message_to_peer`.
+    /// TTL already decremented, num_hops incremented.
+    Forward(Box<RoutedMessage>),
+    /// Message dropped (TTL expired, etc). Metrics/logging already done.
+    Dropped,
 }
 
 impl NetworkState {
@@ -928,6 +944,49 @@ impl NetworkState {
                     None
                 }
             },
+        }
+    }
+
+    /// Processes an incoming routed message after per-connection checks
+    /// (signature dedup, ForwardTx rate limiting, signature verification)
+    /// have passed.
+    ///
+    /// Handles: for-me check, route-back recording, network-wide dedup,
+    /// Ping/Pong, forwarding (TTL decrement + next-hop).
+    ///
+    /// Returns a `RoutedAction` for the caller to execute.
+    pub(crate) fn process_incoming_routed(
+        &self,
+        clock: &time::Clock,
+        from: &PeerId,
+        tier: tcp::Tier,
+        mut msg: Box<RoutedMessage>,
+    ) -> RoutedAction {
+        let for_me = self.message_for_me(msg.target());
+        if for_me {
+            // Network-wide dedup: check if we already received this message
+            // (could arrive via both T1 and T2).
+            let new_hash = CryptoHash::hash_borsh(msg.body());
+            let fastest = self.recent_routed_messages.lock().put(new_hash, ()).is_none();
+            metrics::record_routed_msg_metrics(clock, &msg, tier, fastest);
+        }
+
+        self.add_route_back(clock, from, tier, &msg);
+
+        if for_me {
+            RoutedAction::ForMe(msg)
+        } else {
+            if msg.decrease_ttl() {
+                let num_hops = msg.num_hops_mut();
+                *num_hops = num_hops.saturating_add(1);
+                RoutedAction::Forward(msg)
+            } else {
+                #[cfg(test)]
+                self.config.event_sink.send(Event::RoutedMessageDropped);
+                tracing::debug!(target: "network", ?msg, from = ?from, "message dropped because ttl reached 0");
+                metrics::ROUTED_MESSAGE_DROPPED.with_label_values(&[msg.body_variant()]).inc();
+                RoutedAction::Dropped
+            }
         }
     }
 

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -2,7 +2,6 @@ use super::NetworkState;
 use crate::network_protocol::{
     Edge, EdgeState, PartialEdgeInfo, PeerMessage, RoutedMessage, RoutingTableUpdate,
 };
-use crate::peer_manager::connection;
 use crate::peer_manager::network_state::{EdgesWithSource, PeerIdOrHash};
 use crate::routing::routing_table_view::FindRouteError;
 use crate::stats::metrics;
@@ -152,7 +151,8 @@ impl NetworkState {
     pub(crate) fn add_route_back(
         &self,
         clock: &time::Clock,
-        conn: &connection::Connection,
+        from: &PeerId,
+        tier: tcp::Tier,
         msg: &RoutedMessage,
     ) {
         if !msg.expect_response() {
@@ -160,9 +160,8 @@ impl NetworkState {
         }
 
         tracing::trace!(target: "network", route_back = ?msg.clone(), "received peer message that requires response");
-        let from = &conn.peer_info.id;
 
-        match conn.tier {
+        match tier {
             tcp::Tier::T1 => self.tier1_route_back.lock().insert(&clock, msg.hash(), from.clone()),
             tcp::Tier::T2 => self.tier2_route_back.lock().insert(&clock, msg.hash(), from.clone()),
             tcp::Tier::T3 => {


### PR DESCRIPTION
- Introduce `NetworkState::process_incoming_routed` returning a `RoutedAction` enum
- `ForMe` — for-us message, caller dispatches (Ping/Pong synchronously, others via `handle_peer_message`)
- `Forward` — not for us, TTL decremented + num_hops incremented, caller forwards
- `Dropped` — TTL expired, metrics already emitted
- Enables testloop to handle routed messages without a PeerActor