### PR TITLE
refactor(network): make PeerManagerActor testloop-compatible (2/n)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,6 +4258,7 @@ dependencies = [
  "near-time",
  "parking_lot 0.12.1",
  "rand 0.8.5",
+ "rayon",
  "serde",
  "serde_json",
  "thread-priority",

--- a/chain/chain/src/rayon_spawner.rs
+++ b/chain/chain/src/rayon_spawner.rs
@@ -1,10 +1,1 @@
-use near_async::futures::AsyncComputationSpawner;
-
-pub struct RayonAsyncComputationSpawner;
-
-impl AsyncComputationSpawner for RayonAsyncComputationSpawner {
-    fn spawn_boxed(&self, _name: &str, f: Box<dyn FnOnce() + Send>) {
-        let dispatcher = tracing::dispatcher::get_default(|it| it.clone());
-        rayon::spawn(move || tracing::dispatcher::with_default(&dispatcher, f))
-    }
-}
+pub use near_async::RayonAsyncComputationSpawner;

--- a/chain/network/src/accounts_data/mod.rs
+++ b/chain/network/src/accounts_data/mod.rs
@@ -29,6 +29,7 @@ use crate::concurrency::arc_mutex::ArcMutex;
 use crate::network_protocol;
 use crate::network_protocol::{AccountData, SignedAccountData, VersionedAccountData};
 use crate::types::AccountKeys;
+use near_async::futures::AsyncComputationSpawner;
 use near_async::time;
 use near_crypto::PublicKey;
 use near_primitives::validator_signer::ValidatorSigner;
@@ -191,16 +192,26 @@ impl AccountDataCacheSnapshot {
     }
 }
 
-pub(crate) struct AccountDataCache(ArcMutex<AccountDataCacheSnapshot>);
+pub(crate) struct AccountDataCache {
+    snapshot: ArcMutex<AccountDataCacheSnapshot>,
+    /// Spawner used to run signature verification off the caller's thread.
+    /// Production wires `RayonAsyncComputationSpawner`; testloop wires
+    /// `TestLoopAsyncComputationSpawner` so the resume happens on the
+    /// testloop thread rather than a rayon worker.
+    async_computation_spawner: Arc<dyn AsyncComputationSpawner>,
+}
 
 impl AccountDataCache {
-    pub fn new() -> Self {
-        Self(ArcMutex::new(AccountDataCacheSnapshot {
-            keys_by_id: Arc::new(AccountKeys::default()),
-            keys: im::HashSet::new(),
-            data: im::HashMap::new(),
-            local: None,
-        }))
+    pub fn new(async_computation_spawner: Arc<dyn AsyncComputationSpawner>) -> Self {
+        Self {
+            snapshot: ArcMutex::new(AccountDataCacheSnapshot {
+                keys_by_id: Arc::new(AccountKeys::default()),
+                keys: im::HashSet::new(),
+                data: im::HashMap::new(),
+                local: None,
+            }),
+            async_computation_spawner,
+        }
     }
 
     /// Updates the set of important accounts and their public keys.
@@ -211,7 +222,7 @@ impl AccountDataCache {
     ///   so a call to set_local afterwards is required to do that. For now it is fine because
     ///   the AccountDataCache owner is expected to call set_local periodically anyway.
     pub fn set_keys(&self, keys_by_id: Arc<AccountKeys>) -> bool {
-        self.0
+        self.snapshot
             .try_update(|mut inner| {
                 // Skip further processing if the key set didn't change.
                 // NOTE: if T implements Eq, then Arc<T> short circuits equality for x == x.
@@ -237,7 +248,7 @@ impl AccountDataCache {
         // Filter out non-interesting data, so that we never check signatures for valid non-interesting data.
         // Bad peers may force us to check signatures for fake data anyway, but we will ban them after first invalid signature.
         let mut new_data = HashMap::new();
-        let inner = self.0.load();
+        let inner = self.snapshot.load();
         for d in data {
             // There is a limit on the amount of RAM occupied by per-account datasets.
             // Broadcasting larger datasets is considered malicious behavior.
@@ -259,14 +270,18 @@ impl AccountDataCache {
 
         // Verify the signatures in parallel.
         // Verification will stop at the first encountered error.
-        let (data, ok) = concurrency::rayon::run(move || {
-            concurrency::rayon::try_map(new_data.into_values().par_bridge(), |d| {
-                match d.payload().verify(&d.account_key) {
-                    Ok(()) => Some(d),
-                    Err(()) => None,
-                }
-            })
-        })
+        let (data, ok) = concurrency::rayon::run(
+            self.async_computation_spawner.as_ref(),
+            "AccountDataCache::verify",
+            move || {
+                concurrency::rayon::try_map(new_data.into_values().par_bridge(), |d| {
+                    match d.payload().verify(&d.account_key) {
+                        Ok(()) => Some(d),
+                        Err(()) => None,
+                    }
+                })
+            },
+        )
         .await;
         if !ok {
             return (data, Some(AccountDataError::InvalidSignature));
@@ -279,7 +294,7 @@ impl AccountDataCache {
         clock: &time::Clock,
         local: LocalAccountData,
     ) -> Option<Arc<SignedAccountData>> {
-        self.0.update(|mut inner| {
+        self.snapshot.update(|mut inner| {
             let data = inner.set_local(clock, local);
             (data, inner)
         })
@@ -297,7 +312,7 @@ impl AccountDataCache {
         // Execute verification on the rayon threadpool.
         let (data, err) = this.verify(data).await;
         // Insert the successfully verified data, even if an error has been encountered.
-        let inserted = self.0.update(|mut inner| {
+        let inserted = self.snapshot.update(|mut inner| {
             let inserted = data.into_iter().filter_map(|d| inner.try_insert(clock, d)).collect();
             (inserted, inner)
         });
@@ -307,6 +322,6 @@ impl AccountDataCache {
 
     /// Loads the current cache snapshot.
     pub fn load(&self) -> Arc<AccountDataCacheSnapshot> {
-        self.0.load()
+        self.snapshot.load()
     }
 }

--- a/chain/network/src/accounts_data/tests.rs
+++ b/chain/network/src/accounts_data/tests.rs
@@ -45,7 +45,9 @@ async fn happy_path() {
     let e0 = Arc::new(data::make_account_keys(&signers[0..5]));
     let e1 = Arc::new(data::make_account_keys(&signers[2..7]));
 
-    let cache = Arc::new(AccountDataCache::new());
+    let cache = Arc::new(AccountDataCache::new(Arc::new(
+        crate::concurrency::rayon::RayonAsyncComputationSpawner,
+    )));
     assert_eq!(cache.load().data.values().count(), 0); // initially empty
     assert!(cache.set_keys(e0.clone()));
     assert_eq!(cache.load().data.values().count(), 0); // empty after initial set_keys.
@@ -109,7 +111,9 @@ async fn data_too_large() {
     let signers = make_signers(rng, 3);
     let e = Arc::new(data::make_account_keys(&signers));
 
-    let cache = Arc::new(AccountDataCache::new());
+    let cache = Arc::new(AccountDataCache::new(Arc::new(
+        crate::concurrency::rayon::RayonAsyncComputationSpawner,
+    )));
     cache.set_keys(e);
     let a0 = Arc::new(make_account_data(rng, &clock.clock(), 1, &signers[0]));
     let a1 = Arc::new(make_account_data(rng, &clock.clock(), 1, &signers[1]));
@@ -148,7 +152,9 @@ async fn invalid_signature() {
     let signers = make_signers(rng, 3);
     let e = Arc::new(data::make_account_keys(&signers));
 
-    let cache = Arc::new(AccountDataCache::new());
+    let cache = Arc::new(AccountDataCache::new(Arc::new(
+        crate::concurrency::rayon::RayonAsyncComputationSpawner,
+    )));
     cache.set_keys(e);
     let a0 = Arc::new(make_account_data(rng, &clock.clock(), 1, &signers[0]));
     let mut a1 = make_account_data(rng, &clock.clock(), 1, &signers[1]);
@@ -186,7 +192,9 @@ async fn single_account_multiple_data() {
     let signers = make_signers(rng, 3);
     let e = Arc::new(data::make_account_keys(&signers));
 
-    let cache = Arc::new(AccountDataCache::new());
+    let cache = Arc::new(AccountDataCache::new(Arc::new(
+        crate::concurrency::rayon::RayonAsyncComputationSpawner,
+    )));
     cache.set_keys(e);
     let a0 = Arc::new(make_account_data(rng, &clock.clock(), 1, &signers[0]));
     let a1 = Arc::new(make_account_data(rng, &clock.clock(), 1, &signers[1]));
@@ -219,7 +227,9 @@ async fn set_local() {
     let e0 = Arc::new(data::make_account_keys(&signers[0..2]));
     let e1 = Arc::new(data::make_account_keys(&signers[1..3]));
 
-    let cache = Arc::new(AccountDataCache::new());
+    let cache = Arc::new(AccountDataCache::new(Arc::new(
+        crate::concurrency::rayon::RayonAsyncComputationSpawner,
+    )));
     assert!(cache.set_keys(e0.clone()));
 
     // Set local while local.signer is in cache.keys.

--- a/chain/network/src/concurrency/demux.rs
+++ b/chain/network/src/concurrency/demux.rs
@@ -105,7 +105,11 @@ impl<Arg: 'static + Send, Res: 'static + Send> Demux<Arg, Res> {
 
     // Spawns a subroutine performing the demultiplexing.
     // Panics if rl is not valid.
-    pub fn new(rl: rate::Limit, future_spawner: &dyn FutureSpawner) -> Demux<Arg, Res> {
+    pub fn new(
+        rl: rate::Limit,
+        clock: time::Clock,
+        future_spawner: &dyn FutureSpawner,
+    ) -> Demux<Arg, Res> {
         rl.validate().unwrap();
         let (send, mut recv): (Stream<Arg, Res>, _) = mpsc::unbounded_channel();
         // TODO(gprusak): this task should be running as long as Demux object exists.
@@ -115,23 +119,21 @@ impl<Arg: 'static + Send, Res: 'static + Send> Demux<Arg, Res> {
             let mut calls = vec![];
             let mut closed = false;
             let mut tokens = rl.burst;
-            let mut next_token = None;
-            let interval = (time::Duration::SECOND / rl.qps).try_into().unwrap();
+            let mut next_token: Option<time::Instant> = None;
+            let interval = time::Duration::SECOND / rl.qps;
             while !(calls.is_empty() && closed) {
                 // Restarting the timer every time a new request comes could
                 // cause a starvation, so we compute the next token arrival time
                 // just once for each token.
                 if tokens < rl.burst && next_token.is_none() {
-                    next_token = Some(tokio::time::Instant::now() + interval);
+                    next_token = Some(clock.now() + interval);
                 }
 
                 tokio::select! {
-                    // TODO(gprusak): implement sleep future support for FakeClock,
-                    // so that we don't use tokio directly here.
                     _ = async {
                         // without async {} wrapper, next_token.unwrap() would be evaluated
                         // unconditionally.
-                        tokio::time::sleep_until(next_token.unwrap()).await
+                        clock.sleep_until(next_token.unwrap()).await
                     }, if next_token.is_some() => {
                         tokens += 1;
                         next_token = None;

--- a/chain/network/src/concurrency/rayon.rs
+++ b/chain/network/src/concurrency/rayon.rs
@@ -1,23 +1,8 @@
+pub use near_async::RayonAsyncComputationSpawner;
 use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt};
 use rayon::iter::{Either, ParallelIterator};
 use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
-
-/// `AsyncComputationSpawner` backed by the global rayon thread pool. Used in
-/// production; testloop substitutes `TestLoopAsyncComputationSpawner` so the
-/// closure runs on the testloop event thread instead.
-///
-/// Mirrors `near_chain::rayon_spawner::RayonAsyncComputationSpawner` (cycle
-/// prevents direct reuse). Both copies preserve the tracing dispatcher across
-/// the rayon hop so spans don't disappear from spawned work.
-pub struct RayonAsyncComputationSpawner;
-
-impl AsyncComputationSpawner for RayonAsyncComputationSpawner {
-    fn spawn_boxed(&self, _name: &str, f: Box<dyn FnOnce() + Send>) {
-        let dispatcher = tracing::dispatcher::get_default(|it| it.clone());
-        rayon::spawn(move || tracing::dispatcher::with_default(&dispatcher, f))
-    }
-}
 
 /// Runs a closure via the supplied `AsyncComputationSpawner` and awaits its
 /// completion. Used to bridge sync, parallel work (e.g., signature

--- a/chain/network/src/concurrency/rayon.rs
+++ b/chain/network/src/concurrency/rayon.rs
@@ -1,14 +1,37 @@
+use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt};
 use rayon::iter::{Either, ParallelIterator};
 use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// spawns a closure on a global rayon threadpool and awaits its completion.
-/// Returns the closure result.
+/// `AsyncComputationSpawner` backed by the global rayon thread pool. Used in
+/// production; testloop substitutes `TestLoopAsyncComputationSpawner` so the
+/// closure runs on the testloop event thread instead.
+///
+/// Mirrors `near_chain::rayon_spawner::RayonAsyncComputationSpawner` (cycle
+/// prevents direct reuse). Both impls preserve the tracing dispatcher across
+/// the rayon hop so spans don't disappear from spawned work.
+pub struct RayonAsyncComputationSpawner;
+
+impl AsyncComputationSpawner for RayonAsyncComputationSpawner {
+    fn spawn_boxed(&self, _name: &str, f: Box<dyn FnOnce() + Send>) {
+        let dispatcher = tracing::dispatcher::get_default(|it| it.clone());
+        rayon::spawn(move || tracing::dispatcher::with_default(&dispatcher, f))
+    }
+}
+
+/// Runs a closure via the supplied `AsyncComputationSpawner` and awaits its
+/// completion. Used to bridge sync, parallel work (e.g., signature
+/// verification on rayon) into async code.
+///
 /// WARNING: panicking within a rayon task seems to be causing a double panic,
 /// and hence the panic message is not visible when running "cargo test".
-pub async fn run<T: 'static + Send>(f: impl 'static + Send + FnOnce() -> T) -> T {
+pub async fn run<T: 'static + Send>(
+    spawner: &dyn AsyncComputationSpawner,
+    name: &'static str,
+    f: impl 'static + Send + FnOnce() -> T,
+) -> T {
     let (send, recv) = tokio::sync::oneshot::channel();
-    rayon::spawn(move || {
+    spawner.spawn(name, move || {
         if send.send(f()).is_err() {
             tracing::warn!("rayon::run has been aborted");
         }

--- a/chain/network/src/concurrency/rayon.rs
+++ b/chain/network/src/concurrency/rayon.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// closure runs on the testloop event thread instead.
 ///
 /// Mirrors `near_chain::rayon_spawner::RayonAsyncComputationSpawner` (cycle
-/// prevents direct reuse). Both impls preserve the tracing dispatcher across
+/// prevents direct reuse). Both copies preserve the tracing dispatcher across
 /// the rayon hop so spans don't disappear from spawned work.
 pub struct RayonAsyncComputationSpawner;
 

--- a/chain/network/src/concurrency/tests.rs
+++ b/chain/network/src/concurrency/tests.rs
@@ -2,11 +2,15 @@ use crate::concurrency::arc_mutex::ArcMutex;
 use crate::concurrency::demux;
 use crate::concurrency::rate;
 use near_async::futures::DirectTokioFutureSpawnerForTest;
+use near_async::time::Clock;
 
 #[tokio::test]
 async fn test_demux() {
-    let demux =
-        demux::Demux::new(rate::Limit { qps: 50., burst: 1 }, &DirectTokioFutureSpawnerForTest);
+    let demux = demux::Demux::new(
+        rate::Limit { qps: 50., burst: 1 },
+        Clock::real(),
+        &DirectTokioFutureSpawnerForTest,
+    );
     for _ in 0..5 {
         let mut handles = vec![];
         for i in 0..1000 {
@@ -30,7 +34,11 @@ fn demux_runtime_dropped_before_call() {
     let r1 = tokio::runtime::Runtime::new().unwrap();
     let r2 = tokio::runtime::Runtime::new().unwrap();
     let demux = r1.block_on(async {
-        demux::Demux::new(rate::Limit { qps: 1., burst: 1000 }, &DirectTokioFutureSpawnerForTest)
+        demux::Demux::new(
+            rate::Limit { qps: 1., burst: 1000 },
+            Clock::real(),
+            &DirectTokioFutureSpawnerForTest,
+        )
     });
     drop(r1);
     let call = demux.call(0, |is: Vec<u64>| async { is });
@@ -42,7 +50,11 @@ fn demux_runtime_dropped_during_call() {
     let r1 = tokio::runtime::Runtime::new().unwrap();
     let r2 = tokio::runtime::Runtime::new().unwrap();
     let demux = r1.block_on(async {
-        demux::Demux::new(rate::Limit { qps: 1., burst: 1000 }, &DirectTokioFutureSpawnerForTest)
+        demux::Demux::new(
+            rate::Limit { qps: 1., burst: 1000 },
+            Clock::real(),
+            &DirectTokioFutureSpawnerForTest,
+        )
     });
 
     // Start the call and pause.

--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -1,5 +1,6 @@
 use crate::auto_stop::AutoStopActor;
 use crate::broadcast;
+use crate::concurrency::rayon::RayonAsyncComputationSpawner;
 use crate::config::NetworkConfig;
 use crate::network_protocol::{
     Edge, PartialEdgeInfo, PeerIdOrHash, PeerMessage, RawRoutedMessage, TieredMessageBody,
@@ -94,6 +95,7 @@ impl PeerHandle {
         let network_state = Arc::new(NetworkState::new(
             &clock,
             Arc::from(actor_system.new_future_spawner("network demux")),
+            Arc::new(RayonAsyncComputationSpawner),
             store,
             peer_store::PeerStore::new(&clock, network_cfg.peer_store.clone()).unwrap(),
             network_cfg.verify().unwrap(),

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -6,6 +6,7 @@ use crate::network_protocol::{
 use crate::peer::peer_actor::ClosingReason;
 use crate::peer::testonly::{PeerConfig, PeerHandle};
 use crate::peer_manager::peer_manager_actor::Event;
+use crate::peer_manager::testonly::auto_advance_fake_clock;
 use crate::tcp;
 use crate::testonly::make_rng;
 use crate::testonly::stream::Stream;
@@ -24,6 +25,7 @@ async fn test_peer_communication() -> anyhow::Result<()> {
     init_test_logger();
     let mut rng = make_rng(89028037453);
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
 
     let chain = Arc::new(data::Chain::make(&mut clock, &mut rng, 12));
     let inbound_cfg = PeerConfig { chain: chain.clone(), network: chain.make_config(&mut rng) };
@@ -162,6 +164,7 @@ async fn test_request_update_nonce_rejects_invalid_nonce() -> anyhow::Result<()>
     init_test_logger();
     let mut rng = make_rng(89028037453);
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
 
     let chain = Arc::new(data::Chain::make(&mut clock, &mut rng, 12));
     let inbound_cfg = PeerConfig { chain: chain.clone(), network: chain.make_config(&mut rng) };
@@ -210,6 +213,7 @@ async fn test_handshake() {
     init_test_logger();
     let mut rng = make_rng(89028037453);
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
 
     let chain = Arc::new(data::Chain::make(&mut clock, &mut rng, 12));
     let inbound_cfg = PeerConfig { network: chain.make_config(&mut rng), chain: chain.clone() };

--- a/chain/network/src/peer_manager/connection/tests.rs
+++ b/chain/network/src/peer_manager/connection/tests.rs
@@ -15,6 +15,7 @@ async fn connection_tie_break() {
     let mut rng = make_rng(33955575545);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let mut configs: Vec<_> = (0..3).map(|_| chain.make_config(rng)).collect();
@@ -61,6 +62,7 @@ async fn duplicate_connections() {
     let mut rng = make_rng(33955575545);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -47,7 +47,7 @@ use crate::types::{
 };
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
-use near_async::futures::{FutureSpawner, FutureSpawnerExt};
+use near_async::futures::{AsyncComputationSpawner, FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{CanSend, CanSendAsync, Sender};
 use near_async::time;
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
@@ -268,6 +268,7 @@ impl NetworkState {
     pub fn new(
         clock: &time::Clock,
         future_spawner: Arc<dyn FutureSpawner>,
+        async_computation_spawner: Arc<dyn AsyncComputationSpawner>,
         store: store::Store,
         peer_store: peer_store::PeerStore,
         config: config::VerifiedConfig,
@@ -306,10 +307,13 @@ impl NetworkState {
             chain_info: Default::default(),
             my_public_addr: Arc::new(RwLock::new(config.tier3_public_addr)),
             peer_store,
-            snapshot_hosts: Arc::new(SnapshotHostsCache::new(config.snapshot_hosts.clone())),
+            snapshot_hosts: Arc::new(SnapshotHostsCache::new(
+                config.snapshot_hosts.clone(),
+                async_computation_spawner.clone(),
+            )),
             connection_store: connection_store::ConnectionStore::new(store.clone()).unwrap(),
             pending_reconnect: Mutex::new(Vec::<PeerInfo>::new()),
-            accounts_data: Arc::new(AccountDataCache::new()),
+            accounts_data: Arc::new(AccountDataCache::new(async_computation_spawner)),
             account_announcements: Arc::new(AnnounceAccountCache::new(store)),
             tier2_route_back: Mutex::new(RouteBackCache::default()),
             tier1_route_back: Mutex::new(RouteBackCache::default()),
@@ -321,6 +325,7 @@ impl NetworkState {
             whitelist_nodes,
             add_edges_demux: demux::Demux::new(
                 config.routing_table_update_rate_limit,
+                clock.clone(),
                 future_spawner.as_ref(),
             ),
             set_chain_info_mutex: Mutex::new(()),
@@ -507,6 +512,7 @@ impl NetworkState {
                 peer_info.id.clone(),
                 demux::Demux::new(
                     self.config.accounts_data_broadcast_rate_limit,
+                    clock.clone(),
                     self.ops_spawner.as_ref(),
                 ),
             );
@@ -514,6 +520,7 @@ impl NetworkState {
                 peer_info.id.clone(),
                 demux::Demux::new(
                     self.config.snapshot_hosts_broadcast_rate_limit,
+                    clock.clone(),
                     self.ops_spawner.as_ref(),
                 ),
             );

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -2,6 +2,7 @@ use crate::client::{
     ClientSenderForNetwork, GetCurrentEpochHeight, SetNetworkInfo, SpiceChunkEndorsementMessage,
     StateRequestHeader, StateRequestPart,
 };
+use crate::concurrency::rayon::RayonAsyncComputationSpawner;
 use crate::config;
 use crate::debug::{DebugStatus, GetDebugStatus};
 use crate::network_protocol::{self, T2MessageBody};
@@ -34,7 +35,9 @@ use crate::types::{
 use ::time::ext::InstantExt as _;
 use anyhow::Context as _;
 use itertools::Itertools;
-use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt, FutureSpawnerExt};
+use near_async::futures::{
+    DelayedActionRunner, DelayedActionRunnerExt, FutureSpawner, FutureSpawnerExt,
+};
 use near_async::messaging::{self, CanSendAsync, Sender};
 use near_async::tokio::TokioRuntimeHandle;
 use near_async::{ActorSystem, time};
@@ -103,8 +106,9 @@ const TIER3_IDLE_TIMEOUT: time::Duration = time::Duration::seconds(15);
 /// Actor that manages peers connections.
 pub struct PeerManagerActor {
     pub(crate) clock: time::Clock,
-    /// Handle to spawning futures as well as stopping ourselves for testing.
-    pub(crate) handle: TokioRuntimeHandle<Self>,
+    /// Spawner for async tasks. In production, backed by a tokio runtime.
+    /// In testloop, backed by `PendingEventsSender` (deterministic, FakeClock-driven).
+    pub(crate) spawner: Arc<dyn FutureSpawner>,
     /// Peer information for this node.
     my_peer_id: PeerId,
     /// Flag that track whether we started attempts to establish outbound connections.
@@ -154,9 +158,19 @@ pub enum Event {
 }
 
 impl messaging::Actor for PeerManagerActor {
-    fn start_actor(&mut self, _ctx: &mut dyn DelayedActionRunner<Self>) {
+    fn start_actor(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
+        // Fetch and set the current epoch height for snapshot host validation.
+        let state = self.state.clone();
+        self.spawner.spawn("epoch height fetch", async move {
+            if let Ok(Some(epoch_height)) =
+                state.client.current_epoch_height_request.send_async(GetCurrentEpochHeight).await
+            {
+                state.snapshot_hosts.set_current_epoch_height(epoch_height);
+            }
+        });
+
         // Periodically push network information to client.
-        self.push_network_info_trigger(self.state.config.push_info_period);
+        self.push_network_info_trigger(ctx, self.state.config.push_info_period);
 
         // Attempt to reconnect to recent outbound connections from storage
         if self.state.config.connect_to_reliable_peers_on_startup {
@@ -171,6 +185,7 @@ impl messaging::Actor for PeerManagerActor {
                max_period=?self.state.config.monitor_peers_max_period,
                "monitor_peers_trigger");
         self.monitor_peers_trigger(
+            ctx,
             MONITOR_PEERS_INITIAL_DURATION,
             (MONITOR_PEERS_INITIAL_DURATION, self.state.config.monitor_peers_max_period),
         );
@@ -179,7 +194,7 @@ impl messaging::Actor for PeerManagerActor {
         let clock = self.clock.clone();
         let state = self.state.clone();
         let transport = self.transport.clone();
-        self.handle.spawn("fix_local_edges loop", async move {
+        self.spawner.spawn("fix_local_edges loop", async move {
             let mut interval = time::Interval::new(clock.now(), FIX_LOCAL_EDGES_INTERVAL);
             loop {
                 interval.tick(&clock).await;
@@ -190,7 +205,7 @@ impl messaging::Actor for PeerManagerActor {
         // Periodically update the connection store.
         let clock = self.clock.clone();
         let state = self.state.clone();
-        self.handle.spawn("update_connection_store loop", async move {
+        self.spawner.spawn("update_connection_store loop", async move {
             let mut interval = time::Interval::new(clock.now(), UPDATE_CONNECTION_STORE_INTERVAL);
             loop {
                 interval.tick(&clock).await;
@@ -199,11 +214,11 @@ impl messaging::Actor for PeerManagerActor {
         });
 
         // Periodically prints bandwidth stats for each peer.
-        self.report_bandwidth_stats_trigger(REPORT_BANDWIDTH_STATS_TRIGGER_INTERVAL);
+        self.report_bandwidth_stats_trigger(ctx, REPORT_BANDWIDTH_STATS_TRIGGER_INTERVAL);
 
         // Connect to TIER1 proxies and broadcast the list those connections periodically.
         let tier1 = self.state.config.tier1.clone();
-        self.handle.spawn("connect to TIER1 proxies", {
+        self.spawner.spawn("connect to TIER1 proxies", {
             let clock = self.clock.clone();
             let state = self.state.clone();
             let transport = self.transport.clone();
@@ -218,26 +233,25 @@ impl messaging::Actor for PeerManagerActor {
         });
 
         // Update TIER1 connections periodically.
-        self.handle.spawn("update TIER1 connections", {
+        self.spawner.spawn("update TIER1 connections", {
             let clock = self.clock.clone();
             let state = self.state.clone();
             let transport = self.transport.clone();
-            let mut interval = tokio::time::interval(tier1.connect_interval.try_into().unwrap());
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut interval = time::Interval::new(clock.now(), tier1.connect_interval);
             async move {
                 loop {
-                    interval.tick().await;
+                    interval.tick(&clock).await;
                     state.tier1_connect(&clock, transport.as_ref()).await;
                 }
             }
         });
 
         // Periodically poll the connection store for connections we'd like to re-establish
-        self.handle.spawn("poll connection store for reconnects", {
+        self.spawner.spawn("poll connection store for reconnects", {
             let clock = self.clock.clone();
             let transport = self.transport.clone();
             let state = self.state.clone();
-            let handle = self.handle.clone();
+            let spawner = self.spawner.clone();
             let mut interval = time::Interval::new(clock.now(), POLL_CONNECTION_STORE_INTERVAL);
             async move {
                 loop {
@@ -246,7 +260,7 @@ impl messaging::Actor for PeerManagerActor {
                     let pending_reconnect = state.poll_pending_reconnect();
                     // Spawn a separate reconnect loop for each pending reconnect attempt
                     for peer_info in pending_reconnect {
-                        handle.spawn("reconnect peer", {
+                        spawner.spawn("reconnect peer", {
                             let state = state.clone();
                             let clock = clock.clone();
                             let peer_info = peer_info.clone();
@@ -330,6 +344,24 @@ fn build_connected_peer_info(
 }
 
 impl PeerManagerActor {
+    /// Pure constructor. Takes pre-built dependencies.
+    /// Used by testloop (directly) and production (via spawn).
+    pub(crate) fn new(
+        clock: time::Clock,
+        state: Arc<NetworkState>,
+        transport: Arc<dyn NetworkTransport>,
+        spawner: Arc<dyn FutureSpawner>,
+    ) -> Self {
+        Self {
+            my_peer_id: state.config.node_id(),
+            started_connect_attempts: false,
+            state,
+            transport,
+            clock,
+            spawner,
+        }
+    }
+
     pub fn spawn(
         clock: time::Clock,
         actor_system: ActorSystem,
@@ -361,13 +393,13 @@ impl PeerManagerActor {
             }
             v
         };
-        let my_peer_id = config.node_id();
         let builder = actor_system.new_tokio_builder();
         let handle = builder.handle();
         let clock = clock;
         let state = Arc::new(NetworkState::new(
             &clock,
             Arc::from(handle.future_spawner()),
+            Arc::new(RayonAsyncComputationSpawner),
             store,
             peer_store,
             config,
@@ -385,38 +417,23 @@ impl PeerManagerActor {
             tracing::info!(target: "network", %addr, "using configured tier3 public address");
             metrics::TIER3_PUBLIC_ADDR.with_label_values(&[&addr.to_string()]).set(1);
         }
-        handle.spawn("PeerManagerActor epoch height fetch", {
-            let state = state.clone();
-            async move {
-                if let Ok(Some(epoch_height)) = state
-                    .client
-                    .current_epoch_height_request
-                    .send_async(GetCurrentEpochHeight)
-                    .await
-                {
-                    state.snapshot_hosts.set_current_epoch_height(epoch_height);
-                }
-            }
-        });
         // Build the transport and start the TCP listener. The listener
         // lives inside TcpTransport so that PMA only ever holds
         // `Arc<dyn NetworkTransport>`, never the concrete type.
         let tcp = TcpTransport::new(state.clone(), clock.clone(), actor_system, handle.clone());
         tcp.start();
-        let transport: Arc<dyn NetworkTransport> = tcp.clone();
-        builder.spawn_tokio_actor(Self {
-            my_peer_id,
-            started_connect_attempts: false,
-            state,
-            transport,
-            clock,
-            handle: handle.clone(),
-        });
+        let spawner: Arc<dyn FutureSpawner> = Arc::new(handle.clone());
+        let pma = Self::new(clock, state, tcp.clone(), spawner);
+        builder.spawn_tokio_actor(pma);
         Ok((handle, tcp))
     }
 
     /// Periodically prints bandwidth stats for each peer.
-    fn report_bandwidth_stats_trigger(&self, every: time::Duration) {
+    fn report_bandwidth_stats_trigger(
+        &self,
+        ctx: &mut dyn DelayedActionRunner<Self>,
+        every: time::Duration,
+    ) {
         let _timer = metrics::PEER_MANAGER_TRIGGER_TIME
             .with_label_values(&["report_bandwidth_stats"])
             .start_timer();
@@ -445,11 +462,11 @@ impl PeerManagerActor {
             total_messages_per_sec,
         );
 
-        self.handle.clone().run_later(
+        ctx.run_later(
             "report_bandwidth_stats_trigger",
             every.try_into().unwrap(),
-            move |act, _ctx| {
-                act.report_bandwidth_stats_trigger(every);
+            move |act, ctx| {
+                act.report_bandwidth_stats_trigger(ctx, every);
             },
         );
     }
@@ -667,6 +684,7 @@ impl PeerManagerActor {
     ///       reach value of `max_internal` eventually.
     fn monitor_peers_trigger(
         &mut self,
+        ctx: &mut dyn DelayedActionRunner<Self>,
         mut interval: time::Duration,
         (default_interval, max_interval): (time::Duration, time::Duration),
     ) {
@@ -696,7 +714,7 @@ impl PeerManagerActor {
                     self.started_connect_attempts = true;
                     interval = default_interval;
                 }
-                self.handle.spawn("monitor_peers_trigger_connect", {
+                self.spawner.spawn("monitor_peers_trigger_connect", {
                     let state = self.state.clone();
                     let clock = self.clock.clone();
                     let transport = self.transport.clone();
@@ -728,19 +746,15 @@ impl PeerManagerActor {
 
         let new_interval = min(max_interval, interval * EXPONENTIAL_BACKOFF_RATIO);
 
-        self.handle.clone().run_later(
-            "monitor_peers_trigger",
-            interval.try_into().unwrap(),
-            move |act, _| {
-                act.monitor_peers_trigger(new_interval, (default_interval, max_interval));
-            },
-        );
+        ctx.run_later("monitor_peers_trigger", interval.try_into().unwrap(), move |act, ctx| {
+            act.monitor_peers_trigger(ctx, new_interval, (default_interval, max_interval));
+        });
     }
 
     /// Re-establish each outbound connection in the connection store (single attempt)
     fn bootstrap_outbound_from_recent_connections(&self) {
         for conn_info in self.state.connection_store.get_recent_outbound_connections() {
-            self.handle.spawn("bootstrap_outbound_from_recent_connections", {
+            self.spawner.spawn("bootstrap_outbound_from_recent_connections", {
                 let state = self.state.clone();
                 let clock = self.clock.clone();
                 let transport = self.transport.clone();
@@ -807,7 +821,11 @@ impl PeerManagerActor {
         }
     }
 
-    fn push_network_info_trigger(&self, interval: time::Duration) {
+    fn push_network_info_trigger(
+        &self,
+        ctx: &mut dyn DelayedActionRunner<Self>,
+        interval: time::Duration,
+    ) {
         let _span = tracing::trace_span!(target: "network", "push_network_info_trigger").entered();
         let network_info = self.get_network_info();
         let _timer = metrics::PEER_MANAGER_TRIGGER_TIME
@@ -815,7 +833,7 @@ impl PeerManagerActor {
             .start_timer();
         // TODO(gprusak): just spawn a loop.
         let state = self.state.clone();
-        self.handle.spawn(
+        self.spawner.spawn(
             "push_network_info_trigger_future",
             async move {
                 state.client.send_async(SetNetworkInfo(network_info).span_wrap()).await.ok();
@@ -825,11 +843,11 @@ impl PeerManagerActor {
             ),
         );
 
-        self.handle.clone().run_later(
+        ctx.run_later(
             "push_network_info_trigger",
             interval.try_into().unwrap(),
-            move |act, _| {
-                act.push_network_info_trigger(interval);
+            move |act, ctx| {
+                act.push_network_info_trigger(ctx, interval);
             },
         );
     }
@@ -1093,7 +1111,7 @@ impl PeerManagerActor {
             NetworkRequests::AnnounceAccount(announce_account) => {
                 let state = self.state.clone();
                 let transport = self.transport.clone();
-                self.handle.spawn("announce_account", async move {
+                self.spawner.spawn("announce_account", async move {
                     state.add_accounts(vec![announce_account], transport).await;
                 });
                 NetworkResponses::NoResponse
@@ -1447,7 +1465,7 @@ impl PeerManagerActor {
                 let state = self.state.clone();
                 let clock = self.clock.clone();
                 let transport = self.transport.clone();
-                self.handle.spawn("advertise_tier1_proxies", async move {
+                self.spawner.spawn("advertise_tier1_proxies", async move {
                     state.tier1_advertise_proxies(&clock, transport.as_ref()).await;
                 });
                 PeerManagerMessageResponse::AdvertiseTier1Proxies
@@ -1476,7 +1494,7 @@ impl messaging::Handler<SetChainInfo> for PeerManagerActor {
         let state = self.state.clone();
         let clock = self.clock.clone();
         let transport = self.transport.clone();
-        self.handle.spawn(
+        self.spawner.spawn(
             "handle set_chain_info",
             async move {
                 // This node might have become a TIER1 node due to the change of the key set.
@@ -1534,7 +1552,7 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
         let state = self.state.clone();
         let clock = self.clock.clone();
         let transport = self.transport.clone();
-        self.handle.spawn("handle tier3 request",
+        self.spawner.spawn("handle tier3 request",
             async move {
                 // Process the request.
                 // Unconditionally produce an ack to be sent back over tier2.

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -106,8 +106,13 @@ const TIER3_IDLE_TIMEOUT: time::Duration = time::Duration::seconds(15);
 /// Actor that manages peers connections.
 pub struct PeerManagerActor {
     pub(crate) clock: time::Clock,
-    /// Spawner for async tasks. In production, backed by a tokio runtime.
-    /// In testloop, backed by `PendingEventsSender` (deterministic, FakeClock-driven).
+    /// Spawner for PMA's background work (epoch height fetch, periodic
+    /// triggers, ad-hoc spawns from message handlers). Lifetime is the
+    /// caller's responsibility: tasks are tied to the spawner's runtime
+    /// and may be cancelled at runtime shutdown — callers that await
+    /// `spawner.spawn(...)` results should treat them as best-effort.
+    /// Production wires a tokio runtime handle; testloop wires
+    /// `TestLoopFutureSpawner` (deterministic, FakeClock-driven).
     pub(crate) spawner: Arc<dyn FutureSpawner>,
     /// Peer information for this node.
     my_peer_id: PeerId,

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -65,7 +65,7 @@ impl Debug for WithNetworkState {
 
 impl Handler<WithNetworkState> for PeerManagerActor {
     fn handle(&mut self, WithNetworkState(f): WithNetworkState) {
-        self.handle.spawn("with_network_state", f(self.state.clone()));
+        self.spawner.spawn("with_network_state", f(self.state.clone()));
     }
 }
 
@@ -90,7 +90,7 @@ impl Debug for WithStateAndTransport {
 
 impl Handler<WithStateAndTransport> for PeerManagerActor {
     fn handle(&mut self, WithStateAndTransport(f): WithStateAndTransport) {
-        self.handle
+        self.spawner
             .spawn("with_state_and_transport", f(self.state.clone(), self.transport.clone()));
     }
 }
@@ -101,6 +101,22 @@ pub(crate) struct ActorHandler {
     pub actor: AutoStopActor<PeerManagerActor>,
     pub actor_system: ActorSystem,
     pub tcp: Arc<TcpTransport>,
+}
+
+/// Spawns a real-time tokio task that advances the `FakeClock` by 10 ms every
+/// 10 ms of wall time. The demux's debounce timer is bound to the user-
+/// supplied `time::Clock`, so tests using a `FakeClock` need it advanced for
+/// the demux to refill tokens during connection establishment / gossip. The
+/// task is detached; tokio terminates it at end-of-test.
+pub(crate) fn auto_advance_fake_clock(clock: &time::FakeClock) {
+    let clock = clock.clone();
+    let step = std::time::Duration::from_millis(10);
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(step).await;
+            clock.advance(time::Duration::milliseconds(10));
+        }
+    });
 }
 
 pub(crate) fn unwrap_sync_accounts_data_processed(ev: Event) -> Option<SyncAccountsData> {

--- a/chain/network/src/peer_manager/tests/accounts_data.rs
+++ b/chain/network/src/peer_manager/tests/accounts_data.rs
@@ -24,6 +24,7 @@ async fn broadcast() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let clock = clock.clock();
     let clock = &clock;
@@ -111,6 +112,7 @@ async fn gradual_epoch_change() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let mut pms = vec![];
@@ -178,6 +180,7 @@ async fn slow_test_rate_limiting() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     // TODO(gprusak): 10 connections per peer is not much, try to scale up this test 2x (some config
@@ -188,6 +191,11 @@ async fn slow_test_rate_limiting() {
     for _ in 0..n * m {
         let mut cfg = chain.make_config(rng);
         cfg.accounts_data_broadcast_rate_limit = rate::Limit { qps: 0.5, burst: 1 };
+        // Routing-table rate limit isn't the subject of this test. With the
+        // demux now FakeClock-bound, the default `qps: 10, burst: 1` would
+        // stall edge propagation during connection establishment because
+        // this test doesn't advance the clock until after connections finish.
+        cfg.routing_table_update_rate_limit = rate::Limit { qps: 1000., burst: 1000 };
         pms.push(
             peer_manager::testonly::start(
                 clock.clock(),
@@ -291,6 +299,7 @@ async fn validator_node_restart() {
         let mut rng = make_rng(921853233);
         let rng = &mut rng;
         let mut clock = time::FakeClock::default();
+        peer_manager::testonly::auto_advance_fake_clock(&clock);
         let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
         // Start 2 nodes with node pm0 being a validator.

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -24,6 +24,7 @@ async fn unsolicited_tier3_rejected() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(
@@ -84,6 +85,7 @@ async fn expected_tier3_accepted() {
     let mut rng = make_rng(921853234);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(
@@ -148,6 +150,7 @@ async fn duplicate_handshake_closes_tier3() {
     let mut rng = make_rng(921853235);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(
@@ -223,6 +226,7 @@ async fn t3_disconnect() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(
@@ -299,6 +303,7 @@ async fn slow_test_connection_spam_security_test() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     const PEERS_OVER_LIMIT: usize = 10;
@@ -340,6 +345,7 @@ async fn loop_connection() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(
@@ -407,6 +413,7 @@ async fn owned_account_mismatch() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(
@@ -470,6 +477,7 @@ async fn owned_account_conflict() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(
@@ -508,6 +516,7 @@ async fn invalid_edge() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = peer_manager::testonly::start(

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -33,6 +33,7 @@ async fn simple() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start two nodes");
@@ -63,6 +64,7 @@ async fn three_nodes_path() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "connect three nodes in a line");
@@ -104,6 +106,7 @@ async fn three_nodes_star() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "connect three nodes in a line");
@@ -168,6 +171,7 @@ async fn join_components() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "create two connected components having two nodes each");
@@ -239,6 +243,7 @@ async fn simple_remove() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "connect 3 nodes in a line");
@@ -330,6 +335,7 @@ async fn ping_simple() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start two nodes");
@@ -368,6 +374,7 @@ async fn ping_jump() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start three nodes");
@@ -423,6 +430,7 @@ async fn test_dont_drop_after_ttl() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start three nodes");
@@ -480,6 +488,7 @@ async fn test_drop_after_ttl() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start three nodes");
@@ -533,6 +542,7 @@ async fn test_dropping_duplicate_messages() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start three nodes");
@@ -653,6 +663,7 @@ async fn from_boot_nodes() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start two nodes");
@@ -676,6 +687,7 @@ async fn blacklist_01() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start two nodes with 0 blacklisting 1");
@@ -711,6 +723,7 @@ async fn blacklist_10() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start two nodes with 1 blacklisting 0");
@@ -746,6 +759,7 @@ async fn blacklist_all() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start two nodes with 0 blacklisting everything");
@@ -780,6 +794,7 @@ async fn max_num_peers_limit() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start three nodes with max_num_peers=2");
@@ -883,6 +898,7 @@ async fn ttl_and_num_hops() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let mut pm = peer_manager::testonly::start(
         clock.clock(),
@@ -935,6 +951,7 @@ async fn repeated_data_in_sync_routing_table() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let pm = peer_manager::testonly::start(
         clock.clock(),
@@ -1012,6 +1029,7 @@ async fn square() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "connect 4 nodes in a square");
@@ -1065,6 +1083,7 @@ async fn fix_local_edges() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -1123,6 +1142,7 @@ async fn do_not_block_announce_account_broadcast() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let db0 = TestDB::new();
@@ -1161,6 +1181,7 @@ async fn archival_node() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let mut configs = make_configs(&chain, rng, 5, 5, false);
@@ -1251,6 +1272,7 @@ async fn connect_to_unbanned_peer() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let mut pm0 =
@@ -1298,6 +1320,7 @@ async fn oversized_sync_routing_table_drops_edges_but_keeps_connection() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     // Set a small ingress cap for testing.
@@ -1371,6 +1394,7 @@ async fn oversized_sync_routing_table_still_processes_accounts() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     // Set a small ingress cap for testing.

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -76,6 +76,7 @@ async fn broadcast() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let clock = clock.clock();
     let clock = &clock;
@@ -154,6 +155,7 @@ async fn invalid_signature_not_broadcast() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let clock = clock.clock();
     let clock = &clock;
@@ -218,6 +220,7 @@ async fn too_many_shards_not_broadcast() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let clock = clock.clock();
     let clock = &clock;
@@ -294,6 +297,7 @@ async fn propagate() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     // Adjust the file descriptors limit, so that we can create many connection in the test.
@@ -355,6 +359,7 @@ async fn large_shard_id_in_cache() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let clock = clock.clock();
     let clock = &clock;
@@ -405,6 +410,7 @@ async fn too_many_shards_truncate() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let clock = clock.clock();
     let clock = &clock;
@@ -476,6 +482,7 @@ async fn no_shards_not_broadcast() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let clock = clock.clock();
     let clock = &clock;

--- a/chain/network/src/peer_manager/tests/tier1.rs
+++ b/chain/network/src/peer_manager/tests/tier1.rs
@@ -117,6 +117,7 @@ async fn first_proxy_advertisement() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let pm = start_pm(
         clock.clock(),
@@ -144,6 +145,7 @@ async fn direct_connections() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let mut pms = vec![];
@@ -188,6 +190,7 @@ async fn proxy_connections() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     const N: usize = 5;
@@ -255,6 +258,7 @@ async fn account_keys_change() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let v0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -298,6 +302,7 @@ async fn proxy_change() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     // v0 has proxies {p0,p1}
@@ -361,6 +366,7 @@ async fn tier2_routing_using_accounts_data() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "start 2 nodes and connect them");
@@ -393,6 +399,7 @@ async fn stun_self_discovery() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    peer_manager::testonly::auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     tracing::info!(target:"test", "configure tier1 self discovery to use 2 local stun servers");

--- a/chain/network/src/peer_manager/tests/tier2.rs
+++ b/chain/network/src/peer_manager/tests/tier2.rs
@@ -5,6 +5,7 @@ use crate::peer_manager::network_state::RECONNECT_ATTEMPT_INTERVAL;
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_manager_actor::POLL_CONNECTION_STORE_INTERVAL;
 use crate::peer_manager::testonly::ActorHandler;
+use crate::peer_manager::testonly::auto_advance_fake_clock;
 use crate::peer_manager::testonly::start as start_pm;
 use crate::tcp;
 use crate::testonly::AsSet;
@@ -44,6 +45,7 @@ async fn test_store_outbound_connection() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -76,6 +78,7 @@ async fn test_storage_after_disconnect() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -108,6 +111,7 @@ async fn test_reconnect_after_restart_outbound_side() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm0_db = TestDB::new();
@@ -138,6 +142,7 @@ async fn test_skip_reconnect_after_restart_outbound_side() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm0_db = TestDB::new();
@@ -183,6 +188,7 @@ async fn test_reconnect_after_restart_inbound_side() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -217,6 +223,7 @@ async fn test_reconnect_after_disconnect_inbound_side() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
@@ -251,6 +258,7 @@ async fn test_reconnect_after_restart_outbound_side_multi() {
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let pm0_db = TestDB::new();

--- a/chain/network/src/raw/tests.rs
+++ b/chain/network/src/raw/tests.rs
@@ -1,4 +1,5 @@
 use crate::network_protocol::testonly as data;
+use crate::peer_manager::testonly::auto_advance_fake_clock;
 use crate::raw;
 use crate::tcp;
 use crate::testonly;
@@ -17,6 +18,7 @@ async fn test_raw_conn_pings() {
     let mut rng = testonly::make_rng(33955575545);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let cfg = chain.make_config(rng);
@@ -78,6 +80,7 @@ async fn test_raw_conn_state_parts() {
     let mut rng = testonly::make_rng(33955575545);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let cfg = chain.make_config(rng);
@@ -166,6 +169,7 @@ async fn test_listener() {
     let mut rng = testonly::make_rng(33955575545);
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
+    auto_advance_fake_clock(&clock);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
     let mut cfg = chain.make_config(rng);
     let genesis_id = chain.genesis_id.clone();

--- a/chain/network/src/snapshot_hosts/mod.rs
+++ b/chain/network/src/snapshot_hosts/mod.rs
@@ -9,6 +9,7 @@ use crate::network_protocol::SnapshotHostInfo;
 use crate::network_protocol::SnapshotHostInfoVerificationError;
 use itertools::Itertools;
 use lru::LruCache;
+use near_async::futures::AsyncComputationSpawner;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::EpochHeight;
@@ -297,34 +298,49 @@ impl Inner {
     }
 }
 
-pub(crate) struct SnapshotHostsCache(Mutex<Inner>);
+pub(crate) struct SnapshotHostsCache {
+    inner: Mutex<Inner>,
+    /// See `AccountDataCache::async_computation_spawner` for context.
+    async_computation_spawner: Arc<dyn AsyncComputationSpawner>,
+}
 
 impl SnapshotHostsCache {
-    pub fn new(config: Config) -> Self {
-        Self::new_with_epoch_retention_window(config, STATE_SNAPSHOT_INFO_RETENTION_WINDOW)
+    pub fn new(
+        config: Config,
+        async_computation_spawner: Arc<dyn AsyncComputationSpawner>,
+    ) -> Self {
+        Self::new_with_epoch_retention_window(
+            config,
+            STATE_SNAPSHOT_INFO_RETENTION_WINDOW,
+            async_computation_spawner,
+        )
     }
 
     pub fn new_with_epoch_retention_window(
         config: Config,
         epoch_retention_window: EpochHeight,
+        async_computation_spawner: Arc<dyn AsyncComputationSpawner>,
     ) -> Self {
-        Self(Mutex::new(Inner {
-            hosts: LruCache::new(
-                NonZeroUsize::new(config.snapshot_hosts_cache_size as usize).unwrap(),
-            ),
-            current_state_sync_hash: None,
-            discard_snapshot_infos_below_epoch_height: None,
-            hosts_for_shard: HashMap::new(),
-            peer_selector: HashMap::new(),
-            part_selection_cache_batch_size: config.part_selection_cache_batch_size as usize,
-            epoch_retention_window,
-        }))
+        Self {
+            inner: Mutex::new(Inner {
+                hosts: LruCache::new(
+                    NonZeroUsize::new(config.snapshot_hosts_cache_size as usize).unwrap(),
+                ),
+                current_state_sync_hash: None,
+                discard_snapshot_infos_below_epoch_height: None,
+                hosts_for_shard: HashMap::new(),
+                peer_selector: HashMap::new(),
+                part_selection_cache_batch_size: config.part_selection_cache_batch_size as usize,
+                epoch_retention_window,
+            }),
+            async_computation_spawner,
+        }
     }
 
     /// Updates the minimum epoch height to keep based on chain progression.
     /// Snapshot infos older than STATE_SNAPSHOT_INFO_RETENTION_WINDOW epochs from the given epoch height will be discarded.
     pub fn set_current_epoch_height(&self, epoch_height: EpochHeight) {
-        self.0.lock().update_discard_epoch_threshold(epoch_height);
+        self.inner.lock().update_discard_epoch_threshold(epoch_height);
     }
 
     /// Selects new data and verifies the signatures.
@@ -339,19 +355,23 @@ impl SnapshotHostsCache {
             return (vec![], Some(SnapshotHostInfoError::DuplicatePeerId));
         }
         let new_data = {
-            let inner = self.0.lock();
+            let inner = self.inner.lock();
             data.into_iter().filter(|d| !d.shards.is_empty() && inner.is_new(d)).collect_vec()
         };
         // Verify the signatures in parallel.
         // Verification will stop at the first encountered error.
-        let (data, verification_result) = concurrency::rayon::run(move || {
-            concurrency::rayon::try_map_result(new_data.into_iter().par_bridge(), |d| {
-                match d.verify() {
-                    Ok(()) => Ok(d),
-                    Err(err) => Err(err),
-                }
-            })
-        })
+        let (data, verification_result) = concurrency::rayon::run(
+            self.async_computation_spawner.as_ref(),
+            "SnapshotHostsCache::verify",
+            move || {
+                concurrency::rayon::try_map_result(new_data.into_iter().par_bridge(), |d| {
+                    match d.verify() {
+                        Ok(()) => Ok(d),
+                        Err(err) => Err(err),
+                    }
+                })
+            },
+        )
         .await;
         match verification_result {
             Ok(()) => (data, None),
@@ -372,22 +392,22 @@ impl SnapshotHostsCache {
             return (vec![], err);
         }
         // Insert the successfully verified data.
-        let mut inner = self.0.lock();
+        let mut inner = self.inner.lock();
         data.iter().for_each(|d| inner.insert(d));
         (data, err)
     }
 
     /// Skips signature verification. Used only for the local node's own information.
     pub fn insert_skip_verify(self: &Self, my_info: Arc<SnapshotHostInfo>) {
-        let _ = self.0.lock().try_insert(my_info);
+        let _ = self.inner.lock().try_insert(my_info);
     }
 
     pub fn get_hosts(&self) -> Vec<Arc<SnapshotHostInfo>> {
-        self.0.lock().hosts.iter().map(|(_, v)| v.clone()).collect()
+        self.inner.lock().hosts.iter().map(|(_, v)| v.clone()).collect()
     }
 
     pub(crate) fn get_host_info(&self, peer_id: &PeerId) -> Option<Arc<SnapshotHostInfo>> {
-        self.0.lock().hosts.peek(peer_id).cloned()
+        self.inner.lock().hosts.peek(peer_id).cloned()
     }
 
     /// Given a state header request, selects a peer host to which the request should be sent.
@@ -396,7 +416,7 @@ impl SnapshotHostsCache {
         sync_hash: &CryptoHash,
         shard_id: ShardId,
     ) -> Option<PeerId> {
-        self.0.lock().select_host_for_header(sync_hash, shard_id)
+        self.inner.lock().select_host_for_header(sync_hash, shard_id)
     }
 
     /// Given a state part request, selects a peer host to which the request should be sent.
@@ -406,18 +426,18 @@ impl SnapshotHostsCache {
         shard_id: ShardId,
         part_id: u64,
     ) -> Option<PeerId> {
-        self.0.lock().select_host_for_part(sync_hash, shard_id, part_id)
+        self.inner.lock().select_host_for_part(sync_hash, shard_id, part_id)
     }
 
     /// Triggered by state sync actor after processing a state part.
     pub fn part_received(&self, shard_id: ShardId, part_id: u64) {
-        let mut inner = self.0.lock();
+        let mut inner = self.inner.lock();
         inner.peer_selector.remove(&(shard_id, part_id));
     }
 
     #[cfg(test)]
     pub(crate) fn has_selector(&self, shard_id: ShardId, part_id: u64) -> bool {
-        let inner = self.0.lock();
+        let inner = self.inner.lock();
         inner.peer_selector.contains_key(&(shard_id, part_id))
     }
 }

--- a/chain/network/src/snapshot_hosts/tests.rs
+++ b/chain/network/src/snapshot_hosts/tests.rs
@@ -49,7 +49,10 @@ async fn happy_path() {
     let peer2 = PeerId::new(key2.public_key());
 
     let config = Config { snapshot_hosts_cache_size: 100, part_selection_cache_batch_size: 1 };
-    let cache = SnapshotHostsCache::new(config);
+    let cache = SnapshotHostsCache::new(
+        config,
+        std::sync::Arc::new(crate::concurrency::rayon::RayonAsyncComputationSpawner),
+    );
     assert_eq!(cache.get_hosts().len(), 0); // initially empty
 
     let sid_vec = |v: &[u64]| v.iter().cloned().map(Into::into).collect_vec();
@@ -86,7 +89,10 @@ async fn invalid_signature() {
     let peer1 = PeerId::new(key1.public_key());
 
     let config = Config { snapshot_hosts_cache_size: 100, part_selection_cache_batch_size: 1 };
-    let cache = SnapshotHostsCache::new(config);
+    let cache = SnapshotHostsCache::new(
+        config,
+        std::sync::Arc::new(crate::concurrency::rayon::RayonAsyncComputationSpawner),
+    );
 
     let sid_vec = |v: &[u64]| v.iter().cloned().map(Into::into).collect_vec();
 
@@ -122,7 +128,10 @@ async fn too_many_shards() {
     let peer1 = PeerId::new(key1.public_key());
 
     let config = Config { snapshot_hosts_cache_size: 100, part_selection_cache_batch_size: 1 };
-    let cache = SnapshotHostsCache::new(config);
+    let cache = SnapshotHostsCache::new(
+        config,
+        std::sync::Arc::new(crate::concurrency::rayon::RayonAsyncComputationSpawner),
+    );
 
     let sid_vec = |v: &[u64]| v.iter().cloned().map(Into::into).collect_vec();
 
@@ -160,7 +169,10 @@ async fn duplicate_peer_id() {
     let peer0 = PeerId::new(key0.public_key());
 
     let config = Config { snapshot_hosts_cache_size: 100, part_selection_cache_batch_size: 1 };
-    let cache = SnapshotHostsCache::new(config);
+    let cache = SnapshotHostsCache::new(
+        config,
+        std::sync::Arc::new(crate::concurrency::rayon::RayonAsyncComputationSpawner),
+    );
 
     let sid_vec = |v: &[u64]| v.iter().cloned().map(Into::into).collect_vec();
 
@@ -189,7 +201,10 @@ async fn test_lru_eviction() {
     let peer2 = PeerId::new(key2.public_key());
 
     let config = Config { snapshot_hosts_cache_size: 2, part_selection_cache_batch_size: 1 };
-    let cache = SnapshotHostsCache::new(config);
+    let cache = SnapshotHostsCache::new(
+        config,
+        std::sync::Arc::new(crate::concurrency::rayon::RayonAsyncComputationSpawner),
+    );
 
     let sid_vec = |v: &[u64]| v.iter().cloned().map(Into::into).collect_vec();
 
@@ -407,7 +422,11 @@ async fn run_select_peer_test(
 ) {
     let config =
         Config { snapshot_hosts_cache_size: keys.len() as u32, part_selection_cache_batch_size };
-    let cache = SnapshotHostsCache::new_with_epoch_retention_window(config, 1);
+    let cache = SnapshotHostsCache::new_with_epoch_retention_window(
+        config,
+        1,
+        std::sync::Arc::new(crate::concurrency::rayon::RayonAsyncComputationSpawner),
+    );
 
     tracing::debug!(test_name, "start");
 

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -111,30 +111,6 @@ impl Handler<GetInfo, crate::types::NetworkInfo> for PeerManagerActor {
     }
 }
 
-// `StopSignal is used to stop PeerManagerActor for unit tests
-#[derive(Default, Debug)]
-pub struct StopSignal {
-    pub should_panic: bool,
-}
-
-impl StopSignal {
-    pub fn should_panic() -> Self {
-        Self { should_panic: true }
-    }
-}
-
-impl Handler<StopSignal> for PeerManagerActor {
-    fn handle(&mut self, msg: StopSignal) {
-        tracing::debug!(target: "network", "received stop signal");
-
-        if msg.should_panic {
-            panic!("Node crashed");
-        } else {
-            self.handle.stop();
-        }
-    }
-}
-
 // Mocked `PeerManager` adapter, has a queue of `PeerManagerMessageRequest` messages.
 #[derive(Default)]
 pub struct MockPeerManagerAdapter {

--- a/core/async/Cargo.toml
+++ b/core/async/Cargo.toml
@@ -16,6 +16,7 @@ crossbeam-channel.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
 rand = { workspace = true, optional = true }
+rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true

--- a/core/async/src/lib.rs
+++ b/core/async/src/lib.rs
@@ -1,10 +1,12 @@
 pub use near_async_derive::{MultiSend, MultiSenderFrom};
+pub use rayon_spawner::RayonAsyncComputationSpawner;
 
 mod functional;
 pub mod futures;
 pub mod instrumentation;
 pub mod messaging;
 pub mod multithread;
+mod rayon_spawner;
 pub mod test_loop;
 pub mod test_utils;
 pub mod thread_pool;

--- a/core/async/src/rayon_spawner.rs
+++ b/core/async/src/rayon_spawner.rs
@@ -1,0 +1,14 @@
+use crate::futures::AsyncComputationSpawner;
+
+/// `AsyncComputationSpawner` backed by the global rayon thread pool.
+///
+/// Preserves the caller's `tracing::dispatcher` across the rayon hop so
+/// spans don't disappear from spawned work.
+pub struct RayonAsyncComputationSpawner;
+
+impl AsyncComputationSpawner for RayonAsyncComputationSpawner {
+    fn spawn_boxed(&self, _name: &str, f: Box<dyn FnOnce() + Send>) {
+        let dispatcher = tracing::dispatcher::get_default(|it| it.clone());
+        rayon::spawn(move || tracing::dispatcher::with_default(&dispatcher, f))
+    }
+}

--- a/core/async/src/test_loop/sender.rs
+++ b/core/async/src/test_loop/sender.rs
@@ -116,7 +116,14 @@ where
             Box::new(callback),
             self.sender_delay,
         );
-        async move { Ok(receiver.await.unwrap()) }.boxed()
+        // The callback's `sender` is dropped without sending if the destination
+        // actor's events are skipped (e.g. via `event_denylist` after a node is
+        // killed or shutdown is initiated). Map the resulting `Canceled` to
+        // `AsyncSendError::Dropped` so callers that handle send-failures
+        // gracefully (`.ok()`, `if let Ok(..)`) don't panic. Surfaces under
+        // real-PMA testloop where cross-actor `send_async` calls span node
+        // boundaries.
+        async move { receiver.await.map_err(|_| AsyncSendError::Dropped) }.boxed()
     }
 }
 

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -1,11 +1,11 @@
 use crate::tests::network::runner::*;
-use near_async::messaging::{CanSend, CanSendAsync};
+use near_async::messaging::CanSendAsync;
 use near_async::tokio::TokioRuntimeHandle;
 use near_async::{ActorSystem, time};
 use near_network::PeerManagerActor;
 use near_network::config;
 use near_network::tcp;
-use near_network::test_utils::{GetInfo, StopSignal, convert_boot_nodes, wait_or_timeout};
+use near_network::test_utils::{GetInfo, convert_boot_nodes, wait_or_timeout};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::genesis::GenesisId;
 use parking_lot::Mutex;
@@ -152,8 +152,11 @@ async fn peer_recover() {
                 // Wait a small timeout for connection to be active.
                 state.store(1, Ordering::Relaxed);
             } else if state.load(Ordering::Relaxed) == 1 {
-                // Stop node2.
-                let _ = pm2.lock().send(StopSignal::default());
+                // Stop node2 by cancelling its tokio runtime. This triggers
+                // `stop_actor` on drop (broadcasts Disconnect, shuts down
+                // transport) and cancels all spawned tasks (PeerActors,
+                // background loops), closing the TCP connections to peers.
+                pm2.lock().stop();
                 state.store(2, Ordering::Relaxed);
             } else if state.load(Ordering::Relaxed) == 2 {
                 // Wait until node0 removes node2 from active validators.


### PR DESCRIPTION
PR 1 of n in the testloop integration stack — gets the real `PeerManagerActor` running in testloop by replacing the testloop-incompatible scheduling primitives.

## Changes

- Replace `handle: TokioRuntimeHandle<Self>` with `spawner: Arc<dyn FutureSpawner>` — testloop has no tokio runtime, but provides `PendingEventsSender` which implements `FutureSpawner`
- Thread `ctx: &mut dyn DelayedActionRunner<Self>` through self-rescheduling trigger methods (`push_network_info_trigger`, `monitor_peers_trigger`, `report_bandwidth_stats_trigger`) — replaces `self.handle.clone().run_later(...)`
- Fix `tokio::time::interval` → `near_time::Interval` in tier1_connect loop
- Split `spawn()` into `new()` (pure constructor) + `spawn()` (production entry point)
- Move epoch height fetch from `spawn()` into `start_actor()` so it runs via `self.spawner`

After this PR, all PMA code paths use `FutureSpawner` for async work and `DelayedActionRunner` for scheduling — both work in production and testloop.

Supersedes #15593 (closed by accidental branch-rename API call; same content, new branch name aligned with the testloop/* stack prefix).