### PR TITLE
doc: prefer arc.as_ref() over &*arc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - NEVER use fully qualified paths (e.g., `std::collections::HashMap::new()`). Always add a `use` declaration and reference the type directly. This applies to all Rust code — production, tests, and examples.
 - Don't capitalize string literal messages in logs, errors, `Option::expect`, `panic!`, etc.
+- To borrow from an `Arc<T>` / `Arc<dyn Trait>`, use `arc.as_ref()`, not `&*arc`. Both compile to the same thing; `as_ref()` is cleaner.
 
 ## Pull Requests
 


### PR DESCRIPTION
Add a Rust style rule to AGENTS.md: borrow from an `Arc<T>` / `Arc<dyn Trait>` with `arc.as_ref()` instead of `&*arc`. Both compile to the same thing; `as_ref()` reads cleaner. Came up as a review nit on PR #15578.