### PR TITLE
refactor(network): move tier1 background loops to start_actor (6/n)

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -198,12 +198,12 @@ impl messaging::Actor for PeerManagerActor {
         // Periodically prints bandwidth stats for each peer.
         self.report_bandwidth_stats_trigger(REPORT_BANDWIDTH_STATS_TRIGGER_INTERVAL);
 
-        // Connect to TIER1 proxies and broadcast the list of those connections periodically.
+        // Connect to TIER1 proxies and broadcast the list those connections periodically.
         let tier1 = self.state.config.tier1.clone();
-        let clock = self.clock.clone();
-        let state = self.state.clone();
-        let actor_system = self.actor_system.clone();
         self.handle.spawn("connect to TIER1 proxies", {
+            let clock = self.clock.clone();
+            let state = self.state.clone();
+            let actor_system = self.actor_system.clone();
             let mut interval = time::Interval::new(clock.now(), tier1.advertise_proxies_interval);
             async move {
                 loop {
@@ -215,10 +215,10 @@ impl messaging::Actor for PeerManagerActor {
         });
 
         // Update TIER1 connections periodically.
-        let clock = self.clock.clone();
-        let state = self.state.clone();
-        let actor_system = self.actor_system.clone();
         self.handle.spawn("update TIER1 connections", {
+            let clock = self.clock.clone();
+            let state = self.state.clone();
+            let actor_system = self.actor_system.clone();
             let mut interval = tokio::time::interval(tier1.connect_interval.try_into().unwrap());
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             async move {
@@ -229,30 +229,39 @@ impl messaging::Actor for PeerManagerActor {
             }
         });
 
-        // Periodically poll the connection store for connections we'd like to re-establish.
-        let clock = self.clock.clone();
-        let state = self.state.clone();
-        let actor_system = self.actor_system.clone();
-        let handle = self.handle.clone();
+        // Periodically poll the connection store for connections we'd like to re-establish
         self.handle.spawn("poll connection store for reconnects", {
+            let clock = self.clock.clone();
+            let actor_system = self.actor_system.clone();
+            let state = self.state.clone();
+            let handle = self.handle.clone();
             let mut interval = time::Interval::new(clock.now(), POLL_CONNECTION_STORE_INTERVAL);
             async move {
                 loop {
                     interval.tick(&clock).await;
-                    for peer_info in state.poll_pending_reconnect() {
-                        #[cfg(test)]
-                        state
-                            .config
-                            .event_sink
-                            .send(Event::ReconnectLoopSpawned(peer_info.clone()));
-                        let state = state.clone();
-                        let clock = clock.clone();
-                        let actor_system = actor_system.clone();
-                        handle.spawn("reconnect peer", async move {
-                            state
-                                .reconnect(clock, actor_system, peer_info, MAX_RECONNECT_ATTEMPTS)
-                                .await;
+                    // Poll the NetworkState for all pending reconnect attempts
+                    let pending_reconnect = state.poll_pending_reconnect();
+                    // Spawn a separate reconnect loop for each pending reconnect attempt
+                    for peer_info in pending_reconnect {
+                        handle.spawn("reconnect peer", {
+                            let state = state.clone();
+                            let clock = clock.clone();
+                            let peer_info = peer_info.clone();
+                            let actor_system = actor_system.clone();
+                            async move {
+                                state
+                                    .reconnect(
+                                        clock,
+                                        actor_system,
+                                        peer_info,
+                                        MAX_RECONNECT_ATTEMPTS,
+                                    )
+                                    .await;
+                            }
                         });
+
+                        #[cfg(test)]
+                        state.config.event_sink.send(Event::ReconnectLoopSpawned(peer_info));
                     }
                 }
             }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -198,6 +198,66 @@ impl messaging::Actor for PeerManagerActor {
         // Periodically prints bandwidth stats for each peer.
         self.report_bandwidth_stats_trigger(REPORT_BANDWIDTH_STATS_TRIGGER_INTERVAL);
 
+        // Connect to TIER1 proxies and broadcast the list of those connections periodically.
+        let tier1 = self.state.config.tier1.clone();
+        let clock = self.clock.clone();
+        let state = self.state.clone();
+        let actor_system = self.actor_system.clone();
+        self.handle.spawn("connect to TIER1 proxies", {
+            let mut interval = time::Interval::new(clock.now(), tier1.advertise_proxies_interval);
+            async move {
+                loop {
+                    interval.tick(&clock).await;
+                    state.tier1_request_full_sync();
+                    state.tier1_advertise_proxies(&clock, actor_system.clone()).await;
+                }
+            }
+        });
+
+        // Update TIER1 connections periodically.
+        let clock = self.clock.clone();
+        let state = self.state.clone();
+        let actor_system = self.actor_system.clone();
+        self.handle.spawn("update TIER1 connections", {
+            let mut interval = tokio::time::interval(tier1.connect_interval.try_into().unwrap());
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            async move {
+                loop {
+                    interval.tick().await;
+                    state.tier1_connect(&clock, actor_system.clone()).await;
+                }
+            }
+        });
+
+        // Periodically poll the connection store for connections we'd like to re-establish.
+        let clock = self.clock.clone();
+        let state = self.state.clone();
+        let actor_system = self.actor_system.clone();
+        let handle = self.handle.clone();
+        self.handle.spawn("poll connection store for reconnects", {
+            let mut interval = time::Interval::new(clock.now(), POLL_CONNECTION_STORE_INTERVAL);
+            async move {
+                loop {
+                    interval.tick(&clock).await;
+                    for peer_info in state.poll_pending_reconnect() {
+                        #[cfg(test)]
+                        state
+                            .config
+                            .event_sink
+                            .send(Event::ReconnectLoopSpawned(peer_info.clone()));
+                        let state = state.clone();
+                        let clock = clock.clone();
+                        let actor_system = actor_system.clone();
+                        handle.spawn("reconnect peer", async move {
+                            state
+                                .reconnect(clock, actor_system, peer_info, MAX_RECONNECT_ATTEMPTS)
+                                .await;
+                        });
+                    }
+                }
+            }
+        });
+
         #[cfg(test)]
         self.state.config.event_sink.send(Event::PeerManagerStarted);
     }
@@ -311,67 +371,6 @@ impl PeerManagerActor {
                     });
                 }
 
-                // Connect to TIER1 proxies and broadcast the list those connections periodically.
-                let tier1 = state.config.tier1.clone();
-                handle.spawn("connect to TIER1 proxies", {
-                    let clock = clock.clone();
-                    let state = state.clone();
-                    let actor_system = actor_system.clone();
-                    let mut interval = time::Interval::new(clock.now(), tier1.advertise_proxies_interval);
-                    async move {
-                        loop {
-                            interval.tick(&clock).await;
-                            state.tier1_request_full_sync();
-                            state.tier1_advertise_proxies(&clock, actor_system.clone()).await;
-                        }
-                    }
-                });
-
-                // Update TIER1 connections periodically.
-                handle.spawn("update TIER1 connections", {
-                    let clock = clock.clone();
-                    let state = state.clone();
-                    let actor_system = actor_system.clone();
-                    let mut interval = tokio::time::interval(tier1.connect_interval.try_into().unwrap());
-                    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-                    async move {
-                        loop {
-                            interval.tick().await;
-                            state.tier1_connect(&clock, actor_system.clone()).await;
-                        }
-                    }
-                });
-
-                // Periodically poll the connection store for connections we'd like to re-establish
-                handle.spawn("poll connection store for reconnects", {
-                    let clock = clock.clone();
-                    let actor_system = actor_system.clone();
-                    let state = state.clone();
-                    let handle = handle.clone();
-                    let mut interval = time::Interval::new(clock.now(), POLL_CONNECTION_STORE_INTERVAL);
-                    async move {
-                        loop {
-                            interval.tick(&clock).await;
-                            // Poll the NetworkState for all pending reconnect attempts
-                            let pending_reconnect = state.poll_pending_reconnect();
-                            // Spawn a separate reconnect loop for each pending reconnect attempt
-                            for peer_info in pending_reconnect {
-                                handle.spawn("reconnect peer", {
-                                    let state = state.clone();
-                                    let clock = clock.clone();
-                                    let peer_info = peer_info.clone();
-                                    let actor_system = actor_system.clone();
-                                    async move {
-                                        state.reconnect(clock, actor_system, peer_info, MAX_RECONNECT_ATTEMPTS).await;
-                                    }
-                                });
-
-                                #[cfg(test)]
-                                state.config.event_sink.send(Event::ReconnectLoopSpawned(peer_info));
-                            }
-                        }
-                    }
-                });
             }
         });
         builder.spawn_tokio_actor(Self {


### PR DESCRIPTION
- Move three background loops from `PMA::spawn()` to `start_actor`:
  - `connect to TIER1 proxies` (tier1_advertise_proxies)
  - `update TIER1 connections` (tier1_connect)
  - `poll connection store for reconnects`
- Retain `handle.spawn` pattern (not `run_later`) because existing tests use `FakeClock::advance()` which only affects `near_time` waiters
- `tier1_connect` loop still uses `tokio::time::interval` (pre-existing, fixed in PR 13)