### PR TITLE
feat(rpc): scatter-gather for state-changes RPC methods

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -728,6 +728,15 @@ pub struct GetStateChangesInBlock {
     pub block_hash: CryptoHash,
 }
 
+/// Probe whether the given shard's chunk at `block_hash` was applied on this
+/// node (i.e. `ChunkExtra` exists). Used by the sharded RPC coordinator to
+/// verify a peer actually has the data before trusting its response.
+#[derive(Debug)]
+pub struct GetChunkExtraExists {
+    pub block_hash: CryptoHash,
+    pub shard_uid: near_primitives::shard_layout::ShardUId,
+}
+
 #[derive(Debug)]
 pub struct GetStateChangesWithCauseInBlock {
     pub block_hash: CryptoHash,

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -20,7 +20,7 @@ pub use near_chain::stateless_validation::processing_tracker::{
 pub use near_client_primitives::debug::DebugStatus;
 pub use near_client_primitives::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
-    GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
+    GetChunkExtraExists, GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
     GetExecutionOutcomesForBlock, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
     GetNextLightClientBlock, GetProcessedReceiptIds, GetProtocolConfig, GetReceipt, GetReceiptToTx,
     GetReceiptToTxResponse, GetShardChunk, GetSplitStorageInfo, GetStateChanges,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -17,11 +17,11 @@ use near_chain_configs::{ClientConfig, MutableValidatorSigner, ProtocolConfigVie
 use near_chain_primitives::error::EpochErrorResultToChainError;
 use near_client_primitives::types::{
     Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError, GetBlockProofResponse,
-    GetBlockWithMerkleTree, GetChunkError, GetExecutionOutcome, GetExecutionOutcomeError,
-    GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError, GetMaintenanceWindows,
-    GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProcessedReceiptIds,
-    GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError, GetReceipt,
-    GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
+    GetBlockWithMerkleTree, GetChunkError, GetChunkExtraExists, GetExecutionOutcome,
+    GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError,
+    GetMaintenanceWindows, GetMaintenanceWindowsError, GetNextLightClientBlockError,
+    GetProcessedReceiptIds, GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError,
+    GetReceipt, GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
     GetSplitStorageInfo, GetSplitStorageInfoError, GetStateChangesError,
     GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
     GetValidatorInfoError, Query, QueryError, TxStatus, TxStatusError,
@@ -966,6 +966,22 @@ impl Handler<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChang
             .into_iter()
             .map(Into::into)
             .collect())
+    }
+}
+
+/// Returns whether the given shard's chunk at `block_hash` was applied on
+/// this node, i.e. whether its `ChunkExtra` is present in the store.
+impl Handler<GetChunkExtraExists, Result<bool, GetStateChangesError>> for ViewClientActor {
+    fn handle(&mut self, msg: GetChunkExtraExists) -> Result<bool, GetStateChangesError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetChunkExtraExists"])
+            .start_timer();
+        match self.chain.chain_store().get_chunk_extra(&msg.block_hash, &msg.shard_uid) {
+            Ok(_) => Ok(true),
+            Err(near_chain_primitives::Error::DBNotFoundErr(_)) => Ok(false),
+            Err(err) => Err(err.into()),
+        }
     }
 }
 

--- a/chain/jsonrpc-primitives/src/types/changes.rs
+++ b/chain/jsonrpc-primitives/src/types/changes.rs
@@ -42,6 +42,8 @@ pub enum RpcStateChangesError {
     NotSyncedYet,
     #[error("The node reached its limits. Try again later. More details: {error_message}")]
     InternalError { error_message: String },
+    #[error("shard {shard_id} was not applied at this block on this node")]
+    ShardNotApplied { shard_id: near_primitives::types::ShardId },
 }
 
 impl From<RpcStateChangesError> for crate::errors::RpcError {

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -93,10 +93,10 @@ pub trait RpcTransport: Send + Sync {
 
             let msg: Message =
                 near_jsonrpc_primitives::message::from_slice(&bytes).map_err(|err| {
-                    RpcError::parse_error(format!(
-                        "parsing jsonrpc response message failed: {:?}",
-                        err
-                    ))
+                    RpcError::new_internal_error(
+                        None,
+                        format!("parsing jsonrpc response message failed: {:?}", err),
+                    )
                 })?;
             Ok(msg)
         })

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -4,7 +4,7 @@ use near_jsonrpc_primitives::errors::RpcError;
 use near_jsonrpc_primitives::message::Message;
 use near_jsonrpc_primitives::types::changes::{
     RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
-    RpcStateChangesInBlockRequest,
+    RpcStateChangesInBlockRequest, RpcStateChangesInBlockResponse,
 };
 use near_jsonrpc_primitives::types::receipts::{
     RpcReceiptRequest, RpcReceiptResponse, RpcReceiptToTxRequest, RpcReceiptToTxResponse,
@@ -303,15 +303,14 @@ impl JsonRpcClient {
     pub fn EXPERIMENTAL_changes(
         &self,
         request: RpcStateChangesInBlockByTypeRequest,
-    ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
+    ) -> RpcRequest<RpcStateChangesInBlockResponse> {
         call_method(&self.transport, "EXPERIMENTAL_changes", request)
     }
 
-    #[allow(non_snake_case)]
     pub fn changes(
         &self,
         request: RpcStateChangesInBlockByTypeRequest,
-    ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
+    ) -> RpcRequest<RpcStateChangesInBlockResponse> {
         call_method(&self.transport, "changes", request)
     }
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -4,6 +4,7 @@ use near_jsonrpc_primitives::errors::RpcError;
 use near_jsonrpc_primitives::message::Message;
 use near_jsonrpc_primitives::types::changes::{
     RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
+    RpcStateChangesInBlockRequest,
 };
 use near_jsonrpc_primitives::types::receipts::{
     RpcReceiptRequest, RpcReceiptResponse, RpcReceiptToTxRequest, RpcReceiptToTxResponse,
@@ -312,6 +313,22 @@ impl JsonRpcClient {
         request: RpcStateChangesInBlockByTypeRequest,
     ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
         call_method(&self.transport, "changes", request)
+    }
+
+    pub fn block_effects(
+        &self,
+        request: RpcStateChangesInBlockRequest,
+    ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
+        call_method(&self.transport, "block_effects", request)
+    }
+
+    #[deprecated(since = "2.7.0", note = "Use `block_effects` method instead")]
+    #[allow(non_snake_case)]
+    pub fn EXPERIMENTAL_changes_in_block(
+        &self,
+        request: RpcStateChangesInBlockRequest,
+    ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
+        call_method(&self.transport, "EXPERIMENTAL_changes_in_block", request)
     }
 
     #[allow(non_snake_case)]

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "NEAR Protocol JSON RPC API",
-    "version": "1.2.4"
+    "version": "1.2.5"
   },
   "paths": {
     "/EXPERIMENTAL_call_function": {
@@ -16294,6 +16294,32 @@
               "name": {
                 "enum": [
                   "INTERNAL_ERROR"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "info"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "info": {
+                "properties": {
+                  "shard_id": {
+                    "$ref": "#/components/schemas/ShardId"
+                  }
+                },
+                "required": [
+                  "shard_id"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "enum": [
+                  "SHARD_NOT_APPLIED"
                 ],
                 "type": "string"
               }

--- a/chain/jsonrpc/openapi/src/main.rs
+++ b/chain/jsonrpc/openapi/src/main.rs
@@ -639,7 +639,7 @@ fn whole_spec(all_schemas: SchemasMap, all_paths: PathsMap) -> OpenApi {
         openapi: "3.0.0".to_string(),
         info: okapi::openapi3::Info {
             title: "NEAR Protocol JSON RPC API".to_string(),
-            version: "1.2.4".to_string(),
+            version: "1.2.5".to_string(),
             ..Default::default()
         },
         paths: all_paths,

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -2092,7 +2092,6 @@ impl JsonRpcHandler {
         let mut merged: Vec<(Vec<ShardId>, Value)> = Vec::new();
         let mut remaining_shards = target_shards;
         let mut excluded_nodes: HashSet<usize> = HashSet::new();
-        let mut last_error: Option<RpcError> = None;
 
         while !remaining_shards.is_empty() {
             let assignments = self.pool.read().one_node_per_group_of_shard(
@@ -2100,10 +2099,6 @@ impl JsonRpcHandler {
                 &remaining_shards,
                 &excluded_nodes,
             )?;
-
-            if assignments.is_empty() {
-                break;
-            }
 
             tracing::debug!(
                 target: "jsonrpc",
@@ -2170,23 +2165,10 @@ impl JsonRpcHandler {
                         ) {
                             return Err(e);
                         }
-                        last_error = Some(e);
                         excluded_nodes.insert(node_idx);
                     }
                 }
             }
-        }
-
-        if !remaining_shards.is_empty() {
-            return Err(last_error.unwrap_or_else(|| {
-                RpcError::new_internal_error(
-                    None,
-                    format!(
-                        "scatter-gather: no nodes available for shards: {:?}",
-                        remaining_shards
-                    ),
-                )
-            }));
         }
 
         Ok(merged)

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -219,10 +219,11 @@ fn filter_request_to_shard_group(
     shard_group: &[ShardId],
     shard_layout: &ShardLayout,
 ) -> StateChangesRequestView {
+    let shard_set: HashSet<&ShardId> = shard_group.iter().collect();
     let filter_accounts = |account_ids: &[AccountId]| -> Vec<AccountId> {
         account_ids
             .iter()
-            .filter(|id| shard_group.contains(&shard_layout.account_id_to_shard_id(id)))
+            .filter(|id| shard_set.contains(&shard_layout.account_id_to_shard_id(id)))
             .cloned()
             .collect()
     };
@@ -234,9 +235,7 @@ fn filter_request_to_shard_group(
         StateChangesRequestView::SingleAccessKeyChanges { keys } => {
             let filtered: Vec<_> = keys
                 .iter()
-                .filter(|k| {
-                    shard_group.contains(&shard_layout.account_id_to_shard_id(&k.account_id))
-                })
+                .filter(|k| shard_set.contains(&shard_layout.account_id_to_shard_id(&k.account_id)))
                 .cloned()
                 .collect();
             StateChangesRequestView::SingleAccessKeyChanges { keys: filtered }
@@ -261,8 +260,8 @@ fn filter_request_to_shard_group(
 }
 
 /// Extracts the set of target shards from a `StateChangesRequestView`.
-/// If the request has account_ids, returns the unique shards those accounts
-/// belong to. If empty (or a variant without account_ids), returns all shards.
+/// Returns the unique shards the request's accounts/keys belong to. Returns
+/// an empty set if the request has no accounts or keys.
 fn extract_target_shards(
     request: &StateChangesRequestView,
     shard_layout: &ShardLayout,
@@ -270,8 +269,6 @@ fn extract_target_shards(
     let account_ids: &[AccountId] = match request {
         StateChangesRequestView::AccountChanges { account_ids } => account_ids,
         StateChangesRequestView::SingleAccessKeyChanges { keys } => {
-            // SingleAccessKeyChanges has keys, not account_ids directly.
-            // Extract shards from key.account_id.
             return keys
                 .iter()
                 .map(|k| shard_layout.account_id_to_shard_id(&k.account_id))
@@ -281,11 +278,7 @@ fn extract_target_shards(
         StateChangesRequestView::ContractCodeChanges { account_ids } => account_ids,
         StateChangesRequestView::DataChanges { account_ids, .. } => account_ids,
     };
-    if account_ids.is_empty() {
-        shard_layout.shard_ids().collect()
-    } else {
-        account_ids.iter().map(|id| shard_layout.account_id_to_shard_id(id)).collect()
-    }
+    account_ids.iter().map(|id| shard_layout.account_id_to_shard_id(id)).collect()
 }
 
 /// Processes a specific method call.
@@ -1969,7 +1962,7 @@ impl JsonRpcHandler {
         let block: BlockView = self
             .view_client_send(GetBlock(request.block_reference))
             .await
-            .map_err(|e| <RpcStateChangesError>::from(e))?;
+            .map_err(RpcStateChangesError::from)?;
         let block_hash = block.header.hash;
         let epoch_id = EpochId(block.header.epoch_id);
 
@@ -2028,15 +2021,23 @@ impl JsonRpcHandler {
         let block: BlockView = self
             .view_client_send(GetBlock(request.block_reference))
             .await
-            .map_err(|e| <RpcStateChangesError>::from(e))?;
+            .map_err(RpcStateChangesError::from)?;
         let block_hash = block.header.hash;
         let epoch_id = EpochId(block.header.epoch_id);
 
         let shard_layout = self.shard_layout_for_epoch(&epoch_id)?;
 
         // Determine which shards we need based on the account_ids in the request.
+        // If there are no target accounts/keys, the underlying handler returns
+        // empty results anyway — skip the scatter-gather entirely.
         let target_shards: HashSet<ShardId> =
             extract_target_shards(&request.state_changes_request, &shard_layout);
+        if target_shards.is_empty() {
+            return serialize_response(RpcStateChangesInBlockResponse {
+                block_hash,
+                changes: vec![],
+            });
+        }
 
         let get_params_for_shard_group = |shards: &[ShardId]| {
             let sub_request = filter_request_to_shard_group(
@@ -2067,12 +2068,9 @@ impl JsonRpcHandler {
     }
 
     fn shard_layout_for_epoch(&self, epoch_id: &EpochId) -> Result<ShardLayout, RpcError> {
-        self.pool
-            .read()
-            .shard_tracker
-            .epoch_manager()
-            .get_shard_layout(epoch_id)
-            .map_err(|e| RpcError::new_internal_error(None, e.to_string()))
+        self.pool.read().shard_tracker.epoch_manager().get_shard_layout(epoch_id).map_err(|e| {
+            RpcError::new_internal_error(None, format!("failed to get shard layout for epoch: {e}"))
+        })
     }
 
     /// Scatter-gather: assign target shards to nodes in groups, fan out one
@@ -2107,14 +2105,8 @@ impl JsonRpcHandler {
             let mut request_groups = Vec::new();
             for (handle, node_idx, assigned_shards) in assignments {
                 let params = get_params_for_shard_group(&assigned_shards)?;
-                let req = match Message::request(method.to_string(), params) {
-                    Message::Request(r) => r,
-                    _ => {
-                        return Err(RpcError::new_internal_error(
-                            None,
-                            "scatter-gather: failed to create request".to_string(),
-                        ));
-                    }
+                let Message::Request(req) = Message::request(method.to_string(), params) else {
+                    unreachable!("Message::request always returns Message::Request");
                 };
                 request_groups.push((handle, req, node_idx, assigned_shards));
             }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -40,6 +40,11 @@ use near_jsonrpc_primitives::types::blocks::RpcBlockRequest;
 use near_jsonrpc_primitives::types::call_function::{
     RpcCallFunctionError, RpcCallFunctionRequest, RpcCallFunctionResponse,
 };
+use near_jsonrpc_primitives::types::changes::{
+    RpcStateChangesError, RpcStateChangesInBlockByTypeRequest,
+    RpcStateChangesInBlockByTypeResponse, RpcStateChangesInBlockRequest,
+    RpcStateChangesInBlockResponse,
+};
 use near_jsonrpc_primitives::types::chunks::ChunkReference;
 use near_jsonrpc_primitives::types::config::{RpcProtocolConfigError, RpcProtocolConfigResponse};
 use near_jsonrpc_primitives::types::entity_debug::{EntityDebugHandler, EntityQueryWithParams};
@@ -77,20 +82,25 @@ use near_network::tcp::{self, ListenerAddr};
 use near_o11y::metrics::{Encoder, TextEncoder, prometheus};
 use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
 use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockId, BlockReference, ShardId, TransactionOrReceiptId};
+use near_primitives::types::{
+    AccountId, BlockId, BlockReference, EpochId, ShardId, TransactionOrReceiptId,
+};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, GasPriceView, LightClientBlockView,
     MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, SplitStorageInfoView,
-    StateChangesKindsView, StateChangesView, TxExecutionStatus, TxStatusView,
+    StateChangeKindView, StateChangesKindsView, StateChangesRequestView, StateChangesView,
+    TxExecutionStatus, TxStatusView,
 };
 use parking_lot::RwLock;
 use serde_json::{Value, json};
 use sharded_rpc::{
     BlockHint, CoordinatorRequestStrategy, RequestSource, RpcNodeHandle, ShardHint, ShardedRpcPool,
 };
+use std::collections::HashSet;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -200,6 +210,82 @@ impl RpcConfig {
 #[allow(clippy::result_large_err)]
 fn serialize_response(value: impl serde::ser::Serialize) -> Result<Value, RpcError> {
     serde_json::to_value(value).map_err(|err| RpcError::serialization_error(err.to_string()))
+}
+
+/// Filters a `StateChangesRequestView` to only the accounts belonging to the
+/// given shard group, returning a new sub-request for just those accounts.
+fn filter_request_to_shard_group(
+    request: &StateChangesRequestView,
+    shard_group: &[ShardId],
+    shard_layout: &ShardLayout,
+) -> StateChangesRequestView {
+    let filter_accounts = |account_ids: &[AccountId]| -> Vec<AccountId> {
+        account_ids
+            .iter()
+            .filter(|id| shard_group.contains(&shard_layout.account_id_to_shard_id(id)))
+            .cloned()
+            .collect()
+    };
+
+    match request {
+        StateChangesRequestView::AccountChanges { account_ids } => {
+            StateChangesRequestView::AccountChanges { account_ids: filter_accounts(account_ids) }
+        }
+        StateChangesRequestView::SingleAccessKeyChanges { keys } => {
+            let filtered: Vec<_> = keys
+                .iter()
+                .filter(|k| {
+                    shard_group.contains(&shard_layout.account_id_to_shard_id(&k.account_id))
+                })
+                .cloned()
+                .collect();
+            StateChangesRequestView::SingleAccessKeyChanges { keys: filtered }
+        }
+        StateChangesRequestView::AllAccessKeyChanges { account_ids } => {
+            StateChangesRequestView::AllAccessKeyChanges {
+                account_ids: filter_accounts(account_ids),
+            }
+        }
+        StateChangesRequestView::ContractCodeChanges { account_ids } => {
+            StateChangesRequestView::ContractCodeChanges {
+                account_ids: filter_accounts(account_ids),
+            }
+        }
+        StateChangesRequestView::DataChanges { account_ids, key_prefix } => {
+            StateChangesRequestView::DataChanges {
+                account_ids: filter_accounts(account_ids),
+                key_prefix: key_prefix.clone(),
+            }
+        }
+    }
+}
+
+/// Extracts the set of target shards from a `StateChangesRequestView`.
+/// If the request has account_ids, returns the unique shards those accounts
+/// belong to. If empty (or a variant without account_ids), returns all shards.
+fn extract_target_shards(
+    request: &StateChangesRequestView,
+    shard_layout: &ShardLayout,
+) -> HashSet<ShardId> {
+    let account_ids: &[AccountId] = match request {
+        StateChangesRequestView::AccountChanges { account_ids } => account_ids,
+        StateChangesRequestView::SingleAccessKeyChanges { keys } => {
+            // SingleAccessKeyChanges has keys, not account_ids directly.
+            // Extract shards from key.account_id.
+            return keys
+                .iter()
+                .map(|k| shard_layout.account_id_to_shard_id(&k.account_id))
+                .collect();
+        }
+        StateChangesRequestView::AllAccessKeyChanges { account_ids } => account_ids,
+        StateChangesRequestView::ContractCodeChanges { account_ids } => account_ids,
+        StateChangesRequestView::DataChanges { account_ids, .. } => account_ids,
+    };
+    if account_ids.is_empty() {
+        shard_layout.shard_ids().collect()
+    } else {
+        account_ids.iter().map(|id| shard_layout.account_id_to_shard_id(id)).collect()
+    }
 }
 
 /// Processes a specific method call.
@@ -495,7 +581,14 @@ impl JsonRpcHandler {
             // Handlers ordered alphabetically
             "block" => process_method_call(request, |params| self.block(params)).await,
             "block_effects" | "EXPERIMENTAL_changes_in_block" => {
-                process_method_call(request, |params| self.changes_in_block(params)).await
+                let method = request.method.clone();
+                process_sharded_method_call(
+                    request,
+                    source,
+                    |params| self.changes_in_block_sharded(&method, params),
+                    |params| self.changes_in_block(params),
+                )
+                .await
             }
             "broadcast_tx_async" => {
                 process_method_call(request, |params| async {
@@ -508,7 +601,14 @@ impl JsonRpcHandler {
                 process_method_call(request, |params| self.send_tx_commit(params)).await
             }
             "changes" | "EXPERIMENTAL_changes" => {
-                process_method_call(request, |params| self.changes_in_block_by_type(params)).await
+                let method = request.method.clone();
+                process_sharded_method_call(
+                    request,
+                    source,
+                    |params| self.changes_in_block_by_type_sharded(&method, params),
+                    |params| self.changes_in_block_by_type(params),
+                )
+                .await
             }
             "chunk" => {
                 process_sharded_method_call(
@@ -1821,30 +1921,21 @@ impl JsonRpcHandler {
 
     async fn changes_in_block(
         &self,
-        request: near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockRequest,
-    ) -> Result<
-        near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockByTypeResponse,
-        near_jsonrpc_primitives::types::changes::RpcStateChangesError,
-    > {
+        request: RpcStateChangesInBlockRequest,
+    ) -> Result<RpcStateChangesInBlockByTypeResponse, RpcStateChangesError> {
         let block: near_primitives::views::BlockView =
             self.view_client_send(GetBlock(request.block_reference)).await?;
 
         let block_hash = block.header.hash;
         let changes = self.view_client_send(GetStateChangesInBlock { block_hash }).await?;
 
-        Ok(near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockByTypeResponse {
-            block_hash: block.header.hash,
-            changes,
-        })
+        Ok(RpcStateChangesInBlockByTypeResponse { block_hash: block.header.hash, changes })
     }
 
     async fn changes_in_block_by_type(
         &self,
-        request: near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockByTypeRequest,
-    ) -> Result<
-        near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockResponse,
-        near_jsonrpc_primitives::types::changes::RpcStateChangesError,
-    > {
+        request: RpcStateChangesInBlockByTypeRequest,
+    ) -> Result<RpcStateChangesInBlockResponse, RpcStateChangesError> {
         let block: near_primitives::views::BlockView =
             self.view_client_send(GetBlock(request.block_reference)).await?;
 
@@ -1856,10 +1947,226 @@ impl JsonRpcHandler {
             })
             .await?;
 
-        Ok(near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockResponse {
-            block_hash: block.header.hash,
-            changes,
+        Ok(RpcStateChangesInBlockResponse { block_hash: block.header.hash, changes })
+    }
+
+    /// Scatter-gather coordinator for `block_effects` / `EXPERIMENTAL_changes_in_block`.
+    ///
+    /// Fans out the request to one node per shard, filters each response to the
+    /// assigned shards, and concatenates the results. Retries failed shards with
+    /// different nodes.
+    async fn changes_in_block_sharded(
+        &self,
+        method: &str,
+        request: RpcStateChangesInBlockRequest,
+    ) -> Result<Value, RpcError> {
+        // Fast path: no remote nodes configured, just serve locally.
+        if self.pool.read().nodes.is_empty() {
+            return serialize_response(self.changes_in_block(request).await?);
+        }
+
+        // Resolve block locally to get block_hash and epoch_id.
+        let block: BlockView = self
+            .view_client_send(GetBlock(request.block_reference))
+            .await
+            .map_err(|e| <RpcStateChangesError>::from(e))?;
+        let block_hash = block.header.hash;
+        let epoch_id = EpochId(block.header.epoch_id);
+
+        let shard_layout = self.shard_layout_for_epoch(&epoch_id)?;
+
+        let all_shards: HashSet<ShardId> = shard_layout.shard_ids().collect();
+
+        let get_params_for_shard_group = |_shards: &[ShardId]| {
+            serde_json::to_value(RpcStateChangesInBlockRequest {
+                block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+            })
+            .map_err(|e| RpcError::serialization_error(e.to_string()))
+        };
+
+        // Scatter-gather with retry loop.
+        let merged_responses = self
+            .run_scatter_gather(method, &get_params_for_shard_group, &epoch_id, all_shards)
+            .await?;
+
+        // Post-filter: each node returns changes for all shards it tracks, but we
+        // only want the shards we assigned to it. This relies on every
+        // StateChangeKindView variant having a meaningful account_id().
+        let mut merged_changes: Vec<StateChangeKindView> = Vec::new();
+        for (assigned_shards, value) in merged_responses {
+            let resp: RpcStateChangesInBlockByTypeResponse =
+                serde_json::from_value(value).map_err(|e| RpcError::parse_error(e.to_string()))?;
+            let filtered = resp.changes.into_iter().filter(|change| {
+                assigned_shards.iter().any(|&shard_id| {
+                    shard_layout.account_id_to_shard_id(change.account_id()) == shard_id
+                })
+            });
+            merged_changes.extend(filtered);
+        }
+
+        serialize_response(RpcStateChangesInBlockByTypeResponse {
+            block_hash,
+            changes: merged_changes,
         })
+    }
+
+    /// Scatter-gather coordinator for `changes` / `EXPERIMENTAL_changes`.
+    ///
+    /// Splits the request's account_ids by shard group, sends per-group
+    /// sub-requests to the appropriate nodes, and concatenates the results.
+    async fn changes_in_block_by_type_sharded(
+        &self,
+        method: &str,
+        request: RpcStateChangesInBlockByTypeRequest,
+    ) -> Result<Value, RpcError> {
+        // Fast path: no remote nodes configured, just serve locally.
+        if self.pool.read().nodes.is_empty() {
+            return serialize_response(self.changes_in_block_by_type(request).await?);
+        }
+
+        // Resolve block locally.
+        let block: BlockView = self
+            .view_client_send(GetBlock(request.block_reference))
+            .await
+            .map_err(|e| <RpcStateChangesError>::from(e))?;
+        let block_hash = block.header.hash;
+        let epoch_id = EpochId(block.header.epoch_id);
+
+        let shard_layout = self.shard_layout_for_epoch(&epoch_id)?;
+
+        // Determine which shards we need based on the account_ids in the request.
+        let target_shards: HashSet<ShardId> =
+            extract_target_shards(&request.state_changes_request, &shard_layout);
+
+        let get_params_for_shard_group = |shards: &[ShardId]| {
+            let sub_request = filter_request_to_shard_group(
+                &request.state_changes_request,
+                shards,
+                &shard_layout,
+            );
+            serde_json::to_value(RpcStateChangesInBlockByTypeRequest {
+                block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                state_changes_request: sub_request,
+            })
+            .map_err(|e| RpcError::serialization_error(e.to_string()))
+        };
+
+        // Scatter-gather with retry loop.
+        let merged_responses = self
+            .run_scatter_gather(method, &get_params_for_shard_group, &epoch_id, target_shards)
+            .await?;
+
+        let mut merged_changes = Vec::new();
+        for (_assigned_shards, value) in merged_responses {
+            let resp: RpcStateChangesInBlockResponse =
+                serde_json::from_value(value).map_err(|e| RpcError::parse_error(e.to_string()))?;
+            merged_changes.extend(resp.changes);
+        }
+
+        serialize_response(RpcStateChangesInBlockResponse { block_hash, changes: merged_changes })
+    }
+
+    fn shard_layout_for_epoch(&self, epoch_id: &EpochId) -> Result<ShardLayout, RpcError> {
+        self.pool
+            .read()
+            .shard_tracker
+            .epoch_manager()
+            .get_shard_layout(epoch_id)
+            .map_err(|e| RpcError::new_internal_error(None, e.to_string()))
+    }
+
+    /// Scatter-gather: assign target shards to nodes in groups, fan out one
+    /// request per node group, retry failed groups with different nodes.
+    ///
+    /// Returns `(assigned_shards, response_value)` pairs. Callers interpret
+    /// the responses (filter, parse, merge) as appropriate for the method.
+    async fn run_scatter_gather(
+        &self,
+        method: &str,
+        get_params_for_shard_group: &(dyn Fn(&[ShardId]) -> Result<Value, RpcError> + Sync),
+        epoch_id: &EpochId,
+        target_shards: HashSet<ShardId>,
+    ) -> Result<Vec<(Vec<ShardId>, Value)>, RpcError> {
+        let mut merged: Vec<(Vec<ShardId>, Value)> = Vec::new();
+        let mut remaining_shards = target_shards;
+        let mut excluded_nodes: HashSet<usize> = HashSet::new();
+        let mut last_error: Option<RpcError> = None;
+
+        while !remaining_shards.is_empty() {
+            let assignments = self.pool.read().one_node_per_group_of_shard(
+                epoch_id,
+                &remaining_shards,
+                &excluded_nodes,
+            )?;
+
+            if assignments.is_empty() {
+                break;
+            }
+
+            // Build requests for each node group. Bail on serialization error.
+            let mut request_groups = Vec::new();
+            for (handle, node_idx, assigned_shards) in assignments {
+                let params = get_params_for_shard_group(&assigned_shards)?;
+                let req = match Message::request(method.to_string(), params) {
+                    Message::Request(r) => r,
+                    _ => {
+                        return Err(RpcError::new_internal_error(
+                            None,
+                            "scatter-gather: failed to create request".to_string(),
+                        ));
+                    }
+                };
+                request_groups.push((handle, req, node_idx, assigned_shards));
+            }
+
+            // Fan out in parallel.
+            let futures: Vec<_> = request_groups
+                .into_iter()
+                .map(|(handle, req, node_idx, assigned_shards)| {
+                    let fut = self.run_coordinator_request_on_node(req, handle);
+                    async move { (node_idx, assigned_shards, fut.await) }
+                })
+                .collect();
+
+            let results = futures::future::join_all(futures).await;
+
+            for (node_idx, assigned_shards, result) in results {
+                match result {
+                    Ok(value) => {
+                        for shard_id in &assigned_shards {
+                            remaining_shards.remove(shard_id);
+                        }
+                        merged.push((assigned_shards, value));
+                    }
+                    Err(e) => {
+                        // Don't retry on request validation errors — they're
+                        // deterministic and every node will return the same.
+                        if matches!(
+                            e.error_struct.as_ref(),
+                            Some(RpcErrorKind::RequestValidationError(_))
+                        ) {
+                            return Err(e);
+                        }
+                        last_error = Some(e);
+                        excluded_nodes.insert(node_idx);
+                    }
+                }
+            }
+        }
+
+        if !remaining_shards.is_empty() {
+            return Err(last_error.unwrap_or_else(|| {
+                RpcError::new_internal_error(
+                    None,
+                    format!(
+                        "scatter-gather: no nodes available for shards: {:?}",
+                        remaining_shards
+                    ),
+                )
+            }));
+        }
+
+        Ok(merged)
     }
 
     async fn next_light_client_block(

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1550,9 +1550,10 @@ impl JsonRpcHandler {
 
                 match message {
                     Message::Response(resp) => resp.result,
-                    _ => {
-                        Err(RpcError::parse_error("failed to parse JSON RPC response".to_string()))
-                    }
+                    _ => Err(RpcError::new_internal_error(
+                        None,
+                        "failed to parse JSON RPC response".to_string(),
+                    )),
                 }
             }
             RpcNodeHandle::LocalNode => {

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -2105,6 +2105,14 @@ impl JsonRpcHandler {
                 break;
             }
 
+            tracing::debug!(
+                target: "jsonrpc",
+                method,
+                remaining = remaining_shards.len(),
+                groups = assignments.len(),
+                "scatter-gather round"
+            );
+
             // Build requests for each node group. Bail on serialization error.
             let mut request_groups = Vec::new();
             for NodeRequestAssignment { handle, node_idx, assigned_shards } in assignments {
@@ -2115,12 +2123,23 @@ impl JsonRpcHandler {
                 request_groups.push((handle, req, node_idx, assigned_shards));
             }
 
-            // Fan out in parallel.
+            // Fan out in parallel with per-peer timeout.
+            let per_peer_timeout = Duration::seconds(10);
             let futures: Vec<_> = request_groups
                 .into_iter()
                 .map(|(handle, req, node_idx, assigned_shards)| {
                     let fut = self.run_coordinator_request_on_node(req, handle);
-                    async move { (node_idx, assigned_shards, fut.await) }
+                    let timeout_fut = self.clock.timeout(per_peer_timeout, fut);
+                    async move {
+                        let result = match timeout_fut.await {
+                            Ok(inner) => inner,
+                            Err(_) => Err(RpcError::new_internal_error(
+                                None,
+                                format!("scatter-gather: peer {node_idx} timed out"),
+                            )),
+                        };
+                        (node_idx, assigned_shards, result)
+                    }
                 })
                 .collect();
 
@@ -2135,6 +2154,14 @@ impl JsonRpcHandler {
                         merged.push((assigned_shards, value));
                     }
                     Err(e) => {
+                        tracing::warn!(
+                            target: "jsonrpc",
+                            method,
+                            node_idx,
+                            ?assigned_shards,
+                            error = %e,
+                            "scatter-gather: peer failed"
+                        );
                         // Don't retry on request validation errors — they're
                         // deterministic and every node will return the same.
                         if matches!(

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -14,12 +14,12 @@ use near_async::messaging::{AsyncSendError, AsyncSender, CanSend, CanSendAsync, 
 use near_async::time::{Clock, Duration};
 use near_chain_configs::{ClientConfig, GenesisConfig, ProtocolConfigView};
 use near_client::{
-    DebugStatus, GetBlock, GetBlockProof, GetBlockProofResponse, GetChunk, GetClientConfig,
-    GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice, GetMaintenanceWindows,
-    GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetReceiptToTx,
-    GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo,
-    GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse, Query as ClientQuery, QueryError,
-    Status, StatusResponse, TxStatus, TxStatusError,
+    DebugStatus, GetBlock, GetBlockProof, GetBlockProofResponse, GetChunk, GetChunkExtraExists,
+    GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice,
+    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
+    GetReceiptToTx, GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock,
+    GetValidatorInfo, GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse,
+    Query as ClientQuery, QueryError, Status, StatusResponse, TxStatus, TxStatusError,
 };
 use near_client_primitives::debug::{
     DebugBlockStatusQuery, DebugBlocksStartingMode, DebugStatusResponse,
@@ -82,7 +82,7 @@ use near_network::tcp::{self, ListenerAddr};
 use near_o11y::metrics::{Encoder, TextEncoder, prometheus};
 use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::ShardLayout;
+use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
@@ -258,6 +258,13 @@ fn filter_request_to_shard_group(
             }
         }
     }
+}
+
+/// Convert a low-level `RpcError` (from shard-layout lookups and similar)
+/// into `RpcStateChangesError::InternalError` so it can propagate out of the
+/// local `changes_*` handlers.
+fn to_state_changes_internal(err: RpcError) -> RpcStateChangesError {
+    RpcStateChangesError::InternalError { error_message: err.to_string() }
 }
 
 /// Extracts the set of target shards from a `StateChangesRequestView`.
@@ -438,6 +445,7 @@ pub struct ViewClientSenderForRpc(
     AsyncSender<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>>,
     AsyncSender<GetReceiptToTx, Result<GetReceiptToTxResponse, GetReceiptToTxError>>,
     AsyncSender<GetSplitStorageInfo, Result<SplitStorageInfoView, GetSplitStorageInfoError>>,
+    AsyncSender<GetChunkExtraExists, Result<bool, GetStateChangesError>>,
     AsyncSender<GetStateChanges, Result<StateChangesView, GetStateChangesError>>,
     AsyncSender<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChangesError>>,
     AsyncSender<GetValidatorInfo, Result<EpochValidatorInfo, GetValidatorInfoError>>,
@@ -580,7 +588,7 @@ impl JsonRpcHandler {
                     request,
                     source,
                     |params| self.changes_in_block_sharded(&method, params),
-                    |params| self.changes_in_block(params),
+                    |params| self.changes_in_block(params, RequestSource::Coordinator),
                 )
                 .await
             }
@@ -600,7 +608,7 @@ impl JsonRpcHandler {
                     request,
                     source,
                     |params| self.changes_in_block_by_type_sharded(&method, params),
-                    |params| self.changes_in_block_by_type(params),
+                    |params| self.changes_in_block_by_type(params, RequestSource::Coordinator),
                 )
                 .await
             }
@@ -1917,11 +1925,27 @@ impl JsonRpcHandler {
     async fn changes_in_block(
         &self,
         request: RpcStateChangesInBlockRequest,
+        source: RequestSource,
     ) -> Result<RpcStateChangesInBlockByTypeResponse, RpcStateChangesError> {
         let block: near_primitives::views::BlockView =
             self.view_client_send(GetBlock(request.block_reference)).await?;
 
         let block_hash = block.header.hash;
+
+        // Coordinator-forwarded requests must only be answered for shards this
+        // node actually applied. `block_effects` has no account filter, so the
+        // scope is "every shard this node advertises tracking for at this
+        // epoch" — if any of those is missing a ChunkExtra, the response would
+        // be silently partial, so we fail fast and let the coordinator retry.
+        // Direct user requests preserve the legacy best-effort behavior.
+        if source == RequestSource::Coordinator {
+            let epoch_id = EpochId(block.header.epoch_id);
+            let shard_layout =
+                self.shard_layout_for_epoch(&epoch_id).map_err(to_state_changes_internal)?;
+            let required = self.tracked_shard_uids_at_epoch(&shard_layout, &epoch_id)?;
+            self.ensure_chunks_applied(&block_hash, &required).await?;
+        }
+
         let changes = self.view_client_send(GetStateChangesInBlock { block_hash }).await?;
 
         Ok(RpcStateChangesInBlockByTypeResponse { block_hash: block.header.hash, changes })
@@ -1930,11 +1954,27 @@ impl JsonRpcHandler {
     async fn changes_in_block_by_type(
         &self,
         request: RpcStateChangesInBlockByTypeRequest,
+        source: RequestSource,
     ) -> Result<RpcStateChangesInBlockResponse, RpcStateChangesError> {
         let block: near_primitives::views::BlockView =
             self.view_client_send(GetBlock(request.block_reference)).await?;
 
         let block_hash = block.header.hash;
+
+        if source == RequestSource::Coordinator {
+            let epoch_id = EpochId(block.header.epoch_id);
+            let shard_layout =
+                self.shard_layout_for_epoch(&epoch_id).map_err(to_state_changes_internal)?;
+            let required: Vec<ShardUId> =
+                extract_target_shards(&request.state_changes_request, &shard_layout)
+                    .into_iter()
+                    .map(|shard_id| ShardUId::from_shard_id_and_layout(shard_id, &shard_layout))
+                    .collect();
+            if !required.is_empty() {
+                self.ensure_chunks_applied(&block_hash, &required).await?;
+            }
+        }
+
         let changes = self
             .view_client_send(GetStateChanges {
                 block_hash,
@@ -1943,6 +1983,55 @@ impl JsonRpcHandler {
             .await?;
 
         Ok(RpcStateChangesInBlockResponse { block_hash: block.header.hash, changes })
+    }
+
+    /// Return the `ShardUId`s of shards this node advertises tracking at
+    /// `epoch_id` (via `TrackedShardsConfig` or validator assignment). Used by
+    /// the `block_effects` coordinator path, where the request carries no
+    /// shard filter and the peer's tracked set is the scope of the response.
+    fn tracked_shard_uids_at_epoch(
+        &self,
+        shard_layout: &ShardLayout,
+        epoch_id: &EpochId,
+    ) -> Result<Vec<ShardUId>, RpcStateChangesError> {
+        let pool = self.pool.read();
+        let mut tracked = Vec::new();
+        for shard_uid in shard_layout.shard_uids() {
+            match pool.shard_tracker.rpc_tracks_shard_at_epoch(shard_uid.shard_id(), epoch_id) {
+                Ok(true) => tracked.push(shard_uid),
+                Ok(false) => {}
+                Err(e) => {
+                    return Err(RpcStateChangesError::InternalError {
+                        error_message: format!("failed to resolve tracked shards: {e}"),
+                    });
+                }
+            }
+        }
+        Ok(tracked)
+    }
+
+    /// Verify that this node has applied every given shard's chunk at
+    /// `block_hash`. Returns `ShardNotApplied` on the first shard that isn't
+    /// applied, so the coordinator can retry on another peer.
+    async fn ensure_chunks_applied(
+        &self,
+        block_hash: &CryptoHash,
+        shard_uids: &[ShardUId],
+    ) -> Result<(), RpcStateChangesError> {
+        for shard_uid in shard_uids {
+            let applied = self
+                .view_client_send(GetChunkExtraExists {
+                    block_hash: *block_hash,
+                    shard_uid: *shard_uid,
+                })
+                .await?;
+            if !applied {
+                return Err(RpcStateChangesError::ShardNotApplied {
+                    shard_id: shard_uid.shard_id(),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Scatter-gather coordinator for `block_effects` / `EXPERIMENTAL_changes_in_block`.
@@ -1957,7 +2046,7 @@ impl JsonRpcHandler {
     ) -> Result<Value, RpcError> {
         // Fast path: no remote nodes configured, just serve locally.
         if self.pool.read().nodes.is_empty() {
-            return serialize_response(self.changes_in_block(request).await?);
+            return serialize_response(self.changes_in_block(request, RequestSource::User).await?);
         }
 
         // Resolve block locally to get block_hash and epoch_id.
@@ -2016,7 +2105,9 @@ impl JsonRpcHandler {
     ) -> Result<Value, RpcError> {
         // Fast path: no remote nodes configured, just serve locally.
         if self.pool.read().nodes.is_empty() {
-            return serialize_response(self.changes_in_block_by_type(request).await?);
+            return serialize_response(
+                self.changes_in_block_by_type(request, RequestSource::User).await?,
+            );
         }
 
         // Resolve block locally.

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -267,6 +267,18 @@ fn to_state_changes_internal(err: RpcError) -> RpcStateChangesError {
     RpcStateChangesError::InternalError { error_message: err.to_string() }
 }
 
+/// Returns `true` if the request references no accounts or keys, i.e.
+/// `extract_target_shards` would return an empty set for any shard layout.
+fn state_changes_request_is_empty(request: &StateChangesRequestView) -> bool {
+    match request {
+        StateChangesRequestView::AccountChanges { account_ids }
+        | StateChangesRequestView::AllAccessKeyChanges { account_ids }
+        | StateChangesRequestView::ContractCodeChanges { account_ids }
+        | StateChangesRequestView::DataChanges { account_ids, .. } => account_ids.is_empty(),
+        StateChangesRequestView::SingleAccessKeyChanges { keys } => keys.is_empty(),
+    }
+}
+
 /// Extracts the set of target shards from a `StateChangesRequestView`.
 /// Returns the unique shards the request's accounts/keys belong to. Returns
 /// an empty set if the request has no accounts or keys.
@@ -2110,6 +2122,18 @@ impl JsonRpcHandler {
             );
         }
 
+        // Short-circuit requests with no target accounts/keys *before* the
+        // local view client lookup. Under spice, a non-validator RPC node may
+        // see the block header before its chunks are applied, making
+        // `GetBlock(BlockId::Height(h))` transiently return `UNKNOWN_BLOCK`.
+        // With nothing to fan out there is no reason to resolve the block.
+        if state_changes_request_is_empty(&request.state_changes_request) {
+            return serialize_response(RpcStateChangesInBlockResponse {
+                block_hash: CryptoHash::default(),
+                changes: vec![],
+            });
+        }
+
         // Resolve block locally.
         let block: BlockView = self
             .view_client_send(GetBlock(request.block_reference))
@@ -2121,16 +2145,10 @@ impl JsonRpcHandler {
         let shard_layout = self.shard_layout_for_epoch(&epoch_id)?;
 
         // Determine which shards we need based on the account_ids in the request.
-        // If there are no target accounts/keys, the underlying handler returns
-        // empty results anyway — skip the scatter-gather entirely.
+        // A non-empty request always yields at least one target shard, so we
+        // do not need a second empty-set guard here.
         let target_shards: HashSet<ShardId> =
             extract_target_shards(&request.state_changes_request, &shard_layout);
-        if target_shards.is_empty() {
-            return serialize_response(RpcStateChangesInBlockResponse {
-                block_hash,
-                changes: vec![],
-            });
-        }
 
         let get_params_for_shard_group = |shards: &[ShardId]| {
             let sub_request = filter_request_to_shard_group(

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -98,7 +98,8 @@ use near_primitives::views::{
 use parking_lot::RwLock;
 use serde_json::{Value, json};
 use sharded_rpc::{
-    BlockHint, CoordinatorRequestStrategy, RequestSource, RpcNodeHandle, ShardHint, ShardedRpcPool,
+    BlockHint, CoordinatorRequestStrategy, NodeRequestAssignment, RequestSource, RpcNodeHandle,
+    ShardHint, ShardedRpcPool,
 };
 use std::collections::HashSet;
 use std::future::Future;
@@ -2078,13 +2079,16 @@ impl JsonRpcHandler {
     ///
     /// Returns `(assigned_shards, response_value)` pairs. Callers interpret
     /// the responses (filter, parse, merge) as appropriate for the method.
-    async fn run_scatter_gather(
+    async fn run_scatter_gather<F>(
         &self,
         method: &str,
-        get_params_for_shard_group: &(dyn Fn(&[ShardId]) -> Result<Value, RpcError> + Sync),
+        get_params_for_shard_group: &F,
         epoch_id: &EpochId,
         target_shards: HashSet<ShardId>,
-    ) -> Result<Vec<(Vec<ShardId>, Value)>, RpcError> {
+    ) -> Result<Vec<(Vec<ShardId>, Value)>, RpcError>
+    where
+        F: Fn(&[ShardId]) -> Result<Value, RpcError> + Sync,
+    {
         let mut merged: Vec<(Vec<ShardId>, Value)> = Vec::new();
         let mut remaining_shards = target_shards;
         let mut excluded_nodes: HashSet<usize> = HashSet::new();
@@ -2103,7 +2107,7 @@ impl JsonRpcHandler {
 
             // Build requests for each node group. Bail on serialization error.
             let mut request_groups = Vec::new();
-            for (handle, node_idx, assigned_shards) in assignments {
+            for NodeRequestAssignment { handle, node_idx, assigned_shards } in assignments {
                 let params = get_params_for_shard_group(&assigned_shards)?;
                 let Message::Request(req) = Message::request(method.to_string(), params) else {
                     unreachable!("Message::request always returns Message::Request");

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -363,8 +363,8 @@ impl ShardedRpcPool {
     /// needed per node.
     ///
     /// Prefers the local node (index 0) when it tracks a shard. Falls back to
-    /// the first non-excluded remote node. If no non-excluded node tracks the
-    /// shard, falls back to local as a last resort.
+    /// the first non-excluded remote node. Returns Error if targetshards cannot be
+    /// covered by non-excluded nodes.
     pub fn one_node_per_group_of_shard(
         &self,
         epoch_id: &EpochId,
@@ -387,7 +387,7 @@ impl ShardedRpcPool {
     }
 
     /// Pick the best node for a single shard: local if it tracks it, then
-    /// first non-excluded remote, then local as last resort.
+    /// first non-excluded remote. Returns `Error` if all candidates are excluded.
     fn pick_node_for_shard(
         &self,
         shard_id: ShardId,
@@ -415,8 +415,9 @@ impl ShardedRpcPool {
             }
         }
 
-        // Last resort: local even if it doesn't track this shard.
-        Ok((0, RpcNodeHandle::LocalNode))
+        // No non-excluded node available for this shard.
+        tracing::debug!(target: "jsonrpc", ?shard_id, ?epoch_id, "no available node found for shard");
+        Err(make_rpc_error("No available host for given shard."))
     }
 }
 

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -372,7 +372,7 @@ impl ShardedRpcPool {
     /// needed per node.
     ///
     /// Prefers the local node (index 0) when it tracks a shard. Falls back to
-    /// the first non-excluded remote node. Returns Error if targetshards cannot be
+    /// the first non-excluded remote node. Returns Error if target_shards cannot be
     /// covered by non-excluded nodes.
     pub fn one_node_per_group_of_shard(
         &self,

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -9,7 +9,7 @@ use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{AccountId, BlockHeight, BlockId, BlockReference, EpochId, ShardId};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr, UdpSocket};
 use std::sync::Arc;
 use url::Url;
@@ -80,6 +80,15 @@ pub enum RpcNodeHandle {
     RemoteNode(Arc<JsonRpcClient>),
     /// Handle the request locally.
     LocalNode,
+}
+
+/// A node assignment for scatter-gather: a node handle, its index in the pool,
+/// and the shards it has been assigned to serve.
+pub struct NodeRequestAssignment {
+    pub handle: RpcNodeHandle,
+    /// 0 for the local node, `i + 1` for `pool.nodes[i]`.
+    pub node_idx: usize,
+    pub assigned_shards: Vec<ShardId>,
 }
 
 /// A remote RPC node in the pool, along with the shards it tracks.
@@ -370,9 +379,7 @@ impl ShardedRpcPool {
         epoch_id: &EpochId,
         target_shards: &HashSet<ShardId>,
         exclude: &HashSet<usize>,
-    ) -> Result<Vec<(RpcNodeHandle, usize, Vec<ShardId>)>, RpcError> {
-        use std::collections::HashMap;
-
+    ) -> Result<Vec<NodeRequestAssignment>, RpcError> {
         let mut node_groups: HashMap<usize, (RpcNodeHandle, Vec<ShardId>)> = HashMap::new();
 
         for &shard_id in target_shards {
@@ -382,7 +389,11 @@ impl ShardedRpcPool {
 
         Ok(node_groups
             .into_iter()
-            .map(|(node_idx, (handle, shards))| (handle, node_idx, shards))
+            .map(|(node_idx, (handle, shards))| NodeRequestAssignment {
+                handle,
+                node_idx,
+                assigned_shards: shards,
+            })
             .collect())
     }
 

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -356,35 +356,6 @@ impl ShardedRpcPool {
         }
     }
 
-    /// For scatter-gather: assigns exactly one node per shard, skipping excluded nodes.
-    ///
-    /// Returns `(shard_id, node_index, handle)` triples where `node_index` is
-    /// 0 for the local node and `i + 1` for `self.nodes[i]`. The caller uses
-    /// `node_index` to group shards by node and to track failed nodes across
-    /// retry rounds.
-    ///
-    /// Prefers the local node when it tracks the shard. Falls back to the first
-    /// non-excluded remote node. If no node is available, falls back to local
-    /// (which will likely return partial data).
-    pub fn one_node_per_shard(
-        &self,
-        epoch_id: &EpochId,
-        exclude: &HashSet<usize>,
-    ) -> Result<Vec<(ShardId, usize, RpcNodeHandle)>, RpcError> {
-        let shard_layout = self
-            .shard_tracker
-            .epoch_manager()
-            .get_shard_layout(epoch_id)
-            .map_err(|e| make_rpc_error(e))?;
-
-        let mut result = Vec::new();
-        for shard_id in shard_layout.shard_ids() {
-            let (node_idx, handle) = self.pick_node_for_shard(shard_id, epoch_id, exclude)?;
-            result.push((shard_id, node_idx, handle));
-        }
-        Ok(result)
-    }
-
     /// Assigns groups of target shards to nodes, returning disjoint shard groups.
     ///
     /// Each shard in `target_shards` is assigned to exactly one node. Shards

--- a/chain/jsonrpc/src/sharded_rpc.rs
+++ b/chain/jsonrpc/src/sharded_rpc.rs
@@ -9,6 +9,7 @@ use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{AccountId, BlockHeight, BlockId, BlockReference, EpochId, ShardId};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr, UdpSocket};
 use std::sync::Arc;
 use url::Url;
@@ -353,6 +354,98 @@ impl ShardedRpcPool {
                 None
             }
         }
+    }
+
+    /// For scatter-gather: assigns exactly one node per shard, skipping excluded nodes.
+    ///
+    /// Returns `(shard_id, node_index, handle)` triples where `node_index` is
+    /// 0 for the local node and `i + 1` for `self.nodes[i]`. The caller uses
+    /// `node_index` to group shards by node and to track failed nodes across
+    /// retry rounds.
+    ///
+    /// Prefers the local node when it tracks the shard. Falls back to the first
+    /// non-excluded remote node. If no node is available, falls back to local
+    /// (which will likely return partial data).
+    pub fn one_node_per_shard(
+        &self,
+        epoch_id: &EpochId,
+        exclude: &HashSet<usize>,
+    ) -> Result<Vec<(ShardId, usize, RpcNodeHandle)>, RpcError> {
+        let shard_layout = self
+            .shard_tracker
+            .epoch_manager()
+            .get_shard_layout(epoch_id)
+            .map_err(|e| make_rpc_error(e))?;
+
+        let mut result = Vec::new();
+        for shard_id in shard_layout.shard_ids() {
+            let (node_idx, handle) = self.pick_node_for_shard(shard_id, epoch_id, exclude)?;
+            result.push((shard_id, node_idx, handle));
+        }
+        Ok(result)
+    }
+
+    /// Assigns groups of target shards to nodes, returning disjoint shard groups.
+    ///
+    /// Each shard in `target_shards` is assigned to exactly one node. Shards
+    /// assigned to the same node are grouped together so only one request is
+    /// needed per node.
+    ///
+    /// Prefers the local node (index 0) when it tracks a shard. Falls back to
+    /// the first non-excluded remote node. If no non-excluded node tracks the
+    /// shard, falls back to local as a last resort.
+    pub fn one_node_per_group_of_shard(
+        &self,
+        epoch_id: &EpochId,
+        target_shards: &HashSet<ShardId>,
+        exclude: &HashSet<usize>,
+    ) -> Result<Vec<(RpcNodeHandle, usize, Vec<ShardId>)>, RpcError> {
+        use std::collections::HashMap;
+
+        let mut node_groups: HashMap<usize, (RpcNodeHandle, Vec<ShardId>)> = HashMap::new();
+
+        for &shard_id in target_shards {
+            let (node_idx, handle) = self.pick_node_for_shard(shard_id, epoch_id, exclude)?;
+            node_groups.entry(node_idx).or_insert_with(|| (handle, Vec::new())).1.push(shard_id);
+        }
+
+        Ok(node_groups
+            .into_iter()
+            .map(|(node_idx, (handle, shards))| (handle, node_idx, shards))
+            .collect())
+    }
+
+    /// Pick the best node for a single shard: local if it tracks it, then
+    /// first non-excluded remote, then local as last resort.
+    fn pick_node_for_shard(
+        &self,
+        shard_id: ShardId,
+        epoch_id: &EpochId,
+        exclude: &HashSet<usize>,
+    ) -> Result<(usize, RpcNodeHandle), RpcError> {
+        // Prefer local node (index 0).
+        if !exclude.contains(&0) {
+            match self.shard_tracker.rpc_tracks_shard_at_epoch(shard_id, epoch_id) {
+                Ok(true) => return Ok((0, RpcNodeHandle::LocalNode)),
+                Ok(false) => {}
+                Err(EpochError::EpochOutOfBounds(_)) => return Ok((0, RpcNodeHandle::LocalNode)),
+                Err(e) => return Err(make_rpc_error(e)),
+            }
+        }
+
+        // Try remote nodes.
+        for (i, node) in self.nodes.iter().enumerate() {
+            let node_index = i + 1;
+            if exclude.contains(&node_index) {
+                continue;
+            }
+            if node.tracked_shards.contains(&shard_id) {
+                return Ok((node_index, RpcNodeHandle::RemoteNode(node.client.clone())));
+            }
+        }
+
+        // Last resort: local even if it doesn't track this shard.
+        Ok((0, RpcNodeHandle::LocalNode))
     }
 }
 

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -48,7 +48,7 @@ pub enum Finality {
 }
 
 /// Account ID with its public key.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct AccountWithPublicKey {
     pub account_id: AccountId,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -2702,6 +2702,17 @@ pub enum StateChangeKindView {
     ContractCodeTouched { account_id: AccountId },
 }
 
+impl StateChangeKindView {
+    pub fn account_id(&self) -> &AccountId {
+        match self {
+            Self::AccountTouched { account_id }
+            | Self::AccessKeyTouched { account_id }
+            | Self::DataTouched { account_id }
+            | Self::ContractCodeTouched { account_id } => account_id,
+        }
+    }
+}
+
 impl From<StateChangeKind> for StateChangeKindView {
     fn from(state_change_kind: StateChangeKind) -> Self {
         match state_change_kind {
@@ -2822,6 +2833,22 @@ pub enum StateChangeValueView {
     ContractCodeDeletion {
         account_id: AccountId,
     },
+}
+
+impl StateChangeValueView {
+    pub fn account_id(&self) -> &AccountId {
+        match self {
+            Self::AccountUpdate { account_id, .. }
+            | Self::AccountDeletion { account_id }
+            | Self::AccessKeyUpdate { account_id, .. }
+            | Self::AccessKeyDeletion { account_id, .. }
+            | Self::GasKeyNonceUpdate { account_id, .. }
+            | Self::DataUpdate { account_id, .. }
+            | Self::DataDeletion { account_id, .. }
+            | Self::ContractCodeUpdate { account_id, .. }
+            | Self::ContractCodeDeletion { account_id } => account_id,
+        }
+    }
 }
 
 impl From<StateChangeValue> for StateChangeValueView {

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -1,5 +1,6 @@
 use super::env::TestLoopEnv;
 use super::peer_manager_actor::{TestLoopNetworkSharedState, UnreachableActor};
+use super::rpc::{FaultyRpcTransport, RpcFaultHandle};
 use super::setup::setup_client;
 use super::state::{NodeExecutionData, NodeSetupState, SharedState};
 use crate::utils::account::{
@@ -17,7 +18,7 @@ use near_chain_configs::{
     ClientConfig, DumpConfig, ExternalStorageConfig, ExternalStorageLocation, Genesis,
     StateSyncConfig, SyncConfig, TrackedShardsConfig,
 };
-use near_jsonrpc::client::JsonRpcClient;
+use near_jsonrpc::client::{JsonRpcClient, RpcTransport};
 use near_jsonrpc::sharded_rpc::ShardedRpcNode;
 use near_parameters::RuntimeConfigStore;
 use near_primitives::epoch_manager::EpochConfigStore;
@@ -31,6 +32,7 @@ use near_store::archive::cloud_storage::bucket_config::BucketConfig;
 use near_store::archive::cloud_storage::config::test_cloud_archival_config;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::{TestNodeStorage, create_test_node_storage};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -67,6 +69,10 @@ pub(crate) struct TestLoopBuilder {
     /// `BucketConfig::canonical()`; tests override to use a batch size
     /// different from production.
     bucket_config: BucketConfig,
+    /// Fault handles for pool entries. When a handle is set to `Some(msg)`,
+    /// the corresponding pool entry's transport returns `Err(msg)` instead of
+    /// dispatching the request. Used to simulate unreachable / stale nodes.
+    rpc_pool_fault_handles: HashMap<AccountId, RpcFaultHandle>,
 }
 
 impl TestLoopBuilder {
@@ -85,6 +91,7 @@ impl TestLoopBuilder {
             upgrade_schedule: None,
             rpc_pool: None,
             bucket_config: BucketConfig::canonical(),
+            rpc_pool_fault_handles: HashMap::new(),
         }
     }
 
@@ -325,6 +332,15 @@ impl TestLoopBuilder {
         self
     }
 
+    /// Register a fault handle for a pool entry. Returns the shared handle the
+    /// caller can flip at runtime; setting it to `Some(msg)` makes every pool
+    /// caller receive `Err(msg)` when trying to reach `account`.
+    pub(crate) fn rpc_pool_fault_handle(&mut self, account: AccountId) -> RpcFaultHandle {
+        let handle = Arc::new(parking_lot::RwLock::new(None));
+        self.rpc_pool_fault_handles.insert(account, handle.clone());
+        handle
+    }
+
     /// Custom function to change the configs before constructing each client.
     pub fn config_modifier(
         mut self,
@@ -409,6 +425,7 @@ impl TestLoopBuilder {
         }
 
         let rpc_pool = self.rpc_pool.take();
+        let rpc_pool_fault_handles = std::mem::take(&mut self.rpc_pool_fault_handles);
         let node_states = (0..clients.len())
             .map(|idx| self.setup_node_state(idx, &genesis, &clients))
             .collect_vec();
@@ -421,7 +438,7 @@ impl TestLoopBuilder {
             })
             .collect_vec();
 
-        Self::setup_sharded_rpc_pools(&datas, rpc_pool.as_deref());
+        Self::setup_sharded_rpc_pools(&datas, rpc_pool.as_deref(), &rpc_pool_fault_handles);
 
         TestLoopEnv { test_loop, node_datas: datas, shared_state }
     }
@@ -429,9 +446,12 @@ impl TestLoopBuilder {
     /// Wire each node's sharded RPC pool with clients pointing to other nodes.
     /// When `rpc_pool_accounts` is provided, only those accounts are included
     /// as remote nodes in the pool. Otherwise all nodes are included.
+    /// Pool entries with a registered fault handle have their transport wrapped
+    /// so tests can inject failures at runtime.
     fn setup_sharded_rpc_pools(
         datas: &[NodeExecutionData],
         rpc_pool_accounts: Option<&[AccountId]>,
+        fault_handles: &HashMap<AccountId, RpcFaultHandle>,
     ) {
         let pool_nodes: Vec<ShardedRpcNode> = datas
             .iter()
@@ -439,8 +459,14 @@ impl TestLoopBuilder {
                 rpc_pool_accounts.map_or(true, |accounts| accounts.contains(&data.account_id))
             })
             .map(|data| {
-                let client =
-                    Arc::new(JsonRpcClient::new_with_transport(data.jsonrpc_transport.clone()));
+                let transport: Arc<dyn RpcTransport> = match fault_handles.get(&data.account_id) {
+                    Some(handle) => Arc::new(FaultyRpcTransport::new(
+                        data.jsonrpc_transport.clone(),
+                        handle.clone(),
+                    )),
+                    None => data.jsonrpc_transport.clone(),
+                };
+                let client = Arc::new(JsonRpcClient::new_with_transport(transport));
                 let pool = data.sharded_rpc_pool.read();
                 // TODO(sharded-rpc): find the right shard_ids in TestLoop.
                 let tracked_shards = match pool.shard_tracker.tracked_shards_config() {

--- a/test-loop-tests/src/setup/rpc.rs
+++ b/test-loop-tests/src/setup/rpc.rs
@@ -12,8 +12,55 @@ use near_jsonrpc::sharded_rpc::ShardedRpcPool;
 use near_jsonrpc::{PeerManagerSenderForRpc, RpcConfig, create_jsonrpc_app};
 use near_jsonrpc_primitives::types::entity_debug::DummyEntityDebugHandler;
 use parking_lot::RwLock;
+use std::future::pending;
 use std::sync::Arc;
 use tower_service::Service;
+
+/// Simulated fault mode for an RPC peer.
+#[derive(Clone, Debug)]
+pub(crate) enum RpcFault {
+    /// Return `Err(msg)` immediately — simulates a node that's up but
+    /// can't serve the query (e.g. stale, behind on sync).
+    Fail(String),
+    /// Never resolve — simulates a dead / unreachable node. The
+    /// coordinator's per-peer timeout must fire to recover.
+    Hang,
+}
+
+/// Shared handle used by tests to inject faults into a node's inbound RPC.
+pub(crate) type RpcFaultHandle = Arc<RwLock<Option<RpcFault>>>;
+
+/// RpcTransport decorator that injects failures based on a shared handle.
+/// Wraps another transport so callers see a configurable error without
+/// touching the destination node.
+pub(crate) struct FaultyRpcTransport {
+    inner: Arc<dyn RpcTransport>,
+    fault: RpcFaultHandle,
+}
+
+impl FaultyRpcTransport {
+    pub(crate) fn new(inner: Arc<dyn RpcTransport>, fault: RpcFaultHandle) -> Self {
+        Self { inner, fault }
+    }
+}
+
+impl RpcTransport for FaultyRpcTransport {
+    fn send_http_request(
+        &self,
+        endpoint: &str,
+        body: Vec<u8>,
+        response_size_limit: usize,
+        extra_headers: &[(&str, &str)],
+    ) -> BoxFuture<'static, Result<(StatusCode, Vec<u8>), String>> {
+        match self.fault.read().clone() {
+            Some(RpcFault::Fail(msg)) => Box::pin(async move { Err(msg) }),
+            Some(RpcFault::Hang) => Box::pin(pending()),
+            None => {
+                self.inner.send_http_request(endpoint, body, response_size_limit, extra_headers)
+            }
+        }
+    }
+}
 
 /// In-process transport that routes requests through an axum Router.
 /// Used in TestLoop instead of standard network connections.

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -1514,35 +1514,19 @@ fn test_rpc_changes_scatter_gather() {
     );
 }
 
-/// `changes` with empty account_ids succeeds without error through the
-/// scatter-gather path. The underlying handler treats empty account_ids as
-/// "no accounts requested" and returns an empty result — verify this doesn't
-/// cause an error or timeout.
+/// `changes` with empty account_ids returns an empty result without error.
+/// Empty account_ids means "no accounts requested" — the scatter-gather
+/// coordinator short-circuits without fanning out.
 #[test]
 fn test_rpc_changes_empty_account_ids_scatter_gather() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
 
-    let alice = h.alice.clone();
-    let zoe = h.zoe.clone();
-    let validator = h.validator.clone();
-    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
-    let tx_hash = tx.get_hash();
-    h.env.node_for_account(&validator).submit_tx(tx);
-
-    let target_height = h.env.node_for_account(&validator).head().height + 10;
-    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
-
-    let outcome =
-        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
-    let block_hash = outcome.block_hash;
-
     let zoe_node = h.zoe_node.clone();
+    let head_height = h.env.node_for_account(&h.validator).head().height;
 
-    // Empty account_ids — scatter-gather fans out to all shards but each node
-    // returns empty changes (the handler treats [] as "no accounts requested").
     let params = serde_json::to_value(RpcStateChangesInBlockByTypeRequest {
-        block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+        block_reference: BlockReference::BlockId(BlockId::Height(head_height)),
         state_changes_request: StateChangesRequestView::AccountChanges { account_ids: vec![] },
     })
     .unwrap();
@@ -1564,7 +1548,6 @@ fn test_rpc_changes_empty_account_ids_scatter_gather() {
             let value = resp.result.expect("empty account_ids request should succeed");
             let parsed: RpcStateChangesInBlockResponse =
                 serde_json::from_value(value).expect("failed to parse");
-            // The handler returns empty changes for empty account_ids filter.
             assert!(
                 parsed.changes.is_empty(),
                 "empty account_ids should return empty changes, got: {:?}",
@@ -1634,10 +1617,9 @@ fn test_rpc_changes_single_access_key_scatter_gather() {
         Message::Response(resp) => {
             // The request should succeed — scatter-gather forwards to alice's shard.
             let value = resp.result.expect("SingleAccessKeyChanges request should succeed");
-            let _parsed: RpcStateChangesInBlockResponse =
+            let parsed: RpcStateChangesInBlockResponse =
                 serde_json::from_value(value).expect("failed to parse");
-            // Success is sufficient — the key point is that scatter-gather
-            // correctly routed to alice's shard from zoe's node without error.
+            assert_eq!(parsed.block_hash, block_hash, "response block_hash should match request");
         }
         other => panic!("expected Response, got: {other:?}"),
     }

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -4,6 +4,10 @@ use near_jsonrpc::client::ChunkId;
 use near_jsonrpc_primitives::errors::RpcError;
 use near_jsonrpc_primitives::message::Message;
 use near_jsonrpc_primitives::types::call_function::RpcCallFunctionRequest;
+use near_jsonrpc_primitives::types::changes::{
+    RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
+    RpcStateChangesInBlockRequest, RpcStateChangesInBlockResponse,
+};
 use near_jsonrpc_primitives::types::chunks::ChunkReference;
 use near_jsonrpc_primitives::types::congestion::RpcCongestionLevelRequest;
 use near_jsonrpc_primitives::types::light_client::{
@@ -26,7 +30,7 @@ use near_primitives::types::{
     AccountId, Balance, BlockId, BlockReference, Finality, FunctionArgs, Gas, StoreKey,
     TransactionOrReceiptId,
 };
-use near_primitives::views::QueryRequest;
+use near_primitives::views::{QueryRequest, StateChangesRequestView};
 use near_store::ShardUId;
 
 /// EXPERIMENTAL_view_account queries should be forwarded to the right shard.
@@ -1375,5 +1379,266 @@ fn test_rpc_light_client_proof_unknown_outcome() {
         let err = run_proof_query(&mut h, node_id, bogus_receipt.clone())
             .expect_err("expected UNKNOWN_TRANSACTION_OR_RECEIPT");
         assert_rpc_error(&err, "UNKNOWN_TRANSACTION_OR_RECEIPT");
+    }
+}
+
+/// `block_effects` should scatter-gather across shards: an RPC node tracking
+/// only one shard should return changes for ALL shards by forwarding to peers.
+#[test]
+fn test_rpc_changes_in_block_scatter_gather() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    // Submit a transfer so that alice has account changes in a block.
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+
+    // Find the block where the transaction was executed (has alice's state changes).
+    let outcome =
+        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
+    let block_hash = outcome.block_hash;
+
+    let run_block_effects = |h: &mut TwoShardHarness,
+                             node_id: &AccountId|
+     -> Result<RpcStateChangesInBlockByTypeResponse, RpcError> {
+        h.env.runner_for_account(node_id).run_with_jsonrpc_client(
+            |client| {
+                client.block_effects(RpcStateChangesInBlockRequest {
+                    block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                })
+            },
+            Duration::seconds(5),
+        )
+    };
+
+    // Query from alice_node (tracks shard 0 only) — should get changes for both shards.
+    let alice_node = h.alice_node.clone();
+    let zoe_node = h.zoe_node.clone();
+
+    let result = run_block_effects(&mut h, &alice_node).unwrap();
+    let accounts_touched: Vec<_> = result.changes.iter().map(|c| c.account_id().clone()).collect();
+    assert!(
+        accounts_touched.iter().any(|a| a == &alice),
+        "alice_node: missing alice's changes, got: {accounts_touched:?}",
+    );
+
+    // Same from zoe_node (tracks shard 1 only) — scatter-gather should still find alice.
+    let result = run_block_effects(&mut h, &zoe_node).unwrap();
+    let accounts_touched: Vec<_> = result.changes.iter().map(|c| c.account_id().clone()).collect();
+    assert!(
+        accounts_touched.iter().any(|a| a == &alice),
+        "zoe_node: missing alice's changes, got: {accounts_touched:?}",
+    );
+}
+
+/// `changes` with AccountChanges should scatter-gather: requesting changes for
+/// accounts on different shards from a node that only tracks one shard should
+/// return results for all requested accounts.
+#[test]
+fn test_rpc_changes_scatter_gather() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    // Submit a transfer so alice has state changes.
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+
+    let outcome =
+        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
+    let block_hash = outcome.block_hash;
+
+    let alice_node = h.alice_node.clone();
+    let zoe_node = h.zoe_node.clone();
+
+    // Helper: send a raw "changes" request and parse the response.
+    let send_changes_request =
+        |h: &mut TwoShardHarness, node_id: &AccountId, account_ids: Vec<AccountId>| {
+            let params = serde_json::to_value(RpcStateChangesInBlockByTypeRequest {
+                block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                state_changes_request: StateChangesRequestView::AccountChanges { account_ids },
+            })
+            .unwrap();
+            let response = h
+                .env
+                .runner_for_account(node_id)
+                .run_with_jsonrpc_client(
+                    |client| {
+                        client.transport.send_jsonrpc_request(
+                            Message::request("changes".to_string(), params.clone()),
+                            false,
+                        )
+                    },
+                    Duration::seconds(5),
+                )
+                .unwrap();
+            match response {
+                Message::Response(resp) => {
+                    let value = resp.result.expect("expected Ok result");
+                    serde_json::from_value::<RpcStateChangesInBlockResponse>(value)
+                        .expect("failed to parse changes response")
+                }
+                other => panic!("expected Response, got: {other:?}"),
+            }
+        };
+
+    // Query alice's changes from alice_node (local shard) — baseline.
+    let result = send_changes_request(&mut h, &alice_node, vec![alice.clone()]);
+    let accounts_changed: Vec<_> =
+        result.changes.iter().map(|c| c.value.account_id().clone()).collect();
+    assert!(
+        accounts_changed.contains(&alice),
+        "alice_node (local): missing alice's changes, got: {accounts_changed:?}",
+    );
+
+    // Cross-shard forwarding: query alice's changes from zoe_node (doesn't track alice's shard).
+    let result = send_changes_request(&mut h, &zoe_node, vec![alice.clone()]);
+    let accounts_changed: Vec<_> =
+        result.changes.iter().map(|c| c.value.account_id().clone()).collect();
+    assert!(
+        accounts_changed.contains(&alice),
+        "zoe_node (cross-shard): missing alice's changes, got: {accounts_changed:?}",
+    );
+}
+
+/// `changes` with empty account_ids succeeds without error through the
+/// scatter-gather path. The underlying handler treats empty account_ids as
+/// "no accounts requested" and returns an empty result — verify this doesn't
+/// cause an error or timeout.
+#[test]
+fn test_rpc_changes_empty_account_ids_scatter_gather() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+
+    let outcome =
+        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
+    let block_hash = outcome.block_hash;
+
+    let zoe_node = h.zoe_node.clone();
+
+    // Empty account_ids — scatter-gather fans out to all shards but each node
+    // returns empty changes (the handler treats [] as "no accounts requested").
+    let params = serde_json::to_value(RpcStateChangesInBlockByTypeRequest {
+        block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+        state_changes_request: StateChangesRequestView::AccountChanges { account_ids: vec![] },
+    })
+    .unwrap();
+    let response = h
+        .env
+        .runner_for_account(&zoe_node)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.transport.send_jsonrpc_request(
+                    Message::request("changes".to_string(), params.clone()),
+                    false,
+                )
+            },
+            Duration::seconds(5),
+        )
+        .unwrap();
+    match response {
+        Message::Response(resp) => {
+            let value = resp.result.expect("empty account_ids request should succeed");
+            let parsed: RpcStateChangesInBlockResponse =
+                serde_json::from_value(value).expect("failed to parse");
+            // The handler returns empty changes for empty account_ids filter.
+            assert!(
+                parsed.changes.is_empty(),
+                "empty account_ids should return empty changes, got: {:?}",
+                parsed.changes.len(),
+            );
+        }
+        other => panic!("expected Response, got: {other:?}"),
+    }
+}
+
+/// `changes` with SingleAccessKeyChanges variant should scatter-gather
+/// correctly, routing by the access key's account_id to the right shard.
+#[test]
+fn test_rpc_changes_single_access_key_scatter_gather() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+
+    // Create a transaction so alice has access key changes in a block.
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+
+    let outcome =
+        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
+    let block_hash = outcome.block_hash;
+
+    let zoe_node = h.zoe_node.clone();
+
+    // Use SingleAccessKeyChanges with alice's key — alice is on a different shard
+    // from zoe_node, so scatter-gather must forward to alice's node.
+    let signer = near_crypto::InMemorySigner::from_seed(
+        alice.clone(),
+        near_crypto::KeyType::ED25519,
+        alice.as_ref(),
+    );
+    let params = serde_json::to_value(RpcStateChangesInBlockByTypeRequest {
+        block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+        state_changes_request: StateChangesRequestView::SingleAccessKeyChanges {
+            keys: vec![near_primitives::types::AccountWithPublicKey {
+                account_id: alice.clone(),
+                public_key: signer.public_key(),
+            }],
+        },
+    })
+    .unwrap();
+    let response = h
+        .env
+        .runner_for_account(&zoe_node)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.transport.send_jsonrpc_request(
+                    Message::request("changes".to_string(), params.clone()),
+                    false,
+                )
+            },
+            Duration::seconds(5),
+        )
+        .unwrap();
+    match response {
+        Message::Response(resp) => {
+            // The request should succeed — scatter-gather forwards to alice's shard.
+            let value = resp.result.expect("SingleAccessKeyChanges request should succeed");
+            let _parsed: RpcStateChangesInBlockResponse =
+                serde_json::from_value(value).expect("failed to parse");
+            // Success is sufficient — the key point is that scatter-gather
+            // correctly routed to alice's shard from zoe's node without error.
+        }
+        other => panic!("expected Response, got: {other:?}"),
     }
 }

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -1636,7 +1636,7 @@ fn test_rpc_changes_single_access_key_scatter_gather() {
         block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
         state_changes_request: StateChangesRequestView::SingleAccessKeyChanges {
             keys: vec![near_primitives::types::AccountWithPublicKey {
-                account_id: alice.clone(),
+                account_id: alice,
                 public_key: signer.public_key(),
             }],
         },

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -1446,20 +1446,46 @@ fn test_rpc_changes_scatter_gather() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
 
-    // Submit a transfer so alice has state changes.
     let alice = h.alice.clone();
     let zoe = h.zoe.clone();
     let validator = h.validator.clone();
-    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
-    let tx_hash = tx.get_hash();
-    h.env.node_for_account(&validator).submit_tx(tx);
+
+    // Submit two independent TXs before running any blocks: alice → validator and
+    // zoe → validator. Both are on different shards, so their TX executions (which
+    // produce the sender-side AccountChanges) will land in chunks of the same block.
+    let tx_alice =
+        h.env.node_for_account(&validator).tx_send_money(&alice, &validator, Balance::from_near(1));
+    let tx_zoe =
+        h.env.node_for_account(&validator).tx_send_money(&zoe, &validator, Balance::from_near(1));
+    let tx_alice_hash = tx_alice.get_hash();
+    let tx_zoe_hash = tx_zoe.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx_alice);
+    h.env.node_for_account(&validator).submit_tx(tx_zoe);
 
     let target_height = h.env.node_for_account(&validator).head().height + 10;
     h.env.runner_for_account(&validator).run_until_executed_height(target_height);
 
-    let outcome =
-        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
-    let block_hash = outcome.block_hash;
+    let alice_outcome = h
+        .env
+        .node_for_account(&validator)
+        .client()
+        .chain
+        .get_execution_outcome(&tx_alice_hash)
+        .unwrap();
+    let zoe_outcome = h
+        .env
+        .node_for_account(&validator)
+        .client()
+        .chain
+        .get_execution_outcome(&tx_zoe_hash)
+        .unwrap();
+
+    // Both TXs are on different shards, so they execute in chunks of the same block.
+    let block_hash = alice_outcome.block_hash;
+    assert_eq!(
+        alice_outcome.block_hash, zoe_outcome.block_hash,
+        "alice and zoe TXs should execute in the same block"
+    );
 
     let alice_node = h.alice_node.clone();
     let zoe_node = h.zoe_node.clone();
@@ -1511,6 +1537,22 @@ fn test_rpc_changes_scatter_gather() {
     assert!(
         accounts_changed.contains(&alice),
         "zoe_node (cross-shard): missing alice's changes, got: {accounts_changed:?}",
+    );
+
+    // Cross-shard merge: query alice AND zoe together from zoe_node in a single request.
+    // This exercises the scatter-gather split-by-shard path: the coordinator sends
+    // alice's shard query to alice_node and zoe's shard query to zoe_node (local),
+    // then merges both results.
+    let result = send_changes_request(&mut h, &zoe_node, vec![alice.clone(), zoe.clone()]);
+    let accounts_changed: Vec<_> =
+        result.changes.iter().map(|c| c.value.account_id().clone()).collect();
+    assert!(
+        accounts_changed.contains(&alice),
+        "zoe_node (cross-shard merge): missing alice's changes, got: {accounts_changed:?}",
+    );
+    assert!(
+        accounts_changed.contains(&zoe),
+        "zoe_node (cross-shard merge): missing zoe's changes, got: {accounts_changed:?}",
     );
 }
 

--- a/test-loop-tests/src/tests/sharded_rpc_reliability.rs
+++ b/test-loop-tests/src/tests/sharded_rpc_reliability.rs
@@ -2,6 +2,7 @@ use crate::setup::rpc::RpcFault;
 use crate::utils::sharded_rpc::{ThreeNodeHarness, TwoShardHarness, assert_rpc_error};
 use near_async::time::Duration;
 use near_jsonrpc::client::ChunkId;
+use near_jsonrpc_primitives::errors::RpcErrorKind;
 use near_jsonrpc_primitives::message::Message;
 use near_jsonrpc_primitives::types::changes::{
     RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
@@ -526,6 +527,65 @@ fn test_rpc_block_effects_scatter_gather_retry() {
     got.sort();
     assert_eq!(got, want, "scatter-gather response must match validator baseline");
     assert!(got.contains(&alice), "retry via rpc2 should surface alice's changes; got: {got:?}",);
+}
+
+/// When every candidate for a shard fails, `run_scatter_gather` must exhaust
+/// its retries and surface an error rather than returning a partial response
+/// or hanging. Both rpc0 and rpc2 track alice's shard; faulting both leaves
+/// the coordinator with no candidate after exclusion. The per-round
+/// `one_node_per_group_of_shard` call then returns "No available host for
+/// given shard" once rpc0 and rpc2 are excluded. The log trace (rpc0 failure
+/// → retry → rpc2 failure → give-up) confirms both candidates were tried.
+#[test]
+fn test_rpc_block_effects_scatter_gather_all_nodes_fail() {
+    init_test_logger();
+    let mut h = ThreeNodeHarness::new();
+
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+    let rpc1 = h.rpc1.clone();
+
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+
+    let outcome =
+        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
+    let block_hash = outcome.block_hash;
+
+    *h.rpc0_fault.write() = Some(RpcFault::Fail("rpc0 down".to_string()));
+    *h.rpc2_fault.write() = Some(RpcFault::Fail("rpc2 down".to_string()));
+
+    let err = h
+        .env
+        .runner_for_account(&rpc1)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.block_effects(RpcStateChangesInBlockRequest {
+                    block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                })
+            },
+            Duration::seconds(10),
+        )
+        .expect_err("scatter-gather must fail when no node can serve alice's shard");
+
+    // Must be an InternalError — a RequestValidationError would abort the
+    // whole request before retrying, so seeing one here would mean the retry
+    // path never ran.
+    match err.error_struct.as_ref().expect("expected error_struct") {
+        RpcErrorKind::InternalError(val) => {
+            let msg = val["info"]["error_message"].as_str().unwrap_or("");
+            assert!(
+                msg.contains("No available host"),
+                "error should reflect the exhausted pool; got: {val}",
+            );
+        }
+        other => panic!("expected InternalError, got: {other:?}"),
+    }
 }
 
 /// A `changes` request with a bogus block hash must return UNKNOWN_BLOCK.

--- a/test-loop-tests/src/tests/sharded_rpc_reliability.rs
+++ b/test-loop-tests/src/tests/sharded_rpc_reliability.rs
@@ -315,9 +315,10 @@ fn test_rpc_block_effects_coordinator_bypass() {
     }
 }
 
-/// Coordinator-flagged `changes` requests must be processed locally,
-/// returning only local data. This mirrors test_rpc_block_effects_coordinator_bypass
-/// for the filtered changes method.
+/// Coordinator-flagged `changes` requests must be processed locally. When the
+/// request targets an account whose shard this node doesn't track, the node
+/// must reject with SHARD_NOT_APPLIED rather than silently returning empty
+/// data — otherwise partial results look identical to genuinely empty ones.
 #[test]
 fn test_rpc_changes_coordinator_bypass() {
     init_test_logger();
@@ -375,7 +376,8 @@ fn test_rpc_changes_coordinator_bypass() {
         other => panic!("expected Response, got: {other:?}"),
     }
 
-    // Coordinator-flagged: zoe_node processes locally, can't see alice's shard.
+    // Coordinator-flagged: zoe_node processes locally and must reject with
+    // SHARD_NOT_APPLIED because alice's shard isn't tracked here.
     let coord_response = h
         .env
         .runner_for_account(&zoe_node)
@@ -391,15 +393,10 @@ fn test_rpc_changes_coordinator_bypass() {
         .unwrap();
     match coord_response {
         Message::Response(resp) => {
-            let value = resp.result.expect("coordinator request should succeed with local data");
-            let parsed: RpcStateChangesInBlockResponse =
-                serde_json::from_value(value).expect("failed to parse");
-            let coord_accounts: Vec<_> =
-                parsed.changes.iter().map(|c| c.value.account_id().clone()).collect();
-            assert!(
-                !coord_accounts.contains(&alice),
-                "coordinator bypass: should NOT include alice's changes (wrong shard), got: {coord_accounts:?}",
+            let err = resp.result.expect_err(
+                "coordinator request for an untracked shard must fail with SHARD_NOT_APPLIED",
             );
+            assert_rpc_error(&err, "SHARD_NOT_APPLIED");
         }
         other => panic!("expected Response, got: {other:?}"),
     }

--- a/test-loop-tests/src/tests/sharded_rpc_reliability.rs
+++ b/test-loop-tests/src/tests/sharded_rpc_reliability.rs
@@ -1,4 +1,5 @@
-use crate::utils::sharded_rpc::{TwoShardHarness, assert_rpc_error};
+use crate::setup::rpc::RpcFault;
+use crate::utils::sharded_rpc::{ThreeNodeHarness, TwoShardHarness, assert_rpc_error};
 use near_async::time::Duration;
 use near_jsonrpc::client::ChunkId;
 use near_jsonrpc_primitives::message::Message;
@@ -427,6 +428,104 @@ fn test_rpc_block_effects_bogus_block_hash() {
         )
         .unwrap_err();
     assert_rpc_error(&err, "UNKNOWN_BLOCK");
+}
+
+/// Drive a scatter-gather `block_effects` from rpc1 with rpc0 faulted out, and
+/// assert the response matches the validator's (full, baseline) response.
+///
+/// When the first-picked remote for a shard is unresponsive, `run_scatter_gather`
+/// must exclude it on the per-peer timeout and retry via a backup node. rpc0's
+/// transport is wired to hang, so the coordinator's 10s per-peer timeout fires
+/// and the retry picks rpc2. Both failure modes drive the same retry path; this
+/// test covers the timeout branch.
+///
+/// Same retry path, but rpc0 fails immediately with an internal error
+/// (simulating a stale node) rather than timing out. The retry loop must still
+/// fall back to rpc2.
+#[test]
+fn test_rpc_block_effects_scatter_gather_retry() {
+    init_test_logger();
+    let mut h = ThreeNodeHarness::new();
+
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+    let rpc1 = h.rpc1.clone();
+
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+
+    let outcome =
+        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
+    let block_hash = outcome.block_hash;
+
+    // Baseline: validator tracks all shards so one call returns the full picture.
+    let baseline = h
+        .env
+        .runner_for_account(&validator)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.block_effects(RpcStateChangesInBlockRequest {
+                    block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                })
+            },
+            Duration::seconds(5),
+        )
+        .expect("baseline block_effects query on validator");
+    let mut want: Vec<_> = baseline.changes.iter().map(|c| c.account_id().clone()).collect();
+    want.sort();
+
+    // Case 1: rpc0 hangs, triggers per-peer timeout and retry via rpc2.
+    let fault = RpcFault::Hang;
+    let budget = Duration::seconds(30);
+    *h.rpc0_fault.write() = Some(fault);
+
+    let result = h
+        .env
+        .runner_for_account(&rpc1)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.block_effects(RpcStateChangesInBlockRequest {
+                    block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                })
+            },
+            budget,
+        )
+        .expect("scatter-gather should succeed via rpc2 after rpc0 is excluded");
+
+    assert_eq!(result.block_hash, baseline.block_hash);
+    let mut got: Vec<_> = result.changes.iter().map(|c| c.account_id().clone()).collect();
+    got.sort();
+    assert_eq!(got, want, "scatter-gather response must match validator baseline");
+    assert!(got.contains(&alice), "retry via rpc2 should surface alice's changes; got: {got:?}",);
+
+    // Case 2: rpc0 fails immediately. The retry loop must still exclude rpc0 and succeed via rpc2 within the budget.
+    let fault = RpcFault::Fail("stale rpc0".to_string());
+    let budget = Duration::seconds(10);
+    *h.rpc0_fault.write() = Some(fault);
+
+    let result = h
+        .env
+        .runner_for_account(&rpc1)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.block_effects(RpcStateChangesInBlockRequest {
+                    block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                })
+            },
+            budget,
+        )
+        .expect("scatter-gather should succeed via rpc2 after rpc0 is excluded");
+
+    assert_eq!(result.block_hash, baseline.block_hash);
+    let mut got: Vec<_> = result.changes.iter().map(|c| c.account_id().clone()).collect();
+    got.sort();
+    assert_eq!(got, want, "scatter-gather response must match validator baseline");
+    assert!(got.contains(&alice), "retry via rpc2 should surface alice's changes; got: {got:?}",);
 }
 
 /// A `changes` request with a bogus block hash must return UNKNOWN_BLOCK.

--- a/test-loop-tests/src/tests/sharded_rpc_reliability.rs
+++ b/test-loop-tests/src/tests/sharded_rpc_reliability.rs
@@ -2,6 +2,10 @@ use crate::utils::sharded_rpc::{TwoShardHarness, assert_rpc_error};
 use near_async::time::Duration;
 use near_jsonrpc::client::ChunkId;
 use near_jsonrpc_primitives::message::Message;
+use near_jsonrpc_primitives::types::changes::{
+    RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
+    RpcStateChangesInBlockRequest, RpcStateChangesInBlockResponse,
+};
 use near_jsonrpc_primitives::types::chunks::{ChunkReference, RpcChunkRequest};
 use near_jsonrpc_primitives::types::query::RpcQueryRequest;
 use near_jsonrpc_primitives::types::receipts::{ReceiptReference, RpcReceiptRequest};
@@ -9,7 +13,7 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, Balance, BlockId, BlockReference, Finality};
-use near_primitives::views::QueryRequest;
+use near_primitives::views::{QueryRequest, StateChangesRequestView};
 use near_store::ShardUId;
 
 /// A cross-shard query for a nonexistent account must return UNKNOWN_ACCOUNT,
@@ -227,5 +231,237 @@ fn test_rpc_parallel_take_first_partial_failure() {
             )
             .unwrap_or_else(|e| panic!("receipt query from {node_id} failed: {e:?}"));
         assert_eq!(result.receipt_view.receipt_id, receipt_id);
+    }
+}
+
+/// Coordinator-flagged `block_effects` requests must be processed locally
+/// (no scatter-gather), so a node that doesn't track a shard returns only
+/// its local changes — not changes from other shards. This prevents
+/// forwarding loops in the scatter-gather protocol.
+#[test]
+fn test_rpc_block_effects_coordinator_bypass() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+
+    let outcome =
+        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
+    let block_hash = outcome.block_hash;
+
+    let zoe_node = h.zoe_node.clone();
+
+    // Baseline: a normal request from zoe_node gets changes for both shards
+    // via scatter-gather.
+    let result = h
+        .env
+        .runner_for_account(&zoe_node)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.block_effects(RpcStateChangesInBlockRequest {
+                    block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                })
+            },
+            Duration::seconds(5),
+        )
+        .unwrap();
+    let normal_accounts: Vec<_> = result.changes.iter().map(|c| c.account_id().clone()).collect();
+    assert!(
+        normal_accounts.iter().any(|a| a == &alice),
+        "baseline: scatter-gather should include alice's changes, got: {normal_accounts:?}",
+    );
+
+    // Coordinator-flagged request from zoe_node: processed locally, no scatter-gather.
+    // Zoe's node only tracks zoe's shard, so alice's changes should be missing.
+    let request = Message::request(
+        "block_effects".to_string(),
+        serde_json::to_value(RpcStateChangesInBlockRequest {
+            block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+        })
+        .unwrap(),
+    );
+    let response = h
+        .env
+        .runner_for_account(&zoe_node)
+        .run_with_jsonrpc_client(
+            |client| client.transport.send_jsonrpc_request(request, true),
+            Duration::seconds(5),
+        )
+        .unwrap();
+
+    match response {
+        Message::Response(resp) => {
+            let value = resp.result.expect("coordinator request should succeed with local data");
+            let parsed: RpcStateChangesInBlockByTypeResponse =
+                serde_json::from_value(value).expect("failed to parse response");
+            let coord_accounts: Vec<_> =
+                parsed.changes.iter().map(|c| c.account_id().clone()).collect();
+            assert!(
+                !coord_accounts.contains(&alice),
+                "coordinator bypass: should NOT include alice's changes (wrong shard), got: {coord_accounts:?}",
+            );
+        }
+        other => panic!("expected Response, got: {other:?}"),
+    }
+}
+
+/// Coordinator-flagged `changes` requests must be processed locally,
+/// returning only local data. This mirrors test_rpc_block_effects_coordinator_bypass
+/// for the filtered changes method.
+#[test]
+fn test_rpc_changes_coordinator_bypass() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let alice = h.alice.clone();
+    let zoe = h.zoe.clone();
+    let validator = h.validator.clone();
+    let tx = h.env.node_for_account(&validator).tx_send_money(&alice, &zoe, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    h.env.node_for_account(&validator).submit_tx(tx);
+
+    let target_height = h.env.node_for_account(&validator).head().height + 10;
+    h.env.runner_for_account(&validator).run_until_executed_height(target_height);
+
+    let outcome =
+        h.env.node_for_account(&validator).client().chain.get_execution_outcome(&tx_hash).unwrap();
+    let block_hash = outcome.block_hash;
+
+    let zoe_node = h.zoe_node.clone();
+
+    // Baseline: normal request from zoe_node for alice's changes succeeds via scatter-gather.
+    let params = serde_json::to_value(RpcStateChangesInBlockByTypeRequest {
+        block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+        state_changes_request: StateChangesRequestView::AccountChanges {
+            account_ids: vec![alice.clone()],
+        },
+    })
+    .unwrap();
+    let response = h
+        .env
+        .runner_for_account(&zoe_node)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.transport.send_jsonrpc_request(
+                    Message::request("changes".to_string(), params.clone()),
+                    false,
+                )
+            },
+            Duration::seconds(5),
+        )
+        .unwrap();
+    match &response {
+        Message::Response(resp) => {
+            let value = resp.result.as_ref().expect("baseline should succeed");
+            let parsed: RpcStateChangesInBlockResponse =
+                serde_json::from_value(value.clone()).expect("failed to parse");
+            let accounts: Vec<_> =
+                parsed.changes.iter().map(|c| c.value.account_id().clone()).collect();
+            assert!(
+                accounts.contains(&alice),
+                "baseline: scatter-gather should include alice's changes, got: {accounts:?}",
+            );
+        }
+        other => panic!("expected Response, got: {other:?}"),
+    }
+
+    // Coordinator-flagged: zoe_node processes locally, can't see alice's shard.
+    let coord_response = h
+        .env
+        .runner_for_account(&zoe_node)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.transport.send_jsonrpc_request(
+                    Message::request("changes".to_string(), params.clone()),
+                    true,
+                )
+            },
+            Duration::seconds(5),
+        )
+        .unwrap();
+    match coord_response {
+        Message::Response(resp) => {
+            let value = resp.result.expect("coordinator request should succeed with local data");
+            let parsed: RpcStateChangesInBlockResponse =
+                serde_json::from_value(value).expect("failed to parse");
+            let coord_accounts: Vec<_> =
+                parsed.changes.iter().map(|c| c.value.account_id().clone()).collect();
+            assert!(
+                !coord_accounts.contains(&alice),
+                "coordinator bypass: should NOT include alice's changes (wrong shard), got: {coord_accounts:?}",
+            );
+        }
+        other => panic!("expected Response, got: {other:?}"),
+    }
+}
+
+/// A `block_effects` request with a bogus block hash must return UNKNOWN_BLOCK,
+/// not a timeout or internal error. The scatter-gather coordinator resolves the
+/// block before fanning out, so a bad hash fails immediately.
+#[test]
+fn test_rpc_block_effects_bogus_block_hash() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let bogus_hash = CryptoHash::hash_bytes(b"bogus block hash");
+    let alice_node = h.alice_node.clone();
+
+    let err = h
+        .env
+        .runner_for_account(&alice_node)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.block_effects(RpcStateChangesInBlockRequest {
+                    block_reference: BlockReference::BlockId(BlockId::Hash(bogus_hash)),
+                })
+            },
+            Duration::seconds(5),
+        )
+        .unwrap_err();
+    assert_rpc_error(&err, "UNKNOWN_BLOCK");
+}
+
+/// A `changes` request with a bogus block hash must return UNKNOWN_BLOCK.
+#[test]
+fn test_rpc_changes_bogus_block_hash() {
+    init_test_logger();
+    let mut h = TwoShardHarness::new();
+
+    let bogus_hash = CryptoHash::hash_bytes(b"bogus block hash");
+    let alice_node = h.alice_node.clone();
+    let alice = h.alice.clone();
+
+    let params = serde_json::to_value(RpcStateChangesInBlockByTypeRequest {
+        block_reference: BlockReference::BlockId(BlockId::Hash(bogus_hash)),
+        state_changes_request: StateChangesRequestView::AccountChanges { account_ids: vec![alice] },
+    })
+    .unwrap();
+    let response = h
+        .env
+        .runner_for_account(&alice_node)
+        .run_with_jsonrpc_client(
+            |client| {
+                client.transport.send_jsonrpc_request(
+                    Message::request("changes".to_string(), params.clone()),
+                    false,
+                )
+            },
+            Duration::seconds(5),
+        )
+        .unwrap();
+    match response {
+        Message::Response(resp) => {
+            let err = resp.result.expect_err("bogus block hash should fail");
+            assert_rpc_error(&err, "UNKNOWN_BLOCK");
+        }
+        other => panic!("expected Response, got: {other:?}"),
     }
 }

--- a/test-loop-tests/src/utils/sharded_rpc.rs
+++ b/test-loop-tests/src/utils/sharded_rpc.rs
@@ -105,9 +105,10 @@ impl TwoShardHarness {
 /// - `rpc2` — tracks alice's shard; backup that answers after rpc0 is excluded.
 /// - `validator0` — tracks all shards; baseline source of truth.
 ///
-/// `rpc0` is wired with a fault handle so tests can simulate either a stale
-/// node (`RpcFault::Fail`) or a dead node (`RpcFault::Hang`) by flipping the
-/// handle before sending the scatter-gather query.
+/// Both `rpc0` and `rpc2` are wired with fault handles so tests can simulate
+/// a stale node (`RpcFault::Fail`) or a dead node (`RpcFault::Hang`) on either
+/// of alice's shard candidates. Flipping both exercises the exhaustion path
+/// where no candidate can serve the shard.
 pub(crate) struct ThreeNodeHarness {
     pub(crate) env: TestLoopEnv,
     pub(crate) alice: AccountId,
@@ -118,10 +119,10 @@ pub(crate) struct ThreeNodeHarness {
     #[allow(dead_code)]
     pub(crate) rpc2: AccountId,
     pub(crate) validator: AccountId,
-    /// Fault handle for rpc0's pool entry. Setting `Some(RpcFault::...)`
-    /// causes requests routed to rpc0 via the pool to fail (stale) or hang
-    /// (dead).
+    /// Fault handle for rpc0's pool entry.
     pub(crate) rpc0_fault: RpcFaultHandle,
+    /// Fault handle for rpc2's pool entry.
+    pub(crate) rpc2_fault: RpcFaultHandle,
 }
 
 impl ThreeNodeHarness {
@@ -180,9 +181,10 @@ impl ThreeNodeHarness {
             })
             .add_rpc_pool([rpc0.clone(), rpc1.clone(), rpc2.clone()]);
         let rpc0_fault = builder.rpc_pool_fault_handle(rpc0.clone());
+        let rpc2_fault = builder.rpc_pool_fault_handle(rpc2.clone());
         let env = builder.build();
 
-        Self { env, alice, zoe, rpc0, rpc1, rpc2, validator: validator0, rpc0_fault }
+        Self { env, alice, zoe, rpc0, rpc1, rpc2, validator: validator0, rpc0_fault, rpc2_fault }
     }
 }
 

--- a/test-loop-tests/src/utils/sharded_rpc.rs
+++ b/test-loop-tests/src/utils/sharded_rpc.rs
@@ -1,5 +1,6 @@
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
+use crate::setup::rpc::RpcFaultHandle;
 use crate::utils::account::create_account_id;
 use near_async::time::Duration;
 use near_chain_configs::TrackedShardsConfig;
@@ -92,6 +93,96 @@ impl TwoShardHarness {
             "test precondition failed: final_height ({final_height}) must be < head_height ({head_height})",
         );
         (final_height, head_height)
+    }
+}
+
+/// Test harness with a backup RPC node tracking alice's shard.
+///
+/// Topology (4 clients):
+/// - `rpc0` — tracks alice's shard; first pick for alice's shard from rpc1's pool.
+/// - `rpc1` — tracks zoe's shard; used as coordinator so shard-0 queries must
+///   traverse the pool (rpc0 → rpc2) and exercise the retry loop.
+/// - `rpc2` — tracks alice's shard; backup that answers after rpc0 is excluded.
+/// - `validator0` — tracks all shards; baseline source of truth.
+///
+/// `rpc0` is wired with a fault handle so tests can simulate either a stale
+/// node (`RpcFault::Fail`) or a dead node (`RpcFault::Hang`) by flipping the
+/// handle before sending the scatter-gather query.
+pub(crate) struct ThreeNodeHarness {
+    pub(crate) env: TestLoopEnv,
+    pub(crate) alice: AccountId,
+    pub(crate) zoe: AccountId,
+    #[allow(dead_code)]
+    pub(crate) rpc0: AccountId,
+    pub(crate) rpc1: AccountId,
+    #[allow(dead_code)]
+    pub(crate) rpc2: AccountId,
+    pub(crate) validator: AccountId,
+    /// Fault handle for rpc0's pool entry. Setting `Some(RpcFault::...)`
+    /// causes requests routed to rpc0 via the pool to fail (stale) or hang
+    /// (dead).
+    pub(crate) rpc0_fault: RpcFaultHandle,
+}
+
+impl ThreeNodeHarness {
+    pub(crate) fn new() -> Self {
+        let shard_layout = ShardLayout::multi_shard(2, 1);
+        let shard_uids: Vec<ShardUId> = shard_layout.shard_uids().collect();
+
+        let alice = create_account_id("alice");
+        let zoe = create_account_id("zoe");
+        let alice_shard = shard_layout.account_id_to_shard_id(&alice);
+        let zoe_shard = shard_layout.account_id_to_shard_id(&zoe);
+        assert_ne!(alice_shard, zoe_shard);
+
+        // Figure out which ShardUId is alice's and which is zoe's so that
+        // rpc0 + rpc2 can be pinned to alice's shard and rpc1 to zoe's.
+        let alice_shard_uid = shard_uids
+            .iter()
+            .copied()
+            .find(|uid| uid.shard_id() == alice_shard)
+            .expect("alice's shard uid");
+        let zoe_shard_uid = shard_uids
+            .iter()
+            .copied()
+            .find(|uid| uid.shard_id() == zoe_shard)
+            .expect("zoe's shard uid");
+
+        let validator0: AccountId = create_account_id("validator");
+        let validators_spec = ValidatorsSpec::desired_roles(&[validator0.as_str()], &[]);
+        let genesis = TestLoopBuilder::new_genesis_builder()
+            .shard_layout(shard_layout)
+            .validators_spec(validators_spec)
+            .add_user_account_simple(alice.clone(), Balance::from_near(100))
+            .add_user_account_simple(zoe.clone(), Balance::from_near(200))
+            .build();
+
+        let rpc0: AccountId = create_account_id("rpc0");
+        let rpc1: AccountId = create_account_id("rpc1");
+        let rpc2: AccountId = create_account_id("rpc2");
+        let clients = vec![rpc0.clone(), rpc1.clone(), rpc2.clone(), validator0.clone()];
+        let mut builder = TestLoopBuilder::new()
+            .genesis(genesis)
+            .clients(clients)
+            .config_modifier(move |config, client_index| match client_index {
+                0 => {
+                    config.tracked_shards_config =
+                        TrackedShardsConfig::Shards(vec![alice_shard_uid])
+                }
+                1 => {
+                    config.tracked_shards_config = TrackedShardsConfig::Shards(vec![zoe_shard_uid])
+                }
+                2 => {
+                    config.tracked_shards_config =
+                        TrackedShardsConfig::Shards(vec![alice_shard_uid])
+                }
+                _ => {}
+            })
+            .add_rpc_pool([rpc0.clone(), rpc1.clone(), rpc2.clone()]);
+        let rpc0_fault = builder.rpc_pool_fault_handle(rpc0.clone());
+        let env = builder.build();
+
+        Self { env, alice, zoe, rpc0, rpc1, rpc2, validator: validator0, rpc0_fault }
     }
 }
 


### PR DESCRIPTION
## Summary

  - Add scatter-gather coordination for block_effects, EXPERIMENTAL_changes_in_block, changes, and EXPERIMENTAL_changes RPC methods so that an RPC node tracking a subset of shards can fan out requests to peer nodes and
   merge results
  - block_effects/EXPERIMENTAL_changes_in_block fan out to all shards and post-filter responses by assigned shard
  - changes/EXPERIMENTAL_changes pre-filter requests by shard group (splitting account_ids) so each node only processes its relevant accounts
  - Shared run_scatter_gather retry loop with node exclusion on failure and early bail on RequestValidationError
  - pick_node_for_shard / one_node_per_group_of_shard group shards by node to minimize request count

## Testing
- Added testloop.
- Created a mainnet RPC pool