### PR TITLE
refactor(network): move gossip demuxes from Connection to NetworkState (5/n)

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1,7 +1,6 @@
 use crate::accounts_data::AccountDataError;
 use crate::client::AnnounceAccountRequest;
 use crate::concurrency::atomic_cell::AtomicCell;
-use crate::concurrency::demux;
 use crate::config::PEERS_RESPONSE_MAX_PEERS;
 use crate::network_protocol::{
     Edge, EdgeState, OwnedAccount, PartialEdgeInfo, PeerChainInfoV2, PeerIdOrHash, PeerInfo,
@@ -641,14 +640,6 @@ impl PeerActor {
             last_time_peer_requested: AtomicCell::new(None),
             last_time_received_message: AtomicCell::new(now),
             established_time: now,
-            send_accounts_data_demux: demux::Demux::new(
-                self.network_state.config.accounts_data_broadcast_rate_limit,
-                &*self.handle.future_spawner(),
-            ),
-            send_snapshot_hosts_demux: demux::Demux::new(
-                self.network_state.config.snapshot_hosts_broadcast_rate_limit,
-                &*self.handle.future_spawner(),
-            ),
         });
 
         let tracker = self.tracker.clone();

--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -1,10 +1,6 @@
 use crate::concurrency::arc_mutex::ArcMutex;
 use crate::concurrency::atomic_cell::AtomicCell;
-use crate::concurrency::demux;
-use crate::network_protocol::{
-    PeerInfo, PeerMessage, SignedAccountData, SignedOwnedAccount, SnapshotHostInfo,
-    SyncAccountsData, SyncSnapshotHosts, TieredMessageBody,
-};
+use crate::network_protocol::{PeerInfo, PeerMessage, SignedOwnedAccount, TieredMessageBody};
 use crate::peer::peer_actor;
 use crate::peer::peer_actor::PeerActor;
 use crate::private_messages::SendMessage;
@@ -20,9 +16,7 @@ use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_primitives::genesis::GenesisId;
 use near_primitives::network::PeerId;
 use near_primitives::types::ShardId;
-use std::collections::{HashMap, hash_map::Entry};
 use std::fmt;
-use std::future::Future;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Weak};
 
@@ -128,11 +122,6 @@ pub(crate) struct Connection {
     pub stats: Arc<Stats>,
     /// prometheus gauge point guard.
     pub _peer_connections_metric: metrics::GaugePoint,
-
-    /// Demultiplexer for the calls to send_accounts_data().
-    pub send_accounts_data_demux: demux::Demux<Vec<Arc<SignedAccountData>>, ()>,
-    /// Demultiplexer for the calls to send_snapshot_hosts().
-    pub send_snapshot_hosts_demux: demux::Demux<Vec<Arc<SnapshotHostInfo>>, ()>,
 }
 
 impl fmt::Debug for Connection {
@@ -166,102 +155,6 @@ impl Connection {
         let msg_kind = msg.msg_variant().to_string();
         tracing::trace!(target: "network", ?msg_kind, "sending message");
         self.handle.send(SendMessage { message: msg }.span_wrap());
-    }
-
-    pub fn send_accounts_data(
-        self: &Arc<Self>,
-        data: Vec<Arc<SignedAccountData>>,
-    ) -> impl Future<Output = ()> + use<> {
-        let this = self.clone();
-        async move {
-            let res = this
-                .send_accounts_data_demux
-                .call(data, {
-                    let this = this.clone();
-                    |ds: Vec<Vec<Arc<SignedAccountData>>>| async move {
-                        let res = ds.iter().map(|_| ()).collect();
-                        let mut sum = HashMap::<_, Arc<SignedAccountData>>::new();
-                        for d in ds.into_iter().flatten() {
-                            match sum.entry(d.account_key.clone()) {
-                                Entry::Occupied(mut x) => {
-                                    if x.get().version < d.version {
-                                        x.insert(d);
-                                    }
-                                }
-                                Entry::Vacant(x) => {
-                                    x.insert(d);
-                                }
-                            }
-                        }
-                        let msg = Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
-                            incremental: true,
-                            requesting_full_sync: false,
-                            accounts_data: sum.into_values().collect(),
-                        }));
-                        this.send_message(msg);
-                        res
-                    }
-                })
-                .await;
-            if res.is_err() {
-                tracing::debug!(
-                    peer_id = %this.peer_info.id,
-                    "peer disconnected while sending sync accounts data"
-                );
-            }
-        }
-    }
-
-    // Accepts a list of SnapshotHostInfos to be broadcast to all neighbors of the node.
-    // Multiple calls to this function made in quick succession will be condensed into a
-    // single outgoing message.
-    pub fn send_snapshot_hosts<'a>(
-        self: &'a Arc<Self>,
-        data: Vec<Arc<SnapshotHostInfo>>,
-    ) -> impl Future<Output = ()> + use<> {
-        let this = self.clone();
-        async move {
-            // Pass the data through the snapshot_hosts_demux to
-            // rate-limit the production of network messages.
-            let res = this
-                .send_snapshot_hosts_demux
-                .call(data, {
-                    let this = this.clone();
-                    // This function describes how to combine multiple vectors of
-                    // SnapshotHostInfos into a single batch of data.
-                    |ds: Vec<Vec<Arc<SnapshotHostInfo>>>| async move {
-                        let res = ds.iter().map(|_| ()).collect();
-                        let mut sum = HashMap::<_, Arc<SnapshotHostInfo>>::new();
-                        for d in ds.into_iter().flatten() {
-                            match sum.entry(d.peer_id.clone()) {
-                                Entry::Occupied(mut x) => {
-                                    // If two entries are present for the same peer,
-                                    // keep one with the greatest epoch_height.
-                                    if x.get().epoch_height < d.epoch_height {
-                                        x.insert(d);
-                                    }
-                                }
-                                Entry::Vacant(x) => {
-                                    x.insert(d);
-                                }
-                            }
-                        }
-                        // Send a single SyncSnapshotHosts message with the condensed data.
-                        let msg = Arc::new(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts {
-                            hosts: sum.into_values().collect(),
-                        }));
-                        this.send_message(msg);
-                        res
-                    }
-                })
-                .await;
-            if res.is_err() {
-                tracing::debug!(
-                    peer_id = %this.peer_info.id,
-                    "peer disconnected while sending sync snapshot hosts"
-                );
-            }
-        }
     }
 }
 

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -132,14 +132,12 @@ pub(crate) struct NetworkState {
 
     /// Network-related info about the chain.
     pub chain_info: ArcSwap<Option<ChainInfo>>,
-    /// Per-peer gossip demuxes for T2 peers (moved from Connection).
-    /// Kept as two separate maps rather than a struct so
-    /// `add_accounts_data` and `add_snapshot_hosts` iterate the map
-    /// they need directly — no struct-field extraction step.
-    pub accounts_data_demuxes:
-        Mutex<HashMap<PeerId, demux::Demux<Vec<Arc<SignedAccountData>>, ()>>>,
-    pub snapshot_hosts_demuxes:
-        Mutex<HashMap<PeerId, demux::Demux<Vec<Arc<SnapshotHostInfo>>, ()>>>,
+    /// Per-peer gossip demuxes for T2 peers. Kept as two separate
+    /// maps rather than a struct so `add_accounts_data` and
+    /// `add_snapshot_hosts` iterate the map they need directly — no
+    /// struct-field extraction step.
+    accounts_data_demuxes: Mutex<HashMap<PeerId, demux::Demux<Vec<Arc<SignedAccountData>>, ()>>>,
+    snapshot_hosts_demuxes: Mutex<HashMap<PeerId, demux::Demux<Vec<Arc<SnapshotHostInfo>>, ()>>>,
 
     /// AccountsData for TIER1 accounts.
     pub accounts_data: Arc<AccountDataCache>,
@@ -553,10 +551,10 @@ impl NetworkState {
     ) {
         self.peers.remove(info.tier, &info.peer_info.id);
 
-        self.accounts_data_demuxes.lock().remove(&info.peer_info.id);
-        self.snapshot_hosts_demuxes.lock().remove(&info.peer_info.id);
-
         if info.tier == tcp::Tier::T2 {
+            self.accounts_data_demuxes.lock().remove(&info.peer_info.id);
+            self.snapshot_hosts_demuxes.lock().remove(&info.peer_info.id);
+
             let peer_id = info.peer_info.id.clone();
 
             // If the last edge represents a connection addition, create an edge
@@ -1356,35 +1354,27 @@ impl NetworkState {
             // Broadcast any new data we have found, even in presence of an error.
             // This will prevent a malicious peer from forcing us to re-verify valid
             // datasets. See accounts_data::Cache documentation for details.
-            if !new_data.is_empty() {
-                // Snapshot the demux map first so the MutexGuard is released
-                // before we start spawning tasks (each `this.spawn` may take
-                // unrelated locks). The intermediate `collect` is required
-                // for the lock to drop — clippy's `needless_collect` doesn't
-                // know that.
-                #[allow(clippy::needless_collect)]
-                let peers: Vec<_> = this
-                    .accounts_data_demuxes
-                    .lock()
-                    .iter()
-                    .map(|(id, demux)| (id.clone(), demux.clone()))
-                    .collect();
-                let tasks: Vec<_> = peers
-                    .into_iter()
-                    .map(|(peer_id, demux)| {
-                        this.spawn(
-                            "send_accounts_data",
-                            this.clone().gossip_accounts_data_to_peer(
-                                peer_id,
-                                demux,
-                                new_data.clone(),
-                            ),
-                        )
-                    })
-                    .collect();
-                for t in tasks {
-                    t.await.unwrap();
-                }
+            if new_data.is_empty() {
+                return err;
+            }
+            // Snapshot the demux map in a scoped block so the MutexGuard
+            // drops before we start spawning tasks (each `this.spawn`
+            // may take unrelated locks).
+            let peers: Vec<_> = {
+                let guard = this.accounts_data_demuxes.lock();
+                guard.iter().map(|(id, demux)| (id.clone(), demux.clone())).collect()
+            };
+            let tasks: Vec<_> = peers
+                .into_iter()
+                .map(|(peer_id, demux)| {
+                    this.spawn(
+                        "send_accounts_data",
+                        this.clone().gossip_accounts_data_to_peer(peer_id, demux, new_data.clone()),
+                    )
+                })
+                .collect();
+            for t in tasks {
+                t.await.unwrap();
             }
             err
         })
@@ -1402,33 +1392,30 @@ impl NetworkState {
             let (new_data, err) = this.snapshot_hosts.clone().insert(hosts).await;
             // Broadcast any valid new data, even if an err was returned.
             // The presence of one invalid entry doesn't invalidate the remaining ones.
-            if !new_data.is_empty() {
-                // Snapshot first, then spawn — same reasoning as
-                // `add_accounts_data` (drop the MutexGuard before
-                // spawning).
-                #[allow(clippy::needless_collect)]
-                let peers: Vec<_> = this
-                    .snapshot_hosts_demuxes
-                    .lock()
-                    .iter()
-                    .map(|(id, demux)| (id.clone(), demux.clone()))
-                    .collect();
-                let tasks: Vec<_> = peers
-                    .into_iter()
-                    .map(|(peer_id, demux)| {
-                        this.spawn(
-                            "send_snapshot_hosts",
-                            this.clone().gossip_snapshot_hosts_to_peer(
-                                peer_id,
-                                demux,
-                                new_data.clone(),
-                            ),
-                        )
-                    })
-                    .collect();
-                for t in tasks {
-                    t.await.unwrap();
-                }
+            if new_data.is_empty() {
+                return err;
+            }
+            // Snapshot first, drop the guard, then spawn — same
+            // reasoning as `add_accounts_data`.
+            let peers: Vec<_> = {
+                let guard = this.snapshot_hosts_demuxes.lock();
+                guard.iter().map(|(id, demux)| (id.clone(), demux.clone())).collect()
+            };
+            let tasks: Vec<_> = peers
+                .into_iter()
+                .map(|(peer_id, demux)| {
+                    this.spawn(
+                        "send_snapshot_hosts",
+                        this.clone().gossip_snapshot_hosts_to_peer(
+                            peer_id,
+                            demux,
+                            new_data.clone(),
+                        ),
+                    )
+                })
+                .collect();
+            for t in tasks {
+                t.await.unwrap();
             }
             err
         })

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1357,11 +1357,20 @@ impl NetworkState {
             // This will prevent a malicious peer from forcing us to re-verify valid
             // datasets. See accounts_data::Cache documentation for details.
             if !new_data.is_empty() {
-                let tasks: Vec<_> = this
+                // Snapshot the demux map first so the MutexGuard is released
+                // before we start spawning tasks (each `this.spawn` may take
+                // unrelated locks). The intermediate `collect` is required
+                // for the lock to drop — clippy's `needless_collect` doesn't
+                // know that.
+                #[allow(clippy::needless_collect)]
+                let peers: Vec<_> = this
                     .accounts_data_demuxes
                     .lock()
                     .iter()
                     .map(|(id, demux)| (id.clone(), demux.clone()))
+                    .collect();
+                let tasks: Vec<_> = peers
+                    .into_iter()
                     .map(|(peer_id, demux)| {
                         this.spawn(
                             "send_accounts_data",
@@ -1394,11 +1403,18 @@ impl NetworkState {
             // Broadcast any valid new data, even if an err was returned.
             // The presence of one invalid entry doesn't invalidate the remaining ones.
             if !new_data.is_empty() {
-                let tasks: Vec<_> = this
+                // Snapshot first, then spawn — same reasoning as
+                // `add_accounts_data` (drop the MutexGuard before
+                // spawning).
+                #[allow(clippy::needless_collect)]
+                let peers: Vec<_> = this
                     .snapshot_hosts_demuxes
                     .lock()
                     .iter()
                     .map(|(id, demux)| (id.clone(), demux.clone()))
+                    .collect();
+                let tasks: Vec<_> = peers
+                    .into_iter()
                     .map(|(peer_id, demux)| {
                         this.spawn(
                             "send_snapshot_hosts",

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -11,8 +11,8 @@ use crate::concurrency::demux;
 use crate::config;
 use crate::network_protocol::{
     Edge, EdgeState, PartialEdgeInfo, PeerIdOrHash, PeerInfo, PeerMessage, RawRoutedMessage,
-    RoutedMessage, SignedAccountData, SignedOwnedAccount, SnapshotHostInfo, T1MessageBody,
-    T2MessageBody, TieredMessageBody,
+    RoutedMessage, SignedAccountData, SignedOwnedAccount, SnapshotHostInfo, SyncAccountsData,
+    SyncSnapshotHosts, T1MessageBody, T2MessageBody, TieredMessageBody,
 };
 use crate::peer::peer_actor::ClosingReason;
 use crate::peer::peer_actor::PeerActor;
@@ -57,6 +57,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::AccountId;
 use parking_lot::{Mutex, RwLock};
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -131,6 +132,15 @@ pub(crate) struct NetworkState {
 
     /// Network-related info about the chain.
     pub chain_info: ArcSwap<Option<ChainInfo>>,
+    /// Per-peer gossip demuxes for T2 peers (moved from Connection).
+    /// Kept as two separate maps rather than a struct so
+    /// `add_accounts_data` and `add_snapshot_hosts` iterate the map
+    /// they need directly — no struct-field extraction step.
+    pub accounts_data_demuxes:
+        Mutex<HashMap<PeerId, demux::Demux<Vec<Arc<SignedAccountData>>, ()>>>,
+    pub snapshot_hosts_demuxes:
+        Mutex<HashMap<PeerId, demux::Demux<Vec<Arc<SnapshotHostInfo>>, ()>>>,
+
     /// AccountsData for TIER1 accounts.
     pub accounts_data: Arc<AccountDataCache>,
     /// AnnounceAccounts mapping TIER1 account ids to peer ids.
@@ -299,6 +309,8 @@ impl NetworkState {
             shards_manager_adapter,
             partial_witness_adapter,
             peers: ConnectedPeers::new(),
+            accounts_data_demuxes: Mutex::new(HashMap::new()),
+            snapshot_hosts_demuxes: Mutex::new(HashMap::new()),
             chain_info: Default::default(),
             tier2: connection::Pool::new(config.node_id()),
             tier1: connection::Pool::new(config.node_id()),
@@ -501,6 +513,20 @@ impl NetworkState {
             },
         );
         if tier == tcp::Tier::T2 {
+            self.accounts_data_demuxes.lock().insert(
+                peer_info.id.clone(),
+                demux::Demux::new(
+                    self.config.accounts_data_broadcast_rate_limit,
+                    &*self.ops_spawner,
+                ),
+            );
+            self.snapshot_hosts_demuxes.lock().insert(
+                peer_info.id.clone(),
+                demux::Demux::new(
+                    self.config.snapshot_hosts_broadcast_rate_limit,
+                    &*self.ops_spawner,
+                ),
+            );
             // Broadcast the edge to other peers. The edge was already verified
             // in validate_new_connection (edge.verify()), so add_edges should
             // never fail for a pre-verified local edge. On master this was done
@@ -526,6 +552,9 @@ impl NetworkState {
         #[cfg(test)] stream_id: tcp::StreamId,
     ) {
         self.peers.remove(info.tier, &info.peer_info.id);
+
+        self.accounts_data_demuxes.lock().remove(&info.peer_info.id);
+        self.snapshot_hosts_demuxes.lock().remove(&info.peer_info.id);
 
         if info.tier == tcp::Tier::T2 {
             let peer_id = info.peer_info.id.clone();
@@ -1245,6 +1274,75 @@ impl NetworkState {
         })
     }
 
+    /// Broadcast accounts data to a single peer via its gossip demux.
+    /// Deduplicates by account_key, keeping the highest version.
+    async fn gossip_accounts_data_to_peer(
+        self: Arc<Self>,
+        peer_id: PeerId,
+        demux: demux::Demux<Vec<Arc<SignedAccountData>>, ()>,
+        data: Vec<Arc<SignedAccountData>>,
+    ) {
+        let res = demux
+            .call(data, {
+                let this = self.clone();
+                let peer_id = peer_id.clone();
+                |ds: Vec<Vec<Arc<SignedAccountData>>>| async move {
+                    let res = ds.iter().map(|_| ()).collect();
+                    let mut sum = HashMap::<_, Arc<SignedAccountData>>::new();
+                    for d in ds.into_iter().flatten() {
+                        if sum.get(&d.account_key).map_or(true, |old| old.version < d.version) {
+                            sum.insert(d.account_key.clone(), d);
+                        }
+                    }
+                    let msg = Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
+                        incremental: true,
+                        requesting_full_sync: false,
+                        accounts_data: sum.into_values().collect(),
+                    }));
+                    this.tier2.send_message(peer_id, msg);
+                    res
+                }
+            })
+            .await;
+        if res.is_err() {
+            tracing::debug!(%peer_id, "peer disconnected while sending sync accounts data");
+        }
+    }
+
+    /// Broadcast snapshot hosts to a single peer via its gossip demux.
+    /// Deduplicates by peer_id, keeping the highest epoch_height.
+    async fn gossip_snapshot_hosts_to_peer(
+        self: Arc<Self>,
+        peer_id: PeerId,
+        demux: demux::Demux<Vec<Arc<SnapshotHostInfo>>, ()>,
+        data: Vec<Arc<SnapshotHostInfo>>,
+    ) {
+        let res = demux
+            .call(data, {
+                let this = self.clone();
+                let peer_id = peer_id.clone();
+                |ds: Vec<Vec<Arc<SnapshotHostInfo>>>| async move {
+                    let res = ds.iter().map(|_| ()).collect();
+                    let mut sum = HashMap::<_, Arc<SnapshotHostInfo>>::new();
+                    for d in ds.into_iter().flatten() {
+                        if sum.get(&d.peer_id).map_or(true, |old| old.epoch_height < d.epoch_height)
+                        {
+                            sum.insert(d.peer_id.clone(), d);
+                        }
+                    }
+                    let msg = Arc::new(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts {
+                        hosts: sum.into_values().collect(),
+                    }));
+                    this.tier2.send_message(peer_id, msg);
+                    res
+                }
+            })
+            .await;
+        if res.is_err() {
+            tracing::debug!(%peer_id, "peer disconnected while sending sync snapshot hosts");
+        }
+    }
+
     pub async fn add_accounts_data(
         self: &Arc<Self>,
         clock: &time::Clock,
@@ -1259,12 +1357,20 @@ impl NetworkState {
             // This will prevent a malicious peer from forcing us to re-verify valid
             // datasets. See accounts_data::Cache documentation for details.
             if !new_data.is_empty() {
-                let tier2 = this.tier2.load();
-                let tasks: Vec<_> = tier2
-                    .ready
-                    .values()
-                    .map(|p| {
-                        this.spawn("send_accounts_data", p.send_accounts_data(new_data.clone()))
+                let tasks: Vec<_> = this
+                    .accounts_data_demuxes
+                    .lock()
+                    .iter()
+                    .map(|(id, demux)| (id.clone(), demux.clone()))
+                    .map(|(peer_id, demux)| {
+                        this.spawn(
+                            "send_accounts_data",
+                            this.clone().gossip_accounts_data_to_peer(
+                                peer_id,
+                                demux,
+                                new_data.clone(),
+                            ),
+                        )
                     })
                     .collect();
                 for t in tasks {
@@ -1288,12 +1394,20 @@ impl NetworkState {
             // Broadcast any valid new data, even if an err was returned.
             // The presence of one invalid entry doesn't invalidate the remaining ones.
             if !new_data.is_empty() {
-                let tier2 = this.tier2.load();
-                let tasks: Vec<_> = tier2
-                    .ready
-                    .values()
-                    .map(|p| {
-                        this.spawn("send_snapshot_hosts", p.send_snapshot_hosts(new_data.clone()))
+                let tasks: Vec<_> = this
+                    .snapshot_hosts_demuxes
+                    .lock()
+                    .iter()
+                    .map(|(id, demux)| (id.clone(), demux.clone()))
+                    .map(|(peer_id, demux)| {
+                        this.spawn(
+                            "send_snapshot_hosts",
+                            this.clone().gossip_snapshot_hosts_to_peer(
+                                peer_id,
+                                demux,
+                                new_data.clone(),
+                            ),
+                        )
                     })
                     .collect();
                 for t in tasks {

--- a/cspell.json
+++ b/cspell.json
@@ -103,6 +103,7 @@
         "demultiplexing",
         "Demux",
         "demuxed",
+        "demuxes",
         "deprioritize",
         "deprioritized",
         "Deque",


### PR DESCRIPTION
- Move `accounts_data_demuxes` and `snapshot_hosts_demuxes` from `Connection` to NetworkState as two flat `Mutex<HashMap<PeerId, Demux<...>>>` fields
- `on_peer_connected` inserts entries (T2 only), `on_peer_disconnected` removes them
- Gossip broadcast helpers on NetworkState iterate the HashMap directly