### PR TITLE
fix(pipelining): barrier account lifecycle in receipt prep

### DIFF
--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -84,6 +84,11 @@ struct PrepareTask {
     status: Mutex<PrepareTaskStatus>,
     condvar: Condvar,
     created: Instant,
+    /// Hash of the contract identifier captured at submit time.
+    ///
+    /// Defense in depth: if the receiver's code hash unexpectedly changes between
+    /// preparation and execution, the stale prepared artifact is discarded.
+    expected_hash: CryptoHash,
 }
 
 enum PrepareTaskStatus {
@@ -150,10 +155,18 @@ impl ReceiptPreparationPipeline {
             match action {
                 Action::DeployContract(_)
                 | Action::UseGlobalContract(_)
-                | Action::DeterministicStateInit(_) => {
+                | Action::DeterministicStateInit(_)
+                | Action::CreateAccount(_)
+                | Action::DeleteAccount(_) => {
+                    // Any action that can change the account's executable-code identity within
+                    // this chunk must block preparation for the receiver. Otherwise a later
+                    // function call could be prepared against the account's current contract
+                    // and then executed under a freshly created or recreated account with
+                    // different (or no) code.
+                    //
                     // FIXME: instead of blocking these accounts, move the handling of
-                    // deploy action into here, so that the necessary data dependencies can be
-                    // established.
+                    // code-identity-changing actions into here, so that the necessary data
+                    // dependencies can be established.
                     return self.block_accounts.insert(account_id);
                 }
                 Action::FunctionCall(function_call) => {
@@ -216,7 +229,13 @@ impl ReceiptPreparationPipeline {
                     let method_name = function_call.method_name.clone();
                     let status = Mutex::new(PrepareTaskStatus::Pending);
                     let created = Instant::now();
-                    let task = Arc::new(PrepareTask { status, condvar: Condvar::new(), created });
+                    let expected_hash = identifier.hash();
+                    let task = Arc::new(PrepareTask {
+                        status,
+                        condvar: Condvar::new(),
+                        created,
+                        expected_hash,
+                    });
                     entry.insert(Arc::clone(&task));
                     PIPELINING_ACTIONS_SUBMITTED.inc_by(1);
                     let shard_id = self.shard_id;
@@ -250,12 +269,10 @@ impl ReceiptPreparationPipeline {
                 // No need to handle this receipt as it only generates other new receipts.
                 Action::Delegate(_) => {}
                 // No handling for these.
-                Action::CreateAccount(_)
-                | Action::Transfer(_)
+                Action::Transfer(_)
                 | Action::Stake(_)
                 | Action::AddKey(_)
                 | Action::DeleteKey(_)
-                | Action::DeleteAccount(_)
                 | Action::DeployGlobalContract(_)
                 | Action::TransferToGasKey(_)
                 | Action::WithdrawFromGasKey(_) => {}
@@ -299,7 +316,8 @@ impl ReceiptPreparationPipeline {
             panic!("referenced receipt action is not a function call!");
         };
         let key = PrepareTaskKey { receipt_id: receipt.get_hash(), action_index };
-        let Some(task) = self.map.get(&key) else {
+        // Double-check contract hash matches as defense-in-depth.
+        let Some(task) = self.map.get(&key).filter(|t| t.expected_hash == identifier.hash()) else {
             let start = Instant::now();
             let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
             if !self.block_accounts.contains(account_id) {

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -4173,7 +4173,7 @@ fn test_function_call_after_same_chunk_delete_recreate_resolves_fresh_code() {
     );
     let create_and_call = build_receipt(
         "create_and_call",
-        parent.clone(),
+        parent,
         &parent_signer,
         vec![
             Action::CreateAccount(CreateAccountAction {}),

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -23,8 +23,8 @@ use near_primitives::congestion_info::{
     BlockCongestionInfo, CongestionControl, CongestionInfo, ExtendedCongestionInfo,
 };
 use near_primitives::errors::{
-    ActionErrorKind, DepositCostFailureReason, FunctionCallError, InvalidTxError, MissingTrieValue,
-    TxExecutionError,
+    ActionError, ActionErrorKind, CompilationError, DepositCostFailureReason, FunctionCallError,
+    InvalidTxError, MissingTrieValue, TxExecutionError,
 };
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV0};
@@ -33,8 +33,9 @@ use near_primitives::state::PartialState;
 use near_primitives::stateless_validation::contract_distribution::CodeHash;
 use near_primitives::test_utils::{MockEpochInfoProvider, account_new};
 use near_primitives::transaction::{
-    AddKeyAction, DeleteKeyAction, DeployContractAction, ExecutionOutcomeWithId, ExecutionStatus,
-    FunctionCallAction, SignedTransaction, TransactionNonce, TransferAction,
+    AddKeyAction, CreateAccountAction, DeleteKeyAction, DeployContractAction,
+    ExecutionOutcomeWithId, ExecutionStatus, FunctionCallAction, SignedTransaction,
+    TransactionNonce, TransferAction,
 };
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
@@ -4105,5 +4106,111 @@ fn test_one_yocto_subsidy_tracked_in_stats() {
         apply_result.stats.balance.subsidized_amount,
         Balance::from_yoctonear(2),
         "stats should track 2 yoctoNEAR subsidized across two zero-balance contract calls"
+    );
+}
+
+// A FunctionCall whose receiver is deleted and recreated within the same chunk must
+// resolve to the freshly recreated (no-code) account, not to a stale contract that
+// `ReceiptPreparationPipeline` compiled against the receiver's code as resolved at
+// preparation time.
+#[test]
+fn test_function_call_after_same_chunk_delete_recreate_resolves_fresh_code() {
+    let parent = alice_account();
+    let child: AccountId = "child.alice.near".parse().unwrap();
+    // initial_locked must be 0 so the self-DeleteAccount receipt below passes the
+    // DeleteAccountStaking check in `check_actor_permissions`.
+    let (runtime, tries, root, mut apply_state, signers, epoch_info_provider) = setup_runtime(
+        vec![parent.clone(), child.clone()],
+        Balance::from_near(1_000_000),
+        Balance::ZERO,
+        Gas::from_teragas(1000),
+    );
+    let parent_signer = signers[0].clone();
+    let child_signer = signers[1].clone();
+
+    let deploy = create_receipt_with_actions(
+        child.clone(),
+        child_signer.clone(),
+        vec![Action::DeployContract(DeployContractAction {
+            code: near_test_contracts::trivial_contract().to_vec(),
+        })],
+    );
+    let deploy_result = runtime
+        .apply(
+            tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            &None,
+            &apply_state,
+            &[deploy],
+            SignedValidPeriodTransactions::empty(),
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+    let root =
+        commit_apply_result(&deploy_result, &mut apply_state, &tries, ShardUId::single_shard());
+    apply_state.block_height += 1;
+
+    let build_receipt = |tag: &str, predecessor: AccountId, signer: &Signer, actions| -> Receipt {
+        Receipt::V0(ReceiptV0 {
+            predecessor_id: predecessor.clone(),
+            receiver_id: child.clone(),
+            receipt_id: CryptoHash::hash_borsh((tag, &child)),
+            receipt: ReceiptEnum::Action(ActionReceipt {
+                signer_id: predecessor,
+                signer_public_key: signer.public_key(),
+                gas_price: GAS_PRICE,
+                output_data_receivers: vec![],
+                input_data_ids: vec![],
+                actions,
+            }),
+        })
+    };
+    let delete = build_receipt(
+        "delete",
+        child.clone(),
+        &child_signer,
+        vec![Action::DeleteAccount(DeleteAccountAction { beneficiary_id: parent.clone() })],
+    );
+    let create_and_call = build_receipt(
+        "create_and_call",
+        parent.clone(),
+        &parent_signer,
+        vec![
+            Action::CreateAccount(CreateAccountAction {}),
+            Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "main".to_string(),
+                args: vec![],
+                gas: Gas::from_teragas(10),
+                deposit: Balance::ZERO,
+            })),
+        ],
+    );
+    let call_id = *create_and_call.receipt_id();
+
+    let result = runtime
+        .apply(
+            tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            &None,
+            &apply_state,
+            &[delete, create_and_call],
+            SignedValidPeriodTransactions::empty(),
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+
+    let call_outcome = result
+        .outcomes
+        .iter()
+        .find(|outcome| outcome.id == call_id)
+        .expect("function call outcome missing");
+    assert_matches!(
+        &call_outcome.outcome.status,
+        ExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+            kind: ActionErrorKind::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::CodeDoesNotExist { .. }
+            )),
+            ..
+        }))
     );
 }


### PR DESCRIPTION
`ReceiptPreparationPipeline` could execute a contract prepared against a receiver's pre-chunk code even after a same-chunk delete+recreate wiped the account's code, producing validator divergence that depends on local compilation-pool scheduling.

- Treat `CreateAccount`/`DeleteAccount` as barriers in `submit()` alongside `DeployContract`/`UseGlobalContract`/`DeterministicStateInit` so preparation is never scheduled for a receiver whose code identity may change mid-chunk.
- Defense in depth: capture the resolved contract identifier's hash on `PrepareTask` and discard the prepared artifact in `get_contract` if the freshly resolved hash no longer matches, falling through to main-thread preparation with the fresh identifier.
- Regression test `test_function_call_after_same_chunk_delete_recreate_resolves_fresh_code` applies `[self-DeleteAccount, CreateAccount+FunctionCall]` to a receiver in a single chunk and asserts the FunctionCall fails with `CodeDoesNotExist`; fails deterministically without either patch, passes with either alone.