### PR TITLE
fix(vm-runner): report compilation and cache metrics from all code paths

### DIFF
--- a/runtime/near-vm-runner/src/metrics.rs
+++ b/runtime/near-vm-runner/src/metrics.rs
@@ -11,6 +11,7 @@ thread_local! {
         wasmtime_compilation_time: Duration::new(0, 0),
         compiled_contract_cache_lookups: 0,
         compiled_contract_cache_hits: 0,
+        compiled_contract_memory_cache_hits: 0,
     }) };
 }
 
@@ -56,6 +57,15 @@ static COMPILED_CONTRACT_CACHE_HITS_TOTAL: LazyLock<IntCounterVec> = LazyLock::n
     .unwrap()
 });
 
+static COMPILED_CONTRACT_MEMORY_CACHE_HITS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_vm_compiled_contract_memory_cache_hits_total",
+        "The number of times the runtime finds an entry in the in-memory contracts cache.",
+        &["context", "shard_id"],
+    )
+    .unwrap()
+});
+
 #[derive(Default, Copy, Clone)]
 struct Metrics {
     near_vm_compilation_time: Duration,
@@ -64,6 +74,8 @@ struct Metrics {
     compiled_contract_cache_lookups: u64,
     /// Number of times the lookup from the compiled contract cache finds a match.
     compiled_contract_cache_hits: u64,
+    /// Number of times the in-memory cache had the contract (compiled + execution context).
+    compiled_contract_memory_cache_hits: u64,
 }
 
 #[cfg(any(feature = "near_vm", feature = "wasmtime_vm"))]
@@ -77,14 +89,15 @@ pub(crate) fn compilation_duration(kind: near_parameters::vm::VMKind, duration: 
     });
 }
 
-/// Updates metrics to record a compiled-contract cache lookup,
-/// where is_hit=true indicates that we found an entry in the cache.
-#[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
-pub(crate) fn record_compiled_contract_cache_lookup(is_hit: bool) {
+/// Records the result of a compiled-contract cache lookup.
+pub(crate) fn record_compiled_contract_cache_lookup(is_hit: bool, is_memory_hit: bool) {
     METRICS.with_borrow_mut(|m| {
         m.compiled_contract_cache_lookups += 1;
         if is_hit {
             m.compiled_contract_cache_hits += 1;
+        }
+        if is_memory_hit {
+            m.compiled_contract_memory_cache_hits += 1;
         }
     });
 }
@@ -99,27 +112,40 @@ pub(crate) fn set_compiled_contract_cache_metrics(cache_id: &str, items: usize, 
 }
 
 /// Reports the current metrics at the end of a single VM invocation (eg. to run a function call).
-pub fn report_metrics(shard_id: &str, caller_context: &str) {
+pub fn report_metrics(shard_id: impl std::fmt::Display, caller_context: &str) {
     METRICS.with_borrow_mut(|m| {
+        let has_data = !m.near_vm_compilation_time.is_zero()
+            || !m.wasmtime_compilation_time.is_zero()
+            || m.compiled_contract_cache_lookups > 0;
+        if !has_data {
+            *m = Metrics::default();
+            return;
+        }
+        let shard_id = shard_id.to_string();
         if !m.near_vm_compilation_time.is_zero() {
             COMPILATION_TIME
-                .with_label_values(&["near_vm", shard_id])
+                .with_label_values(&["near_vm", &shard_id])
                 .observe(m.near_vm_compilation_time.as_secs_f64());
         }
         if !m.wasmtime_compilation_time.is_zero() {
             COMPILATION_TIME
-                .with_label_values(&["wasmtime", shard_id])
+                .with_label_values(&["wasmtime", &shard_id])
                 .observe(m.wasmtime_compilation_time.as_secs_f64());
         }
         if m.compiled_contract_cache_lookups > 0 {
             COMPILED_CONTRACT_CACHE_LOOKUPS_TOTAL
-                .with_label_values(&[caller_context, shard_id])
+                .with_label_values(&[caller_context, &shard_id])
                 .inc_by(m.compiled_contract_cache_lookups);
         }
         if m.compiled_contract_cache_hits > 0 {
             COMPILED_CONTRACT_CACHE_HITS_TOTAL
-                .with_label_values(&[caller_context, shard_id])
+                .with_label_values(&[caller_context, &shard_id])
                 .inc_by(m.compiled_contract_cache_hits);
+        }
+        if m.compiled_contract_memory_cache_hits > 0 {
+            COMPILED_CONTRACT_MEMORY_CACHE_HITS_TOTAL
+                .with_label_values(&[caller_context, &shard_id])
+                .inc_by(m.compiled_contract_memory_cache_hits);
         }
 
         *m = Metrics::default();

--- a/runtime/near-vm-runner/src/metrics.rs
+++ b/runtime/near-vm-runner/src/metrics.rs
@@ -90,6 +90,7 @@ pub(crate) fn compilation_duration(kind: near_parameters::vm::VMKind, duration: 
 }
 
 /// Records the result of a compiled-contract cache lookup.
+#[cfg(any(feature = "near_vm", feature = "wasmtime_vm"))]
 pub(crate) fn record_compiled_contract_cache_lookup(is_hit: bool, is_memory_hit: bool) {
     METRICS.with_borrow_mut(|m| {
         m.compiled_contract_cache_lookups += 1;

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -246,10 +246,14 @@ impl NearVM {
         // To identify a cache hit from either in-memory and on-disk cache correctly, we first assume that we have a cache hit here,
         // and then we set it to false when we fail to find any entry and decide to compile (by calling compile_and_cache below).
         let mut is_cache_hit = true;
+        // Track whether the in-memory cache had the entry. The generate closure only runs on
+        // memory cache miss, so if it stays true the lookup was served from memory.
+        let mut is_memory_hit = true;
         let key = get_contract_cache_key(contract.hash(), &self.config, near_vm_vm_hash());
         let (wasm_bytes, artifact_result) = cache.memory_cache().try_lookup(
             key,
             || {
+                is_memory_hit = false;
                 // `cache` stores compiled machine code in the database
                 //
                 // Caches also cache _compilation_ errors, so that we don't have to
@@ -340,7 +344,7 @@ impl NearVM {
             },
         )?;
 
-        crate::metrics::record_compiled_contract_cache_lookup(is_cache_hit);
+        crate::metrics::record_compiled_contract_cache_lookup(is_cache_hit, is_memory_hit);
         let config = Arc::clone(&self.config);
         let result = gas_counter.before_loading_executable(&config, &method, wasm_bytes);
         if let Err(e) = result {

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -578,10 +578,13 @@ impl WasmtimeVM {
         type MemoryCacheType =
             (u64, Result<Result<PreparedModule, FunctionCallError>, CompilationError>);
         let to_any = |v: MemoryCacheType| -> Box<dyn std::any::Any + Send> { Box::new(v) };
+        let mut is_cache_hit = true;
+        let mut is_memory_hit = true;
         let key = get_contract_cache_key(contract.hash(), &self.config, self.vm_hash());
         let (wasm_bytes, pre_result) = cache.memory_cache().try_lookup(
             key,
             || {
+                is_memory_hit = false;
                 let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
                 let (wasm_bytes, module) =
                     if let Some(CompiledContractInfo { wasm_bytes, compiled }) = cache_record {
@@ -595,6 +598,7 @@ impl WasmtimeVM {
                             CompiledContract::Code(module) => (wasm_bytes, module),
                         }
                     } else {
+                        is_cache_hit = false;
                         let Some(code) = contract.get_code() else {
                             return Err(VMRunnerError::ContractCodeNotPresent);
                         };
@@ -671,6 +675,7 @@ impl WasmtimeVM {
             },
         )?;
 
+        crate::metrics::record_compiled_contract_cache_lookup(is_cache_hit, is_memory_hit);
         let config = Arc::clone(&self.config);
         let result = gas_counter.before_loading_executable(&config, &method, wasm_bytes);
         if let Err(e) = result {

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -272,6 +272,7 @@ pub(crate) fn action_implicit_account_creation_transfer(
                     apply_state.cache.as_deref(),
                 )
                 .ok();
+                near_vm_runner::report_metrics(apply_state.shard_id, "deploy");
             }
         }
         AccountType::NearDeterministicAccount => {

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -290,10 +290,7 @@ pub(crate) fn execute_function_call(
 
     near_vm_runner::reset_metrics();
     let result = near_vm_runner::run(contract, runtime_ext, &context, Arc::clone(&config.fees));
-    near_vm_runner::report_metrics(
-        &apply_state.shard_id.to_string(),
-        &apply_state.apply_reason.to_string(),
-    );
+    near_vm_runner::report_metrics(apply_state.shard_id, &apply_state.apply_reason.to_string());
 
     // There are many specific errors that the runtime can encounter.
     // Some can be translated to the more general `RuntimeError`, which allows to pass

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -250,6 +250,7 @@ fn apply_distribution_current_shard(
         config,
         apply_state.cache.as_deref(),
     );
+    near_vm_runner::report_metrics(apply_state.shard_id, "global_contract");
     Ok(())
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -516,6 +516,7 @@ impl Runtime {
                     apply_state.cache.as_deref(),
                     apply_state.current_protocol_version,
                 )?;
+                near_vm_runner::report_metrics(apply_state.shard_id, "deploy");
             }
             Action::DeployGlobalContract(deploy_global_contract) => {
                 metrics::ACTION_CALLED_COUNT.deploy_global_contract.inc();
@@ -3060,6 +3061,7 @@ impl<'a> ApplyProcessingState<'a> {
             self.apply_state.cache.as_ref().map(|v| v.handle()),
             self.state_update.contract_storage().clone(),
             self.epoch_info_provider.chain_id(),
+            self.apply_state.shard_id,
         );
         ApplyProcessingReceiptState {
             pipeline_manager,
@@ -3279,6 +3281,7 @@ pub mod estimator {
             apply_state.cache.as_ref().map(|c| c.handle()),
             state_update.contract_storage().clone(),
             epoch_info_provider.chain_id(),
+            apply_state.shard_id,
         );
         let mut receipt_to_tx = Vec::new();
         let apply_result = Runtime {}.apply_action_receipt(

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -14,7 +14,7 @@ use near_primitives::config::ViewConfig;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{Receipt, ReceiptEnum};
 use near_primitives::trie_key::TrieKey;
-use near_primitives::types::{AccountId, Gas};
+use near_primitives::types::{AccountId, Gas, ShardId};
 use near_store::contract::ContractStorage;
 use near_store::trie::AccessOptions;
 use near_store::{TrieUpdate, get_pure};
@@ -69,6 +69,9 @@ pub(crate) struct ReceiptPreparationPipeline {
     storage: ContractStorage,
 
     chain_id: String,
+
+    /// Shard ID for metric labels, formatted at report time.
+    shard_id: ShardId,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -80,6 +83,7 @@ struct PrepareTaskKey {
 struct PrepareTask {
     status: Mutex<PrepareTaskStatus>,
     condvar: Condvar,
+    created: Instant,
 }
 
 enum PrepareTaskStatus {
@@ -95,6 +99,7 @@ impl ReceiptPreparationPipeline {
         contract_cache: Option<Box<dyn ContractRuntimeCache>>,
         storage: ContractStorage,
         chain_id: String,
+        shard_id: ShardId,
     ) -> Self {
         Self {
             map: Default::default(),
@@ -104,6 +109,7 @@ impl ReceiptPreparationPipeline {
             contract_cache,
             storage,
             chain_id,
+            shard_id,
         }
     }
 
@@ -207,12 +213,13 @@ impl ReceiptPreparationPipeline {
                     let config = Arc::clone(&self.config.wasm_config);
                     let cache = self.contract_cache.as_ref().map(|c| c.handle());
                     let storage = self.storage.clone();
-                    let created = Instant::now();
                     let method_name = function_call.method_name.clone();
                     let status = Mutex::new(PrepareTaskStatus::Pending);
-                    let task = Arc::new(PrepareTask { status, condvar: Condvar::new() });
+                    let created = Instant::now();
+                    let task = Arc::new(PrepareTask { status, condvar: Condvar::new(), created });
                     entry.insert(Arc::clone(&task));
                     PIPELINING_ACTIONS_SUBMITTED.inc_by(1);
+                    let shard_id = self.shard_id;
                     contract_compilation_pool().spawn_boxed(Box::new(move || {
                         let task_status = {
                             let mut status = task.status.lock();
@@ -221,7 +228,8 @@ impl ReceiptPreparationPipeline {
                         let PrepareTaskStatus::Pending = task_status else {
                             return;
                         };
-                        PIPELINING_ACTIONS_TASK_DELAY_TIME.inc_by(created.elapsed().as_secs_f64());
+                        PIPELINING_ACTIONS_TASK_DELAY_TIME
+                            .inc_by(task.created.elapsed().as_secs_f64());
                         let start = Instant::now();
                         let contract = prepare_function_call(
                             &storage,
@@ -231,6 +239,7 @@ impl ReceiptPreparationPipeline {
                             identifier,
                             &method_name,
                         );
+                        near_vm_runner::report_metrics(shard_id, "pipelining");
                         let mut status = task.status.lock();
                         *status = PrepareTaskStatus::Prepared(contract);
                         PIPELINING_ACTIONS_TASK_WORKING_TIME.inc_by(start.elapsed().as_secs_f64());
@@ -309,6 +318,7 @@ impl ReceiptPreparationPipeline {
                 identifier,
                 &function_call.method_name,
             );
+            near_vm_runner::report_metrics(self.shard_id, "pipelining");
             PIPELINING_ACTIONS_NOT_SUBMITTED.inc_by(1);
             PIPELINING_ACTIONS_MAIN_THREAD_WORKING_TIME.inc_by(start.elapsed().as_secs_f64());
             return result;
@@ -320,6 +330,7 @@ impl ReceiptPreparationPipeline {
                 PrepareTaskStatus::Pending => {
                     *status_guard = PrepareTaskStatus::Finished;
                     drop(status_guard);
+                    PIPELINING_ACTIONS_TASK_DELAY_TIME.inc_by(task.created.elapsed().as_secs_f64());
                     let start = Instant::now();
                     tracing::trace!(
                         target: "runtime::pipelining",
@@ -338,6 +349,7 @@ impl ReceiptPreparationPipeline {
                         identifier,
                         &method_name,
                     );
+                    near_vm_runner::report_metrics(self.shard_id, "pipelining");
                     PIPELINING_ACTIONS_PREPARED_IN_MAIN_THREAD.inc_by(1);
                     PIPELINING_ACTIONS_MAIN_THREAD_WORKING_TIME
                         .inc_by(start.elapsed().as_secs_f64());

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -331,6 +331,7 @@ impl TrieViewer {
             apply_state.cache.as_ref().map(|v| v.handle()),
             state_update.contract_storage().clone(),
             epoch_info_provider.chain_id(),
+            apply_state.shard_id,
         );
         let max_gas_burnt_view = self.max_gas_burnt_view(view_state.current_protocol_version);
         let view_config = Some(ViewConfig { max_gas_burnt: max_gas_burnt_view });


### PR DESCRIPTION
`report_metrics()`, which flushes vm-runner's thread-local metric accumulators to Prometheus, was only called on the function-call path. Compilation triggered by contract deployment, global contract distribution, or pipelining accumulated into thread-locals but never flushed — the data was silently lost.

Add `report_metrics()`` calls at each of these call sites, where the shard context is available, so the existing near_vm_runner_compilation_seconds histogram and cache counters capture all compilations with proper shard_id and caller context labels. The simpler approach to observe directly in the `compile_uncached()` would loose the "shard_id" information.

Also add near_vm_compiled_contract_memory_cache_hits_total to distinguish in-memory cache hits from disk hits. Disk hit rate can be derived as (total_hits - memory_hits) / (total_lookups - memory_hits).