### PR TITLE
fix(network): reject unsolicited inbound Tier3 connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4827,6 +4827,7 @@ dependencies = [
  "bytes",
  "bytesize 1.1.0",
  "criterion",
+ "dashmap",
  "enum-map",
  "futures",
  "futures-util",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -21,6 +21,7 @@ arc-swap.workspace = true
 borsh.workspace = true
 bytes.workspace = true
 bytesize.workspace = true
+dashmap.workspace = true
 enum-map.workspace = true
 futures-util.workspace = true
 futures.workspace = true

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1170,8 +1170,9 @@ impl PeerActor {
             PeerMessage::Tier1Handshake(_)
             | PeerMessage::Tier2Handshake(_)
             | PeerMessage::Tier3Handshake(_) => {
-                // Received handshake after already have seen handshake from this peer.
-                tracing::debug!(target: "network", peer_info = %self.peer_info, "duplicate handshake");
+                // Handshakes should not appear after the session is established.
+                tracing::debug!(target: "network", peer_info = %self.peer_info, "duplicate handshake, closing");
+                self.stop(ClosingReason::DisallowedMessage);
             }
             PeerMessage::PeersRequest(PeersRequest { max_peers, max_direct_peers }) => {
                 let mut num_peers = self.network_state.config.max_send_peers;
@@ -1672,7 +1673,18 @@ impl messaging::Handler<stream::Frame> for PeerActor {
                         tracing::warn!(target: "network", %peer_msg, peer_type = ?this.peer_type, "received message from closing connection, ignoring");
                         return;
                     }
-                    conn.last_time_received_message.store(now);
+                    // Do not refresh the liveness timestamp for handshake messages.
+                    // A duplicate handshake on an established connection is
+                    // semantically meaningless; refreshing the timestamp would let
+                    // a remote peer keep idle Tier3 connections alive indefinitely.
+                    if !matches!(
+                        peer_msg,
+                        PeerMessage::Tier1Handshake(_)
+                            | PeerMessage::Tier2Handshake(_)
+                            | PeerMessage::Tier3Handshake(_)
+                    ) {
+                        conn.last_time_received_message.store(now);
+                    }
                     // Check if the message type is allowed given the TIER of the connection:
                     // TIER1 connections are reserved exclusively for BFT consensus messages.
                     if !conn.tier.is_allowed_receive(&peer_msg) {

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1673,16 +1673,7 @@ impl messaging::Handler<stream::Frame> for PeerActor {
                         tracing::warn!(target: "network", %peer_msg, peer_type = ?this.peer_type, "received message from closing connection, ignoring");
                         return;
                     }
-                    // Do not refresh the liveness timestamp for handshake
-                    // messages on Tier3 connections. A duplicate handshake is
-                    // semantically meaningless; refreshing the timestamp would
-                    // let a remote peer keep idle Tier3 connections alive
-                    // indefinitely by resetting the 15-second idle timeout.
-                    if !(conn.tier == tcp::Tier::T3
-                        && matches!(peer_msg, PeerMessage::Tier3Handshake(_)))
-                    {
-                        conn.last_time_received_message.store(now);
-                    }
+                    conn.last_time_received_message.store(now);
                     // Check if the message type is allowed given the TIER of the connection:
                     // TIER1 connections are reserved exclusively for BFT consensus messages.
                     if !conn.tier.is_allowed_receive(&peer_msg) {

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1673,16 +1673,14 @@ impl messaging::Handler<stream::Frame> for PeerActor {
                         tracing::warn!(target: "network", %peer_msg, peer_type = ?this.peer_type, "received message from closing connection, ignoring");
                         return;
                     }
-                    // Do not refresh the liveness timestamp for handshake messages.
-                    // A duplicate handshake on an established connection is
-                    // semantically meaningless; refreshing the timestamp would let
-                    // a remote peer keep idle Tier3 connections alive indefinitely.
-                    if !matches!(
-                        peer_msg,
-                        PeerMessage::Tier1Handshake(_)
-                            | PeerMessage::Tier2Handshake(_)
-                            | PeerMessage::Tier3Handshake(_)
-                    ) {
+                    // Do not refresh the liveness timestamp for handshake
+                    // messages on Tier3 connections. A duplicate handshake is
+                    // semantically meaningless; refreshing the timestamp would
+                    // let a remote peer keep idle Tier3 connections alive
+                    // indefinitely by resetting the 15-second idle timeout.
+                    if !(conn.tier == tcp::Tier::T3
+                        && matches!(peer_msg, PeerMessage::Tier3Handshake(_)))
+                    {
                         conn.last_time_received_message.store(now);
                     }
                     // Check if the message type is allowed given the TIER of the connection:

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -397,8 +397,11 @@ impl NetworkState {
                 tcp::Tier::T3 => {
                     if conn.peer_type == PeerType::Inbound {
                         // Reject inbound Tier3 connections that don't correspond to a
-                        // state sync request we sent.
-                        if this.pending_tier3_requests.remove(&peer_info.id).is_none() {
+                        // state sync request we sent. We check without removing so that
+                        // the entry remains valid for the full timeout window — the peer
+                        // may need to open additional T3 connections (e.g. if the first
+                        // was idle-closed before a later response is ready).
+                        if !this.pending_tier3_requests.contains_key(&peer_info.id) {
                             return Err(RegisterPeerError::UnexpectedTier3Connection);
                         }
                     }

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -41,6 +41,7 @@ use crate::types::{
 };
 use anyhow::Context;
 use arc_swap::ArcSwap;
+use dashmap::DashMap;
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{CanSend, CanSendAsync, Sender};
 use near_async::{ActorSystem, new_owned_future_spawner, time};
@@ -74,6 +75,11 @@ pub const PRUNE_EDGES_AFTER: time::Duration = time::Duration::minutes(30);
 
 /// How long to wait between reconnection attempts to the same peer
 pub(crate) const RECONNECT_ATTEMPT_INTERVAL: time::Duration = time::Duration::seconds(10);
+
+/// How long a pending Tier3 request remains valid. After sending a state sync request over
+/// Tier2, we expect the peer to open an inbound Tier3 connection within this window. Entries
+/// older than this are cleaned up periodically.
+pub(crate) const PENDING_TIER3_REQUEST_TIMEOUT: time::Duration = time::Duration::seconds(60);
 
 impl WhitelistNode {
     pub fn from_peer_info(pi: &PeerInfo) -> anyhow::Result<Self> {
@@ -152,6 +158,11 @@ pub(crate) struct NetworkState {
     /// Shared counter across all PeerActors, which counts number of `RoutedMessageBody::ForwardTx`
     /// messages since last block.
     pub txns_since_last_block: AtomicUsize,
+
+    /// Peers from which we expect an inbound Tier3 connection, because we sent them a state
+    /// sync request over Tier2. Maps peer_id to the time the request was sent. Entries are
+    /// cleaned up after PENDING_TIER3_REQUEST_TIMEOUT.
+    pub pending_tier3_requests: DashMap<PeerId, time::Instant>,
 
     /// Whitelisted nodes, which are allowed to connect even if the connection limit has been
     /// reached.
@@ -233,6 +244,7 @@ impl NetworkState {
                 NonZeroUsize::new(RECENT_ROUTED_MESSAGES_CACHE_SIZE).unwrap(),
             )),
             txns_since_last_block: AtomicUsize::new(0),
+            pending_tier3_requests: DashMap::new(),
             whitelist_nodes,
             add_edges_demux: demux::Demux::new(
                 config.routing_table_update_rate_limit,
@@ -384,10 +396,11 @@ impl NetworkState {
                 }
                 tcp::Tier::T3 => {
                     if conn.peer_type == PeerType::Inbound {
-                        // TODO(saketh): When a peer initiates a TIER3 connection it should be
-                        // responding to a request sent previously by the local node. If we
-                        // maintain some state about pending requests it would be possible to add
-                        // an additional layer of security here and reject unexpected connections.
+                        // Reject inbound Tier3 connections that don't correspond to a
+                        // state sync request we sent.
+                        if this.pending_tier3_requests.remove(&peer_info.id).is_none() {
+                            return Err(RegisterPeerError::UnexpectedTier3Connection);
+                        }
                     }
                     if !edge.verify() {
                         return Err(RegisterPeerError::InvalidEdge);

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -395,18 +395,21 @@ impl NetworkState {
                     this.peer_store.peer_connected(&clock, peer_info);
                 }
                 tcp::Tier::T3 => {
+                    if !edge.verify() {
+                        return Err(RegisterPeerError::InvalidEdge);
+                    }
                     if conn.peer_type == PeerType::Inbound {
                         // Reject inbound Tier3 connections that don't correspond to a
                         // state sync request we sent. We check without removing so that
                         // the entry remains valid for the full timeout window — the peer
                         // may need to open additional T3 connections (e.g. if the first
                         // was idle-closed before a later response is ready).
+                        //
+                        // Edge verification is done first so that a spoofed peer_id with
+                        // an invalid edge cannot influence the pending-request lookup.
                         if !this.pending_tier3_requests.contains_key(&peer_info.id) {
                             return Err(RegisterPeerError::UnexpectedTier3Connection);
                         }
-                    }
-                    if !edge.verify() {
-                        return Err(RegisterPeerError::InvalidEdge);
                     }
                     this.tier3.insert_ready(conn).map_err(RegisterPeerError::PoolError)?;
                 }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -12,7 +12,9 @@ use crate::network_protocol::{
 use crate::network_protocol::{SyncSnapshotHosts, T1MessageBody};
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::connection;
-use crate::peer_manager::network_state::{NetworkState, WhitelistNode};
+use crate::peer_manager::network_state::{
+    NetworkState, PENDING_TIER3_REQUEST_TIMEOUT, WhitelistNode,
+};
 use crate::peer_manager::peer_store;
 use crate::shards_manager::ShardsManagerRequestFromNetwork;
 use crate::spice_data_distribution::SpiceDataDistributorSenderForNetwork;
@@ -604,6 +606,12 @@ impl PeerManagerActor {
             .values()
             .filter(|p| now - p.last_time_received_message.load() > TIER3_IDLE_TIMEOUT)
             .for_each(|p| p.stop(None));
+        // Clean up stale pending Tier3 request entries for peers that never connected back.
+        // retain() does a full scan of the map, but this is fine: the map is bounded by the
+        // number of in-flight state sync requests (typically tens at most).
+        self.state
+            .pending_tier3_requests
+            .retain(|_, sent_at| now - *sent_at <= PENDING_TIER3_REQUEST_TIMEOUT);
     }
 
     /// Periodically monitor list of peers and:
@@ -876,6 +884,8 @@ impl PeerManagerActor {
                     return NetworkResponses::RouteNotFound;
                 }
 
+                // Record that we expect an inbound Tier3 connection from this peer.
+                self.state.pending_tier3_requests.insert(peer_id.clone(), self.clock.now());
                 tracing::debug!(target: "network", %shard_id, ?sync_hash, %peer_id, "requesting state header from host");
                 NetworkResponses::SelectedDestination(peer_id)
             }
@@ -920,6 +930,8 @@ impl PeerManagerActor {
                     return NetworkResponses::RouteNotFound;
                 }
 
+                // Record that we expect an inbound Tier3 connection from this peer.
+                self.state.pending_tier3_requests.insert(peer_id.clone(), self.clock.now());
                 tracing::debug!(target: "network", %shard_id, ?sync_hash, ?part_id, %peer_id, "requesting state part from host");
                 NetworkResponses::SelectedDestination(peer_id)
             }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -880,12 +880,11 @@ impl PeerManagerActor {
                     },
                 );
 
+                self.state.pending_tier3_requests.insert(peer_id.clone(), self.clock.now());
                 if !self.state.send_message_to_peer(&self.clock, tcp::Tier::T2, routed_message) {
+                    self.state.pending_tier3_requests.remove(&peer_id);
                     return NetworkResponses::RouteNotFound;
                 }
-
-                // Record that we expect an inbound Tier3 connection from this peer.
-                self.state.pending_tier3_requests.insert(peer_id.clone(), self.clock.now());
                 tracing::debug!(target: "network", %shard_id, ?sync_hash, %peer_id, "requesting state header from host");
                 NetworkResponses::SelectedDestination(peer_id)
             }
@@ -926,12 +925,11 @@ impl PeerManagerActor {
                     },
                 );
 
+                self.state.pending_tier3_requests.insert(peer_id.clone(), self.clock.now());
                 if !self.state.send_message_to_peer(&self.clock, tcp::Tier::T2, routed_message) {
+                    self.state.pending_tier3_requests.remove(&peer_id);
                     return NetworkResponses::RouteNotFound;
                 }
-
-                // Record that we expect an inbound Tier3 connection from this peer.
-                self.state.pending_tier3_requests.insert(peer_id.clone(), self.clock.now());
                 tracing::debug!(target: "network", %shard_id, ?sync_hash, ?part_id, %peer_id, "requesting state part from host");
                 NetworkResponses::SelectedDestination(peer_id)
             }

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -18,9 +18,6 @@ use near_primitives::version::PROTOCOL_VERSION;
 use std::sync::Arc;
 
 // Verify that unsolicited inbound Tier3 connections are rejected.
-// An attacker could open Tier3 connections without a prior state sync request,
-// consuming sockets and actor resources. The fix rejects inbound Tier3 connections
-// unless the local node has a pending state sync request for that peer.
 #[tokio::test]
 async fn unsolicited_tier3_rejected() {
     init_test_logger();
@@ -40,7 +37,6 @@ async fn unsolicited_tier3_rejected() {
     let cfg = chain.make_config(rng);
 
     // Attempt an inbound Tier3 connection without any prior state sync request.
-    // This simulates the attack: a remote peer opens a Tier3 connection we never asked for.
     let stream = tcp::Stream::connect(&pm.peer_info(), tcp::Tier::T3, &SocketOptions::default())
         .await
         .unwrap();
@@ -144,9 +140,7 @@ async fn expected_tier3_accepted() {
         .await;
 }
 
-// A peer with a legitimate Tier3 connection could send duplicate handshakes just
-// before the idle timeout to keep the connection alive indefinitely. Verify that
-// duplicate handshakes on established sessions close the connection immediately,
+// Verify that duplicate handshakes on established sessions close the connection immediately,
 // so the keepalive attempt itself terminates the session.
 #[tokio::test]
 async fn duplicate_handshake_closes_tier3() {
@@ -167,7 +161,7 @@ async fn duplicate_handshake_closes_tier3() {
     let cfg = chain.make_config(rng);
     let peer_id = cfg.node_id();
 
-    // Step 1: Establish a legitimate T3 connection (we "sent" a state request).
+    // establish a legitimate T3 connection (we "sent" a state request).
     let now = clock.clock().now();
     pm.with_state(move |s| async move {
         s.pending_tier3_requests.insert(peer_id, now);
@@ -207,13 +201,11 @@ async fn duplicate_handshake_closes_tier3() {
         })
         .await;
 
-    // Step 2: The attacker's keepalive — send a duplicate handshake just before
-    // the 15-second idle timeout would close the connection.
+    // a duplicate handshake just before the 15-second idle timeout would close the connection
     clock.advance(time::Duration::seconds(14));
     stream.write(&PeerMessage::Tier3Handshake(handshake)).await;
 
-    // Step 3: The connection should be closed because duplicate handshakes on
-    // established sessions are no longer tolerated.
+    // the connection should be closed because duplicate handshakes are not tolerated
     let reason = events
         .recv_until(|ev| match ev {
             Event::ConnectionClosed(ev) if ev.stream_id == stream_id => Some(ev.reason),

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -17,6 +17,212 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::version::PROTOCOL_VERSION;
 use std::sync::Arc;
 
+// Verify that unsolicited inbound Tier3 connections are rejected.
+// An attacker could open Tier3 connections without a prior state sync request,
+// consuming sockets and actor resources. The fix rejects inbound Tier3 connections
+// unless the local node has a pending state sync request for that peer.
+#[tokio::test]
+async fn unsolicited_tier3_rejected() {
+    init_test_logger();
+    let mut rng = make_rng(921853233);
+    let rng = &mut rng;
+    let mut clock = time::FakeClock::default();
+    let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
+
+    let pm = peer_manager::testonly::start(
+        clock.clock(),
+        near_store::db::TestDB::new(),
+        chain.make_config(rng),
+        chain.clone(),
+    )
+    .await;
+
+    let cfg = chain.make_config(rng);
+
+    // Attempt an inbound Tier3 connection without any prior state sync request.
+    // This simulates the attack: a remote peer opens a Tier3 connection we never asked for.
+    let stream = tcp::Stream::connect(&pm.peer_info(), tcp::Tier::T3, &SocketOptions::default())
+        .await
+        .unwrap();
+    let stream_id = stream.id();
+    let port = stream.local_addr.port();
+    let mut events = pm.events.from_now();
+    let mut stream = Stream::new(stream);
+    stream
+        .write(&PeerMessage::Tier3Handshake(Handshake {
+            protocol_version: PROTOCOL_VERSION,
+            oldest_supported_version: PROTOCOL_VERSION,
+            sender_peer_id: cfg.node_id(),
+            target_peer_id: pm.cfg.node_id(),
+            sender_listen_port: Some(port),
+            sender_chain_info: chain.get_peer_chain_info(),
+            partial_edge_info: PartialEdgeInfo::new(
+                &cfg.node_id(),
+                &pm.cfg.node_id(),
+                Edge::create_fresh_nonce(&clock.clock()),
+                &cfg.node_key,
+            ),
+            owned_account: None,
+        }))
+        .await;
+    let reason = events
+        .recv_until(|ev| match ev {
+            Event::ConnectionClosed(ev) if ev.stream_id == stream_id => Some(ev.reason),
+            Event::HandshakeCompleted(ev) if ev.stream_id == stream_id => {
+                panic!("PeerManager accepted unsolicited Tier3 handshake")
+            }
+            _ => None,
+        })
+        .await;
+    assert_eq!(
+        ClosingReason::RejectedByPeerManager(RegisterPeerError::UnexpectedTier3Connection),
+        reason,
+    );
+}
+
+// Verify that an inbound Tier3 connection is accepted when we have a pending state sync
+// request for that peer.
+#[tokio::test]
+async fn expected_tier3_accepted() {
+    init_test_logger();
+    let mut rng = make_rng(921853234);
+    let rng = &mut rng;
+    let mut clock = time::FakeClock::default();
+    let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
+
+    let pm = peer_manager::testonly::start(
+        clock.clock(),
+        near_store::db::TestDB::new(),
+        chain.make_config(rng),
+        chain.clone(),
+    )
+    .await;
+
+    let cfg = chain.make_config(rng);
+    let peer_id = cfg.node_id();
+
+    // Simulate having sent a state sync request to this peer by inserting into
+    // pending_tier3_requests.
+    let now = clock.clock().now();
+    pm.with_state(move |s| async move {
+        s.pending_tier3_requests.insert(peer_id, now);
+    })
+    .await;
+
+    let stream = tcp::Stream::connect(&pm.peer_info(), tcp::Tier::T3, &SocketOptions::default())
+        .await
+        .unwrap();
+    let stream_id = stream.id();
+    let port = stream.local_addr.port();
+    let mut events = pm.events.from_now();
+    let mut stream = Stream::new(stream);
+    stream
+        .write(&PeerMessage::Tier3Handshake(Handshake {
+            protocol_version: PROTOCOL_VERSION,
+            oldest_supported_version: PROTOCOL_VERSION,
+            sender_peer_id: cfg.node_id(),
+            target_peer_id: pm.cfg.node_id(),
+            sender_listen_port: Some(port),
+            sender_chain_info: chain.get_peer_chain_info(),
+            partial_edge_info: PartialEdgeInfo::new(
+                &cfg.node_id(),
+                &pm.cfg.node_id(),
+                Edge::create_fresh_nonce(&clock.clock()),
+                &cfg.node_key,
+            ),
+            owned_account: None,
+        }))
+        .await;
+    events
+        .recv_until(|ev| match ev {
+            Event::HandshakeCompleted(ev) if ev.stream_id == stream_id => Some(()),
+            Event::ConnectionClosed(ev) if ev.stream_id == stream_id => {
+                panic!("PeerManager rejected expected Tier3 handshake: {:?}", ev.reason)
+            }
+            _ => None,
+        })
+        .await;
+}
+
+// A peer with a legitimate Tier3 connection could send duplicate handshakes just
+// before the idle timeout to keep the connection alive indefinitely. Verify that
+// duplicate handshakes on established sessions close the connection immediately,
+// so the keepalive attempt itself terminates the session.
+#[tokio::test]
+async fn duplicate_handshake_closes_tier3() {
+    init_test_logger();
+    let mut rng = make_rng(921853235);
+    let rng = &mut rng;
+    let mut clock = time::FakeClock::default();
+    let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
+
+    let pm = peer_manager::testonly::start(
+        clock.clock(),
+        near_store::db::TestDB::new(),
+        chain.make_config(rng),
+        chain.clone(),
+    )
+    .await;
+
+    let cfg = chain.make_config(rng);
+    let peer_id = cfg.node_id();
+
+    // Step 1: Establish a legitimate T3 connection (we "sent" a state request).
+    let now = clock.clock().now();
+    pm.with_state(move |s| async move {
+        s.pending_tier3_requests.insert(peer_id, now);
+    })
+    .await;
+
+    let stream = tcp::Stream::connect(&pm.peer_info(), tcp::Tier::T3, &SocketOptions::default())
+        .await
+        .unwrap();
+    let stream_id = stream.id();
+    let port = stream.local_addr.port();
+    let mut events = pm.events.from_now();
+    let mut stream = Stream::new(stream);
+    let handshake = Handshake {
+        protocol_version: PROTOCOL_VERSION,
+        oldest_supported_version: PROTOCOL_VERSION,
+        sender_peer_id: cfg.node_id(),
+        target_peer_id: pm.cfg.node_id(),
+        sender_listen_port: Some(port),
+        sender_chain_info: chain.get_peer_chain_info(),
+        partial_edge_info: PartialEdgeInfo::new(
+            &cfg.node_id(),
+            &pm.cfg.node_id(),
+            Edge::create_fresh_nonce(&clock.clock()),
+            &cfg.node_key,
+        ),
+        owned_account: None,
+    };
+    stream.write(&PeerMessage::Tier3Handshake(handshake.clone())).await;
+    events
+        .recv_until(|ev| match ev {
+            Event::HandshakeCompleted(ev) if ev.stream_id == stream_id => Some(()),
+            Event::ConnectionClosed(ev) if ev.stream_id == stream_id => {
+                panic!("handshake rejected: {:?}", ev.reason)
+            }
+            _ => None,
+        })
+        .await;
+
+    // Step 2: The attacker's keepalive — send a duplicate handshake just before
+    // the 15-second idle timeout would close the connection.
+    clock.advance(time::Duration::seconds(14));
+    stream.write(&PeerMessage::Tier3Handshake(handshake)).await;
+
+    // Step 3: The connection should be closed because duplicate handshakes on
+    // established sessions are no longer tolerated.
+    let reason = events
+        .recv_until(|ev| match ev {
+            Event::ConnectionClosed(ev) if ev.stream_id == stream_id => Some(ev.reason),
+            _ => None,
+        })
+        .await;
+    assert_eq!(reason, ClosingReason::DisallowedMessage);
+}
+
 // Verify that a Disconnect message received on a T3 connection is accepted
 // (not rejected as a disallowed message).
 #[tokio::test]
@@ -36,13 +242,55 @@ async fn t3_disconnect() {
     .await;
 
     let cfg = chain.make_config(rng);
-    let conn = pm.start_outbound(chain.clone(), cfg, tcp::Tier::T3).await;
-    let stream_id = conn.stream.id();
+    let peer_id = cfg.node_id();
+
+    // Register the peer as expected so the inbound T3 connection is accepted.
+    let now = clock.clock().now();
+    pm.with_state(move |s| async move {
+        s.pending_tier3_requests.insert(peer_id, now);
+    })
+    .await;
+
+    let stream = tcp::Stream::connect(&pm.peer_info(), tcp::Tier::T3, &SocketOptions::default())
+        .await
+        .unwrap();
+    let stream_id = stream.id();
+    let port = stream.local_addr.port();
     let mut events = pm.events.from_now();
-    let peer = conn.handshake(&clock.clock()).await;
+    let mut stream = Stream::new(stream);
+    stream
+        .write(&PeerMessage::Tier3Handshake(Handshake {
+            protocol_version: PROTOCOL_VERSION,
+            oldest_supported_version: PROTOCOL_VERSION,
+            sender_peer_id: cfg.node_id(),
+            target_peer_id: pm.cfg.node_id(),
+            sender_listen_port: Some(port),
+            sender_chain_info: chain.get_peer_chain_info(),
+            partial_edge_info: PartialEdgeInfo::new(
+                &cfg.node_id(),
+                &pm.cfg.node_id(),
+                Edge::create_fresh_nonce(&clock.clock()),
+                &cfg.node_key,
+            ),
+            owned_account: None,
+        }))
+        .await;
+
+    // Wait for the handshake to complete.
+    events
+        .recv_until(|ev| match ev {
+            Event::HandshakeCompleted(ev) if ev.stream_id == stream_id => Some(()),
+            Event::ConnectionClosed(ev) if ev.stream_id == stream_id => {
+                panic!("handshake rejected: {:?}", ev.reason)
+            }
+            _ => None,
+        })
+        .await;
 
     // Send a Disconnect message from the peer side over T3.
-    peer.send(PeerMessage::Disconnect(Disconnect { remove_from_connection_store: false })).await;
+    stream
+        .write(&PeerMessage::Disconnect(Disconnect { remove_from_connection_store: false }))
+        .await;
 
     let reason = events
         .recv_until(|ev| match ev {
@@ -346,10 +594,13 @@ async fn invalid_edge() {
                     _ => None,
                 })
                 .await;
-            assert_eq!(
-                ClosingReason::RejectedByPeerManager(RegisterPeerError::InvalidEdge),
-                reason
-            );
+            // Unsolicited inbound T3 connections are rejected before edge validation.
+            let expected = if tier == tcp::Tier::T3 {
+                ClosingReason::RejectedByPeerManager(RegisterPeerError::UnexpectedTier3Connection)
+            } else {
+                ClosingReason::RejectedByPeerManager(RegisterPeerError::InvalidEdge)
+            };
+            assert_eq!(expected, reason);
         }
     }
 }

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -594,13 +594,70 @@ async fn invalid_edge() {
                     _ => None,
                 })
                 .await;
-            // Unsolicited inbound T3 connections are rejected before edge validation.
-            let expected = if tier == tcp::Tier::T3 {
-                ClosingReason::RejectedByPeerManager(RegisterPeerError::UnexpectedTier3Connection)
-            } else {
-                ClosingReason::RejectedByPeerManager(RegisterPeerError::InvalidEdge)
-            };
-            assert_eq!(expected, reason);
+            assert_eq!(
+                ClosingReason::RejectedByPeerManager(RegisterPeerError::InvalidEdge),
+                reason,
+            );
         }
+    }
+
+    // Dedicated T3 sub-case: insert the peer into pending_tier3_requests so the
+    // connection passes the authorization check, then verify the invalid edge is
+    // still caught, and that the pending entry is NOT consumed by the failed attempt.
+    for (name, edge) in &testcases {
+        tracing::info!(target:"test", %name, tier=?tcp::Tier::T3, "test case (pending T3)");
+
+        let peer_id = cfg.node_id();
+        let now = clock.clock().now();
+        pm.with_state(move |s| async move {
+            s.pending_tier3_requests.insert(peer_id, now);
+        })
+        .await;
+
+        let stream =
+            tcp::Stream::connect(&pm.peer_info(), tcp::Tier::T3, &SocketOptions::default())
+                .await
+                .unwrap();
+        let stream_id = stream.id();
+        let port = stream.local_addr.port();
+        let mut events = pm.events.from_now();
+        let mut stream = Stream::new(stream);
+        let signer = cfg.validator.signer.get().unwrap();
+        let handshake = Handshake {
+            protocol_version: PROTOCOL_VERSION,
+            oldest_supported_version: PROTOCOL_VERSION,
+            sender_peer_id: cfg.node_id(),
+            target_peer_id: pm.cfg.node_id(),
+            sender_listen_port: Some(port),
+            sender_chain_info: chain.get_peer_chain_info(),
+            partial_edge_info: edge.clone(),
+            owned_account: Some(
+                OwnedAccount {
+                    account_key: signer.public_key(),
+                    peer_id: cfg.node_id(),
+                    timestamp: clock.now_utc(),
+                }
+                .sign(&signer),
+            ),
+        };
+        stream.write(&PeerMessage::Tier3Handshake(handshake)).await;
+        let reason = events
+            .recv_until(|ev| match ev {
+                Event::ConnectionClosed(ev) if ev.stream_id == stream_id => Some(ev.reason),
+                Event::HandshakeCompleted(ev) if ev.stream_id == stream_id => {
+                    panic!("PeerManager accepted the handshake")
+                }
+                _ => None,
+            })
+            .await;
+        assert_eq!(ClosingReason::RejectedByPeerManager(RegisterPeerError::InvalidEdge), reason,);
+
+        // The pending entry must survive the failed attempt so the real peer
+        // can still connect.
+        let peer_id = cfg.node_id();
+        let still_pending = pm
+            .with_state(move |s| async move { s.pending_tier3_requests.contains_key(&peer_id) })
+            .await;
+        assert!(still_pending, "pending_tier3_requests entry was consumed by a failed edge check");
     }
 }

--- a/chain/network/src/private_messages.rs
+++ b/chain/network/src/private_messages.rs
@@ -14,6 +14,7 @@ pub(crate) enum RegisterPeerError {
     NotTier1Peer,
     Tier1InboundDisabled,
     InvalidEdge,
+    UnexpectedTier3Connection,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Tier3 connections are intended to be short-lived, ad-hoc channels for transferring state sync responses. This commit tightens the Tier3 lifecycle:

- Track expected Tier3 peers: when sending `StateHeaderRequest` or `StatePartRequest` over Tier2, record the target peer_id in a new DashMap (`pending_tier3_requests`) on NetworkState. Inbound Tier3 connections are rejected in register() unless the peer is in this map, resolving a TODO that acknowledged this missing check. The check uses contains_key() rather than remove() so the entry remains valid for the full timeout window — the peer may need to open additional T3 connections if the first is idle-closed before a later response is ready. Edge verification runs before the pending-request check so that a spoofed peer_id with an invalid edge is rejected before it reaches the authorization lookup. Stale entries are cleaned up alongside idle Tier3 connections.
- Close on duplicate handshake: a handshake received after the session is already established now terminates the connection instead of being silently ignored.

The existing `t3_disconnect` test used `start_outbound()` to create a loopback Tier3 connection, which worked because the test peer's side did not validate inbound T3. With the new check, the test peer's own NetworkState (a separate instance created inside start_endpoint()) would also reject the PM's handshake as unexpected. Rather than threading the expected peer_id through the test infrastructure, the test is rewritten to use raw TCP — matching the pattern used by the new tests and more directly modeling a real inbound T3 connection. The invalid_edge test is extended with a dedicated T3 sub-case that inserts the peer into pending_tier3_requests, sends an invalid-edge handshake, and asserts both that the edge is rejected and that the pending entry is not consumed by the failure.
