### PR TITLE
test(spice): enable validator_rotation and memtrie tests

### DIFF
--- a/test-loop-tests/src/examples/validator_rotation.rs
+++ b/test-loop-tests/src/examples/validator_rotation.rs
@@ -9,8 +9,6 @@ use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, Balance, NumSeats};
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_validator_rotation() {
     init_test_logger();
 

--- a/test-loop-tests/src/tests/in_memory_tries.rs
+++ b/test-loop-tests/src/tests/in_memory_tries.rs
@@ -16,8 +16,6 @@ use near_primitives::types::{AccountId, Balance};
 /// and loading memtrie failed because of missing `ChunkExtra` with desired
 /// state root.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_load_memtrie_after_empty_chunks() {
     init_test_logger();
     let builder = TestLoopBuilder::new();


### PR DESCRIPTION
Two test-loop-tests that were ignored under `protocol_feature_spice` already pass with no code changes. Dropping the `#[cfg_attr]`:

- `examples::validator_rotation::test_validator_rotation`
- `tests::in_memory_tries::test_load_memtrie_after_empty_chunks`