### PR TITLE
feat(network): eliminate remaining Pool reads from NetworkState (11/n)

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1206,9 +1206,10 @@ impl PeerActor {
                 }
                 let network_state = self.network_state.clone();
                 let clock = self.clock.clone();
+                let tcp = self.tcp.clone();
                 self.handle.spawn("handle sync accounts data", async move {
                     if let Some(err) =
-                        network_state.add_accounts_data(&clock, msg.accounts_data).await
+                        network_state.add_accounts_data(&clock, msg.accounts_data, tcp).await
                     {
                         conn.stop(Some(match err {
                             AccountDataError::InvalidSignature => ReasonForBan::InvalidSignature,
@@ -1229,8 +1230,9 @@ impl PeerActor {
                     return;
                 }
                 let network_state = self.network_state.clone();
+                let tcp = self.tcp.clone();
                 self.handle.spawn("handle sync snapshot hosts", async move {
-                    if let Some(err) = network_state.add_snapshot_hosts(msg.hosts).await {
+                    if let Some(err) = network_state.add_snapshot_hosts(msg.hosts, tcp).await {
                         conn.stop(Some(match err {
                             SnapshotHostInfoError::VerificationError(
                                 SnapshotHostInfoVerificationError::InvalidSignature,

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -788,14 +788,15 @@ impl PeerActor {
                                         async move {
                                             loop {
                                                 interval.tick(&clock).await;
-                                                conn.send_message(Arc::new(
-                                                    PeerMessage::RequestUpdateNonce(PartialEdgeInfo::new(
+                                                let nonce_request = PeerMessage::RequestUpdateNonce(
+                                                    PartialEdgeInfo::new(
                                                         &network_state.config.node_id(),
                                                         &conn.peer_info.id,
                                                         Edge::create_fresh_nonce(&clock),
                                                         &network_state.config.node_key,
-                                                    )
-                                                )));
+                                                    ),
+                                                );
+                                                conn.send_message(Arc::new(nonce_request));
 
                                             }
                                         }

--- a/chain/network/src/peer_manager/connection_store/mod.rs
+++ b/chain/network/src/peer_manager/connection_store/mod.rs
@@ -1,12 +1,12 @@
 use crate::concurrency::arc_mutex::ArcMutex;
 use crate::peer::peer_actor::ClosingReason;
-use crate::peer_manager::connection;
+use crate::peer_manager::connected_peers::ConnectedPeerState;
 use crate::store;
 use crate::types::{ConnectionInfo, PeerInfo, PeerType};
 use ::time::ext::InstantExt;
 use near_async::time;
 use near_primitives::network::PeerId;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 #[cfg(test)]
 mod testonly;
@@ -113,25 +113,25 @@ impl ConnectionStore {
         return self.0.load().contains_outbound(&peer_info.id);
     }
 
-    /// Given a snapshot of the TIER2 connection pool, updates the connections in storage.
-    pub fn update(&self, clock: &time::Clock, tier2: &connection::PoolSnapshot) {
+    /// Given a snapshot of the TIER2 connected peers, updates the connections in storage.
+    pub fn update(&self, clock: &time::Clock, tier2: &HashMap<PeerId, ConnectedPeerState>) {
         let now = clock.now();
         let now_utc = clock.now_utc();
 
         // Gather information about active outbound connections which have lasted long enough
         let mut outbound = vec![];
-        for c in tier2.ready.values() {
-            if c.peer_type != PeerType::Outbound {
+        for s in tier2.values() {
+            if s.peer_type != PeerType::Outbound {
                 continue;
             }
 
-            let connected_duration: time::Duration = now.signed_duration_since(c.established_time);
+            let connected_duration: time::Duration = now.signed_duration_since(s.established_time);
             if connected_duration < STORED_CONNECTIONS_MIN_DURATION {
                 continue;
             }
 
             outbound.push(ConnectionInfo {
-                peer_info: c.peer_info.clone(),
+                peer_info: s.peer_info.clone(),
                 time_established: now_utc - connected_duration,
                 time_connected_until: now_utc,
             });

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -369,10 +369,10 @@ impl NetworkState {
         clock: &time::Clock,
         peer_id: &PeerId,
         ban_reason: ReasonForBan,
+        transport: &dyn NetworkTransport,
     ) {
-        let tier2 = self.tier2.load();
-        if let Some(peer) = tier2.ready.get(peer_id) {
-            peer.stop(Some(ban_reason));
+        if self.peers.is_connected_on_tier(peer_id, tcp::Tier::T2) {
+            transport.disconnect_peer(peer_id, Some(ban_reason));
         } else {
             if let Err(err) = self.peer_store.peer_ban(clock, peer_id, ban_reason) {
                 tracing::debug!(target: "network", ?err, "failed to save peer data");
@@ -392,10 +392,11 @@ impl NetworkState {
     }
 
     /// predicate checking whether we should allow an inbound connection from peer_info.
-    fn is_inbound_allowed(&self, peer_info: &PeerInfo) -> bool {
+    fn is_inbound_allowed(&self, peer_info: &PeerInfo, transport: &dyn NetworkTransport) -> bool {
         // Check if we have spare inbound connections capacity.
-        let tier2 = self.tier2.load();
-        if tier2.ready.len() + tier2.outbound_handshakes.len() < self.config.max_num_peers as usize
+        let t2_count = self.peers.tier2().len();
+        let pending_outbound = transport.transport_info().pending_outbound.len();
+        if t2_count + pending_outbound < self.config.max_num_peers as usize
             && !self.config.inbound_disabled
         {
             return true;
@@ -415,6 +416,7 @@ impl NetworkState {
         &self,
         info: &PeerConnectionInfo,
         edge: &Edge,
+        transport: &dyn NetworkTransport,
     ) -> Result<(), RegisterPeerError> {
         let peer_info = &info.peer_info;
         if peer_info.addr.as_ref().map_or(true, |addr| self.peer_store.is_blacklisted(addr)) {
@@ -444,11 +446,12 @@ impl NetworkState {
             }
             tcp::Tier::T2 => {
                 if info.peer_type == PeerType::Inbound {
-                    if !self.is_inbound_allowed(peer_info) {
+                    if !self.is_inbound_allowed(peer_info, transport) {
                         // TODO(1896): Gracefully drop inbound connection for other peer.
-                        let tier2 = self.tier2.load();
+                        let t2_count = self.peers.tier2().len();
+                        let pending_outbound = transport.transport_info().pending_outbound.len();
                         tracing::debug!(target: "network",
-                            tier2 = tier2.ready.len(), outgoing_peers = tier2.outbound_handshakes.len(),
+                            tier2 = t2_count, outgoing_peers = pending_outbound,
                             max_num_peers = self.config.max_num_peers,
                             "dropping handshake (network at max capacity)"
                         );
@@ -621,7 +624,7 @@ impl NetworkState {
         let clock = clock.clone();
         self.spawn("register_connection", async move {
             let info: PeerConnectionInfo = conn.as_ref().into();
-            this.validate_new_connection(&info, &edge)?;
+            this.validate_new_connection(&info, &edge, &*transport)?;
             match conn.tier {
                 tcp::Tier::T1 => this.tier1.insert_ready(conn.clone()),
                 tcp::Tier::T2 => this.tier2.insert_ready(conn.clone()),
@@ -881,19 +884,19 @@ impl NetworkState {
                     Some(data) => data,
                     None => continue,
                 };
-                let conn = match self.get_tier1_proxy(data) {
-                    Some(conn) => conn,
+                let peer_id = match self.get_tier1_proxy(data) {
+                    Some(peer_id) => peer_id,
                     None => continue,
                 };
                 // TODO(gprusak): in case of PartialEncodedChunk, consider stripping everything
                 // but the header. This will bound the message size
-                conn.send_message(Arc::new(PeerMessage::Routed(self.sign_message(
-                    clock,
-                    RawRoutedMessage {
-                        target: PeerIdOrHash::PeerId(data.peer_id.clone()),
-                        body: msg,
-                    },
-                ))));
+                let raw = RawRoutedMessage {
+                    target: PeerIdOrHash::PeerId(data.peer_id.clone()),
+                    body: msg,
+                };
+                let signed = self.sign_message(clock, raw);
+                let peer_msg = Arc::new(PeerMessage::Routed(signed));
+                transport.send_message(tcp::Tier::T1, peer_id, peer_msg);
                 return true;
             }
         }
@@ -1297,11 +1300,12 @@ impl NetworkState {
         peer_id: PeerId,
         demux: demux::Demux<Vec<Arc<SignedAccountData>>, ()>,
         data: Vec<Arc<SignedAccountData>>,
+        transport: Arc<dyn NetworkTransport>,
     ) {
         let res = demux
             .call(data, {
-                let this = self.clone();
                 let peer_id = peer_id.clone();
+                let transport = transport.clone();
                 |ds: Vec<Vec<Arc<SignedAccountData>>>| async move {
                     let res = ds.iter().map(|_| ()).collect();
                     let mut sum = HashMap::<_, Arc<SignedAccountData>>::new();
@@ -1315,7 +1319,7 @@ impl NetworkState {
                         requesting_full_sync: false,
                         accounts_data: sum.into_values().collect(),
                     }));
-                    this.tier2.send_message(peer_id, msg);
+                    transport.send_message(tcp::Tier::T2, peer_id, msg);
                     res
                 }
             })
@@ -1332,11 +1336,12 @@ impl NetworkState {
         peer_id: PeerId,
         demux: demux::Demux<Vec<Arc<SnapshotHostInfo>>, ()>,
         data: Vec<Arc<SnapshotHostInfo>>,
+        transport: Arc<dyn NetworkTransport>,
     ) {
         let res = demux
             .call(data, {
-                let this = self.clone();
                 let peer_id = peer_id.clone();
+                let transport = transport.clone();
                 |ds: Vec<Vec<Arc<SnapshotHostInfo>>>| async move {
                     let res = ds.iter().map(|_| ()).collect();
                     let mut sum = HashMap::<_, Arc<SnapshotHostInfo>>::new();
@@ -1349,7 +1354,7 @@ impl NetworkState {
                     let msg = Arc::new(PeerMessage::SyncSnapshotHosts(SyncSnapshotHosts {
                         hosts: sum.into_values().collect(),
                     }));
-                    this.tier2.send_message(peer_id, msg);
+                    transport.send_message(tcp::Tier::T2, peer_id, msg);
                     res
                 }
             })
@@ -1363,6 +1368,7 @@ impl NetworkState {
         self: &Arc<Self>,
         clock: &time::Clock,
         accounts_data: Vec<Arc<SignedAccountData>>,
+        transport: Arc<dyn NetworkTransport>,
     ) -> Option<AccountDataError> {
         let this = self.clone();
         let clock = clock.clone();
@@ -1387,7 +1393,12 @@ impl NetworkState {
                 .map(|(peer_id, demux)| {
                     this.spawn(
                         "send_accounts_data",
-                        this.clone().gossip_accounts_data_to_peer(peer_id, demux, new_data.clone()),
+                        this.clone().gossip_accounts_data_to_peer(
+                            peer_id,
+                            demux,
+                            new_data.clone(),
+                            transport.clone(),
+                        ),
                     )
                 })
                 .collect();
@@ -1403,6 +1414,7 @@ impl NetworkState {
     pub async fn add_snapshot_hosts(
         self: &Arc<Self>,
         hosts: Vec<Arc<SnapshotHostInfo>>,
+        transport: Arc<dyn NetworkTransport>,
     ) -> Option<SnapshotHostInfoError> {
         let this = self.clone();
         self.spawn("add_snapshot_hosts", async move {
@@ -1428,6 +1440,7 @@ impl NetworkState {
                             peer_id,
                             demux,
                             new_data.clone(),
+                            transport.clone(),
                         ),
                     )
                 })
@@ -1455,38 +1468,43 @@ impl NetworkState {
         let clock = clock.clone();
         self.spawn("fix_local_edges", async move {
             let graph = this.graph.load();
-            let tier2 = this.tier2.load();
+            let tier2 = this.peers.tier2();
             let mut tasks = vec![];
             for edge in graph.local_edges.values() {
                 let edge = edge.clone();
                 let node_id = this.config.node_id();
                 let other_peer = edge.other(&node_id).unwrap();
-                match (tier2.ready.get(other_peer), edge.edge_type()) {
+                match (tier2.contains_key(other_peer), edge.edge_type()) {
                     // This is an active connection, while the edge indicates it shouldn't.
-                    (Some(conn), EdgeState::Removed) => {
+                    (true, EdgeState::Removed) => {
                         tasks.push(this.spawn("fix_local_edges", {
                             let this = this.clone();
-                            let conn = conn.clone();
+                            let other_peer = other_peer.clone();
                             let clock = clock.clone();
+                            let transport = transport.clone();
                             async move {
-                                conn.send_message(Arc::new(PeerMessage::RequestUpdateNonce(
-                                    PartialEdgeInfo::new(
-                                        &node_id,
-                                        &conn.peer_info.id,
-                                        std::cmp::max(
-                                            Edge::create_fresh_nonce(&clock),
-                                            edge.next(),
+                                transport.send_message(
+                                    tcp::Tier::T2,
+                                    other_peer.clone(),
+                                    Arc::new(PeerMessage::RequestUpdateNonce(
+                                        PartialEdgeInfo::new(
+                                            &node_id,
+                                            &other_peer,
+                                            std::cmp::max(
+                                                Edge::create_fresh_nonce(&clock),
+                                                edge.next(),
+                                            ),
+                                            &this.config.node_key,
                                         ),
-                                        &this.config.node_key,
-                                    ),
-                                )));
+                                    )),
+                                );
                                 // TODO(gprusak): here we should synchronically wait for the RequestUpdateNonce
                                 // response (with timeout). Until network round trips are implemented, we just
                                 // blindly wait for a while, then check again.
                                 clock.sleep(timeout).await;
-                                match this.graph.load().local_edges.get(&conn.peer_info.id) {
+                                match this.graph.load().local_edges.get(&other_peer) {
                                     Some(edge) if edge.edge_type() == EdgeState::Active => return,
-                                    _ => conn.stop(None),
+                                    _ => transport.disconnect_peer(&other_peer, None),
                                 }
                             }
                         }))
@@ -1494,7 +1512,7 @@ impl NetworkState {
                     // We are not connected to this peer, but routing table contains
                     // information that we do. We should wait and remove that peer
                     // from routing table
-                    (None, EdgeState::Active) => tasks.push(this.spawn("fix_local_edges", {
+                    (false, EdgeState::Active) => tasks.push(this.spawn("fix_local_edges", {
                         let this = this.clone();
                         let clock = clock.clone();
                         let other_peer = other_peer.clone();
@@ -1503,7 +1521,7 @@ impl NetworkState {
                             // This edge says this is an connected peer, which is currently not in the set of connected peers.
                             // Wait for some time to let the connection begin or broadcast edge removal instead.
                             clock.sleep(timeout).await;
-                            if this.tier2.load().ready.contains_key(&other_peer) {
+                            if this.peers.is_connected_on_tier(&other_peer, tcp::Tier::T2) {
                                 return;
                             }
                             // Peer is still not connected after waiting a timeout.
@@ -1532,7 +1550,7 @@ impl NetworkState {
     }
 
     pub fn update_connection_store(self: &Arc<Self>, clock: &time::Clock) {
-        self.connection_store.update(clock, &self.tier2.load());
+        self.connection_store.update(clock, &self.peers.tier2());
     }
 
     /// Clears pending_reconnect and returns the cleared values
@@ -1545,12 +1563,16 @@ impl NetworkState {
 
     /// Collects and returns PeerInfos for all directly connected TIER2 peers.
     pub fn get_direct_peers(self: &Arc<Self>) -> Vec<PeerInfo> {
-        return self.tier2.load().ready.values().map(|c| c.peer_info.clone()).collect();
+        self.peers.tier2().into_values().map(|s| s.peer_info).collect()
     }
 
     /// Sets the chain info, and updates the set of TIER1 keys.
     /// Returns true iff the set of TIER1 keys has changed.
-    pub fn set_chain_info(self: &Arc<Self>, info: ChainInfo) -> bool {
+    pub fn set_chain_info(
+        self: &Arc<Self>,
+        info: ChainInfo,
+        transport: &dyn NetworkTransport,
+    ) -> bool {
         let _mutex = self.set_chain_info_mutex.lock();
 
         // We set state.chain_info and call accounts_data.set_keys
@@ -1562,7 +1584,7 @@ impl NetworkState {
         // accounts_data that our peers know about.
         let has_changed = self.accounts_data.set_keys(info.tier1_accounts);
         if has_changed {
-            self.tier1_request_full_sync();
+            self.tier1_request_full_sync(transport);
         }
         has_changed
     }

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -3,7 +3,6 @@ use crate::config::{self, FrozenValidatorConfig};
 use crate::network_protocol::{
     AccountData, PeerAddr, PeerInfo, PeerMessage, SignedAccountData, SyncAccountsData,
 };
-use crate::peer_manager::connection;
 use crate::peer_manager::network_transport::NetworkTransport;
 use crate::stun;
 use crate::tcp;
@@ -41,12 +40,12 @@ impl super::NetworkState {
         transport: &dyn NetworkTransport,
         proxies: &[PeerAddr],
     ) {
-        let tier1 = self.tier1.load();
+        let tier1 = self.peers.tier1();
         // Try to connect to all proxies in parallel.
         let mut handles = vec![];
         for proxy in proxies {
             // Skip the proxies we are already connected to.
-            if tier1.ready.contains_key(&proxy.peer_id) {
+            if tier1.contains_key(&proxy.peer_id) {
                 continue;
             }
             let peer_info =
@@ -64,8 +63,8 @@ impl super::NetworkState {
     /// Requests direct peers for accounts data full sync.
     /// Should be called whenever the accounts_data.keys changes, and
     /// periodically just in case.
-    pub fn tier1_request_full_sync(&self) {
-        self.tier2.broadcast_message(Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
+    pub fn tier1_request_full_sync(&self, transport: &dyn NetworkTransport) {
+        transport.broadcast_message(Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
             incremental: true,
             requesting_full_sync: true,
             accounts_data: vec![],
@@ -137,16 +136,16 @@ impl super::NetworkState {
         self.tier1_connect_to_my_proxies(clock, transport, &proxies).await;
 
         // Snapshot tier1 connections again before broadcasting.
-        let tier1 = self.tier1.load();
+        let tier1 = self.peers.tier1();
 
         let my_proxies = match &vc.proxies {
             // In case of dynamic configuration, only the node itself can be its proxy,
             // so we look for a loop connection which would prove our node's address.
-            config::ValidatorProxies::Dynamic(_) => match tier1.ready.get(&self.config.node_id()) {
-                Some(conn) => {
-                    log_assert!(PeerType::Outbound == conn.peer_type);
-                    log_assert!(conn.peer_info.addr.is_some());
-                    match conn.peer_info.addr {
+            config::ValidatorProxies::Dynamic(_) => match tier1.get(&self.config.node_id()) {
+                Some(s) => {
+                    log_assert!(PeerType::Outbound == s.peer_type);
+                    log_assert!(s.peer_info.addr.is_some());
+                    match s.peer_info.addr {
                         Some(addr) => vec![PeerAddr { peer_id: self.config.node_id(), addr }],
                         None => vec![],
                     }
@@ -157,7 +156,7 @@ impl super::NetworkState {
             config::ValidatorProxies::Static(proxies) => {
                 let mut connected_proxies = vec![];
                 for proxy in proxies {
-                    match tier1.ready.get(&proxy.peer_id) {
+                    match tier1.get(&proxy.peer_id) {
                         // Here we compare the address from the config with the
                         // address of the connection (which is the IP, to which the
                         // TCP socket is connected + port indicated by the peer).
@@ -171,11 +170,11 @@ impl super::NetworkState {
                         // pools, so that both endpoints can keep a connection
                         // to the IP that they prefer. This is a corner case which can happen
                         // only if 2 TIER1 validators are proxies for some other validator.
-                        Some(conn) if conn.peer_info.addr == Some(proxy.addr) => {
+                        Some(s) if s.peer_info.addr == Some(proxy.addr) => {
                             connected_proxies.push(proxy.clone());
                         }
-                        Some(conn) => {
-                            tracing::info!(target: "network", peer_id = %conn.peer_info.id, peer_addr = ?conn.peer_info.addr, wanted_addr = %proxy.addr, "connected to peer, but got different addr")
+                        Some(s) => {
+                            tracing::info!(target: "network", peer_id = %s.peer_info.id, peer_addr = ?s.peer_info.addr, wanted_addr = %proxy.addr, "connected to peer, but got different addr")
                         }
                         _ => {}
                     }
@@ -194,7 +193,7 @@ impl super::NetworkState {
         // Early exit in case this node is not a TIER1 node any more.
         let new_data = new_data?;
         // Advertise the new_data.
-        self.tier2.broadcast_message(Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
+        transport.broadcast_message(Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
             incremental: true,
             requesting_full_sync: false,
             accounts_data: vec![new_data.clone()],
@@ -226,9 +225,9 @@ impl super::NetworkState {
         }
 
         // Browse the connections from newest to oldest.
-        let tier1 = self.tier1.load();
-        let mut ready: Vec<_> = tier1.ready.values().collect();
-        ready.sort_unstable_by_key(|c| c.established_time);
+        let tier1 = self.peers.tier1();
+        let mut ready: Vec<(&PeerId, &super::ConnectedPeerState)> = tier1.iter().collect();
+        ready.sort_unstable_by_key(|(_, s)| s.established_time);
         ready.reverse();
 
         // Select the oldest TIER1 connection for each account.
@@ -238,19 +237,20 @@ impl super::NetworkState {
             // TIER1 nodes can establish outbound connections to other TIER1 nodes and TIER1 proxies.
             // TIER1 nodes can also accept inbound connections from TIER1 nodes.
             Some(_) => {
-                for conn in &ready {
-                    if conn.peer_type != PeerType::Outbound {
+                for (peer_id, s) in &ready {
+                    if s.peer_type != PeerType::Outbound {
                         continue;
                     }
-                    let peer_id = &conn.peer_info.id;
-                    for key in accounts_by_proxy.get(peer_id).into_iter().flatten() {
-                        safe.insert(key, peer_id);
+                    for key in accounts_by_proxy.get(*peer_id).into_iter().flatten() {
+                        safe.insert(key, *peer_id);
                     }
                 }
                 // Direct TIER1 connections have priority over proxy connections.
                 for key in &accounts_data.keys {
-                    if let Some(conn) = tier1.ready_by_account_key.get(&key) {
-                        safe.insert(key, &conn.peer_info.id);
+                    if let Some(peer_id) = self.peers.tier1_peer_for_account(key) {
+                        if let Some((t1_peer_id, _)) = tier1.get_key_value(&peer_id) {
+                            safe.insert(key, t1_peer_id);
+                        }
                     }
                 }
             }
@@ -258,9 +258,11 @@ impl super::NetworkState {
             // (to act as a TIER1 proxy).
             None => {
                 for key in &accounts_data.keys {
-                    if let Some(conn) = tier1.ready_by_account_key.get(&key) {
-                        if conn.peer_type == PeerType::Inbound {
-                            safe.insert(key, &conn.peer_info.id);
+                    if let Some(peer_id) = self.peers.tier1_peer_for_account(key) {
+                        if let Some((t1_peer_id, s)) = tier1.get_key_value(&peer_id) {
+                            if s.peer_type == PeerType::Inbound {
+                                safe.insert(key, t1_peer_id);
+                            }
                         }
                     }
                 }
@@ -284,9 +286,9 @@ impl super::NetworkState {
             }
         }
         // Close all other connections, as they are redundant or are no longer TIER1.
-        for conn in tier1.ready.values() {
-            if !safe_set.contains(&conn.peer_info.id) {
-                conn.stop(None);
+        for peer_id in tier1.keys() {
+            if !safe_set.contains(peer_id) {
+                transport.disconnect_peer(peer_id, None);
             }
         }
         if let Some(vc) = validator_cfg {
@@ -339,42 +341,42 @@ impl super::NetworkState {
         }
     }
 
-    /// Finds a TIER1 connection for the given SignedAccountData.
+    /// Finds a TIER1 peer for the given SignedAccountData. Returns the
+    /// `PeerId` of either a direct T1 connection (preferred) or a T1
+    /// proxy of the account. Callers use the returned `PeerId` with
+    /// `transport.send_message(T1, peer_id, msg)`.
     /// It is expected to perform <10 lookups total on average,
     /// so the call latency should be negligible wrt sending a TCP packet.
-    // TODO(gprusak): If not, consider precomputing the AccountKey -> Connection mapping.
-    pub fn get_tier1_proxy(&self, data: &SignedAccountData) -> Option<Arc<connection::Connection>> {
-        let tier1 = self.tier1.load();
+    // TODO(gprusak): If not, consider precomputing the AccountKey -> PeerId mapping.
+    pub fn get_tier1_proxy(&self, data: &SignedAccountData) -> Option<PeerId> {
         // Prefer direct connections.
-        if let Some(conn) = tier1.ready_by_account_key.get(&data.account_key) {
-            return Some(conn.clone());
+        if let Some(peer_id) = self.peers.tier1_peer_for_account(&data.account_key) {
+            return Some(peer_id);
         }
         // In case there is no direct connection and our node is a TIER1 validator, use a proxy.
         // TODO(gprusak): add a check that our node is actually a TIER1 validator.
+        let tier1 = self.peers.tier1();
         for proxy in &data.proxies {
-            if let Some(conn) = tier1.ready.get(&proxy.peer_id) {
-                return Some(conn.clone());
+            if tier1.contains_key(&proxy.peer_id) {
+                return Some(proxy.peer_id.clone());
             }
         }
         None
     }
 
-    /// Finds a TIER1 connection for the given AccountId. Currently used only for OptimisticBlock,
+    /// Finds a TIER1 peer for the given AccountId. Currently used only for OptimisticBlock,
     /// which is implemented as a PeerMessage but has targets identified by AccountId.
     /// TODO(saketh): consider simplifying things by changing the message type of OptimisticBlock.
-    pub fn get_tier1_proxy_for_account_id(
-        &self,
-        account_id: &AccountId,
-    ) -> Option<Arc<connection::Connection>> {
+    pub fn get_tier1_proxy_for_account_id(&self, account_id: &AccountId) -> Option<PeerId> {
         let accounts_data = self.accounts_data.load();
         for key in accounts_data.keys_by_id.get(account_id).iter().flat_map(|keys| keys.iter()) {
             let Some(data) = accounts_data.data.get(key) else {
                 continue;
             };
-            let Some(conn) = self.get_tier1_proxy(data) else {
+            let Some(peer_id) = self.get_tier1_proxy(data) else {
                 continue;
             };
-            return Some(conn);
+            return Some(peer_id);
         }
         None
     }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -211,7 +211,7 @@ impl messaging::Actor for PeerManagerActor {
             async move {
                 loop {
                     interval.tick(&clock).await;
-                    state.tier1_request_full_sync();
+                    state.tier1_request_full_sync(transport.as_ref());
                     state.tier1_advertise_proxies(&clock, transport.as_ref()).await;
                 }
             }
@@ -851,8 +851,10 @@ impl PeerManagerActor {
                 // a conversion here from AccountId to peer connection. Consider reworking this.
                 let msg = Arc::new(PeerMessage::OptimisticBlock(optimistic_block));
                 for target_account in &*chunk_producers {
-                    if let Some(conn) = self.state.get_tier1_proxy_for_account_id(&target_account) {
-                        conn.send_message(msg.clone());
+                    if let Some(peer_id) =
+                        self.state.get_tier1_proxy_for_account_id(&target_account)
+                    {
+                        self.transport.send_message(tcp::Tier::T1, peer_id, msg.clone());
                     }
                 }
                 NetworkResponses::NoResponse
@@ -1085,7 +1087,7 @@ impl PeerManagerActor {
                 NetworkResponses::NoResponse
             }
             NetworkRequests::BanPeer { peer_id, ban_reason } => {
-                self.state.disconnect_and_ban(&self.clock, &peer_id, ban_reason);
+                self.state.disconnect_and_ban(&self.clock, &peer_id, ban_reason, &*self.transport);
                 NetworkResponses::NoResponse
             }
             NetworkRequests::AnnounceAccount(announce_account) => {
@@ -1466,7 +1468,7 @@ impl messaging::Handler<SetChainInfo> for PeerManagerActor {
         // synchronously, therefore, assuming actor in-order delivery,
         // there will be no race condition between subsequent SetChainInfo
         // calls.
-        if !self.state.set_chain_info(info) {
+        if !self.state.set_chain_info(info, &*self.transport) {
             // We early exit in case the set of TIER1 account keys hasn't changed.
             return;
         }
@@ -1613,12 +1615,10 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                 let already_connected_t3 =
                     state.peers.is_connected_on_tier(&sender, tcp::Tier::T3);
                 if !already_connected_t3 {
-                    let result = transport
+                    if let Err(err) = transport
                         .connect_to_peer(&clock, request.peer_info.clone(), tcp::Tier::T3)
                         .await
-                        .map_err(|err| anyhow::anyhow!("connect_to_peer: {err:?}"));
-
-                    if let Err(ref err) = result {
+                    {
                         tracing::debug!(target: "network", ?err, peer_info = %request.peer_info, "tier3 failed to connect");
                     }
                 }

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -379,7 +379,10 @@ impl ActorHandler {
     }
 
     pub async fn set_chain_info(&self, chain_info: ChainInfo) -> bool {
-        self.with_state(move |s| async move { s.set_chain_info(chain_info) }).await
+        self.with_state_and_transport(move |s, transport| async move {
+            s.set_chain_info(chain_info, transport.as_ref())
+        })
+        .await
     }
 
     pub async fn tier1_advertise_proxies(
@@ -422,8 +425,10 @@ impl ActorHandler {
         // TODO(gprusak): figure out how to await for both ends to disconnect.
         let clock = clock.clone();
         let peer_id = peer_id.clone();
-        self.with_state(move |s| async move { s.disconnect_and_ban(&clock, &peer_id, reason) })
-            .await
+        self.with_state_and_transport(move |s, transport| async move {
+            s.disconnect_and_ban(&clock, &peer_id, reason, transport.as_ref())
+        })
+        .await
     }
 
     pub async fn peer_store_update(&self, clock: &time::Clock) {


### PR DESCRIPTION
After this PR, NetworkState has zero Pool reads — only register/unregister writes remain (moved in PR 12).

- `disconnect_and_ban` → `transport.disconnect_peer` + `peers.is_connected_on_tier`
- `validate_new_connection` T2 capacity → `peers.tier2().len()` + `transport_info().pending_outbound.len()`
- `fix_local_edges` → iterates `peers.tier2()`, uses `transport.send_message`/`disconnect_peer`
- `update_connection_store` → accepts `&HashMap<PeerId, ConnectedPeerState>`
- `get_direct_peers` → `peers.tier2()`
- T1 message sends → `transport.send_message(T1, ...)`