### PR TITLE
feat(network): connection management through the trait (10/n)

### DIFF
--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(enable_const_type_id, feature(const_type_id))]
 
 pub use crate::peer_manager::peer_manager_actor::{Event, PeerManagerActor};
+pub use crate::peer_manager::tcp_transport::TcpTransport;
 pub use crate::rate_limits::messages_limits::OverrideConfig as MessagesLimitsOverrideConfig;
 
 mod accounts_data;

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -13,7 +13,6 @@ use crate::peer_manager::connection;
 use crate::peer_manager::network_state::{
     EdgesWithSource, NetworkState, PRUNE_EDGES_AFTER, RoutedAction,
 };
-use crate::peer_manager::network_transport::NetworkTransport;
 #[cfg(test)]
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_manager_actor::MAX_TIER2_PEERS;
@@ -149,7 +148,7 @@ pub(crate) struct PeerActor {
     /// Shared state of the network module.
     network_state: Arc<NetworkState>,
     /// Transport for sending/broadcasting messages.
-    transport: Arc<dyn NetworkTransport>,
+    tcp: Arc<TcpTransport>,
     /// This node's id and address (either listening or socket address).
     my_node_info: PeerInfo,
 
@@ -229,10 +228,10 @@ impl PeerActor {
         actor_system: ActorSystem,
         stream: tcp::Stream,
         network_state: Arc<NetworkState>,
+        tcp: Arc<TcpTransport>,
     ) -> anyhow::Result<TokioRuntimeHandle<Self>> {
-        let transport = TcpTransport::new(network_state.clone());
         let (addr, handshake_signal) =
-            Self::spawn(clock, actor_system, stream, network_state, transport)?;
+            Self::spawn(clock, actor_system, stream, network_state, tcp)?;
         // Await for the handshake to complete, by awaiting the handshake_signal channel.
         // This is a receiver of Infallible, so it only completes when the channel is closed.
         handshake_signal.await.err().unwrap();
@@ -248,13 +247,13 @@ impl PeerActor {
         actor_system: ActorSystem,
         stream: tcp::Stream,
         network_state: Arc<NetworkState>,
-        transport: Arc<dyn NetworkTransport>,
+        tcp: Arc<TcpTransport>,
     ) -> anyhow::Result<(TokioRuntimeHandle<Self>, HandshakeSignal)> {
         #[cfg(test)]
         let stream_id = stream.id();
         #[cfg(test)]
         let network_state_clone = network_state.clone();
-        match Self::spawn_inner(clock, actor_system, stream, network_state, transport) {
+        match Self::spawn_inner(clock, actor_system, stream, network_state, tcp) {
             Ok(it) => Ok(it),
             Err(reason) => {
                 #[cfg(test)]
@@ -271,7 +270,7 @@ impl PeerActor {
         actor_system: ActorSystem,
         stream: tcp::Stream,
         network_state: Arc<NetworkState>,
-        transport: Arc<dyn NetworkTransport>,
+        tcp: Arc<TcpTransport>,
     ) -> Result<(TokioRuntimeHandle<Self>, HandshakeSignal), ClosingReason> {
         let connecting_status = match &stream.type_ {
             tcp::StreamType::Inbound => ConnectingStatus::Inbound(
@@ -376,7 +375,7 @@ impl PeerActor {
             }
             .into(),
             network_state,
-            transport,
+            tcp,
             received_messages_rate_limits,
             registration_buffered_actions: RegistrationBufferedActions::NotRegistering,
         };
@@ -696,7 +695,7 @@ impl PeerActor {
             let network_state = self.network_state.clone();
             let clock = self.clock.clone();
             let handle = self.handle.clone();
-            let transport = self.transport.clone();
+            let transport = self.tcp.clone();
             async move {
                 let register_result = network_state.register(&clock, edge, conn.clone(), transport).await;
                 handle.clone().run_later("register peer followup", Duration::ZERO, move |act, _| {
@@ -1115,7 +1114,7 @@ impl PeerActor {
             PeerMessage::RequestUpdateNonce(edge_info) => {
                 let clock = self.clock.clone();
                 let network_state = self.network_state.clone();
-                let transport = self.transport.clone();
+                let transport = self.tcp.clone();
                 self.handle.spawn("handle request update nonce", async move {
                     if let Err(err) = verify_nonce(&clock, edge_info.nonce) {
                         tracing::debug!(
@@ -1161,7 +1160,7 @@ impl PeerActor {
             PeerMessage::SyncRoutingTable(rtu) => {
                 let clock = self.clock.clone();
                 let network_state = self.network_state.clone();
-                let transport = self.transport.clone();
+                let transport = self.tcp.clone();
                 self.handle.spawn("handle sync routing table", async move {
                     Self::handle_sync_routing_table(
                         &clock,
@@ -1307,7 +1306,7 @@ impl PeerActor {
                                         conn.tier,
                                         ping.nonce,
                                         msg.hash(),
-                                        &*self.transport,
+                                        &*self.tcp,
                                     );
                                     // TODO(gprusak): deprecate Event::Ping/Pong in favor of
                                     // MessageProcessed.
@@ -1338,7 +1337,7 @@ impl PeerActor {
                             &self.clock,
                             conn.tier,
                             msg,
-                            &*self.transport,
+                            &*self.tcp,
                         );
                     }
                     RoutedAction::Dropped => {}
@@ -1359,7 +1358,7 @@ impl PeerActor {
         network_state: &Arc<NetworkState>,
         conn: Arc<connection::Connection>,
         rtu: RoutingTableUpdate,
-        transport: Arc<dyn NetworkTransport>,
+        tcp: Arc<TcpTransport>,
     ) {
         // Ingress cap: check BEFORE dedup/verification to avoid wasted work.
         let max_edges = network_state.config.routing_graph_max_edges_per_message;
@@ -1380,7 +1379,7 @@ impl PeerActor {
                     edges: rtu.edges.clone(),
                     source: conn.peer_info.id.clone(),
                 },
-                transport.clone(),
+                tcp.clone(),
             )
             .await
         {
@@ -1404,7 +1403,7 @@ impl PeerActor {
             .collect();
         match network_state.client.send_async(AnnounceAccountRequest(accounts)).await {
             Ok(Err(ban_reason)) => conn.stop(Some(ban_reason)),
-            Ok(Ok(accounts)) => network_state.add_accounts(accounts, transport).await,
+            Ok(Ok(accounts)) => network_state.add_accounts(accounts, tcp).await,
             Err(_) => {}
         }
     }
@@ -1478,7 +1477,7 @@ impl messaging::Actor for PeerActor {
                 let network_state = self.network_state.clone();
                 let clock = self.clock.clone();
                 let conn = conn.clone();
-                let transport = self.transport.clone();
+                let transport = self.tcp.clone();
                 network_state.unregister(
                     &clock,
                     &conn,

--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -7,7 +7,6 @@ use crate::network_protocol::{
 use crate::network_protocol::{RoutedMessage, testonly as data};
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::network_state::NetworkState;
-use crate::peer_manager::network_transport::NetworkTransport;
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_store;
 use crate::peer_manager::tcp_transport::TcpTransport;
@@ -108,9 +107,14 @@ impl PeerHandle {
             noop().into_multi_sender(),
             noop().into_sender(),
         ));
-        let transport: Arc<dyn NetworkTransport> = TcpTransport::new(network_state.clone());
+        let tcp = TcpTransport::new_with_spawner(
+            network_state.clone(),
+            clock.clone(),
+            actor_system.clone(),
+            actor_system.new_future_spawner("peer testonly"),
+        );
         let actor = AutoStopActor(
-            PeerActor::spawn(clock, actor_system, stream, network_state, transport).unwrap().0,
+            PeerActor::spawn(clock, actor_system, stream, network_state, tcp).unwrap().0,
         );
         Self { actor, cfg, events: recv, edge: None }
     }

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -15,7 +15,6 @@ use crate::network_protocol::{
     SyncSnapshotHosts, T1MessageBody, T2MessageBody, TieredMessageBody,
 };
 use crate::peer::peer_actor::ClosingReason;
-use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::connected_peers::{ConnectedPeerState, ConnectedPeers};
 use crate::peer_manager::connection;
 use crate::peer_manager::connection_store;
@@ -23,7 +22,6 @@ use crate::peer_manager::network_transport::NetworkTransport;
 #[cfg(test)]
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_store;
-use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::private_messages::RegisterPeerError;
 use crate::routing::route_back_cache::RouteBackCache;
 use crate::shards_manager::ShardsManagerRequestFromNetwork;
@@ -47,12 +45,11 @@ use crate::types::{
     StateHeaderRequestBody, StatePartRequestBody, StateRequestSenderForNetwork, Tier3Request,
     Tier3RequestBody,
 };
-use anyhow::Context;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{CanSend, CanSendAsync, Sender};
-use near_async::{ActorSystem, new_owned_future_spawner, time};
+use near_async::{new_owned_future_spawner, time};
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_primitives::genesis::GenesisId;
 use near_primitives::hash::CryptoHash;
@@ -678,7 +675,7 @@ impl NetworkState {
     pub async fn reconnect(
         self: &Arc<Self>,
         clock: time::Clock,
-        actor_system: ActorSystem,
+        transport: Arc<dyn NetworkTransport>,
         peer_info: PeerInfo,
         max_attempts: usize,
     ) {
@@ -686,24 +683,12 @@ impl NetworkState {
         for _attempt in 0..max_attempts {
             interval.tick(&clock).await;
 
-            let result = async {
-                let stream =
-                    tcp::Stream::connect(&peer_info, tcp::Tier::T2, &self.config.socket_options)
-                        .await
-                        .context("tcp::Stream::connect()")?;
-                PeerActor::spawn_and_handshake(
-                    clock.clone(),
-                    actor_system.clone(),
-                    stream,
-                    self.clone(),
-                )
+            let result = transport
+                .connect_to_peer(&clock, peer_info.clone(), tcp::Tier::T2)
                 .await
-                .context("PeerActor::spawn()")?;
-                anyhow::Ok(())
-            }
-            .await;
+                .map_err(|err| anyhow::anyhow!("connect_to_peer: {err:?}"));
 
-            let succeeded = !result.is_err();
+            let succeeded = result.is_ok();
 
             if let Err(ref err) = result {
                 tracing::info!(target:"network", %err, %peer_info, "failed to connect");
@@ -1460,7 +1445,12 @@ impl NetworkState {
     /// b) there is an edge indicating that we should be disconnected from a peer, but we are connected.
     /// Try to resolve the inconsistency.
     /// We call this function every FIX_LOCAL_EDGES_INTERVAL from peer_manager_actor.rs.
-    pub async fn fix_local_edges(self: &Arc<Self>, clock: &time::Clock, timeout: time::Duration) {
+    pub async fn fix_local_edges(
+        self: &Arc<Self>,
+        clock: &time::Clock,
+        timeout: time::Duration,
+        transport: Arc<dyn NetworkTransport>,
+    ) {
         let this = self.clone();
         let clock = clock.clone();
         self.spawn("fix_local_edges", async move {
@@ -1508,6 +1498,7 @@ impl NetworkState {
                         let this = this.clone();
                         let clock = clock.clone();
                         let other_peer = other_peer.clone();
+                        let transport = transport.clone();
                         async move {
                             // This edge says this is an connected peer, which is currently not in the set of connected peers.
                             // Wait for some time to let the connection begin or broadcast edge removal instead.
@@ -1519,7 +1510,6 @@ impl NetworkState {
                             // Unwrap is safe, because new_edge is always valid.
                             let new_edge =
                                 edge.remove_edge(this.config.node_id(), &this.config.node_key);
-                            let transport = TcpTransport::new(this.clone());
                             this.add_edges(
                                 &clock,
                                 EdgesWithSource::Local(vec![new_edge.clone()]),

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -38,7 +38,7 @@ impl super::NetworkState {
     async fn tier1_connect_to_my_proxies(
         self: &Arc<Self>,
         clock: &time::Clock,
-        transport: &Arc<dyn NetworkTransport>,
+        transport: &dyn NetworkTransport,
         proxies: &[PeerAddr],
     ) {
         let tier1 = self.tier1.load();
@@ -78,7 +78,7 @@ impl super::NetworkState {
     pub async fn tier1_advertise_proxies(
         self: &Arc<Self>,
         clock: &time::Clock,
-        transport: &Arc<dyn NetworkTransport>,
+        transport: &dyn NetworkTransport,
     ) -> Option<Arc<SignedAccountData>> {
         // Tier1 advertise proxies calls should be disjoint,
         // to avoid a race condition while connecting to the proxies.
@@ -207,7 +207,7 @@ impl super::NetworkState {
     pub async fn tier1_connect(
         self: &Arc<Self>,
         clock: &time::Clock,
-        transport: &Arc<dyn NetworkTransport>,
+        transport: &dyn NetworkTransport,
     ) {
         if !self.config.tier1.enable_outbound {
             return;

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -3,12 +3,12 @@ use crate::config::{self, FrozenValidatorConfig};
 use crate::network_protocol::{
     AccountData, PeerAddr, PeerInfo, PeerMessage, SignedAccountData, SyncAccountsData,
 };
-use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::connection;
+use crate::peer_manager::network_transport::NetworkTransport;
 use crate::stun;
 use crate::tcp;
 use crate::types::PeerType;
-use near_async::{ActorSystem, time};
+use near_async::time;
 use near_crypto::PublicKey;
 use near_o11y::log_assert;
 use near_primitives::network::PeerId;
@@ -38,7 +38,7 @@ impl super::NetworkState {
     async fn tier1_connect_to_my_proxies(
         self: &Arc<Self>,
         clock: &time::Clock,
-        actor_system: ActorSystem,
+        transport: &Arc<dyn NetworkTransport>,
         proxies: &[PeerAddr],
     ) {
         let tier1 = self.tier1.load();
@@ -49,22 +49,11 @@ impl super::NetworkState {
             if tier1.ready.contains_key(&proxy.peer_id) {
                 continue;
             }
-            let actor_system = actor_system.clone();
+            let peer_info =
+                PeerInfo { id: proxy.peer_id.clone(), addr: Some(proxy.addr), account_id: None };
+            let handle = transport.connect_to_peer(clock, peer_info, tcp::Tier::T1);
             handles.push(async move {
-                let res = async {
-                    let stream = tcp::Stream::connect(
-                        &PeerInfo {
-                            id: proxy.peer_id.clone(),
-                            addr: Some(proxy.addr),
-                            account_id: None,
-                        },
-                        tcp::Tier::T1,
-                        &self.config.socket_options,
-                    )
-                    .await?;
-                    anyhow::Ok(PeerActor::spawn_and_handshake(clock.clone(), actor_system, stream, self.clone()).await?)
-                }.await;
-                if let Err(err) = res {
+                if let Err(err) = handle.await {
                     tracing::warn!(target: "network", ?err, ?proxy, "failed to establish connection to TIER1 proxy");
                 }
             });
@@ -89,7 +78,7 @@ impl super::NetworkState {
     pub async fn tier1_advertise_proxies(
         self: &Arc<Self>,
         clock: &time::Clock,
-        actor_system: ActorSystem,
+        transport: &Arc<dyn NetworkTransport>,
     ) -> Option<Arc<SignedAccountData>> {
         // Tier1 advertise proxies calls should be disjoint,
         // to avoid a race condition while connecting to the proxies.
@@ -145,7 +134,7 @@ impl super::NetworkState {
                 }
             }
         };
-        self.tier1_connect_to_my_proxies(clock, actor_system, &proxies).await;
+        self.tier1_connect_to_my_proxies(clock, transport, &proxies).await;
 
         // Snapshot tier1 connections again before broadcasting.
         let tier1 = self.tier1.load();
@@ -215,7 +204,11 @@ impl super::NetworkState {
 
     /// Closes TIER1 connections from nodes which are not TIER1 any more.
     /// If this node is TIER1, it additionally connects to proxies of other TIER1 nodes.
-    pub async fn tier1_connect(self: &Arc<Self>, clock: &time::Clock, actor_system: ActorSystem) {
+    pub async fn tier1_connect(
+        self: &Arc<Self>,
+        clock: &time::Clock,
+        transport: &Arc<dyn NetworkTransport>,
+    ) {
         if !self.config.tier1.enable_outbound {
             return;
         }
@@ -326,30 +319,17 @@ impl super::NetworkState {
                 let proxy = proxies.iter().choose(&mut rand::thread_rng());
                 if let Some(proxy) = proxy {
                     let proxy = (*proxy).clone();
-                    let actor_system = actor_system.clone();
+                    let peer_info = PeerInfo {
+                        id: proxy.peer_id.clone(),
+                        addr: Some(proxy.addr),
+                        account_id: None,
+                    };
+                    let handle = transport.connect_to_peer(clock, peer_info, tcp::Tier::T1);
+                    let node_id = self.config.node_id();
                     handles.push(async move {
-                        async {
-                            let stream = tcp::Stream::connect(
-                                &PeerInfo {
-                                    id: proxy.peer_id,
-                                    addr: Some(proxy.addr),
-                                    account_id: None,
-                                },
-                                tcp::Tier::T1,
-                                &self.config.socket_options,
-                            )
-                            .await?;
-                            PeerActor::spawn_and_handshake(
-                                clock.clone(),
-                                actor_system,
-                                stream,
-                                self.clone(),
-                            )
-                            .await
-                        }.await
-                        .inspect_err(|err| {
-                            tracing::info!(target: "network", %err, node_id = %self.config.node_id(), peer_addr = %proxy.addr, "failed to establish a tier1 connection");
-                        })
+                        if let Err(err) = handle.await {
+                            tracing::info!(target: "network", ?err, %node_id, peer_addr = %proxy.addr, "failed to establish a tier1 connection");
+                        }
                     });
                 }
             }

--- a/chain/network/src/peer_manager/network_transport.rs
+++ b/chain/network/src/peer_manager/network_transport.rs
@@ -79,9 +79,11 @@ pub struct PeerTransportStats {
 }
 
 /// Error returned by connect_to_peer.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum ConnectError {
+    /// The connection attempt failed (TCP dial, handshake, or register).
+    Failed,
+    /// The sender was dropped before a result was sent.
     Cancelled,
 }
 
@@ -95,7 +97,6 @@ pub struct ConnectHandle {
     rx: oneshot::Receiver<Result<(), ConnectError>>,
 }
 
-#[allow(dead_code)]
 impl ConnectHandle {
     pub(crate) fn new(rx: oneshot::Receiver<Result<(), ConnectError>>) -> Self {
         Self { rx }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -212,7 +212,7 @@ impl messaging::Actor for PeerManagerActor {
                 loop {
                     interval.tick(&clock).await;
                     state.tier1_request_full_sync();
-                    state.tier1_advertise_proxies(&clock, &*transport).await;
+                    state.tier1_advertise_proxies(&clock, transport.as_ref()).await;
                 }
             }
         });
@@ -227,7 +227,7 @@ impl messaging::Actor for PeerManagerActor {
             async move {
                 loop {
                     interval.tick().await;
-                    state.tier1_connect(&clock, &*transport).await;
+                    state.tier1_connect(&clock, transport.as_ref()).await;
                 }
             }
         });
@@ -1446,7 +1446,7 @@ impl PeerManagerActor {
                 let clock = self.clock.clone();
                 let transport = self.transport.clone();
                 self.handle.spawn("advertise_tier1_proxies", async move {
-                    state.tier1_advertise_proxies(&clock, &*transport).await;
+                    state.tier1_advertise_proxies(&clock, transport.as_ref()).await;
                 });
                 PeerManagerMessageResponse::AdvertiseTier1Proxies
             }
@@ -1484,7 +1484,7 @@ impl messaging::Handler<SetChainInfo> for PeerManagerActor {
                 // and this node won't be able to connect to proxies until it happens (and only the
                 // connected proxies are included in the advertisement). We run tier1_advertise_proxies
                 // periodically in the background anyway to cover those cases.
-                state.tier1_advertise_proxies(&clock, &*transport).await;
+                state.tier1_advertise_proxies(&clock, transport.as_ref()).await;
             }
             .in_current_span(),
         );
@@ -1601,7 +1601,7 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                         body: tier2_ack,
                     },
                 );
-                if !state.send_message_to_peer(&clock, tcp::Tier::T2, routed_message, &*transport) {
+                if !state.send_message_to_peer(&clock, tcp::Tier::T2, routed_message, transport.as_ref()) {
                     tracing::debug!(target: "network", sender = %sender, "failed to route ack");
                 }
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -10,7 +10,6 @@ use crate::network_protocol::{
     StatePartRequest, StateRequestAck,
 };
 use crate::network_protocol::{SyncSnapshotHosts, T1MessageBody};
-use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::connected_peers::ConnectedPeerState;
 use crate::peer_manager::network_state::{
     NetworkState, PENDING_TIER3_REQUEST_TIMEOUT, WhitelistNode,
@@ -104,8 +103,6 @@ const TIER3_IDLE_TIMEOUT: time::Duration = time::Duration::seconds(15);
 /// Actor that manages peers connections.
 pub struct PeerManagerActor {
     pub(crate) clock: time::Clock,
-    /// Actor system for spawning PeerActors.
-    pub(crate) actor_system: ActorSystem,
     /// Handle to spawning futures as well as stopping ourselves for testing.
     pub(crate) handle: TokioRuntimeHandle<Self>,
     /// Peer information for this node.
@@ -181,11 +178,12 @@ impl messaging::Actor for PeerManagerActor {
         // Periodically fix local edges.
         let clock = self.clock.clone();
         let state = self.state.clone();
+        let transport = self.transport.clone();
         self.handle.spawn("fix_local_edges loop", async move {
             let mut interval = time::Interval::new(clock.now(), FIX_LOCAL_EDGES_INTERVAL);
             loop {
                 interval.tick(&clock).await;
-                state.fix_local_edges(&clock, FIX_LOCAL_EDGES_TIMEOUT).await;
+                state.fix_local_edges(&clock, FIX_LOCAL_EDGES_TIMEOUT, transport.clone()).await;
             }
         });
 
@@ -208,13 +206,13 @@ impl messaging::Actor for PeerManagerActor {
         self.handle.spawn("connect to TIER1 proxies", {
             let clock = self.clock.clone();
             let state = self.state.clone();
-            let actor_system = self.actor_system.clone();
+            let transport = self.transport.clone();
             let mut interval = time::Interval::new(clock.now(), tier1.advertise_proxies_interval);
             async move {
                 loop {
                     interval.tick(&clock).await;
                     state.tier1_request_full_sync();
-                    state.tier1_advertise_proxies(&clock, actor_system.clone()).await;
+                    state.tier1_advertise_proxies(&clock, &transport).await;
                 }
             }
         });
@@ -223,13 +221,13 @@ impl messaging::Actor for PeerManagerActor {
         self.handle.spawn("update TIER1 connections", {
             let clock = self.clock.clone();
             let state = self.state.clone();
-            let actor_system = self.actor_system.clone();
+            let transport = self.transport.clone();
             let mut interval = tokio::time::interval(tier1.connect_interval.try_into().unwrap());
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             async move {
                 loop {
                     interval.tick().await;
-                    state.tier1_connect(&clock, actor_system.clone()).await;
+                    state.tier1_connect(&clock, &transport).await;
                 }
             }
         });
@@ -237,7 +235,7 @@ impl messaging::Actor for PeerManagerActor {
         // Periodically poll the connection store for connections we'd like to re-establish
         self.handle.spawn("poll connection store for reconnects", {
             let clock = self.clock.clone();
-            let actor_system = self.actor_system.clone();
+            let transport = self.transport.clone();
             let state = self.state.clone();
             let handle = self.handle.clone();
             let mut interval = time::Interval::new(clock.now(), POLL_CONNECTION_STORE_INTERVAL);
@@ -252,15 +250,10 @@ impl messaging::Actor for PeerManagerActor {
                             let state = state.clone();
                             let clock = clock.clone();
                             let peer_info = peer_info.clone();
-                            let actor_system = actor_system.clone();
+                            let transport = transport.clone();
                             async move {
                                 state
-                                    .reconnect(
-                                        clock,
-                                        actor_system,
-                                        peer_info,
-                                        MAX_RECONNECT_ATTEMPTS,
-                                    )
+                                    .reconnect(clock, transport, peer_info, MAX_RECONNECT_ATTEMPTS)
                                     .await;
                             }
                         });
@@ -350,7 +343,7 @@ impl PeerManagerActor {
         spice_data_distributor_adapter: SpiceDataDistributorSenderForNetwork,
         spice_core_writer_adapter: Sender<SpiceChunkEndorsementMessage>,
         genesis_id: GenesisId,
-    ) -> anyhow::Result<TokioRuntimeHandle<Self>> {
+    ) -> anyhow::Result<(TokioRuntimeHandle<Self>, Arc<TcpTransport>)> {
         let config = config.verify().context("config")?;
         let store = store::Store::from(store);
         let peer_store = peer_store::PeerStore::new(&clock, config.peer_store.clone())
@@ -392,64 +385,34 @@ impl PeerManagerActor {
             tracing::info!(target: "network", %addr, "using configured tier3 public address");
             metrics::TIER3_PUBLIC_ADDR.with_label_values(&[&addr.to_string()]).set(1);
         }
-        handle.spawn("PeerManagerActor server", {
-            let handle = handle.clone();
+        handle.spawn("PeerManagerActor epoch height fetch", {
             let state = state.clone();
-            let clock = clock.clone();
-            let actor_system = actor_system.clone();
             async move {
-                if let Ok(Some(epoch_height)) = state.client.current_epoch_height_request.send_async(GetCurrentEpochHeight).await {
+                if let Ok(Some(epoch_height)) = state
+                    .client
+                    .current_epoch_height_request
+                    .send_async(GetCurrentEpochHeight)
+                    .await
+                {
                     state.snapshot_hosts.set_current_epoch_height(epoch_height);
                 }
-                // Start server if address provided.
-                if let Some(server_addr) = &state.config.node_addr {
-                    tracing::debug!(target: "network", at = ?server_addr, "starting public server");
-                    let listener = match server_addr.listener() {
-                        Ok(it) => it,
-                        Err(e) => {
-                            panic!("failed to start listening on server_addr={server_addr:?} e={e:?}")
-                        }
-                    };
-                    #[cfg(test)]
-                    state.config.event_sink.send(Event::ServerStarted);
-                    handle.spawn("PeerManagerActor listener loop", {
-                        let clock = clock.clone();
-                        let state = state.clone();
-                        let actor_system = actor_system.clone();
-                        let transport: Arc<dyn NetworkTransport> = TcpTransport::new(state.clone());
-                        async move {
-                            loop {
-                                if let Ok(stream) = listener.accept().await {
-                                    // Always let the new peer to send a handshake message.
-                                    // Only then we can decide whether we should accept a connection.
-                                    // It is expected to be reasonably cheap: eventually, for TIER2 network
-                                    // we would like to exchange set of connected peers even without establishing
-                                    // a proper connection.
-                                    tracing::debug!(target: "network", from = ?stream.peer_addr, "got new connection");
-                                    if let Err(err) =
-                                        PeerActor::spawn(clock.clone(), actor_system.clone(), stream, state.clone(), transport.clone())
-                                    {
-                                        tracing::info!(target:"network", ?err, "peer actor spawn failed");
-                                    }
-                                }
-                            }
-                        }
-                    });
-                }
-
             }
         });
-        let transport = TcpTransport::new(state.clone());
+        // Build the transport and start the TCP listener. The listener
+        // lives inside TcpTransport so that PMA only ever holds
+        // `Arc<dyn NetworkTransport>`, never the concrete type.
+        let tcp = TcpTransport::new(state.clone(), clock.clone(), actor_system, handle.clone());
+        tcp.start();
+        let transport: Arc<dyn NetworkTransport> = tcp.clone();
         builder.spawn_tokio_actor(Self {
             my_peer_id,
             started_connect_attempts: false,
             state,
             transport,
             clock,
-            actor_system,
             handle: handle.clone(),
         });
-        Ok(handle)
+        Ok((handle, tcp))
     }
 
     /// Periodically prints bandwidth stats for each peer.
@@ -736,13 +699,12 @@ impl PeerManagerActor {
                 self.handle.spawn("monitor_peers_trigger_connect", {
                     let state = self.state.clone();
                     let clock = self.clock.clone();
-                    let actor_system = self.actor_system.clone();
+                    let transport = self.transport.clone();
                     async move {
-                        let result = async {
-                            let stream = tcp::Stream::connect(&peer_info, tcp::Tier::T2, &state.config.socket_options).await.context("tcp::Stream::connect()")?;
-                            PeerActor::spawn_and_handshake(clock.clone(), actor_system, stream,state.clone()).await.context("PeerActor::spawn()")?;
-                            anyhow::Ok(())
-                        }.await;
+                        let result = transport
+                            .connect_to_peer(&clock, peer_info.clone(), tcp::Tier::T2)
+                            .await
+                            .map_err(|err| anyhow::anyhow!("connect_to_peer: {err:?}"));
 
                         if let Err(ref err) = result {
                             tracing::info!(target: "network", %err, %peer_info, "tier2 failed to connect");
@@ -781,10 +743,10 @@ impl PeerManagerActor {
             self.handle.spawn("bootstrap_outbound_from_recent_connections", {
                 let state = self.state.clone();
                 let clock = self.clock.clone();
-                let actor_system = self.actor_system.clone();
+                let transport = self.transport.clone();
                 let peer_info = conn_info.peer_info.clone();
                 async move {
-                    state.reconnect(clock, actor_system, peer_info, 1).await;
+                    state.reconnect(clock, transport, peer_info, 1).await;
                 }
             });
 
@@ -1482,24 +1444,11 @@ impl PeerManagerActor {
             PeerManagerMessageRequest::AdvertiseTier1Proxies => {
                 let state = self.state.clone();
                 let clock = self.clock.clone();
-                let actor_system = self.actor_system.clone();
+                let transport = self.transport.clone();
                 self.handle.spawn("advertise_tier1_proxies", async move {
-                    state.tier1_advertise_proxies(&clock, actor_system).await;
+                    state.tier1_advertise_proxies(&clock, &transport).await;
                 });
                 PeerManagerMessageResponse::AdvertiseTier1Proxies
-            }
-            PeerManagerMessageRequest::OutboundTcpConnect(stream) => {
-                let peer_addr = stream.peer_addr;
-                if let Err(err) = PeerActor::spawn(
-                    self.clock.clone(),
-                    self.actor_system.clone(),
-                    stream,
-                    self.state.clone(),
-                    self.transport.clone(),
-                ) {
-                    tracing::info!(target:"network", ?err, ?peer_addr, "spawn_outbound()");
-                }
-                PeerManagerMessageResponse::OutboundTcpConnect
             }
             // TEST-ONLY
             PeerManagerMessageRequest::FetchRoutingTable => {
@@ -1524,7 +1473,7 @@ impl messaging::Handler<SetChainInfo> for PeerManagerActor {
 
         let state = self.state.clone();
         let clock = self.clock.clone();
-        let actor_system = self.actor_system.clone();
+        let transport = self.transport.clone();
         self.handle.spawn(
             "handle set_chain_info",
             async move {
@@ -1535,7 +1484,7 @@ impl messaging::Handler<SetChainInfo> for PeerManagerActor {
                 // and this node won't be able to connect to proxies until it happens (and only the
                 // connected proxies are included in the advertisement). We run tier1_advertise_proxies
                 // periodically in the background anyway to cover those cases.
-                state.tier1_advertise_proxies(&clock, actor_system).await;
+                state.tier1_advertise_proxies(&clock, &transport).await;
             }
             .in_current_span(),
         );
@@ -1582,7 +1531,6 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
 
         let state = self.state.clone();
         let clock = self.clock.clone();
-        let actor_system = self.actor_system.clone();
         let transport = self.transport.clone();
         self.handle.spawn("handle tier3 request",
             async move {
@@ -1665,15 +1613,10 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                 let already_connected_t3 =
                     state.peers.is_connected_on_tier(&sender, tcp::Tier::T3);
                 if !already_connected_t3 {
-                    let result = async {
-                        let stream = tcp::Stream::connect(
-                            &request.peer_info,
-                            tcp::Tier::T3,
-                            &state.config.socket_options
-                        ).await.context("tcp::Stream::connect()")?;
-                        PeerActor::spawn_and_handshake(clock.clone(), actor_system, stream, state.clone()).await.context("PeerActor::spawn()")?;
-                        anyhow::Ok(())
-                    }.await;
+                    let result = transport
+                        .connect_to_peer(&clock, request.peer_info.clone(), tcp::Tier::T3)
+                        .await
+                        .map_err(|err| anyhow::anyhow!("connect_to_peer: {err:?}"));
 
                     if let Err(ref err) = result {
                         tracing::debug!(target: "network", ?err, peer_info = %request.peer_info, "tier3 failed to connect");

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -212,7 +212,7 @@ impl messaging::Actor for PeerManagerActor {
                 loop {
                     interval.tick(&clock).await;
                     state.tier1_request_full_sync();
-                    state.tier1_advertise_proxies(&clock, &transport).await;
+                    state.tier1_advertise_proxies(&clock, &*transport).await;
                 }
             }
         });
@@ -227,7 +227,7 @@ impl messaging::Actor for PeerManagerActor {
             async move {
                 loop {
                     interval.tick().await;
-                    state.tier1_connect(&clock, &transport).await;
+                    state.tier1_connect(&clock, &*transport).await;
                 }
             }
         });
@@ -1446,7 +1446,7 @@ impl PeerManagerActor {
                 let clock = self.clock.clone();
                 let transport = self.transport.clone();
                 self.handle.spawn("advertise_tier1_proxies", async move {
-                    state.tier1_advertise_proxies(&clock, &transport).await;
+                    state.tier1_advertise_proxies(&clock, &*transport).await;
                 });
                 PeerManagerMessageResponse::AdvertiseTier1Proxies
             }
@@ -1484,7 +1484,7 @@ impl messaging::Handler<SetChainInfo> for PeerManagerActor {
                 // and this node won't be able to connect to proxies until it happens (and only the
                 // connected proxies are included in the advertisement). We run tier1_advertise_proxies
                 // periodically in the background anyway to cover those cases.
-                state.tier1_advertise_proxies(&clock, &transport).await;
+                state.tier1_advertise_proxies(&clock, &*transport).await;
             }
             .in_current_span(),
         );

--- a/chain/network/src/peer_manager/tcp_transport.rs
+++ b/chain/network/src/peer_manager/tcp_transport.rs
@@ -1,22 +1,136 @@
+use crate::network_protocol::PeerInfo;
+use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::network_state::NetworkState;
-use crate::peer_manager::network_transport::{NetworkTransport, PeerTransportStats, TransportInfo};
+use crate::peer_manager::network_transport::{
+    ConnectError, ConnectHandle, NetworkTransport, PeerTransportStats, TransportInfo,
+};
+#[cfg(test)]
+use crate::peer_manager::peer_manager_actor::Event;
+use crate::peer_manager::peer_manager_actor::PeerManagerActor;
 use crate::tcp;
 use crate::types::{PeerMessage, ReasonForBan};
+use anyhow::Context as _;
+use near_async::ActorSystem;
+use near_async::futures::FutureSpawner;
+use near_async::time;
+use near_async::tokio::TokioRuntimeHandle;
 use near_primitives::network::PeerId;
+use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, Weak};
+use tokio::sync::oneshot;
 
-/// Production implementation of NetworkTransport.
-/// Transitional: wraps NetworkState's Pools. In PR 10, Pools move to
-/// TcpTransport directly.
-pub(crate) struct TcpTransport {
-    pub state: Arc<NetworkState>,
+/// Production implementation of `NetworkTransport`.
+///
+/// Holds `Arc<NetworkState>` to pass to `PeerActor::spawn` when
+/// accepting inbound connections or initiating outbound ones, and to
+/// reach the connection Pools via `self.state.tier_N` for trait-impl
+/// routing. TcpTransport's own methods never call NetworkState for
+/// business logic — only PeerActor does.
+pub struct TcpTransport {
+    pub(crate) state: Arc<NetworkState>,
+    clock: time::Clock,
+    #[allow(dead_code)]
+    actor_system: ActorSystem,
+    spawner: Box<dyn FutureSpawner>,
+    /// Self-reference used by `connect_to_peer` to pass an
+    /// `Arc<TcpTransport>` to `PeerActor::spawn_and_handshake`.
+    /// Populated at construction via `Arc::new_cyclic`.
+    self_weak: Weak<Self>,
+    /// Signals the TCP listener to exit. `shutdown()` drops the sender,
+    /// which closes the receiver and breaks the accept loop.
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
 }
 
 impl TcpTransport {
-    pub fn new(state: Arc<NetworkState>) -> Arc<Self> {
-        Arc::new(Self { state })
+    /// Production constructor.
+    pub(crate) fn new(
+        state: Arc<NetworkState>,
+        clock: time::Clock,
+        actor_system: ActorSystem,
+        handle: TokioRuntimeHandle<PeerManagerActor>,
+    ) -> Arc<Self> {
+        Self::new_with_spawner(state, clock, actor_system, handle.future_spawner())
+    }
+
+    /// Shared constructor. Production passes a PMA-backed spawner;
+    /// tests can pass a standalone tokio spawner.
+    pub(crate) fn new_with_spawner(
+        state: Arc<NetworkState>,
+        clock: time::Clock,
+        actor_system: ActorSystem,
+        spawner: Box<dyn FutureSpawner>,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|self_weak| Self {
+            state,
+            clock,
+            actor_system,
+            spawner,
+            self_weak: self_weak.clone(),
+            shutdown_tx: Mutex::new(None),
+        })
+    }
+
+    /// Spawns the TCP accept loop if `node_addr` is configured. Intended
+    /// to be called exactly once, after PMA construction.
+    pub fn start(self: &Arc<Self>) {
+        let Some(server_addr) = self.state.config.node_addr else {
+            return;
+        };
+        tracing::debug!(target: "network", at = ?server_addr, "starting public server");
+        let listener = match server_addr.listener() {
+            Ok(it) => it,
+            Err(e) => panic!("failed to start listening on server_addr={server_addr:?} e={e:?}"),
+        };
+        #[cfg(test)]
+        self.state.config.event_sink.send(Event::ServerStarted);
+
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        *self.shutdown_tx.lock() = Some(shutdown_tx);
+
+        let this = self.clone();
+        self.spawner.spawn_boxed("PeerManagerActor listener loop", Box::pin(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    res = listener.accept() => {
+                        let Ok(stream) = res else { continue };
+                        // Always let the new peer to send a handshake message.
+                        // Only then we can decide whether we should accept a connection.
+                        // It is expected to be reasonably cheap: eventually, for TIER2 network
+                        // we would like to exchange set of connected peers even without establishing
+                        // a proper connection.
+                        tracing::debug!(target: "network", from = ?stream.peer_addr, "got new connection");
+                        if let Err(err) = PeerActor::spawn(
+                            this.clock.clone(),
+                            this.actor_system.clone(),
+                            stream,
+                            this.state.clone(),
+                            this.clone(),
+                        ) {
+                            tracing::info!(target:"network", ?err, "peer actor spawn failed");
+                        }
+                    }
+                }
+            }
+        }));
+    }
+
+    /// Spawn a PeerActor from an already-opened stream. Intended for
+    /// test fixtures (both unit tests and integration-tests) that need to
+    /// exercise the handshake flow without going through the production
+    /// `connect_to_peer` dial. Tests drive this method directly via the
+    /// `Arc<TcpTransport>` exposed from `PeerManagerActor::spawn`.
+    pub fn spawn_outbound_from_stream(self: &Arc<Self>, stream: tcp::Stream) -> anyhow::Result<()> {
+        PeerActor::spawn(
+            self.clock.clone(),
+            self.actor_system.clone(),
+            stream,
+            self.state.clone(),
+            self.clone(),
+        )?;
+        Ok(())
     }
 }
 
@@ -33,6 +147,64 @@ impl NetworkTransport for TcpTransport {
         self.state.tier2.broadcast_message(msg);
     }
 
+    fn connect_to_peer(
+        &self,
+        clock: &time::Clock,
+        peer_info: PeerInfo,
+        tier: tcp::Tier,
+    ) -> ConnectHandle {
+        // Idempotency guard: if we already have a ready connection on this
+        // tier, skip the dial. The Pool's `start_outbound` inside
+        // PeerActor::spawn_inner is the authoritative check against
+        // duplicate in-flight handshakes; this early-return just avoids a
+        // wasted TCP dial when we already have the peer in the Pool.
+        let already_ready = match tier {
+            tcp::Tier::T1 => self.state.tier1.load().ready.contains_key(&peer_info.id),
+            tcp::Tier::T2 => self.state.tier2.load().ready.contains_key(&peer_info.id),
+            tcp::Tier::T3 => self.state.tier3.load().ready.contains_key(&peer_info.id),
+        };
+        if already_ready {
+            return ConnectHandle::noop();
+        }
+
+        // Recover Arc<Self> via the stored Weak. The Weak is always live
+        // here because PMA holds an Arc to us for the duration of the
+        // actor's lifetime.
+        let Some(this) = self.self_weak.upgrade() else {
+            return ConnectHandle::noop();
+        };
+        let (tx, rx) = oneshot::channel();
+        let clock = clock.clone();
+        self.spawner.spawn_boxed("connect_to_peer", Box::pin(async move {
+            let result: anyhow::Result<()> = async {
+                let stream = tcp::Stream::connect(
+                    &peer_info,
+                    tier,
+                    &this.state.config.socket_options,
+                )
+                .await
+                .context("tcp::Stream::connect()")?;
+                PeerActor::spawn_and_handshake(
+                    clock,
+                    this.actor_system.clone(),
+                    stream,
+                    this.state.clone(),
+                    this.clone(),
+                )
+                .await
+                .context("PeerActor::spawn()")?;
+                Ok(())
+            }
+            .await;
+            let result = result.map_err(|err| {
+                tracing::info!(target: "network", %err, %peer_info, ?tier, "connect_to_peer failed");
+                ConnectError::Failed
+            });
+            let _ = tx.send(result);
+        }));
+        ConnectHandle::new(rx)
+    }
+
     fn disconnect_peer(&self, peer_id: &PeerId, ban_reason: Option<ReasonForBan>) {
         // A peer may be connected on multiple tiers simultaneously
         // (e.g. T1 + T2 for a validator). Stop the connection on every
@@ -44,6 +216,11 @@ impl NetworkTransport for TcpTransport {
                 conn.stop(ban_reason);
             }
         }
+    }
+
+    fn shutdown(&self) {
+        // Drop the sender — the listener's select! closes and the loop exits.
+        drop(self.shutdown_tx.lock().take());
     }
 
     fn transport_info(&self) -> TransportInfo {

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -18,6 +18,7 @@ use crate::network_protocol::{
 use crate::peer;
 use crate::peer::peer_actor::ClosingReason;
 use crate::peer_manager::network_state::NetworkState;
+use crate::peer_manager::network_transport::NetworkTransport;
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::snapshot_hosts::SnapshotHostsCache;
@@ -30,7 +31,7 @@ use crate::types::{
 };
 use near_async::futures::FutureSpawnerExt;
 use near_async::messaging::{
-    AsyncSender, CanSend, CanSendAsync, Handler, IntoMultiSender, IntoSender, Sender, noop,
+    AsyncSender, CanSendAsync, Handler, IntoMultiSender, IntoSender, Sender, noop,
 };
 use near_async::{ActorSystem, time};
 use near_primitives::network::{AnnounceAccount, PeerId};
@@ -68,11 +69,38 @@ impl Handler<WithNetworkState> for PeerManagerActor {
     }
 }
 
+/// Boxed future returned by test-only PMA message callbacks.
+type BoxFut = Pin<Box<dyn Send + 'static + Future<Output = ()>>>;
+
+/// Callback that receives both NetworkState and the real transport.
+type StateTransportFn =
+    Box<dyn Send + FnOnce(Arc<NetworkState>, Arc<dyn NetworkTransport>) -> BoxFut>;
+
+/// Test-only message: run a closure with access to both NetworkState
+/// and the real `Arc<dyn NetworkTransport>` held by PMA. Needed because
+/// methods like `tier1_advertise_proxies` call `transport.connect_to_peer`
+/// which requires the real TcpTransport (not a `new_wrapping` stub).
+struct WithStateAndTransport(StateTransportFn);
+
+impl Debug for WithStateAndTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("WithStateAndTransport").finish()
+    }
+}
+
+impl Handler<WithStateAndTransport> for PeerManagerActor {
+    fn handle(&mut self, WithStateAndTransport(f): WithStateAndTransport) {
+        self.handle
+            .spawn("with_state_and_transport", f(self.state.clone(), self.transport.clone()));
+    }
+}
+
 pub(crate) struct ActorHandler {
     pub cfg: config::NetworkConfig,
     pub events: broadcast::Receiver<Event>,
     pub actor: AutoStopActor<PeerManagerActor>,
     pub actor_system: ActorSystem,
+    pub tcp: Arc<TcpTransport>,
 }
 
 pub(crate) fn unwrap_sync_accounts_data_processed(ev: Event) -> Option<SyncAccountsData> {
@@ -175,7 +203,7 @@ impl ActorHandler {
         let stream = tcp::Stream::connect(&peer_info, tier, &config::SocketOptions::default())
             .await
             .unwrap();
-        self.actor.send(PeerManagerMessageRequest::OutboundTcpConnect(stream));
+        self.tcp.spawn_outbound_from_stream(stream).unwrap();
     }
 
     pub fn connect_to(
@@ -183,7 +211,7 @@ impl ActorHandler {
         peer_info: &PeerInfo,
         tier: tcp::Tier,
     ) -> impl 'static + Send + Future<Output = tcp::StreamId> {
-        let addr = self.actor.0.clone();
+        let tcp = self.tcp.clone();
         let events = self.events.clone();
         let peer_info = peer_info.clone();
         async move {
@@ -192,7 +220,7 @@ impl ActorHandler {
                 .unwrap();
             let mut events = events.from_now();
             let stream_id = stream.id();
-            addr.send(PeerManagerMessageRequest::OutboundTcpConnect(stream));
+            tcp.spawn_outbound_from_stream(stream).unwrap();
             events
                 .recv_until(|ev| match &ev {
                     Event::HandshakeCompleted(ev) if ev.stream_id == stream_id => Some(stream_id),
@@ -213,6 +241,27 @@ impl ActorHandler {
         self.actor
             .send_async(WithNetworkState(Box::new(|s| {
                 Box::pin(async { send.send(f(s).await).ok().unwrap() })
+            })))
+            .await
+            .unwrap();
+        recv.await.unwrap()
+    }
+
+    /// Like `with_state`, but the closure also receives the real
+    /// `Arc<dyn NetworkTransport>` held by PMA. Needed by tests that
+    /// drive methods invoking `transport.connect_to_peer` (e.g.
+    /// `tier1_advertise_proxies`, `tier1_connect`).
+    pub async fn with_state_and_transport<
+        R: 'static + Send,
+        Fut: 'static + Send + Future<Output = R>,
+    >(
+        &self,
+        f: impl 'static + Send + FnOnce(Arc<NetworkState>, Arc<dyn NetworkTransport>) -> Fut,
+    ) -> R {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.actor
+            .send_async(WithStateAndTransport(Box::new(|s, t| {
+                Box::pin(async { send.send(f(s, t).await).ok().unwrap() })
             })))
             .await
             .unwrap();
@@ -261,7 +310,7 @@ impl ActorHandler {
             tcp::Stream::loopback(network_cfg.node_id(), tier).await;
         let stream_id = outbound_stream.id();
         let events = self.events.from_now();
-        self.actor.send(PeerManagerMessageRequest::OutboundTcpConnect(outbound_stream));
+        self.tcp.spawn_outbound_from_stream(outbound_stream).unwrap();
         let conn = RawConnection {
             events,
             stream: inbound_stream,
@@ -321,7 +370,10 @@ impl ActorHandler {
 
     pub async fn fix_local_edges(&self, clock: &time::Clock, timeout: time::Duration) {
         let clock = clock.clone();
-        self.with_state(move |s| async move { s.fix_local_edges(&clock, timeout).await }).await
+        self.with_state_and_transport(move |s, transport| async move {
+            s.fix_local_edges(&clock, timeout, transport).await
+        })
+        .await
     }
 
     pub async fn set_chain_info(&self, chain_info: ChainInfo) -> bool {
@@ -333,10 +385,9 @@ impl ActorHandler {
         clock: &time::Clock,
     ) -> Option<Arc<SignedAccountData>> {
         let clock = clock.clone();
-        let actor_system = self.actor_system.clone();
-        self.with_state(
-            move |s| async move { s.tier1_advertise_proxies(&clock, actor_system).await },
-        )
+        self.with_state_and_transport(move |s, transport| async move {
+            s.tier1_advertise_proxies(&clock, &transport).await
+        })
         .await
     }
 
@@ -380,8 +431,7 @@ impl ActorHandler {
 
     pub async fn send_ping(&self, clock: &time::Clock, nonce: u64, target: PeerId) {
         let clock = clock.clone();
-        self.with_state(move |s| async move {
-            let transport = TcpTransport::new(s.clone());
+        self.with_state_and_transport(move |s, transport| async move {
             s.send_ping(&clock, tcp::Tier::T2, nonce, target, &*transport);
         })
         .await;
@@ -517,9 +567,8 @@ impl ActorHandler {
     /// Executes `NetworkState::tier1_connect` method.
     pub async fn tier1_connect(&self, clock: &time::Clock) {
         let clock = clock.clone();
-        let actor_system = self.actor_system.clone();
-        self.with_state(move |s| async move {
-            s.tier1_connect(&clock, actor_system).await;
+        self.with_state_and_transport(move |s, transport| async move {
+            s.tier1_connect(&clock, &transport).await;
         })
         .await;
     }
@@ -568,7 +617,7 @@ pub(crate) async fn start(
         });
 
     let actor_system = ActorSystem::new();
-    let actor = PeerManagerActor::spawn(
+    let (actor, tcp) = PeerManagerActor::spawn(
         clock,
         actor_system.clone(),
         store,
@@ -584,7 +633,7 @@ pub(crate) async fn start(
     )
     .unwrap();
     let actor = AutoStopActor(actor);
-    let h = ActorHandler { cfg, actor, events: recv.clone(), actor_system };
+    let h = ActorHandler { cfg, actor, events: recv.clone(), actor_system, tcp };
     // Wait for the server to start.
     recv.recv_until(|ev| match ev {
         Event::ServerStarted => Some(()),

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -388,7 +388,7 @@ impl ActorHandler {
     ) -> Option<Arc<SignedAccountData>> {
         let clock = clock.clone();
         self.with_state_and_transport(move |s, transport| async move {
-            s.tier1_advertise_proxies(&clock, &transport).await
+            s.tier1_advertise_proxies(&clock, &*transport).await
         })
         .await
     }
@@ -570,7 +570,7 @@ impl ActorHandler {
     pub async fn tier1_connect(&self, clock: &time::Clock) {
         let clock = clock.clone();
         self.with_state_and_transport(move |s, transport| async move {
-            s.tier1_connect(&clock, &transport).await;
+            s.tier1_connect(&clock, &*transport).await;
         })
         .await;
     }

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -310,7 +310,9 @@ impl ActorHandler {
             tcp::Stream::loopback(network_cfg.node_id(), tier).await;
         let stream_id = outbound_stream.id();
         let events = self.events.from_now();
-        self.tcp.spawn_outbound_from_stream(outbound_stream).unwrap();
+        if let Err(err) = self.tcp.spawn_outbound_from_stream(outbound_stream) {
+            tracing::info!(target:"network", ?err, "start_outbound: spawn failed");
+        }
         let conn = RawConnection {
             events,
             stream: inbound_stream,

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -388,7 +388,7 @@ impl ActorHandler {
     ) -> Option<Arc<SignedAccountData>> {
         let clock = clock.clone();
         self.with_state_and_transport(move |s, transport| async move {
-            s.tier1_advertise_proxies(&clock, &*transport).await
+            s.tier1_advertise_proxies(&clock, transport.as_ref()).await
         })
         .await
     }
@@ -434,7 +434,7 @@ impl ActorHandler {
     pub async fn send_ping(&self, clock: &time::Clock, nonce: u64, target: PeerId) {
         let clock = clock.clone();
         self.with_state_and_transport(move |s, transport| async move {
-            s.send_ping(&clock, tcp::Tier::T2, nonce, target, &*transport);
+            s.send_ping(&clock, tcp::Tier::T2, nonce, target, transport.as_ref());
         })
         .await;
     }
@@ -570,7 +570,7 @@ impl ActorHandler {
     pub async fn tier1_connect(&self, clock: &time::Clock) {
         let clock = clock.clone();
         self.with_state_and_transport(move |s, transport| async move {
-            s.tier1_connect(&clock, &*transport).await;
+            s.tier1_connect(&clock, transport.as_ref()).await;
         })
         .await;
     }

--- a/chain/network/src/peer_manager/tests/tier1.rs
+++ b/chain/network/src/peer_manager/tests/tier1.rs
@@ -3,7 +3,6 @@ use crate::network_protocol::testonly as data;
 use crate::network_protocol::{PeerAddr, PeerMessage, T1MessageBody, TieredMessageBody};
 use crate::peer_manager;
 use crate::peer_manager::peer_manager_actor::Event;
-use crate::peer_manager::tcp_transport::TcpTransport;
 use crate::peer_manager::testonly::start as start_pm;
 use crate::stun;
 use crate::tcp;
@@ -61,8 +60,7 @@ async fn send_tier1_message(
     let want: TieredMessageBody =
         T1MessageBody::BlockApproval(make_block_approval(rng, from_signer.as_ref())).into();
     let clock = clock.clone();
-    from.with_state(move |s| async move {
-        let transport = TcpTransport::new(s.clone());
+    from.with_state_and_transport(move |s, transport| async move {
         if s.send_message_to_account(&clock, &target, want.clone(), &*transport) {
             Some(want)
         } else {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -174,10 +174,6 @@ pub enum PeerManagerMessageRequest {
     /// The effect would be accounts data known by this node broadcasted to other tier1 nodes.
     /// That includes info about validator signer of this node.
     AdvertiseTier1Proxies,
-    /// Request PeerManager to connect to the given peer.
-    /// Used in tests and internally by PeerManager.
-    /// TODO: replace it with AsyncContext::spawn/run_later for internal use.
-    OutboundTcpConnect(crate::tcp::Stream),
     /// The following types of requests are used to trigger actions in the Peer Manager for testing.
     /// TEST-ONLY: Fetch current routing table.
     FetchRoutingTable,
@@ -206,8 +202,6 @@ impl PeerManagerMessageRequest {
 pub enum PeerManagerMessageResponse {
     NetworkResponses(NetworkResponses),
     AdvertiseTier1Proxies,
-    /// TEST-ONLY
-    OutboundTcpConnect,
     FetchRoutingTable(RoutingTableInfo),
 }
 

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -43,6 +43,7 @@ fn make_peer_manager(
         GenesisId::default(),
     )
     .unwrap()
+    .0
 }
 
 #[tokio::test]

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -55,7 +55,7 @@ fn setup_network_node(
     validators: Vec<AccountId>,
     chain_genesis: ChainGenesis,
     config: config::NetworkConfig,
-) -> TokioRuntimeHandle<PeerManagerActor> {
+) -> (TokioRuntimeHandle<PeerManagerActor>, Arc<near_network::TcpTransport>) {
     let node_storage = create_in_memory_rpc_node_storage();
     let num_validators = validators.len() as ValidatorId;
 
@@ -220,7 +220,7 @@ fn setup_network_node(
         Arc::new(RayonAsyncComputationSpawner),
     ));
     shards_manager_adapter.bind(shards_manager_actor);
-    let peer_manager = PeerManagerActor::spawn(
+    let (peer_manager, tcp) = PeerManagerActor::spawn(
         time::Clock::real(),
         actor_system,
         db.clone(),
@@ -241,7 +241,7 @@ fn setup_network_node(
     )
     .unwrap();
     network_adapter.bind(peer_manager.clone());
-    peer_manager
+    (peer_manager, tcp)
 }
 
 // TODO: Deprecate this in favor of separate functions.
@@ -305,11 +305,13 @@ impl StateMachine {
             Action::AddEdge { from, to, force } => {
                 self.actions.push(Box::new(move |info: &mut RunningInfo| Box::pin(async move {
                     tracing::debug!(target: "test", num_prev_actions, action = ?action_clone, "runner.rs: action");
-                    let pm = info.get_node(from)?.actor.clone();
+                    let node = info.get_node(from)?;
+                    let pm = node.actor.clone();
+                    let tcp_transport = node.tcp.clone();
                     let peer_info = info.runner.test_config[to].peer_info();
                     match tcp::Stream::connect(&peer_info, tcp::Tier::T2, &config::SocketOptions::default()).await {
                         Ok(stream) => {
-                            let _: PeerManagerMessageResponse = pm.send_async(PeerManagerMessageRequest::OutboundTcpConnect(stream)).await?;
+                            let _ = tcp_transport.spawn_outbound_from_stream(stream);
                         },
                         Err(err) => tracing::debug!("tcp::Stream::connect({peer_info}): {err}"),
                     }
@@ -409,6 +411,7 @@ pub(crate) struct Runner {
 
 struct NodeHandle {
     actor: AutoStopActor<PeerManagerActor>,
+    tcp: Arc<near_network::TcpTransport>,
 }
 
 impl Runner {
@@ -547,15 +550,14 @@ impl Runner {
         let validators = self.validators.clone();
         let chain_genesis = self.chain_genesis.clone();
 
-        Ok(NodeHandle {
-            actor: AutoStopActor(setup_network_node(
-                self.actor_system.clone(),
-                account_id,
-                validators,
-                chain_genesis,
-                network_config,
-            )),
-        })
+        let (actor, tcp) = setup_network_node(
+            self.actor_system.clone(),
+            account_id,
+            validators,
+            chain_genesis,
+            network_config,
+        );
+        Ok(NodeHandle { actor: AutoStopActor(actor), tcp })
     }
 
     fn build(self) -> anyhow::Result<RunningInfo> {

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -720,7 +720,7 @@ pub async fn start_with_config_and_synchronization_impl(
     let hot_store = storage.get_hot_store();
     let cold_store = storage.get_cold_store();
 
-    let network_actor = PeerManagerActor::spawn(
+    let (network_actor, _tcp) = PeerManagerActor::spawn(
         Clock::real(),
         actor_system.clone(),
         storage.into_inner(near_store::Temperature::Hot),


### PR DESCRIPTION
- `PeerManagerActor::spawn` returns `(TokioRuntimeHandle<Self>, Arc<TcpTransport>)`
- Remove `OutboundTcpConnect` message variant — tests call `TcpTransport::spawn_outbound_from_stream` directly
- TcpTransport gains `self_weak: Weak<Self>` (via `Arc::new_cyclic`), `spawner: Box<dyn FutureSpawner>`, `shutdown_tx`
- `connect_to_peer` and the listener loop live on TcpTransport, not PMA
- Tier3 connection in `Tier3Request` handler → `transport.connect_to_peer()`
- `fix_local_edges` takes `Arc<dyn NetworkTransport>` param
- PeerActor field `transport: Arc<dyn NetworkTransport>` → `tcp: Arc<TcpTransport>`
- Test infra: `ActorHandler.tcp` field, `WithStateAndTransport` with type aliases