### PR TITLE
fix(runtime): clamp protocol version for view calls on archival nodes

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -34,7 +34,9 @@ use near_primitives::types::{
     AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, MerkleHash,
     Nonce, NonceIndex, NumShards, ShardId, StateRoot, StateRootNode,
 };
-use near_primitives::version::{ProtocolFeature, ProtocolVersion};
+use near_primitives::version::{
+    ProtocolFeature, ProtocolVersion, clamp_to_supported_protocol_version,
+};
 use near_primitives::views::{
     AccessKeyInfoView, CallResult, ContractCodeView, GasKeyNoncesView, QueryRequest, QueryResponse,
     QueryResponseKind, ViewStateResult,
@@ -1696,7 +1698,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
         self.trie_viewer.view_account_contract_code(
             &state_update,
             account_id,
-            current_protocol_version,
+            clamp_to_supported_protocol_version(current_protocol_version),
             &self.genesis_config.chain_id,
         )
     }
@@ -1725,7 +1727,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
             epoch_id: *epoch_id,
             epoch_height,
             block_timestamp,
-            current_protocol_version,
+            current_protocol_version: clamp_to_supported_protocol_version(current_protocol_version),
             cache: Some(self.compiled_contract_cache.handle()),
         };
         self.trie_viewer.call_function(

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -525,6 +525,31 @@ pub const PROD_GENESIS_PROTOCOL_VERSION: ProtocolVersion = 29;
 /// Minimum supported protocol version for the current binary
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 80;
 
+/// Returns the effective protocol version to use for processing a request.
+///
+/// Archival nodes can serve requests for blocks from protocol versions older than
+/// `MIN_SUPPORTED_PROTOCOL_VERSION`. Some features from those old versions may no longer be
+/// available in the current binary (e.g. the Wasmer0/Wasmer2 VM backends have been removed).
+/// For read-only view calls that don't produce on-chain state, it is safe to clamp the protocol
+/// version to `MIN_SUPPORTED_PROTOCOL_VERSION` so the request is processed with the config of
+/// the oldest fully-supported version.
+pub fn clamp_to_supported_protocol_version(
+    current_protocol_version: ProtocolVersion,
+) -> ProtocolVersion {
+    current_protocol_version.max(MIN_SUPPORTED_PROTOCOL_VERSION)
+}
+
+/// Panics if `current_protocol_version` is below `MIN_SUPPORTED_PROTOCOL_VERSION`.
+///
+/// Use this at callee boundaries to enforce that the caller has already clamped the version
+/// via [`clamp_to_supported_protocol_version`].
+pub fn assert_supported_protocol_version(current_protocol_version: ProtocolVersion) {
+    assert!(
+        current_protocol_version >= MIN_SUPPORTED_PROTOCOL_VERSION,
+        "protocol version {current_protocol_version} is below minimum supported {MIN_SUPPORTED_PROTOCOL_VERSION}"
+    );
+}
+
 /// Current protocol version used on the mainnet with all stable features.
 const STABLE_PROTOCOL_VERSION: ProtocolVersion = 85;
 

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -19,6 +19,8 @@ pub use near_primitives_core::version::MIN_SUPPORTED_PROTOCOL_VERSION;
 pub use near_primitives_core::version::PROD_GENESIS_PROTOCOL_VERSION;
 pub use near_primitives_core::version::PROTOCOL_VERSION;
 pub use near_primitives_core::version::ProtocolFeature;
+pub use near_primitives_core::version::assert_supported_protocol_version;
+pub use near_primitives_core::version::clamp_to_supported_protocol_version;
 
 /// Minimum gas price proposed in NEP 92 and the associated protocol version
 pub const MIN_GAS_PRICE_NEP_92: Balance = Balance::from_yoctonear(1_000_000_000);

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -22,6 +22,7 @@ use near_primitives::trie_key::trie_key_parsers::{
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, Nonce, ShardId,
 };
+use near_primitives::version::assert_supported_protocol_version;
 use near_primitives::views::{StateItem, ViewStateResult};
 use near_primitives_core::config::ViewConfig;
 use near_store::trie::AccessOptions;
@@ -97,6 +98,7 @@ impl TrieViewer {
         current_protocol_version: ProtocolVersion,
         chain_id: &str,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
+        assert_supported_protocol_version(current_protocol_version);
         let account = self.view_account(state_update, account_id)?;
         let wasm_config =
             &self.runtime_config_store.get_config(current_protocol_version).wasm_config;
@@ -271,6 +273,7 @@ impl TrieViewer {
         logs: &mut Vec<String>,
         epoch_info_provider: &dyn EpochInfoProvider,
     ) -> Result<Vec<u8>, errors::CallFunctionError> {
+        assert_supported_protocol_version(view_state.current_protocol_version);
         let now = Instant::now();
         let root = *state_update.get_root();
         let account = get_account(&state_update, contract_id)?.ok_or_else(|| {


### PR DESCRIPTION
- Archival nodes can serve view call queries against blocks from protocol versions older than `MIN_SUPPORTED_PROTOCOL_VERSION`, where the runtime config references VM backends (Wasmer0, Wasmer2) that have been removed from the binary, causing a panic
- Clamp the protocol version to `MIN_SUPPORTED_PROTOCOL_VERSION` in `NightshadeRuntime` before passing it to the state viewer
- Add `clamp_to_supported_protocol_version` and `assert_supported_protocol_version` helpers in `core/primitives-core/src/version.rs`
- Add precondition asserts in `TrieViewer::call_function` and `TrieViewer::view_account_contract_code`

See [zulip](https://near.zulipchat.com/#narrow/channel/533300-releases.2F2.2E11/topic/Mainnet.20archival.20node.20crashes.20on.20some.20RPC.20query/with/585060345) for more context.