### PR TITLE
chore(config): unify chunk_wait_mult default

### DIFF
--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -549,7 +549,7 @@ pub fn default_state_sync_external_backoff() -> Duration {
 }
 
 pub fn default_chunk_wait_mult() -> Rational32 {
-    Rational32::new(1, 6)
+    Rational32::new(1, 3)
 }
 
 pub fn default_header_sync_expected_height_per_second() -> u64 {

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -86,9 +86,6 @@ pub const TESTNET_MAX_BLOCK_PRODUCTION_DELAY: i64 = 1_800;
 /// Maximum time until skipping the previous block is ms.
 pub const MAX_BLOCK_WAIT_DELAY: i64 = 6_000;
 
-/// Multiplier for the wait time for all chunks to be received.
-pub const CHUNK_WAIT_DENOMINATOR: i32 = 3;
-
 /// Horizon at which instead of fetching block, fetch full state.
 const BLOCK_FETCH_HORIZON: BlockHeightDelta = 50;
 
@@ -206,7 +203,7 @@ impl Default for Consensus {
             min_block_production_delay: Duration::milliseconds(MIN_BLOCK_PRODUCTION_DELAY),
             max_block_production_delay: Duration::milliseconds(MAX_BLOCK_PRODUCTION_DELAY),
             max_block_wait_delay: Duration::milliseconds(MAX_BLOCK_WAIT_DELAY),
-            chunk_wait_mult: Rational32::new(1, CHUNK_WAIT_DENOMINATOR),
+            chunk_wait_mult: default_chunk_wait_mult(),
             produce_empty_blocks: true,
             block_fetch_horizon: BLOCK_FETCH_HORIZON,
             block_header_fetch_horizon: BLOCK_HEADER_FETCH_HORIZON,


### PR DESCRIPTION
The `chunk_wait_mult` field had two competing defaults: `Consensus::default()` wrote `1/3` (via `CHUNK_WAIT_DENOMINATOR`), while the serde fallback `default_chunk_wait_mult()` returned `1/6`. This dated back to [#13030](https://github.com/near/nearcore/pull/13030), which intentionally kept `1/6` as a backwards-compat default for existing `config.json` files predating the field.

Mainnet and testnet now ship with `1/3`, so the `1/6` fallback is confusing.