### PR TITLE
fix(vm-runner): use verify_prehash in p256_verify

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -292,6 +292,8 @@
         "Prefetcher",
         "prefetchers",
         "prefunded",
+        "prehash",
+        "prehashed",
         "privkey",
         "profraw",
         "profraws",

--- a/runtime/near-test-contracts/estimator-contract/src/lib.rs
+++ b/runtime/near-test-contracts/estimator-contract/src/lib.rs
@@ -613,15 +613,17 @@ pub unsafe fn p256_verify_32b_500() {
         184, 146, 59, 97, 250, 108, 230, 105, 98, 46, 96, 242, 159, 182,
     ];
 
-    // 32-byte message (all 0x07)
+    // 32-byte prehash (all 0x07). The host does not hash — per NEP-635 the
+    // caller supplies a prehashed digest — so this array is what gets signed
+    // and verified directly.
     let message: [u8; 32] = [7; 32];
 
-    // ECDSA signature (r || s, 64 bytes) over `message` using the above key.
+    // ECDSA signature (r || s, 64 bytes) over the prehash using the above key.
     let signature: [u8; 64] = [
-        17, 132, 253, 183, 29, 227, 67, 230, 123, 146, 104, 48, 119, 115, 205, 207, 181, 155,
-        202, 61, 112, 54, 186, 139, 38, 91, 136, 236, 108, 41, 63, 187, 146, 208, 118, 6, 188,
-        199, 222, 167, 51, 238, 177, 150, 114, 42, 134, 96, 20, 142, 18, 56, 236, 90, 141, 79,
-        37, 166, 192, 105, 219, 112, 212, 207,
+        17, 55, 25, 23, 171, 17, 204, 202, 8, 236, 116, 68, 216, 160, 93, 172, 108, 37, 59, 25,
+        207, 22, 60, 251, 117, 180, 8, 205, 210, 19, 79, 251, 80, 37, 55, 199, 202, 214, 102, 97,
+        212, 16, 80, 5, 254, 23, 162, 155, 94, 39, 255, 35, 168, 31, 146, 54, 165, 72, 178, 237,
+        166, 134, 29, 100,
     ];
 
     for _ in 0..500 {
@@ -642,10 +644,10 @@ pub unsafe fn p256_verify_32b_500() {
 /// Function to measure `p256_verify_byte`.
 #[unsafe(no_mangle)]
 pub unsafe fn p256_verify_16kib_64() {
-    // 16 KiB message. Every byte participates in verification — SHA-256 hashes
-    // the whole message before the curve math — so `p256_verify_byte` is
-    // priced to cover that linear message-dependent cost (host-side
-    // marshalling plus the hash itself).
+    // 16 KiB prehash input. The host does not hash, so the curve math only
+    // sees the leading field-bytes of the input after `bits2field`
+    // truncation; `p256_verify_byte` is priced to cover the host-side
+    // marshalling of every byte of the declared input length.
     let message = [b'a'; 16384];
 
     // Same key pair as p256_verify_32b_500.
@@ -654,12 +656,12 @@ pub unsafe fn p256_verify_16kib_64() {
         184, 146, 59, 97, 250, 108, 230, 105, 98, 46, 96, 242, 159, 182,
     ];
 
-    // Signature over the 16 KiB message using the same secret key.
+    // Signature over the 16 KiB prehash using the same secret key.
     let signature: [u8; 64] = [
-        244, 82, 38, 60, 140, 34, 239, 251, 245, 7, 113, 222, 224, 9, 20, 186, 140, 83, 208, 10,
-        184, 222, 51, 61, 96, 27, 127, 22, 221, 130, 84, 136, 159, 222, 96, 50, 142, 161, 131,
-        254, 145, 40, 210, 13, 73, 198, 47, 118, 91, 233, 77, 21, 244, 173, 178, 125, 52, 67,
-        212, 40, 249, 21, 182, 120,
+        19, 216, 85, 47, 78, 51, 197, 229, 248, 83, 63, 76, 66, 105, 230, 101, 15, 57, 161, 173,
+        167, 74, 125, 119, 137, 44, 200, 17, 110, 202, 129, 11, 43, 11, 18, 12, 185, 66, 191,
+        147, 75, 162, 163, 237, 197, 169, 172, 178, 92, 201, 144, 78, 232, 171, 46, 74, 221, 11,
+        63, 51, 73, 241, 78, 180,
     ];
 
     for _ in 0..64 {

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -1817,12 +1817,18 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         }
     }
 
-    /// Verify a P-256 ECDSA signature given a message and a public key.
+    /// Verify a P-256 ECDSA signature given a prehashed message and a public
+    /// key.
     ///
-    /// The signature must be 64 bytes, encoded as `r || s`. The public key must
-    /// be a 33-byte compressed SEC1 encoding.
+    /// The signature must be 64 bytes, encoded as `r || s`. The public key
+    /// must be a 33-byte compressed SEC1 encoding. Per [NEP-635], this host
+    /// function does not hash the message: the caller is responsible for
+    /// applying the appropriate protocol (for example SHA-256 for WebAuthn)
+    /// before calling.
     ///
     /// Returns a bool indicating success (1) or failure (0) as a `u64`.
+    ///
+    /// [NEP-635]: https://github.com/near/NEPs/pull/635
     ///
     /// # Errors
     ///
@@ -1853,7 +1859,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         public_key_len: u64,
         public_key_ptr: u64,
     ) -> Result<u64> {
-        use p256::ecdsa::signature::Verifier;
+        use p256::ecdsa::signature::hazmat::PrehashVerifier;
         use p256::ecdsa::{Signature, VerifyingKey};
 
         self.result_state.gas_counter.pay_base(p256_verify_base)?;
@@ -1887,7 +1893,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
             }
         };
 
-        match public_key.verify(&message, &signature) {
+        match public_key.verify_prehash(&message, &signature) {
             Err(_) => Ok(false as u64),
             Ok(()) => Ok(true as u64),
         }

--- a/runtime/near-vm-runner/src/logic/tests/p256_verify.rs
+++ b/runtime/near-vm-runner/src/logic/tests/p256_verify.rs
@@ -5,13 +5,15 @@ use crate::logic::tests::vm_logic_builder::VMLogicBuilder;
 use crate::map;
 use near_parameters::ExtCosts;
 use p256::ecdsa::SigningKey;
-use p256::ecdsa::signature::Signer;
+use p256::ecdsa::signature::hazmat::PrehashSigner;
 use std::collections::HashMap;
 
-/// Deterministic key-pair plus arbitrary 32-byte message. RustCrypto's `p256`
-/// uses deterministic RFC6979 nonces by default, so calling `sign` on the same
-/// key/message produces the same signature every time; we rely on that for
-/// reproducibility.
+/// Deterministic key-pair plus arbitrary 32-byte prehash. RustCrypto's `p256`
+/// uses deterministic RFC6979 nonces by default, so calling `sign_prehash` on
+/// the same key/prehash produces the same signature every time; we rely on
+/// that for reproducibility. The host function does not hash — per NEP-635 the
+/// caller supplies a prehashed digest — so tests sign and verify the same raw
+/// bytes.
 fn p256_test_vectors() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
     let secret_key: [u8; 32] = [
         0xc9, 0xaf, 0xa9, 0xd8, 0x45, 0xba, 0x75, 0x16, 0x6b, 0x5c, 0x21, 0x57, 0x67, 0xb1, 0xd6,
@@ -20,7 +22,7 @@ fn p256_test_vectors() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
     ];
     let message = vec![7u8; 32];
     let signing_key = SigningKey::from_bytes(&secret_key.into()).unwrap();
-    let signature: p256::ecdsa::Signature = signing_key.sign(&message);
+    let signature: p256::ecdsa::Signature = signing_key.sign_prehash(&message).unwrap();
     let signature_bytes = signature.to_vec();
     let public_key = p256::ecdsa::VerifyingKey::from(&signing_key).to_encoded_point(true);
     let public_key_bytes = public_key.as_bytes().to_vec();
@@ -288,8 +290,9 @@ fn test_p256_verify_empty_message() {
 
 #[test]
 fn test_p256_verify_long_message() {
-    // Sign a longer message (256 bytes) to ensure byte-based gas accounting
-    // scales with message length.
+    // Feed the host a longer "prehash" (256 bytes) to ensure the per-byte gas
+    // accounting scales with input length even though bits2field truncates the
+    // prehash to the field size before verification.
     let secret_key: [u8; 32] = [
         0xc9, 0xaf, 0xa9, 0xd8, 0x45, 0xba, 0x75, 0x16, 0x6b, 0x5c, 0x21, 0x57, 0x67, 0xb1, 0xd6,
         0x93, 0x4e, 0x50, 0xc3, 0xdb, 0x36, 0xe8, 0x9b, 0x12, 0x7b, 0x8a, 0x62, 0x2b, 0x12, 0x0f,
@@ -297,7 +300,7 @@ fn test_p256_verify_long_message() {
     ];
     let signing_key = SigningKey::from_bytes(&secret_key.into()).unwrap();
     let message: Vec<u8> = (0..256u16).map(|i| (i & 0xff) as u8).collect();
-    let signature: p256::ecdsa::Signature = signing_key.sign(&message);
+    let signature: p256::ecdsa::Signature = signing_key.sign_prehash(&message).unwrap();
     let signature = signature.to_vec();
     let public_key =
         p256::ecdsa::VerifyingKey::from(&signing_key).to_encoded_point(true).as_bytes().to_vec();

--- a/runtime/near-vm-runner/src/logic/tests/p256_verify_wycheproof.rs
+++ b/runtime/near-vm-runner/src/logic/tests/p256_verify_wycheproof.rs
@@ -7,6 +7,10 @@
 //! (33 bytes). These exist to catch regressions where the p256 crate or our
 //! wrapper changes behavior around edge-case signatures.
 //!
+//! The `_sha256_` suite signs `SHA-256(msg)`, and our host function expects a
+//! prehashed digest (NEP-635 leaves hashing to the caller), so the test helper
+//! feeds `SHA-256(msg)` into `p256_verify`.
+//!
 //! These tests cover the RustCrypto `p256` crate's behavior rather than our
 //! own code — we pass signatures through unchanged. In particular, `p256`
 //! accepts high-s signatures (FIPS 186-5 compliant; low-s enforcement is a
@@ -14,24 +18,26 @@
 //! be protocol-breaking. See `test_p256_verify_wycheproof_high_s_accepted`.
 
 use crate::logic::tests::vm_logic_builder::VMLogicBuilder;
+use sha2::{Digest, Sha256};
 
 fn run_wycheproof(pubkey_hex: &str, msg_hex: &str, sig_hex: &str, expected: u64) {
     let signature = hex::decode(sig_hex).expect("bad sig hex");
     let message = hex::decode(msg_hex).expect("bad msg hex");
+    let prehash = Sha256::digest(&message).to_vec();
     let public_key = hex::decode(pubkey_hex).expect("bad pk hex");
 
     let mut builder = VMLogicBuilder::default();
     let mut logic = builder.build();
 
     let sig_ptr = logic.internal_mem_write(&signature).ptr;
-    let msg_ptr = logic.internal_mem_write(&message).ptr;
+    let msg_ptr = logic.internal_mem_write(&prehash).ptr;
     let pk_ptr = logic.internal_mem_write(&public_key).ptr;
 
     let result = logic
         .p256_verify(
             signature.len() as u64,
             sig_ptr,
-            message.len() as u64,
+            prehash.len() as u64,
             msg_ptr,
             public_key.len() as u64,
             pk_ptr,

--- a/runtime/near-vm-runner/src/tests/p256_verify_integration.rs
+++ b/runtime/near-vm-runner/src/tests/p256_verify_integration.rs
@@ -16,7 +16,7 @@ use crate::runner::VMKindExt;
 use crate::tests::{create_context, test_vm_config, with_vm_variants};
 use near_parameters::RuntimeFeesConfig;
 use near_parameters::vm::VMKind;
-use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
+use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::hazmat::PrehashSigner};
 use std::cell::RefCell;
 use std::sync::Arc;
 
@@ -92,7 +92,7 @@ fn make_signing_key() -> SigningKey {
 
 fn sign_and_keys(message: &[u8; 32]) -> (Vec<u8>, Vec<u8>) {
     let signing_key = make_signing_key();
-    let signature: Signature = signing_key.sign(message);
+    let signature: Signature = signing_key.sign_prehash(message).unwrap();
     let signature_bytes = signature.to_vec();
     let public_key = VerifyingKey::from(&signing_key).to_encoded_point(true).as_bytes().to_vec();
     (signature_bytes, public_key)

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -1822,12 +1822,16 @@ pub fn ed25519_verify(
     }
 }
 
-/// Verify a P-256 ECDSA signature given a message and a public key.
+/// Verify a P-256 ECDSA signature given a prehashed message and a public key.
 ///
-/// The signature must be 64 bytes, encoded as `r || s`. The public key must be
-/// a 33-byte compressed SEC1 encoding.
+/// The signature must be 64 bytes, encoded as `r || s`. The public key must
+/// be a 33-byte compressed SEC1 encoding. Per [NEP-635], this host function
+/// does not hash the message: the caller is responsible for applying the
+/// appropriate protocol (for example SHA-256 for WebAuthn) before calling.
 ///
 /// Returns a bool indicating success (1) or failure (0) as a `u64`.
+///
+/// [NEP-635]: https://github.com/near/NEPs/pull/635
 ///
 /// # Errors
 ///
@@ -1859,7 +1863,7 @@ pub fn p256_verify(
     public_key_len: u64,
     public_key_ptr: u64,
 ) -> Result<u64> {
-    use p256::ecdsa::signature::Verifier;
+    use p256::ecdsa::signature::hazmat::PrehashVerifier;
     use p256::ecdsa::{Signature, VerifyingKey};
 
     ctx.result_state.gas_counter.pay_base(p256_verify_base)?;
@@ -1911,7 +1915,7 @@ pub fn p256_verify(
         }
     };
 
-    match public_key.verify(&message, &signature) {
+    match public_key.verify_prehash(&message, &signature) {
         Err(_) => Ok(false as u64),
         Ok(()) => Ok(true as u64),
     }

--- a/test-loop-tests/src/tests/p256_verify.rs
+++ b/test-loop-tests/src/tests/p256_verify.rs
@@ -7,7 +7,7 @@ use near_primitives::errors::{ActionError, ActionErrorKind, TxExecutionError};
 use near_primitives::gas::Gas;
 use near_primitives::types::Balance;
 use near_primitives::views::FinalExecutionStatus;
-use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
+use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::hazmat::PrehashSigner};
 
 /// Build a WASM contract that imports `env.p256_verify`, bakes the supplied
 /// `signature || public_key || message` into linear memory at fixed offsets,
@@ -68,8 +68,8 @@ fn p256_verify_wasm(signature: &[u8], public_key: &[u8], message: &[u8]) -> Vec<
 }
 
 /// Deterministic signing key (shared with the vm-runner unit tests). RustCrypto
-/// uses RFC6979, so `sign` on the same key+message always yields the same
-/// signature.
+/// uses RFC6979, so `sign_prehash` on the same key+prehash always yields the
+/// same signature.
 const DETERMINISTIC_SECRET: [u8; 32] = [
     0xc9, 0xaf, 0xa9, 0xd8, 0x45, 0xba, 0x75, 0x16, 0x6b, 0x5c, 0x21, 0x57, 0x67, 0xb1, 0xd6, 0x93,
     0x4e, 0x50, 0xc3, 0xdb, 0x36, 0xe8, 0x9b, 0x12, 0x7b, 0x8a, 0x62, 0x2b, 0x12, 0x0f, 0x67, 0x21,
@@ -77,7 +77,7 @@ const DETERMINISTIC_SECRET: [u8; 32] = [
 
 fn sign_and_keys(message: &[u8]) -> (Vec<u8>, Vec<u8>) {
     let signing_key = SigningKey::from_bytes(&DETERMINISTIC_SECRET.into()).unwrap();
-    let signature: Signature = signing_key.sign(message);
+    let signature: Signature = signing_key.sign_prehash(message).unwrap();
     let public_key = VerifyingKey::from(&signing_key).to_encoded_point(true).as_bytes().to_vec();
     (signature.to_vec(), public_key)
 }


### PR DESCRIPTION
Followup to #15588, addressing [mitinarseny's review](https://github.com/near/nearcore/pull/15588#pullrequestreview-4158599890).

[NEP-635](https://github.com/near/NEPs/pull/635) says `p256_verify` does not hash — the caller supplies a prehashed digest (e.g. `SHA-256(msg)` for WebAuthn). The merged implementation used `Verifier::verify`, which SHA-256-hashes the message internally, so a contract passing a raw 32-byte prehash would fail to verify.

Switches to `PrehashVerifier::verify_prehash` in both host-function copies (`VMLogic::p256_verify` and the wasmtime-runner `p256_verify`), and updates unit / integration / test-loop tests plus the estimator contract's hardcoded signatures accordingly. Wycheproof `ecdsa_secp256r1_sha256_p1363` vectors still expect `SHA-256(msg)` to be signed, so the test helper now hashes the message before handing it to `p256_verify`.

Gas model is unchanged.