### PR TITLE
fix(network): bound routing graph growth via edge injection limits

### DIFF
--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -28,6 +28,12 @@ pub const HIGHEST_PEER_HORIZON: u64 = 5;
 /// Maximum amount of routes to store for each account id.
 pub const MAX_ROUTES_TO_STORE: usize = 5;
 
+/// Default routing graph limits.
+pub const DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_MESSAGE: usize = 50_000;
+pub const DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_SOURCE: usize = 50_000;
+pub const DEFAULT_ROUTING_GRAPH_MAX_PEERS: usize = 100_000;
+pub const DEFAULT_ROUTING_GRAPH_MAX_EDGES: usize = 1_000_000;
+
 /// Maximum number of PeerAddrs in the ValidatorConfig::endpoints field.
 pub const MAX_PEER_ADDRS: usize = 10;
 
@@ -212,6 +218,15 @@ pub struct NetworkConfig {
     /// Configuration of rate limits for incoming messages.
     pub received_messages_rate_limits: messages_limits::Config,
 
+    /// Maximum number of edges allowed in a single SyncRoutingTable message.
+    pub routing_graph_max_edges_per_message: usize,
+    /// Maximum number of new edge keys a single remote peer can introduce.
+    pub routing_graph_max_edges_per_source: usize,
+    /// Maximum number of unique peer IDs in the BFS routing graph.
+    pub routing_graph_max_peers: usize,
+    /// Maximum total number of edges stored in the routing graph.
+    pub routing_graph_max_edges: usize,
+
     #[cfg(test)]
     pub(crate) event_sink:
         near_async::messaging::Sender<crate::peer_manager::peer_manager_actor::Event>,
@@ -259,6 +274,18 @@ impl NetworkConfig {
         }
         if let Some(rate_limits) = overrides.received_messages_rate_limits {
             self.received_messages_rate_limits.apply_overrides(rate_limits);
+        }
+        if let Some(v) = overrides.routing_graph_max_edges_per_message {
+            self.routing_graph_max_edges_per_message = v;
+        }
+        if let Some(v) = overrides.routing_graph_max_edges_per_source {
+            self.routing_graph_max_edges_per_source = v;
+        }
+        if let Some(v) = overrides.routing_graph_max_peers {
+            self.routing_graph_max_peers = v;
+        }
+        if let Some(v) = overrides.routing_graph_max_edges {
+            self.routing_graph_max_edges = v;
         }
     }
 
@@ -408,6 +435,10 @@ impl NetworkConfig {
                 None
             },
             received_messages_rate_limits: messages_limits::Config::standard_preset(),
+            routing_graph_max_edges_per_message: DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_MESSAGE,
+            routing_graph_max_edges_per_source: DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_SOURCE,
+            routing_graph_max_peers: DEFAULT_ROUTING_GRAPH_MAX_PEERS,
+            routing_graph_max_edges: DEFAULT_ROUTING_GRAPH_MAX_EDGES,
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),
@@ -488,6 +519,10 @@ impl NetworkConfig {
             },
             skip_tombstones: None,
             received_messages_rate_limits: messages_limits::Config::default(),
+            routing_graph_max_edges_per_message: DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_MESSAGE,
+            routing_graph_max_edges_per_source: DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_SOURCE,
+            routing_graph_max_peers: DEFAULT_ROUTING_GRAPH_MAX_PEERS,
+            routing_graph_max_edges: DEFAULT_ROUTING_GRAPH_MAX_EDGES,
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),
@@ -546,6 +581,21 @@ impl NetworkConfig {
         if let Err(err) = self.received_messages_rate_limits.validate() {
             anyhow::bail!("One or more invalid rate limits: {err:?}");
         }
+
+        anyhow::ensure!(
+            self.routing_graph_max_edges_per_message > 0,
+            "routing_graph_max_edges_per_message must be > 0"
+        );
+        anyhow::ensure!(
+            self.routing_graph_max_edges_per_source > 0,
+            "routing_graph_max_edges_per_source must be > 0"
+        );
+        anyhow::ensure!(self.routing_graph_max_peers > 0, "routing_graph_max_peers must be > 0");
+        anyhow::ensure!(self.routing_graph_max_edges > 0, "routing_graph_max_edges must be > 0");
+        anyhow::ensure!(
+            self.routing_graph_max_edges_per_source <= self.routing_graph_max_edges,
+            "routing_graph_max_edges_per_source must be <= routing_graph_max_edges"
+        );
 
         Ok(VerifiedConfig { node_id: self.node_id(), inner: self })
     }
@@ -677,6 +727,26 @@ mod test {
                 &after.accounts_data_broadcast_rate_limit.qps,
                 &overrides.accounts_data_broadcast_rate_limit_qps
             ));
+            assert!(check_override_field(
+                &before.routing_graph_max_edges_per_message,
+                &after.routing_graph_max_edges_per_message,
+                &overrides.routing_graph_max_edges_per_message
+            ));
+            assert!(check_override_field(
+                &before.routing_graph_max_edges_per_source,
+                &after.routing_graph_max_edges_per_source,
+                &overrides.routing_graph_max_edges_per_source
+            ));
+            assert!(check_override_field(
+                &before.routing_graph_max_peers,
+                &after.routing_graph_max_peers,
+                &overrides.routing_graph_max_peers
+            ));
+            assert!(check_override_field(
+                &before.routing_graph_max_edges,
+                &after.routing_graph_max_edges,
+                &overrides.routing_graph_max_edges
+            ));
         };
         let no_overrides = NetworkConfigOverrides::default();
         let mut overrides = NetworkConfigOverrides::default();
@@ -685,6 +755,10 @@ mod test {
         overrides.routed_message_ttl = Some(43);
         overrides.accounts_data_broadcast_rate_limit_burst = Some(44);
         overrides.accounts_data_broadcast_rate_limit_qps = Some(45.0);
+        overrides.routing_graph_max_edges_per_message = Some(10_000);
+        overrides.routing_graph_max_edges_per_source = Some(20_000);
+        overrides.routing_graph_max_peers = Some(30_000);
+        overrides.routing_graph_max_edges = Some(40_000);
 
         let nc_before =
             config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
@@ -725,6 +799,39 @@ mod test {
         };
         let sad = ad.sign(&signer.into()).unwrap();
         assert!(sad.payload().len() <= network_protocol::MAX_ACCOUNT_DATA_SIZE_BYTES);
+    }
+
+    #[test]
+    fn test_routing_graph_config_validation() {
+        // max_edges_per_message = 0 should fail.
+        let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
+        nc.routing_graph_max_edges_per_message = 0;
+        assert!(nc.verify().is_err());
+
+        // max_edges_per_source = 0 should fail.
+        let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
+        nc.routing_graph_max_edges_per_source = 0;
+        assert!(nc.verify().is_err());
+
+        // max_peers = 0 should fail.
+        let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
+        nc.routing_graph_max_peers = 0;
+        assert!(nc.verify().is_err());
+
+        // max_edges = 0 should fail.
+        let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
+        nc.routing_graph_max_edges = 0;
+        assert!(nc.verify().is_err());
+
+        // max_edges_per_source > max_edges should fail.
+        let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
+        nc.routing_graph_max_edges_per_source = 100;
+        nc.routing_graph_max_edges = 50;
+        assert!(nc.verify().is_err());
+
+        // Valid config should pass.
+        let nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
+        assert!(nc.verify().is_ok());
     }
 
     #[test]

--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -330,6 +330,14 @@ pub struct NetworkConfigOverrides {
     pub routing_table_update_rate_limit_burst: Option<u64>,
     pub routing_table_update_rate_limit_qps: Option<f64>,
     pub received_messages_rate_limits: Option<messages_limits::OverrideConfig>,
+    /// Maximum number of edges allowed in a single SyncRoutingTable message.
+    pub routing_graph_max_edges_per_message: Option<usize>,
+    /// Maximum number of new edge keys a single remote peer can introduce.
+    pub routing_graph_max_edges_per_source: Option<usize>,
+    /// Maximum number of unique peer IDs in the BFS routing graph.
+    pub routing_graph_max_peers: Option<usize>,
+    /// Maximum total number of edges stored in the routing graph.
+    pub routing_graph_max_edges: Option<usize>,
 }
 
 impl Default for Config {

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1488,8 +1488,27 @@ impl PeerActor {
         conn: Arc<connection::Connection>,
         rtu: RoutingTableUpdate,
     ) {
-        if let Err(ban_reason) =
-            network_state.add_edges(&clock, EdgesWithSource::Remote(rtu.edges.clone())).await
+        // Ingress cap: check BEFORE dedup/verification to avoid wasted work.
+        let max_edges = network_state.config.routing_graph_max_edges_per_message;
+        if rtu.edges.len() > max_edges {
+            tracing::warn!(
+                target: "network",
+                peer_id = %conn.peer_info.id,
+                edges_count = rtu.edges.len(),
+                limit = max_edges,
+                "too many edges in SyncRoutingTable message, dropping edges"
+            );
+            metrics::EDGE_DROPPED.inc_by(rtu.edges.len() as u64);
+            // Don't process edges at all, but still process accounts below.
+        } else if let Err(ban_reason) = network_state
+            .add_edges(
+                &clock,
+                EdgesWithSource::Remote {
+                    edges: rtu.edges.clone(),
+                    source: conn.peer_info.id.clone(),
+                },
+            )
+            .await
         {
             conn.stop(Some(ban_reason));
         }

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -182,13 +182,15 @@ pub(crate) struct NetworkState {
 /// Self-connected edges are not allowed from remote peers.
 pub(crate) enum EdgesWithSource {
     Local(Vec<Edge>),
-    Remote(Vec<Edge>),
+    Remote { edges: Vec<Edge>, source: PeerId },
 }
 
 impl EdgesWithSource {
     pub(crate) fn is_empty(&self) -> bool {
         match self {
-            EdgesWithSource::Local(edges) | EdgesWithSource::Remote(edges) => edges.is_empty(),
+            EdgesWithSource::Local(edges) | EdgesWithSource::Remote { edges, .. } => {
+                edges.is_empty()
+            }
         }
     }
 }
@@ -218,6 +220,9 @@ impl NetworkState {
                     node_id: config.node_id(),
                     prune_unreachable_peers_after: PRUNE_UNREACHABLE_PEERS_AFTER,
                     prune_edges_after: Some(PRUNE_EDGES_AFTER),
+                    max_edges_per_source: config.routing_graph_max_edges_per_source,
+                    max_total_edges: config.routing_graph_max_edges,
+                    max_graph_peers: config.routing_graph_max_peers,
                 },
             ),
             genesis_id,

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -1290,3 +1290,125 @@ async fn connect_to_unbanned_peer() {
     drop(pm0);
     drop(pm1);
 }
+
+/// Oversized SyncRoutingTable messages should have their edges dropped,
+/// but the connection should stay alive and subsequent valid updates should work.
+#[tokio::test]
+async fn oversized_sync_routing_table_drops_edges_but_keeps_connection() {
+    abort_on_panic();
+    let mut rng = make_rng(921853233);
+    let rng = &mut rng;
+    let mut clock = time::FakeClock::default();
+    let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
+
+    // Set a small ingress cap for testing.
+    let mut cfg0 = chain.make_config(rng);
+    cfg0.routing_graph_max_edges_per_message = 10;
+    let mut pm = start_pm(clock.clock(), TestDB::new(), cfg0, chain.clone()).await;
+    let cfg = peer::testonly::PeerConfig { network: chain.make_config(rng), chain };
+    let stream = tcp::Stream::connect(&pm.peer_info(), tcp::Tier::T2, &SocketOptions::default())
+        .await
+        .unwrap();
+    let mut peer =
+        peer::testonly::PeerHandle::start_endpoint(clock.clock(), ActorSystem::new(), cfg, stream);
+    peer.complete_handshake().await;
+
+    let peer_id = peer.cfg.id();
+    pm.wait_for_routing_table(&[(peer_id.clone(), vec![peer_id.clone()])]).await;
+
+    // Send an oversized SyncRoutingTable (> 10 edges).
+    let fake_edges: Vec<Edge> = (0..20)
+        .map(|_| {
+            let k1 = data::make_secret_key(rng);
+            let k2 = data::make_secret_key(rng);
+            data::make_edge(&k1, &k2, 1)
+        })
+        .collect();
+    peer.send(PeerMessage::SyncRoutingTable(RoutingTableUpdate {
+        edges: fake_edges.clone(),
+        accounts: vec![],
+    }))
+    .await;
+
+    // Send a valid small update afterwards.
+    let valid_key = data::make_secret_key(rng);
+    let valid_edge = data::make_edge(
+        &peer.cfg.network.node_key,
+        &valid_key,
+        Edge::create_fresh_nonce(&clock.clock()),
+    );
+    peer.send(PeerMessage::SyncRoutingTable(RoutingTableUpdate {
+        edges: vec![valid_edge.clone()],
+        accounts: vec![],
+    }))
+    .await;
+
+    // Wait for the valid edge to be added. This proves:
+    // 1. The oversized message didn't ban/disconnect the peer.
+    // 2. Subsequent valid messages are still processed.
+    pm.events
+        .recv_until(|ev| match ev {
+            Event::EdgesAdded(edges) if edges.contains(&valid_edge) => Some(()),
+            _ => None,
+        })
+        .await;
+
+    // Verify oversized fake edges were NOT added.
+    let fake_keys: Vec<_> = fake_edges.iter().map(|e| e.key().clone()).collect();
+    let has_fake = pm
+        .with_state(move |s| async move {
+            let snapshot = s.graph.load();
+            fake_keys.iter().any(|k| snapshot.edges.contains_key(k))
+        })
+        .await;
+    assert!(!has_fake, "oversized edges should not have been added");
+}
+
+/// Oversized SyncRoutingTable should drop edges but still process accounts
+/// in the same message.
+#[tokio::test]
+async fn oversized_sync_routing_table_still_processes_accounts() {
+    abort_on_panic();
+    let mut rng = make_rng(921853233);
+    let rng = &mut rng;
+    let mut clock = time::FakeClock::default();
+    let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
+
+    // Set a small ingress cap for testing.
+    let mut cfg0 = chain.make_config(rng);
+    cfg0.routing_graph_max_edges_per_message = 5;
+    let mut pm = start_pm(clock.clock(), TestDB::new(), cfg0, chain.clone()).await;
+    let cfg = peer::testonly::PeerConfig { network: chain.make_config(rng), chain: chain.clone() };
+    let stream = tcp::Stream::connect(&pm.peer_info(), tcp::Tier::T2, &SocketOptions::default())
+        .await
+        .unwrap();
+    let mut peer =
+        peer::testonly::PeerHandle::start_endpoint(clock.clock(), ActorSystem::new(), cfg, stream);
+    peer.complete_handshake().await;
+
+    let peer_id = peer.cfg.id();
+    pm.wait_for_routing_table(&[(peer_id.clone(), vec![peer_id.clone()])]).await;
+
+    // Send an oversized SyncRoutingTable that also contains an account announcement.
+    let fake_edges: Vec<Edge> = (0..10)
+        .map(|_| {
+            let k1 = data::make_secret_key(rng);
+            let k2 = data::make_secret_key(rng);
+            data::make_edge(&k1, &k2, 1)
+        })
+        .collect();
+    let account = data::make_announce_account(rng);
+    peer.send(PeerMessage::SyncRoutingTable(RoutingTableUpdate {
+        edges: fake_edges,
+        accounts: vec![account.clone()],
+    }))
+    .await;
+
+    // The account should still be processed even though edges were dropped.
+    pm.events
+        .recv_until(|ev| match ev {
+            Event::AccountsAdded(accounts) if accounts.contains(&account) => Some(()),
+            _ => None,
+        })
+        .await;
+}

--- a/chain/network/src/routing/bfs.rs
+++ b/chain/network/src/routing/bfs.rs
@@ -25,10 +25,12 @@ pub struct Graph {
 
     /// Total number of edges used for stats.
     total_active_edges: u64,
+    /// Maximum number of unique peer IDs allowed in the graph.
+    max_peers: usize,
 }
 
 impl Graph {
-    pub fn new(source: PeerId) -> Self {
+    pub fn new(source: PeerId, max_peers: usize) -> Self {
         let mut res = Self {
             source_id: 0,
             p2id: HashMap::default(),
@@ -37,6 +39,7 @@ impl Graph {
             unused: Vec::default(),
             adjacency: Vec::default(),
             total_active_edges: 0,
+            max_peers,
         };
         res.id2p.push(source.clone());
         res.adjacency.push(Vec::default());
@@ -101,17 +104,26 @@ impl Graph {
         }
     }
 
-    pub fn add_edge(&mut self, peer0: &PeerId, peer1: &PeerId) {
+    /// Adds an edge between two peers. Returns false if the edge would exceed
+    /// the max_peers limit, true otherwise (including if the edge already exists).
+    pub fn add_edge(&mut self, peer0: &PeerId, peer1: &PeerId) -> bool {
         assert_ne!(peer0, peer1);
-        if !self.contains_edge(peer0, peer1) {
-            let id0 = self.get_id(peer0);
-            let id1 = self.get_id(peer1);
-
-            self.adjacency[id0 as usize].push(id1);
-            self.adjacency[id1 as usize].push(id0);
-
-            self.total_active_edges += 1;
+        if self.contains_edge(peer0, peer1) {
+            return true;
         }
+        let new_peers =
+            (!self.p2id.contains_key(peer0) as usize) + (!self.p2id.contains_key(peer1) as usize);
+        if new_peers > 0 && self.p2id.len() + new_peers > self.max_peers {
+            return false;
+        }
+        let id0 = self.get_id(peer0);
+        let id1 = self.get_id(peer1);
+
+        self.adjacency[id0 as usize].push(id1);
+        self.adjacency[id1 as usize].push(id0);
+
+        self.total_active_edges += 1;
+        true
     }
 
     pub fn remove_edge(&mut self, peer0: &PeerId, peer1: &PeerId) {
@@ -254,7 +266,7 @@ mod test {
         let node0 = random_peer_id();
         let node1 = random_peer_id();
 
-        let mut graph = Graph::new(source.clone());
+        let mut graph = Graph::new(source.clone(), 100_000);
 
         assert!(graph.contains_edge(&source, &node0).not());
         assert!(graph.contains_edge(&source, &node1).not());
@@ -282,7 +294,7 @@ mod test {
         let source = random_peer_id();
         let node0 = random_peer_id();
 
-        let mut graph = Graph::new(source.clone());
+        let mut graph = Graph::new(source.clone(), 100_000);
         graph.add_edge(&source, &node0);
         graph.remove_edge(&source, &node0);
         graph.add_edge(&source, &node0);
@@ -301,7 +313,7 @@ mod test {
         let source = random_peer_id();
         let nodes: Vec<_> = (0..3).map(|_| random_peer_id()).collect();
 
-        let mut graph = Graph::new(source);
+        let mut graph = Graph::new(source, 100_000);
 
         graph.add_edge(&nodes[0], &nodes[1]);
         graph.add_edge(&nodes[2], &nodes[1]);
@@ -318,7 +330,7 @@ mod test {
         let source = random_peer_id();
         let nodes: Vec<_> = (0..3).map(|_| random_peer_id()).collect();
 
-        let mut graph = Graph::new(source.clone());
+        let mut graph = Graph::new(source.clone(), 100_000);
 
         graph.add_edge(&nodes[0], &nodes[1]);
         graph.add_edge(&nodes[2], &nodes[1]);
@@ -342,7 +354,7 @@ mod test {
         let source = random_peer_id();
         let nodes: Vec<_> = (0..3).map(|_| random_peer_id()).collect();
 
-        let mut graph = Graph::new(source.clone());
+        let mut graph = Graph::new(source.clone(), 100_000);
 
         graph.add_edge(&nodes[0], &nodes[1]);
         graph.add_edge(&nodes[2], &nodes[1]);
@@ -378,7 +390,7 @@ mod test {
         let source = random_peer_id();
         let nodes: Vec<_> = (0..11).map(|_| random_peer_id()).collect();
 
-        let mut graph = Graph::new(source.clone());
+        let mut graph = Graph::new(source.clone(), 100_000);
 
         for node in &nodes[0..3] {
             graph.add_edge(&source, node);
@@ -416,7 +428,7 @@ mod test {
         let source = random_peer_id();
         let nodes: Vec<_> = (0..11).map(|_| random_peer_id()).collect();
 
-        let mut graph = Graph::new(source.clone());
+        let mut graph = Graph::new(source.clone(), 100_000);
 
         for node in &nodes[0..3] {
             graph.add_edge(&source, node);
@@ -457,7 +469,7 @@ mod test {
         let source = random_peer_id();
         let nodes: Vec<_> = (0..4).map(|_| random_peer_id()).collect();
 
-        let mut graph = Graph::new(source.clone());
+        let mut graph = Graph::new(source.clone(), 100_000);
         graph.add_edge(&source, &nodes[0]);
         graph.add_edge(&source, &nodes[2]);
         graph.add_edge(&nodes[2], &nodes[3]);

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -26,6 +26,9 @@ pub struct GraphConfig {
     pub node_id: PeerId,
     pub prune_unreachable_peers_after: time::Duration,
     pub prune_edges_after: Option<time::Duration>,
+    pub max_edges_per_source: usize,
+    pub max_total_edges: usize,
+    pub max_graph_peers: usize,
 }
 
 #[derive(Default)]
@@ -47,6 +50,10 @@ struct Inner {
     edges: im::HashMap<EdgeKey, Edge>,
     /// Last time a peer was reachable.
     peer_reachable_at: HashMap<PeerId, time::Instant>,
+    /// Maps each edge key to the remote peer that first introduced it.
+    edge_source: HashMap<EdgeKey, PeerId>,
+    /// Count of new edge keys introduced by each remote peer.
+    source_edge_count: HashMap<PeerId, usize>,
 }
 
 fn has(set: &im::HashMap<EdgeKey, Edge>, edge: &Edge) -> bool {
@@ -56,15 +63,48 @@ fn has(set: &im::HashMap<EdgeKey, Edge>, edge: &Edge) -> bool {
 impl Inner {
     /// Adds an edge without validating the signatures. O(1).
     /// Returns true, iff <edge> was newer than an already known version of this edge.
-    fn update_edge(&mut self, edge: Edge) -> bool {
+    /// `source` is the remote peer that sent this edge, or None for local edges.
+    /// Enforces global edge/peer caps and per-source caps.
+    fn update_edge(&mut self, edge: Edge, source: Option<&PeerId>) -> bool {
         if has(&self.edges, &edge) {
             return false;
         }
         let key = edge.key();
-        // Add the edge.
+        let is_new_key = !self.edges.contains_key(key);
+        if is_new_key {
+            // Global edge cap (applies to local AND remote).
+            if self.edges.len() >= self.config.max_total_edges {
+                metrics::EDGE_DROPPED.inc();
+                return false;
+            }
+            // Per-source cap (remote only).
+            if let Some(source) = source {
+                let count = self.source_edge_count.get(source).copied().unwrap_or(0);
+                if count >= self.config.max_edges_per_source {
+                    metrics::EDGE_DROPPED.inc();
+                    return false;
+                }
+            }
+        }
         match edge.edge_type() {
-            EdgeState::Active => self.graph.add_edge(&key.0, &key.1),
+            EdgeState::Active => {
+                if !self.graph.add_edge(&key.0, &key.1) {
+                    // BFS peer cap exceeded.
+                    metrics::EDGE_DROPPED.inc();
+                    return false;
+                }
+            }
             EdgeState::Removed => self.graph.remove_edge(&key.0, &key.1),
+        }
+        // Pin edges to their original introducing source. We intentionally
+        // don't reattribute on nonce updates so that an attacker cannot recycle
+        // budget across multiple colluding peers by replaying edges with bumped
+        // nonces from a fresh source.
+        if is_new_key {
+            if let Some(source) = source {
+                self.edge_source.insert(key.clone(), source.clone());
+                *self.source_edge_count.entry(source.clone()).or_insert(0) += 1;
+            }
         }
         self.edges.insert(key.clone(), edge);
         true
@@ -74,6 +114,14 @@ impl Inner {
     fn remove_edge(&mut self, key: &EdgeKey) {
         if self.edges.remove(key).is_some() {
             self.graph.remove_edge(&key.0, &key.1);
+            if let Some(source) = self.edge_source.remove(key) {
+                if let Some(count) = self.source_edge_count.get_mut(&source) {
+                    *count -= 1;
+                    if *count == 0 {
+                        self.source_edge_count.remove(&source);
+                    }
+                }
+            }
         }
     }
 
@@ -130,7 +178,8 @@ impl Inner {
 
     /// Verifies edges, then adds them to the graph.
     /// Returns a list of newly added edges (not known so far), which should be broadcasted.
-    /// Returns true iff all the edges provided were valid.
+    /// Returns true iff all the edges provided were valid (signatures + no self-loops from remote).
+    /// Limit-triggered drops are non-punitive and do NOT affect the `ok` return value.
     ///
     /// This method implements a security measure against an adversary sending invalid edges:
     /// * it deduplicates edges and drops known edges before verification, because verification is expensive.
@@ -143,9 +192,9 @@ impl Inner {
         clock: &time::Clock,
         edges_and_source: EdgesWithSource,
     ) -> (Vec<Edge>, bool) {
-        let (mut edges, self_loop_allowed) = match edges_and_source {
-            EdgesWithSource::Local(edges) => (edges, true),
-            EdgesWithSource::Remote(edges) => (edges, false),
+        let (mut edges, self_loop_allowed, source) = match edges_and_source {
+            EdgesWithSource::Local(edges) => (edges, true, None),
+            EdgesWithSource::Remote { edges, source } => (edges, false, Some(source)),
         };
 
         metrics::EDGE_UPDATES.inc_by(edges.len() as u64);
@@ -169,12 +218,23 @@ impl Inner {
                 }
             }
 
-            return true;
+            true
         });
+
+        // Use batch-local provisional counters to track how many new keys we're
+        // accepting in this batch, so we can skip expensive signature verification
+        // once caps are reached.
+        let mut provisional_new_edges: usize = 0;
+        let base_edge_count = self.edges.len();
+        let base_source_count = source
+            .as_ref()
+            .map(|s| self.source_edge_count.get(s).copied().unwrap_or(0))
+            .unwrap_or(0);
 
         // Stop at first invalid edge.
         let mut valid_edges = Vec::<Edge>::new();
         let mut ok = true;
+        let mut dropped_by_pre_check: u64 = 0;
         for edge in edges {
             if edge.key().0 == edge.key().1 {
                 // Locally a node might create a self-loop to validate its self-discovered public IP, but that
@@ -186,15 +246,47 @@ impl Inner {
                 ok = false;
                 break;
             }
+            // Cheap pre-check: skip signature verification if this new key would
+            // be rejected by source or global caps anyway.
+            let is_new_key = !self.edges.contains_key(edge.key());
+            if is_new_key {
+                if base_edge_count + provisional_new_edges >= self.config.max_total_edges {
+                    metrics::EDGE_DROPPED.inc();
+                    dropped_by_pre_check += 1;
+                    continue;
+                }
+                if source.is_some()
+                    && base_source_count + provisional_new_edges >= self.config.max_edges_per_source
+                {
+                    metrics::EDGE_DROPPED.inc();
+                    dropped_by_pre_check += 1;
+                    continue;
+                }
+            }
             if !edge.verify() {
                 ok = false;
                 break;
+            }
+            if is_new_key {
+                provisional_new_edges += 1;
             }
             valid_edges.push(edge);
         }
 
         // Add the verified edges to the graph.
-        valid_edges.retain(|e| self.update_edge(e.clone()));
+        // Limit drops may still happen here (e.g., BFS peer cap).
+        let pre_retain_count = valid_edges.len();
+        valid_edges.retain(|e| self.update_edge(e.clone(), source.as_ref()));
+        let dropped_by_update = (pre_retain_count - valid_edges.len()) as u64;
+
+        if dropped_by_pre_check + dropped_by_update > 0 {
+            tracing::info!(
+                target: "network",
+                dropped_by_pre_check,
+                dropped_by_update,
+                "edges dropped due to routing graph limits"
+            );
+        }
         (valid_edges, ok)
     }
 
@@ -262,10 +354,12 @@ impl Graph {
                 clock: clock.clone(),
                 graph: weak.clone(),
                 inner: Inner {
-                    graph: bfs::Graph::new(config.node_id.clone()),
+                    graph: bfs::Graph::new(config.node_id.clone(), config.max_graph_peers),
                     config: config.clone(),
                     edges: Default::default(),
                     peer_reachable_at: HashMap::new(),
+                    edge_source: HashMap::new(),
+                    source_edge_count: HashMap::new(),
                 },
             });
             Self {

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -97,7 +97,7 @@ impl Inner {
             EdgeState::Removed => self.graph.remove_edge(&key.0, &key.1),
         }
         // Pin edges to their original introducing source. We intentionally
-        // don't reattribute on nonce updates so that an attacker cannot recycle
+        // don't reassign attribution on nonce updates so that an attacker cannot recycle
         // budget across multiple colluding peers by replaying edges with bumped
         // nonces from a fresh source.
         if is_new_key {

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -282,6 +282,7 @@ impl Inner {
         if dropped_by_pre_check + dropped_by_update > 0 {
             tracing::info!(
                 target: "network",
+                ?source,
                 dropped_by_pre_check,
                 dropped_by_update,
                 "edges dropped due to routing graph limits"

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -1,4 +1,8 @@
 use super::{Graph, GraphConfig};
+use crate::config::{
+    DEFAULT_ROUTING_GRAPH_MAX_EDGES, DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_SOURCE,
+    DEFAULT_ROUTING_GRAPH_MAX_PEERS,
+};
 use crate::network_protocol::Edge;
 use crate::network_protocol::testonly as data;
 use crate::peer_manager::network_state::EdgesWithSource;
@@ -10,10 +14,27 @@ use near_primitives::network::PeerId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Default test config with generous limits so existing tests aren't affected.
+fn test_graph_config(node_id: PeerId) -> GraphConfig {
+    GraphConfig {
+        node_id,
+        prune_unreachable_peers_after: time::Duration::seconds(3),
+        prune_edges_after: None,
+        max_edges_per_source: DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_SOURCE,
+        max_total_edges: DEFAULT_ROUTING_GRAPH_MAX_EDGES,
+        max_graph_peers: DEFAULT_ROUTING_GRAPH_MAX_PEERS,
+    }
+}
+
 impl Graph {
     async fn simple_update(self: &Arc<Self>, edges: Vec<Edge>) {
         let edges = EdgesWithSource::Local(edges);
         assert_eq!(vec![true], self.update(vec![edges]).await.1);
+    }
+
+    async fn remote_update(self: &Arc<Self>, source: PeerId, edges: Vec<Edge>) -> Vec<bool> {
+        let edges = EdgesWithSource::Remote { edges, source };
+        self.update(vec![edges]).await.1
     }
 
     fn check(&self, want_mem: &[Edge]) {
@@ -39,11 +60,7 @@ async fn empty() {
     let mut rng = make_rng(87927345);
     let rng = &mut rng;
     let node_key = data::make_secret_key(rng);
-    let cfg = GraphConfig {
-        node_id: peer_id(&node_key),
-        prune_unreachable_peers_after: time::Duration::seconds(3),
-        prune_edges_after: None,
-    };
+    let cfg = test_graph_config(peer_id(&node_key));
     let clock = time::FakeClock::default();
     let g = Graph::new(clock.clock(), cfg);
     g.check(&[]);
@@ -58,11 +75,7 @@ async fn one_edge() {
     let mut rng = make_rng(87927345);
     let rng = &mut rng;
     let node_key = data::make_secret_key(rng);
-    let cfg = GraphConfig {
-        node_id: peer_id(&node_key),
-        prune_unreachable_peers_after: time::Duration::seconds(3),
-        prune_edges_after: None,
-    };
+    let cfg = test_graph_config(peer_id(&node_key));
     let g = Arc::new(Graph::new(clock.clock(), cfg.clone()));
 
     let p1 = data::make_secret_key(rng);
@@ -108,9 +121,9 @@ async fn expired_edges() {
     let rng = &mut rng;
     let node_key = data::make_secret_key(rng);
     let cfg = GraphConfig {
-        node_id: peer_id(&node_key),
         prune_unreachable_peers_after: time::Duration::hours(100),
         prune_edges_after: Some(110 * SEC),
+        ..test_graph_config(peer_id(&node_key))
     };
     let g = Arc::new(Graph::new(clock.clock(), cfg.clone()));
 
@@ -161,4 +174,356 @@ async fn expired_edges() {
     clock.advance(100 * SEC);
     g.simple_update(vec![]).await;
     g.check(&[]);
+}
+
+// ======================== Routing graph limit tests ========================
+//
+// All limit tests create edges adjacent to `node_key` so the introduced peers
+// are reachable from the graph source and won't be pruned by the
+// prune_unreachable_peers pass that runs after every graph update.
+//
+// Invariant: limit drops are non-punitive — `ok` (the bool returned by
+// update()) must be `true` even when edges are dropped by caps. Only
+// signature/self-loop failures set `ok = false`.
+
+#[tokio::test]
+async fn source_cap_enforced() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    let mut rng = make_rng(87927345);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    let max_per_source = 5;
+    let cfg = GraphConfig {
+        max_edges_per_source: max_per_source,
+        max_total_edges: 1_000,
+        max_graph_peers: 1_000,
+        ..test_graph_config(peer_id(&node_key))
+    };
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
+
+    let source_key = data::make_secret_key(rng);
+    let source = peer_id(&source_key);
+
+    // Send more edges than the per-source cap. Edges connect to node_key
+    // so they are reachable and won't be pruned.
+    let edges: Vec<Edge> = (0..max_per_source + 5)
+        .map(|_| {
+            let k = data::make_secret_key(rng);
+            data::make_edge(&node_key, &k, 1)
+        })
+        .collect();
+    g.remote_update(source, edges).await;
+
+    let snapshot = g.load();
+    assert_eq!(
+        snapshot.edges.len(),
+        max_per_source,
+        "expected exactly {} edges (per-source cap), got {}",
+        max_per_source,
+        snapshot.edges.len()
+    );
+}
+
+#[tokio::test]
+async fn source_cap_allows_updates() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    let mut rng = make_rng(87927345);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    let max_per_source = 3;
+    let cfg = GraphConfig {
+        max_edges_per_source: max_per_source,
+        max_total_edges: 1_000,
+        max_graph_peers: 1_000,
+        ..test_graph_config(peer_id(&node_key))
+    };
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
+
+    let source_key = data::make_secret_key(rng);
+    let source = peer_id(&source_key);
+
+    // Create edge keys that we'll update later.
+    let k1 = data::make_secret_key(rng);
+    let e1 = data::make_edge(&node_key, &k1, 1);
+
+    let k2 = data::make_secret_key(rng);
+    let e2 = data::make_edge(&node_key, &k2, 1);
+
+    let k3 = data::make_secret_key(rng);
+    let e3 = data::make_edge(&node_key, &k3, 1);
+
+    // Fill source to cap.
+    g.remote_update(source.clone(), vec![e1.clone(), e2.clone(), e3.clone()]).await;
+    let snapshot = g.load();
+    assert_eq!(snapshot.edges.len(), 3);
+
+    // Update existing edge (higher nonce) — should succeed even though source is at cap.
+    let e1_updated = data::make_edge(&node_key, &k1, 3);
+    g.remote_update(source, vec![e1_updated.clone()]).await;
+    let snapshot = g.load();
+    // Edge count stays the same (update, not new key).
+    assert_eq!(snapshot.edges.len(), 3);
+    // Verify the edge was actually updated.
+    assert_eq!(snapshot.edges.get(e1.key()).unwrap().nonce(), 3);
+}
+
+#[tokio::test]
+async fn source_cap_accumulates_across_messages() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    let mut rng = make_rng(87927345);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    let max_per_source = 5;
+    let cfg = GraphConfig {
+        max_edges_per_source: max_per_source,
+        max_total_edges: 1_000,
+        max_graph_peers: 1_000,
+        ..test_graph_config(peer_id(&node_key))
+    };
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
+
+    let source_key = data::make_secret_key(rng);
+    let source = peer_id(&source_key);
+
+    // First message: send 3 edges (under cap).
+    let edges1: Vec<Edge> = (0..3)
+        .map(|_| {
+            let k = data::make_secret_key(rng);
+            data::make_edge(&node_key, &k, 1)
+        })
+        .collect();
+    g.remote_update(source.clone(), edges1).await;
+    assert_eq!(g.load().edges.len(), 3, "first batch should be fully accepted");
+
+    // Second message: send 3 more edges from the same source (total would be 6 > cap=5).
+    let edges2: Vec<Edge> = (0..3)
+        .map(|_| {
+            let k = data::make_secret_key(rng);
+            data::make_edge(&node_key, &k, 1)
+        })
+        .collect();
+    g.remote_update(source, edges2).await;
+    assert_eq!(
+        g.load().edges.len(),
+        max_per_source,
+        "source cap should accumulate across messages: expected {}, got {}",
+        max_per_source,
+        g.load().edges.len()
+    );
+}
+
+#[tokio::test]
+async fn global_edge_cap() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    let mut rng = make_rng(87927345);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    let max_total = 10;
+    let cfg = GraphConfig {
+        max_edges_per_source: 100,
+        max_total_edges: max_total,
+        max_graph_peers: 1_000,
+        ..test_graph_config(peer_id(&node_key))
+    };
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
+
+    // Send edges from multiple sources exceeding global cap.
+    for _ in 0..3 {
+        let source_key = data::make_secret_key(rng);
+        let source = peer_id(&source_key);
+        let edges: Vec<Edge> = (0..5)
+            .map(|_| {
+                let k = data::make_secret_key(rng);
+                data::make_edge(&node_key, &k, 1)
+            })
+            .collect();
+        g.remote_update(source, edges).await;
+    }
+
+    let snapshot = g.load();
+    assert_eq!(
+        snapshot.edges.len(),
+        max_total,
+        "expected exactly {} edges (global cap), got {}",
+        max_total,
+        snapshot.edges.len()
+    );
+}
+
+#[tokio::test]
+async fn global_peer_cap() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    let mut rng = make_rng(87927345);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    // Each edge (node_key, random_k) adds 1 new peer (the random_k side).
+    // node_key itself is the BFS source and already in the graph = 1 peer.
+    // With max_graph_peers=4, we can add at most 3 edges (3 new peers + 1 = 4).
+    let cfg = GraphConfig {
+        max_edges_per_source: 100,
+        max_total_edges: 1_000,
+        max_graph_peers: 4,
+        ..test_graph_config(peer_id(&node_key))
+    };
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
+
+    let source_key = data::make_secret_key(rng);
+    let source = peer_id(&source_key);
+
+    let edges: Vec<Edge> = (0..10)
+        .map(|_| {
+            let k = data::make_secret_key(rng);
+            data::make_edge(&node_key, &k, 1)
+        })
+        .collect();
+    g.remote_update(source, edges).await;
+
+    let snapshot = g.load();
+    // 3 edges fit (3 new peers + 1 existing = 4 = max), 4th edge would need 5 > 4.
+    assert_eq!(
+        snapshot.edges.len(),
+        3,
+        "expected exactly 3 edges (peer cap), got {}",
+        snapshot.edges.len()
+    );
+}
+
+#[tokio::test]
+async fn local_edges_obey_global_caps() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    let mut rng = make_rng(87927345);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    let max_total = 5;
+    let cfg = GraphConfig {
+        max_edges_per_source: 100,
+        max_total_edges: max_total,
+        max_graph_peers: 1_000,
+        ..test_graph_config(peer_id(&node_key))
+    };
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
+
+    // Local edges should also obey max_total_edges.
+    let edges: Vec<Edge> = (0..max_total + 5)
+        .map(|_| {
+            let k = data::make_secret_key(rng);
+            data::make_edge(&node_key, &k, 1)
+        })
+        .collect();
+    g.simple_update(edges).await;
+
+    let snapshot = g.load();
+    assert_eq!(
+        snapshot.edges.len(),
+        max_total,
+        "expected exactly {} edges (global cap for local edges), got {}",
+        max_total,
+        snapshot.edges.len()
+    );
+}
+
+/// Limit-triggered drops must NOT set ok=false (which would map to
+/// ReasonForBan::InvalidEdge). Only signature/self-loop failures do that.
+#[tokio::test]
+async fn limit_drops_are_non_punitive() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    let mut rng = make_rng(87927345);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    let cfg = GraphConfig {
+        max_edges_per_source: 3,
+        max_total_edges: 5,
+        max_graph_peers: 4,
+        ..test_graph_config(peer_id(&node_key))
+    };
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
+
+    let source_key = data::make_secret_key(rng);
+    let source = peer_id(&source_key);
+
+    // Send 10 edges — many will be dropped by various caps.
+    let edges: Vec<Edge> = (0..10)
+        .map(|_| {
+            let k = data::make_secret_key(rng);
+            data::make_edge(&node_key, &k, 1)
+        })
+        .collect();
+    let oks = g.remote_update(source, edges).await;
+
+    // ok must be true: limit drops are non-punitive.
+    assert_eq!(oks, vec![true], "limit drops must not set ok=false");
+
+    // Some edges should have been dropped (graph can't hold all 10).
+    let snapshot = g.load();
+    assert!(snapshot.edges.len() < 10);
+}
+
+/// After filling and then pruning a source's edges, the source should be
+/// able to introduce new edge keys again (budget recovery).
+#[tokio::test]
+async fn source_budget_recovery_after_prune() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    clock.set_utc(time::Utc::UNIX_EPOCH + time::Duration::days(2));
+    let mut rng = make_rng(87927345);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    let max_per_source = 3;
+    let cfg = GraphConfig {
+        max_edges_per_source: max_per_source,
+        max_total_edges: 1_000,
+        max_graph_peers: 1_000,
+        prune_unreachable_peers_after: time::Duration::hours(100),
+        prune_edges_after: Some(time::Duration::seconds(60)),
+        ..test_graph_config(peer_id(&node_key))
+    };
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
+
+    let source_key = data::make_secret_key(rng);
+    let source = peer_id(&source_key);
+
+    // Fill source to cap with 3 edges.
+    let now = clock.now_utc();
+    let edges: Vec<Edge> = (0..max_per_source)
+        .map(|_| {
+            let k = data::make_secret_key(rng);
+            data::make_edge(&node_key, &k, to_active_nonce(now))
+        })
+        .collect();
+    g.remote_update(source.clone(), edges).await;
+    assert_eq!(g.load().edges.len(), 3);
+
+    // A 4th edge should be rejected (source cap reached).
+    let extra_key = data::make_secret_key(rng);
+    let extra_edge = data::make_edge(&node_key, &extra_key, to_active_nonce(now));
+    g.remote_update(source.clone(), vec![extra_edge]).await;
+    assert_eq!(g.load().edges.len(), 3, "4th edge should be rejected");
+
+    // Advance time so old edges get pruned.
+    clock.advance(time::Duration::seconds(120));
+    // Trigger a pruning pass by sending an empty local update.
+    g.simple_update(vec![]).await;
+    assert_eq!(g.load().edges.len(), 0, "all old edges should be pruned");
+
+    // Now the same source should be able to introduce new edge keys again.
+    let fresh_now = clock.now_utc();
+    let new_edges: Vec<Edge> = (0..max_per_source)
+        .map(|_| {
+            let k = data::make_secret_key(rng);
+            data::make_edge(&node_key, &k, to_active_nonce(fresh_now))
+        })
+        .collect();
+    g.remote_update(source, new_edges).await;
+    assert_eq!(
+        g.load().edges.len(),
+        max_per_source,
+        "source should be able to introduce new keys after budget recovery"
+    );
 }

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -255,6 +255,14 @@ pub(crate) static EDGE_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
         .unwrap()
 });
 
+pub(crate) static EDGE_DROPPED: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_edge_dropped",
+        "Number of edges rejected due to routing graph limits",
+    )
+    .unwrap()
+});
+
 pub(crate) static EDGE_TOMBSTONE_SENDING_SKIPPED: LazyLock<IntCounter> = LazyLock::new(|| {
     try_create_int_counter(
         "near_edge_tombstone_sending_skip",

--- a/nearcore/src/config_duration_test.rs
+++ b/nearcore/src/config_duration_test.rs
@@ -66,6 +66,10 @@ fn test_config_duration_all_std() {
                     received_messages_rate_limits: Some(
                         near_network::MessagesLimitsOverrideConfig::default(),
                     ),
+                    routing_graph_max_edges_per_message: Some(50_000),
+                    routing_graph_max_edges_per_source: Some(50_000),
+                    routing_graph_max_peers: Some(100_000),
+                    routing_graph_max_edges: Some(1_000_000),
                 },
                 ..Default::default()
             },


### PR DESCRIPTION
- Add four configurable limits to prevent unbounded memory growth from fabricated-but-validly-signed routing edges:
  - **Ingress cap**: drop SyncRoutingTable messages exceeding `max_edges_per_message` before any dedup/verification work
  - **Per-source cap**: track new edge keys per remote PeerId, reject when `max_edges_per_source` is reached (updates to existing keys always allowed)
  - **Global edge cap**: reject new edges when `max_total_edges` is reached (applies to both local and remote edges for memory safety)
  - **Global peer cap**: reject edges introducing peers beyond `max_graph_peers` in the BFS routing graph
- All limits are non-punitive (no ban/disconnect), emit `EDGE_DROPPED` metric and warning logs on drops
- All four values are runtime-configurable via `NetworkConfigOverrides`
- Defaults: 50K edges/message, 50K edges/source, 100K peers, 1M total edges
- Comprehensive test coverage: per-source cap, cross-message accumulation, global edge/peer caps, non-punitive semantics, budget recovery after prune, oversized message integration tests
- Independently discovered by Warpsync