### PR TITLE
chore: notify Zulip when external contributors merge to master

### DIFF
--- a/.github/workflows/notify_zulip_external_merge.yml
+++ b/.github/workflows/notify_zulip_external_merge.yml
@@ -4,6 +4,14 @@ on:
   pull_request_target:
     types: [closed]
     branches: [master]
+  # TODO: remove workflow_dispatch + the dispatch branch in the run script
+  # once this notifier has been verified end-to-end against Zulip.
+  workflow_dispatch:
+    inputs:
+      message:
+        description: "Custom Zulip message (for testing the notifier end-to-end)"
+        required: false
+        default: ":test_tube: Test message from `notify_zulip_external_merge` workflow"
 
 permissions:
   contents: read
@@ -13,10 +21,12 @@ jobs:
   notify:
     name: "Notify Zulip"
     if: >-
+      github.event_name == 'workflow_dispatch' || (
       github.event.pull_request.merged == true &&
       github.event.pull_request.author_association != 'MEMBER' &&
       github.event.pull_request.author_association != 'OWNER' &&
       github.event.pull_request.author_association != 'COLLABORATOR'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: "notify zulip on external contributor merge"
@@ -26,6 +36,8 @@ jobs:
           ZULIP_URL: "https://near.zulipchat.com"
           ZULIP_STREAM: "nearone/private"
           ZULIP_TOPIC: "Security"
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_MESSAGE: ${{ inputs.message }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -36,11 +48,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          SHORT_SHA="${MERGE_SHA:0:12}"
-          CONTENT=":merge: External contributor merge to \`near/nearcore\` \`master\` branch
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            CONTENT="$DISPATCH_MESSAGE"
+          else
+            SHORT_SHA="${MERGE_SHA:0:12}"
+            CONTENT=":merge: External contributor merge to \`near/nearcore\` \`master\` branch
           **PR**: [#${PR_NUMBER} — ${PR_TITLE}](${PR_URL})
           **Author**: [@${PR_AUTHOR}](${PR_AUTHOR_URL}) (\`${PR_AUTHOR_ASSOC}\`)
           **Merge commit**: \`${SHORT_SHA}\`"
+          fi
 
           response=$(curl -sS -w '\n%{http_code}' -X POST "${ZULIP_URL%/}/api/v1/messages" \
             -u "${ZULIP_EMAIL}:${ZULIP_API_KEY}" \

--- a/.github/workflows/notify_zulip_external_merge.yml
+++ b/.github/workflows/notify_zulip_external_merge.yml
@@ -1,0 +1,61 @@
+name: Notify Zulip on External Contributor Merge
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: "Notify Zulip"
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR'
+    runs-on: ubuntu-latest
+    steps:
+      - name: "notify zulip on external contributor merge"
+        env:
+          ZULIP_API_KEY: ${{ secrets.ZULIP_GHA_API_KEY }}
+          ZULIP_EMAIL: "gha-bot@near.zulipchat.com"
+          ZULIP_URL: "https://near.zulipchat.com"
+          ZULIP_STREAM: "nearone/private"
+          ZULIP_TOPIC: "Security"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_URL: ${{ github.event.pull_request.user.html_url }}
+          PR_AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          SHORT_SHA="${MERGE_SHA:0:12}"
+          CONTENT=":merge: External contributor merge to \`near/nearcore\` \`master\` branch
+          **PR**: [#${PR_NUMBER} — ${PR_TITLE}](${PR_URL})
+          **Author**: [@${PR_AUTHOR}](${PR_AUTHOR_URL}) (\`${PR_AUTHOR_ASSOC}\`)
+          **Merge commit**: \`${SHORT_SHA}\`"
+
+          response=$(curl -sS -w '\n%{http_code}' -X POST "${ZULIP_URL%/}/api/v1/messages" \
+            -u "${ZULIP_EMAIL}:${ZULIP_API_KEY}" \
+            --data-urlencode "type=stream" \
+            --data-urlencode "to=${ZULIP_STREAM}" \
+            --data-urlencode "topic=${ZULIP_TOPIC}" \
+            --data-urlencode "content=${CONTENT}")
+
+          body=$(printf '%s\n' "$response" | sed '$d')
+          status=$(printf '%s\n' "$response" | tail -n1)
+
+          echo "Zulip API HTTP $status"
+          echo "$body"
+
+          if [[ "$status" != "200" ]]; then
+            echo "::error::Zulip API call failed (HTTP $status)"
+            exit 1
+          fi

--- a/cspell.json
+++ b/cspell.json
@@ -442,6 +442,7 @@
         "unsync",
         "unvalidated",
         "upto",
+        "urlencode",
         "useragent",
         "usize",
         "utoipa",


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that posts a Zulip message to `nearone/private` > `Security` whenever a PR from an external contributor is merged into `master`.

"External" is determined by `pull_request.author_association`: anything other than `MEMBER`, `OWNER`, or `COLLABORATOR` triggers a notification (so `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `NONE`, etc. — including bots that aren't org members).

The message includes the repo, PR number/title/link, author handle, association tag, and the short merge commit SHA.

## Implementation notes

- Uses `pull_request_target` (not `pull_request`) so secrets are available even when the PR comes from a fork. The job only reads PR metadata — it never checks out fork code, so there's no untrusted-code-execution risk from this trigger.
- Uses `author_association` instead of an org-membership API call to avoid needing a token with `read:org` scope.
- Job fails (red CI) if Zulip returns non-200, so a misconfigured token / stream surfaces visibly.

## Out of scope

- Co-authored-by trailers are not inspected — only the PR opener is checked.
- No allowlist for known external bots (e.g. dependabot). Easy to add later if it gets noisy.
