### PR TITLE
feat(test-loop): add TestLoopTransport scaffolding (4/n)

### DIFF
--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -1,5 +1,11 @@
 #![cfg_attr(enable_const_type_id, feature(const_type_id))]
 
+pub use crate::peer::peer_actor::ClosingReason;
+pub use crate::peer_manager::connected_peers::{ConnectedPeerState, ConnectedPeers};
+pub use crate::peer_manager::network_state::{NetworkState, PeerDisconnectInfo, RoutedAction};
+pub use crate::peer_manager::network_transport::{
+    ConnectError, ConnectHandle, NetworkTransport, PeerTransportStats, TransportInfo,
+};
 pub use crate::peer_manager::peer_manager_actor::{Event, PeerManagerActor};
 pub use crate::peer_manager::tcp_transport::TcpTransport;
 pub use crate::rate_limits::messages_limits::OverrideConfig as MessagesLimitsOverrideConfig;

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -89,7 +89,8 @@ pub struct HandshakeCompletedEvent {
 }
 
 #[derive(thiserror::Error, Clone, PartialEq, Eq, Debug)]
-pub(crate) enum ClosingReason {
+#[allow(private_interfaces)]
+pub enum ClosingReason {
     #[error("too many inbound connections in connecting state")]
     TooManyInbound,
     #[error("outbound not allowed: {0}")]

--- a/chain/network/src/peer_manager/connected_peers.rs
+++ b/chain/network/src/peer_manager/connected_peers.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 /// (Block updates `block_info`), removed on unregister.
 #[allow(dead_code)]
 #[derive(Clone)]
-pub(crate) struct ConnectedPeerState {
+pub struct ConnectedPeerState {
     pub peer_info: PeerInfo,
     /// Highest block we've heard of from this peer. `None` until the
     /// first `Block` message arrives. Distinct from `Connection::last_block`:
@@ -53,7 +53,7 @@ pub(crate) struct ConnectedPeerState {
 /// Invariant: `tier1_by_account_key[k] = p` iff there is a T1 entry
 /// at `p` with `owned_account_key == Some(k)`. Maintained by `insert`
 /// and `remove`.
-pub(crate) struct ConnectedPeers {
+pub struct ConnectedPeers {
     tier1_peers: Mutex<HashMap<PeerId, ConnectedPeerState>>,
     tier2_peers: Mutex<HashMap<PeerId, ConnectedPeerState>>,
     tier3_peers: Mutex<HashMap<PeerId, ConnectedPeerState>>,

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -105,7 +105,8 @@ pub(crate) struct WhitelistNode {
     account_id: Option<AccountId>,
 }
 
-pub(crate) struct NetworkState {
+#[allow(private_interfaces)]
+pub struct NetworkState {
     /// Spawner for NetworkState's background operations (gossip
     /// processing, edge correction, send-to-self delivery). The
     /// spawner's runtime lifetime is the caller's responsibility;
@@ -210,7 +211,7 @@ impl EdgesWithSource {
 /// Action to take after processing an incoming routed message.
 /// Returned by `NetworkState::process_incoming_routed` for the caller
 /// (PeerActor or TestLoopTransport) to execute.
-pub(crate) enum RoutedAction {
+pub enum RoutedAction {
     /// Message is for us — caller should handle (Ping/Pong synchronously,
     /// others via `handle_peer_message`).
     ForMe(Box<RoutedMessage>),
@@ -238,7 +239,7 @@ pub(crate) struct PeerConnectionInfo {
 
 /// Minimal peer identity carried through the disconnect path. Only
 /// what `on_peer_disconnected` actually reads.
-pub(crate) struct PeerDisconnectInfo {
+pub struct PeerDisconnectInfo {
     pub peer_info: PeerInfo,
     pub tier: tcp::Tier,
     pub peer_type: PeerType,
@@ -265,7 +266,7 @@ impl From<&connection::Connection> for PeerDisconnectInfo {
 }
 
 impl NetworkState {
-    pub fn new(
+    pub(crate) fn new(
         clock: &time::Clock,
         future_spawner: Arc<dyn FutureSpawner>,
         async_computation_spawner: Arc<dyn AsyncComputationSpawner>,
@@ -541,7 +542,11 @@ impl NetworkState {
     /// internally, only when the removed peer was T1, with a defensive
     /// check against account-key reuse races). For T2: edge removal
     /// broadcast, peer_store, connection_store, pending_reconnect.
-    pub(crate) async fn on_peer_disconnected(
+    // tcp::StreamId is pub(crate) and #[cfg(test)]-gated; from outside
+    // the crate the parameter is invisible. The allow silences the lint
+    // for the in-crate test build only.
+    #[allow(private_interfaces)]
+    pub async fn on_peer_disconnected(
         self: &Arc<Self>,
         clock: &time::Clock,
         info: &PeerDisconnectInfo,
@@ -679,7 +684,11 @@ impl NetworkState {
         self.send_message_to_peer(clock, tier, self.sign_message(clock, msg), transport);
     }
 
-    pub fn sign_message(&self, clock: &time::Clock, msg: RawRoutedMessage) -> Box<RoutedMessage> {
+    pub(crate) fn sign_message(
+        &self,
+        clock: &time::Clock,
+        msg: RawRoutedMessage,
+    ) -> Box<RoutedMessage> {
         Box::new(msg.sign(
             &self.config.node_key,
             self.config.routed_message_ttl,
@@ -1063,7 +1072,7 @@ impl NetworkState {
     ///
     /// Returns a `RoutedAction` for the caller to execute. Ping/Pong
     /// special-casing happens on the caller side.
-    pub(crate) fn process_incoming_routed(
+    pub fn process_incoming_routed(
         &self,
         clock: &time::Clock,
         from: &PeerId,
@@ -1292,7 +1301,7 @@ impl NetworkState {
         }
     }
 
-    pub async fn add_accounts_data(
+    pub(crate) async fn add_accounts_data(
         self: &Arc<Self>,
         clock: &time::Clock,
         accounts_data: Vec<Arc<SignedAccountData>>,
@@ -1339,7 +1348,7 @@ impl NetworkState {
         .unwrap_or(None)
     }
 
-    pub async fn add_snapshot_hosts(
+    pub(crate) async fn add_snapshot_hosts(
         self: &Arc<Self>,
         hosts: Vec<Arc<SnapshotHostInfo>>,
         transport: Arc<dyn NetworkTransport>,

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -96,7 +96,7 @@ impl NetworkState {
     /// Validates edges, then adds them to the graph and then broadcasts all the edges that
     /// hasn't been observed before. Returns an error iff any edge was invalid. Even if an
     /// error was returned some of the valid input edges might have been added to the graph.
-    pub async fn add_edges(
+    pub(crate) async fn add_edges(
         self: &Arc<Self>,
         clock: &time::Clock,
         edges: EdgesWithSource,

--- a/test-loop-tests/src/setup/mod.rs
+++ b/test-loop-tests/src/setup/mod.rs
@@ -5,3 +5,4 @@ pub(crate) mod peer_manager_actor;
 pub(crate) mod rpc;
 pub mod setup;
 pub mod state;
+pub(crate) mod testloop_transport;

--- a/test-loop-tests/src/setup/testloop_transport/mod.rs
+++ b/test-loop-tests/src/setup/testloop_transport/mod.rs
@@ -1,0 +1,11 @@
+pub mod registry;
+pub mod shared_state;
+pub mod transport;
+
+// Re-exports consumed in T4 (`#[allow(unused_imports)]` cleared there).
+#[allow(unused_imports)]
+pub(crate) use registry::TestLoopNodeRegistry;
+#[allow(unused_imports)]
+pub use shared_state::{DelayPredicate, TestLoopNetworkSharedStateV2, TransportMessageFilter};
+#[allow(unused_imports)]
+pub use transport::{NETWORK_DELAY, TestLoopTransport};

--- a/test-loop-tests/src/setup/testloop_transport/registry.rs
+++ b/test-loop-tests/src/setup/testloop_transport/registry.rs
@@ -1,0 +1,33 @@
+use super::transport::TestLoopTransport;
+use near_primitives::network::PeerId;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Cross-node lookup for testloop transports. Populated as nodes start
+/// (via `setup_client`) and updated by `kill_node` / `restart_node`.
+#[derive(Clone, Default)]
+#[allow(dead_code)]
+pub(crate) struct TestLoopNodeRegistry {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    nodes: Mutex<HashMap<PeerId, Arc<TestLoopTransport>>>,
+}
+
+#[allow(dead_code)]
+impl TestLoopNodeRegistry {
+    pub(crate) fn register(&self, peer_id: PeerId, transport: Arc<TestLoopTransport>) {
+        self.inner.nodes.lock().insert(peer_id, transport);
+    }
+
+    pub(crate) fn unregister(&self, peer_id: &PeerId) {
+        self.inner.nodes.lock().remove(peer_id);
+    }
+
+    pub(crate) fn get(&self, peer_id: &PeerId) -> Option<Arc<TestLoopTransport>> {
+        self.inner.nodes.lock().get(peer_id).cloned()
+    }
+}

--- a/test-loop-tests/src/setup/testloop_transport/shared_state.rs
+++ b/test-loop-tests/src/setup/testloop_transport/shared_state.rs
@@ -1,0 +1,162 @@
+use near_async::time;
+use near_network::types::PeerMessage;
+use near_primitives::network::PeerId;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Filter applied to messages between two specific peers. Returns
+/// `Some(msg)` to continue delivery (possibly modified), `None` to
+/// drop. Filters chain in registration order; first `None` wins.
+pub type TransportMessageFilter =
+    Arc<dyn Fn(&PeerId, &PeerId, &PeerMessage) -> Option<PeerMessage> + Send + Sync>;
+
+/// Predicate for an additional delay applied to matching messages.
+pub type DelayPredicate = Arc<dyn Fn(&PeerId, &PeerId, &PeerMessage) -> bool + Send + Sync>;
+
+/// Test-controlled hooks: filters and delays. Cloneable so `TestLoopEnv`
+/// can hand it to the builder, the registry, and to test code.
+#[derive(Clone, Default)]
+#[allow(dead_code)]
+pub struct TestLoopNetworkSharedStateV2 {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    filters: Mutex<Vec<TransportMessageFilter>>,
+    delays: Mutex<Vec<(DelayPredicate, time::Duration)>>,
+}
+
+#[allow(dead_code)]
+impl TestLoopNetworkSharedStateV2 {
+    pub fn register_message_filter(&self, f: TransportMessageFilter) {
+        self.inner.filters.lock().push(f);
+    }
+
+    pub fn add_message_delay(&self, predicate: DelayPredicate, duration: time::Duration) {
+        self.inner.delays.lock().push((predicate, duration));
+    }
+
+    /// Apply all filters in order. Short-circuit on first `None`.
+    /// Lock is released before the (owned) message is returned.
+    pub(super) fn apply_filters(
+        &self,
+        from: &PeerId,
+        to: &PeerId,
+        msg: &PeerMessage,
+    ) -> Option<PeerMessage> {
+        let filters = self.inner.filters.lock();
+        let mut current = msg.clone();
+        for f in filters.iter() {
+            current = f(from, to, &current)?;
+        }
+        Some(current)
+    }
+
+    /// Maximum delay across matching predicates. Base NETWORK_DELAY is
+    /// added by the caller.
+    pub(super) fn compute_extra_delay(
+        &self,
+        from: &PeerId,
+        to: &PeerId,
+        msg: &PeerMessage,
+    ) -> time::Duration {
+        let delays = self.inner.delays.lock();
+        delays
+            .iter()
+            .filter(|(pred, _)| pred(from, to, msg))
+            .map(|(_, d)| *d)
+            .max()
+            .unwrap_or(time::Duration::ZERO)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use near_crypto::{KeyType, SecretKey};
+    use near_network::types::{Disconnect, PeerMessage};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn peer_id(seed: &str) -> PeerId {
+        PeerId::new(SecretKey::from_seed(KeyType::ED25519, seed).public_key())
+    }
+
+    fn dummy_msg() -> PeerMessage {
+        PeerMessage::Disconnect(Disconnect { remove_from_connection_store: false })
+    }
+
+    #[test]
+    fn filters_chain_in_order_and_short_circuit_on_none() {
+        let shared = TestLoopNetworkSharedStateV2::default();
+        let order: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let order_a = order.clone();
+        shared.register_message_filter(Arc::new(move |_, _, m| {
+            order_a.lock().push(1);
+            Some(m.clone())
+        }));
+        let order_b = order.clone();
+        shared.register_message_filter(Arc::new(move |_, _, _| {
+            order_b.lock().push(2);
+            None
+        }));
+        // Should never be called: filter 2 returns None.
+        let order_c = order.clone();
+        shared.register_message_filter(Arc::new(move |_, _, m| {
+            order_c.lock().push(3);
+            Some(m.clone())
+        }));
+
+        let result = shared.apply_filters(&peer_id("a"), &peer_id("b"), &dummy_msg());
+        assert!(result.is_none());
+        assert_eq!(*order.lock(), vec![1, 2]);
+    }
+
+    #[test]
+    fn filter_modifies_message_passed_to_next_filter() {
+        let shared = TestLoopNetworkSharedStateV2::default();
+        let observed = Arc::new(AtomicUsize::new(0));
+
+        // First filter swaps Disconnect's flag.
+        shared.register_message_filter(Arc::new(|_, _, m| match m {
+            PeerMessage::Disconnect(d) => {
+                Some(PeerMessage::Disconnect(near_network::types::Disconnect {
+                    remove_from_connection_store: !d.remove_from_connection_store,
+                }))
+            }
+            other => Some(other.clone()),
+        }));
+
+        let observed_clone = observed.clone();
+        shared.register_message_filter(Arc::new(move |_, _, m| {
+            if let PeerMessage::Disconnect(d) = m {
+                if d.remove_from_connection_store {
+                    observed_clone.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+            Some(m.clone())
+        }));
+
+        let _ = shared.apply_filters(&peer_id("a"), &peer_id("b"), &dummy_msg());
+        assert_eq!(observed.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn delays_take_max_not_sum() {
+        let shared = TestLoopNetworkSharedStateV2::default();
+        shared.add_message_delay(Arc::new(|_, _, _| true), time::Duration::milliseconds(100));
+        shared.add_message_delay(Arc::new(|_, _, _| true), time::Duration::milliseconds(50));
+        shared.add_message_delay(Arc::new(|_, _, _| true), time::Duration::milliseconds(200));
+        let d = shared.compute_extra_delay(&peer_id("a"), &peer_id("b"), &dummy_msg());
+        assert_eq!(d, time::Duration::milliseconds(200));
+    }
+
+    #[test]
+    fn no_matching_predicate_returns_zero() {
+        let shared = TestLoopNetworkSharedStateV2::default();
+        shared.add_message_delay(Arc::new(|_, _, _| false), time::Duration::milliseconds(100));
+        let d = shared.compute_extra_delay(&peer_id("a"), &peer_id("b"), &dummy_msg());
+        assert_eq!(d, time::Duration::ZERO);
+    }
+}

--- a/test-loop-tests/src/setup/testloop_transport/transport.rs
+++ b/test-loop-tests/src/setup/testloop_transport/transport.rs
@@ -55,8 +55,32 @@ impl TestLoopTransport {
         })
     }
 
+    /// Read-only accessor for the underlying `NetworkState`. Mirrors
+    /// the production transport pattern: callers within the testloop
+    /// crate use this rather than reaching into a `pub(super)` field.
+    pub(super) fn state(&self) -> &Arc<NetworkState> {
+        &self.state
+    }
+
     fn self_arc(&self) -> Arc<Self> {
         self.self_weak.upgrade().expect("TestLoopTransport self_weak upgrade")
+    }
+
+    /// Spawn an `on_peer_disconnected` task. Used by `disconnect_peer`
+    /// to notify both ends of the connection. The state, info, reason,
+    /// and transport vary per call; the spawn shape is identical.
+    fn spawn_disconnect(
+        &self,
+        target_state: Arc<NetworkState>,
+        info: PeerDisconnectInfo,
+        reason: ClosingReason,
+        transport: Arc<dyn NetworkTransport>,
+        label: &'static str,
+    ) {
+        let clock = self.clock.clone();
+        self.future_spawner.spawn(label, async move {
+            target_state.on_peer_disconnected(&clock, &info, reason, transport).await;
+        });
     }
 
     /// Entry point invoked by another node's `send_message` after the
@@ -178,12 +202,13 @@ impl NetworkTransport for TestLoopTransport {
         // disconnect — the ban applies to us about them, not the reverse.
         let my_reason =
             ban_reason.map(ClosingReason::Ban).unwrap_or(ClosingReason::DisconnectMessage);
-        let my_state = self.state.clone();
-        let my_transport: Arc<dyn NetworkTransport> = self.self_arc();
-        let clock_a = self.clock.clone();
-        self.future_spawner.spawn("testloop disconnect (initiator)", async move {
-            my_state.on_peer_disconnected(&clock_a, &my_info, my_reason, my_transport).await;
-        });
+        self.spawn_disconnect(
+            self.state.clone(),
+            my_info,
+            my_reason,
+            self.self_arc(),
+            "testloop disconnect (initiator)",
+        );
 
         if let Some(target) = self.registry.get(peer_id) {
             if let Some(their_peer_state) = target.state.peers.get(&self.my_peer_id) {
@@ -192,19 +217,13 @@ impl NetworkTransport for TestLoopTransport {
                     tier: their_peer_state.tier,
                     peer_type: their_peer_state.peer_type,
                 };
-                let their_state = target.state.clone();
-                let their_transport: Arc<dyn NetworkTransport> = target.clone();
-                let clock_b = self.clock.clone();
-                self.future_spawner.spawn("testloop disconnect (target)", async move {
-                    their_state
-                        .on_peer_disconnected(
-                            &clock_b,
-                            &their_info,
-                            ClosingReason::DisconnectMessage,
-                            their_transport,
-                        )
-                        .await;
-                });
+                self.spawn_disconnect(
+                    target.state.clone(),
+                    their_info,
+                    ClosingReason::DisconnectMessage,
+                    target.clone(),
+                    "testloop disconnect (target)",
+                );
             }
         }
     }

--- a/test-loop-tests/src/setup/testloop_transport/transport.rs
+++ b/test-loop-tests/src/setup/testloop_transport/transport.rs
@@ -1,0 +1,216 @@
+use super::registry::TestLoopNodeRegistry;
+use super::shared_state::TestLoopNetworkSharedStateV2;
+use near_async::futures::{FutureSpawner, FutureSpawnerExt};
+use near_async::time;
+use near_network::tcp;
+use near_network::types::{PeerInfo, PeerMessage, ReasonForBan};
+use near_network::{
+    ClosingReason, ConnectHandle, NetworkState, NetworkTransport, PeerDisconnectInfo, RoutedAction,
+    TransportInfo,
+};
+use near_primitives::network::PeerId;
+use std::sync::{Arc, Weak};
+
+/// Simulated network transit delay applied once per hop. Matches the
+/// 10 ms delay the mock applied via `with_delay` on senders.
+pub const NETWORK_DELAY: time::Duration = time::Duration::milliseconds(10);
+
+/// In-memory `NetworkTransport` for testloop. Owns nothing more than
+/// what it takes to deliver a `PeerMessage` from one peer to another.
+/// Routing, dispatch, peer management, and the connect/disconnect
+/// lifecycle all live on `NetworkState` — shared with production.
+#[allow(dead_code)]
+pub struct TestLoopTransport {
+    my_peer_id: PeerId,
+    pub(super) state: Arc<NetworkState>,
+    shared: TestLoopNetworkSharedStateV2,
+    registry: TestLoopNodeRegistry,
+    future_spawner: Arc<dyn FutureSpawner>,
+    clock: time::Clock,
+    /// Self-reference used when handing `Arc<dyn NetworkTransport>` to
+    /// NetworkState lifecycle methods (`on_peer_disconnected`,
+    /// `disconnect_and_ban`). Mirrors `TcpTransport::self_weak`. The
+    /// Weak always upgrades because the testloop env holds an Arc.
+    self_weak: Weak<Self>,
+}
+
+#[allow(dead_code)]
+impl TestLoopTransport {
+    pub fn new(
+        my_peer_id: PeerId,
+        state: Arc<NetworkState>,
+        shared: TestLoopNetworkSharedStateV2,
+        registry: TestLoopNodeRegistry,
+        future_spawner: Arc<dyn FutureSpawner>,
+        clock: time::Clock,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|self_weak| Self {
+            my_peer_id,
+            state,
+            shared,
+            registry,
+            future_spawner,
+            clock,
+            self_weak: self_weak.clone(),
+        })
+    }
+
+    fn self_arc(&self) -> Arc<Self> {
+        self.self_weak.upgrade().expect("TestLoopTransport self_weak upgrade")
+    }
+
+    /// Entry point invoked by another node's `send_message` after the
+    /// simulated network delay elapses. Mirrors PeerActor's incoming
+    /// dispatch: routed messages go through `process_incoming_routed`
+    /// (TTL + dedup + route-back), everything else goes straight to
+    /// `handle_peer_message`.
+    async fn deliver_incoming(
+        self: Arc<Self>,
+        from: PeerId,
+        tier: tcp::Tier,
+        msg: Arc<PeerMessage>,
+    ) {
+        match (*msg).clone() {
+            PeerMessage::Routed(routed) => {
+                let action = self.state.process_incoming_routed(&self.clock, &from, tier, routed);
+                match action {
+                    RoutedAction::ForMe(m) => {
+                        self.dispatch_to_client(from, PeerMessage::Routed(m), tier).await
+                    }
+                    RoutedAction::Forward(m) => {
+                        let transport: &dyn NetworkTransport = self.as_ref();
+                        self.state.send_message_to_peer(&self.clock, tier, m, transport);
+                    }
+                    RoutedAction::Dropped => {}
+                }
+            }
+            other => self.dispatch_to_client(from, other, tier).await,
+        }
+    }
+
+    async fn dispatch_to_client(self: &Arc<Self>, from: PeerId, msg: PeerMessage, tier: tcp::Tier) {
+        let result = self
+            .state
+            .handle_peer_message(&self.clock, from.clone(), msg, /* was_requested */ false)
+            .await;
+        match result {
+            Ok(Some(resp)) => {
+                self.send_message(tier, from, Arc::new(resp));
+            }
+            Ok(None) => {}
+            Err(ban) => {
+                let transport: &dyn NetworkTransport = self.as_ref();
+                self.state.disconnect_and_ban(&self.clock, &from, ban, transport);
+            }
+        }
+    }
+}
+
+impl NetworkTransport for TestLoopTransport {
+    fn send_message(&self, tier: tcp::Tier, peer_id: PeerId, msg: Arc<PeerMessage>) -> bool {
+        // Connectivity gate. state.peers is the canonical map; banned
+        // peers are absent (peer_store.peer_ban + on_peer_disconnected
+        // remove them). Partitions are filters.
+        if !self.state.peers.is_connected_on_tier(&peer_id, tier) {
+            return false;
+        }
+
+        let Some(filtered) = self.shared.apply_filters(&self.my_peer_id, &peer_id, &msg) else {
+            return false;
+        };
+        let extra = self.shared.compute_extra_delay(&self.my_peer_id, &peer_id, &filtered);
+
+        let Some(target) = self.registry.get(&peer_id) else {
+            return false;
+        };
+
+        let from = self.my_peer_id.clone();
+        let clock = self.clock.clone();
+        let msg = Arc::new(filtered);
+        self.future_spawner.spawn("testloop deliver", async move {
+            clock.sleep(NETWORK_DELAY + extra).await;
+            target.deliver_incoming(from, tier, msg).await;
+        });
+        true
+    }
+
+    fn broadcast_message(&self, msg: Arc<PeerMessage>) {
+        // Trait-level broadcast is T2-only by design.
+        let peers: Vec<PeerId> = self.state.peers.tier2().keys().cloned().collect();
+        for peer_id in peers {
+            self.send_message(tcp::Tier::T2, peer_id, msg.clone());
+        }
+    }
+
+    fn transport_info(&self) -> TransportInfo {
+        TransportInfo::default()
+    }
+
+    fn connect_to_peer(
+        &self,
+        _clock: &time::Clock,
+        _peer_info: PeerInfo,
+        _tier: tcp::Tier,
+    ) -> ConnectHandle {
+        // No-op. T4 setup directly populates state.peers, peer_store,
+        // and account_announcements; PMA's monitor_peers_trigger and
+        // tier1_connect short-circuit on the relevant idempotency /
+        // status checks.
+        ConnectHandle::noop()
+    }
+
+    fn disconnect_peer(&self, peer_id: &PeerId, ban_reason: Option<ReasonForBan>) {
+        // The one place the transport touches connectivity state.
+        // Mirrors production: PeerActor's stopping() invokes
+        // on_peer_disconnected, which writes peer_store + clears
+        // state.peers + broadcasts edge removal. We do the same on
+        // both sides via direct calls into NetworkState.
+
+        let Some(my_peer_state) = self.state.peers.get(peer_id) else {
+            return;
+        };
+        let my_info = PeerDisconnectInfo {
+            peer_info: my_peer_state.peer_info.clone(),
+            tier: my_peer_state.tier,
+            peer_type: my_peer_state.peer_type,
+        };
+        // ClosingReason::Ban only on the initiator; target sees graceful
+        // disconnect — the ban applies to us about them, not the reverse.
+        let my_reason =
+            ban_reason.map(ClosingReason::Ban).unwrap_or(ClosingReason::DisconnectMessage);
+        let my_state = self.state.clone();
+        let my_transport: Arc<dyn NetworkTransport> = self.self_arc();
+        let clock_a = self.clock.clone();
+        self.future_spawner.spawn("testloop disconnect (initiator)", async move {
+            my_state.on_peer_disconnected(&clock_a, &my_info, my_reason, my_transport).await;
+        });
+
+        if let Some(target) = self.registry.get(peer_id) {
+            if let Some(their_peer_state) = target.state.peers.get(&self.my_peer_id) {
+                let their_info = PeerDisconnectInfo {
+                    peer_info: their_peer_state.peer_info.clone(),
+                    tier: their_peer_state.tier,
+                    peer_type: their_peer_state.peer_type,
+                };
+                let their_state = target.state.clone();
+                let their_transport: Arc<dyn NetworkTransport> = target.clone();
+                let clock_b = self.clock.clone();
+                self.future_spawner.spawn("testloop disconnect (target)", async move {
+                    their_state
+                        .on_peer_disconnected(
+                            &clock_b,
+                            &their_info,
+                            ClosingReason::DisconnectMessage,
+                            their_transport,
+                        )
+                        .await;
+                });
+            }
+        }
+    }
+
+    fn shutdown(&self) {
+        // No-op. kill_node in T4 unregisters from the registry, which
+        // is what actually stops delivery.
+    }
+}


### PR DESCRIPTION
PR 2 of n in the testloop integration stack. Stacked on top of #15651.

Adds the `TestLoopTransport` scaffolding without wiring any test to it (T4 does that). Implements `NetworkTransport` for in-memory delivery between testloop nodes following the **Position Y** design.

## What

New `test-loop-tests/src/setup/testloop_transport/` module:

- `transport.rs` — `TestLoopTransport`. `connect_to_peer = ConnectHandle::noop()`; `disconnect_peer` triggers production `on_peer_disconnected` on both sides; `send_message` reads `state.peers.is_connected_on_tier` to gate delivery. The `ClosingReason::Ban` branch propagates only on the initiator side — the ban applies to us about them, not the reverse.
- `registry.rs` — `TestLoopNodeRegistry`: cross-node lookup `PeerId → Arc<TestLoopTransport>`.
- `shared_state.rs` — `TestLoopNetworkSharedStateV2`: filters + delays. Filters chain in registration order; first `None` wins. Delays take max across matching predicates, not sum.

`NETWORK_DELAY = 10ms`, applied once per hop in the transport (matches the mock's `with_delay`).

## Production-side change

Visibility widening in `near-network`. The intermediate modules (`peer_manager`, `peer`, etc.) stay private; named items get `pub use` re-exports at `chain/network/src/lib.rs`:

- `ClosingReason`, `ConnectedPeerState`, `ConnectedPeers`, `NetworkState`, `PeerDisconnectInfo`, `RoutedAction`, `NetworkTransport`, `ConnectHandle`, `ConnectError`, `TransportInfo`, `PeerTransportStats` — all re-exported.
- `pub(crate)` → `pub` on the underlying types and on `on_peer_disconnected`, `process_incoming_routed`.
- Methods used only in-crate (`NetworkState::new`, `sign_message`, `add_accounts_data`, `add_snapshot_hosts`, `add_edges`) demoted to `pub(crate)` so the public API stays tight (no `private_interfaces` warnings other than the one `#[cfg(test)]`-gated `tcp::StreamId` parameter on `on_peer_disconnected`, which is allow'd locally).

## Tests

Inline tests in `shared_state.rs`:
- filter chaining order + short-circuit on `None`
- filter modify-and-pass-through
- delays take max not sum
- no matching predicate returns zero

Transport-level unit tests are deferred to T4 integration. They need `NetworkState::new` callable from outside the crate, which requires widening `WhitelistNode` / `PeerStore` / `store::Store` — better done as part of T4's setup rather than expanding T3's scope.

## Dead code

Each new type carries `#[allow(dead_code)]`. T4 wires them in and removes the suppressions.