### PR TITLE
feat(network): define NetworkTransport trait + TcpTransport (7/n)

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -13,9 +13,11 @@ use crate::peer_manager::connection;
 use crate::peer_manager::network_state::{
     EdgesWithSource, NetworkState, PRUNE_EDGES_AFTER, RoutedAction,
 };
+use crate::peer_manager::network_transport::NetworkTransport;
 #[cfg(test)]
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_manager_actor::MAX_TIER2_PEERS;
+use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::private_messages::{RegisterPeerError, SendMessage};
 use crate::rate_limits::messages_limits;
 use crate::routing::edge::verify_nonce;
@@ -146,6 +148,8 @@ pub(crate) struct PeerActor {
 
     /// Shared state of the network module.
     network_state: Arc<NetworkState>,
+    /// Transport for sending/broadcasting messages.
+    transport: Arc<dyn NetworkTransport>,
     /// This node's id and address (either listening or socket address).
     my_node_info: PeerInfo,
 
@@ -226,7 +230,9 @@ impl PeerActor {
         stream: tcp::Stream,
         network_state: Arc<NetworkState>,
     ) -> anyhow::Result<TokioRuntimeHandle<Self>> {
-        let (addr, handshake_signal) = Self::spawn(clock, actor_system, stream, network_state)?;
+        let transport = TcpTransport::new(network_state.clone());
+        let (addr, handshake_signal) =
+            Self::spawn(clock, actor_system, stream, network_state, transport)?;
         // Await for the handshake to complete, by awaiting the handshake_signal channel.
         // This is a receiver of Infallible, so it only completes when the channel is closed.
         handshake_signal.await.err().unwrap();
@@ -242,12 +248,13 @@ impl PeerActor {
         actor_system: ActorSystem,
         stream: tcp::Stream,
         network_state: Arc<NetworkState>,
+        transport: Arc<dyn NetworkTransport>,
     ) -> anyhow::Result<(TokioRuntimeHandle<Self>, HandshakeSignal)> {
         #[cfg(test)]
         let stream_id = stream.id();
         #[cfg(test)]
         let network_state_clone = network_state.clone();
-        match Self::spawn_inner(clock, actor_system, stream, network_state) {
+        match Self::spawn_inner(clock, actor_system, stream, network_state, transport) {
             Ok(it) => Ok(it),
             Err(reason) => {
                 #[cfg(test)]
@@ -264,6 +271,7 @@ impl PeerActor {
         actor_system: ActorSystem,
         stream: tcp::Stream,
         network_state: Arc<NetworkState>,
+        transport: Arc<dyn NetworkTransport>,
     ) -> Result<(TokioRuntimeHandle<Self>, HandshakeSignal), ClosingReason> {
         let connecting_status = match &stream.type_ {
             tcp::StreamType::Inbound => ConnectingStatus::Inbound(
@@ -368,6 +376,7 @@ impl PeerActor {
             }
             .into(),
             network_state,
+            transport,
             received_messages_rate_limits,
             registration_buffered_actions: RegistrationBufferedActions::NotRegistering,
         };
@@ -685,8 +694,9 @@ impl PeerActor {
             let network_state = self.network_state.clone();
             let clock = self.clock.clone();
             let handle = self.handle.clone();
+            let transport = self.transport.clone();
             async move {
-                let register_result = network_state.register(&clock, edge, conn.clone()).await;
+                let register_result = network_state.register(&clock, edge, conn.clone(), transport).await;
                 handle.clone().run_later("register peer followup", Duration::ZERO, move |act, _| {
                     match register_result {
                         Ok(()) => {
@@ -1103,6 +1113,7 @@ impl PeerActor {
             PeerMessage::RequestUpdateNonce(edge_info) => {
                 let clock = self.clock.clone();
                 let network_state = self.network_state.clone();
+                let transport = self.transport.clone();
                 self.handle.spawn("handle request update nonce", async move {
                     if let Err(err) = verify_nonce(&clock, edge_info.nonce) {
                         tracing::debug!(
@@ -1129,7 +1140,12 @@ impl PeerActor {
                         // Sign the edge and broadcast it to everyone (finalize_edge does both).
                         _ => {
                             if let Err(ban_reason) = network_state
-                                .finalize_edge(&clock, peer_id.clone(), edge_info)
+                                .finalize_edge(
+                                    &clock,
+                                    peer_id.clone(),
+                                    edge_info,
+                                    transport.clone(),
+                                )
                                 .await
                             {
                                 conn.stop(Some(ban_reason));
@@ -1143,9 +1159,16 @@ impl PeerActor {
             PeerMessage::SyncRoutingTable(rtu) => {
                 let clock = self.clock.clone();
                 let network_state = self.network_state.clone();
+                let transport = self.transport.clone();
                 self.handle.spawn("handle sync routing table", async move {
-                    Self::handle_sync_routing_table(&clock, &network_state, conn.clone(), rtu)
-                        .await;
+                    Self::handle_sync_routing_table(
+                        &clock,
+                        &network_state,
+                        conn.clone(),
+                        rtu,
+                        transport,
+                    )
+                    .await;
                     #[cfg(test)]
                     message_processed_event();
                 });
@@ -1282,6 +1305,7 @@ impl PeerActor {
                                         conn.tier,
                                         ping.nonce,
                                         msg.hash(),
+                                        &*self.transport,
                                     );
                                     // TODO(gprusak): deprecate Event::Ping/Pong in favor of
                                     // MessageProcessed.
@@ -1308,7 +1332,12 @@ impl PeerActor {
                         }
                     }
                     RoutedAction::Forward(msg) => {
-                        self.network_state.send_message_to_peer(&self.clock, conn.tier, msg);
+                        self.network_state.send_message_to_peer(
+                            &self.clock,
+                            conn.tier,
+                            msg,
+                            &*self.transport,
+                        );
                     }
                     RoutedAction::Dropped => {}
                 }
@@ -1328,6 +1357,7 @@ impl PeerActor {
         network_state: &Arc<NetworkState>,
         conn: Arc<connection::Connection>,
         rtu: RoutingTableUpdate,
+        transport: Arc<dyn NetworkTransport>,
     ) {
         // Ingress cap: check BEFORE dedup/verification to avoid wasted work.
         let max_edges = network_state.config.routing_graph_max_edges_per_message;
@@ -1348,6 +1378,7 @@ impl PeerActor {
                     edges: rtu.edges.clone(),
                     source: conn.peer_info.id.clone(),
                 },
+                transport.clone(),
             )
             .await
         {
@@ -1371,7 +1402,7 @@ impl PeerActor {
             .collect();
         match network_state.client.send_async(AnnounceAccountRequest(accounts)).await {
             Ok(Err(ban_reason)) => conn.stop(Some(ban_reason)),
-            Ok(Ok(accounts)) => network_state.add_accounts(accounts).await,
+            Ok(Ok(accounts)) => network_state.add_accounts(accounts, transport).await,
             Err(_) => {}
         }
     }
@@ -1445,12 +1476,14 @@ impl messaging::Actor for PeerActor {
                 let network_state = self.network_state.clone();
                 let clock = self.clock.clone();
                 let conn = conn.clone();
+                let transport = self.transport.clone();
                 network_state.unregister(
                     &clock,
                     &conn,
                     #[cfg(test)]
                     self.stream_id,
                     closing_reason,
+                    transport,
                 );
             }
         }

--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -7,8 +7,10 @@ use crate::network_protocol::{
 use crate::network_protocol::{RoutedMessage, testonly as data};
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::network_state::NetworkState;
+use crate::peer_manager::network_transport::NetworkTransport;
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_store;
+use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::private_messages::SendMessage;
 use crate::store;
 use crate::tcp;
@@ -106,8 +108,10 @@ impl PeerHandle {
             noop().into_multi_sender(),
             noop().into_sender(),
         ));
-        let actor =
-            AutoStopActor(PeerActor::spawn(clock, actor_system, stream, network_state).unwrap().0);
+        let transport: Arc<dyn NetworkTransport> = TcpTransport::new(network_state.clone());
+        let actor = AutoStopActor(
+            PeerActor::spawn(clock, actor_system, stream, network_state, transport).unwrap().0,
+        );
         Self { actor, cfg, events: recv, edge: None }
     }
 }

--- a/chain/network/src/peer_manager/mod.rs
+++ b/chain/network/src/peer_manager/mod.rs
@@ -2,8 +2,10 @@ pub(crate) mod connected_peers;
 pub(crate) mod connection;
 pub(crate) mod connection_store;
 pub(crate) mod network_state;
+pub(crate) mod network_transport;
 pub(crate) mod peer_manager_actor;
 pub(crate) mod peer_store;
+pub(crate) mod tcp_transport;
 
 #[cfg(test)]
 pub(crate) mod testonly;

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -19,9 +19,11 @@ use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::connected_peers::{ConnectedPeerState, ConnectedPeers};
 use crate::peer_manager::connection;
 use crate::peer_manager::connection_store;
+use crate::peer_manager::network_transport::NetworkTransport;
 #[cfg(test)]
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_store;
+use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::private_messages::RegisterPeerError;
 use crate::routing::route_back_cache::RouteBackCache;
 use crate::shards_manager::ShardsManagerRequestFromNetwork;
@@ -492,6 +494,7 @@ impl NetworkState {
         clock: &time::Clock,
         edge: Edge,
         info: PeerConnectionInfo,
+        transport: Arc<dyn NetworkTransport>,
     ) {
         let account_key = info.owned_account.as_ref().map(|oa| oa.account_key.clone());
         let peer_id = info.peer_info.id.clone();
@@ -530,7 +533,7 @@ impl NetworkState {
             // never fail for a pre-verified local edge. On master this was done
             // before pool_insert; now done after — the broadcast is independent
             // of whether the peer is in the pool.
-            self.add_edges(clock, EdgesWithSource::Local(vec![edge]))
+            self.add_edges(clock, EdgesWithSource::Local(vec![edge]), transport)
                 .await
                 .expect("local edge was verified in validate_new_connection");
             self.peer_store.peer_connected(clock, &peer_info);
@@ -548,6 +551,7 @@ impl NetworkState {
         info: &PeerDisconnectInfo,
         reason: ClosingReason,
         #[cfg(test)] stream_id: tcp::StreamId,
+        transport: Arc<dyn NetworkTransport>,
     ) {
         self.peers.remove(info.tier, &info.peer_info.id);
 
@@ -563,9 +567,13 @@ impl NetworkState {
                 if edge.edge_type() == EdgeState::Active {
                     let edge_update =
                         edge.remove_edge(self.config.node_id(), &self.config.node_key);
-                    self.add_edges(clock, EdgesWithSource::Local(vec![edge_update.clone()]))
-                        .await
-                        .unwrap();
+                    self.add_edges(
+                        clock,
+                        EdgesWithSource::Local(vec![edge_update.clone()]),
+                        transport.clone(),
+                    )
+                    .await
+                    .unwrap();
                 }
             }
 
@@ -610,6 +618,7 @@ impl NetworkState {
         clock: &time::Clock,
         edge: Edge,
         conn: Arc<connection::Connection>,
+        transport: Arc<dyn NetworkTransport>,
     ) -> Result<(), RegisterPeerError> {
         let this = self.clone();
         let clock = clock.clone();
@@ -622,7 +631,7 @@ impl NetworkState {
                 tcp::Tier::T3 => this.tier3.insert_ready(conn.clone()),
             }
             .map_err(RegisterPeerError::PoolError)?;
-            this.on_peer_connected(&clock, edge, info).await;
+            this.on_peer_connected(&clock, edge, info, transport).await;
             Ok(())
         })
         .await
@@ -641,6 +650,7 @@ impl NetworkState {
         conn: &Arc<connection::Connection>,
         #[cfg(test)] stream_id: tcp::StreamId,
         reason: ClosingReason,
+        transport: Arc<dyn NetworkTransport>,
     ) {
         let this = self.clone();
         let clock = clock.clone();
@@ -658,6 +668,7 @@ impl NetworkState {
                 reason,
                 #[cfg(test)]
                 stream_id,
+                transport,
             )
             .await;
         });
@@ -718,24 +729,38 @@ impl NetworkState {
     }
 
     #[cfg(test)]
-    pub fn send_ping(&self, clock: &time::Clock, tier: tcp::Tier, nonce: u64, target: PeerId) {
+    pub fn send_ping(
+        &self,
+        clock: &time::Clock,
+        tier: tcp::Tier,
+        nonce: u64,
+        target: PeerId,
+        transport: &dyn NetworkTransport,
+    ) {
         let body = T2MessageBody::Ping(crate::network_protocol::Ping {
             nonce,
             source: self.config.node_id(),
         })
         .into();
         let msg = RawRoutedMessage { target: PeerIdOrHash::PeerId(target), body };
-        self.send_message_to_peer(clock, tier, self.sign_message(clock, msg));
+        self.send_message_to_peer(clock, tier, self.sign_message(clock, msg), transport);
     }
 
-    pub fn send_pong(&self, clock: &time::Clock, tier: tcp::Tier, nonce: u64, target: CryptoHash) {
+    pub fn send_pong(
+        &self,
+        clock: &time::Clock,
+        tier: tcp::Tier,
+        nonce: u64,
+        target: CryptoHash,
+        transport: &dyn NetworkTransport,
+    ) {
         let body = T2MessageBody::Pong(crate::network_protocol::Pong {
             nonce,
             source: self.config.node_id(),
         })
         .into();
         let msg = RawRoutedMessage { target: PeerIdOrHash::Hash(target), body };
-        self.send_message_to_peer(clock, tier, self.sign_message(clock, msg));
+        self.send_message_to_peer(clock, tier, self.sign_message(clock, msg), transport);
     }
 
     pub fn sign_message(&self, clock: &time::Clock, msg: RawRoutedMessage) -> Box<RoutedMessage> {
@@ -753,6 +778,7 @@ impl NetworkState {
         clock: &time::Clock,
         tier: tcp::Tier,
         msg: Box<RoutedMessage>,
+        transport: &dyn NetworkTransport,
     ) -> bool {
         let my_peer_id = self.config.node_id();
 
@@ -777,46 +803,52 @@ impl NetworkState {
                     }
                     PeerIdOrHash::PeerId(peer_id) => peer_id.clone(),
                 };
-                return self.tier1.send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
+                return transport.send_message(
+                    tcp::Tier::T1,
+                    peer_id,
+                    Arc::new(PeerMessage::Routed(msg)),
+                );
             }
-            tcp::Tier::T2 => {
-                match self.tier2_find_route(&clock, msg.target()) {
-                    Ok(peer_id) => {
-                        // Remember if we expect a response for this message.
-                        if *msg.author() == my_peer_id && msg.expect_response() {
-                            tracing::trace!(target: "network", ?msg, "initiate route back");
-                            self.tier2_route_back.lock().insert(clock, msg.hash(), my_peer_id);
-                        }
-                        return self
-                            .tier2
-                            .send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
+            tcp::Tier::T2 => match self.tier2_find_route(&clock, msg.target()) {
+                Ok(peer_id) => {
+                    // Remember if we expect a response for this message.
+                    if *msg.author() == my_peer_id && msg.expect_response() {
+                        tracing::trace!(target: "network", ?msg, "initiate route back");
+                        self.tier2_route_back.lock().insert(clock, msg.hash(), my_peer_id);
                     }
-                    Err(find_route_error) => {
-                        // TODO(MarX, #1369): Message is dropped here. Define policy for this case.
-                        metrics::MessageDropped::NoRouteFound.inc(msg.body());
-
-                        tracing::debug!(target: "network",
-                              account_id = ?self.config.validator.account_id(),
-                              to = ?msg.target(),
-                              reason = ?find_route_error,
-                              known_peers = ?self.graph.routing_table.reachable_peers(),
-                              msg = ?msg.body(),
-                            "dropping signed message"
-                        );
-                        return false;
-                    }
+                    return transport.send_message(
+                        tcp::Tier::T2,
+                        peer_id,
+                        Arc::new(PeerMessage::Routed(msg)),
+                    );
                 }
-            }
+                Err(find_route_error) => {
+                    // TODO(MarX, #1369): Message is dropped here. Define policy for this case.
+                    metrics::MessageDropped::NoRouteFound.inc(msg.body());
+                    tracing::debug!(target: "network",
+                          account_id = ?self.config.validator.account_id(),
+                          to = ?msg.target(),
+                          reason = ?find_route_error,
+                          known_peers = ?self.graph.routing_table.reachable_peers(),
+                          msg = ?msg.body(),
+                        "dropping signed message"
+                    );
+                    return false;
+                }
+            },
             tcp::Tier::T3 => {
                 let peer_id = match msg.target() {
                     PeerIdOrHash::Hash(_) => {
-                        // There is no route back cache for TIER3 as all connections are direct
                         debug_assert!(false);
                         return false;
                     }
                     PeerIdOrHash::PeerId(peer_id) => peer_id.clone(),
                 };
-                return self.tier3.send_message(peer_id, Arc::new(PeerMessage::Routed(msg)));
+                return transport.send_message(
+                    tcp::Tier::T3,
+                    peer_id,
+                    Arc::new(PeerMessage::Routed(msg)),
+                );
             }
         }
     }
@@ -829,6 +861,7 @@ impl NetworkState {
         clock: &time::Clock,
         account_id: &AccountId,
         msg: TieredMessageBody,
+        transport: &dyn NetworkTransport,
     ) -> bool {
         // If the message is allowed to be sent to self, we handle it directly.
         if self.config.validator.account_id().is_some_and(|id| &id == account_id) {
@@ -914,7 +947,7 @@ impl NetworkState {
         let msg = RawRoutedMessage { target: PeerIdOrHash::PeerId(target), body: msg };
         let msg = self.sign_message(clock, msg);
         for _ in 0..msg.body().message_resend_count() {
-            success |= self.send_message_to_peer(clock, tcp::Tier::T2, msg.clone());
+            success |= self.send_message_to_peer(clock, tcp::Tier::T2, msg.clone(), transport);
         }
         success
     }
@@ -1486,9 +1519,14 @@ impl NetworkState {
                             // Unwrap is safe, because new_edge is always valid.
                             let new_edge =
                                 edge.remove_edge(this.config.node_id(), &this.config.node_key);
-                            this.add_edges(&clock, EdgesWithSource::Local(vec![new_edge.clone()]))
-                                .await
-                                .unwrap()
+                            let transport = TcpTransport::new(this.clone());
+                            this.add_edges(
+                                &clock,
+                                EdgesWithSource::Local(vec![new_edge.clone()]),
+                                transport,
+                            )
+                            .await
+                            .unwrap()
                         }
                     })),
                     // OK

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -27,7 +27,7 @@ impl NetworkState {
         }
         rtu.edges = Edge::deduplicate(rtu.edges);
         let msg = Arc::new(PeerMessage::SyncRoutingTable(rtu));
-        transport.broadcast_message(tcp::Tier::T2, msg);
+        transport.broadcast_message(msg);
     }
 
     /// Adds AnnounceAccounts (without validating them) to the routing table.

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -3,6 +3,7 @@ use crate::network_protocol::{
     Edge, EdgeState, PartialEdgeInfo, PeerMessage, RoutedMessage, RoutingTableUpdate,
 };
 use crate::peer_manager::network_state::{EdgesWithSource, PeerIdOrHash};
+use crate::peer_manager::network_transport::NetworkTransport;
 use crate::routing::routing_table_view::FindRouteError;
 use crate::stats::metrics;
 use crate::tcp;
@@ -16,20 +17,26 @@ use std::sync::Arc;
 impl NetworkState {
     // TODO(gprusak): eventually, this should be blocking, as it should be up to the caller
     // whether to wait for the broadcast to finish, or run it in parallel with sth else.
-    fn broadcast_routing_table_update(&self, mut rtu: RoutingTableUpdate) {
+    fn broadcast_routing_table_update(
+        &self,
+        mut rtu: RoutingTableUpdate,
+        transport: &dyn NetworkTransport,
+    ) {
         if rtu == RoutingTableUpdate::default() {
             return;
         }
         rtu.edges = Edge::deduplicate(rtu.edges);
         let msg = Arc::new(PeerMessage::SyncRoutingTable(rtu));
-        for conn in self.tier2.load().ready.values() {
-            conn.send_message(msg.clone());
-        }
+        transport.broadcast_message(tcp::Tier::T2, msg);
     }
 
     /// Adds AnnounceAccounts (without validating them) to the routing table.
     /// Then it broadcasts all the AnnounceAccounts that haven't been seen before.
-    pub async fn add_accounts(self: &Arc<NetworkState>, accounts: Vec<AnnounceAccount>) {
+    pub async fn add_accounts(
+        self: &Arc<NetworkState>,
+        accounts: Vec<AnnounceAccount>,
+        transport: Arc<dyn NetworkTransport>,
+    ) {
         let this = self.clone();
         self.spawn("add_accounts", async move {
             let new_accounts = this.account_announcements.add_accounts(accounts);
@@ -38,7 +45,7 @@ impl NetworkState {
             this.config.event_sink.send(crate::peer_manager::peer_manager_actor::Event::AccountsAdded(new_accounts.clone()));
             this.broadcast_routing_table_update(RoutingTableUpdate::from_accounts(
                 new_accounts,
-            ));
+            ), &*transport);
         }).await.unwrap()
     }
 
@@ -73,6 +80,7 @@ impl NetworkState {
         clock: &time::Clock,
         peer_id: PeerId,
         edge_info: PartialEdgeInfo,
+        transport: Arc<dyn NetworkTransport>,
     ) -> Result<Edge, ReasonForBan> {
         let edge = Edge::build_with_secret_key(
             self.config.node_id(),
@@ -81,7 +89,7 @@ impl NetworkState {
             &self.config.node_key,
             edge_info.signature,
         );
-        self.add_edges(&clock, EdgesWithSource::Local(vec![edge.clone()])).await?;
+        self.add_edges(&clock, EdgesWithSource::Local(vec![edge.clone()]), transport).await?;
         Ok(edge)
     }
 
@@ -92,6 +100,7 @@ impl NetworkState {
         self: &Arc<Self>,
         clock: &time::Clock,
         edges: EdgesWithSource,
+        transport: Arc<dyn NetworkTransport>,
     ) -> Result<(), ReasonForBan> {
         if edges.is_empty() {
             return Ok(());
@@ -116,7 +125,10 @@ impl NetworkState {
                 this.config.event_sink.send(
                     crate::peer_manager::peer_manager_actor::Event::EdgesAdded(edges.clone()),
                 );
-                this.broadcast_routing_table_update(RoutingTableUpdate::from_edges(edges));
+                this.broadcast_routing_table_update(
+                    RoutingTableUpdate::from_edges(edges),
+                    &*transport,
+                );
                 oks.iter()
                     .map(|ok| match ok {
                         true => Ok(()),

--- a/chain/network/src/peer_manager/network_transport.rs
+++ b/chain/network/src/peer_manager/network_transport.rs
@@ -1,0 +1,84 @@
+use crate::network_protocol::PeerInfo;
+use crate::tcp;
+use crate::types::{PeerMessage, ReasonForBan};
+use near_async::time;
+use near_primitives::network::PeerId;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::sync::oneshot;
+
+/// The narrow interface between business logic (NetworkState) and message
+/// delivery. This is the ONLY thing that differs between production
+/// (TcpTransport) and testloop (TestLoopTransport).
+///
+/// NetworkState receives `&dyn NetworkTransport` (or `Arc<dyn>` for
+/// closures) as a method parameter. PMA holds `Arc<dyn NetworkTransport>`.
+#[allow(dead_code)]
+pub trait NetworkTransport: Send + Sync + 'static {
+    /// Deliver a message to a specific peer over the given tier.
+    /// Returns true if the message was enqueued; false if not connected.
+    fn send_message(&self, tier: tcp::Tier, peer_id: PeerId, msg: Arc<PeerMessage>) -> bool;
+
+    /// Broadcast a message to all connected peers on the given tier.
+    /// Must be synchronous (enqueue-only) — stop_actor calls this and is
+    /// itself synchronous.
+    fn broadcast_message(&self, tier: tcp::Tier, msg: Arc<PeerMessage>);
+
+    /// Initiate a connection to a peer. Returns a ConnectHandle that can
+    /// be awaited or dropped (fire-and-forget).
+    /// Idempotent: no-op if already connected or handshaking.
+    fn connect_to_peer(
+        &self,
+        _clock: &time::Clock,
+        _peer_info: PeerInfo,
+        _tier: tcp::Tier,
+    ) -> ConnectHandle {
+        ConnectHandle::noop()
+    }
+
+    /// Close a connection to a peer.
+    /// ban_reason: None = graceful disconnect, Some = ban.
+    fn disconnect_peer(&self, _peer_id: &PeerId, _ban_reason: Option<ReasonForBan>) {}
+
+    /// Graceful shutdown.
+    fn shutdown(&self) {}
+}
+
+/// Error returned by connect_to_peer.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum ConnectError {
+    Cancelled,
+}
+
+/// Handle returned by `connect_to_peer`. Implements `Future` so callers
+/// can `.await` it directly, or drop it for fire-and-forget. The
+/// spawned dial + handshake task lives on the transport's spawner
+/// independently of the handle — dropping the handle doesn't cancel
+/// the work, it only stops listening for the result.
+#[allow(dead_code)]
+pub struct ConnectHandle {
+    rx: oneshot::Receiver<Result<(), ConnectError>>,
+}
+
+#[allow(dead_code)]
+impl ConnectHandle {
+    pub(crate) fn new(rx: oneshot::Receiver<Result<(), ConnectError>>) -> Self {
+        Self { rx }
+    }
+
+    pub fn noop() -> Self {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Ok(()));
+        Self { rx }
+    }
+}
+
+impl Future for ConnectHandle {
+    type Output = Result<(), ConnectError>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.rx).poll(cx).map(|r| r.unwrap_or(Err(ConnectError::Cancelled)))
+    }
+}

--- a/chain/network/src/peer_manager/network_transport.rs
+++ b/chain/network/src/peer_manager/network_transport.rs
@@ -21,10 +21,10 @@ pub trait NetworkTransport: Send + Sync + 'static {
     /// Returns true if the message was enqueued; false if not connected.
     fn send_message(&self, tier: tcp::Tier, peer_id: PeerId, msg: Arc<PeerMessage>) -> bool;
 
-    /// Broadcast a message to all connected peers on the given tier.
-    /// Must be synchronous (enqueue-only) — stop_actor calls this and is
-    /// itself synchronous.
-    fn broadcast_message(&self, tier: tcp::Tier, msg: Arc<PeerMessage>);
+    /// Broadcast a message to all connected TIER2 peers. T1 and T3 do
+    /// not have broadcast semantics. Must be synchronous (enqueue-only)
+    /// — stop_actor calls this and is itself synchronous.
+    fn broadcast_message(&self, msg: Arc<PeerMessage>);
 
     /// Initiate a connection to a peer. Returns a ConnectHandle that can
     /// be awaited or dropped (fire-and-forget).

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -15,7 +15,9 @@ use crate::peer_manager::connection;
 use crate::peer_manager::network_state::{
     NetworkState, PENDING_TIER3_REQUEST_TIMEOUT, WhitelistNode,
 };
+use crate::peer_manager::network_transport::NetworkTransport;
 use crate::peer_manager::peer_store;
+use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::shards_manager::ShardsManagerRequestFromNetwork;
 use crate::spice_data_distribution::SpiceDataDistributorSenderForNetwork;
 use crate::state_witness::PartialWitnessSenderForNetwork;
@@ -112,6 +114,8 @@ pub struct PeerManagerActor {
 
     /// State that is shared between multiple threads (including PeerActors).
     pub(crate) state: Arc<NetworkState>,
+    /// Transport for sending/broadcasting messages.
+    pub(crate) transport: Arc<dyn NetworkTransport>,
 }
 
 /// TEST-ONLY
@@ -274,9 +278,11 @@ impl messaging::Actor for PeerManagerActor {
     /// Try to gracefully disconnect from connected peers.
     fn stop_actor(&mut self) {
         tracing::debug!(target: "network", "peer manager stopping");
-        self.state.tier2.broadcast_message(Arc::new(PeerMessage::Disconnect(Disconnect {
-            remove_from_connection_store: false,
-        })));
+        self.transport.broadcast_message(
+            tcp::Tier::T2,
+            Arc::new(PeerMessage::Disconnect(Disconnect { remove_from_connection_store: false })),
+        );
+        self.transport.shutdown();
     }
 }
 
@@ -360,6 +366,7 @@ impl PeerManagerActor {
                         let clock = clock.clone();
                         let state = state.clone();
                         let actor_system = actor_system.clone();
+                        let transport: Arc<dyn NetworkTransport> = TcpTransport::new(state.clone());
                         async move {
                             loop {
                                 if let Ok(stream) = listener.accept().await {
@@ -370,7 +377,7 @@ impl PeerManagerActor {
                                     // a proper connection.
                                     tracing::debug!(target: "network", from = ?stream.peer_addr, "got new connection");
                                     if let Err(err) =
-                                        PeerActor::spawn(clock.clone(), actor_system.clone(), stream, state.clone())
+                                        PeerActor::spawn(clock.clone(), actor_system.clone(), stream, state.clone(), transport.clone())
                                     {
                                         tracing::info!(target:"network", ?err, "peer actor spawn failed");
                                     }
@@ -382,10 +389,12 @@ impl PeerManagerActor {
 
             }
         });
+        let transport = TcpTransport::new(state.clone());
         builder.spawn_tokio_actor(Self {
             my_peer_id,
             started_connect_attempts: false,
             state,
+            transport,
             clock,
             actor_system,
             handle: handle.clone(),
@@ -835,6 +844,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &approval_message.target,
                     T1MessageBody::BlockApproval(approval_message.approval).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -889,7 +899,12 @@ impl PeerManagerActor {
                 );
 
                 self.state.pending_tier3_requests.insert(peer_id.clone(), self.clock.now());
-                if !self.state.send_message_to_peer(&self.clock, tcp::Tier::T2, routed_message) {
+                if !self.state.send_message_to_peer(
+                    &self.clock,
+                    tcp::Tier::T2,
+                    routed_message,
+                    &*self.transport,
+                ) {
                     self.state.pending_tier3_requests.remove(&peer_id);
                     return NetworkResponses::RouteNotFound;
                 }
@@ -934,7 +949,12 @@ impl PeerManagerActor {
                 );
 
                 self.state.pending_tier3_requests.insert(peer_id.clone(), self.clock.now());
-                if !self.state.send_message_to_peer(&self.clock, tcp::Tier::T2, routed_message) {
+                if !self.state.send_message_to_peer(
+                    &self.clock,
+                    tcp::Tier::T2,
+                    routed_message,
+                    &*self.transport,
+                ) {
                     self.state.pending_tier3_requests.remove(&peer_id);
                     return NetworkResponses::RouteNotFound;
                 }
@@ -962,7 +982,12 @@ impl PeerManagerActor {
                     },
                 );
 
-                if !self.state.send_message_to_peer(&self.clock, tcp::Tier::T2, routed_message) {
+                if !self.state.send_message_to_peer(
+                    &self.clock,
+                    tcp::Tier::T2,
+                    routed_message,
+                    &*self.transport,
+                ) {
                     return NetworkResponses::RouteNotFound;
                 }
 
@@ -1044,8 +1069,9 @@ impl PeerManagerActor {
             }
             NetworkRequests::AnnounceAccount(announce_account) => {
                 let state = self.state.clone();
+                let transport = self.transport.clone();
                 self.handle.spawn("announce_account", async move {
-                    state.add_accounts(vec![announce_account]).await;
+                    state.add_accounts(vec![announce_account], transport).await;
                 });
                 NetworkResponses::NoResponse
             }
@@ -1064,6 +1090,7 @@ impl PeerManagerActor {
                                 &self.clock,
                                 account_id,
                                 T2MessageBody::PartialEncodedChunkRequest(request.clone()).into(),
+                                &*self.transport,
                             ) {
                                 success = true;
                                 break;
@@ -1097,6 +1124,7 @@ impl PeerManagerActor {
                                         .into(),
                                     },
                                 ),
+                                &*self.transport,
                             ) {
                                 success = true;
                                 break;
@@ -1125,6 +1153,7 @@ impl PeerManagerActor {
                             body: T2MessageBody::PartialEncodedChunkResponse(response).into(),
                         },
                     ),
+                    &*self.transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1139,6 +1168,7 @@ impl PeerManagerActor {
                         partial_encoded_chunk.into(),
                     ))
                     .into(),
+                    &*self.transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1150,6 +1180,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &account_id,
                     T1MessageBody::PartialEncodedChunkForward(forward).into(),
+                    &*self.transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1161,6 +1192,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &account_id,
                     T2MessageBody::ForwardTx(tx).into(),
+                    &*self.transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1172,6 +1204,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &account_id,
                     T2MessageBody::TxStatusRequest(signer_account_id, tx_hash).into(),
+                    &*self.transport,
                 ) {
                     NetworkResponses::NoResponse
                 } else {
@@ -1183,6 +1216,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T2MessageBody::ChunkStateWitnessAck(ack).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1191,6 +1225,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::VersionedChunkEndorsement(endorsement).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1213,6 +1248,7 @@ impl PeerManagerActor {
                         &self.clock,
                         &chunk_validator,
                         T1MessageBody::PartialEncodedStateWitness(partial_witness).into(),
+                        &*self.transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1235,6 +1271,7 @@ impl PeerManagerActor {
                         &chunk_validator,
                         T1MessageBody::PartialEncodedStateWitnessForward(partial_witness.clone())
                             .into(),
+                        &*self.transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1263,6 +1300,7 @@ impl PeerManagerActor {
                         &self.clock,
                         &validator,
                         T1MessageBody::ChunkContractAccesses(accesses.clone()).into(),
+                        &*self.transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1272,6 +1310,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::ContractCodeRequest(request).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1280,6 +1319,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::ContractCodeResponse(response).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1291,12 +1331,14 @@ impl PeerManagerActor {
                         &self.clock,
                         &account,
                         T2MessageBody::PartialEncodedContractDeploys(deploys.clone()).into(),
+                        &*self.transport,
                     );
                 }
                 self.state.send_message_to_account(
                     &self.clock,
                     &last_account,
                     T2MessageBody::PartialEncodedContractDeploys(deploys).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1310,6 +1352,7 @@ impl PeerManagerActor {
                         // TODO(spice): Once spice data distribution retries are implemented
                         // reconsider if sending data over T1 still makes sense.
                         T1MessageBody::SpicePartialData(partial_data).into(),
+                        &*self.transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1319,6 +1362,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::SpiceChunkEndorsement(endorsement).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1327,6 +1371,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &producer,
                     T1MessageBody::SpicePartialDataRequest(request).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1336,6 +1381,7 @@ impl PeerManagerActor {
                         &self.clock,
                         &target,
                         T1MessageBody::SpiceChunkContractAccesses(accesses.clone()).into(),
+                        &*self.transport,
                     );
                 }
                 NetworkResponses::NoResponse
@@ -1345,6 +1391,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::SpiceContractCodeRequest(request).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1353,6 +1400,7 @@ impl PeerManagerActor {
                     &self.clock,
                     &target,
                     T1MessageBody::SpiceContractCodeResponse(response).into(),
+                    &*self.transport,
                 );
                 NetworkResponses::NoResponse
             }
@@ -1383,6 +1431,7 @@ impl PeerManagerActor {
                     self.actor_system.clone(),
                     stream,
                     self.state.clone(),
+                    self.transport.clone(),
                 ) {
                     tracing::info!(target:"network", ?err, ?peer_addr, "spawn_outbound()");
                 }
@@ -1470,7 +1519,8 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
         let state = self.state.clone();
         let clock = self.clock.clone();
         let actor_system = self.actor_system.clone();
-        self.handle.spawn("handle tier3 request", 
+        let transport = self.transport.clone();
+        self.handle.spawn("handle tier3 request",
             async move {
                 // Process the request.
                 // Unconditionally produce an ack to be sent back over tier2.
@@ -1539,7 +1589,7 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                         body: tier2_ack,
                     },
                 );
-                if !state.send_message_to_peer(&clock, tcp::Tier::T2, routed_message) {
+                if !state.send_message_to_peer(&clock, tcp::Tier::T2, routed_message, &*transport) {
                     tracing::debug!(target: "network", sender = %sender, "failed to route ack");
                 }
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -278,10 +278,9 @@ impl messaging::Actor for PeerManagerActor {
     /// Try to gracefully disconnect from connected peers.
     fn stop_actor(&mut self) {
         tracing::debug!(target: "network", "peer manager stopping");
-        self.transport.broadcast_message(
-            tcp::Tier::T2,
-            Arc::new(PeerMessage::Disconnect(Disconnect { remove_from_connection_store: false })),
-        );
+        self.transport.broadcast_message(Arc::new(PeerMessage::Disconnect(Disconnect {
+            remove_from_connection_store: false,
+        })));
         self.transport.shutdown();
     }
 }

--- a/chain/network/src/peer_manager/tcp_transport.rs
+++ b/chain/network/src/peer_manager/tcp_transport.rs
@@ -28,21 +28,25 @@ impl NetworkTransport for TcpTransport {
     }
 
     fn broadcast_message(&self, tier: tcp::Tier, msg: Arc<PeerMessage>) {
-        debug_assert!(tier == tcp::Tier::T2);
+        // Broadcast is only supported on T2. T1 and T3 are direct
+        // tiers — the trait contract forbids broadcasting over them.
         match tier {
-            tcp::Tier::T1 => self.state.tier1.broadcast_message(msg),
             tcp::Tier::T2 => self.state.tier2.broadcast_message(msg),
-            tcp::Tier::T3 => self.state.tier3.broadcast_message(msg),
+            tcp::Tier::T1 | tcp::Tier::T3 => {
+                unreachable!("broadcast_message called with unsupported tier {:?}", tier);
+            }
         }
     }
 
     fn disconnect_peer(&self, peer_id: &PeerId, ban_reason: Option<ReasonForBan>) {
-        // Search all tiers for the connection.
+        // A peer may be connected on multiple tiers simultaneously
+        // (e.g. T1 + T2 for a validator). Stop the connection on every
+        // tier we find it on — partial disconnect would leave a stale
+        // entry on the other tier.
         for pool in [&self.state.tier1, &self.state.tier2, &self.state.tier3] {
             let snapshot = pool.load();
             if let Some(conn) = snapshot.ready.get(peer_id) {
                 conn.stop(ban_reason);
-                return;
             }
         }
     }

--- a/chain/network/src/peer_manager/tcp_transport.rs
+++ b/chain/network/src/peer_manager/tcp_transport.rs
@@ -27,15 +27,8 @@ impl NetworkTransport for TcpTransport {
         }
     }
 
-    fn broadcast_message(&self, tier: tcp::Tier, msg: Arc<PeerMessage>) {
-        // Broadcast is only supported on T2. T1 and T3 are direct
-        // tiers — the trait contract forbids broadcasting over them.
-        match tier {
-            tcp::Tier::T2 => self.state.tier2.broadcast_message(msg),
-            tcp::Tier::T1 | tcp::Tier::T3 => {
-                unreachable!("broadcast_message called with unsupported tier {:?}", tier);
-            }
-        }
+    fn broadcast_message(&self, msg: Arc<PeerMessage>) {
+        self.state.tier2.broadcast_message(msg);
     }
 
     fn disconnect_peer(&self, peer_id: &PeerId, ban_reason: Option<ReasonForBan>) {

--- a/chain/network/src/peer_manager/tcp_transport.rs
+++ b/chain/network/src/peer_manager/tcp_transport.rs
@@ -1,0 +1,49 @@
+use crate::peer_manager::network_state::NetworkState;
+use crate::peer_manager::network_transport::NetworkTransport;
+use crate::tcp;
+use crate::types::{PeerMessage, ReasonForBan};
+use near_primitives::network::PeerId;
+use std::sync::Arc;
+
+/// Production implementation of NetworkTransport.
+/// Transitional: wraps NetworkState's Pools. In PR 9, Pools move to
+/// TcpTransport directly.
+pub(crate) struct TcpTransport {
+    pub state: Arc<NetworkState>,
+}
+
+impl TcpTransport {
+    pub fn new(state: Arc<NetworkState>) -> Arc<Self> {
+        Arc::new(Self { state })
+    }
+}
+
+impl NetworkTransport for TcpTransport {
+    fn send_message(&self, tier: tcp::Tier, peer_id: PeerId, msg: Arc<PeerMessage>) -> bool {
+        match tier {
+            tcp::Tier::T1 => self.state.tier1.send_message(peer_id, msg),
+            tcp::Tier::T2 => self.state.tier2.send_message(peer_id, msg),
+            tcp::Tier::T3 => self.state.tier3.send_message(peer_id, msg),
+        }
+    }
+
+    fn broadcast_message(&self, tier: tcp::Tier, msg: Arc<PeerMessage>) {
+        debug_assert!(tier == tcp::Tier::T2);
+        match tier {
+            tcp::Tier::T1 => self.state.tier1.broadcast_message(msg),
+            tcp::Tier::T2 => self.state.tier2.broadcast_message(msg),
+            tcp::Tier::T3 => self.state.tier3.broadcast_message(msg),
+        }
+    }
+
+    fn disconnect_peer(&self, peer_id: &PeerId, ban_reason: Option<ReasonForBan>) {
+        // Search all tiers for the connection.
+        for pool in [&self.state.tier1, &self.state.tier2, &self.state.tier3] {
+            let snapshot = pool.load();
+            if let Some(conn) = snapshot.ready.get(peer_id) {
+                conn.stop(ban_reason);
+                return;
+            }
+        }
+    }
+}

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -19,6 +19,7 @@ use crate::peer;
 use crate::peer::peer_actor::ClosingReason;
 use crate::peer_manager::network_state::NetworkState;
 use crate::peer_manager::peer_manager_actor::Event;
+use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::snapshot_hosts::SnapshotHostsCache;
 use crate::tcp;
 use crate::test_utils;
@@ -380,7 +381,8 @@ impl ActorHandler {
     pub async fn send_ping(&self, clock: &time::Clock, nonce: u64, target: PeerId) {
         let clock = clock.clone();
         self.with_state(move |s| async move {
-            s.send_ping(&clock, tcp::Tier::T2, nonce, target);
+            let transport = TcpTransport::new(s.clone());
+            s.send_ping(&clock, tcp::Tier::T2, nonce, target, &*transport);
         })
         .await;
     }

--- a/chain/network/src/peer_manager/tests/tier1.rs
+++ b/chain/network/src/peer_manager/tests/tier1.rs
@@ -3,6 +3,7 @@ use crate::network_protocol::testonly as data;
 use crate::network_protocol::{PeerAddr, PeerMessage, T1MessageBody, TieredMessageBody};
 use crate::peer_manager;
 use crate::peer_manager::peer_manager_actor::Event;
+use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::peer_manager::testonly::start as start_pm;
 use crate::stun;
 use crate::tcp;
@@ -61,7 +62,12 @@ async fn send_tier1_message(
         T1MessageBody::BlockApproval(make_block_approval(rng, from_signer.as_ref())).into();
     let clock = clock.clone();
     from.with_state(move |s| async move {
-        if s.send_message_to_account(&clock, &target, want.clone()) { Some(want) } else { None }
+        let transport = TcpTransport::new(s.clone());
+        if s.send_message_to_account(&clock, &target, want.clone(), &*transport) {
+            Some(want)
+        } else {
+            None
+        }
     })
     .await
 }


### PR DESCRIPTION
- `NetworkTransport` trait — 5-method dyn-safe trait:
  - `send_message(tier, peer_id, msg)`, `broadcast_message(tier, msg)`
  - `connect_to_peer(clock, peer_info, tier) -> ConnectHandle` (async, default no-op)
  - `disconnect_peer(peer_id, ban_reason)` (default no-op), `shutdown()` (default no-op)
- `transport_info()` is added in PR 9
- `TcpTransport` — production impl wrapping existing Pool-based code
- `ConnectHandle` — implements `Future<Output = Result<(), ConnectError>>`
- PeerManagerActor now holds `Arc<dyn NetworkTransport>` alongside `Arc<NetworkState>`