### PR TITLE
feat(cloud-archive): configurable state snapshot frequency

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3631,11 +3631,11 @@ impl Chain {
     /// Function to check whether we need to create a new snapshot while processing the current block
     /// Note that this functions is called as a part of block preprocessing, so the head is not updated to current block
     fn should_make_snapshot(&self) -> Result<SnapshotAction, Error> {
-        if let StateSnapshotConfig::Disabled =
-            self.runtime_adapter.get_tries().state_snapshot_config()
-        {
+        let tries = self.runtime_adapter.get_tries();
+        if let StateSnapshotConfig::Disabled = tries.state_snapshot_config() {
             return Ok(SnapshotAction::None);
         }
+        let snapshot_every_n_epochs = tries.state_snapshot_config().snapshot_frequency();
 
         // head value is that of the previous block, i.e. curr_block.prev_hash
         let head = self.head()?;
@@ -3645,13 +3645,17 @@ impl Chain {
         }
 
         let is_sync_prev = self.state_sync_adapter.is_sync_prev_hash(&head)?;
-        if is_sync_prev {
-            // Here the head block is the prev block of what the sync hash will be, and the previous
-            // block is the point in the chain we want to snapshot state for
-            Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
-        } else {
-            Ok(SnapshotAction::None)
+        if !is_sync_prev {
+            return Ok(SnapshotAction::None);
         }
+        // Here the head block is the prev block of what the sync hash will be, and the previous
+        // block is the point in the chain we want to snapshot state for.
+        let epoch_height =
+            self.epoch_manager.get_epoch_height_from_prev_block(&head.prev_block_hash)?;
+        if epoch_height % snapshot_every_n_epochs != 0 {
+            return Ok(SnapshotAction::None);
+        }
+        Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
     }
 
     pub fn transaction_validity_period(&self) -> BlockHeightDelta {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3635,7 +3635,7 @@ impl Chain {
         if let StateSnapshotConfig::Disabled = tries.state_snapshot_config() {
             return Ok(SnapshotAction::None);
         }
-        let snapshot_every_n_epochs = tries.state_snapshot_config().snapshot_frequency();
+        let snapshot_every_n_epochs = tries.state_snapshot_config().snapshot_cadence();
 
         // head value is that of the previous block, i.e. curr_block.prev_hash
         let head = self.head()?;

--- a/chain/chain/src/runtime/test_utils.rs
+++ b/chain/chain/src/runtime/test_utils.rs
@@ -45,6 +45,7 @@ impl NightshadeRuntime {
         trie_config: TrieConfig,
         gc_num_epochs_to_keep: u64,
         is_cloud_archival_writer: bool,
+        snapshot_every_n_epochs: u64,
         save_receipt_to_tx: bool,
     ) -> Arc<Self> {
         Self::new(
@@ -57,7 +58,10 @@ impl NightshadeRuntime {
             runtime_config_store,
             gc_num_epochs_to_keep,
             trie_config,
-            StateSnapshotConfig::enabled(home_dir.join("data")),
+            StateSnapshotConfig::enabled_with_frequency(
+                home_dir.join("data"),
+                snapshot_every_n_epochs,
+            ),
             DEFAULT_STATE_PARTS_COMPRESSION_LEVEL,
             is_cloud_archival_writer,
             save_receipt_to_tx,

--- a/chain/chain/src/runtime/test_utils.rs
+++ b/chain/chain/src/runtime/test_utils.rs
@@ -58,7 +58,7 @@ impl NightshadeRuntime {
             runtime_config_store,
             gc_num_epochs_to_keep,
             trie_config,
-            StateSnapshotConfig::enabled_with_frequency(
+            StateSnapshotConfig::enabled_with_cadence(
                 home_dir.join("data"),
                 snapshot_every_n_epochs,
             ),

--- a/chain/client/src/archive/cloud_archival_reader.rs
+++ b/chain/client/src/archive/cloud_archival_reader.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
-use near_primitives::types::{BlockHeight, EpochId};
+use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::index_to_bytes;
 use near_store::archive::cloud_storage::{BlockData, CloudStorage, EpochData};
 use near_store::{DBCol, Store};
@@ -149,6 +149,51 @@ fn backfill_epoch_start(
     }
 
     Ok(epoch_data)
+}
+
+/// Walks epochs backward from `height` and returns the first `(epoch_height, epoch_id)`
+/// whose state-header is present in cloud for `shard_id`, or `None` after the genesis
+/// epoch.
+pub fn find_snapshot_at_or_before(
+    cloud_storage: &CloudStorage,
+    height: BlockHeight,
+    shard_id: ShardId,
+) -> anyhow::Result<Option<(EpochHeight, EpochId)>> {
+    let initial_batch = cloud_storage
+        .get_block_batch_for_height(height)
+        .with_context(|| format!("failed to download block batch at height {height}"))?;
+    let mut epoch_id = *initial_batch.get_block_at_height(height).block().header().epoch_id();
+
+    loop {
+        let epoch_data = cloud_storage
+            .get_epoch_data(epoch_id)
+            .with_context(|| format!("failed to download epoch data for {epoch_id:?}"))?;
+        let epoch_height = epoch_data.epoch_info().epoch_height();
+        let epoch_start_height = epoch_data.epoch_start_height();
+
+        tracing::info!(epoch_height, ?epoch_id, "probing for state snapshot");
+
+        if cloud_storage.get_state_header(epoch_height, epoch_id, shard_id).is_ok() {
+            return Ok(Some((epoch_height, epoch_id)));
+        }
+
+        // Miss: step to the previous epoch. Fetch the epoch-start block so we
+        // can detect the genesis epoch (its prev_hash is the default hash) and
+        // then read the block immediately before it to get the previous epoch_id.
+        let epoch_start_batch =
+            cloud_storage.get_block_batch_for_height(epoch_start_height).with_context(|| {
+                format!("failed to download batch at epoch-start height {epoch_start_height}")
+            })?;
+        let epoch_start_block = epoch_start_batch.get_block_at_height(epoch_start_height);
+        if epoch_start_block.block().header().is_genesis() {
+            return Ok(None);
+        }
+        let prev_height = epoch_start_height - 1;
+        let prev_batch = cloud_storage
+            .get_block_batch_for_height(prev_height)
+            .with_context(|| format!("failed to download block batch at height {prev_height}"))?;
+        epoch_id = *prev_batch.get_block_at_height(prev_height).block().header().epoch_id();
+    }
 }
 
 /// Downloads and saves epoch-level data for a new epoch. Also saves the epoch

--- a/chain/client/src/archive/cloud_archival_reader.rs
+++ b/chain/client/src/archive/cloud_archival_reader.rs
@@ -173,7 +173,7 @@ pub fn find_snapshot_at_or_before(
 
         tracing::info!(epoch_height, ?epoch_id, "probing for state snapshot");
 
-        if cloud_storage.get_state_header(epoch_height, epoch_id, shard_id).is_ok() {
+        if cloud_storage.is_state_header_stored(epoch_height, epoch_id, shard_id)? {
             return Ok(Some((epoch_height, epoch_id)));
         }
 

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -3786,6 +3786,13 @@
               "secs": 1
             },
             "description": "Interval at which the system checks for new blocks or chunks to archive."
+          },
+          "snapshot_every_n_epochs": {
+            "default": 10,
+            "description": "Cadence of state snapshots, in epochs. Higher values reduce bucket cost at\nthe expense of potentially longer delta replay during reader bootstrap.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
           }
         },
         "type": "object"

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -2722,6 +2722,13 @@
               "secs": 1
             },
             "description": "Interval at which the system checks for new blocks or chunks to archive."
+          },
+          "snapshot_every_n_epochs": {
+            "default": 10,
+            "description": "Cadence of state snapshots, in epochs. Higher values reduce bucket cost at\nthe expense of potentially longer delta replay during reader bootstrap.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
           }
         },
         "title": "CloudArchivalWriterConfig",

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -227,6 +227,10 @@ pub fn default_archival_writer_polling_interval() -> Duration {
     Duration::seconds(1)
 }
 
+pub fn default_snapshot_every_n_epochs() -> u64 {
+    10
+}
+
 /// Configuration for a cloud-based archival writer. If this config is present, the writer is enabled and
 /// writes chunk-related data based on the tracked shards. This config also controls additional archival
 /// behavior such as block data and polling interval.
@@ -242,6 +246,11 @@ pub struct CloudArchivalWriterConfig {
     #[cfg_attr(feature = "schemars", schemars(with = "DurationAsStdSchemaProvider"))]
     #[serde(default = "default_archival_writer_polling_interval")]
     pub polling_interval: Duration,
+
+    /// Cadence of state snapshots, in epochs. Higher values reduce bucket cost at
+    /// the expense of potentially longer delta replay during reader bootstrap.
+    #[serde(default = "default_snapshot_every_n_epochs")]
+    pub snapshot_every_n_epochs: u64,
 }
 
 impl Default for CloudArchivalWriterConfig {
@@ -249,6 +258,7 @@ impl Default for CloudArchivalWriterConfig {
         Self {
             archive_block_data: false,
             polling_interval: default_archival_writer_polling_interval(),
+            snapshot_every_n_epochs: default_snapshot_every_n_epochs(),
         }
     }
 }

--- a/core/store/src/archive/cloud_storage/file_id.rs
+++ b/core/store/src/archive/cloud_storage/file_id.rs
@@ -42,6 +42,7 @@ impl BatchRange {
 pub enum ListableCloudDir {
     Metadata,
     ShardHeads,
+    StateHeader { epoch_height: EpochHeight, epoch_id: EpochId, shard_id: ShardId },
 }
 
 impl ListableCloudDir {
@@ -49,6 +50,10 @@ impl ListableCloudDir {
         match self {
             Self::Metadata => "archive/metadata".into(),
             Self::ShardHeads => "archive/metadata/shard_head".into(),
+            Self::StateHeader { epoch_height, epoch_id, shard_id } => format!(
+                "epoch_height={epoch_height}/epoch_id={}/headers/shard_id={shard_id}",
+                epoch_id.0
+            ),
         }
     }
 }

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -62,6 +62,16 @@ impl CloudStorage {
         Ok(state_header)
     }
 
+    pub fn is_state_header_stored(
+        &self,
+        epoch_height: EpochHeight,
+        epoch_id: EpochId,
+        shard_id: ShardId,
+    ) -> Result<bool> {
+        let dir = ListableCloudDir::StateHeader { epoch_height, epoch_id, shard_id };
+        block_on_future(self.dir_contains(&dir, "header")).map_err(Error::other)
+    }
+
     pub fn get_epoch_data(&self, epoch_id: EpochId) -> Result<EpochData> {
         let epoch_data =
             block_on_future(self.retrieve_epoch_data(epoch_id)).map_err(Error::other)?;

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -144,10 +144,10 @@ impl StateSnapshotConfig {
     const STATE_SNAPSHOT_DIR: &str = "state_snapshot";
 
     pub fn enabled(hot_store_path: impl AsRef<Path>) -> Self {
-        Self::enabled_with_frequency(hot_store_path, 1)
+        Self::enabled_with_cadence(hot_store_path, 1)
     }
 
-    pub fn enabled_with_frequency(
+    pub fn enabled_with_cadence(
         hot_store_path: impl AsRef<Path>,
         snapshot_every_n_epochs: u64,
     ) -> Self {
@@ -168,7 +168,7 @@ impl StateSnapshotConfig {
     }
 
     /// Configured snapshot cadence in epochs. Defaults to `1`.
-    pub fn snapshot_frequency(&self) -> u64 {
+    pub fn snapshot_cadence(&self) -> u64 {
         if let StateSnapshotConfig::Enabled { snapshot_every_n_epochs, .. } = self {
             return *snapshot_every_n_epochs;
         }

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -133,26 +133,46 @@ impl StateSnapshot {
 #[derive(Debug)]
 pub enum StateSnapshotConfig {
     Disabled,
-    Enabled { state_snapshots_dir: PathBuf },
+    Enabled {
+        state_snapshots_dir: PathBuf,
+        /// Only epoch heights that are multiples of this value produce a snapshot.
+        snapshot_every_n_epochs: u64,
+    },
 }
 
 impl StateSnapshotConfig {
     const STATE_SNAPSHOT_DIR: &str = "state_snapshot";
 
     pub fn enabled(hot_store_path: impl AsRef<Path>) -> Self {
+        Self::enabled_with_frequency(hot_store_path, 1)
+    }
+
+    pub fn enabled_with_frequency(
+        hot_store_path: impl AsRef<Path>,
+        snapshot_every_n_epochs: u64,
+    ) -> Self {
         // Assumptions:
         // * RocksDB checkpoints are taken instantly and for free, because the filesystem supports hard links.
         // * The best place for checkpoints is within the `hot_store_path`, because that directory is often a separate disk.
         Self::Enabled {
             state_snapshots_dir: hot_store_path.as_ref().join(Self::STATE_SNAPSHOT_DIR),
+            snapshot_every_n_epochs,
         }
     }
 
     pub fn state_snapshots_dir(&self) -> Option<&Path> {
         match self {
             StateSnapshotConfig::Disabled => None,
-            StateSnapshotConfig::Enabled { state_snapshots_dir } => Some(state_snapshots_dir),
+            StateSnapshotConfig::Enabled { state_snapshots_dir, .. } => Some(state_snapshots_dir),
         }
+    }
+
+    /// Configured snapshot cadence in epochs. Defaults to `1`.
+    pub fn snapshot_frequency(&self) -> u64 {
+        if let StateSnapshotConfig::Enabled { snapshot_every_n_epochs, .. } = self {
+            return *snapshot_every_n_epochs;
+        }
+        1
     }
 }
 

--- a/integration-tests/src/env/nightshade_setup.rs
+++ b/integration-tests/src/env/nightshade_setup.rs
@@ -94,6 +94,7 @@ impl TestEnvNightshadeSetupExt for TestEnvBuilder {
                     trie_config,
                     DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
                     false,
+                    1,
                     true,
                 )
             };

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -878,9 +878,17 @@ impl NightshadeRuntime {
         #[allow(clippy::or_fun_call)] // Closure cannot return reference to a temporary value
         let state_snapshot_config =
             match config.config.store.state_snapshot_config.state_snapshot_type {
-                StateSnapshotType::Enabled => StateSnapshotConfig::enabled(
-                    home_dir.join(config.config.store.path.as_ref().unwrap_or(&"data".into())),
-                ),
+                StateSnapshotType::Enabled => {
+                    let hot_store_path =
+                        home_dir.join(config.config.store.path.as_ref().unwrap_or(&"data".into()));
+                    match &config.client_config.cloud_archival_writer {
+                        Some(writer_config) => StateSnapshotConfig::enabled_with_frequency(
+                            hot_store_path,
+                            writer_config.snapshot_every_n_epochs,
+                        ),
+                        None => StateSnapshotConfig::enabled(hot_store_path),
+                    }
+                }
                 StateSnapshotType::Disabled => StateSnapshotConfig::Disabled,
             };
         // FIXME: this (and other contract runtime resources) should probably get constructed by

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -882,7 +882,7 @@ impl NightshadeRuntime {
                     let hot_store_path =
                         home_dir.join(config.config.store.path.as_ref().unwrap_or(&"data".into()));
                     match &config.client_config.cloud_archival_writer {
-                        Some(writer_config) => StateSnapshotConfig::enabled_with_frequency(
+                        Some(writer_config) => StateSnapshotConfig::enabled_with_cadence(
                             hot_store_path,
                             writer_config.snapshot_every_n_epochs,
                         ),

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -291,6 +291,12 @@ impl<'a> ConfigValidator<'a> {
                 "`cloud_archival_writer` must track at least one shard unless it is configured to `archive_block_data` only.".to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
+        if writer_config.snapshot_every_n_epochs == 0 {
+            let error_message =
+                "`cloud_archival_writer.snapshot_every_n_epochs` must be greater than 0."
+                    .to_string();
+            self.validation_errors.push_config_semantics_error(error_message);
+        }
     }
 
     fn validate_tracked_shards_config(&mut self) {
@@ -328,7 +334,7 @@ impl<'a> ConfigValidator<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use near_chain_configs::{StateSyncConfig, TrackedShardsConfig};
+    use near_chain_configs::{CloudArchivalWriterConfig, StateSyncConfig, TrackedShardsConfig};
     use near_store::archive::cloud_storage::config::test_cloud_archival_config;
 
     #[test]
@@ -476,6 +482,20 @@ mod tests {
         let mut config = Config::default();
         config.cloud_archival = Some(test_cloud_archival_config(""));
         config.cloud_archival_writer = Some(Default::default());
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "\\nconfig.json semantic issue: `cloud_archival_writer.snapshot_every_n_epochs` must be greater than 0."
+    )]
+    fn test_cloud_archival_writer_snapshot_frequency_nonzero() {
+        let mut config = Config::default();
+        config.cloud_archival = Some(test_cloud_archival_config(""));
+        let mut writer_config = CloudArchivalWriterConfig::default();
+        writer_config.archive_block_data = true;
+        writer_config.snapshot_every_n_epochs = 0;
+        config.cloud_archival_writer = Some(writer_config);
         validate_config(&config).unwrap();
     }
 

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -489,7 +489,7 @@ mod tests {
     #[should_panic(
         expected = "\\nconfig.json semantic issue: `cloud_archival_writer.snapshot_every_n_epochs` must be greater than 0."
     )]
-    fn test_cloud_archival_writer_snapshot_frequency_nonzero() {
+    fn test_cloud_archival_writer_snapshot_cadence_nonzero() {
         let mut config = Config::default();
         config.cloud_archival = Some(test_cloud_archival_config(""));
         let mut writer_config = CloudArchivalWriterConfig::default();

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -817,6 +817,9 @@ impl StateDumper {
                 self.clock.sleep(iteration_delay).await;
                 continue;
             };
+            if !self.should_dump_epoch(sync_header.epoch_id())? {
+                return Ok(());
+            }
             match self.get_dump_state(&sync_header)? {
                 NewDump::Dump(mut dump, mut senders) => {
                     self.check_old_progress(sync_header.epoch_id(), &mut dump, &mut senders)?;
@@ -908,6 +911,9 @@ impl StateDumper {
             }
             CurrentDump::None => {}
         };
+        if !self.should_dump_epoch(sync_header.epoch_id())? {
+            return Ok(());
+        }
         match self.get_dump_state(&sync_header)? {
             NewDump::Dump(mut dump, sender) => {
                 self.header_uploader(&dump).upload_headers(&mut dump).await;
@@ -919,6 +925,22 @@ impl StateDumper {
             }
         };
         Ok(())
+    }
+
+    /// Returns whether the configured snapshot cadence allows dumping state for this epoch.
+    /// Cadence `1` (default) always dumps; larger cadences skip epochs whose `epoch_height`
+    /// is not a multiple of the configured value.
+    fn should_dump_epoch(&self, epoch_id: &EpochId) -> anyhow::Result<bool> {
+        let snapshot_frequency =
+            self.runtime.get_tries().state_snapshot_config().snapshot_frequency();
+        if snapshot_frequency <= 1 {
+            return Ok(true);
+        }
+        let epoch_info = self
+            .epoch_manager
+            .get_epoch_info(epoch_id)
+            .with_context(|| format!("Failed getting epoch info {:?}", epoch_id))?;
+        Ok(epoch_info.epoch_height() % snapshot_frequency == 0)
     }
 }
 

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -903,6 +903,10 @@ impl StateDumper {
                     "canceling existing dump of state for epoch upon new epoch"
                 );
                 dump.cancel().await;
+                // TODO(cloud_archival): test cancel-then-skip. `cancel()` empties
+                // `dump.dump_state`; leaving `InProgress` would panic the next
+                // `await_parts_upload`.
+                self.current_dump = CurrentDump::None;
             }
             CurrentDump::Done(epoch_id) => {
                 if epoch_id == sync_header.epoch_id() {

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -931,16 +931,15 @@ impl StateDumper {
     /// Cadence `1` (default) always dumps; larger cadences skip epochs whose `epoch_height`
     /// is not a multiple of the configured value.
     fn should_dump_epoch(&self, epoch_id: &EpochId) -> anyhow::Result<bool> {
-        let snapshot_frequency =
-            self.runtime.get_tries().state_snapshot_config().snapshot_frequency();
-        if snapshot_frequency <= 1 {
+        let snapshot_cadence = self.runtime.get_tries().state_snapshot_config().snapshot_cadence();
+        if snapshot_cadence <= 1 {
             return Ok(true);
         }
         let epoch_info = self
             .epoch_manager
             .get_epoch_info(epoch_id)
             .with_context(|| format!("Failed getting epoch info {:?}", epoch_id))?;
-        Ok(epoch_info.epoch_height() % snapshot_frequency == 0)
+        Ok(epoch_info.epoch_height() % snapshot_cadence == 0)
     }
 }
 

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -106,6 +106,11 @@ pub fn setup_client(
     );
 
     let contract_cache = FilesystemContractRuntimeCache::test().expect("filesystem contract cache");
+    let snapshot_every_n_epochs = client_config
+        .cloud_archival_writer
+        .as_ref()
+        .map(|writer_config| writer_config.snapshot_every_n_epochs)
+        .unwrap_or(1);
     let runtime_adapter = NightshadeRuntime::test_with_trie_config(
         &homedir,
         storage.hot_store.clone(),
@@ -116,6 +121,7 @@ pub fn setup_client(
         TrieConfig::from_store_config(&store_config),
         client_config.gc.gc_num_epochs_to_keep,
         client_config.cloud_archival_writer.is_some(),
+        snapshot_every_n_epochs,
         client_config.save_receipt_to_tx,
     );
 
@@ -210,6 +216,7 @@ pub fn setup_client(
                 TrieConfig::from_store_config(&store_config),
                 client_config.gc.gc_num_epochs_to_keep,
                 client_config.cloud_archival_writer.is_some(),
+                snapshot_every_n_epochs,
                 client_config.save_receipt_to_tx,
             );
             (view_epoch_manager, view_shard_tracker, view_runtime_adapter)

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -3,13 +3,14 @@ use crate::setup::env::TestLoopEnv;
 use crate::utils::account::archival_account_id;
 use crate::utils::cloud_archival::{
     WriterConfig, add_writer_node, apply_writer_settings, bootstrap_reader, check_account_balance,
-    check_data_at_height_for_shards, gc_and_heads_sanity_checks, get_cloud_head, get_writer_handle,
-    run_node_until, simulate_lagging_shard, snapshots_sanity_check, stop_and_restart_node,
-    verify_block_range,
+    check_data_at_height_for_shards, gc_and_heads_sanity_checks, get_cloud_head, get_cloud_storage,
+    get_writer_handle, run_node_until, simulate_lagging_shard, snapshots_sanity_check,
+    stop_and_restart_node, verify_block_range,
 };
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
 use near_chain_configs::MIN_GC_NUM_EPOCHS_TO_KEEP;
+use near_client::archive::cloud_archival_reader::find_snapshot_at_or_before;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, Balance, BlockHeight, BlockHeightDelta, ShardId};
 use near_store::ShardUId;
@@ -25,6 +26,8 @@ struct CloudArchiveHarness {
     epoch_length: BlockHeightDelta,
     /// Whether cold (split) storage is enabled on the archival node.
     cold_storage_enabled: bool,
+    /// Cadence of state snapshots, passed through to assertions.
+    snapshot_every_n_epochs: u64,
     /// Account ID of the reader node, set after `bootstrap_reader()`.
     reader_id: Option<AccountId>,
 }
@@ -50,11 +53,17 @@ impl CloudArchiveHarnessBuilder {
         self
     }
 
+    fn snapshot_every_n_epochs(mut self, frequency: u64) -> Self {
+        self.writer.snapshot_every_n_epochs = frequency;
+        self
+    }
+
     fn build(self) -> CloudArchiveHarness {
         let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
         let archival_kind =
             if self.cold_storage { ArchivalKind::ColdAndCloud } else { ArchivalKind::Cloud };
         let archival_id = self.writer.id.clone();
+        let snapshot_every_n_epochs = self.writer.snapshot_every_n_epochs;
         let env = TestLoopBuilder::new()
             .shard_layout(CloudArchiveHarness::default_shard_layout())
             .epoch_length(CloudArchiveHarness::DEFAULT_EPOCH_LENGTH)
@@ -69,6 +78,7 @@ impl CloudArchiveHarnessBuilder {
                     config,
                     self.writer.archive_block_data,
                     &self.writer.tracked_shards,
+                    snapshot_every_n_epochs,
                 );
             })
             .build();
@@ -77,6 +87,7 @@ impl CloudArchiveHarnessBuilder {
             archival_id,
             epoch_length: CloudArchiveHarness::DEFAULT_EPOCH_LENGTH,
             cold_storage_enabled: self.cold_storage,
+            snapshot_every_n_epochs,
             reader_id: None,
         }
     }
@@ -94,6 +105,7 @@ impl CloudArchiveHarness {
                 id: archival_account_id(),
                 archive_block_data: true,
                 tracked_shards: Self::all_shard_uids(),
+                snapshot_every_n_epochs: 1,
             },
         }
     }
@@ -151,7 +163,12 @@ impl CloudArchiveHarness {
     fn assert_snapshots_ok(&self) {
         let head_height = self.env.archival_node().head().height;
         let final_epoch_height = head_height / self.epoch_length;
-        snapshots_sanity_check(&self.env, &self.archival_id, final_epoch_height);
+        snapshots_sanity_check(
+            &self.env,
+            &self.archival_id,
+            final_epoch_height,
+            self.snapshot_every_n_epochs,
+        );
     }
 
     fn assert_reader_blocks(&self, start_height: BlockHeight, end_height: BlockHeight) {
@@ -391,6 +408,7 @@ fn test_cloud_archival_writer_joins_later() {
         id: writer_b_id.clone(),
         archive_block_data: false,
         tracked_shards: vec![all_shard_uids[1], all_shard_uids[2]],
+        snapshot_every_n_epochs: 1,
     });
     get_writer_handle(&h.env, &writer_b_id).0.stop();
     // Let writer_b catch up to join_height (hot store advances) while its
@@ -429,6 +447,7 @@ fn test_cloud_archival_multi_writer_same_shards() {
         id: "writer_b".parse().unwrap(),
         archive_block_data: true,
         tracked_shards: all_shard_uids,
+        snapshot_every_n_epochs: 1,
     });
     h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
     h.check_data(&[(2, &all_shard_ids), (h.epoch_length + 1, &all_shard_ids)]);
@@ -451,9 +470,36 @@ fn test_cloud_archival_multi_writer_disjoint_shards() {
         id: "writer_b".parse().unwrap(),
         archive_block_data: false,
         tracked_shards: vec![all_shard_uids[2]],
+        snapshot_every_n_epochs: 1,
     });
     h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
     // Both writers start together: all shards are archived.
     h.check_data(&[(h.epoch_length / 2, &all_shard_ids), (h.epoch_length + 1, &all_shard_ids)]);
     h.assert_heads_and_gc_ok();
+}
+
+/// Verifies that a writer with `snapshot_every_n_epochs = 2` only snapshots even epochs
+/// and that the discovery helper locates the nearest snapshot at or before a given height.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_custom_snapshot_frequency() {
+    let mut h = CloudArchiveHarness::builder().snapshot_every_n_epochs(2).build();
+    h.run_until_epoch(6);
+    h.assert_snapshots_ok();
+
+    let shard_id = CloudArchiveHarness::all_shard_ids()[0];
+    let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
+    // Read epoch ids from cloud so the lookup survives local GC of the block.
+    let epoch_id_of =
+        |height| *cloud_storage.get_block_data(height).unwrap().block().header().epoch_id();
+
+    // Epoch 4 was snapshotted: first probe hits.
+    let hit_at_45 = find_snapshot_at_or_before(&cloud_storage, 45, shard_id).unwrap();
+    assert_eq!(hit_at_45, Some((4, epoch_id_of(45))));
+
+    // Epoch 3 was skipped: probe misses, walks back to epoch 2.
+    let hit_at_35 = find_snapshot_at_or_before(&cloud_storage, 35, shard_id).unwrap();
+    assert_eq!(hit_at_35, Some((2, epoch_id_of(25))));
+
+    h.shutdown();
 }

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -53,8 +53,8 @@ impl CloudArchiveHarnessBuilder {
         self
     }
 
-    fn snapshot_every_n_epochs(mut self, frequency: u64) -> Self {
-        self.writer.snapshot_every_n_epochs = frequency;
+    fn snapshot_every_n_epochs(mut self, cadence: u64) -> Self {
+        self.writer.snapshot_every_n_epochs = cadence;
         self
     }
 
@@ -482,7 +482,7 @@ fn test_cloud_archival_multi_writer_disjoint_shards() {
 /// and that the discovery helper locates the nearest snapshot at or before a given height.
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
-fn test_cloud_archival_custom_snapshot_frequency() {
+fn test_cloud_archival_custom_snapshot_cadence() {
     let mut h = CloudArchiveHarness::builder().snapshot_every_n_epochs(2).build();
     h.run_until_epoch(6);
     h.assert_snapshots_ok();

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -38,6 +38,7 @@ pub(crate) struct WriterConfig {
     pub id: AccountId,
     pub archive_block_data: bool,
     pub tracked_shards: Vec<ShardUId>,
+    pub snapshot_every_n_epochs: u64,
 }
 
 pub fn run_node_until(env: &mut TestLoopEnv, account_id: &AccountId, target_height: BlockHeight) {
@@ -146,9 +147,13 @@ pub(crate) fn apply_writer_settings(
     config: &mut ClientConfig,
     archive_block_data: bool,
     tracked_shards: &[ShardUId],
+    snapshot_every_n_epochs: u64,
 ) {
-    config.cloud_archival_writer =
-        Some(CloudArchivalWriterConfig { archive_block_data, ..Default::default() });
+    config.cloud_archival_writer = Some(CloudArchivalWriterConfig {
+        archive_block_data,
+        snapshot_every_n_epochs,
+        ..Default::default()
+    });
     config.tracked_shards_config = if tracked_shards.is_empty() {
         TrackedShardsConfig::NoShards
     } else {
@@ -176,12 +181,18 @@ pub(crate) fn simulate_lagging_shard(
 pub(crate) fn add_writer_node(env: &mut TestLoopEnv, config: &WriterConfig) {
     let archive_block_data = config.archive_block_data;
     let tracked_shards = config.tracked_shards.clone();
+    let snapshot_every_n_epochs = config.snapshot_every_n_epochs;
     let node_state = env
         .node_state_builder()
         .account_id(&config.id)
         .cloud_storage(true)
         .config_modifier(move |cfg| {
-            apply_writer_settings(cfg, archive_block_data, &tracked_shards);
+            apply_writer_settings(
+                cfg,
+                archive_block_data,
+                &tracked_shards,
+                snapshot_every_n_epochs,
+            );
         })
         .build();
     env.add_node(config.id.as_ref(), node_state);
@@ -235,11 +246,13 @@ pub fn check_account_balance(
 
 /// Checks that each epoch (except the final one) has a state header uploaded for each
 /// shard and has epoch data uploaded. Panics if headers are missing for some shards
-/// within an epoch or if epoch data is missing.
+/// within an epoch or if epoch data is missing. With cadence > 1, only epoch heights
+/// that are multiples of the cadence are expected to carry snapshots.
 pub fn snapshots_sanity_check(
     env: &TestLoopEnv,
     archival_id: &AccountId,
     final_epoch_height: EpochHeight,
+    snapshot_every_n_epochs: u64,
 ) {
     let store = get_hot_store(env, archival_id);
     let cloud_storage = get_cloud_storage(env, archival_id);
@@ -279,7 +292,9 @@ pub fn snapshots_sanity_check(
         }
     }
     // Snapshots for the most recent epoch have not been uploaded yet.
-    let expected_snapshots = HashSet::from_iter(1..final_epoch_height);
+    // With a cadence > 1, only epoch heights that are multiples of the cadence carry a snapshot.
+    let expected_snapshots: HashSet<EpochHeight> =
+        (1..final_epoch_height).filter(|h| h % snapshot_every_n_epochs == 0).collect();
     assert_eq!(epoch_heights_with_snapshot, expected_snapshots);
 
     // Epoch data is uploaded by the cloud archival writer at the last block of each


### PR DESCRIPTION
Adds `snapshot_every_n_epochs` to `CloudArchivalWriterConfig` (default 10) so a cloud archival writer can take state snapshots every N epochs instead of every epoch. State-part uploads dominate bucket cost for a dedicated writer/dumper; a 10-epoch cadence (~70h on mainnet) cuts that cost proportionally. Reader bootstrap still works — it applies per-block deltas on top of the nearest snapshot, so longer gaps just mean more delta replay.

The cadence is enforced at two places: `Chain::should_make_snapshot` (local snapshot production) and `StateDumper` (cloud uploads). Non-writer nodes see cadence 1 so both gates are no-ops for validators.

Reader gets a `find_snapshot_at_or_before(height, shard_id)` helper that walks epochs backward until it finds a snapshot, returning the epoch height and id.

## Tests

- `test_cloud_archival_custom_snapshot_frequency` — verifies snapshots land only on expected epochs and `find_snapshot_at_or_before` walks back correctly past skipped epochs.
- `test_cloud_archival_writer_snapshot_frequency_nonzero` — validator rejects `snapshot_every_n_epochs = 0`.
- 11 existing testloop cloud archival tests pass unchanged.