### PR TITLE
refactor(test-loop): env.delay_endorsements_propagation

### DIFF
--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -474,6 +474,7 @@ impl TestLoopBuilder {
             drop_conditions: Default::default(),
             load_memtries_for_tracked_shards: self.load_memtries_for_tracked_shards,
             warmup_pending,
+            endorsement_delay_handlers_installed: Arc::new(AtomicBool::new(false)),
         };
         (self.test_loop, shared_state)
     }

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -512,6 +512,7 @@ impl TestLoopBuilder {
             load_memtries_for_tracked_shards: self.load_memtries_for_tracked_shards,
             warmup_pending,
             bucket_config: self.bucket_config.clone(),
+            endorsement_delay_handlers_installed: Arc::new(AtomicBool::new(false)),
         };
         (self.test_loop, shared_state)
     }

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -32,6 +32,7 @@ use near_store::archive::cloud_storage::bucket_config::BucketConfig;
 use near_store::archive::cloud_storage::config::test_cloud_archival_config;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::{TestNodeStorage, create_test_node_storage};
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -512,7 +513,7 @@ impl TestLoopBuilder {
             load_memtries_for_tracked_shards: self.load_memtries_for_tracked_shards,
             warmup_pending,
             bucket_config: self.bucket_config.clone(),
-            endorsement_delay_handlers_installed: Arc::new(AtomicBool::new(false)),
+            spice_endorsement_delay: Arc::new(Mutex::new(Default::default())),
         };
         (self.test_loop, shared_state)
     }

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -40,7 +40,7 @@ use near_store::test_utils::TestNodeStorage;
 use nearcore::state_sync::StateSyncDumpHandle;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -70,10 +70,16 @@ pub struct SharedState {
     /// Archive-wide config for cloud archival nodes. Defaults to
     /// `BucketConfig::canonical()`; tests may override.
     pub bucket_config: BucketConfig,
-    /// True once `TestLoopEnv::delay_endorsements_propagation` has installed
-    /// its per-node network handlers, so subsequent calls only update the
-    /// shared delay value instead of stacking another handler chain.
-    pub endorsement_delay_handlers_installed: Arc<AtomicBool>,
+    /// Per-node installation state for the spice endorsement-delay handler.
+    pub spice_endorsement_delay: Arc<Mutex<SpiceEndorsementDelayState>>,
+}
+
+/// Shared state for the spice endorsement-delay network handler installed by
+/// `TestLoopEnv::delay_endorsements_propagation`.
+#[derive(Default)]
+pub struct SpiceEndorsementDelayState {
+    pub installed_for: HashSet<String>,
+    pub senders: HashMap<AccountId, TestLoopSender<SpiceCoreWriterActor>>,
 }
 
 /// This is the state associated with each node in the test loop environment before being built.

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -70,6 +70,10 @@ pub struct SharedState {
     /// Archive-wide config for cloud archival nodes. Defaults to
     /// `BucketConfig::canonical()`; tests may override.
     pub bucket_config: BucketConfig,
+    /// True once `TestLoopEnv::delay_endorsements_propagation` has installed
+    /// its per-node network handlers, so subsequent calls only update the
+    /// shared delay value instead of stacking another handler chain.
+    pub endorsement_delay_handlers_installed: Arc<AtomicBool>,
 }
 
 /// This is the state associated with each node in the test loop environment before being built.
@@ -122,6 +126,13 @@ impl NodeExecutionData {
 
     pub fn set_expected_execution_delay(&self, delay: u64) {
         self.expected_execution_delay.store(delay, Ordering::Relaxed);
+    }
+
+    /// Returns a clone of the shared atomic backing `expected_execution_delay`,
+    /// so the endorsement-delay network handler can read the same value that
+    /// timeouts do without extra plumbing.
+    pub fn expected_execution_delay_handle(&self) -> Arc<AtomicU64> {
+        self.expected_execution_delay.clone()
     }
 
     pub fn jsonrpc_client(&self) -> JsonRpcClient {

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -66,6 +66,10 @@ pub struct SharedState {
     pub load_memtries_for_tracked_shards: bool,
     /// Flag to indicate if warmup is pending. This is used to ensure that warmup is only done once.
     pub warmup_pending: Arc<AtomicBool>,
+    /// True once `TestLoopEnv::delay_endorsements_propagation` has installed
+    /// its per-node network handlers, so subsequent calls only update the
+    /// shared delay value instead of stacking another handler chain.
+    pub endorsement_delay_handlers_installed: Arc<AtomicBool>,
 }
 
 /// This is the state associated with each node in the test loop environment before being built.
@@ -118,6 +122,13 @@ impl NodeExecutionData {
 
     pub fn set_expected_execution_delay(&self, delay: u64) {
         self.expected_execution_delay.store(delay, Ordering::Relaxed);
+    }
+
+    /// Returns a clone of the shared atomic backing `expected_execution_delay`,
+    /// so the endorsement-delay network handler can read the same value that
+    /// timeouts do without extra plumbing.
+    pub fn expected_execution_delay_handle(&self) -> Arc<AtomicU64> {
+        self.expected_execution_delay.clone()
     }
 
     pub fn jsonrpc_client(&self) -> JsonRpcClient {

--- a/test-loop-tests/src/tests/pending_transaction_queue.rs
+++ b/test-loop-tests/src/tests/pending_transaction_queue.rs
@@ -1,4 +1,3 @@
-use super::spice_utils::delay_endorsements_propagation;
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
 use crate::utils::account::create_account_id;
@@ -87,7 +86,7 @@ fn test_ptq_p_max_contract_account() {
         .delay_warmup()
         .build();
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
     deploy_contract_and_certify(&mut env, &contract_account);
 
@@ -122,7 +121,7 @@ fn test_ptq_no_p_max_for_non_contract_account() {
         .delay_warmup()
         .build();
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
 
     let num_txs = P_MAX + 2;
@@ -151,7 +150,7 @@ fn test_ptq_nonce_constraint() {
         .delay_warmup()
         .build();
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
 
     // Submit a tx with nonce 1 and wait for inclusion.
@@ -203,7 +202,7 @@ fn test_ptq_deploy_exclusivity() {
         .delay_warmup()
         .build();
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
 
     // Submit a deploy tx and a transfer tx from the same account.
@@ -263,7 +262,7 @@ fn test_ptq_accumulates_across_blocks() {
         .delay_warmup()
         .build();
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
     deploy_contract_and_certify(&mut env, &contract_account);
 
@@ -314,7 +313,7 @@ fn test_ptq_cleanup_on_certification() {
         .delay_warmup()
         .build();
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
     deploy_contract_and_certify(&mut env, &contract_account);
 
@@ -353,7 +352,7 @@ fn setup_gas_key_spice_env(
         .delay_warmup()
         .build();
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
     let gas_key_signer: Signer =
         InMemorySigner::from_seed(account.clone(), KeyType::ED25519, "gas_key").into();

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -1,4 +1,3 @@
-use super::spice_utils::delay_endorsements_propagation;
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
 use crate::setup::peer_manager_actor::HandlerResult;
@@ -183,7 +182,7 @@ fn test_spice_chain_with_delayed_execution() {
 
     let execution_delay = 4;
     // We delay endorsements to simulate slow execution validation causing execution to lag behind.
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
 
     env = env.warmup();
 
@@ -222,7 +221,7 @@ fn setup_spice_env_with_execution_delay() -> (TestLoopEnv, AccountId) {
         .build();
 
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
 
     let mut env = env.warmup();
 
@@ -368,7 +367,7 @@ fn test_spice_garbage_collection_witnesses() {
 
     // We delay endorsements to simulate slow execution validation causing execution to lag behind.
     let execution_delay = 4;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     env = env.warmup();
 
     // Use a chunk producer node (not RPC) since only chunk producers store witnesses.
@@ -522,7 +521,7 @@ fn test_restart_producer_node() {
     let execution_delay = 2;
     // Delay is required to make sure that new blocks processing doesn't trigger requests for
     // missing data.
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
 
     let mut env = env.warmup();
 
@@ -594,7 +593,7 @@ fn test_restart_validator_node() {
     let execution_delay = 2;
     // Delay is required to make sure that new blocks processing doesn't trigger requests of
     // missing data.
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
 
     let mut env = env.warmup();
 

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -564,6 +564,49 @@ fn test_restart_producer_node() {
     assert_eq!(view_account_result.amount, Balance::from_near(1));
 }
 
+/// After `add_node`, call `delay_endorsements_propagation` again so the new
+/// peer manager actor picks up the endorsement-delay handler. Installation is
+/// tracked per node identifier, so existing nodes aren't instrumented twice.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_delay_endorsements_propagation_instruments_added_node() {
+    init_test_logger();
+
+    let validators_spec = create_validators_spec(2, 0);
+    let clients = validators_spec_clients(&validators_spec);
+    let genesis = TestLoopBuilder::new_genesis_builder().validators_spec(validators_spec).build();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(clients.clone())
+        .delay_warmup()
+        .build();
+
+    env.delay_endorsements_propagation(2);
+    let mut env = env.warmup();
+    env.node_runner(0).run_until_head_height(5);
+
+    let delay_state = env.shared_state.spice_endorsement_delay.clone();
+    let original_identifier = env.get_node_data_by_account_id(&clients[0]).identifier.clone();
+    assert!(delay_state.lock().installed_for.contains(&original_identifier));
+
+    let new_account = create_account_id("new_node");
+    let new_identifier = "new_node";
+    let node_state = env.node_state_builder().account_id(&new_account).build();
+    env.add_node(new_identifier, node_state);
+    assert!(!delay_state.lock().installed_for.contains(new_identifier));
+
+    // Re-run to pick up the new peer; existing identifiers are not
+    // re-registered (idempotent).
+    env.delay_endorsements_propagation(2);
+    let installed_now = delay_state.lock().installed_for.clone();
+    assert!(installed_now.contains(new_identifier));
+    assert!(installed_now.contains(&original_identifier));
+
+    // Chain keeps progressing.
+    env.node_runner(0).run_for_number_of_blocks(5);
+}
+
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_restart_validator_node() {

--- a/test-loop-tests/src/tests/spice_resharding.rs
+++ b/test-loop-tests/src/tests/spice_resharding.rs
@@ -1,4 +1,3 @@
-use super::spice_utils::delay_endorsements_propagation;
 use crate::setup::builder::TestLoopBuilder;
 use crate::utils::account::{create_validators_spec, validators_spec_clients};
 use crate::utils::setups::derive_new_epoch_config_from_boundary;
@@ -56,7 +55,7 @@ fn test_spice_certified_results_across_resharding() {
         .build();
 
     let execution_delay = 2;
-    delay_endorsements_propagation(&mut env, execution_delay);
+    env.delay_endorsements_propagation(execution_delay);
     env = env.warmup();
 
     let epoch_manager = env.validator().client().epoch_manager.clone();

--- a/test-loop-tests/src/tests/spice_utils.rs
+++ b/test-loop-tests/src/tests/spice_utils.rs
@@ -10,55 +10,76 @@ use near_primitives::types::{AccountId, BlockHeight};
 use parking_lot::RwLock;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
-pub(super) fn delay_endorsements_propagation(env: &mut TestLoopEnv, delay_height: u64) {
-    for node in &env.node_datas {
-        node.set_expected_execution_delay(delay_height);
-    }
+impl TestLoopEnv {
+    /// Set the endorsement propagation delay to `delay_height` blocks.
+    ///
+    /// The first call installs a per-node network handler that holds back
+    /// endorsements until later blocks catch up. Subsequent calls just update
+    /// the delay value (including setting it to 0 to let queued endorsements
+    /// drain as new blocks arrive); the handler picks up the new value on its
+    /// next invocation.
+    pub fn delay_endorsements_propagation(&mut self, delay_height: u64) {
+        for node in &self.node_datas {
+            node.set_expected_execution_delay(delay_height);
+        }
+        if self.shared_state.endorsement_delay_handlers_installed.swap(true, Ordering::Relaxed) {
+            return;
+        }
 
-    let core_writer_senders: HashMap<_, _> = env
-        .node_datas
-        .iter()
-        .map(|datas| (datas.account_id.clone(), datas.spice_core_writer_sender.clone()))
-        .collect();
+        let core_writer_senders: HashMap<_, _> = self
+            .node_datas
+            .iter()
+            .map(|datas| (datas.account_id.clone(), datas.spice_core_writer_sender.clone()))
+            .collect();
 
-    for node in &env.node_datas {
-        let senders = core_writer_senders.clone();
-        let block_heights: Arc<RwLock<HashMap<CryptoHash, BlockHeight>>> =
-            Arc::new(RwLock::new(HashMap::new()));
-        let delayed_endorsements: Arc<
-            RwLock<VecDeque<(CryptoHash, AccountId, SpiceChunkEndorsement)>>,
-        > = Arc::new(RwLock::new(VecDeque::new()));
-        let peer_actor = env.test_loop.data.get_mut(&node.peer_manager_sender.actor_handle());
-        peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
-            match request {
-                NetworkRequests::Block { ref block } => {
-                    block_heights.write().insert(*block.hash(), block.header().height());
+        for node in &self.node_datas {
+            let senders = core_writer_senders.clone();
+            let delay = node.expected_execution_delay_handle();
+            let block_heights: Arc<RwLock<HashMap<CryptoHash, BlockHeight>>> =
+                Arc::new(RwLock::new(HashMap::new()));
+            let delayed_endorsements: Arc<
+                RwLock<VecDeque<(CryptoHash, AccountId, SpiceChunkEndorsement)>>,
+            > = Arc::new(RwLock::new(VecDeque::new()));
+            let peer_actor = self.test_loop.data.get_mut(&node.peer_manager_sender.actor_handle());
+            peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
+                let delay_height = delay.load(Ordering::Relaxed);
+                match request {
+                    NetworkRequests::Block { ref block } => {
+                        block_heights.write().insert(*block.hash(), block.header().height());
 
-                    let mut delayed_endorsements = delayed_endorsements.write();
-                    loop {
-                        let Some(front) = delayed_endorsements.front() else {
-                            break;
-                        };
-                        let height = block_heights.read()[&front.0];
-                        if height + delay_height >= block.header().height() {
-                            break;
+                        let mut delayed_endorsements = delayed_endorsements.write();
+                        loop {
+                            let Some(front) = delayed_endorsements.front() else {
+                                break;
+                            };
+                            let height = block_heights.read()[&front.0];
+                            if height + delay_height >= block.header().height() {
+                                break;
+                            }
+                            let (_, target, endorsement) =
+                                delayed_endorsements.pop_front().unwrap();
+                            senders[&target].send(SpiceChunkEndorsementMessage(endorsement));
                         }
-                        let (_, target, endorsement) = delayed_endorsements.pop_front().unwrap();
-                        senders[&target].send(SpiceChunkEndorsementMessage(endorsement));
+                        HandlerResult::Unhandled(request)
                     }
-                    HandlerResult::Unhandled(request)
+                    NetworkRequests::SpiceChunkEndorsement(target, endorsement) => {
+                        if delay_height == 0 {
+                            return HandlerResult::Unhandled(
+                                NetworkRequests::SpiceChunkEndorsement(target, endorsement),
+                            );
+                        }
+                        delayed_endorsements.write().push_back((
+                            *endorsement.block_hash(),
+                            target,
+                            endorsement,
+                        ));
+                        HandlerResult::Handled(NetworkResponses::NoResponse)
+                    }
+                    _ => HandlerResult::Unhandled(request),
                 }
-                NetworkRequests::SpiceChunkEndorsement(target, endorsement) => {
-                    delayed_endorsements.write().push_back((
-                        *endorsement.block_hash(),
-                        target,
-                        endorsement,
-                    ));
-                    HandlerResult::Handled(NetworkResponses::NoResponse)
-                }
-                _ => HandlerResult::Unhandled(request),
-            }
-        }));
+            }));
+        }
     }
 }

--- a/test-loop-tests/src/tests/spice_utils.rs
+++ b/test-loop-tests/src/tests/spice_utils.rs
@@ -1,7 +1,8 @@
 use crate::setup::env::TestLoopEnv;
 use crate::setup::peer_manager_actor::HandlerResult;
-use crate::setup::state::SpiceEndorsementDelayState;
+use crate::setup::state::{NodeExecutionData, SpiceEndorsementDelayState};
 use near_async::messaging::CanSend as _;
+use near_async::test_loop::data::TestLoopData;
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::types::NetworkRequests;
 use near_network::types::NetworkResponses;
@@ -46,8 +47,8 @@ impl TestLoopEnv {
 }
 
 fn install_endorsement_delay_handler(
-    data: &mut near_async::test_loop::data::TestLoopData,
-    node: &crate::setup::state::NodeExecutionData,
+    data: &mut TestLoopData,
+    node: &NodeExecutionData,
     state: Arc<Mutex<SpiceEndorsementDelayState>>,
 ) {
     let delay = node.expected_execution_delay_handle();
@@ -67,7 +68,12 @@ fn install_endorsement_delay_handler(
                     let Some(front) = delayed_endorsements.front() else {
                         break;
                     };
-                    let height = block_heights.read()[&front.0];
+                    let Some(&height) = block_heights.read().get(&front.0) else {
+                        // Endorsed block not observed on this handler yet; wait
+                        // until it arrives before deciding if the delay has
+                        // elapsed.
+                        break;
+                    };
                     if height + delay_height >= block.header().height() {
                         break;
                     }

--- a/test-loop-tests/src/tests/spice_utils.rs
+++ b/test-loop-tests/src/tests/spice_utils.rs
@@ -13,15 +13,9 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 impl TestLoopEnv {
-    /// Set the endorsement propagation delay to `delay_height` blocks.
-    ///
-    /// The first call with a non-zero delay installs a per-node network
-    /// handler that holds back endorsements until later blocks catch up.
-    /// Subsequent calls just update the delay value (including setting it to 0
-    /// to let queued endorsements drain as new blocks arrive); the handler
-    /// picks up the new value on its next invocation. A call with
-    /// `delay_height == 0` before the handler has been installed is a no-op,
-    /// so conditional callsites can always call this unconditionally.
+    /// Set the endorsement propagation delay to `delay_height` blocks. Safe
+    /// to call unconditionally; installs the network handler lazily on the
+    /// first non-zero call.
     pub fn delay_endorsements_propagation(&mut self, delay_height: u64) {
         let installed =
             self.shared_state.endorsement_delay_handlers_installed.load(Ordering::Relaxed);

--- a/test-loop-tests/src/tests/spice_utils.rs
+++ b/test-loop-tests/src/tests/spice_utils.rs
@@ -1,5 +1,6 @@
 use crate::setup::env::TestLoopEnv;
 use crate::setup::peer_manager_actor::HandlerResult;
+use crate::setup::state::SpiceEndorsementDelayState;
 use near_async::messaging::CanSend as _;
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::types::NetworkRequests;
@@ -7,7 +8,7 @@ use near_network::types::NetworkResponses;
 use near_primitives::hash::CryptoHash;
 use near_primitives::stateless_validation::spice_chunk_endorsement::SpiceChunkEndorsement;
 use near_primitives::types::{AccountId, BlockHeight};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -15,73 +16,84 @@ use std::sync::atomic::Ordering;
 impl TestLoopEnv {
     /// Set the endorsement propagation delay to `delay_height` blocks. Safe
     /// to call unconditionally; installs the network handler lazily on the
-    /// first non-zero call.
+    /// first non-zero call, and re-running it after `add_node` /
+    /// `restart_node` instruments any node that doesn't have the handler yet.
     pub fn delay_endorsements_propagation(&mut self, delay_height: u64) {
-        let installed =
-            self.shared_state.endorsement_delay_handlers_installed.load(Ordering::Relaxed);
-        if !installed && delay_height == 0 {
+        let state = self.shared_state.spice_endorsement_delay.clone();
+        if state.lock().installed_for.is_empty() && delay_height == 0 {
             return;
         }
         for node in &self.node_datas {
             node.set_expected_execution_delay(delay_height);
         }
-        if installed {
-            return;
+        // Refresh routing so handlers installed earlier can still deliver
+        // endorsements to nodes added since.
+        {
+            let mut state = state.lock();
+            state.senders = self
+                .node_datas
+                .iter()
+                .map(|n| (n.account_id.clone(), n.spice_core_writer_sender.clone()))
+                .collect();
         }
-        self.shared_state.endorsement_delay_handlers_installed.store(true, Ordering::Relaxed);
-
-        let core_writer_senders: HashMap<_, _> = self
-            .node_datas
-            .iter()
-            .map(|datas| (datas.account_id.clone(), datas.spice_core_writer_sender.clone()))
-            .collect();
-
         for node in &self.node_datas {
-            let senders = core_writer_senders.clone();
-            let delay = node.expected_execution_delay_handle();
-            let block_heights: Arc<RwLock<HashMap<CryptoHash, BlockHeight>>> =
-                Arc::new(RwLock::new(HashMap::new()));
-            let delayed_endorsements: Arc<
-                RwLock<VecDeque<(CryptoHash, AccountId, SpiceChunkEndorsement)>>,
-            > = Arc::new(RwLock::new(VecDeque::new()));
-            let peer_actor = self.test_loop.data.get_mut(&node.peer_manager_sender.actor_handle());
-            peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
-                let delay_height = delay.load(Ordering::Relaxed);
-                match request {
-                    NetworkRequests::Block { ref block } => {
-                        block_heights.write().insert(*block.hash(), block.header().height());
-
-                        let mut delayed_endorsements = delayed_endorsements.write();
-                        loop {
-                            let Some(front) = delayed_endorsements.front() else {
-                                break;
-                            };
-                            let height = block_heights.read()[&front.0];
-                            if height + delay_height >= block.header().height() {
-                                break;
-                            }
-                            let (_, target, endorsement) =
-                                delayed_endorsements.pop_front().unwrap();
-                            senders[&target].send(SpiceChunkEndorsementMessage(endorsement));
-                        }
-                        HandlerResult::Unhandled(request)
-                    }
-                    NetworkRequests::SpiceChunkEndorsement(target, endorsement) => {
-                        if delay_height == 0 {
-                            return HandlerResult::Unhandled(
-                                NetworkRequests::SpiceChunkEndorsement(target, endorsement),
-                            );
-                        }
-                        delayed_endorsements.write().push_back((
-                            *endorsement.block_hash(),
-                            target,
-                            endorsement,
-                        ));
-                        HandlerResult::Handled(NetworkResponses::NoResponse)
-                    }
-                    _ => HandlerResult::Unhandled(request),
-                }
-            }));
+            if !state.lock().installed_for.insert(node.identifier.clone()) {
+                continue;
+            }
+            install_endorsement_delay_handler(&mut self.test_loop.data, node, state.clone());
         }
     }
+}
+
+fn install_endorsement_delay_handler(
+    data: &mut near_async::test_loop::data::TestLoopData,
+    node: &crate::setup::state::NodeExecutionData,
+    state: Arc<Mutex<SpiceEndorsementDelayState>>,
+) {
+    let delay = node.expected_execution_delay_handle();
+    let block_heights: Arc<RwLock<HashMap<CryptoHash, BlockHeight>>> = Default::default();
+    let delayed_endorsements: Arc<
+        RwLock<VecDeque<(CryptoHash, AccountId, SpiceChunkEndorsement)>>,
+    > = Default::default();
+    let peer_actor = data.get_mut(&node.peer_manager_sender.actor_handle());
+    peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
+        let delay_height = delay.load(Ordering::Relaxed);
+        match request {
+            NetworkRequests::Block { ref block } => {
+                block_heights.write().insert(*block.hash(), block.header().height());
+
+                let mut delayed_endorsements = delayed_endorsements.write();
+                loop {
+                    let Some(front) = delayed_endorsements.front() else {
+                        break;
+                    };
+                    let height = block_heights.read()[&front.0];
+                    if height + delay_height >= block.header().height() {
+                        break;
+                    }
+                    let (_, target, endorsement) = delayed_endorsements.pop_front().unwrap();
+                    let Some(sender) = state.lock().senders.get(&target).cloned() else {
+                        continue;
+                    };
+                    sender.send(SpiceChunkEndorsementMessage(endorsement));
+                }
+                HandlerResult::Unhandled(request)
+            }
+            NetworkRequests::SpiceChunkEndorsement(target, endorsement) => {
+                if delay_height == 0 {
+                    return HandlerResult::Unhandled(NetworkRequests::SpiceChunkEndorsement(
+                        target,
+                        endorsement,
+                    ));
+                }
+                delayed_endorsements.write().push_back((
+                    *endorsement.block_hash(),
+                    target,
+                    endorsement,
+                ));
+                HandlerResult::Handled(NetworkResponses::NoResponse)
+            }
+            _ => HandlerResult::Unhandled(request),
+        }
+    }));
 }

--- a/test-loop-tests/src/tests/spice_utils.rs
+++ b/test-loop-tests/src/tests/spice_utils.rs
@@ -15,18 +15,26 @@ use std::sync::atomic::Ordering;
 impl TestLoopEnv {
     /// Set the endorsement propagation delay to `delay_height` blocks.
     ///
-    /// The first call installs a per-node network handler that holds back
-    /// endorsements until later blocks catch up. Subsequent calls just update
-    /// the delay value (including setting it to 0 to let queued endorsements
-    /// drain as new blocks arrive); the handler picks up the new value on its
-    /// next invocation.
+    /// The first call with a non-zero delay installs a per-node network
+    /// handler that holds back endorsements until later blocks catch up.
+    /// Subsequent calls just update the delay value (including setting it to 0
+    /// to let queued endorsements drain as new blocks arrive); the handler
+    /// picks up the new value on its next invocation. A call with
+    /// `delay_height == 0` before the handler has been installed is a no-op,
+    /// so conditional callsites can always call this unconditionally.
     pub fn delay_endorsements_propagation(&mut self, delay_height: u64) {
+        let installed =
+            self.shared_state.endorsement_delay_handlers_installed.load(Ordering::Relaxed);
+        if !installed && delay_height == 0 {
+            return;
+        }
         for node in &self.node_datas {
             node.set_expected_execution_delay(delay_height);
         }
-        if self.shared_state.endorsement_delay_handlers_installed.swap(true, Ordering::Relaxed) {
+        if installed {
             return;
         }
+        self.shared_state.endorsement_delay_handlers_installed.store(true, Ordering::Relaxed);
 
         let core_writer_senders: HashMap<_, _> = self
             .node_datas

--- a/test-loop-tests/src/tests/stake_nodes.rs
+++ b/test-loop-tests/src/tests/stake_nodes.rs
@@ -67,9 +67,7 @@ fn test_stake_nodes_impl(epoch_length: u64, execution_delay: u64) {
         .clients(accounts.clone())
         .delay_warmup()
         .build();
-    if execution_delay > 0 {
-        env.delay_endorsements_propagation(execution_delay);
-    }
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
 
     // Submit stake transaction from accounts[1]
@@ -142,9 +140,7 @@ fn test_validator_kickout_impl(epoch_length: u64, execution_delay: u64) {
         .track_all_shards()
         .delay_warmup()
         .build();
-    if execution_delay > 0 {
-        env.delay_endorsements_propagation(execution_delay);
-    }
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
 
     // Submit reduced stake transactions for nodes 0 and 1
@@ -251,9 +247,7 @@ fn test_validator_join_impl(epoch_length: u64, execution_delay: u64) {
         .track_all_shards()
         .delay_warmup()
         .build();
-    if execution_delay > 0 {
-        env.delay_endorsements_propagation(execution_delay);
-    }
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
 
     // Node1 unstakes, Node2 stakes
@@ -339,9 +333,7 @@ fn test_staking_join_and_leave_impl(execution_delay: u64) {
         .track_all_shards()
         .delay_warmup()
         .build();
-    if execution_delay > 0 {
-        env.delay_endorsements_propagation(execution_delay);
-    }
+    env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
 
     // Verify initial validator set.

--- a/test-loop-tests/src/tests/stake_nodes.rs
+++ b/test-loop-tests/src/tests/stake_nodes.rs
@@ -1,4 +1,3 @@
-use super::spice_utils::delay_endorsements_propagation;
 use crate::setup::builder::TestLoopBuilder;
 use crate::utils::account::{
     create_validator_ids, create_validators_spec, validators_spec_clients,
@@ -69,7 +68,7 @@ fn test_stake_nodes_impl(epoch_length: u64, execution_delay: u64) {
         .delay_warmup()
         .build();
     if execution_delay > 0 {
-        delay_endorsements_propagation(&mut env, execution_delay);
+        env.delay_endorsements_propagation(execution_delay);
     }
     let mut env = env.warmup();
 
@@ -144,7 +143,7 @@ fn test_validator_kickout_impl(epoch_length: u64, execution_delay: u64) {
         .delay_warmup()
         .build();
     if execution_delay > 0 {
-        delay_endorsements_propagation(&mut env, execution_delay);
+        env.delay_endorsements_propagation(execution_delay);
     }
     let mut env = env.warmup();
 
@@ -253,7 +252,7 @@ fn test_validator_join_impl(epoch_length: u64, execution_delay: u64) {
         .delay_warmup()
         .build();
     if execution_delay > 0 {
-        delay_endorsements_propagation(&mut env, execution_delay);
+        env.delay_endorsements_propagation(execution_delay);
     }
     let mut env = env.warmup();
 
@@ -341,7 +340,7 @@ fn test_staking_join_and_leave_impl(execution_delay: u64) {
         .delay_warmup()
         .build();
     if execution_delay > 0 {
-        delay_endorsements_propagation(&mut env, execution_delay);
+        env.delay_endorsements_propagation(execution_delay);
     }
     let mut env = env.warmup();
 
@@ -450,7 +449,7 @@ fn test_spice_uncertified_restake_prevents_stake_return() {
         })
         .delay_warmup()
         .build();
-    delay_endorsements_propagation(&mut env, endorsement_delay);
+    env.delay_endorsements_propagation(endorsement_delay);
     let mut env = env.warmup();
 
     let genesis_height = env.node(unstaker_idx).client().chain.genesis().height();

--- a/test-loop-tests/src/tests/stake_nodes.rs
+++ b/test-loop-tests/src/tests/stake_nodes.rs
@@ -1,4 +1,3 @@
-use super::spice_utils::delay_endorsements_propagation;
 use crate::setup::builder::TestLoopBuilder;
 use crate::utils::account::{
     create_validator_ids, create_validators_spec, validators_spec_clients,
@@ -60,7 +59,7 @@ fn test_stake_nodes_impl(epoch_length: u64, execution_delay: u64) {
         .delay_warmup()
         .build();
     if execution_delay > 0 {
-        delay_endorsements_propagation(&mut env, execution_delay);
+        env.delay_endorsements_propagation(execution_delay);
     }
     let mut env = env.warmup();
 
@@ -135,7 +134,7 @@ fn test_validator_kickout_impl(epoch_length: u64, execution_delay: u64) {
         .delay_warmup()
         .build();
     if execution_delay > 0 {
-        delay_endorsements_propagation(&mut env, execution_delay);
+        env.delay_endorsements_propagation(execution_delay);
     }
     let mut env = env.warmup();
 
@@ -244,7 +243,7 @@ fn test_validator_join_impl(epoch_length: u64, execution_delay: u64) {
         .delay_warmup()
         .build();
     if execution_delay > 0 {
-        delay_endorsements_propagation(&mut env, execution_delay);
+        env.delay_endorsements_propagation(execution_delay);
     }
     let mut env = env.warmup();
 
@@ -332,7 +331,7 @@ fn test_staking_join_and_leave_impl(execution_delay: u64) {
         .delay_warmup()
         .build();
     if execution_delay > 0 {
-        delay_endorsements_propagation(&mut env, execution_delay);
+        env.delay_endorsements_propagation(execution_delay);
     }
     let mut env = env.warmup();
 
@@ -441,7 +440,7 @@ fn test_spice_uncertified_restake_prevents_stake_return() {
         })
         .delay_warmup()
         .build();
-    delay_endorsements_propagation(&mut env, endorsement_delay);
+    env.delay_endorsements_propagation(endorsement_delay);
     let mut env = env.warmup();
 
     let genesis_height = env.node(unstaker_idx).client().chain.genesis().height();


### PR DESCRIPTION
Move the free-function body into an impl TestLoopEnv block and make it idempotent via a flag on SharedState: first call installs the per-node network handler, subsequent calls only update the shared delay value (which is read from each node's expected_execution_delay atomic, so run_until_executed_height timeouts stay in sync).

Migrates the existing callsites to the method form and removes the free function.

This is a preparatory refactor for #15600 which will reset the delay to 0 in testing.