### PR TITLE
test(rpc): fix view_history flake from skipped block 1

### DIFF
--- a/pytest/tests/sanity/rpc_view_history.py
+++ b/pytest/tests/sanity/rpc_view_history.py
@@ -55,6 +55,12 @@ class TestRpcViewHistory(unittest.TestCase):
 
         utils.wait_for_blocks(nodes[0], target=3)
 
+        # Pin a canonical pre-payment block to query later. Doomslug can skip
+        # heights in dev clusters (e.g. block 1 isn't guaranteed to be on the
+        # canonical chain), so a hardcoded height like `block=1` races. Using
+        # the height of a block we just observed via `get_latest_block` is
+        # safe — it's already on the canonical chain.
+        pre_payment_height = nodes[0].get_latest_block().height
         balances = {
             account: int(nodes[0].get_account('test0')['result']['amount'])
             for account in ['test0', 'test1']
@@ -89,7 +95,7 @@ class TestRpcViewHistory(unittest.TestCase):
 
             # Now check that the RPC will provide historical results.
             historical_amount = int(nodes[0].get_account(
-                acc_id, block=1)['result']['amount'])
+                acc_id, block=pre_payment_height)['result']['amount'])
             self.assertEqual(balances[acc_id], historical_amount)
 
 


### PR DESCRIPTION
## Background

\`pytest sanity/rpc_view_history.py\` has been failing intermittently in the merge queue. Initial diagnosis (see PR description history) suggested a master-state regression, but a closer look at the test0 logs from a failing run showed the test was racing on doomslug's first-block timing.

## What's actually wrong

The test queries account state at \`block=1\` to verify historical RPC works. In a 3-validator dev cluster with \`min_block_production_delay=1s\`, doomslug can skip the very first height — endorsements for block 1 don't arrive in time, the cluster goes straight from height 0 to height 2, and \`BlockHeight\` column has no entry for height 1.

Sequence from the failing test0 log:
\`\`\`
19:49:20.865 producing optimistic block validator=test0 height=1 prev_height=0
19:49:21.745 collect_block_approval target_height=1   (test1 endorsement)
19:49:22.888 considering blocks for production start_height=1 end_height=2
19:49:22.889 doomslug: not ready to produce block target_height=1
19:49:22.892 produce_block{next_height=2}              ← jumped to 2
\`\`\`

When the test then queries \`block=1\`, \`get_block_hash_by_height(1)\` returns \`DBNotFoundErr\` → \`UnknownBlock\` → \`handle_unknown_block\` returns HTTP 422.

This is a flake in the test, not a regression. Same flake hit:
- [run 4557](https://nayduck.nearone.org/#/run/4557) (PR #15478, master \`6c6c99a\`) — non-nightly variant
- [run 4561](https://nayduck.nearone.org/#/run/4561), [run 4562](https://nayduck.nearone.org/#/run/4562) (PR #15575, master \`a9a453b\`) — nightly variant

A successful retry of PR #15478 ([run 4560](https://nayduck.nearone.org/#/run/4560)) passed the same test on the same SHA \`a9a453b\`, confirming the flake.

## Fix

Capture the block height after \`wait_for_blocks(target=3)\` via \`get_latest_block().height\` — that block is already on the canonical chain, so it's safe to query. Replace the hardcoded \`block=1\` with this captured height.

## Verification

[NayDuck run #4565](https://nayduck.nearone.org/#/run/4565) — 15× each of the stable and nightly variants (30 total) on this branch.