### PR TITLE
fix(wasmtime): trampoline-only contract workarounds

### DIFF
--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -310,6 +310,40 @@ fn test_guest_panic() {
 }
 
 #[test]
+fn test_trampoline_only_start_section() {
+    test_builder()
+        .wat(
+            r#"
+(module
+  (import "env" "panic" (func $panic))
+  (start $panic)
+  (export "main" (func $panic))
+)"#,
+        )
+        .expect(&expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 364482479 used gas 364482479
+            Err: Smart contract panicked: explicit guest panic
+        "#]]);
+}
+
+#[test]
+fn test_trampoline_only_remaining_gas_global() {
+    test_builder()
+        .wat(
+            r#"
+(module
+  (import "env" "panic" (func $panic))
+  (global $g i32 (i32.const 0))
+  (export "main" (func $panic))
+)"#,
+        )
+        .expect(&expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 376464724 used gas 376464724
+            Err: Smart contract panicked: explicit guest panic
+        "#]]);
+}
+
+#[test]
 fn test_panic_re_export() {
     test_builder()
         .wat(

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -895,14 +895,19 @@ impl crate::PreparedContract for VMResult<PreparedContract> {
         // function bodies), LoadedCode::push_module stores the module in
         // modules_with_only_trampolines, but LoadedCode::module() only
         // searches self.modules, causing module_for_instance to panic.
+        // Seems to have been resolved in wasmtime 40, by a registry refactor.
+        // Until then the workaround is necessary.
         if let Export::Unresolved(_) = store.data().memory {
             if let Some(memory) = instance.get_memory(&mut store, MEMORY_EXPORT) {
                 store.data_mut().memory = Export::Resolved(memory);
             }
         }
-        if let Some(global) = remaining_gas {
-            let Some(Extern::Global(global)) = instance.get_module_export(&mut store, &global)
-            else {
+        if remaining_gas.is_some() {
+            // Uses string-based instance.get_global instead of
+            // instance.get_module_export due to the same wasmtime issue
+            // documented for the memory pre-resolution above: trampoline-only
+            // modules cause module_for_instance to panic.
+            let Some(global) = instance.get_global(&mut store, REMAINING_GAS_EXPORT) else {
                 panic!("gas global export was present on the module, but not on the instance");
             };
             store.call_hook(move |mut store, hook| {
@@ -931,8 +936,12 @@ impl crate::PreparedContract for VMResult<PreparedContract> {
                 Ok(())
             });
         }
-        if let Some(start) = start {
-            let Some(Extern::Func(start)) = instance.get_module_export(&mut store, &start) else {
+        if start.is_some() {
+            // Uses string-based instance.get_func instead of
+            // instance.get_module_export due to the same wasmtime issue
+            // documented for the memory pre-resolution above: trampoline-only
+            // modules cause module_for_instance to panic.
+            let Some(start) = instance.get_func(&mut store, START_EXPORT) else {
                 panic!("start function export was present on the module, but not on the instance");
             };
             if let Err(err) = start.call(&mut store, &[], &mut []) {


### PR DESCRIPTION
For the same reason mentioned around [here](https://github.com/near/nearcore/compare/master...darioush:nearcore:fix-trampoline-only?expand=1#diff-3b0e3ce5c494a5ea5eb9cba949eac53481928d1ac39d0010697a28aa28f2521eR886-R897), `get_module_export` can't be used for trampoline only modules with the current version of wasmtime.
