### PR TITLE
feat(cloud-archive): batch block and shard uploads

### DIFF
--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -65,6 +65,8 @@ pub enum CloudArchivalInitializationError {
     UpdateError { error: CloudArchivingError },
     #[error("Error when retrieving from cloud archival during initialization: {error}")]
     RetrievalError { error: CloudRetrievalError },
+    #[error("batch_size ({batch_size}) must be < epoch_length ({epoch_length})")]
+    InvalidBatchSize { batch_size: u64, epoch_length: u64 },
 }
 
 impl From<std::io::Error> for CloudArchivalInitializationError {
@@ -424,7 +426,7 @@ impl CloudArchivalWriter {
         runtime_adapter: &Arc<dyn RuntimeAdapter>,
     ) -> Result<(), CloudArchivalInitializationError> {
         self.cloud_storage.ensure_bucket_config().await?;
-        self.assert_batch_size_below_epoch_length()?;
+        self.check_batch_size_below_epoch_length()?;
         let hot_final_height = self.get_hot_final_head_height()?;
         // TODO(cloud_archival): support resharding
         let tracked_shard_ids = self.get_tracked_shard_ids(hot_final_height)?;
@@ -564,7 +566,7 @@ impl CloudArchivalWriter {
     /// a batch crosses at most one epoch boundary (the writer resolves
     /// `shard_layout` once from the batch's start). `batch_size == epoch_length`
     /// would satisfy this, but we keep a strict `<` as a defensive margin.
-    fn assert_batch_size_below_epoch_length(&self) -> Result<(), CloudArchivalInitializationError> {
+    fn check_batch_size_below_epoch_length(&self) -> Result<(), CloudArchivalInitializationError> {
         let height = self.get_hot_final_head_height()?;
         let block_hash = self.hot_store.chain_store().get_block_hash_by_height(height)?;
         let epoch_id = self
@@ -577,10 +579,12 @@ impl CloudArchivalWriter {
             .map_err(near_chain_primitives::Error::from)?
             .epoch_length;
         let batch_size = self.cloud_storage.batch_size() as u64;
-        assert!(
-            batch_size < epoch_length,
-            "batch_size ({batch_size}) must be < epoch_length ({epoch_length})",
-        );
+        if batch_size >= epoch_length {
+            return Err(CloudArchivalInitializationError::InvalidBatchSize {
+                batch_size,
+                epoch_length,
+            });
+        }
         Ok(())
     }
 

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -7,15 +7,14 @@ use near_chain::types::{RuntimeAdapter, Tip};
 use near_chain_configs::{CloudArchivalWriterConfig, InterruptHandle};
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
-use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::types::{BlockHeight, EpochId, ShardId};
+use near_primitives::types::{BlockHeight, ShardId};
 use near_store::adapter::StoreAdapter;
-use near_store::archive::cloud_storage::BatchRange;
 use near_store::archive::cloud_storage::CloudStorage;
 use near_store::archive::cloud_storage::archive::CloudArchivingError;
 use near_store::archive::cloud_storage::retrieve::CloudRetrievalError;
+use near_store::archive::cloud_storage::{BatchRange, compute_next_batch};
 use near_store::db::{
     CLOUD_BLOCK_HEAD_KEY, CLOUD_MIN_HEAD_KEY, DBTransaction, cloud_shard_head_key,
 };
@@ -276,23 +275,25 @@ impl CloudArchivalWriter {
     async fn try_archive_data_impl(&self) -> Result<CloudArchivingOutcome, CloudArchivingError> {
         let min_head =
             self.get_local_cloud_min_head()?.expect("CLOUD_MIN_HEAD should exist in hot store");
-        let height_to_archive = min_head + 1;
+        let batch_range = self.next_batch_after(min_head);
         let hot_final_height = self.get_hot_final_head_height()?;
-        tracing::trace!(target: "cloud_archival", height_to_archive, hot_final_height, "try_archive");
+        tracing::trace!(target: "cloud_archival", ?batch_range, hot_final_height, "try_archive");
 
-        // Archive only while the height to archive is below the finalized height, since
-        // the next block should be finalized first (for `DBCol::NextBlockHashes`).
-        if height_to_archive >= hot_final_height {
+        // The entire batch must be below hot_final_height: the last block in
+        // the batch needs NextBlockHashes, which requires the next block to
+        // be finalized.
+        if batch_range.end() >= hot_final_height {
             return Ok(CloudArchivingOutcome::Idle { cloud_head: min_head });
         }
 
-        self.archive_lagging_components(height_to_archive).await?;
+        self.archive_lagging_components(&batch_range).await?;
 
-        let outcome = if height_to_archive + 1 == hot_final_height {
-            CloudArchivingOutcome::Recent { batch_end: height_to_archive }
+        let next_batch = self.next_batch_after(batch_range.end());
+        let outcome = if next_batch.end() >= hot_final_height {
+            CloudArchivingOutcome::Recent { batch_end: batch_range.end() }
         } else {
             CloudArchivingOutcome::Old {
-                batch_end: height_to_archive,
+                batch_end: batch_range.end(),
                 target_height: hot_final_height - 1,
             }
         };
@@ -300,74 +301,94 @@ impl CloudArchivalWriter {
         Ok(outcome)
     }
 
-    /// Archives all lagging components at the given height and advances local heads.
+    /// Returns the batch that follows `height`. Aligned to `batch_size`;
+    /// may be partial when `height` is unaligned (first batch after genesis
+    /// or fresh init).
+    fn next_batch_after(&self, height: BlockHeight) -> BatchRange {
+        compute_next_batch(height, self.cloud_storage.batch_size())
+    }
+
+    /// Archives all lagging components for the given batch and advances local heads.
     async fn archive_lagging_components(
         &self,
-        height: BlockHeight,
+        batch_range: &BatchRange,
     ) -> Result<(), CloudArchivingError> {
-        let block_hash = self.hot_store.chain_store().get_block_hash_by_height(height)?;
-        let epoch_id = self.epoch_manager.get_epoch_id(&block_hash)?;
+        // TODO(cloud_archival): support resharding.
+        let start_block_hash =
+            self.hot_store.chain_store().get_block_hash_by_height(batch_range.start())?;
+        let start_epoch_id = self.epoch_manager.get_epoch_id(&start_block_hash)?;
+        let shard_layout = self.epoch_manager.get_shard_layout(&start_epoch_id)?;
         let tracked_shards =
-            self.shard_tracker.get_tracked_shards_for_non_validator_in_epoch(&epoch_id)?;
-        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+            self.shard_tracker.get_tracked_shards_for_non_validator_in_epoch(&start_epoch_id)?;
 
         let block_advanced = if self.config.archive_block_data {
-            self.archive_block_and_epoch_if_lagging(height, &block_hash, epoch_id, &shard_layout)
-                .await?
+            self.archive_block_batch_if_lagging(batch_range).await?
         } else {
             false
         };
-        let advanced_shards =
-            self.archive_shards_if_lagging(height, &tracked_shards, &shard_layout).await?;
-        self.advance_local_heads(height, block_advanced, &advanced_shards)?;
+        let advanced_shards = self
+            .archive_shard_batches_if_lagging(batch_range, &shard_layout, &tracked_shards)
+            .await?;
+        self.advance_local_heads(batch_range.end(), block_advanced, &advanced_shards)?;
         Ok(())
     }
 
-    /// Archives block and epoch data if the local block head is behind `height`.
-    /// Epoch data is uploaded at epoch boundaries since it is keyed by epoch ID
-    /// and naturally belongs with the last block of the epoch.
-    /// Returns true if the block head was advanced.
-    async fn archive_block_and_epoch_if_lagging(
+    /// Uploads epoch data for any epoch whose last block falls in this batch.
+    async fn archive_epochs_ending_in_batch(
         &self,
-        height: BlockHeight,
-        block_hash: &CryptoHash,
-        epoch_id: EpochId,
-        shard_layout: &ShardLayout,
+        batch_range: &BatchRange,
+    ) -> Result<(), CloudArchivingError> {
+        for height in batch_range.start()..=batch_range.end() {
+            let block_hash = self.hot_store.chain_store().get_block_hash_by_height(height)?;
+            if !self.epoch_manager.is_next_block_epoch_start(&block_hash)? {
+                continue;
+            }
+            let epoch_id = self.epoch_manager.get_epoch_id(&block_hash)?;
+            let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+            self.cloud_storage.archive_epoch_data(&self.hot_store, &shard_layout, epoch_id).await?;
+        }
+        Ok(())
+    }
+
+    /// Archives the block batch if the local block head is behind `batch_range.end()`.
+    /// Also uploads epoch data for any epoch ending in the batch (gated on
+    /// the same lag check so non-block writers and already-caught-up writers
+    /// don't re-upload).
+    /// Returns true if the block head was advanced.
+    async fn archive_block_batch_if_lagging(
+        &self,
+        batch_range: &BatchRange,
     ) -> Result<bool, CloudArchivingError> {
         if let Some(head) = self.get_local_block_head()? {
-            if head >= height {
+            if head >= batch_range.end() {
                 return Ok(false);
             }
         }
         // TODO(cloud_archival): Race condition between this check and the upload below.
         // Will be replaced with ifGenerationMatch:0 atomic uploads + hash metadata verification.
         let ext_head = self.cloud_storage.retrieve_cloud_block_head_if_exists().await?;
-        if ext_head.is_some_and(|h| h >= height) {
+        if ext_head.is_some_and(|h| h >= batch_range.end()) {
             return Ok(false);
         }
-        if self.epoch_manager.is_next_block_epoch_start(block_hash)? {
-            self.cloud_storage.archive_epoch_data(&self.hot_store, shard_layout, epoch_id).await?;
-        }
-        self.cloud_storage
-            .archive_block_batch(&self.hot_store, &BatchRange::new(height, height))
-            .await?;
-        self.cloud_storage.update_cloud_block_head(height).await?;
+        self.archive_epochs_ending_in_batch(batch_range).await?;
+        self.cloud_storage.archive_block_batch(&self.hot_store, batch_range).await?;
+        self.cloud_storage.update_cloud_block_head(batch_range.end()).await?;
         Ok(true)
     }
 
-    /// Archives shard data for tracked shards whose local head is behind `height`.
-    /// Returns the shard IDs that were advanced.
-    async fn archive_shards_if_lagging(
+    /// Archives shard batches for tracked shards whose local head is behind
+    /// `batch_range.end()`. Returns the shard IDs that were advanced.
+    async fn archive_shard_batches_if_lagging(
         &self,
-        height: BlockHeight,
-        tracked_shards: &[ShardUId],
+        batch_range: &BatchRange,
         shard_layout: &ShardLayout,
+        tracked_shards: &[ShardUId],
     ) -> Result<Vec<ShardId>, CloudArchivingError> {
         let mut advanced_shards = Vec::new();
         for shard_uid in tracked_shards {
             let shard_id = shard_uid.shard_id();
             let lagging = match self.get_local_shard_head(shard_id)? {
-                Some(head) => head < height,
+                Some(head) => head < batch_range.end(),
                 None => true,
             };
             if !lagging {
@@ -376,7 +397,7 @@ impl CloudArchivalWriter {
             // TODO(cloud_archival): Race condition between this check and the upload below.
             // Will be replaced with ifGenerationMatch:0 atomic uploads + hash metadata verification.
             let ext_head = self.cloud_storage.retrieve_cloud_shard_head_if_exists(shard_id).await?;
-            if ext_head.is_some_and(|h| h >= height) {
+            if ext_head.is_some_and(|h| h >= batch_range.end()) {
                 continue;
             }
             self.cloud_storage
@@ -384,11 +405,11 @@ impl CloudArchivalWriter {
                     &self.hot_store,
                     self.genesis_height,
                     shard_layout,
-                    &BatchRange::new(height, height),
+                    batch_range,
                     *shard_uid,
                 )
                 .await?;
-            self.cloud_storage.update_cloud_shard_head(shard_id, height).await?;
+            self.cloud_storage.update_cloud_shard_head(shard_id, batch_range.end()).await?;
             advanced_shards.push(shard_id);
         }
         Ok(advanced_shards)
@@ -403,6 +424,7 @@ impl CloudArchivalWriter {
         runtime_adapter: &Arc<dyn RuntimeAdapter>,
     ) -> Result<(), CloudArchivalInitializationError> {
         self.cloud_storage.ensure_bucket_config().await?;
+        self.assert_batch_size_below_epoch_length()?;
         let hot_final_height = self.get_hot_final_head_height()?;
         // TODO(cloud_archival): support resharding
         let tracked_shard_ids = self.get_tracked_shard_ids(hot_final_height)?;
@@ -536,6 +558,30 @@ impl CloudArchivalWriter {
             .get_tracked_shards_for_non_validator_in_epoch(&epoch_id)
             .map_err(near_chain_primitives::Error::from)?;
         Ok(tracked_shards.iter().map(|uid| uid.shard_id()).collect())
+    }
+
+    /// A batch must never contain an entire epoch as a strict subset, so that
+    /// a batch crosses at most one epoch boundary (the writer resolves
+    /// `shard_layout` once from the batch's start). `batch_size == epoch_length`
+    /// would satisfy this, but we keep a strict `<` as a defensive margin.
+    fn assert_batch_size_below_epoch_length(&self) -> Result<(), CloudArchivalInitializationError> {
+        let height = self.get_hot_final_head_height()?;
+        let block_hash = self.hot_store.chain_store().get_block_hash_by_height(height)?;
+        let epoch_id = self
+            .epoch_manager
+            .get_epoch_id(&block_hash)
+            .map_err(near_chain_primitives::Error::from)?;
+        let epoch_length = self
+            .epoch_manager
+            .get_epoch_config(&epoch_id)
+            .map_err(near_chain_primitives::Error::from)?
+            .epoch_length;
+        let batch_size = self.cloud_storage.batch_size() as u64;
+        assert!(
+            batch_size < epoch_length,
+            "batch_size ({batch_size}) must be < epoch_length ({epoch_length})",
+        );
+        Ok(())
     }
 
     /// Ensures the cloud min head has not been garbage collected.

--- a/core/store/src/archive/cloud_storage/archive.rs
+++ b/core/store/src/archive/cloud_storage/archive.rs
@@ -1,11 +1,10 @@
 use crate::Store;
 use crate::archive::cloud_storage::CloudStorage;
+use crate::archive::cloud_storage::batch::{BatchRange, compute_batch_id};
 use crate::archive::cloud_storage::blocks::build_block_batch;
 use crate::archive::cloud_storage::bucket_config::BucketConfig;
 use crate::archive::cloud_storage::epoch_data::build_epoch_data;
-use crate::archive::cloud_storage::file_id::{
-    BatchRange, CloudStorageFileID, ListableCloudDir, compute_batch_id,
-};
+use crate::archive::cloud_storage::file_id::{CloudStorageFileID, ListableCloudDir};
 use crate::archive::cloud_storage::retrieve::CloudRetrievalError;
 use crate::archive::cloud_storage::shards::build_shard_batch;
 use near_primitives::errors::EpochError;

--- a/core/store/src/archive/cloud_storage/batch.rs
+++ b/core/store/src/archive/cloud_storage/batch.rs
@@ -1,0 +1,126 @@
+//! Batch identifiers, ranges, and arithmetic.
+//!
+//! Batches sit on a global grid of `batch_size`-aligned windows and are
+//! keyed in cloud paths by the window's `BatchId`. The heights actually
+//! covered live inside the blob and may be narrower than the window for a
+//! partial first batch (genesis / fresh init / new child shard post-
+//! resharding). TODO(cloud_archival, resharding): a parent shard's last
+//! batch can also end early at a reshard boundary.
+
+use near_primitives::types::BlockHeight;
+
+/// Start height of the global batch window. Names the cloud blob for that
+/// window (scoped by `shard_id` for shard batches).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BatchId(pub BlockHeight);
+
+/// Returns the `BatchId` of the window containing `height`.
+pub fn compute_batch_id(height: BlockHeight, batch_size: u32) -> BatchId {
+    let batch_size = batch_size as u64;
+    BatchId((height / batch_size) * batch_size)
+}
+
+/// Inclusive height range `[start, end]` covered by a single batch.
+#[derive(Clone, Copy, Debug)]
+pub struct BatchRange {
+    start: BlockHeight,
+    end: BlockHeight,
+}
+
+impl BatchRange {
+    /// See the module doc for partial batches where the range is narrower
+    /// than `batch_size`.
+    pub fn new(start: BlockHeight, end: BlockHeight) -> Self {
+        assert!(end >= start, "invalid batch range [{start}, {end}]");
+        Self { start, end }
+    }
+
+    pub fn start(&self) -> BlockHeight {
+        self.start
+    }
+
+    pub fn end(&self) -> BlockHeight {
+        self.end
+    }
+}
+
+/// Returns the next batch to archive after `height` (the last archived
+/// height, or a pre-archive cut for genesis / fresh init / resharded
+/// child). Starts at `height + 1` and ends at the next batch-aligned
+/// boundary.
+/// TODO(cloud_archival, resharding): also end early at reshard boundaries.
+pub fn compute_next_batch(height: BlockHeight, batch_size: u32) -> BatchRange {
+    let batch_size = batch_size as u64;
+    let start = height + 1;
+    // Steady state: full window.
+    if start % batch_size == 0 {
+        return BatchRange { start, end: start + batch_size - 1 };
+    }
+    // Genesis / fresh init / resharded child: partial window to next boundary.
+    let end = ((start / batch_size) + 1) * batch_size - 1;
+    BatchRange { start, end }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_batch_id_aligns_down_to_multiple() {
+        assert_eq!(compute_batch_id(0, 4), BatchId(0));
+        assert_eq!(compute_batch_id(1, 4), BatchId(0));
+        assert_eq!(compute_batch_id(3, 4), BatchId(0));
+        assert_eq!(compute_batch_id(4, 4), BatchId(4));
+        assert_eq!(compute_batch_id(7, 4), BatchId(4));
+        assert_eq!(compute_batch_id(100, 32), BatchId(96));
+    }
+
+    #[test]
+    fn compute_batch_id_batch_size_one() {
+        assert_eq!(compute_batch_id(0, 1), BatchId(0));
+        assert_eq!(compute_batch_id(42, 1), BatchId(42));
+    }
+
+    #[test]
+    #[should_panic]
+    fn compute_batch_id_panics_on_zero_batch_size() {
+        let _ = compute_batch_id(10, 0);
+    }
+
+    /// `height` on a batch boundary - full window.
+    #[test]
+    fn compute_next_batch_steady_state() {
+        let r = compute_next_batch(3, 4);
+        assert_eq!((r.start(), r.end()), (4, 7));
+
+        let r = compute_next_batch(127, 32);
+        assert_eq!((r.start(), r.end()), (128, 159));
+    }
+
+    /// `height = 0` means "genesis already archived".
+    #[test]
+    fn compute_next_batch_genesis() {
+        let r = compute_next_batch(0, 4);
+        assert_eq!((r.start(), r.end()), (1, 3));
+
+        let r = compute_next_batch(0, 32);
+        assert_eq!((r.start(), r.end()), (1, 31));
+    }
+
+    /// Fresh init: `height` lands mid-window; first batch is partial.
+    #[test]
+    fn compute_next_batch_fresh_init_mid_window() {
+        let r = compute_next_batch(99, 32);
+        assert_eq!((r.start(), r.end()), (100, 127));
+    }
+
+    /// Post-resharding child: pre-archive cut mid-window; first batch is
+    /// partial. `BatchId` coincides with the parent's last batch; paths
+    /// are disambiguated by `shard_id`.
+    #[test]
+    fn compute_next_batch_child_shard_start() {
+        let r = compute_next_batch(47, 32);
+        assert_eq!((r.start(), r.end()), (48, 63));
+        assert_eq!(compute_batch_id(r.start(), 32), BatchId(32));
+    }
+}

--- a/core/store/src/archive/cloud_storage/blocks.rs
+++ b/core/store/src/archive/cloud_storage/blocks.rs
@@ -1,6 +1,6 @@
 use crate::Store;
 use crate::adapter::StoreAdapter;
-use crate::archive::cloud_storage::file_id::BatchRange;
+use crate::archive::cloud_storage::batch::BatchRange;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_chain_primitives::Error;
 use near_primitives::block::Block;

--- a/core/store/src/archive/cloud_storage/bucket_config.rs
+++ b/core/store/src/archive/cloud_storage/bucket_config.rs
@@ -28,9 +28,7 @@ impl BucketConfig {
     /// The bucket stores one copy of this; mismatches across writers are rejected.
     pub fn canonical() -> Self {
         // TODO(cloud_archival): Benchmark compression levels before releasing.
-        // TODO(cloud_archival): Bump batch_size once writer batches multiple
-        // heights per upload.
-        Self::V1(BucketConfigV1::new(3, 1))
+        Self::V1(BucketConfigV1::new(3, 32))
     }
 
     /// Test-only constructor that overrides `batch_size`. All other fields match `canonical()`.

--- a/core/store/src/archive/cloud_storage/file_id.rs
+++ b/core/store/src/archive/cloud_storage/file_id.rs
@@ -1,40 +1,6 @@
 use crate::archive::cloud_storage::CloudStorage;
-use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
-
-/// Batch identifier: the start height of a batch.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct BatchId(pub BlockHeight);
-
-/// Computes the batch ID for a given height and batch size.
-pub fn compute_batch_id(height: BlockHeight, batch_size: u32) -> BatchId {
-    let batch_size = batch_size as u64;
-    BatchId((height / batch_size) * batch_size)
-}
-
-/// Inclusive height range covered by a single archival batch.
-#[derive(Clone, Copy, Debug)]
-pub struct BatchRange {
-    start: BlockHeight,
-    end: BlockHeight,
-}
-
-impl BatchRange {
-    // `start` is not required to match `BatchId(start)` and `end - start` can
-    // be smaller than `batch_size`: resharding may end a batch early, or a
-    // batch may start later than the batch_id would indicate.
-    pub fn new(start: BlockHeight, end: BlockHeight) -> Self {
-        assert!(end >= start, "invalid batch range [{start}, {end}]");
-        Self { start, end }
-    }
-
-    pub fn start(&self) -> BlockHeight {
-        self.start
-    }
-
-    pub fn end(&self) -> BlockHeight {
-        self.end
-    }
-}
+use crate::archive::cloud_storage::batch::BatchId;
+use near_primitives::types::{EpochHeight, EpochId, ShardId};
 
 /// Cloud directories that can be safely listed (recursively).
 /// Unbounded directories (blocks/, shards/, epochs/) must not be listed.
@@ -111,32 +77,5 @@ impl CloudStorage {
     pub fn file_path(&self, file_id: &CloudStorageFileID) -> String {
         let (location_dir, file_name) = self.location_dir_and_file(file_id);
         format!("{}/{}", location_dir, file_name)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn compute_batch_id_aligns_down_to_multiple() {
-        assert_eq!(compute_batch_id(0, 4), BatchId(0));
-        assert_eq!(compute_batch_id(1, 4), BatchId(0));
-        assert_eq!(compute_batch_id(3, 4), BatchId(0));
-        assert_eq!(compute_batch_id(4, 4), BatchId(4));
-        assert_eq!(compute_batch_id(7, 4), BatchId(4));
-        assert_eq!(compute_batch_id(100, 32), BatchId(96));
-    }
-
-    #[test]
-    fn compute_batch_id_batch_size_one() {
-        assert_eq!(compute_batch_id(0, 1), BatchId(0));
-        assert_eq!(compute_batch_id(42, 1), BatchId(42));
-    }
-
-    #[test]
-    #[should_panic]
-    fn compute_batch_id_panics_on_zero_batch_size() {
-        let _ = compute_batch_id(10, 0);
     }
 }

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -1,7 +1,8 @@
+use crate::archive::cloud_storage::batch::compute_batch_id;
+pub use crate::archive::cloud_storage::batch::{BatchId, BatchRange, compute_next_batch};
 pub use crate::archive::cloud_storage::blocks::{BlockBatch, BlockData};
 pub use crate::archive::cloud_storage::bucket_config::BucketConfig;
 pub use crate::archive::cloud_storage::epoch_data::EpochData;
-use crate::archive::cloud_storage::file_id::compute_batch_id;
 pub use crate::archive::cloud_storage::shards::{ShardBatch, ShardData};
 use near_external_storage::ExternalConnection;
 use near_primitives::state_sync::ShardStateSyncResponseHeader;
@@ -15,12 +16,13 @@ pub mod archive;
 pub mod bucket_config;
 pub mod retrieve;
 
+pub(super) mod batch;
 pub(super) mod blocks;
 pub(super) mod epoch_data;
 pub(super) mod file_id;
 pub(super) mod shards;
 
-pub use file_id::{BatchRange, ListableCloudDir};
+pub use file_id::ListableCloudDir;
 
 /// Handles operations related to cloud storage used for archival data.
 pub struct CloudStorage {
@@ -117,7 +119,8 @@ fn block_on_future<F: Future>(fut: F) -> F::Output {
 #[cfg(test)]
 mod tests {
     use super::CloudStorage;
-    use super::file_id::{BatchId, CloudStorageFileID};
+    use super::batch::BatchId;
+    use super::file_id::CloudStorageFileID;
     use crate::archive::cloud_storage::bucket_config::BucketConfig;
     use near_external_storage::ExternalConnection;
 

--- a/core/store/src/archive/cloud_storage/retrieve.rs
+++ b/core/store/src/archive/cloud_storage/retrieve.rs
@@ -1,7 +1,8 @@
 use crate::archive::cloud_storage::CloudStorage;
+use crate::archive::cloud_storage::batch::BatchId;
 use crate::archive::cloud_storage::blocks::BlockBatch;
 use crate::archive::cloud_storage::epoch_data::EpochData;
-use crate::archive::cloud_storage::file_id::{BatchId, CloudStorageFileID, ListableCloudDir};
+use crate::archive::cloud_storage::file_id::{CloudStorageFileID, ListableCloudDir};
 use crate::archive::cloud_storage::shards::ShardBatch;
 use borsh::BorshDeserialize;
 use near_primitives::state_sync::ShardStateSyncResponseHeader;

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -8,7 +8,7 @@ use near_primitives::sharding::{ReceiptProof, ShardChunk};
 // TODO(cloud_archival): Re-enable once `get_state_header()` is fixed (see below).
 //use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use crate::adapter::StoreAdapter;
-use crate::archive::cloud_storage::file_id::BatchRange;
+use crate::archive::cloud_storage::batch::BatchRange;
 use crate::{DBCol, KeyForStateChanges, Store};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -95,6 +95,11 @@ impl TestLoopBuilder {
         }
     }
 
+    pub(crate) fn bucket_config(mut self, bucket_config: BucketConfig) -> Self {
+        self.bucket_config = bucket_config;
+        self
+    }
+
     // Creates TestLoop-compatible genesis builder
     pub(crate) fn new_genesis_builder() -> TestGenesisBuilder {
         TestGenesisBuilder::new()

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -3,9 +3,9 @@ use crate::setup::env::TestLoopEnv;
 use crate::utils::account::archival_account_id;
 use crate::utils::cloud_archival::{
     WriterConfig, add_writer_node, apply_writer_settings, bootstrap_reader, check_account_balance,
-    check_data_at_height_for_shards, gc_and_heads_sanity_checks, get_cloud_head, get_writer_handle,
-    run_node_until, simulate_lagging_shard, snapshots_sanity_check, stop_and_restart_node,
-    verify_block_range,
+    check_data_at_height_for_shards, gc_and_heads_sanity_checks, get_cloud_head, get_cloud_storage,
+    get_writer_handle, run_node_until, simulate_lagging_shard, snapshots_sanity_check,
+    stop_and_restart_node, verify_block_range,
 };
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
@@ -13,6 +13,7 @@ use near_chain_configs::MIN_GC_NUM_EPOCHS_TO_KEEP;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, Balance, BlockHeight, BlockHeightDelta, ShardId};
 use near_store::ShardUId;
+use near_store::archive::cloud_storage::bucket_config::BucketConfig;
 
 /// Test harness for cloud archival tests. Owns the `TestLoopEnv` and exposes
 /// composable action and assertion methods so each test reads as an explicit
@@ -61,6 +62,9 @@ impl CloudArchiveHarnessBuilder {
             .add_user_account(&user_account, CloudArchiveHarness::USER_BALANCE)
             .enable_archival_node(archival_kind)
             .gc_num_epochs_to_keep(MIN_GC_NUM_EPOCHS_TO_KEEP)
+            .bucket_config(BucketConfig::with_batch_size_for_test(
+                CloudArchiveHarness::TEST_BATCH_SIZE,
+            ))
             .config_modifier(move |config, _client_index| {
                 if !config.archive {
                     return;
@@ -84,6 +88,7 @@ impl CloudArchiveHarnessBuilder {
 
 impl CloudArchiveHarness {
     const DEFAULT_EPOCH_LENGTH: BlockHeightDelta = 10;
+    const TEST_BATCH_SIZE: u32 = 4;
     const USER_ACCOUNT: &str = "user_account";
     const USER_BALANCE: Balance = Balance::from_near(42);
 
@@ -167,6 +172,12 @@ impl CloudArchiveHarness {
 
     fn cloud_head(&self) -> BlockHeight {
         get_cloud_head(&self.env, &self.archival_id)
+    }
+
+    fn block_batch_exists_at(&self, block_height: BlockHeight) -> bool {
+        get_cloud_storage(&self.env, &self.archival_id)
+            .get_block_batch_for_height(block_height)
+            .is_ok()
     }
 
     fn gc_tail(&self) -> BlockHeight {
@@ -279,6 +290,42 @@ fn test_cloud_archival_read_data_at_height() {
         (h.epoch_length / 2, &all_shards),
         (h.epoch_length + 1, &all_shards),
     ]);
+    h.shutdown();
+}
+
+/// cloud_head is always at a batch boundary (last height of an archived batch).
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_batching_cloud_head_at_batch_boundary() {
+    assert_eq!(CloudArchiveHarness::DEFAULT_EPOCH_LENGTH, 10);
+    assert_eq!(CloudArchiveHarness::TEST_BATCH_SIZE, 4);
+    let mut h = CloudArchiveHarness::builder().build();
+    h.run_until_epoch(3);
+    // chain head is ~30, so cloud_head is at a batch boundary below it.
+    let head = h.cloud_head();
+    let batch_size = CloudArchiveHarness::TEST_BATCH_SIZE as u64;
+    assert!(head <= 27 && (head + 1) % batch_size == 0, "cloud_head: {head}");
+    h.shutdown();
+}
+
+/// Every batch up to cloud_head has been uploaded as its own blob, and the
+/// batch past cloud_head has not.
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_batching_blob_per_batch() {
+    assert_eq!(CloudArchiveHarness::DEFAULT_EPOCH_LENGTH, 10);
+    assert_eq!(CloudArchiveHarness::TEST_BATCH_SIZE, 4);
+    let mut h = CloudArchiveHarness::builder().build();
+    h.run_until_epoch(3);
+    let batch_size = CloudArchiveHarness::TEST_BATCH_SIZE as u64;
+    let cloud_head = h.cloud_head();
+    // Each archived batch has a blob; one batch past cloud_head does not.
+    for id in (0..=cloud_head).step_by(batch_size as usize) {
+        assert!(h.block_batch_exists_at(id), "batch at {id} should exist");
+    }
+    assert!(!h.block_batch_exists_at(cloud_head + 1));
     h.shutdown();
 }
 


### PR DESCRIPTION
Stacked on #15604. Bumps the canonical batch size to 32 and makes the writer upload one blob per batch instead of one per height, cutting block and shard uploads ~32x. Reader is unchanged - the batch id is computed from the requested height.

## Testing

- 11 existing testloop cloud archival tests pass, including one that bootstraps a reader across an epoch boundary.
- Two new testloop tests assert the cloud head lands on a batch boundary and every batch up to it has a blob (the next one does not).
- Unit tests on compute_next_batch cover genesis clamping and steady-state advancement.

## Localnet smoke test

Single-validator localnet, epoch_length = 60, canonical batch_size = 32, filesystem-backed cloud archive, writer run for ~2 minutes.

Writer produced the expected batch blobs under the new layout:

```
$ find bucket -path '*blocks*batch_id*/data' | sort
bucket/chain_id=.../archive/blocks/batch_id=0/data
bucket/chain_id=.../archive/blocks/batch_id=32/data
bucket/chain_id=.../archive/blocks/batch_id=64/data
bucket/chain_id=.../archive/blocks/batch_id=96/data
bucket/chain_id=.../archive/blocks/batch_id=128/data
bucket/chain_id=.../archive/blocks/batch_id=160/data
```

`neard cloud-archive status` shows local and external heads agree at a batch boundary (`32 × 6 − 1 = 191`):

```
=== External storage (cloud) ===
  block head:  Some(191)
  shard 0 head: 191

=== Local storage (DB) ===
  cloud min head:   Some(191)
  cloud block head: Some(191)
  cloud shard 0 head: 191

  chain HEAD:       194
  chain FINAL_HEAD: 192
```

A second node with only the cloud archive config bootstrapped 101 blocks spanning two epoch boundaries (60, 120) across four batches:

```
$ neard --home reader cloud-archive bootstrap-reader --start-height 50 --end-height 150
…
bootstrap progress height=50  end_height=150
bootstrap progress height=60  end_height=150
bootstrap progress height=70  end_height=150
bootstrap progress height=80  end_height=150
bootstrap progress height=90  end_height=150
bootstrap progress height=100 end_height=150
bootstrap progress height=110 end_height=150
bootstrap progress height=120 end_height=150
bootstrap progress height=130 end_height=150
bootstrap progress height=140 end_height=150
bootstrap progress height=150 end_height=150
bootstrap complete start_height=50 end_height=150 blocks=101
```