### PR TITLE
test(spice): enable 4 yield-related tests under spice

### DIFF
--- a/test-loop-tests/src/tests/yield_resume.rs
+++ b/test-loop-tests/src/tests/yield_resume.rs
@@ -354,9 +354,9 @@ fn test_yield_then_resume_two_actions() {
         ],
         *genesis_block.hash(),
     );
-    env.validator().submit_tx(yield_resume_transaction.clone());
-    let target_height = env.validator().head().height + 3;
-    env.validator_runner().run_until_executed_height(target_height);
+    env.validator_runner()
+        .execute_tx(yield_resume_transaction.clone(), Duration::seconds(5))
+        .unwrap();
 
     {
         let node = env.validator();

--- a/test-loop-tests/src/tests/yield_resume.rs
+++ b/test-loop-tests/src/tests/yield_resume.rs
@@ -327,8 +327,6 @@ fn test_yield_then_resume_same_block() {
 /// With the feature everything should work fine.
 /// See https://github.com/near/nearcore/issues/14904, this test reproduces case 4)
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_yield_then_resume_two_actions() {
     let mut env = prepare_env();
     let signer = create_user_test_signer(&AccountId::from_str("test0").unwrap());
@@ -357,7 +355,8 @@ fn test_yield_then_resume_two_actions() {
         *genesis_block.hash(),
     );
     env.validator().submit_tx(yield_resume_transaction.clone());
-    env.validator_runner().run_for_number_of_blocks(3);
+    let target_height = env.validator().head().height + 3;
+    env.validator_runner().run_until_executed_height(target_height);
 
     {
         let node = env.validator();

--- a/test-loop-tests/src/tests/yield_timeouts.rs
+++ b/test-loop-tests/src/tests/yield_timeouts.rs
@@ -66,9 +66,9 @@ fn find_yield_data_ids_from_latest_block(env: &TestLoopEnv) -> Vec<CryptoHash> {
 pub(crate) fn get_yield_data_ids_in_latest_state(env: &TestLoopEnv) -> Vec<CryptoHash> {
     let node = env.validator();
     let client = node.client();
-    let head = client.chain.head().unwrap();
-    let block_hash = head.last_block_hash;
-    let epoch_id = head.epoch_id;
+    let last_executed = node.last_executed();
+    let block_hash = last_executed.last_block_hash;
+    let epoch_id = last_executed.epoch_id;
     let shard_layout = client.epoch_manager.get_shard_layout(&epoch_id).unwrap();
     let shard_uid = shard_layout.account_id_to_shard_uid(&"test0".parse::<AccountId>().unwrap());
 
@@ -266,7 +266,7 @@ fn prepare_env_with_yield(
     };
     assert_eq!(yield_data_ids.len(), 1);
 
-    let last_block_height = env.validator().head().height;
+    let last_block_height = env.validator().last_executed().height;
     assert_eq!(NEXT_BLOCK_HEIGHT_AFTER_SETUP, last_block_height + 1);
 
     (env, yield_tx_hash, yield_data_ids[0])

--- a/test-loop-tests/src/tests/yield_timeouts.rs
+++ b/test-loop-tests/src/tests/yield_timeouts.rs
@@ -157,12 +157,12 @@ fn get_promise_yield_statuses_in_state(
 pub(crate) fn assert_no_promise_yield_status_in_state(env: &TestLoopEnv) {
     let node = env.validator();
     let client = node.client();
-    let head = client.chain.head().unwrap();
-    let epoch_id = head.epoch_id;
+    let last_executed = node.last_executed();
+    let epoch_id = last_executed.epoch_id;
     let shard_layout = client.epoch_manager.get_shard_layout(&epoch_id).unwrap();
     let shard_uid = shard_layout.account_id_to_shard_uid(&"test0".parse::<AccountId>().unwrap());
 
-    let state_root = get_latest_state_state_root(client, head.last_block_hash, shard_uid);
+    let state_root = get_latest_state_state_root(client, last_executed.last_block_hash, shard_uid);
     let promise_yield_statuses = get_promise_yield_statuses_in_state(client, state_root, shard_uid);
     assert_eq!(promise_yield_statuses, Vec::new());
 }

--- a/test-loop-tests/src/tests/yield_timeouts.rs
+++ b/test-loop-tests/src/tests/yield_timeouts.rs
@@ -209,13 +209,8 @@ fn prepare_env_with_yield(
     );
     env.validator().submit_tx(deploy_contract_tx.clone());
 
-    // Allow two blocks for the contract to be deployed.
-    // With spice, execution is async so we must wait for execution, not just consensus.
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(2);
-    } else {
-        env.validator_runner().run_until_head_height(2);
-    }
+    // Allow two blocks to execute for the contract to be deployed.
+    env.validator_runner().run_until_executed_height(2);
     assert!(matches!(
         env.validator()
             .client()
@@ -242,11 +237,7 @@ fn prepare_env_with_yield(
     );
     let yield_tx_hash = yield_transaction.get_hash();
     env.validator().submit_tx(yield_transaction);
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(4);
-    } else {
-        env.validator_runner().run_until_head_height(4);
-    }
+    env.validator_runner().run_until_executed_height(4);
     assert!(matches!(
         env.validator()
             .client()
@@ -347,12 +338,8 @@ fn test_simple_yield_timeout() {
         );
     }
 
-    // In this block the timeout is processed, producing a YieldResume receipt.
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT);
-    } else {
-        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT);
-    }
+    // When this block executes, the timeout is processed, producing a YieldResume receipt.
+    env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT);
     // Checks that the anticipated YieldResume receipt was produced.
     assert_eq!(find_yield_data_ids_from_latest_block(&env), vec![data_id]);
     assert_eq!(
@@ -365,12 +352,8 @@ fn test_simple_yield_timeout() {
         FinalExecutionStatus::Started
     );
 
-    // In this block the resume receipt is applied and the callback will execute.
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
-    } else {
-        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 1);
-    }
+    // When this block executes, the resume receipt is applied and the callback will execute.
+    env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
     assert_eq!(
         env.validator()
             .client()
@@ -461,12 +444,8 @@ fn test_yield_resume_just_before_timeout() {
         );
     }
 
-    // In this block the `yield_resume` host function is invoked, producing a YieldResume receipt.
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT);
-    } else {
-        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT);
-    }
+    // When this block executes `yield_resume` host function is invoked, producing a YieldResume receipt.
+    env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT);
     assert_eq!(
         env.validator()
             .client()
@@ -479,12 +458,8 @@ fn test_yield_resume_just_before_timeout() {
     // Here we expect two receipts to be produced; one from yield_resume and one from timeout.
     assert_eq!(find_yield_data_ids_from_latest_block(&env), vec![data_id, data_id]);
 
-    // In this block the resume receipt is applied and the callback is executed with the resume payload.
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
-    } else {
-        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 1);
-    }
+    // When this block executes, the resume receipt is applied and the callback is executed with the resume payload.
+    env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
     assert_eq!(
         env.validator()
             .client()
@@ -591,9 +566,8 @@ fn test_skip_timeout_height() {
     env.validator_runner()
         .run_until_head_height_with_timeout(YIELD_TIMEOUT_HEIGHT + 1, Duration::seconds(3));
     assert_eq!(env.validator().head().height, YIELD_TIMEOUT_HEIGHT + 1);
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
-    }
+    // In spice, this waits for the specified block to execute.
+    env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
     // The block at YIELD_TIMEOUT_HEIGHT should be missing.
     assert_matches!(
         env.validator().client().chain.get_block_by_height(YIELD_TIMEOUT_HEIGHT),
@@ -612,12 +586,8 @@ fn test_skip_timeout_height() {
         FinalExecutionStatus::Started
     );
 
-    // In this block the resume receipt is applied and the callback will execute.
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 2);
-    } else {
-        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 2);
-    }
+    // When this block executes, the resume receipt is applied and the callback will execute.
+    env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 2);
     assert_eq!(
         env.validator()
             .client()
@@ -667,23 +637,14 @@ fn test_yield_timeout_resume_receipt_has_receipt_to_tx() {
         env.validator_runner().run_until_head_height(block_height);
     }
 
-    // In this block the timeout fires, producing a PromiseResume receipt.
-    // With spice, we must wait for execution to complete before querying results.
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT);
-    } else {
-        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT);
-    }
+    // When this block executes, the timeout fires, producing a PromiseResume receipt.
+    env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT);
     let resume_receipt_ids = find_promise_resume_receipt_ids_from_latest_block(&env);
     assert_eq!(resume_receipt_ids.len(), 1, "expected exactly one PromiseResume receipt");
     let resume_receipt_id = resume_receipt_ids[0];
 
-    // In this block the resume receipt is applied and the callback executes.
-    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
-    } else {
-        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 1);
-    }
+    // When this block executes, the resume receipt is applied and the callback executes.
+    env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
     assert_eq!(
         env.validator()
             .client()

--- a/test-loop-tests/src/tests/yield_timeouts.rs
+++ b/test-loop-tests/src/tests/yield_timeouts.rs
@@ -31,7 +31,7 @@ const NEXT_BLOCK_HEIGHT_AFTER_SETUP: u64 = 5;
 // producing a YieldResume receipt.
 const YIELD_TIMEOUT_HEIGHT: u64 = YIELD_CREATE_HEIGHT + TEST_CONFIG_YIELD_TIMEOUT_LENGTH;
 
-/// Helper function which checks the outgoing receipts from the latest block.
+/// Helper function which checks the outgoing receipts from the latest executed block.
 /// Returns yield data ids for all PromiseYield and PromiseResume receipts.
 fn find_yield_data_ids_from_latest_block(env: &TestLoopEnv) -> Vec<CryptoHash> {
     let node = env.validator();
@@ -40,8 +40,9 @@ fn find_yield_data_ids_from_latest_block(env: &TestLoopEnv) -> Vec<CryptoHash> {
     let epoch_id = *genesis_block.header().epoch_id();
     let shard_layout = client.epoch_manager.get_shard_layout(&epoch_id).unwrap();
     let shard_id = shard_layout.account_id_to_shard_id(&"test0".parse::<AccountId>().unwrap());
-    let last_block_hash = client.chain.head().unwrap().last_block_hash;
-    let last_block_height = client.chain.head().unwrap().height;
+    let last_executed = node.last_executed();
+    let last_block_hash = last_executed.last_block_hash;
+    let last_block_height = last_executed.height;
 
     let mut result = vec![];
 
@@ -630,7 +631,7 @@ fn test_skip_timeout_height() {
     assert_no_promise_yield_status_in_state(&env);
 }
 
-/// Helper: finds PromiseResume receipt IDs from the outgoing receipts at the latest block.
+/// Helper: finds PromiseResume receipt IDs from the outgoing receipts at the latest executed block.
 fn find_promise_resume_receipt_ids_from_latest_block(env: &TestLoopEnv) -> Vec<CryptoHash> {
     let node = env.validator();
     let client = node.client();
@@ -638,8 +639,9 @@ fn find_promise_resume_receipt_ids_from_latest_block(env: &TestLoopEnv) -> Vec<C
     let epoch_id = *genesis_block.header().epoch_id();
     let shard_layout = client.epoch_manager.get_shard_layout(&epoch_id).unwrap();
     let shard_id = shard_layout.account_id_to_shard_id(&"test0".parse::<AccountId>().unwrap());
-    let last_block_hash = client.chain.head().unwrap().last_block_hash;
-    let last_block_height = client.chain.head().unwrap().height;
+    let last_executed = node.last_executed();
+    let last_block_hash = last_executed.last_block_hash;
+    let last_block_height = last_executed.height;
 
     let mut result = vec![];
     for receipt in client

--- a/test-loop-tests/src/tests/yield_timeouts.rs
+++ b/test-loop-tests/src/tests/yield_timeouts.rs
@@ -326,8 +326,6 @@ fn create_congestion(env: &TestLoopEnv) {
 /// Simple test of timeout execution.
 /// Advances sufficiently many blocks, then verifies that the callback was executed.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_simple_yield_timeout() {
     let (mut env, yield_tx_hash, data_id) = prepare_env_with_yield(vec![], None);
     assert!(NEXT_BLOCK_HEIGHT_AFTER_SETUP < YIELD_TIMEOUT_HEIGHT);
@@ -349,7 +347,11 @@ fn test_simple_yield_timeout() {
     }
 
     // In this block the timeout is processed, producing a YieldResume receipt.
-    env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT);
+    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
+        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT);
+    } else {
+        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT);
+    }
     // Checks that the anticipated YieldResume receipt was produced.
     assert_eq!(find_yield_data_ids_from_latest_block(&env), vec![data_id]);
     assert_eq!(
@@ -363,7 +365,11 @@ fn test_simple_yield_timeout() {
     );
 
     // In this block the resume receipt is applied and the callback will execute.
-    env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 1);
+    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
+        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
+    } else {
+        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 1);
+    }
     assert_eq!(
         env.validator()
             .client()
@@ -429,8 +435,6 @@ fn test_yield_timeout_under_congestion() {
 
 /// In this case we invoke yield_resume at the last block possible.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_yield_resume_just_before_timeout() {
     let yield_payload = vec![6u8; 16];
     let (mut env, yield_tx_hash, data_id) = prepare_env_with_yield(yield_payload.clone(), None);
@@ -457,7 +461,11 @@ fn test_yield_resume_just_before_timeout() {
     }
 
     // In this block the `yield_resume` host function is invoked, producing a YieldResume receipt.
-    env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT);
+    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
+        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT);
+    } else {
+        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT);
+    }
     assert_eq!(
         env.validator()
             .client()
@@ -471,7 +479,11 @@ fn test_yield_resume_just_before_timeout() {
     assert_eq!(find_yield_data_ids_from_latest_block(&env), vec![data_id, data_id]);
 
     // In this block the resume receipt is applied and the callback is executed with the resume payload.
-    env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 1);
+    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
+        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
+    } else {
+        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 1);
+    }
     assert_eq!(
         env.validator()
             .client()
@@ -540,9 +552,7 @@ fn test_yield_resume_after_timeout_height() {
 
 /// In this test there is no block produced at height YIELD_TIMEOUT_HEIGHT.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg(feature = "test_features")]
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_skip_timeout_height() {
     use assert_matches::assert_matches;
     use near_chain::Error;
@@ -580,6 +590,9 @@ fn test_skip_timeout_height() {
     env.validator_runner()
         .run_until_head_height_with_timeout(YIELD_TIMEOUT_HEIGHT + 1, Duration::seconds(3));
     assert_eq!(env.validator().head().height, YIELD_TIMEOUT_HEIGHT + 1);
+    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
+        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 1);
+    }
     // The block at YIELD_TIMEOUT_HEIGHT should be missing.
     assert_matches!(
         env.validator().client().chain.get_block_by_height(YIELD_TIMEOUT_HEIGHT),
@@ -599,7 +612,11 @@ fn test_skip_timeout_height() {
     );
 
     // In this block the resume receipt is applied and the callback will execute.
-    env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 2);
+    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
+        env.validator_runner().run_until_executed_height(YIELD_TIMEOUT_HEIGHT + 2);
+    } else {
+        env.validator_runner().run_until_head_height(YIELD_TIMEOUT_HEIGHT + 2);
+    }
     assert_eq!(
         env.validator()
             .client()


### PR DESCRIPTION
Test-only changes to handle spice's async execution:
- Use `execute_tx` in `test_yield_then_resume_two_actions` to wait for the tx outcome instead of a fixed block count.
- Replace `run_until_head_height(N)` with `run_until_executed_height(N)` where the assertion depends on execution.
- Switch yield state/receipt helpers to read `node.last_executed()` instead of `client.chain.head()`, so they always inspect an executed block even if consensus has raced ahead.

No production code changes.