### PR TITLE
fix(vm-runner): report compilation and cache metrics from all code paths

### DIFF
--- a/runtime/near-vm-runner/src/metrics.rs
+++ b/runtime/near-vm-runner/src/metrics.rs
@@ -11,6 +11,7 @@ thread_local! {
         wasmtime_compilation_time: Duration::new(0, 0),
         compiled_contract_cache_lookups: 0,
         compiled_contract_cache_hits: 0,
+        compiled_contract_memory_cache_hits: 0,
     }) };
 }
 
@@ -56,6 +57,15 @@ static COMPILED_CONTRACT_CACHE_HITS_TOTAL: LazyLock<IntCounterVec> = LazyLock::n
     .unwrap()
 });
 
+static COMPILED_CONTRACT_MEMORY_CACHE_HITS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_vm_compiled_contract_memory_cache_hits_total",
+        "The number of times the runtime finds an entry in the in-memory compiled-contract cache, avoiding a disk lookup. Disk hits can be derived as total hits minus memory hits",
+        &["context", "shard_id"],
+    )
+    .unwrap()
+});
+
 #[derive(Default, Copy, Clone)]
 struct Metrics {
     near_vm_compilation_time: Duration,
@@ -64,6 +74,8 @@ struct Metrics {
     compiled_contract_cache_lookups: u64,
     /// Number of times the lookup from the compiled contract cache finds a match.
     compiled_contract_cache_hits: u64,
+    /// Number of times the in-memory cache had the compiled contract (no disk lookup needed).
+    compiled_contract_memory_cache_hits: u64,
 }
 
 #[cfg(any(feature = "near_vm", feature = "wasmtime_vm"))]
@@ -86,6 +98,14 @@ pub(crate) fn record_compiled_contract_cache_lookup(is_hit: bool) {
         if is_hit {
             m.compiled_contract_cache_hits += 1;
         }
+    });
+}
+
+/// Records an in-memory compiled-contract cache hit.
+#[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
+pub(crate) fn record_compiled_contract_memory_cache_hit() {
+    METRICS.with_borrow_mut(|m| {
+        m.compiled_contract_memory_cache_hits += 1;
     });
 }
 
@@ -120,6 +140,11 @@ pub fn report_metrics(shard_id: &str, caller_context: &str) {
             COMPILED_CONTRACT_CACHE_HITS_TOTAL
                 .with_label_values(&[caller_context, shard_id])
                 .inc_by(m.compiled_contract_cache_hits);
+        }
+        if m.compiled_contract_memory_cache_hits > 0 {
+            COMPILED_CONTRACT_MEMORY_CACHE_HITS_TOTAL
+                .with_label_values(&[caller_context, shard_id])
+                .inc_by(m.compiled_contract_memory_cache_hits);
         }
 
         *m = Metrics::default();

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -246,10 +246,14 @@ impl NearVM {
         // To identify a cache hit from either in-memory and on-disk cache correctly, we first assume that we have a cache hit here,
         // and then we set it to false when we fail to find any entry and decide to compile (by calling compile_and_cache below).
         let mut is_cache_hit = true;
+        // Track whether the in-memory cache had the entry. The generate closure only runs on
+        // memory cache miss, so if it stays true the lookup was served from memory.
+        let mut is_memory_hit = true;
         let key = get_contract_cache_key(contract.hash(), &self.config, near_vm_vm_hash());
         let (wasm_bytes, artifact_result) = cache.memory_cache().try_lookup(
             key,
             || {
+                is_memory_hit = false;
                 // `cache` stores compiled machine code in the database
                 //
                 // Caches also cache _compilation_ errors, so that we don't have to
@@ -341,6 +345,9 @@ impl NearVM {
         )?;
 
         crate::metrics::record_compiled_contract_cache_lookup(is_cache_hit);
+        if is_memory_hit {
+            crate::metrics::record_compiled_contract_memory_cache_hit();
+        }
         let config = Arc::clone(&self.config);
         let result = gas_counter.before_loading_executable(&config, &method, wasm_bytes);
         if let Err(e) = result {

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -266,12 +266,14 @@ pub(crate) fn action_implicit_account_creation_transfer(
                 // Precompile Wallet Contract and store result (compiled code or error) in the database.
                 // Note this contract is shared among ETH-implicit accounts and `precompile_contract`
                 // is a no-op if the contract was already compiled.
+                let shard_id = apply_state.shard_id.to_string();
                 precompile_contract(
                     &wallet_contract(contract_hash).expect("should definitely exist"),
                     Arc::clone(&apply_state.config.wasm_config),
                     apply_state.cache.as_deref(),
                 )
                 .ok();
+                near_vm_runner::report_metrics(&shard_id, "deploy");
             }
         }
         AccountType::NearDeterministicAccount => {

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -245,11 +245,13 @@ fn apply_distribution_current_shard(
         GlobalContractIdentifier::CodeHash(hash) => Some(*hash),
         GlobalContractIdentifier::AccountId(_) => None,
     };
+    let shard_id = apply_state.shard_id.to_string();
     let _ = precompile_contract(
         &ContractCode::new(global_contract_data.code().to_vec(), code_hash),
         config,
         apply_state.cache.as_deref(),
     );
+    near_vm_runner::report_metrics(&shard_id, "global_contract");
     Ok(())
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -516,6 +516,7 @@ impl Runtime {
                     apply_state.cache.as_deref(),
                     apply_state.current_protocol_version,
                 )?;
+                near_vm_runner::report_metrics(&apply_state.shard_id.to_string(), "deploy");
             }
             Action::DeployGlobalContract(deploy_global_contract) => {
                 metrics::ACTION_CALLED_COUNT.deploy_global_contract.inc();
@@ -3060,6 +3061,7 @@ impl<'a> ApplyProcessingState<'a> {
             self.apply_state.cache.as_ref().map(|v| v.handle()),
             self.state_update.contract_storage().clone(),
             self.epoch_info_provider.chain_id(),
+            self.apply_state.shard_id.to_string(),
         );
         ApplyProcessingReceiptState {
             pipeline_manager,
@@ -3279,6 +3281,7 @@ pub mod estimator {
             apply_state.cache.as_ref().map(|c| c.handle()),
             state_update.contract_storage().clone(),
             epoch_info_provider.chain_id(),
+            apply_state.shard_id.to_string(),
         );
         let mut receipt_to_tx = Vec::new();
         let apply_result = Runtime {}.apply_action_receipt(

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -69,6 +69,9 @@ pub(crate) struct ReceiptPreparationPipeline {
     storage: ContractStorage,
 
     chain_id: String,
+
+    /// Pre-formatted shard ID for metric labels.
+    shard_id: String,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -95,6 +98,7 @@ impl ReceiptPreparationPipeline {
         contract_cache: Option<Box<dyn ContractRuntimeCache>>,
         storage: ContractStorage,
         chain_id: String,
+        shard_id: String,
     ) -> Self {
         Self {
             map: Default::default(),
@@ -104,6 +108,7 @@ impl ReceiptPreparationPipeline {
             contract_cache,
             storage,
             chain_id,
+            shard_id,
         }
     }
 
@@ -213,6 +218,7 @@ impl ReceiptPreparationPipeline {
                     let task = Arc::new(PrepareTask { status, condvar: Condvar::new() });
                     entry.insert(Arc::clone(&task));
                     PIPELINING_ACTIONS_SUBMITTED.inc_by(1);
+                    let shard_id = self.shard_id.clone();
                     contract_compilation_pool().spawn_boxed(Box::new(move || {
                         let task_status = {
                             let mut status = task.status.lock();
@@ -231,6 +237,7 @@ impl ReceiptPreparationPipeline {
                             identifier,
                             &method_name,
                         );
+                        near_vm_runner::report_metrics(&shard_id, "pipelining");
                         let mut status = task.status.lock();
                         *status = PrepareTaskStatus::Prepared(contract);
                         PIPELINING_ACTIONS_TASK_WORKING_TIME.inc_by(start.elapsed().as_secs_f64());

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -331,6 +331,7 @@ impl TrieViewer {
             apply_state.cache.as_ref().map(|v| v.handle()),
             state_update.contract_storage().clone(),
             epoch_info_provider.chain_id(),
+            apply_state.shard_id.to_string(),
         );
         let max_gas_burnt_view = self.max_gas_burnt_view(view_state.current_protocol_version);
         let view_config = Some(ViewConfig { max_gas_burnt: max_gas_burnt_view });


### PR DESCRIPTION
`report_metrics()`, which flushes vm-runner's thread-local metric accumulators to Prometheus, was only called on the function-call path. Compilation triggered by contract deployment, global contract distribution, or pipelining accumulated into thread-locals but never flushed — the data was silently lost.

Add `report_metrics()`` calls at each of these call sites, where the shard context is available, so the existing near_vm_runner_compilation_seconds histogram and cache counters capture all compilations with proper shard_id and caller context labels. The simpler approach to observe directly in the `compile_uncached()` would loose the "shard_id" information.

Also add near_vm_compiled_contract_memory_cache_hits_total to distinguish in-memory cache hits from disk hits. Disk hit rate can be derived as (total_hits - memory_hits) / (total_lookups - memory_hits).