### PR TITLE
perf(database): switch backfill ReceiptToTx writes to SST ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,6 +4414,7 @@ dependencies = [
  "near-store",
  "near-telemetry",
  "near-vm-runner",
+ "nix 0.24.3",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.1",

--- a/chain/chain/src/backfill_receipt_to_tx.rs
+++ b/chain/chain/src/backfill_receipt_to_tx.rs
@@ -10,6 +10,7 @@ use near_primitives::types::BlockHeight;
 use near_primitives::utils::get_block_shard_id_rev;
 use near_store::{DBCol, NodeStorage, Store};
 use rayon::prelude::*;
+use std::path::PathBuf;
 
 /// Routes the three distinct storage roles used by the ReceiptToTx backfill:
 /// reads of chain state, writes of ReceiptToTx entries, and checkpoint state.
@@ -28,6 +29,22 @@ pub struct BackfillStorage {
     /// Where the backfill checkpoint is stored. Always `hot_store`: the
     /// checkpoint is transient operational state, not archival data.
     pub checkpoint_store: Store,
+    /// When `Some`, [`process_one_batch`] writes ReceiptToTx entries via
+    /// RocksDB SST file ingestion under this directory; when `None`, it
+    /// falls back to per-key `StoreUpdate.insert` and `commit()`.
+    ///
+    /// SST ingest avoids the compaction death spiral the legacy path triggers
+    /// on archival cold storage (many small writes → memtable flush to L0 →
+    /// L0 stack faster than compaction can merge → batch latency goes from
+    /// seconds to many minutes). The per-key path is kept for callers whose
+    /// underlying database doesn't implement `ingest_external_sst_files`
+    /// (e.g. the in-memory test store) or that haven't opted in yet.
+    ///
+    /// The directory must live on the same filesystem as `write_store` so
+    /// the underlying ingest can rename files into the DB instead of copying.
+    /// Callers are responsible for choosing a path that no other writer
+    /// (CLI or actor) will share, and for cleaning it up at startup.
+    pub sst_temp_dir: Option<PathBuf>,
 }
 
 impl BackfillStorage {
@@ -36,6 +53,9 @@ impl BackfillStorage {
     /// - `read_store`: `split_store` if present, else `hot_store`.
     /// - `write_store`: `cold_store` if present, else `hot_store`.
     /// - `checkpoint_store`: always `hot_store` (checkpoints are transient).
+    /// - `sst_temp_dir`: passed through verbatim. Path resolution lives at the
+    ///   caller (mirroring the migration-time SST ingest path) so this
+    ///   constructor stays purely about role wiring.
     ///
     /// IMPORTANT: on split-storage archival nodes, ReceiptToTx entries written
     /// by this backfill land only in cold. The RPC read path (`GetReceiptToTx`)
@@ -45,12 +65,13 @@ impl BackfillStorage {
     /// view_runtime wiring ever changes to use `hot_store` directly, backfilled
     /// entries become invisible to RPC queries. Keep the view_runtime ↔
     /// [`BackfillStorage`] invariant aligned.
-    pub fn for_node(storage: &NodeStorage) -> Self {
+    pub fn for_node(storage: &NodeStorage, sst_temp_dir: Option<PathBuf>) -> Self {
         let hot = storage.get_hot_store();
         Self {
             read_store: storage.get_split_store().unwrap_or_else(|| hot.clone()),
             write_store: storage.get_cold_store().unwrap_or_else(|| hot.clone()),
             checkpoint_store: hot,
+            sst_temp_dir,
         }
     }
 }
@@ -236,15 +257,32 @@ pub fn process_height(
 /// Shared by both the CLI (ascending direction, checkpoint key = [`BACKFILL_CHECKPOINT_KEY`])
 /// and the background actor (descending direction, checkpoint key = [`BACKFILL_CHECKPOINT_KEY_LOW`]).
 /// The caller controls iteration direction by the order of `heights` — `par_iter` preserves
-/// input order, so writes happen in the same order the caller supplied.
+/// input order.
 ///
 /// Semantics:
 /// 1. Reads for all `heights` run in parallel on `pool`.
-/// 2. Results are applied to `storage.write_store` in input order (single `store_update`).
+/// 2. Results are sorted+deduped by receipt id and applied to `storage.write_store` either
+///    via SST file ingestion (when `storage.sst_temp_dir` is `Some`) or per-key
+///    `StoreUpdate.insert` + `commit()` (when `None`).
 /// 3. If `checkpoint` is `Some((key, height))`, that entry is written to
 ///    `storage.checkpoint_store` *after* entries are committed. The two commits are
 ///    non-atomic; a crash between them replays safely because `DBCol::ReceiptToTx` is
 ///    insert-only. Pass `None` to skip the checkpoint write (e.g. one-shot CLI reruns).
+///
+/// # Production deployment assumption (SST path)
+///
+/// The SST path assumes a fresh archival deployment with **no pre-existing
+/// ReceiptToTx data**. Within a single actor instance no key overlap is
+/// possible: each height is processed exactly once, receipt ids are unique
+/// across the chain by construction, and the same-batch dedupe below catches
+/// the rare case where one receipt id is observed at multiple heights inside
+/// the same batch (e.g. cross-shard receipts visible at producer + receiver
+/// heights).
+///
+/// Cross-batch overlap with already-stored keys can only arise if the CLI
+/// tool ran first or if the CLI and actor run concurrently. Neither scenario
+/// happens on this deploy; `test_sequential_forward_then_backward_converge`
+/// is the regression net for the hypothetical concurrent path.
 pub fn process_one_batch(
     chain_store: &ChainStore,
     storage: &BackfillStorage,
@@ -257,12 +295,13 @@ pub fn process_one_batch(
     let results: Vec<_> =
         pool.install(|| heights.par_iter().map(|h| process_height(chain_store, *h)).collect());
 
-    let mut entry_update = storage.write_store.store_update();
+    let mut entries: Vec<(CryptoHash, Vec<u8>)> = Vec::new();
     for result in results {
         match result {
             Ok(Some(height_result)) => {
                 for (receipt_id, info) in height_result.entries {
-                    entry_update.insert_ser(DBCol::ReceiptToTx, receipt_id.as_ref(), &info);
+                    let value = borsh::to_vec(&info).context("serialize ReceiptToTxInfo")?;
+                    entries.push((receipt_id, value));
                     stats.entries_written += 1;
                 }
                 stats.blocks_processed += 1;
@@ -276,7 +315,51 @@ pub fn process_one_batch(
             Err(e) => return Err(e),
         }
     }
-    entry_update.commit();
+
+    if !entries.is_empty() {
+        // Sort + dedupe by raw key bytes. SST ingest requires strict ordering,
+        // and the legacy path's debug-only `assert_no_overwrite` is the
+        // correctness guarantee we replace here: if a duplicate key carries a
+        // different value, that's non-determinism in the chain-data resolution
+        // and we surface it as an error in release too.
+        entries.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
+        let mut deduped: Vec<(CryptoHash, Vec<u8>)> = Vec::with_capacity(entries.len());
+        for (k, v) in entries {
+            match deduped.last() {
+                Some((prev_k, prev_v)) if prev_k.as_ref() == k.as_ref() => {
+                    if prev_v != &v {
+                        return Err(anyhow::anyhow!(
+                            "backfill produced two different ReceiptToTxInfo values for receipt_id {k}; \
+                             this indicates non-determinism in chain data resolution"
+                        ));
+                    }
+                    // Pre-dedupe count included this duplicate; subtract it to keep
+                    // entries_written aligned with what actually lands in the DB.
+                    stats.entries_written -= 1;
+                }
+                _ => deduped.push((k, v)),
+            }
+        }
+
+        match &storage.sst_temp_dir {
+            Some(temp_dir) => {
+                let kvs: Vec<(&[u8], &[u8])> =
+                    deduped.iter().map(|(k, v)| (k.as_ref(), v.as_slice())).collect();
+                storage.write_store.ingest_insert_only_sst(DBCol::ReceiptToTx, &kvs, temp_dir)?;
+            }
+            None => {
+                let mut entry_update = storage.write_store.store_update();
+                for (receipt_id, value) in &deduped {
+                    entry_update.insert(
+                        DBCol::ReceiptToTx,
+                        receipt_id.as_ref().to_vec(),
+                        value.clone(),
+                    );
+                }
+                entry_update.commit();
+            }
+        }
+    }
 
     if let Some((key, height)) = checkpoint {
         let mut cp_update = storage.checkpoint_store.store_update();

--- a/chain/chain/src/backfill_receipt_to_tx.rs
+++ b/chain/chain/src/backfill_receipt_to_tx.rs
@@ -1,16 +1,39 @@
 use crate::{ChainStore, ChainStoreAccess, Error};
 use anyhow::Context;
+use borsh::BorshDeserialize;
 use near_o11y::tracing;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
-    ReceiptOrigin, ReceiptOriginReceipt, ReceiptOriginTransaction, ReceiptToTxInfo,
+    Receipt, ReceiptOrigin, ReceiptOriginReceipt, ReceiptOriginTransaction, ReceiptToTxInfo,
     ReceiptToTxInfoV1,
 };
-use near_primitives::types::BlockHeight;
-use near_primitives::utils::get_block_shard_id_rev;
+use near_primitives::transaction::ExecutionOutcomeWithProof;
+use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash};
 use near_store::{DBCol, NodeStorage, Store};
 use rayon::prelude::*;
+use std::collections::HashMap;
 use std::path::PathBuf;
+use thiserror::Error;
+
+/// Errors emitted by [`process_one_batch`] that callers may want to inspect.
+///
+/// These are returned through `anyhow::Error` so they can be downcast at the
+/// actor layer (e.g. to record dedicated metrics) while still flowing through
+/// the existing `anyhow::Result` plumbing.
+#[derive(Debug, Error)]
+pub enum BackfillError {
+    /// Two within-batch entries shared a receipt id but disagreed on the
+    /// `ReceiptToTxInfo` payload. The batch is quarantined: the checkpoint is
+    /// not advanced and no entries are written. The actor surfaces this as a
+    /// metric increment plus an error-level log.
+    #[error(
+        "backfill produced two different ReceiptToTxInfo values for receipt_id {key} \
+         (prev={prev_value:02x?}, new={new_value:02x?}); \
+         this indicates non-determinism in chain data resolution"
+    )]
+    ValueDivergence { key: CryptoHash, prev_value: Vec<u8>, new_value: Vec<u8> },
+}
 
 /// Routes the three distinct storage roles used by the ReceiptToTx backfill:
 /// reads of chain state, writes of ReceiptToTx entries, and checkpoint state.
@@ -138,11 +161,36 @@ pub struct HeightResult {
     pub missing_parent_receipts: u64,
 }
 
+/// One outcome's worth of state carried between the per-height MultiGet
+/// stages.  Built from Stage 1's `TransactionResultForBlock` MultiGet
+/// result; consumed by the assembly loop after Stage 2A/2B fill in receipts
+/// and is_tx.
+struct StagedOutcome {
+    outcome_id: CryptoHash,
+    shard_id: ShardId,
+    outcome: ExecutionOutcomeWithProof,
+}
+
 /// Process a single height: read all execution outcomes and build ReceiptToTxInfo entries.
 ///
 /// Returns `Ok(None)` only when there is no block at `height` (counted as a skipped height).
 /// Returns `Ok(Some(_))` whenever the height has a block — the `HeightResult` carries the
 /// entries produced and the per-category counts of data that was expected but missing.
+///
+/// **Read pattern:** the per-height work collapses the chain reads into
+/// three single-CF batched MultiGets:
+///
+/// * Stage 1 — `TransactionResultForBlock` MultiGet for all outcome
+///   composite keys (30-50 keys).
+/// * Stage 2A — `Receipts` pinned multi-get for parents+children
+///   combined (~190 keys, single CF, pinned slices).
+/// * Stage 2B — `Transactions` `multi_exists` to classify each outcome
+///   as tx-origin vs receipt-origin (30-50 keys). Refcount stripping
+///   ensures tombstones are not misclassified as live transactions.
+///
+/// The `OutcomeIds` prefix iter is unchanged: it's already a sequential
+/// range scan after one disk seek and the keys are clustered by block
+/// hash, so it has nothing to gain from MultiGet.
 pub fn process_height(
     chain_store: &ChainStore,
     height: BlockHeight,
@@ -161,87 +209,185 @@ pub fn process_height(
     let mut missing_child_receipts: u64 = 0;
     let mut missing_parent_receipts: u64 = 0;
 
+    // Pass 0 — walk the OutcomeIds prefix iterator, collect the
+    // (outcome_id, shard_id) descriptors for the height.
+    let mut outcome_descriptors: Vec<(CryptoHash, ShardId)> = Vec::new();
     for (key, outcome_ids) in
         read_store.iter_prefix_ser::<Vec<CryptoHash>>(DBCol::OutcomeIds, block_hash.as_ref())
     {
         let (_, shard_id) = get_block_shard_id_rev(&key).expect("invalid OutcomeIds key");
-
         for outcome_id in outcome_ids {
-            let outcome_with_proof =
-                match chain_store.get_outcome_by_id_and_block_hash(&outcome_id, &block_hash) {
-                    Some(o) => o,
-                    None => {
-                        missing_outcomes += 1;
-                        tracing::warn!(
-                            %outcome_id,
-                            height,
-                            %shard_id,
-                            "missing execution outcome, skipping"
-                        );
-                        continue;
-                    }
-                };
-            let outcome = &outcome_with_proof.outcome;
+            outcome_descriptors.push((outcome_id, shard_id));
+        }
+    }
 
-            if outcome.receipt_ids.is_empty() {
-                continue;
+    if outcome_descriptors.is_empty() {
+        return Ok(Some(HeightResult {
+            entries,
+            missing_outcomes,
+            missing_child_receipts,
+            missing_parent_receipts,
+        }));
+    }
+
+    // Stage 1 — single MultiGet on TransactionResultForBlock for all
+    // outcome composite keys.  The composite key is
+    // `get_outcome_id_block_hash(outcome_id, block_hash)` which is what
+    // `ChainStore::get_outcome_by_id_and_block_hash` builds internally.
+    let outcome_keys_owned: Vec<Vec<u8>> = outcome_descriptors
+        .iter()
+        .map(|(oid, _)| get_outcome_id_block_hash(oid, &block_hash))
+        .collect();
+    let outcome_key_refs: Vec<&[u8]> = outcome_keys_owned.iter().map(Vec::as_slice).collect();
+    let outcome_results = read_store.multi_get(DBCol::TransactionResultForBlock, &outcome_key_refs);
+
+    // Build the StagedOutcome list.  Skip outcomes with no children — they
+    // contribute nothing to ReceiptToTx and also nothing to Stage 2.
+    let mut staged: Vec<StagedOutcome> = Vec::with_capacity(outcome_descriptors.len());
+    for ((outcome_id, shard_id), result) in
+        outcome_descriptors.iter().zip(outcome_results.into_iter())
+    {
+        match result {
+            Some(bytes) => {
+                let outcome = ExecutionOutcomeWithProof::try_from_slice(bytes.as_slice())
+                    .expect("borsh deserialization should not fail");
+                if outcome.outcome.receipt_ids.is_empty() {
+                    continue;
+                }
+                staged.push(StagedOutcome {
+                    outcome_id: *outcome_id,
+                    shard_id: *shard_id,
+                    outcome,
+                });
             }
-
-            let is_tx = read_store.exists(DBCol::Transactions, outcome_id.as_ref());
-
-            // For receipt outcomes, look up the parent receipt once (not per child).
-            let parent_receipt = if !is_tx { chain_store.get_receipt(&outcome_id) } else { None };
-
-            for child_receipt_id in &outcome.receipt_ids {
-                let child_receipt = match chain_store.get_receipt(child_receipt_id) {
-                    Some(r) => r,
-                    None => {
-                        missing_child_receipts += 1;
-                        tracing::debug!(
-                            %child_receipt_id,
-                            %outcome_id,
-                            height,
-                            "missing child receipt, skipping"
-                        );
-                        continue;
-                    }
-                };
-
-                let info = if is_tx {
-                    ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
-                        origin: ReceiptOrigin::FromTransaction(ReceiptOriginTransaction {
-                            tx_hash: outcome_id,
-                            sender_account_id: outcome.executor_id.clone(),
-                        }),
-                        receiver_account_id: child_receipt.receiver_id().clone(),
-                        shard_id,
-                    })
-                } else {
-                    let parent = match &parent_receipt {
-                        Some(r) => r,
-                        None => {
-                            missing_parent_receipts += 1;
-                            tracing::debug!(
-                                %outcome_id,
-                                height,
-                                "missing parent receipt for receipt outcome, skipping"
-                            );
-                            continue;
-                        }
-                    };
-                    ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
-                        origin: ReceiptOrigin::FromReceipt(ReceiptOriginReceipt {
-                            parent_receipt_id: outcome_id,
-                            parent_predecessor_id: parent.predecessor_id().clone(),
-                        }),
-                        receiver_account_id: child_receipt.receiver_id().clone(),
-                        shard_id,
-                    })
-                };
-
-                entries.push((*child_receipt_id, info));
+            None => {
+                missing_outcomes += 1;
+                tracing::warn!(
+                    %outcome_id,
+                    height,
+                    %shard_id,
+                    "missing execution outcome, skipping"
+                );
             }
         }
+    }
+
+    if staged.is_empty() {
+        return Ok(Some(HeightResult {
+            entries,
+            missing_outcomes,
+            missing_child_receipts,
+            missing_parent_receipts,
+        }));
+    }
+
+    // Stage 2B — multi_exists on `Transactions` to classify each outcome
+    // as tx-origin (true) or receipt-origin (false).  The Store::multi_exists
+    // wrapper applies refcount-aware logic via Store::multi_get, so RC
+    // tombstones for `Transactions` (an RC column) are correctly reported
+    // as absent.
+    let outcome_id_owned: Vec<&CryptoHash> = staged.iter().map(|s| &s.outcome_id).collect();
+    let outcome_id_refs: Vec<&[u8]> = outcome_id_owned.iter().map(|h| h.as_ref()).collect();
+    let is_tx_results = read_store.multi_exists(DBCol::Transactions, &outcome_id_refs);
+
+    // Stage 2A — single batched MultiGet on `Receipts` covering BOTH parent
+    // receipts (one per receipt-origin outcome, ~6-15 per height) AND child
+    // receipts (every entry in every outcome's `receipt_ids`, ~120-180 per
+    // height).  Combining them into one call lets RocksDB sort across the
+    // whole 195-key set internally, which gives the kernel block layer a
+    // larger LBA-sortable submission than splitting per-role would.
+    let mut parent_keys: Vec<&[u8]> = Vec::new();
+    // For each parent in `parent_keys`, the index into `staged` it belongs to.
+    let mut parent_to_staged_idx: Vec<usize> = Vec::new();
+    let mut child_keys: Vec<&[u8]> = Vec::new();
+    // For each child in `child_keys`, (staged_idx, position-within-outcome).
+    let mut child_origins: Vec<(usize, usize)> = Vec::new();
+
+    for (staged_idx, s) in staged.iter().enumerate() {
+        if !is_tx_results[staged_idx] {
+            parent_keys.push(s.outcome_id.as_ref());
+            parent_to_staged_idx.push(staged_idx);
+        }
+        for (child_pos, child_id) in s.outcome.outcome.receipt_ids.iter().enumerate() {
+            child_keys.push(child_id.as_ref());
+            child_origins.push((staged_idx, child_pos));
+        }
+    }
+
+    let parent_count = parent_keys.len();
+    let mut combined_receipt_keys: Vec<&[u8]> = Vec::with_capacity(parent_count + child_keys.len());
+    combined_receipt_keys.extend_from_slice(&parent_keys);
+    combined_receipt_keys.extend_from_slice(&child_keys);
+    let receipt_results = read_store.multi_get(DBCol::Receipts, &combined_receipt_keys);
+    let (parent_results, child_results) = receipt_results.split_at(parent_count);
+
+    // Deserialize parents into a sparse lookup table indexed by `staged_idx`.
+    // None entries are fine — we'll count them as `missing_parent_receipts`
+    // when the assembly loop tries to use them.
+    let mut parent_by_staged_idx: HashMap<usize, Receipt> = HashMap::with_capacity(parent_count);
+    for (i, &staged_idx) in parent_to_staged_idx.iter().enumerate() {
+        if let Some(bytes) = &parent_results[i] {
+            let receipt = Receipt::try_from_slice(bytes.as_slice())
+                .expect("borsh deserialization should not fail");
+            parent_by_staged_idx.insert(staged_idx, receipt);
+        }
+    }
+
+    // Assembly — walk children in input order; build entries.
+    for ((staged_idx, child_pos), child_result) in child_origins.iter().zip(child_results.iter()) {
+        let s = &staged[*staged_idx];
+        let outcome = &s.outcome.outcome;
+        let child_receipt_id = &outcome.receipt_ids[*child_pos];
+        let is_tx = is_tx_results[*staged_idx];
+
+        let child_receipt = match child_result {
+            Some(bytes) => Receipt::try_from_slice(bytes.as_slice())
+                .expect("borsh deserialization should not fail"),
+            None => {
+                missing_child_receipts += 1;
+                tracing::debug!(
+                    %child_receipt_id,
+                    outcome_id = %s.outcome_id,
+                    height,
+                    "missing child receipt, skipping"
+                );
+                continue;
+            }
+        };
+
+        let info = if is_tx {
+            ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+                origin: ReceiptOrigin::FromTransaction(ReceiptOriginTransaction {
+                    tx_hash: s.outcome_id,
+                    sender_account_id: outcome.executor_id.clone(),
+                }),
+                receiver_account_id: child_receipt.receiver_id().clone(),
+                shard_id: s.shard_id,
+            })
+        } else {
+            let parent = match parent_by_staged_idx.get(staged_idx) {
+                Some(r) => r,
+                None => {
+                    missing_parent_receipts += 1;
+                    tracing::debug!(
+                        outcome_id = %s.outcome_id,
+                        height,
+                        "missing parent receipt for receipt outcome, skipping"
+                    );
+                    continue;
+                }
+            };
+            ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+                origin: ReceiptOrigin::FromReceipt(ReceiptOriginReceipt {
+                    parent_receipt_id: s.outcome_id,
+                    parent_predecessor_id: parent.predecessor_id().clone(),
+                }),
+                receiver_account_id: child_receipt.receiver_id().clone(),
+                shard_id: s.shard_id,
+            })
+        };
+
+        entries.push((*child_receipt_id, info));
     }
 
     Ok(Some(HeightResult {
@@ -302,7 +448,6 @@ pub fn process_one_batch(
                 for (receipt_id, info) in height_result.entries {
                     let value = borsh::to_vec(&info).context("serialize ReceiptToTxInfo")?;
                     entries.push((receipt_id, value));
-                    stats.entries_written += 1;
                 }
                 stats.blocks_processed += 1;
                 stats.missing_outcomes += height_result.missing_outcomes;
@@ -317,29 +462,8 @@ pub fn process_one_batch(
     }
 
     if !entries.is_empty() {
-        // Sort + dedupe by raw key bytes. SST ingest requires strict ordering,
-        // and the legacy path's debug-only `assert_no_overwrite` is the
-        // correctness guarantee we replace here: if a duplicate key carries a
-        // different value, that's non-determinism in the chain-data resolution
-        // and we surface it as an error in release too.
-        entries.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
-        let mut deduped: Vec<(CryptoHash, Vec<u8>)> = Vec::with_capacity(entries.len());
-        for (k, v) in entries {
-            match deduped.last() {
-                Some((prev_k, prev_v)) if prev_k.as_ref() == k.as_ref() => {
-                    if prev_v != &v {
-                        return Err(anyhow::anyhow!(
-                            "backfill produced two different ReceiptToTxInfo values for receipt_id {k}; \
-                             this indicates non-determinism in chain data resolution"
-                        ));
-                    }
-                    // Pre-dedupe count included this duplicate; subtract it to keep
-                    // entries_written aligned with what actually lands in the DB.
-                    stats.entries_written -= 1;
-                }
-                _ => deduped.push((k, v)),
-            }
-        }
+        let deduped = sort_and_dedupe_entries(entries)?;
+        stats.entries_written = deduped.len() as u64;
 
         match &storage.sst_temp_dir {
             Some(temp_dir) => {
@@ -349,12 +473,8 @@ pub fn process_one_batch(
             }
             None => {
                 let mut entry_update = storage.write_store.store_update();
-                for (receipt_id, value) in &deduped {
-                    entry_update.insert(
-                        DBCol::ReceiptToTx,
-                        receipt_id.as_ref().to_vec(),
-                        value.clone(),
-                    );
+                for (receipt_id, value) in deduped {
+                    entry_update.insert(DBCol::ReceiptToTx, receipt_id.as_ref().to_vec(), value);
                 }
                 entry_update.commit();
             }
@@ -368,4 +488,81 @@ pub fn process_one_batch(
     }
 
     Ok(stats)
+}
+
+/// Sort `entries` by key and drop exact duplicates. Returns
+/// [`BackfillError::ValueDivergence`] if any duplicate key has a different
+/// value, so the caller can quarantine the batch (no checkpoint advance, no
+/// entries written) instead of letting the SST ingest silently accept one
+/// of the conflicting values.
+fn sort_and_dedupe_entries(
+    mut entries: Vec<(CryptoHash, Vec<u8>)>,
+) -> Result<Vec<(CryptoHash, Vec<u8>)>, BackfillError> {
+    entries.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
+    let mut deduped: Vec<(CryptoHash, Vec<u8>)> = Vec::with_capacity(entries.len());
+    for (k, v) in entries {
+        match deduped.last() {
+            Some((prev_k, prev_v)) if prev_k.as_ref() == k.as_ref() => {
+                if prev_v != &v {
+                    return Err(BackfillError::ValueDivergence {
+                        key: k,
+                        prev_value: prev_v.clone(),
+                        new_value: v,
+                    });
+                }
+            }
+            _ => deduped.push((k, v)),
+        }
+    }
+    Ok(deduped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(byte: u8) -> CryptoHash {
+        CryptoHash([byte; 32])
+    }
+
+    #[test]
+    fn sort_and_dedupe_passes_unique_entries_through() {
+        let input = vec![(h(2), b"bb".to_vec()), (h(1), b"aa".to_vec()), (h(3), b"cc".to_vec())];
+        let out = sort_and_dedupe_entries(input).expect("unique keys must succeed");
+        assert_eq!(
+            out,
+            vec![(h(1), b"aa".to_vec()), (h(2), b"bb".to_vec()), (h(3), b"cc".to_vec())]
+        );
+    }
+
+    #[test]
+    fn sort_and_dedupe_collapses_exact_duplicates() {
+        let input = vec![(h(1), b"aa".to_vec()), (h(1), b"aa".to_vec()), (h(2), b"bb".to_vec())];
+        let out = sort_and_dedupe_entries(input).expect("identical duplicate must collapse");
+        assert_eq!(out, vec![(h(1), b"aa".to_vec()), (h(2), b"bb".to_vec())]);
+    }
+
+    #[test]
+    fn sort_and_dedupe_surfaces_value_divergence() {
+        let input =
+            vec![(h(1), b"aa".to_vec()), (h(1), b"different".to_vec()), (h(2), b"bb".to_vec())];
+        let err = sort_and_dedupe_entries(input).expect_err("divergent values must error");
+        match err {
+            BackfillError::ValueDivergence { key, prev_value, new_value } => {
+                assert_eq!(key, h(1));
+                // The "kept" value is whichever sorted first by Vec::sort_by stability;
+                // both inputs have the same key so order between them is preserved.
+                // We only check both byte payloads were captured.
+                let payloads = [&prev_value[..], &new_value[..]];
+                assert!(payloads.contains(&&b"aa"[..]));
+                assert!(payloads.contains(&&b"different"[..]));
+            }
+        }
+    }
+
+    #[test]
+    fn sort_and_dedupe_handles_empty_input() {
+        let out = sort_and_dedupe_entries(Vec::new()).expect("empty input is valid");
+        assert!(out.is_empty());
+    }
 }

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -18,6 +18,7 @@ bytesize.workspace = true
 futures.workspace = true
 itertools.workspace = true
 lru.workspace = true
+nix.workspace = true
 num-rational.workspace = true
 parking_lot.workspace = true
 rand.workspace = true

--- a/chain/client/src/backfill_receipt_to_tx_actor.rs
+++ b/chain/client/src/backfill_receipt_to_tx_actor.rs
@@ -136,6 +136,11 @@ impl BackfillReceiptToTxActor {
     /// Process one batch of heights in descending order.
     /// Returns `Ok(true)` when backfill is complete (reached genesis).
     /// Returns `Ok(false)` when there's more work to do.
+    ///
+    /// Runs synchronously — including the SST ingest call when configured.
+    /// The actor is spawned via `spawn_tokio_actor`, which gives it a dedicated
+    /// single-worker tokio runtime, so blocking the worker only stalls this
+    /// actor's own iterations and never starves the rest of the node.
     pub fn backfill_batch(&mut self) -> anyhow::Result<bool> {
         let batch_start = Instant::now();
 
@@ -260,6 +265,16 @@ impl BackfillReceiptToTxActor {
 
 impl Actor for BackfillReceiptToTxActor {
     fn start_actor(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
+        // If a previous run of this PID left an SST temp directory behind (rare but
+        // possible after a hard crash + PID reuse), wipe it before starting fresh.
+        // The path is owned by this PID, so this only touches files we wrote.
+        if let Some(temp_dir) = &self.storage.sst_temp_dir {
+            if temp_dir.exists() {
+                if let Err(e) = std::fs::remove_dir_all(temp_dir) {
+                    tracing::warn!(?temp_dir, ?e, "failed to clean stale SST temp dir on startup",);
+                }
+            }
+        }
         self.backfill_loop(ctx);
     }
 }

--- a/chain/client/src/backfill_receipt_to_tx_actor.rs
+++ b/chain/client/src/backfill_receipt_to_tx_actor.rs
@@ -3,22 +3,40 @@ use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt};
 use near_async::messaging::Actor;
 use near_async::time::Duration;
 use near_chain::backfill_receipt_to_tx::{
-    BACKFILL_CHECKPOINT_KEY_LOW, BackfillStorage, process_one_batch,
+    BACKFILL_CHECKPOINT_KEY_LOW, BackfillError, BackfillStorage, process_one_batch,
 };
 use near_chain::{ChainGenesis, ChainStore, ChainStoreAccess};
 use near_chain_configs::BackfillReceiptToTxConfig;
 use near_o11y::tracing;
 use near_primitives::types::{BlockHeight, BlockHeightDelta};
 use near_store::DBCol;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::metrics;
 
 const SYNC_GAP_THRESHOLD: BlockHeightDelta = 100;
 
+/// Number of consecutive failed batches after which the actor halts
+/// permanently. With a 5s `batch_delay` the retry schedule is 30s, 60s,
+/// 120s, 240s, then 5 min — so 100 errors corresponds to ~8.1 hours of
+/// zero progress. Long enough to ride out transient I/O blips, short
+/// enough that a permanent failure surfaces operationally rather than
+/// silently spamming logs forever.
+const MAX_CONSECUTIVE_ERRORS: u32 = 100;
+
 fn is_chain_at_tip(block_head: BlockHeight, header_head: BlockHeight) -> bool {
-    header_head.saturating_sub(block_head) <= SYNC_GAP_THRESHOLD
+    if block_head > header_head {
+        // Invariant violation: header head should always be at or ahead of block head.
+        // Don't crash the actor — log loudly and treat as not-at-tip so backfill stays paused.
+        tracing::error!(
+            block_head,
+            header_head,
+            "receipt-to-tx backfill: block_head exceeds header_head — chain state invariant violated"
+        );
+        return false;
+    }
+    header_head - block_head <= SYNC_GAP_THRESHOLD
 }
 
 fn next_retry_delay(consecutive_errors: u32, batch_delay: Duration) -> Duration {
@@ -45,6 +63,12 @@ pub struct BackfillReceiptToTxActor {
     config: BackfillReceiptToTxConfig,
     consecutive_errors: u32,
     start_height_validated: bool,
+    /// File handle holding an exclusive `flock` on the SST staging-directory
+    /// sentinel for the lifetime of the actor. Dropping the handle releases
+    /// the lock (and the kernel also releases it on process death). Stays
+    /// `None` when SST mode is disabled or when lock acquisition failed at
+    /// startup (in which case the actor falls back to the legacy write path).
+    _sst_dir_lock: Option<std::fs::File>,
 }
 
 impl BackfillReceiptToTxActor {
@@ -72,6 +96,7 @@ impl BackfillReceiptToTxActor {
             config,
             consecutive_errors: 0,
             start_height_validated: false,
+            _sst_dir_lock: None,
         })
     }
 
@@ -88,6 +113,9 @@ impl BackfillReceiptToTxActor {
                 return;
             }
             Err(e) => {
+                if self.record_error_and_maybe_halt(&e) {
+                    return;
+                }
                 let delay = next_retry_delay(self.consecutive_errors, self.config.batch_delay);
                 self.consecutive_errors += 1;
                 tracing::warn!(
@@ -118,6 +146,9 @@ impl BackfillReceiptToTxActor {
                 );
             }
             Err(e) => {
+                if self.record_error_and_maybe_halt(&e) {
+                    return;
+                }
                 let delay = next_retry_delay(self.consecutive_errors, self.config.batch_delay);
                 self.consecutive_errors += 1;
                 tracing::warn!(?e, ?delay, "receipt-to-tx backfill error, retrying");
@@ -126,6 +157,40 @@ impl BackfillReceiptToTxActor {
                 });
             }
         }
+    }
+
+    /// Record per-error metrics/logs and, if the consecutive-error budget is
+    /// exhausted, halt the actor. Returns `true` if the actor halted (caller
+    /// must NOT schedule another retry).
+    ///
+    /// Halting is permanent for the life of this process: no further
+    /// `run_later` is scheduled. An operator restart with the underlying
+    /// fault resolved is required to resume backfill.
+    fn record_error_and_maybe_halt(&mut self, e: &anyhow::Error) -> bool {
+        if let Some(BackfillError::ValueDivergence { key, prev_value, new_value }) =
+            e.downcast_ref::<BackfillError>()
+        {
+            metrics::BACKFILL_RECEIPT_TO_TX_VALUE_DIVERGENCE_TOTAL.inc();
+            tracing::error!(
+                %key,
+                prev_value = ?prev_value,
+                new_value = ?new_value,
+                "receipt-to-tx backfill: within-batch value divergence; batch quarantined"
+            );
+        }
+        if self.consecutive_errors + 1 >= MAX_CONSECUTIVE_ERRORS {
+            metrics::BACKFILL_RECEIPT_TO_TX_HALTED_TOTAL
+                .with_label_values(&["consecutive_errors"])
+                .inc();
+            tracing::error!(
+                consecutive_errors = self.consecutive_errors + 1,
+                last_error = ?e,
+                "receipt-to-tx backfill: halting after exceeding consecutive-error budget; \
+                 operator intervention required"
+            );
+            return true;
+        }
+        false
     }
 
     fn check_chain_at_tip(&self) -> anyhow::Result<bool> {
@@ -158,7 +223,15 @@ impl BackfillReceiptToTxActor {
         // On the first batch, validate `config.start_height` before using it. The checks
         // only matter once — after the first batch writes a checkpoint, `start_height` is
         // irrelevant forever (the resume logic uses the checkpoint instead).
+        //
+        // Set `start_height_validated = true` UNCONDITIONALLY at the top of the block,
+        // so a bounds-violation Err on a typo (e.g. `start_height` above head) does not
+        // wedge the actor in a permanent re-validation loop. Subsequent retries skip
+        // this block and proceed with the (bogus) start_height; reads of non-existent
+        // heights return `Ok(None)` and the actor self-corrects as it walks down.
+        // The retry loop is bounded by `MAX_CONSECUTIVE_ERRORS`.
         if !self.start_height_validated {
+            self.start_height_validated = true;
             if let Some(start_height) = self.config.start_height {
                 if let Some(cp) = checkpoint {
                     tracing::warn!(
@@ -181,7 +254,6 @@ impl BackfillReceiptToTxActor {
                     }
                 }
             }
-            self.start_height_validated = true;
         }
 
         let current_height = match checkpoint {
@@ -264,18 +336,51 @@ impl BackfillReceiptToTxActor {
     }
 }
 
-/// Removes any stale contents in the actor's per-PID SST staging directory.
+/// Sibling sentinel path one level up from the per-PID SST temp dir.
 ///
-/// Invoked from `Actor::start_actor`. Idempotent and `None`-safe so callers
-/// don't need to guard. The path is owned by this PID, so a previous run
-/// of this PID is the only thing this can touch — possible (but rare) after
-/// a hard crash followed by PID reuse.
+/// Layout: parent / "pid-{pid}/" (the staging dir) and parent /
+/// "pid-{pid}.lock" (the sibling sentinel). The sentinel must live OUTSIDE
+/// the dir so cleanup can `remove_dir_all` the dir without touching the
+/// locked file (unlinking the locked inode would release the lock and let
+/// a peer immediately re-acquire it).
+fn sst_dir_sentinel_path(temp_dir: &Path) -> Option<PathBuf> {
+    let parent = temp_dir.parent()?;
+    let name = temp_dir.file_name()?.to_str()?;
+    Some(parent.join(format!("{name}.lock")))
+}
+
+/// Try to acquire an exclusive non-blocking flock on the sentinel file.
 ///
-/// Lives as a free function so it can be unit-tested without spinning up
-/// the actor's tokio runtime; `Actor::start_actor` only fires when the
-/// actor is spawned, which is awkward to drive from a `#[test]`.
-fn clean_stale_sst_temp_dir(temp_dir: Option<&Path>) {
-    let Some(temp_dir) = temp_dir else { return };
+/// The returned `File` holds the lock for as long as it lives — the caller
+/// stores it on the actor so the lock is held for the actor's lifetime.
+/// POSIX advisory locks release on process death (including SIGKILL), so
+/// no manual cleanup is needed across crashes.
+///
+/// Lock failure means another process holds the sentinel: the staging dir
+/// belongs to that peer and must NOT be touched.
+fn try_acquire_sst_dir_lock(sentinel: &Path) -> anyhow::Result<std::fs::File> {
+    use nix::fcntl::{FlockArg, flock};
+    use std::os::unix::io::AsRawFd;
+
+    if let Some(parent) = sentinel.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create sentinel parent dir {parent:?}"))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(sentinel)
+        .with_context(|| format!("open sentinel {sentinel:?}"))?;
+    flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock)
+        .with_context(|| format!("flock {sentinel:?}: held by another process"))?;
+    Ok(file)
+}
+
+/// Remove the contents of the per-PID SST staging directory while leaving
+/// the sibling sentinel in place. Safe to call after acquiring the lock —
+/// the directory belongs to this PID exclusively at that point.
+fn clean_locked_sst_temp_dir(temp_dir: &Path) {
     if !temp_dir.exists() {
         return;
     }
@@ -286,7 +391,34 @@ fn clean_stale_sst_temp_dir(temp_dir: Option<&Path>) {
 
 impl Actor for BackfillReceiptToTxActor {
     fn start_actor(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
-        clean_stale_sst_temp_dir(self.storage.sst_temp_dir.as_deref());
+        if let Some(temp_dir) = self.storage.sst_temp_dir.clone() {
+            match sst_dir_sentinel_path(&temp_dir) {
+                Some(sentinel) => match try_acquire_sst_dir_lock(&sentinel) {
+                    Ok(lock_file) => {
+                        self._sst_dir_lock = Some(lock_file);
+                        clean_locked_sst_temp_dir(&temp_dir);
+                    }
+                    Err(e) => {
+                        metrics::BACKFILL_RECEIPT_TO_TX_SST_LOCK_CONTENTION_TOTAL.inc();
+                        tracing::warn!(
+                            ?temp_dir,
+                            ?sentinel,
+                            ?e,
+                            "could not acquire SST staging dir lock; falling back to legacy write path"
+                        );
+                        self.storage.sst_temp_dir = None;
+                    }
+                },
+                None => {
+                    tracing::warn!(
+                        ?temp_dir,
+                        "SST staging dir has no parent or non-utf8 file name; \
+                         falling back to legacy write path",
+                    );
+                    self.storage.sst_temp_dir = None;
+                }
+            }
+        }
         self.backfill_loop(ctx);
     }
 }
@@ -301,8 +433,8 @@ mod tests {
         assert!(is_chain_at_tip(100, 200));
         assert!(!is_chain_at_tip(100, 201));
         assert!(!is_chain_at_tip(0, 1000));
-        // header_head < block_head (saturating_sub handles gracefully)
-        assert!(is_chain_at_tip(200, 100));
+        // header_head < block_head is an invariant violation: not at tip.
+        assert!(!is_chain_at_tip(200, 100));
     }
 
     #[test]
@@ -326,34 +458,110 @@ mod tests {
     }
 
     /// Pre-existing files in the SST staging directory left behind by a prior
-    /// run with this PID are wiped on startup.
+    /// run with this PID are wiped on startup once the lock is held.
     #[test]
-    fn test_clean_stale_sst_temp_dir_removes_pre_existing_files() {
+    fn test_clean_locked_sst_temp_dir_removes_pre_existing_files() {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let stale = tmp.path().join("ingest-1234-7.sst");
         std::fs::write(&stale, b"leftover").expect("write stub");
         assert!(stale.exists());
 
-        clean_stale_sst_temp_dir(Some(tmp.path()));
+        clean_locked_sst_temp_dir(tmp.path());
 
         assert!(!tmp.path().exists(), "cleanup should remove the entire dir");
     }
 
-    /// `None` means SST mode is disabled — cleanup is a no-op and must not panic.
-    #[test]
-    fn test_clean_stale_sst_temp_dir_none_is_noop() {
-        clean_stale_sst_temp_dir(None);
-    }
-
     /// Missing path is the common fresh-process case — must not panic.
     #[test]
-    fn test_clean_stale_sst_temp_dir_missing_path_is_noop() {
+    fn test_clean_locked_sst_temp_dir_missing_path_is_noop() {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let missing = tmp.path().join("does-not-exist");
         assert!(!missing.exists());
 
-        clean_stale_sst_temp_dir(Some(&missing));
+        clean_locked_sst_temp_dir(&missing);
 
         assert!(!missing.exists(), "cleanup must not create the missing path");
+    }
+
+    /// Sentinel sits one level up from the per-PID dir, sharing its name with
+    /// a `.lock` suffix. This isolation is what keeps `remove_dir_all` of
+    /// the staging dir from unlinking the locked file.
+    #[test]
+    fn test_sst_dir_sentinel_path_layout() {
+        let temp_dir = Path::new("/tmp/backfill-receipt-to-tx-sst/pid-1234");
+        let sentinel = sst_dir_sentinel_path(temp_dir).unwrap();
+        assert_eq!(sentinel, Path::new("/tmp/backfill-receipt-to-tx-sst/pid-1234.lock"));
+        // Sibling, not child — `remove_dir_all(temp_dir)` cannot touch the sentinel.
+        assert_eq!(sentinel.parent(), temp_dir.parent());
+    }
+
+    /// Two actors targeting the same staging dir: the first acquires the
+    /// lock; the second's lock attempt fails. The second must NOT touch
+    /// the staging dir contents.
+    #[test]
+    fn test_sst_dir_lock_contention_blocks_second_acquirer() {
+        let parent = tempfile::tempdir().expect("create parent dir");
+        let temp_dir = parent.path().join("pid-1234");
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let canary = temp_dir.join("first-actors-data.sst");
+        std::fs::write(&canary, b"belongs to first actor").expect("write canary");
+
+        let sentinel = sst_dir_sentinel_path(&temp_dir).expect("sentinel path");
+        let _first_lock = try_acquire_sst_dir_lock(&sentinel).expect("first lock acquires");
+
+        // Second attempt must fail while the first lock is held.
+        let second = try_acquire_sst_dir_lock(&sentinel);
+        assert!(second.is_err(), "second flock attempt must fail under contention");
+
+        // First actor's data must be untouched.
+        assert!(canary.exists(), "second actor must not delete the first's data");
+    }
+
+    /// Once the holder drops the lock, a fresh attempt succeeds.
+    #[test]
+    fn test_sst_dir_lock_releases_on_drop() {
+        let parent = tempfile::tempdir().expect("create parent dir");
+        let temp_dir = parent.path().join("pid-9999");
+        let sentinel = sst_dir_sentinel_path(&temp_dir).expect("sentinel path");
+        {
+            let _lock = try_acquire_sst_dir_lock(&sentinel).expect("first lock acquires");
+        }
+        let _retry = try_acquire_sst_dir_lock(&sentinel).expect("after drop, lock is reacquirable");
+    }
+
+    /// Halt budget: at `consecutive_errors == MAX - 1`, the next failure halts
+    /// (the +1 in the check counts the in-flight error).
+    #[test]
+    fn test_halt_threshold_fires_at_budget_exhaustion() {
+        let halt_at_budget = MAX_CONSECUTIVE_ERRORS - 1;
+        // The "in-flight" error is the (consecutive_errors + 1)-th consecutive failure.
+        assert_eq!(halt_at_budget + 1, MAX_CONSECUTIVE_ERRORS);
+        // One below budget: keep retrying.
+        assert!(halt_at_budget - 1 + 1 < MAX_CONSECUTIVE_ERRORS);
+    }
+
+    /// `BackfillError::ValueDivergence` round-trips through `anyhow::Error`
+    /// so the actor's `downcast_ref` path can detect it. This is the
+    /// load-bearing guarantee for the metric-and-log handler in
+    /// `record_error_and_maybe_halt`.
+    #[test]
+    fn test_value_divergence_downcast_roundtrip() {
+        use near_primitives::hash::CryptoHash;
+        let key = CryptoHash([7u8; 32]);
+        let err: anyhow::Error = BackfillError::ValueDivergence {
+            key,
+            prev_value: b"prev".to_vec(),
+            new_value: b"new".to_vec(),
+        }
+        .into();
+        let downcast = err.downcast_ref::<BackfillError>();
+        match downcast {
+            Some(BackfillError::ValueDivergence { key: k, prev_value, new_value }) => {
+                assert_eq!(*k, key);
+                assert_eq!(prev_value, b"prev");
+                assert_eq!(new_value, b"new");
+            }
+            None => panic!("BackfillError must be downcastable from anyhow::Error"),
+        }
     }
 }

--- a/chain/client/src/backfill_receipt_to_tx_actor.rs
+++ b/chain/client/src/backfill_receipt_to_tx_actor.rs
@@ -10,6 +10,7 @@ use near_chain_configs::BackfillReceiptToTxConfig;
 use near_o11y::tracing;
 use near_primitives::types::{BlockHeight, BlockHeightDelta};
 use near_store::DBCol;
+use std::path::Path;
 use std::time::Instant;
 
 use crate::metrics;
@@ -263,18 +264,29 @@ impl BackfillReceiptToTxActor {
     }
 }
 
+/// Removes any stale contents in the actor's per-PID SST staging directory.
+///
+/// Invoked from `Actor::start_actor`. Idempotent and `None`-safe so callers
+/// don't need to guard. The path is owned by this PID, so a previous run
+/// of this PID is the only thing this can touch — possible (but rare) after
+/// a hard crash followed by PID reuse.
+///
+/// Lives as a free function so it can be unit-tested without spinning up
+/// the actor's tokio runtime; `Actor::start_actor` only fires when the
+/// actor is spawned, which is awkward to drive from a `#[test]`.
+fn clean_stale_sst_temp_dir(temp_dir: Option<&Path>) {
+    let Some(temp_dir) = temp_dir else { return };
+    if !temp_dir.exists() {
+        return;
+    }
+    if let Err(e) = std::fs::remove_dir_all(temp_dir) {
+        tracing::warn!(?temp_dir, ?e, "failed to clean stale SST temp dir on startup");
+    }
+}
+
 impl Actor for BackfillReceiptToTxActor {
     fn start_actor(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
-        // If a previous run of this PID left an SST temp directory behind (rare but
-        // possible after a hard crash + PID reuse), wipe it before starting fresh.
-        // The path is owned by this PID, so this only touches files we wrote.
-        if let Some(temp_dir) = &self.storage.sst_temp_dir {
-            if temp_dir.exists() {
-                if let Err(e) = std::fs::remove_dir_all(temp_dir) {
-                    tracing::warn!(?temp_dir, ?e, "failed to clean stale SST temp dir on startup",);
-                }
-            }
-        }
+        clean_stale_sst_temp_dir(self.storage.sst_temp_dir.as_deref());
         self.backfill_loop(ctx);
     }
 }
@@ -311,5 +323,37 @@ mod tests {
         assert_eq!(next_retry_delay(1, batch_delay), Duration::seconds(120));
         assert_eq!(next_retry_delay(2, batch_delay), Duration::seconds(240));
         assert_eq!(next_retry_delay(3, batch_delay), Duration::seconds(300));
+    }
+
+    /// Pre-existing files in the SST staging directory left behind by a prior
+    /// run with this PID are wiped on startup.
+    #[test]
+    fn test_clean_stale_sst_temp_dir_removes_pre_existing_files() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let stale = tmp.path().join("ingest-1234-7.sst");
+        std::fs::write(&stale, b"leftover").expect("write stub");
+        assert!(stale.exists());
+
+        clean_stale_sst_temp_dir(Some(tmp.path()));
+
+        assert!(!tmp.path().exists(), "cleanup should remove the entire dir");
+    }
+
+    /// `None` means SST mode is disabled — cleanup is a no-op and must not panic.
+    #[test]
+    fn test_clean_stale_sst_temp_dir_none_is_noop() {
+        clean_stale_sst_temp_dir(None);
+    }
+
+    /// Missing path is the common fresh-process case — must not panic.
+    #[test]
+    fn test_clean_stale_sst_temp_dir_missing_path_is_noop() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let missing = tmp.path().join("does-not-exist");
+        assert!(!missing.exists());
+
+        clean_stale_sst_temp_dir(Some(&missing));
+
+        assert!(!missing.exists(), "cleanup must not create the missing path");
     }
 }

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -839,6 +839,46 @@ pub(crate) static BACKFILL_RECEIPT_TO_TX_LOWEST_COMPLETED_HEIGHT: LazyLock<IntGa
         .unwrap()
     });
 
+/// Number of batches quarantined because two within-batch entries shared a
+/// receipt id but disagreed on the `ReceiptToTxInfo` payload. Non-zero values
+/// indicate non-determinism in chain-data resolution; the affected batch's
+/// checkpoint is NOT advanced.
+pub(crate) static BACKFILL_RECEIPT_TO_TX_VALUE_DIVERGENCE_TOTAL: LazyLock<IntCounter> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "near_backfill_receipt_to_tx_value_divergence_total",
+            "Total ReceiptToTx backfill batches quarantined due to within-batch value divergence",
+        )
+        .unwrap()
+    });
+
+/// Number of times the ReceiptToTx backfill actor halted after exceeding the
+/// consecutive-error budget. Each increment corresponds to a permanent halt
+/// requiring operator intervention.
+pub(crate) static BACKFILL_RECEIPT_TO_TX_HALTED_TOTAL: LazyLock<IntCounterVec> =
+    LazyLock::new(|| {
+        try_create_int_counter_vec(
+            "near_backfill_receipt_to_tx_halted_total",
+            "Total ReceiptToTx backfill actor halts, labelled by reason",
+            &["reason"],
+        )
+        .unwrap()
+    });
+
+/// Number of times the ReceiptToTx backfill actor failed to acquire its
+/// per-PID SST staging-directory lock. A non-zero value indicates another
+/// process is already using the directory (PID reuse / collision); the
+/// affected actor instance falls back to the legacy per-key write path
+/// for the lifetime of the process.
+pub(crate) static BACKFILL_RECEIPT_TO_TX_SST_LOCK_CONTENTION_TOTAL: LazyLock<IntCounter> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "near_backfill_receipt_to_tx_sst_lock_contention_total",
+            "Total ReceiptToTx backfill SST staging-directory lock acquisition failures",
+        )
+        .unwrap()
+    });
+
 pub static SPICE_INVALID_CHUNK_REPLACED_WITH_EMPTY_TOTAL: LazyLock<IntCounterVec> =
     LazyLock::new(|| {
         try_create_int_counter_vec(

--- a/core/store/src/db/colddb.rs
+++ b/core/store/src/db/colddb.rs
@@ -49,6 +49,30 @@ impl Database for ColdDB {
         self.cold.get_with_rc_stripped(col, key)
     }
 
+    fn multi_get_raw_bytes(&self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        Self::assert_is_in_colddb(col);
+        self.cold.multi_get_raw_bytes(col, keys)
+    }
+
+    fn pinned_multi_get_raw_bytes(&self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        Self::assert_is_in_colddb(col);
+        self.cold.pinned_multi_get_raw_bytes(col, keys)
+    }
+
+    fn multi_get_with_rc_stripped(&self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        Self::assert_is_in_colddb(col);
+        self.cold.multi_get_with_rc_stripped(col, keys)
+    }
+
+    fn pinned_multi_get_with_rc_stripped(
+        &self,
+        col: DBCol,
+        keys: &[&[u8]],
+    ) -> Vec<Option<DBSlice<'_>>> {
+        Self::assert_is_in_colddb(col);
+        self.cold.pinned_multi_get_with_rc_stripped(col, keys)
+    }
+
     /// Iterates over all values in a column.
     fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
         Self::assert_is_in_colddb(col);

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -205,6 +205,80 @@ pub trait Database: Sync + Send {
         self.get_raw_bytes(col, key).and_then(DBSlice::strip_refcount)
     }
 
+    /// Returns raw bytes for every key in `keys`, in input order.
+    ///
+    /// Semantically equivalent to calling [`Self::get_raw_bytes`] once per
+    /// key.  Backends can override this with a batched implementation that
+    /// reduces per-key syscall and userspace overhead.  The default impl
+    /// here is just N scalar gets, so backends that don't override get
+    /// correct (but unoptimised) behaviour for free.
+    ///
+    /// As with [`Self::get_raw_bytes`], the returned bytes for RC columns
+    /// include the trailing reference count and cells with non-positive
+    /// refcount are returned as `Some(...)`.  Use higher-level wrappers
+    /// (e.g. `Store::multi_get`) for refcount-stripped semantics.
+    ///
+    /// On a per-key backend error, implementations panic — matching the
+    /// existing scalar `get_raw_bytes` behaviour.  Returning `Result` here
+    /// would change the actor's crash-on-corruption semantics.
+    fn multi_get_raw_bytes<'a>(&'a self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'a>>> {
+        keys.iter().map(|k| self.get_raw_bytes(col, k)).collect()
+    }
+
+    /// Single-CF multi-key read, with the option for backends to return
+    /// pinned (zero-copy) slices.
+    ///
+    /// All keys must target the same column family `col`. Backends with a
+    /// pinned-slice fast path (RocksDB's `batched_multi_get_cf`) override
+    /// this; the default forwards to [`Self::multi_get_raw_bytes`] so
+    /// backends without one behave correctly with no extra work.
+    ///
+    /// Returned slices may be borrowed from the backend's block cache and
+    /// must not outlive this call.
+    fn pinned_multi_get_raw_bytes<'a>(
+        &'a self,
+        col: DBCol,
+        keys: &[&[u8]],
+    ) -> Vec<Option<DBSlice<'a>>> {
+        self.multi_get_raw_bytes(col, keys)
+    }
+
+    /// Returns refcount-stripped values for every key in `keys`, in input
+    /// order.  Multi-key analogue of [`Self::get_with_rc_stripped`].
+    ///
+    /// **Panics** if the column is not reference counted.
+    ///
+    /// The default impl strips refcounts from [`Self::multi_get_raw_bytes`]
+    /// per element.  Backends that need different fall-through semantics
+    /// for RC columns (notably [`super::SplitDB`], where a hot-side
+    /// tombstone must NOT shadow a real cold-side value) override this.
+    fn multi_get_with_rc_stripped<'a>(
+        &'a self,
+        col: DBCol,
+        keys: &[&[u8]],
+    ) -> Vec<Option<DBSlice<'a>>> {
+        assert!(col.is_rc());
+        self.multi_get_raw_bytes(col, keys)
+            .into_iter()
+            .map(|opt| opt.and_then(DBSlice::strip_refcount))
+            .collect()
+    }
+
+    /// Single-CF, refcount-stripped multi-key read with optional pinned
+    /// slices. See [`Self::pinned_multi_get_raw_bytes`] for the pinning
+    /// semantics.
+    fn pinned_multi_get_with_rc_stripped<'a>(
+        &'a self,
+        col: DBCol,
+        keys: &[&[u8]],
+    ) -> Vec<Option<DBSlice<'a>>> {
+        assert!(col.is_rc());
+        self.pinned_multi_get_raw_bytes(col, keys)
+            .into_iter()
+            .map(|opt| opt.and_then(DBSlice::strip_refcount))
+            .collect()
+    }
+
     /// Iterate over all items in given column in lexicographical order sorted
     /// by the key.
     ///

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -399,6 +399,50 @@ impl Database for RocksDB {
         result
     }
 
+    fn multi_get_raw_bytes(&self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        let timer = metrics::DATABASE_OP_LATENCY_HIST
+            .with_label_values::<&str>(&["multi_get", col.into()])
+            .start_timer();
+        let read_options = rocksdb_read_options();
+        let cf = self.cf_handle(col);
+        let cfs_and_keys: Vec<(&ColumnFamily, &[u8])> = keys.iter().map(|k| (cf, *k)).collect();
+        let result = self
+            .db
+            .multi_get_cf_opt(cfs_and_keys, &read_options)
+            .into_iter()
+            .map(|res| {
+                res.unwrap_or_else(|err| panic!("{col}: multi_get_cf_opt failed: {err}"))
+                    .map(DBSlice::from_vec)
+            })
+            .collect();
+        timer.observe_duration();
+        result
+    }
+
+    fn pinned_multi_get_raw_bytes(&self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        // Metric label intentionally kept as "batched_multi_get" to preserve
+        // existing operator dashboards. The Rust method name was renamed to
+        // `pinned_multi_get_*` to match its actual single-CF + pinned-slice
+        // semantics; the label is operator-facing and renaming would break
+        // Grafana queries.
+        let timer = metrics::DATABASE_OP_LATENCY_HIST
+            .with_label_values::<&str>(&["batched_multi_get", col.into()])
+            .start_timer();
+        let read_options = rocksdb_read_options();
+        let cf = self.cf_handle(col);
+        let result = self
+            .db
+            .batched_multi_get_cf_opt(cf, keys.iter().copied(), false, &read_options)
+            .into_iter()
+            .map(|res| {
+                res.unwrap_or_else(|err| panic!("{col}: batched_multi_get_cf_opt failed: {err}"))
+                    .map(DBSlice::from_rocksdb_slice)
+            })
+            .collect();
+        timer.observe_duration();
+        result
+    }
+
     fn iter_raw_bytes(&self, col: DBCol) -> DBIterator {
         Box::new(self.iter_raw_bytes_internal(col, None, None, None))
     }

--- a/core/store/src/db/splitdb.rs
+++ b/core/store/src/db/splitdb.rs
@@ -87,6 +87,112 @@ impl Database for SplitDB {
         None
     }
 
+    /// Multi-key analogue of [`Self::get_raw_bytes`].
+    ///
+    /// One batched call to hot for all keys, then a second batched call to
+    /// cold for the positions where hot returned `None` (only when the
+    /// column is cold-resident).  Mirrors scalar `get_raw_bytes` semantics
+    /// per slot.
+    fn multi_get_raw_bytes(&self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        let mut results = self.hot.multi_get_raw_bytes(col, keys);
+        if !col.is_cold() {
+            return results;
+        }
+        let cold_indices: Vec<usize> = results
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| if v.is_none() { Some(i) } else { None })
+            .collect();
+        if cold_indices.is_empty() {
+            return results;
+        }
+        let cold_keys: Vec<&[u8]> = cold_indices.iter().map(|&i| keys[i]).collect();
+        let cold_values = self.cold.multi_get_raw_bytes(col, &cold_keys);
+        for (i, cold_value) in cold_indices.into_iter().zip(cold_values.into_iter()) {
+            results[i] = cold_value;
+        }
+        results
+    }
+
+    /// Single-CF optimised variant of [`Self::multi_get_raw_bytes`].
+    fn pinned_multi_get_raw_bytes(&self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        let mut results = self.hot.pinned_multi_get_raw_bytes(col, keys);
+        if !col.is_cold() {
+            return results;
+        }
+        let cold_indices: Vec<usize> = results
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| if v.is_none() { Some(i) } else { None })
+            .collect();
+        if cold_indices.is_empty() {
+            return results;
+        }
+        let cold_keys: Vec<&[u8]> = cold_indices.iter().map(|&i| keys[i]).collect();
+        let cold_values = self.cold.pinned_multi_get_raw_bytes(col, &cold_keys);
+        for (i, cold_value) in cold_indices.into_iter().zip(cold_values.into_iter()) {
+            results[i] = cold_value;
+        }
+        results
+    }
+
+    /// Multi-key analogue of [`Self::get_with_rc_stripped`].
+    ///
+    /// **Panics** if the column is not reference counted.
+    ///
+    /// Calls each side with refcount stripping applied, so a tombstone in
+    /// hot (refcount ≤ 0) does NOT shadow a real value in cold.  This is
+    /// the load-bearing semantic that the naive raw-bytes wrapper would
+    /// have broken.
+    fn multi_get_with_rc_stripped(&self, col: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        assert!(col.is_rc());
+        let mut results = self.hot.multi_get_with_rc_stripped(col, keys);
+        if !col.is_cold() {
+            return results;
+        }
+        let cold_indices: Vec<usize> = results
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| if v.is_none() { Some(i) } else { None })
+            .collect();
+        if cold_indices.is_empty() {
+            return results;
+        }
+        let cold_keys: Vec<&[u8]> = cold_indices.iter().map(|&i| keys[i]).collect();
+        let cold_values = self.cold.multi_get_with_rc_stripped(col, &cold_keys);
+        for (i, cold_value) in cold_indices.into_iter().zip(cold_values.into_iter()) {
+            results[i] = cold_value;
+        }
+        results
+    }
+
+    /// Single-CF optimised variant of [`Self::multi_get_with_rc_stripped`].
+    fn pinned_multi_get_with_rc_stripped(
+        &self,
+        col: DBCol,
+        keys: &[&[u8]],
+    ) -> Vec<Option<DBSlice<'_>>> {
+        assert!(col.is_rc());
+        let mut results = self.hot.pinned_multi_get_with_rc_stripped(col, keys);
+        if !col.is_cold() {
+            return results;
+        }
+        let cold_indices: Vec<usize> = results
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| if v.is_none() { Some(i) } else { None })
+            .collect();
+        if cold_indices.is_empty() {
+            return results;
+        }
+        let cold_keys: Vec<&[u8]> = cold_indices.iter().map(|&i| keys[i]).collect();
+        let cold_values = self.cold.pinned_multi_get_with_rc_stripped(col, &cold_keys);
+        for (i, cold_value) in cold_indices.into_iter().zip(cold_values.into_iter()) {
+            results[i] = cold_value;
+        }
+        results
+    }
+
     /// Iterate over all items in given column in lexicographical order sorted
     /// by the key.
     ///

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -3,17 +3,31 @@ use crate::adapter::{StoreAdapter, StoreUpdateAdapter};
 use crate::db::metadata::{DbKind, DbMetadata, DbVersion, KIND_KEY, VERSION_KEY};
 use crate::db::{DBIterator, DBOp, DBSlice, DBTransaction, Database, StoreStatistics, refcount};
 use crate::deserialized_column;
+use anyhow::Context as _;
 use borsh::{BorshDeserialize, BorshSerialize};
 use enum_map::EnumMap;
 use near_fmt::{AbbrBytes, StorageKey};
+use rocksdb::{DBCompressionType, Options as RocksDbOptions, SstFileWriter};
+use std::cmp::Ordering;
 use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::{fmt, io};
 use strum::IntoEnumIterator;
 
 const STATE_COLUMNS: [DBCol; 2] = [DBCol::State, DBCol::FlatState];
 const STATE_FILE_END_MARK: u8 = 255;
+
+/// Hard cap on the size of an SST file produced by [`Store::ingest_insert_only_sst`].
+/// If a single batch ever exceeds this size, the helper fails loudly instead of
+/// producing an oversized file.
+const MAX_SST_INGEST_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Process-wide monotonic counter used to disambiguate SST filenames produced by
+/// [`Store::ingest_insert_only_sst`]. Combined with the process id this makes
+/// filename collisions impossible without depending on system time.
+static SST_INGEST_FILE_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Node’s single storage source.
 ///
@@ -279,6 +293,90 @@ impl Store {
 
     pub fn get_store_statistics(&self) -> Option<StoreStatistics> {
         self.storage.get_store_statistics()
+    }
+
+    /// Bulk insert sorted, deduplicated `(key, value)` pairs into an insert-only column
+    /// via RocksDB SST file ingestion. Bypasses the memtable / WAL / L0 compaction path,
+    /// which is what makes this dramatically cheaper than per-key `insert()` for large
+    /// batches on archival storage.
+    ///
+    /// Caller invariants (asserted/checked):
+    /// - `col.is_insert_only()` — asserted; panics otherwise.
+    /// - `entries` are pre-sorted by key bytes and contain no duplicate keys — checked,
+    ///   returns an error if violated. (RocksDB's [`SstFileWriter::put`] requires both;
+    ///   we verify here so callers see a clear message instead of the underlying error.)
+    /// - `temp_dir` is on the same filesystem as the underlying database, so the
+    ///   `move_files=true` ingest below is a rename rather than a copy.
+    ///
+    /// Side effects:
+    /// - Creates `temp_dir` if it doesn't exist; the directory is owned by the caller.
+    /// - Writes a single SST file under `temp_dir`. On success the file is moved into
+    ///   the DB by the ingest call. On failure the file is removed so the caller can
+    ///   safely retry without leaking disk.
+    /// - Returns an error if the resulting SST file exceeds [`MAX_SST_INGEST_BYTES`];
+    ///   the operator's recourse is to reduce the caller's batch size.
+    pub fn ingest_insert_only_sst<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+        &self,
+        col: DBCol,
+        entries: &[(K, V)],
+        temp_dir: &Path,
+    ) -> anyhow::Result<()> {
+        assert!(
+            col.is_insert_only(),
+            "ingest_insert_only_sst requires insert-only column, got {col:?}"
+        );
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        for w in entries.windows(2) {
+            match w[0].0.as_ref().cmp(w[1].0.as_ref()) {
+                Ordering::Less => {}
+                Ordering::Equal => {
+                    anyhow::bail!("ingest_insert_only_sst: duplicate key in entries");
+                }
+                Ordering::Greater => {
+                    anyhow::bail!("ingest_insert_only_sst: entries not sorted");
+                }
+            }
+        }
+
+        std::fs::create_dir_all(temp_dir)
+            .with_context(|| format!("create SST temp dir {}", temp_dir.display()))?;
+
+        let seq = SST_INGEST_FILE_SEQ.fetch_add(1, AtomicOrdering::Relaxed);
+        let path = temp_dir.join(format!("ingest-{}-{}.sst", std::process::id(), seq));
+
+        let mut opts = RocksDbOptions::default();
+        opts.set_compression_type(DBCompressionType::Lz4);
+        let mut writer = SstFileWriter::create(&opts);
+        writer.open(&path).with_context(|| format!("open SST writer at {}", path.display()))?;
+        for (k, v) in entries {
+            writer.put(k.as_ref(), v.as_ref()).with_context(|| {
+                format!("write SST entry to {} for column {col:?}", path.display())
+            })?;
+        }
+        writer.finish().with_context(|| format!("finalize SST file at {}", path.display()))?;
+
+        let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        if file_size > MAX_SST_INGEST_BYTES {
+            let _ = std::fs::remove_file(&path);
+            anyhow::bail!(
+                "ingest_insert_only_sst: SST file size {file_size} exceeds cap {MAX_SST_INGEST_BYTES}; \
+                 reduce caller batch size",
+            );
+        }
+
+        // move_files=true asks RocksDB to rename the file into the DB on success. On
+        // failure it stays put, so we delete it ourselves to keep the temp dir clean
+        // and leave the caller free to retry.
+        if let Err(e) =
+            self.storage.ingest_external_sst_files(col, &[path.clone()], /*move_files=*/ true)
+        {
+            let _ = std::fs::remove_file(&path);
+            return Err(e);
+        }
+        Ok(())
     }
 }
 

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -140,6 +140,46 @@ impl Store {
         self.get(column, key).is_some()
     }
 
+    /// Fetches values for multiple keys in `column` via a single batched
+    /// backend call.
+    ///
+    /// `result[i]` corresponds to `keys[i]`; missing keys map to `None`.
+    /// For reference-counted columns, refcount stripping is applied so
+    /// tombstone cells (refcount ≤ 0) appear as `None` — mirroring scalar
+    /// [`Self::get`] semantics.  The RC vs non-RC dispatch happens at the
+    /// [`crate::db::Database`] trait level because [`crate::db::SplitDB`]
+    /// must fall through hot tombstones to cold real values, which a
+    /// raw-bytes-then-strip wrapper at this layer would break.
+    ///
+    /// Uses the single-CF backend path (`pinned_multi_get_*`). On RocksDB
+    /// this exploits `batched_multi_get_cf` and returns pinned slices
+    /// (zero-copy).
+    pub fn multi_get(&self, column: DBCol, keys: &[&[u8]]) -> Vec<Option<DBSlice<'_>>> {
+        let values = if column.is_rc() {
+            self.storage.pinned_multi_get_with_rc_stripped(column, keys)
+        } else {
+            self.storage.pinned_multi_get_raw_bytes(column, keys)
+        };
+        tracing::trace!(
+            target: "store",
+            db_op = "multi_get",
+            col = %column,
+            n = keys.len(),
+            present = values.iter().filter(|v| v.is_some()).count()
+        );
+        values
+    }
+
+    /// Multi-key existence check.  Returns a parallel `Vec<bool>` where
+    /// `result[i] == true` iff a value is present for `keys[i]`.
+    ///
+    /// For RC columns, tombstones (refcount ≤ 0) are correctly reported
+    /// as absent — implemented in terms of [`Self::multi_get`] which
+    /// already dispatches RC handling correctly.
+    pub fn multi_exists(&self, column: DBCol, keys: &[&[u8]]) -> Vec<bool> {
+        self.multi_get(column, keys).into_iter().map(|opt| opt.is_some()).collect()
+    }
+
     pub fn store_update(&self) -> StoreUpdate {
         StoreUpdate { transaction: DBTransaction::new(), store: self.clone() }
     }

--- a/core/store/tests/database_conformance.rs
+++ b/core/store/tests/database_conformance.rs
@@ -1,0 +1,366 @@
+//! Parametrised conformance suite for the new MultiGet trait surface.
+//!
+//! Goals:
+//!
+//! * Verify `Database::multi_get_raw_bytes`, `pinned_multi_get_raw_bytes`,
+//!   `multi_get_with_rc_stripped`, and `pinned_multi_get_with_rc_stripped`
+//!   return semantically the same results as the equivalent N scalar
+//!   `get_raw_bytes` / `get_with_rc_stripped` calls — for every backend.
+//!
+//! * Lock in two correctness gates:
+//!     - `Store::multi_exists` on an RC column returns `false` for cells
+//!       with refcount ≤ 0 (tombstones), matching scalar `Store::exists`.
+//!     - `SplitDB::multi_get_with_rc_stripped` correctly falls through
+//!       hot tombstones to cold real values; a hot-side cell with
+//!       refcount ≤ 0 must NOT shadow a real cold-side value.
+//!
+//! Backends covered: `TestDB`, `ColdDB(TestDB)`, `SplitDB(TestDB hot,
+//! ColdDB(TestDB) cold)`, `MixedDB(read=TestDB, write=TestDB)`,
+//! `RecoveryDB(ColdDB(TestDB))`.  Real-RocksDB-specific behaviour
+//! (pinned slices, large-batch ordering) is covered separately in
+//! `multi_get.rs`.
+
+use near_store::DBCol;
+use near_store::db::{
+    ColdDB, DBSlice, DBTransaction, Database, MixedDB, ReadOrder, RecoveryDB, SplitDB, TestDB,
+};
+use std::sync::Arc;
+
+// ---------- Test helpers ----------
+
+const NON_RC_COLD: DBCol = DBCol::Block; // cold-resident, non-RC
+const NON_RC_HOT: DBCol = DBCol::BlockMerkleTree; // hot-only, non-RC
+const RC_COLD: DBCol = DBCol::Transactions; // cold-resident, RC
+const RC_RECEIPTS: DBCol = DBCol::Receipts; // cold-resident, RC
+
+fn put_raw(db: &Arc<dyn Database>, col: DBCol, key: &[u8], value: &[u8]) {
+    let mut tx = DBTransaction::new();
+    tx.set(col, key.to_vec(), value.to_vec());
+    db.write(tx);
+}
+
+/// Write a raw bytes payload to an RC column with a refcount of `rc`
+/// appended. Uses `DBOp::Set` so we can synthesise tombstones (rc ≤ 0)
+/// directly — `UpdateRefcount` panics in debug builds for non-positive
+/// merged refcounts, which is the wrong shape for testing the stripping
+/// path.
+fn put_rc(db: &Arc<dyn Database>, col: DBCol, key: &[u8], payload: &[u8], rc: i64) {
+    let bytes: Vec<u8> = [payload, &rc.to_le_bytes()[..]].concat();
+    let mut tx = DBTransaction::new();
+    tx.set(col, key.to_vec(), bytes);
+    db.write(tx);
+}
+
+/// Construct a fresh TestDB-backed `Arc<dyn Database>`.
+fn make_testdb() -> Arc<dyn Database> {
+    TestDB::new()
+}
+
+/// Construct a fresh ColdDB(TestDB)-backed `Arc<dyn Database>`.
+fn make_colddb() -> Arc<dyn Database> {
+    Arc::new(ColdDB::new(TestDB::new()))
+}
+
+/// Construct a SplitDB given a freshly created hot and cold inner.  The
+/// caller writes to the inner backends directly via the returned tuple.
+fn make_splitdb() -> (Arc<dyn Database>, Arc<dyn Database>, Arc<dyn Database>) {
+    let hot = TestDB::new() as Arc<dyn Database>;
+    let cold_inner = TestDB::new() as Arc<dyn Database>;
+    let cold = Arc::new(ColdDB::new(cold_inner.clone())) as Arc<dyn Database>;
+    let split = SplitDB::new(hot.clone(), cold.clone()) as Arc<dyn Database>;
+    (hot, cold_inner, split)
+}
+
+fn make_mixeddb() -> Arc<dyn Database> {
+    let read_db = TestDB::new() as Arc<dyn Database>;
+    let write_db = TestDB::new() as Arc<dyn Database>;
+    MixedDB::new(read_db, write_db, ReadOrder::WriteDBFirst)
+}
+
+fn make_recoverydb() -> Arc<dyn Database> {
+    let cold = Arc::new(ColdDB::new(TestDB::new()));
+    Arc::new(RecoveryDB::new(cold))
+}
+
+fn assert_eq_payload(actual: &Option<DBSlice<'_>>, expected: Option<&[u8]>) {
+    match (actual, expected) {
+        (Some(a), Some(e)) => assert_eq!(a.as_slice(), e, "payload mismatch"),
+        (None, None) => {}
+        (a, e) => panic!("presence mismatch: actual={:?}, expected={:?}", a.is_some(), e.is_some()),
+    }
+}
+
+// ---------- Generic correctness invariants ----------
+
+/// `multi_get_raw_bytes` returns the same Option<bytes> per slot as N
+/// scalar `get_raw_bytes` calls — for every backend.
+fn check_multi_get_matches_scalar(db: &Arc<dyn Database>, col: DBCol, keys: &[&[u8]]) {
+    let multi = db.multi_get_raw_bytes(col, keys);
+    assert_eq!(multi.len(), keys.len(), "result length mismatch");
+    for (i, key) in keys.iter().enumerate() {
+        let scalar = db.get_raw_bytes(col, key);
+        assert_eq_payload(&multi[i], scalar.as_deref());
+    }
+}
+
+/// `pinned_multi_get_raw_bytes` returns the same Option<bytes> per slot
+/// as N scalar `get_raw_bytes` calls.
+fn check_batched_matches_scalar(db: &Arc<dyn Database>, col: DBCol, keys: &[&[u8]]) {
+    let multi = db.pinned_multi_get_raw_bytes(col, keys);
+    assert_eq!(multi.len(), keys.len(), "result length mismatch");
+    for (i, key) in keys.iter().enumerate() {
+        let scalar = db.get_raw_bytes(col, key);
+        assert_eq_payload(&multi[i], scalar.as_deref());
+    }
+}
+
+/// `multi_get_with_rc_stripped` returns the same Option<bytes> per slot
+/// as N scalar `get_with_rc_stripped` calls.  RC column required.
+fn check_rc_stripped_matches_scalar(db: &Arc<dyn Database>, col: DBCol, keys: &[&[u8]]) {
+    assert!(col.is_rc(), "must be RC column");
+    let multi = db.multi_get_with_rc_stripped(col, keys);
+    assert_eq!(multi.len(), keys.len(), "result length mismatch");
+    for (i, key) in keys.iter().enumerate() {
+        let scalar = db.get_with_rc_stripped(col, key);
+        assert_eq_payload(&multi[i], scalar.as_deref());
+    }
+    let batched = db.pinned_multi_get_with_rc_stripped(col, keys);
+    for (i, key) in keys.iter().enumerate() {
+        let scalar = db.get_with_rc_stripped(col, key);
+        assert_eq_payload(&batched[i], scalar.as_deref());
+    }
+}
+
+// ---------- Per-backend: generic invariants ----------
+
+#[test]
+fn testdb_multi_get_matches_scalar_non_rc() {
+    let db = make_testdb();
+    put_raw(&db, NON_RC_COLD, b"k1", b"v1");
+    put_raw(&db, NON_RC_COLD, b"k3", b"v3");
+    let keys: &[&[u8]] = &[b"k1", b"k2", b"k3", b""];
+    check_multi_get_matches_scalar(&db, NON_RC_COLD, keys);
+    check_batched_matches_scalar(&db, NON_RC_COLD, keys);
+}
+
+#[test]
+fn testdb_multi_get_with_rc_stripped_basic() {
+    let db = make_testdb();
+    put_rc(&db, RC_COLD, b"alive", b"hello", 1);
+    put_rc(&db, RC_COLD, b"alive2", b"world", 5);
+    let keys: &[&[u8]] = &[b"alive", b"alive2", b"missing"];
+    check_rc_stripped_matches_scalar(&db, RC_COLD, keys);
+
+    // Sanity: scalar returns the stripped payloads.
+    assert_eq!(db.get_with_rc_stripped(RC_COLD, b"alive").unwrap().as_slice(), b"hello");
+    assert_eq!(db.get_with_rc_stripped(RC_COLD, b"alive2").unwrap().as_slice(), b"world");
+}
+
+#[test]
+fn testdb_empty_keys_returns_empty_vec() {
+    let db = make_testdb();
+    put_raw(&db, NON_RC_COLD, b"k", b"v");
+    let empty: &[&[u8]] = &[];
+    assert!(db.multi_get_raw_bytes(NON_RC_COLD, empty).is_empty());
+    assert!(db.pinned_multi_get_raw_bytes(NON_RC_COLD, empty).is_empty());
+    assert!(db.multi_get_with_rc_stripped(RC_COLD, empty).is_empty());
+    assert!(db.pinned_multi_get_with_rc_stripped(RC_COLD, empty).is_empty());
+}
+
+#[test]
+fn testdb_ordering_preserved() {
+    let db = make_testdb();
+    put_raw(&db, NON_RC_COLD, b"a", b"A");
+    put_raw(&db, NON_RC_COLD, b"b", b"B");
+    put_raw(&db, NON_RC_COLD, b"c", b"C");
+    // Request keys in non-sorted order; result[i] must align with keys[i].
+    let keys: &[&[u8]] = &[b"c", b"a", b"missing", b"b"];
+    let result = db.multi_get_raw_bytes(NON_RC_COLD, keys);
+    assert_eq!(result.len(), 4);
+    assert_eq_payload(&result[0], Some(b"C"));
+    assert_eq_payload(&result[1], Some(b"A"));
+    assert_eq_payload(&result[2], None);
+    assert_eq_payload(&result[3], Some(b"B"));
+}
+
+#[test]
+fn colddb_multi_get_forwards_correctly() {
+    let db = make_colddb();
+    put_raw(&db, NON_RC_COLD, b"k1", b"v1");
+    put_rc(&db, RC_COLD, b"k2", b"v2", 1);
+    let non_rc_keys: &[&[u8]] = &[b"k1", b"missing"];
+    check_multi_get_matches_scalar(&db, NON_RC_COLD, non_rc_keys);
+    check_batched_matches_scalar(&db, NON_RC_COLD, non_rc_keys);
+    let rc_keys: &[&[u8]] = &[b"k2", b"missing"];
+    check_rc_stripped_matches_scalar(&db, RC_COLD, rc_keys);
+}
+
+#[test]
+fn mixeddb_multi_get_uses_default_impl_correctly() {
+    let db = make_mixeddb();
+    put_raw(&db, NON_RC_COLD, b"k1", b"v1");
+    let keys: &[&[u8]] = &[b"k1", b"missing"];
+    check_multi_get_matches_scalar(&db, NON_RC_COLD, keys);
+    check_batched_matches_scalar(&db, NON_RC_COLD, keys);
+}
+
+#[test]
+fn recoverydb_multi_get_uses_default_impl_correctly() {
+    let db = make_recoverydb();
+    // RecoveryDB is built around cold/state recovery; reads forward to
+    // ColdDB which forwards to TestDB.  Populate via direct write to the
+    // RecoveryDB (its `write` op is gated to State, but read works for
+    // any cold-resident column populated through the cold path).  For
+    // the conformance check we just verify multi_get matches scalar.
+    let keys: &[&[u8]] = &[b"any"];
+    check_multi_get_matches_scalar(&db, NON_RC_COLD, keys);
+    check_batched_matches_scalar(&db, NON_RC_COLD, keys);
+}
+
+// ---------- Tombstones in RC column → multi_get_with_rc_stripped returns None ----------
+
+#[test]
+fn multi_get_with_rc_stripped_treats_tombstone_as_absent() {
+    let db = make_testdb();
+    // Live cell: refcount = +1.
+    put_rc(&db, RC_COLD, b"live", b"alive_payload", 1);
+    // Tombstone: refcount = 0 (raw bytes still stored).
+    put_rc(&db, RC_COLD, b"tombstone_zero", b"stale_payload", 0);
+    // Tombstone: refcount = -2 (also tombstoned per refcount semantics).
+    put_rc(&db, RC_COLD, b"tombstone_neg", b"stale_payload", -2);
+    // Truly absent.
+    let keys: &[&[u8]] = &[b"live", b"tombstone_zero", b"tombstone_neg", b"absent"];
+
+    // Cross-check: scalar `get_raw_bytes` returns the tombstone bytes (refcount appended).
+    assert!(db.get_raw_bytes(RC_COLD, b"tombstone_zero").is_some());
+    assert!(db.get_raw_bytes(RC_COLD, b"tombstone_neg").is_some());
+
+    // The actual contract: rc-stripped multi-get treats tombstones as None.
+    let multi = db.multi_get_with_rc_stripped(RC_COLD, keys);
+    assert_eq_payload(&multi[0], Some(b"alive_payload"));
+    assert_eq_payload(&multi[1], None); // zero refcount → None
+    assert_eq_payload(&multi[2], None); // negative refcount → None
+    assert_eq_payload(&multi[3], None);
+
+    let batched = db.pinned_multi_get_with_rc_stripped(RC_COLD, keys);
+    assert_eq_payload(&batched[0], Some(b"alive_payload"));
+    assert_eq_payload(&batched[1], None);
+    assert_eq_payload(&batched[2], None);
+    assert_eq_payload(&batched[3], None);
+}
+
+#[test]
+fn store_multi_exists_returns_false_for_tombstone() {
+    let db = make_testdb();
+    put_rc(&db, RC_COLD, b"live", b"alive_payload", 1);
+    put_rc(&db, RC_COLD, b"tombstone", b"stale_payload", 0);
+
+    // Construct a Store wrapping the TestDB to exercise the public API the
+    // backfill actor uses.
+    let store = near_store::Store::new(db);
+
+    let keys: &[&[u8]] = &[b"live", b"tombstone", b"absent"];
+    let exists = store.multi_exists(RC_COLD, keys);
+    assert_eq!(exists, vec![true, false, false], "tombstone must report false");
+
+    // Sanity-check the multi_get path produces the same shape (Some/None aligned).
+    let multi = store.multi_get(RC_COLD, keys);
+    assert_eq_payload(&multi[0], Some(b"alive_payload"));
+    assert_eq_payload(&multi[1], None);
+    assert_eq_payload(&multi[2], None);
+}
+
+// ---------- SplitDB hot tombstone + cold real → cold real wins ----------
+
+#[test]
+fn splitdb_hot_tombstone_falls_through_to_cold_real() {
+    let (hot, cold_inner, split) = make_splitdb();
+
+    // Set up: hot has a tombstone (refcount 0), cold has a real value.
+    put_rc(&hot, RC_COLD, b"key", b"hot_stale", 0);
+    put_rc(&cold_inner, RC_COLD, b"key", b"cold_real", 1);
+
+    // Scalar `get_with_rc_stripped` already does this correctly per the
+    // existing SplitDB override; sanity-check before testing multi-get.
+    let scalar = split.get_with_rc_stripped(RC_COLD, b"key");
+    assert_eq!(scalar.unwrap().as_slice(), b"cold_real", "scalar fall-through must work");
+
+    // multi_get_with_rc_stripped must also fall through hot tombstones.
+    let multi = split.multi_get_with_rc_stripped(RC_COLD, &[b"key"]);
+    assert_eq_payload(&multi[0], Some(b"cold_real"));
+
+    let batched = split.pinned_multi_get_with_rc_stripped(RC_COLD, &[b"key"]);
+    assert_eq_payload(&batched[0], Some(b"cold_real"));
+}
+
+#[test]
+fn splitdb_hot_real_shadows_cold_real() {
+    let (hot, cold_inner, split) = make_splitdb();
+    put_rc(&hot, RC_COLD, b"key", b"hot_real", 1);
+    put_rc(&cold_inner, RC_COLD, b"key", b"cold_real", 1);
+
+    let multi = split.multi_get_with_rc_stripped(RC_COLD, &[b"key"]);
+    assert_eq_payload(&multi[0], Some(b"hot_real"));
+    let batched = split.pinned_multi_get_with_rc_stripped(RC_COLD, &[b"key"]);
+    assert_eq_payload(&batched[0], Some(b"hot_real"));
+}
+
+#[test]
+fn splitdb_hot_only_no_cold() {
+    let (hot, _cold_inner, split) = make_splitdb();
+    put_rc(&hot, RC_COLD, b"key", b"hot_real", 1);
+
+    let multi = split.multi_get_with_rc_stripped(RC_COLD, &[b"key", b"missing"]);
+    assert_eq_payload(&multi[0], Some(b"hot_real"));
+    assert_eq_payload(&multi[1], None);
+}
+
+#[test]
+fn splitdb_cold_only_no_hot() {
+    let (_hot, cold_inner, split) = make_splitdb();
+    put_rc(&cold_inner, RC_COLD, b"key", b"cold_real", 1);
+
+    let multi = split.multi_get_with_rc_stripped(RC_COLD, &[b"key", b"missing"]);
+    assert_eq_payload(&multi[0], Some(b"cold_real"));
+    assert_eq_payload(&multi[1], None);
+}
+
+#[test]
+fn splitdb_non_cold_column_does_not_consult_cold() {
+    let (hot, cold_inner, split) = make_splitdb();
+    // Non-cold column: only hot should be read, cold should be ignored even
+    // if it has data.  (Though writing to cold for a non-cold column via
+    // ColdDB would panic — so we skip that and just verify the read shape.)
+    put_raw(&hot, NON_RC_HOT, b"hot_key", b"hot_val");
+    let _ = cold_inner; // unused; non-cold column wouldn't legally have cold data
+
+    let multi = split.multi_get_raw_bytes(NON_RC_HOT, &[b"hot_key", b"missing"]);
+    assert_eq_payload(&multi[0], Some(b"hot_val"));
+    assert_eq_payload(&multi[1], None);
+}
+
+// ---------- Larger batch sanity (still TestDB) ----------
+
+#[test]
+fn large_batch_correctness_against_testdb() {
+    let db = make_testdb();
+    // Populate 100 RC entries.
+    for i in 0..100u32 {
+        let k = format!("key-{i:03}");
+        let v = format!("val-{i:03}");
+        put_rc(&db, RC_RECEIPTS, k.as_bytes(), v.as_bytes(), 1);
+    }
+    // Build a query of 200 keys: half present, half absent, randomly ordered.
+    let mut keys_owned: Vec<Vec<u8>> = Vec::with_capacity(200);
+    for i in 0..200u32 {
+        keys_owned.push(format!("key-{i:03}").into_bytes());
+    }
+    let keys: Vec<&[u8]> = keys_owned.iter().map(Vec::as_slice).collect();
+
+    let multi = db.multi_get_with_rc_stripped(RC_RECEIPTS, &keys);
+    assert_eq!(multi.len(), 200);
+    for (i, slot) in multi.iter().enumerate() {
+        let expected = if i < 100 { Some(format!("val-{i:03}").into_bytes()) } else { None };
+        assert_eq_payload(slot, expected.as_deref());
+    }
+}

--- a/core/store/tests/multi_get.rs
+++ b/core/store/tests/multi_get.rs
@@ -1,0 +1,211 @@
+//! Real-RocksDB tests for `Store::multi_get` and `Store::multi_exists`.
+//!
+//! The cross-backend correctness contract is covered by
+//! `database_conformance.rs`.  This file focuses on RocksDB-specific
+//! behaviour: large batches, mixed present/absent keys at scale, refcount
+//! handling in the actual RC merge path, ordering invariants under real
+//! LSM-level reads, and the pinned-slice path through
+//! `batched_multi_get_cf`.
+
+use near_store::{DBCol, NodeStorage, Store};
+use std::num::NonZeroU32;
+use tempfile::TempDir;
+
+const RC_COL: DBCol = DBCol::Receipts; // RC, cold-resident
+const NON_RC_COL: DBCol = DBCol::Block; // non-RC, cold-resident
+
+/// Open a fresh on-disk RocksDB-backed `Store`.  The `TempDir` must
+/// outlive the `Store`.
+fn fresh_rocksdb_store() -> (TempDir, Store) {
+    let (db_tmp, opener) = NodeStorage::test_opener();
+    let storage = opener.open().expect("open test store");
+    let store = storage.get_hot_store();
+    (db_tmp, store)
+}
+
+fn put_non_rc(store: &Store, col: DBCol, key: &[u8], value: &[u8]) {
+    let mut update = store.store_update();
+    // `Block` is an insert-only column, so use `insert` instead of `set`;
+    // `set` panics on insert-only columns at store.rs:546.
+    update.insert(col, key.to_vec(), value.to_vec());
+    update.commit();
+}
+
+fn put_rc(store: &Store, col: DBCol, key: &[u8], value: &[u8], rc: u32) {
+    let mut update = store.store_update();
+    update.increment_refcount_by(col, key, value, NonZeroU32::new(rc).expect("rc > 0"));
+    update.commit();
+}
+
+#[test]
+fn empty_keys_returns_empty_vec() {
+    let (_tmp, store) = fresh_rocksdb_store();
+    let empty: &[&[u8]] = &[];
+    assert!(store.multi_get(NON_RC_COL, empty).is_empty());
+    assert!(store.multi_get(RC_COL, empty).is_empty());
+    assert!(store.multi_exists(RC_COL, empty).is_empty());
+}
+
+#[test]
+fn small_batch_present_and_absent_aligned() {
+    let (_tmp, store) = fresh_rocksdb_store();
+    put_non_rc(&store, NON_RC_COL, &[1u8; 32], b"v1");
+    put_non_rc(&store, NON_RC_COL, &[3u8; 32], b"v3");
+
+    let key1 = [1u8; 32];
+    let key2 = [2u8; 32];
+    let key3 = [3u8; 32];
+    let keys: &[&[u8]] = &[&key1, &key2, &key3];
+    let results = store.multi_get(NON_RC_COL, keys);
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].as_deref(), Some(b"v1".as_ref()));
+    assert!(results[1].is_none(), "missing key must be None at the right index");
+    assert_eq!(results[2].as_deref(), Some(b"v3".as_ref()));
+}
+
+#[test]
+fn rc_column_strips_refcount() {
+    let (_tmp, store) = fresh_rocksdb_store();
+    let key = [42u8; 32];
+    put_rc(&store, RC_COL, &key, b"payload", 1);
+
+    let results = store.multi_get(RC_COL, &[&key]);
+    assert_eq!(results[0].as_deref(), Some(b"payload".as_ref()), "refcount must be stripped");
+
+    let exists = store.multi_exists(RC_COL, &[&key]);
+    assert_eq!(exists, vec![true]);
+}
+
+#[test]
+fn rc_column_decrement_then_lookup_returns_none() {
+    let (_tmp, store) = fresh_rocksdb_store();
+    let key = [7u8; 32];
+    put_rc(&store, RC_COL, &key, b"payload", 1);
+
+    // Decrement to refcount = 0.
+    let mut update = store.store_update();
+    update.decrement_refcount(RC_COL, &key);
+    update.commit();
+
+    let results = store.multi_get(RC_COL, &[&key]);
+    assert!(results[0].is_none(), "decremented-to-zero key must be absent under rc-stripping");
+    assert_eq!(store.multi_exists(RC_COL, &[&key]), vec![false]);
+}
+
+#[test]
+fn large_batch_ordering_preserved() {
+    let (_tmp, store) = fresh_rocksdb_store();
+    // 1000 entries with deterministic 32-byte keys.
+    let mut owned_keys: Vec<[u8; 32]> = Vec::with_capacity(1000);
+    for i in 0..1000u32 {
+        let mut k = [0u8; 32];
+        k[..4].copy_from_slice(&i.to_be_bytes());
+        owned_keys.push(k);
+        let v = format!("value-{i}");
+        put_non_rc(&store, NON_RC_COL, &k, v.as_bytes());
+    }
+
+    // Query in a non-sorted order: even keys first, then odd, plus 100 absent.
+    let mut query_owned: Vec<[u8; 32]> = Vec::new();
+    for i in (0..1000u32).step_by(2) {
+        let mut k = [0u8; 32];
+        k[..4].copy_from_slice(&i.to_be_bytes());
+        query_owned.push(k);
+    }
+    for i in (1..1000u32).step_by(2) {
+        let mut k = [0u8; 32];
+        k[..4].copy_from_slice(&i.to_be_bytes());
+        query_owned.push(k);
+    }
+    for i in 1000..1100u32 {
+        let mut k = [0u8; 32];
+        k[..4].copy_from_slice(&i.to_be_bytes());
+        query_owned.push(k);
+    }
+    let query: Vec<&[u8]> = query_owned.iter().map(|k| k.as_slice()).collect();
+
+    let results = store.multi_get(NON_RC_COL, &query);
+    assert_eq!(results.len(), query.len());
+
+    for (i, slot) in results.iter().enumerate() {
+        let expected = if i < 1000 {
+            // i < 500: even keys; i in [500, 1000): odd keys.
+            let key_idx = if i < 500 { (i * 2) as u32 } else { (((i - 500) * 2) + 1) as u32 };
+            Some(format!("value-{key_idx}"))
+        } else {
+            None
+        };
+        match (slot.as_deref(), expected.as_deref()) {
+            (Some(actual), Some(expected)) => {
+                assert_eq!(actual, expected.as_bytes(), "slot {i} mismatch")
+            }
+            (None, None) => {}
+            (a, e) => {
+                panic!(
+                    "slot {i} presence mismatch: actual={:?}, expected={:?}",
+                    a.is_some(),
+                    e.is_some()
+                )
+            }
+        }
+    }
+}
+
+#[test]
+fn batched_multi_get_returns_pinned_slices() {
+    // The trait surface returns `Vec<Option<DBSlice>>`; pinned vs Vec is
+    // an implementation detail.  Verify that a moderate-sized RC batch
+    // round-trips correctly through `batched_multi_get_cf` (the path that
+    // returns DBPinnableSlice and which `Store::multi_get` selects via
+    // `batched_multi_get_with_rc_stripped`).
+    let (_tmp, store) = fresh_rocksdb_store();
+    let mut owned_keys: Vec<[u8; 32]> = Vec::with_capacity(200);
+    for i in 0..200u32 {
+        let mut k = [0u8; 32];
+        k[..4].copy_from_slice(&i.to_be_bytes());
+        owned_keys.push(k);
+        let v = format!("rc-payload-{i}");
+        put_rc(&store, RC_COL, &k, v.as_bytes(), 1);
+    }
+    let query: Vec<&[u8]> = owned_keys.iter().map(|k| k.as_slice()).collect();
+    let results = store.multi_get(RC_COL, &query);
+    assert_eq!(results.len(), 200);
+    for (i, slot) in results.iter().enumerate() {
+        let expected = format!("rc-payload-{i}");
+        assert_eq!(slot.as_deref(), Some(expected.as_bytes()), "slot {i}");
+    }
+}
+
+#[test]
+fn multi_get_returns_same_as_scalar_get() {
+    let (_tmp, store) = fresh_rocksdb_store();
+    // Mix of present + missing in a non-trivial pattern.
+    for i in 0..50u32 {
+        if i % 3 != 0 {
+            let mut k = [0u8; 32];
+            k[..4].copy_from_slice(&i.to_be_bytes());
+            put_rc(&store, RC_COL, &k, format!("v{i}").as_bytes(), 1);
+        }
+    }
+    let mut query_owned: Vec<[u8; 32]> = Vec::new();
+    for i in 0..60u32 {
+        let mut k = [0u8; 32];
+        k[..4].copy_from_slice(&i.to_be_bytes());
+        query_owned.push(k);
+    }
+    let query: Vec<&[u8]> = query_owned.iter().map(|k| k.as_slice()).collect();
+
+    let multi = store.multi_get(RC_COL, &query);
+    for (i, key) in query.iter().enumerate() {
+        let scalar = store.get(RC_COL, key);
+        match (multi[i].as_deref(), scalar.as_deref()) {
+            (Some(a), Some(e)) => assert_eq!(a, e, "slot {i} value mismatch"),
+            (None, None) => {}
+            (a, e) => panic!(
+                "slot {i} presence mismatch: multi={:?} scalar={:?}",
+                a.is_some(),
+                e.is_some()
+            ),
+        }
+    }
+}

--- a/core/store/tests/sst_ingest.rs
+++ b/core/store/tests/sst_ingest.rs
@@ -1,0 +1,130 @@
+//! Unit tests for [`Store::ingest_insert_only_sst`] against a real RocksDB tempdir.
+//!
+//! Driven by the SST ingest plan: the in-memory `TestDB` does not support
+//! `ingest_external_sst_files`, so we exercise the helper directly here against
+//! a real on-disk RocksDB instance to cover all the documented invariants.
+
+use near_store::{DBCol, NodeStorage, Store};
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use tempfile::TempDir;
+
+/// Open a fresh on-disk RocksDB-backed `Store` and return it together with the
+/// `TempDir` that owns its files. The `TempDir` must outlive the `Store`.
+fn fresh_rocksdb_store() -> (TempDir, TempDir, Store) {
+    let (db_tmp, opener) = NodeStorage::test_opener();
+    let storage = opener.open().expect("open test store");
+    let store = storage.get_hot_store();
+    let sst_tmp = tempfile::tempdir().expect("create sst tempdir");
+    (db_tmp, sst_tmp, store)
+}
+
+#[test]
+fn empty_input_returns_ok_without_creating_a_file() {
+    let (_db_tmp, sst_tmp, store) = fresh_rocksdb_store();
+    let entries: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    store
+        .ingest_insert_only_sst(DBCol::ReceiptToTx, &entries, sst_tmp.path())
+        .expect("empty input should succeed");
+    let any_entries = std::fs::read_dir(sst_tmp.path()).map(|d| d.count()).unwrap_or(0);
+    assert_eq!(any_entries, 0, "no SST files should be created for empty input");
+}
+
+#[test]
+fn sorted_unique_entries_ingest_and_become_readable() {
+    let (_db_tmp, sst_tmp, store) = fresh_rocksdb_store();
+    let entries: Vec<(Vec<u8>, Vec<u8>)> =
+        (0u8..16).map(|i| (vec![i; 32], format!("value-{i}").into_bytes())).collect();
+    store
+        .ingest_insert_only_sst(DBCol::ReceiptToTx, &entries, sst_tmp.path())
+        .expect("ingest should succeed");
+
+    for (k, v) in &entries {
+        let got = store.get(DBCol::ReceiptToTx, k).expect("entry should be readable after ingest");
+        assert_eq!(&*got, v.as_slice());
+    }
+}
+
+#[test]
+fn non_sorted_entries_return_error() {
+    let (_db_tmp, sst_tmp, store) = fresh_rocksdb_store();
+    let entries: Vec<(Vec<u8>, Vec<u8>)> =
+        vec![(vec![2; 32], b"a".to_vec()), (vec![1; 32], b"b".to_vec())];
+    let err = store
+        .ingest_insert_only_sst(DBCol::ReceiptToTx, &entries, sst_tmp.path())
+        .expect_err("unsorted input must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("not sorted"), "error should mention sort order, got: {msg}");
+
+    let leftover = std::fs::read_dir(sst_tmp.path()).map(|d| d.count()).unwrap_or(0);
+    assert_eq!(leftover, 0, "no SST file should persist when entries are unsorted");
+}
+
+#[test]
+fn duplicate_keys_same_value_return_error() {
+    let (_db_tmp, sst_tmp, store) = fresh_rocksdb_store();
+    let entries: Vec<(Vec<u8>, Vec<u8>)> =
+        vec![(vec![1; 32], b"v".to_vec()), (vec![1; 32], b"v".to_vec())];
+    let err = store
+        .ingest_insert_only_sst(DBCol::ReceiptToTx, &entries, sst_tmp.path())
+        .expect_err("duplicate keys must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("duplicate key"), "error should mention duplicate, got: {msg}");
+}
+
+#[test]
+fn duplicate_keys_different_values_return_same_error() {
+    let (_db_tmp, sst_tmp, store) = fresh_rocksdb_store();
+    // The helper does not distinguish duplicate-with-different-values from
+    // duplicate-with-same-values; dedupe with value-equality is the caller's job.
+    let entries: Vec<(Vec<u8>, Vec<u8>)> =
+        vec![(vec![1; 32], b"a".to_vec()), (vec![1; 32], b"b".to_vec())];
+    let err = store
+        .ingest_insert_only_sst(DBCol::ReceiptToTx, &entries, sst_tmp.path())
+        .expect_err("duplicate keys must fail regardless of values");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("duplicate key"), "error should mention duplicate, got: {msg}");
+}
+
+#[test]
+fn entries_exceeding_size_cap_return_error_and_remove_file() {
+    let (_db_tmp, sst_tmp, store) = fresh_rocksdb_store();
+    // Build entries with genuinely random bytes so LZ4 cannot compress them
+    // below the 256 MB hard cap. Using a seeded ChaCha rng keeps the test
+    // deterministic; ChaCha output is statistically indistinguishable from
+    // random and therefore incompressible in practice.
+    let value_size: usize = 256 * 1024;
+    let total_target: usize = 320 * 1024 * 1024;
+    let count = total_target / value_size;
+    let mut rng = ChaCha8Rng::seed_from_u64(0xDEAD_BEEF_C0DE_F00D);
+    let mut entries: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(count);
+    for i in 0..count {
+        let mut key = vec![0u8; 32];
+        key[..8].copy_from_slice(&(i as u64).to_be_bytes());
+        let mut value = vec![0u8; value_size];
+        rng.fill_bytes(&mut value);
+        entries.push((key, value));
+    }
+
+    let err = store
+        .ingest_insert_only_sst(DBCol::ReceiptToTx, &entries, sst_tmp.path())
+        .expect_err("oversized batch should fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("exceeds cap"), "error should mention size cap, got: {msg}");
+
+    let mut leftover_sst = std::fs::read_dir(sst_tmp.path())
+        .expect("read sst tempdir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "sst"));
+    assert!(leftover_sst.next().is_none(), "oversized SST file should not persist");
+}
+
+#[test]
+#[should_panic(expected = "ingest_insert_only_sst requires insert-only column")]
+fn non_insert_only_column_panics() {
+    let (_db_tmp, sst_tmp, store) = fresh_rocksdb_store();
+    let entries: Vec<(Vec<u8>, Vec<u8>)> = vec![(vec![1; 8], b"v".to_vec())];
+    // BlockMisc is `set`-able; not an insert-only column.
+    let _ = store.ingest_insert_only_sst(DBCol::BlockMisc, &entries, sst_tmp.path());
+}

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -588,8 +588,24 @@ pub async fn start_with_config_and_synchronization_impl(
         && config.client_config.backfill_receipt_to_tx.enabled
     {
         if split_store.is_some() {
+            // Resolve the cold store path the same way `copy_block_headers_to_cold_db`
+            // does in `migrations.rs`. The SST staging directory must live on the
+            // cold store's filesystem so RocksDB can rename instead of copy when
+            // ingesting the file. The per-PID subdirectory makes ownership obvious
+            // — only this process writes there, so startup cleanup is safe.
+            let cold_store_path = home_dir.join(
+                config
+                    .config
+                    .cold_store
+                    .as_ref()
+                    .and_then(|c| c.path.as_deref())
+                    .unwrap_or_else(|| Path::new("cold-data")),
+            );
+            let sst_temp_dir = cold_store_path
+                .join("backfill-receipt-to-tx-sst")
+                .join(format!("pid-{}", std::process::id()));
             let _backfill_actor = actor_system.spawn_tokio_actor(BackfillReceiptToTxActor::new(
-                BackfillStorage::for_node(&storage),
+                BackfillStorage::for_node(&storage, Some(sst_temp_dir)),
                 config.client_config.save_trie_changes,
                 &chain_genesis,
                 config.client_config.backfill_receipt_to_tx.clone(),

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/actor.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/actor.rs
@@ -47,7 +47,7 @@ fn test_backward_backfill_matches_forward() {
     // Run forward backfill to get the reference entries.
     let forward_stats = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),
@@ -74,7 +74,7 @@ fn test_backward_backfill_matches_forward() {
     let heights: Vec<BlockHeight> = (genesis_height..=head_height).rev().collect();
     let backward_stats = process_one_batch(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         &pool,
         &heights,
         Some((BACKFILL_CHECKPOINT_KEY_LOW, genesis_height)),
@@ -143,7 +143,7 @@ fn test_backfill_actor_processes_heights() {
     let genesis = &env.shared_state.genesis;
     let chain_genesis = ChainGenesis::new(&genesis.config);
     let mut actor = BackfillReceiptToTxActor::new(
-        shared_storage(&store),
+        shared_storage(&store, None),
         true,
         &chain_genesis,
         BackfillReceiptToTxConfig {
@@ -199,7 +199,7 @@ fn test_backfill_actor_processes_heights() {
     let head_height = env.validator().head().height;
     let forward_stats = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),
@@ -279,7 +279,7 @@ fn test_actor_respects_start_height() {
     let genesis = &env.shared_state.genesis;
     let chain_genesis = ChainGenesis::new(&genesis.config);
     let mut actor = BackfillReceiptToTxActor::new(
-        shared_storage(&store),
+        shared_storage(&store, None),
         true,
         &chain_genesis,
         BackfillReceiptToTxConfig {
@@ -349,7 +349,7 @@ fn test_actor_rejects_invalid_start_height() {
 
     let make_actor = |start_height: BlockHeight| {
         BackfillReceiptToTxActor::new(
-            shared_storage(&store),
+            shared_storage(&store, None),
             true,
             &chain_genesis,
             BackfillReceiptToTxConfig {
@@ -423,7 +423,7 @@ fn test_sequential_forward_then_backward_converge() {
     // Phase 1: CLI forward backfill over [genesis, mid_height].
     backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         mid_height,
         &BackfillOptions { batch_size: 100, num_threads: 1, use_checkpoint: true },
@@ -435,7 +435,7 @@ fn test_sequential_forward_then_backward_converge() {
     let genesis = &env.shared_state.genesis;
     let chain_genesis = ChainGenesis::new(&genesis.config);
     let mut actor = BackfillReceiptToTxActor::new(
-        shared_storage(&store),
+        shared_storage(&store, None),
         true,
         &chain_genesis,
         BackfillReceiptToTxConfig {
@@ -472,7 +472,7 @@ fn test_sequential_forward_then_backward_converge() {
     }
     backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),
@@ -532,7 +532,7 @@ fn test_actor_resumes_from_checkpoint_after_restart() {
     // Phase 1: run a fresh actor for a few batches (partial progress).
     {
         let mut actor = BackfillReceiptToTxActor::new(
-            shared_storage(&store),
+            shared_storage(&store, None),
             true,
             &chain_genesis,
             BackfillReceiptToTxConfig {
@@ -574,7 +574,7 @@ fn test_actor_resumes_from_checkpoint_after_restart() {
     // Phase 2: create a fresh actor and drive to completion.
     {
         let mut actor = BackfillReceiptToTxActor::new(
-            shared_storage(&store),
+            shared_storage(&store, None),
             true,
             &chain_genesis,
             BackfillReceiptToTxConfig {
@@ -620,7 +620,7 @@ fn test_actor_resumes_from_checkpoint_after_restart() {
 
     let forward_stats = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/actor.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/actor.rs
@@ -425,7 +425,7 @@ fn test_sequential_forward_then_backward_converge() {
     let head_height = env.validator().head().height;
     let mid_height = genesis_height + (head_height - genesis_height) / 2;
 
-    // Phase 1: CLI forward backfill over [genesis, mid_height].
+    // First: CLI forward backfill over [genesis, mid_height].
     backfill_receipt_to_tx(
         chain_store,
         &shared_storage(&store, None),
@@ -436,7 +436,7 @@ fn test_sequential_forward_then_backward_converge() {
     )
     .expect("forward CLI backfill should succeed");
 
-    // Phase 2: actor backward backfill from head down — overlaps phase 1 in [genesis, mid_height].
+    // Then: actor backward backfill from head down — overlaps the forward run in [genesis, mid_height].
     let genesis = &env.shared_state.genesis;
     let chain_genesis = ChainGenesis::new(&genesis.config);
     let mut actor = BackfillReceiptToTxActor::new(
@@ -534,7 +534,7 @@ fn test_actor_resumes_from_checkpoint_after_restart() {
     let genesis = &env.shared_state.genesis;
     let chain_genesis = ChainGenesis::new(&genesis.config);
 
-    // Phase 1: run a fresh actor for a few batches (partial progress).
+    // First: run a fresh actor for a few batches (partial progress).
     {
         let mut actor = BackfillReceiptToTxActor::new(
             shared_storage(&store, None),
@@ -566,17 +566,17 @@ fn test_actor_resumes_from_checkpoint_after_restart() {
     }
     // Actor is dropped; checkpoint persists in the store.
 
-    let checkpoint_after_phase1 = store
+    let checkpoint_after_partial = store
         .get_ser::<BlockHeight>(DBCol::Misc, BACKFILL_CHECKPOINT_KEY_LOW)
         .expect("checkpoint should exist after partial run");
     assert!(
-        checkpoint_after_phase1 > genesis_height,
+        checkpoint_after_partial > genesis_height,
         "checkpoint should be above genesis after partial run"
     );
     let partial_entry_count = store.iter(DBCol::ReceiptToTx).count();
     assert!(partial_entry_count > 0, "should have written some entries in partial run");
 
-    // Phase 2: create a fresh actor and drive to completion.
+    // Then: create a fresh actor and drive to completion.
     {
         let mut actor = BackfillReceiptToTxActor::new(
             shared_storage(&store, None),
@@ -935,4 +935,159 @@ fn test_sst_path_handles_cross_batch_value_divergence() {
             );
         }
     }
+}
+
+/// Byte-equivalence between the MultiGet `process_height` and a scalar
+/// reference implementation. The reference walks the same chain state with
+/// per-key Gets (the shape `process_height` collapses into batched calls).
+/// For the same chain state, both implementations must produce identical
+/// `(receipt_id, ReceiptToTxInfo)` entries — drift here would silently
+/// corrupt `ReceiptToTx` data on archival nodes.
+///
+/// The scalar reference is intentionally verbose and parallel to the
+/// per-key shape so future readers can spot divergence at the call-site
+/// level.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_multi_get_path_matches_scalar_reference() {
+    use near_chain::ChainStoreAccess;
+    use near_primitives::receipt::{ReceiptOriginReceipt, ReceiptOriginTransaction};
+    use near_primitives::utils::get_block_shard_id_rev;
+
+    init_test_logger();
+
+    let user_account = create_account_id("account0");
+    let receiver_account = create_account_id("account1");
+
+    let mut env = TestLoopBuilder::new()
+        .add_user_account(&user_account, Balance::from_near(1_000_000))
+        .add_user_account(&receiver_account, Balance::from_near(1_000_000))
+        .epoch_length(EPOCH_LENGTH)
+        .config_modifier(|config, _| {
+            config.save_receipt_to_tx = false;
+        })
+        .gc_num_epochs_to_keep(20)
+        .build();
+
+    generate_diverse_traffic(&mut env);
+
+    let chain_store = env.validator().client().chain.chain_store();
+    let genesis_height = chain_store.get_genesis_height();
+    let head_height = env.validator().head().height;
+
+    /// Scalar reference implementation — mirrors the pre-Phase-1 shape of
+    /// `process_height` exactly.  Returns the same `(receipt_id, info)`
+    /// list the new MultiGet code is expected to produce.
+    fn scalar_reference_process_height(
+        chain_store: &near_chain::ChainStore,
+        height: BlockHeight,
+    ) -> Vec<(CryptoHash, ReceiptToTxInfo)> {
+        let block_hash = match chain_store.get_block_hash_by_height(height) {
+            Ok(hash) => hash,
+            Err(_) => return Vec::new(),
+        };
+        let read_store = chain_store.store();
+        let mut entries = Vec::new();
+        for (key, outcome_ids) in
+            read_store.iter_prefix_ser::<Vec<CryptoHash>>(DBCol::OutcomeIds, block_hash.as_ref())
+        {
+            let (_, shard_id) = get_block_shard_id_rev(&key).expect("invalid OutcomeIds key");
+            for outcome_id in outcome_ids {
+                let outcome_with_proof =
+                    match chain_store.get_outcome_by_id_and_block_hash(&outcome_id, &block_hash) {
+                        Some(o) => o,
+                        None => continue,
+                    };
+                let outcome = &outcome_with_proof.outcome;
+                if outcome.receipt_ids.is_empty() {
+                    continue;
+                }
+                let is_tx = read_store.exists(DBCol::Transactions, outcome_id.as_ref());
+                let parent_receipt =
+                    if !is_tx { chain_store.get_receipt(&outcome_id) } else { None };
+                for child_receipt_id in &outcome.receipt_ids {
+                    let child_receipt = match chain_store.get_receipt(child_receipt_id) {
+                        Some(r) => r,
+                        None => continue,
+                    };
+                    let info = if is_tx {
+                        ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+                            origin: ReceiptOrigin::FromTransaction(ReceiptOriginTransaction {
+                                tx_hash: outcome_id,
+                                sender_account_id: outcome.executor_id.clone(),
+                            }),
+                            receiver_account_id: child_receipt.receiver_id().clone(),
+                            shard_id,
+                        })
+                    } else {
+                        let parent = match &parent_receipt {
+                            Some(r) => r,
+                            None => continue,
+                        };
+                        ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+                            origin: ReceiptOrigin::FromReceipt(ReceiptOriginReceipt {
+                                parent_receipt_id: outcome_id,
+                                parent_predecessor_id: parent.predecessor_id().clone(),
+                            }),
+                            receiver_account_id: child_receipt.receiver_id().clone(),
+                            shard_id,
+                        })
+                    };
+                    entries.push((*child_receipt_id, info));
+                }
+            }
+        }
+        entries
+    }
+
+    // Walk every height; collect the entry set produced by each path.
+    let mut multi_get_total: Vec<(CryptoHash, ReceiptToTxInfo)> = Vec::new();
+    let mut scalar_total: Vec<(CryptoHash, ReceiptToTxInfo)> = Vec::new();
+    let mut heights_with_entries = 0usize;
+    for h in genesis_height..=head_height {
+        if let Some(result) =
+            process_height(chain_store, h).expect("process_height should not error on test chain")
+        {
+            if !result.entries.is_empty() {
+                heights_with_entries += 1;
+            }
+            multi_get_total.extend(result.entries);
+        }
+        scalar_total.extend(scalar_reference_process_height(chain_store, h));
+    }
+
+    assert!(
+        heights_with_entries > 0,
+        "diverse traffic must produce at least one ReceiptToTx entry"
+    );
+
+    // Sort both by receipt_id to make the comparison order-independent
+    // (the assembly loops walk in slightly different orders by construction).
+    let key = |e: &(CryptoHash, ReceiptToTxInfo)| e.0;
+    multi_get_total.sort_by_key(key);
+    scalar_total.sort_by_key(key);
+
+    // Compare via Borsh-serialised bytes — same equality semantics as the
+    // SST-vs-legacy test (`ReceiptToTxInfo` is `BorshSerialize`).
+    let to_bytes = |entries: &[(CryptoHash, ReceiptToTxInfo)]| {
+        entries
+            .iter()
+            .map(|(k, v)| {
+                let v = borsh::to_vec(v).expect("serialize ReceiptToTxInfo");
+                (*k, v)
+            })
+            .collect::<Vec<(CryptoHash, Vec<u8>)>>()
+    };
+    let multi_bytes = to_bytes(&multi_get_total);
+    let scalar_bytes = to_bytes(&scalar_total);
+
+    assert_eq!(
+        multi_bytes.len(),
+        scalar_bytes.len(),
+        "MultiGet and scalar paths must produce the same number of entries",
+    );
+    assert_eq!(
+        multi_bytes, scalar_bytes,
+        "MultiGet `process_height` must produce byte-identical entries to the scalar reference",
+    );
 }

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/actor.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/actor.rs
@@ -4,15 +4,20 @@ use crate::utils::account::create_account_id;
 use near_async::time::Duration;
 use near_chain::ChainGenesis;
 use near_chain::backfill_receipt_to_tx::{
-    BACKFILL_CHECKPOINT_KEY, BACKFILL_CHECKPOINT_KEY_LOW, process_height, process_one_batch,
+    BACKFILL_CHECKPOINT_KEY, BACKFILL_CHECKPOINT_KEY_LOW, BackfillStorage, process_height,
+    process_one_batch,
 };
 use near_chain_configs::BackfillReceiptToTxConfig;
 use near_client::backfill_receipt_to_tx_actor::BackfillReceiptToTxActor;
 use near_database_tool::backfill_receipt_to_tx::{BackfillOptions, backfill_receipt_to_tx};
 use near_o11y::testonly::init_test_logger;
-use near_primitives::receipt::ReceiptToTxInfo;
-use near_primitives::types::{Balance, BlockHeight};
-use near_store::DBCol;
+use near_primitives::hash::CryptoHash;
+use near_primitives::receipt::{
+    ReceiptOrigin, ReceiptOriginTransaction, ReceiptToTxInfo, ReceiptToTxInfoV1,
+};
+use near_primitives::types::{AccountId, Balance, BlockHeight, ShardId};
+use near_store::test_utils::create_test_store;
+use near_store::{DBCol, NodeStorage, Store};
 
 /// Background actor backfills in descending order using BACKFILL_CHECKPOINT_KEY_LOW.
 ///
@@ -644,5 +649,290 @@ fn test_actor_resumes_from_checkpoint_after_restart() {
             "restart-resume entry should match forward for key {:?}",
             key
         );
+    }
+}
+
+/// Open a fresh on-disk RocksDB-backed `Store` for use as a `write_store`.
+///
+/// The returned `tempfile::TempDir` must outlive the `Store`; both are bound
+/// in the caller's scope.
+fn fresh_rocksdb_write_store() -> (tempfile::TempDir, Store) {
+    let (tmp, opener) = NodeStorage::test_opener();
+    let storage = opener.open().expect("open test rocksdb store");
+    (tmp, storage.get_hot_store())
+}
+
+/// SST and legacy write paths produce byte-identical `ReceiptToTx` content.
+///
+/// Drives the same forward CLI backfill twice over the same chain data, with
+/// only the `sst_temp_dir` field of `BackfillStorage` differing. Both runs
+/// land in independent real-RocksDB write stores; iteration over `ReceiptToTx`
+/// must be identical, key-for-key and value-for-value.
+///
+/// Catches: SST sort/dedup/ingest mechanics, borsh-serialization equivalence
+/// between `insert_ser` (legacy) and `borsh::to_vec(&info)` (SST path),
+/// multi-batch SST behavior, and checkpoint correctness in the SST mode.
+///
+/// Does NOT exercise cross-batch overlap with already-stored keys — that path
+/// is explicitly out of the production assumption documented on
+/// `process_one_batch`. Test 2 covers a separate divergent-value scenario
+/// without depending on overlap correctness.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_sst_path_matches_legacy_forward_only() {
+    init_test_logger();
+
+    let user_account = create_account_id("account0");
+    let receiver_account = create_account_id("account1");
+
+    let mut env = TestLoopBuilder::new()
+        .add_user_account(&user_account, Balance::from_near(1_000_000))
+        .add_user_account(&receiver_account, Balance::from_near(1_000_000))
+        .epoch_length(EPOCH_LENGTH)
+        .config_modifier(|config, _| {
+            config.save_receipt_to_tx = false;
+        })
+        .gc_num_epochs_to_keep(20)
+        .build();
+
+    generate_diverse_traffic(&mut env);
+
+    let read_store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+    let genesis_height = chain_store.get_genesis_height();
+    let head_height = env.validator().head().height;
+
+    // Two independent RocksDB write stores. Bind both TempDirs to outer scope.
+    let (_sst_db_tmp, sst_write_store) = fresh_rocksdb_write_store();
+    let (_legacy_db_tmp, legacy_write_store) = fresh_rocksdb_write_store();
+    let sst_temp_dir = tempfile::tempdir().expect("create sst staging dir");
+
+    let sst_storage = BackfillStorage {
+        read_store: read_store.clone(),
+        write_store: sst_write_store.clone(),
+        checkpoint_store: create_test_store(),
+        sst_temp_dir: Some(sst_temp_dir.path().to_path_buf()),
+    };
+    let legacy_storage = BackfillStorage {
+        read_store,
+        write_store: legacy_write_store.clone(),
+        checkpoint_store: create_test_store(),
+        sst_temp_dir: None,
+    };
+
+    let options = BackfillOptions { batch_size: 100, num_threads: 1, use_checkpoint: true };
+
+    let sst_stats = backfill_receipt_to_tx(
+        chain_store,
+        &sst_storage,
+        genesis_height,
+        head_height,
+        &options,
+        None,
+    )
+    .expect("SST forward backfill should succeed");
+    let legacy_stats = backfill_receipt_to_tx(
+        chain_store,
+        &legacy_storage,
+        genesis_height,
+        head_height,
+        &options,
+        None,
+    )
+    .expect("legacy forward backfill should succeed");
+
+    assert_eq!(sst_stats.entries_written, legacy_stats.entries_written, "entry counts must match",);
+
+    // Both stores are RocksDB-backed, so iteration is sorted-by-key. Direct
+    // Vec equality is sufficient: same key set, same value bytes, same order.
+    let sst_entries: Vec<(Box<[u8]>, Box<[u8]>)> =
+        sst_write_store.iter(DBCol::ReceiptToTx).collect();
+    let legacy_entries: Vec<(Box<[u8]>, Box<[u8]>)> =
+        legacy_write_store.iter(DBCol::ReceiptToTx).collect();
+    assert!(!sst_entries.is_empty(), "diverse traffic must produce entries");
+    assert_eq!(sst_entries, legacy_entries, "SST output must be byte-identical to legacy output",);
+
+    // Checkpoint state must agree on the highest-completed height.
+    let sst_checkpoint = sst_storage
+        .checkpoint_store
+        .get_ser::<BlockHeight>(DBCol::Misc, BACKFILL_CHECKPOINT_KEY)
+        .expect("SST checkpoint must exist");
+    let legacy_checkpoint = legacy_storage
+        .checkpoint_store
+        .get_ser::<BlockHeight>(DBCol::Misc, BACKFILL_CHECKPOINT_KEY)
+        .expect("legacy checkpoint must exist");
+    assert_eq!(sst_checkpoint, legacy_checkpoint, "checkpoint heights must match");
+    assert_eq!(sst_checkpoint, head_height, "checkpoint must reach head");
+}
+
+/// Locks in cross-batch divergent-value behavior of the SST path.
+///
+/// A pre-existing `(K, V1)` is planted directly in `write_store` via
+/// `set_raw_bytes` (bypassing the insert-only assertion). A single backfill
+/// run then produces `(K, V2 != V1)`, simulating an unreachable-in-production
+/// scenario the plan flags for explicit coverage.
+///
+/// Locked-in behavior on this scenario:
+///
+/// - SST path: silently overwrites V1 with V2. RocksDB's
+///   `allow_global_seqno=true` (set in `Database::ingest_external_sst_files`)
+///   makes the newly-ingested row visible in preference to the planted row.
+/// - Legacy path in **debug** builds: panics with "write once column
+///   overwritten" because `core/store/src/db/rocksdb.rs:354-358` runs
+///   `assert_no_overwrite` only behind `cfg!(debug_assertions)`.
+/// - Legacy path in **release** builds: silently overwrites V1 with V2,
+///   matching the SST path.
+///
+/// Catching the divergence in debug is the point. If a future change makes
+/// the SST path's behavior diverge from this contract — whether by adding a
+/// guard, dropping the seqno-based ingest, or changing the dedup loop — this
+/// test fails and the divergence is forced to the surface rather than
+/// drifting silently.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_sst_path_handles_cross_batch_value_divergence() {
+    init_test_logger();
+
+    let user_account = create_account_id("account0");
+    let receiver_account = create_account_id("account1");
+
+    let mut env = TestLoopBuilder::new()
+        .add_user_account(&user_account, Balance::from_near(1_000_000))
+        .add_user_account(&receiver_account, Balance::from_near(1_000_000))
+        .epoch_length(EPOCH_LENGTH)
+        .config_modifier(|config, _| {
+            config.save_receipt_to_tx = false;
+        })
+        .gc_num_epochs_to_keep(20)
+        .build();
+
+    generate_diverse_traffic(&mut env);
+
+    let read_store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+    let genesis_height = chain_store.get_genesis_height();
+    let head_height = env.validator().head().height;
+
+    // Pick a real receipt id the backfill will produce by running it once
+    // against a scratch store. The pre-existing-key scenario we want requires
+    // a key the run will actually try to write.
+    let scratch_store = create_test_store();
+    let scratch_storage = BackfillStorage {
+        read_store: read_store.clone(),
+        write_store: scratch_store.clone(),
+        checkpoint_store: create_test_store(),
+        sst_temp_dir: None,
+    };
+    backfill_receipt_to_tx(
+        chain_store,
+        &scratch_storage,
+        genesis_height,
+        head_height,
+        &BackfillOptions { batch_size: 1000, num_threads: 1, use_checkpoint: false },
+        None,
+    )
+    .expect("scratch forward backfill should succeed");
+    let (real_key_bytes, real_v_bytes): (Box<[u8]>, Box<[u8]>) = scratch_store
+        .iter(DBCol::ReceiptToTx)
+        .next()
+        .expect("scratch backfill must produce at least one entry");
+    let real_key = CryptoHash::try_from(real_key_bytes.as_ref()).expect("32-byte key");
+
+    // Hand-built V1 byte-distinct from anything the chain produces. Writing
+    // `set_raw_bytes` rather than `insert` is intentional: it bypasses the
+    // insert-only assertion so we can plant stale state for the run to clobber.
+    let synthetic_v1 = ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+        origin: ReceiptOrigin::FromTransaction(ReceiptOriginTransaction {
+            tx_hash: CryptoHash::default(),
+            sender_account_id: "synthetic-sender.test.near".parse::<AccountId>().unwrap(),
+        }),
+        receiver_account_id: "synthetic-receiver.test.near".parse::<AccountId>().unwrap(),
+        shard_id: ShardId::new(0),
+    });
+    let synthetic_v1_bytes = borsh::to_vec(&synthetic_v1).expect("borsh serialize V1");
+    assert_ne!(synthetic_v1_bytes, real_v_bytes.as_ref(), "V1 must differ from V2");
+
+    // Helper: build a fresh RocksDB write_store with V1 planted at real_key,
+    // then run forward backfill in either SST or legacy mode.
+    let run_backfill = |sst_temp_dir: Option<std::path::PathBuf>| -> (tempfile::TempDir, Store) {
+        let (db_tmp, write_store) = fresh_rocksdb_write_store();
+        {
+            let mut update = write_store.store_update();
+            update.set_raw_bytes(DBCol::ReceiptToTx, real_key.as_ref(), &synthetic_v1_bytes);
+            update.commit();
+        }
+        let pre: Vec<u8> = write_store
+            .get(DBCol::ReceiptToTx, real_key.as_ref())
+            .expect("V1 planted")
+            .as_ref()
+            .to_vec();
+        assert_eq!(pre.as_slice(), synthetic_v1_bytes.as_slice(), "V1 must be visible pre-run");
+
+        let storage = BackfillStorage {
+            read_store: read_store.clone(),
+            write_store: write_store.clone(),
+            checkpoint_store: create_test_store(),
+            sst_temp_dir,
+        };
+        backfill_receipt_to_tx(
+            chain_store,
+            &storage,
+            genesis_height,
+            head_height,
+            &BackfillOptions { batch_size: 100, num_threads: 1, use_checkpoint: true },
+            None,
+        )
+        .expect("backfill should succeed despite pre-existing key");
+        (db_tmp, write_store)
+    };
+
+    // SST path: must silently overwrite V1 → V2. The seqno semantics of
+    // `ingest_external_sst_files` make the newer entry shadow the older one.
+    let sst_temp_dir = tempfile::tempdir().expect("create sst staging dir");
+    let (_sst_db_tmp, sst_store) = run_backfill(Some(sst_temp_dir.path().to_path_buf()));
+    let sst_observed: Vec<u8> = sst_store
+        .get(DBCol::ReceiptToTx, real_key.as_ref())
+        .expect("SST run leaves a value at the key")
+        .as_ref()
+        .to_vec();
+    assert_eq!(
+        sst_observed,
+        real_v_bytes.as_ref(),
+        "SST path must silently overwrite V1 with V2 (RocksDB seqno semantics)",
+    );
+
+    // Legacy path: panics in debug, silent overwrite in release. Capture the
+    // panic via catch_unwind in debug; assert equivalence with SST in release.
+    let legacy_result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_backfill(None)));
+    match legacy_result {
+        Err(panic_payload) => {
+            assert!(cfg!(debug_assertions), "legacy path panicked unexpectedly in release build",);
+            // The panic message comes from `core/store/src/db/mod.rs::assert_no_overwrite`.
+            let msg = panic_payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| panic_payload.downcast_ref::<&'static str>().copied())
+                .unwrap_or("");
+            assert!(
+                msg.contains("write once column overwritten"),
+                "expected assert_no_overwrite panic, got: {msg:?}",
+            );
+        }
+        Ok((_legacy_db_tmp, legacy_store)) => {
+            assert!(
+                !cfg!(debug_assertions),
+                "legacy path must panic in debug builds on cross-batch divergent value",
+            );
+            let legacy_observed: Vec<u8> = legacy_store
+                .get(DBCol::ReceiptToTx, real_key.as_ref())
+                .expect("legacy run leaves a value at the key")
+                .as_ref()
+                .to_vec();
+            assert_eq!(
+                legacy_observed, sst_observed,
+                "in release, SST and legacy must agree on the final value",
+            );
+        }
     }
 }

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/cli.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/cli.rs
@@ -332,7 +332,7 @@ fn test_checkpoint_resume_after_partial_completion() {
     let options_with_checkpoint =
         BackfillOptions { batch_size: 1000, num_threads: 1, use_checkpoint: true };
 
-    // Phase 1: backfill only the first half.
+    // First: backfill only the first half.
     let stats1 = backfill_receipt_to_tx(
         chain_store,
         &shared_storage(&store, None),
@@ -350,7 +350,7 @@ fn test_checkpoint_resume_after_partial_completion() {
 
     let entries_after_first_half = store.iter(DBCol::ReceiptToTx).count();
 
-    // Phase 2: resume from checkpoint+1 to head.
+    // Then: resume from checkpoint+1 to head.
     let stats2 = backfill_receipt_to_tx(
         chain_store,
         &shared_storage(&store, None),

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/cli.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/cli.rs
@@ -80,7 +80,7 @@ fn test_backfill_matches_normal_processing() {
 
     let stats = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),
@@ -151,7 +151,7 @@ fn test_backfill_idempotent() {
     // Run backfill once.
     let stats1 = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),
@@ -168,7 +168,7 @@ fn test_backfill_idempotent() {
     // Run backfill again (idempotent).
     let stats2 = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),
@@ -241,7 +241,7 @@ fn test_checkpoint_does_not_skip_mid_height_receipts() {
     let options = BackfillOptions { batch_size: 1, num_threads: 1, use_checkpoint: true };
     let stats = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &options,
@@ -265,7 +265,7 @@ fn test_checkpoint_does_not_skip_mid_height_receipts() {
     // this height is done" — no receipts were skipped mid-height.
     let stats2 = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         checkpoint_value + 1,
         head_height,
         &options,
@@ -335,7 +335,7 @@ fn test_checkpoint_resume_after_partial_completion() {
     // Phase 1: backfill only the first half.
     let stats1 = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         mid_height,
         &options_with_checkpoint,
@@ -353,7 +353,7 @@ fn test_checkpoint_resume_after_partial_completion() {
     // Phase 2: resume from checkpoint+1 to head.
     let stats2 = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         checkpoint + 1,
         head_height,
         &options_with_checkpoint,
@@ -387,7 +387,7 @@ fn test_checkpoint_resume_after_partial_completion() {
 
     let stats_full = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),
@@ -440,6 +440,7 @@ fn test_split_storage_wiring() {
         read_store: read_store.clone(),
         write_store: write_store.clone(),
         checkpoint_store: checkpoint_store.clone(),
+        sst_temp_dir: None,
     };
 
     let chain_store = env.validator().client().chain.chain_store();
@@ -541,7 +542,7 @@ fn test_crash_between_entries_and_checkpoint_replay() {
     let partial_heights: Vec<BlockHeight> = (genesis_height..=mid_height).collect();
     let partial_stats = process_one_batch(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         &pool,
         &partial_heights,
         Some((BACKFILL_CHECKPOINT_KEY, mid_height)),
@@ -563,7 +564,7 @@ fn test_crash_between_entries_and_checkpoint_replay() {
     // Replay from genesis — no checkpoint present — covers the same heights and then some.
     let replay_stats = backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &BackfillOptions { batch_size: 100, num_threads: 1, use_checkpoint: true },
@@ -588,7 +589,7 @@ fn test_crash_between_entries_and_checkpoint_replay() {
     }
     backfill_receipt_to_tx(
         chain_store,
-        &shared_storage(&store),
+        &shared_storage(&store, None),
         genesis_height,
         head_height,
         &default_options(),

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/common.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/common.rs
@@ -7,6 +7,7 @@ use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{Balance, Gas};
 use near_store::Store;
+use std::path::PathBuf;
 
 pub(super) const EPOCH_LENGTH: u64 = 5;
 
@@ -16,11 +17,20 @@ pub(super) fn default_options() -> BackfillOptions {
 
 /// Build a `BackfillStorage` where all three roles share the same underlying store.
 /// Useful for non-split-storage tests.
-pub(super) fn shared_storage(store: &Store) -> BackfillStorage {
+///
+/// `sst_temp_dir` is required (no implicit default) so each test makes an explicit
+/// choice about which write path it exercises. Tests on the in-memory test store
+/// must pass `None` because that store does not implement
+/// `Database::ingest_external_sst_files`; the SST path is exercised end-to-end by
+/// the unit tests in `core/store/tests/sst_ingest.rs` against a real RocksDB
+/// tempdir, so the actor tests verifying the `process_one_batch` glue stay on the
+/// legacy `insert + commit` path.
+pub(super) fn shared_storage(store: &Store, sst_temp_dir: Option<PathBuf>) -> BackfillStorage {
     BackfillStorage {
         read_store: store.clone(),
         write_store: store.clone(),
         checkpoint_store: store.clone(),
+        sst_temp_dir,
     }
 }
 

--- a/tools/database/src/backfill_receipt_to_tx.rs
+++ b/tools/database/src/backfill_receipt_to_tx.rs
@@ -64,7 +64,10 @@ impl BackfillReceiptToTxCommand {
         }
         let node_storage = open_storage(home, &near_config).context("failed to open storage")?;
 
-        let storage = BackfillStorage::for_node(&node_storage);
+        // CLI keeps the legacy per-key `insert + commit` write path. Switching the CLI
+        // to SST ingest is a deferred follow-up — the existing CLI is not on the urgent
+        // path that drove the actor change.
+        let storage = BackfillStorage::for_node(&node_storage, None);
 
         let chain_store = ChainStore::new(
             storage.read_store.clone(),


### PR DESCRIPTION
## Summary

The legacy per-key `insert + commit` write path triggered a compaction death spiral on the production archival cold store: many small writes per batch landed in the memtable, flushed to L0 faster than compaction could merge, and pushed read amplification high enough to take a single batch from ~3s to ~600s.

This PR mirrors the v48→49 migration's SST ingestion pattern for the actor's batch writes. A new `Store::ingest_insert_only_sst` helper builds a sorted, deduplicated SST file under a temp dir on the cold-store filesystem, then RocksDB renames it directly into the LSM tree — bypassing memtable, WAL, and L0 entirely. The helper is narrow: asserts insert-only column, verifies sort/dedup, caps file size at 256 MB, and cleans up on failure.

`BackfillStorage` gains an `sst_temp_dir` field. `process_one_batch` sorts and dedupes by receipt id (with a value-equality check that replaces the legacy debug-only `assert_no_overwrite`) and chooses between SST ingest (`Some`) or the legacy path (`None`). The actor cleans its own per-PID staging dir on startup; `nearcore` wires the path the same way `copy_block_headers_to_cold_db` does.

## Notes

- CLI keeps the legacy path; `--use-sst-ingest` is a deferred follow-up.
- 4 SST-specific Prometheus metrics are deferred; the existing `near_backfill_receipt_to_tx_lowest_completed_height` gauge remains the operator signal for v1.
- `TestDB` doesn't implement `ingest_external_sst_files`, so test-loop tests pass `None` and exercise the legacy glue. The SST helper is covered by 7 unit tests in `core/store/tests/sst_ingest.rs` against a real RocksDB tempdir.
- The actor calls the helper from a fully sync code path (`backfill_loop` → `backfill_batch`), so the planned `tokio::task::spawn_blocking` wrapper is omitted: it would require an async refactor of `Actor::start_actor` and `DelayedActionRunner`. The actor runs on its own dedicated single-worker tokio runtime, so blocking only stalls this actor, not the rest of the node.

## Base

This PR is based on the actor branch's working tree minus its temporary debug-logging commit. Once the actor PR lands on master, this branch rebases cleanly.