### PR TITLE
refactor(network): inline Graph state as Mutex

### DIFF
--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -109,7 +109,7 @@ impl NetworkState {
         let clock = clock.clone();
         self.add_edges_demux
             .call(edges, |edges: Vec<EdgesWithSource>| async move {
-                let (mut edges, oks) = this.graph.update(edges).await;
+                let (mut edges, oks) = this.graph.update(edges);
                 // Don't send tombstones during the initial time.
                 // Most of the network is created during this time, which results
                 // in us sending a lot of tombstones to peers.

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -5,13 +5,12 @@ use crate::routing::routing_table_view::RoutingTableView;
 use crate::stats::metrics;
 use ::time::ext::InstantExt as _;
 use arc_swap::ArcSwap;
-use near_async::messaging::{Actor, CanSendAsync, Handler};
-use near_async::multithread::MultithreadRuntimeHandle;
+use near_async::time;
 use near_async::time::Clock;
-use near_async::{new_owned_multithread_actor, time};
 use near_primitives::network::PeerId;
+use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 #[cfg(test)]
 mod tests;
@@ -344,31 +343,25 @@ pub(crate) struct Graph {
     snapshot: ArcSwap<GraphSnapshot>,
     unreliable_peers: ArcSwap<HashSet<PeerId>>,
     pub routing_table: RoutingTableView,
-    updater: MultithreadRuntimeHandle<GraphActor>,
+    inner: Mutex<Inner>,
+    clock: Clock,
 }
 
 impl Graph {
     pub fn new(clock: Clock, config: GraphConfig) -> Arc<Self> {
-        Arc::new_cyclic(|weak| {
-            let weak = weak.clone();
-            let updater = new_owned_multithread_actor(1, move || GraphActor {
-                clock: clock.clone(),
-                graph: weak.clone(),
-                inner: Inner {
-                    graph: bfs::Graph::new(config.node_id.clone(), config.max_graph_peers),
-                    config: config.clone(),
-                    edges: Default::default(),
-                    peer_reachable_at: HashMap::new(),
-                    edge_source: HashMap::new(),
-                    source_edge_count: HashMap::new(),
-                },
-            });
-            Self {
-                routing_table: RoutingTableView::new(),
-                unreliable_peers: ArcSwap::default(),
-                snapshot: ArcSwap::default(),
-                updater,
-            }
+        Arc::new(Self {
+            routing_table: RoutingTableView::new(),
+            unreliable_peers: ArcSwap::default(),
+            snapshot: ArcSwap::default(),
+            inner: Mutex::new(Inner {
+                graph: bfs::Graph::new(config.node_id.clone(), config.max_graph_peers),
+                config,
+                edges: Default::default(),
+                peer_reachable_at: HashMap::new(),
+                edge_source: HashMap::new(),
+                source_edge_count: HashMap::new(),
+            }),
+            clock,
         })
     }
 
@@ -395,37 +388,19 @@ impl Graph {
     /// node. The node would then validate all the edges every time, then reject the whole set
     /// because just the last edge was invalid. Instead, we accept all the edges verified so
     /// far and return an error only afterwards.
-    pub async fn update(&self, edges: Vec<EdgesWithSource>) -> (Vec<Edge>, Vec<bool>) {
-        self.updater.send_async(UpdateEdges(edges)).await.unwrap()
-    }
-}
-
-struct GraphActor {
-    clock: Clock,
-    graph: Weak<Graph>,
-    inner: Inner,
-}
-
-impl Actor for GraphActor {}
-
-#[derive(Debug)]
-struct UpdateEdges(Vec<EdgesWithSource>);
-
-impl Handler<UpdateEdges, (Vec<Edge>, Vec<bool>)> for GraphActor {
-    fn handle(&mut self, msg: UpdateEdges) -> (Vec<Edge>, Vec<bool>) {
+    pub fn update(&self, edges: Vec<EdgesWithSource>) -> (Vec<Edge>, Vec<bool>) {
+        let mut inner = self.inner.lock();
         let mut new_edges = vec![];
         let mut oks = vec![];
-        for es in msg.0 {
-            let (es, ok) = self.inner.add_edges(&self.clock, es);
+        for es in edges {
+            let (es, ok) = inner.add_edges(&self.clock, es);
             oks.push(ok);
             new_edges.extend(es);
         }
-        if let Some(graph) = self.graph.upgrade() {
-            let snapshot = self.inner.update(&self.clock, &graph.unreliable_peers.load());
-            let snapshot = Arc::new(snapshot);
-            graph.routing_table.update(snapshot.next_hops.clone(), snapshot.distances.clone());
-            graph.snapshot.store(snapshot);
-        }
+        let snapshot = inner.update(&self.clock, &self.unreliable_peers.load());
+        let snapshot = Arc::new(snapshot);
+        self.routing_table.update(snapshot.next_hops.clone(), snapshot.distances.clone());
+        self.snapshot.store(snapshot);
         (new_edges, oks)
     }
 }

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -27,14 +27,14 @@ fn test_graph_config(node_id: PeerId) -> GraphConfig {
 }
 
 impl Graph {
-    async fn simple_update(self: &Arc<Self>, edges: Vec<Edge>) {
+    fn simple_update(self: &Arc<Self>, edges: Vec<Edge>) {
         let edges = EdgesWithSource::Local(edges);
-        assert_eq!(vec![true], self.update(vec![edges]).await.1);
+        assert_eq!(vec![true], self.update(vec![edges]).1);
     }
 
-    async fn remote_update(self: &Arc<Self>, source: PeerId, edges: Vec<Edge>) -> Vec<bool> {
+    fn remote_update(self: &Arc<Self>, source: PeerId, edges: Vec<Edge>) -> Vec<bool> {
         let edges = EdgesWithSource::Remote { edges, source };
-        self.update(vec![edges]).await.1
+        self.update(vec![edges]).1
     }
 
     fn check(&self, want_mem: &[Edge]) {
@@ -76,7 +76,7 @@ async fn one_edge() {
     let rng = &mut rng;
     let node_key = data::make_secret_key(rng);
     let cfg = test_graph_config(peer_id(&node_key));
-    let g = Arc::new(Graph::new(clock.clock(), cfg.clone()));
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
 
     let p1 = data::make_secret_key(rng);
     let e1 = data::make_edge(&node_key, &p1, 1);
@@ -84,23 +84,23 @@ async fn one_edge() {
 
     tracing::info!(target:"test", "add an active edge, update rt with pruning");
     // NOOP, since p1 is reachable.
-    g.simple_update(vec![e1.clone()]).await;
+    g.simple_update(vec![e1.clone()]);
     g.check(std::slice::from_ref(&e1));
 
     tracing::info!(target:"test", "override with an inactive edge");
-    g.simple_update(vec![e1v2.clone()]).await;
+    g.simple_update(vec![e1v2.clone()]);
     g.check(std::slice::from_ref(&e1v2));
 
     tracing::info!(target:"test", "after 2s, simple_update rt with pruning unreachable for 3s");
     // NOOP, since p1 is unreachable for 2s.
     clock.advance(2 * SEC);
-    g.simple_update(vec![]).await;
+    g.simple_update(vec![]);
     g.check(std::slice::from_ref(&e1v2));
 
     tracing::info!(target:"test", "update rt with pruning unreachable for 1s");
     // p1 should be moved to DB.
     clock.advance(2 * SEC);
-    g.simple_update(vec![]).await;
+    g.simple_update(vec![]);
     g.check(&[]);
 }
 
@@ -125,7 +125,7 @@ async fn expired_edges() {
         prune_edges_after: Some(110 * SEC),
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg.clone()));
+    let g = Arc::new(Graph::new(clock.clock(), cfg));
 
     let p1 = data::make_secret_key(rng);
     let p2 = data::make_secret_key(rng);
@@ -137,42 +137,42 @@ async fn expired_edges() {
     let fresh_e2 = data::make_edge(&node_key, &p2, to_active_nonce(now));
 
     tracing::info!(target:"test", "add an active edge");
-    g.simple_update(vec![e1.clone(), old_e2.clone()]).await;
-    g.check(&[e1.clone(), old_e2.clone()]);
+    g.simple_update(vec![e1.clone(), old_e2.clone()]);
+    g.check(&[e1.clone(), old_e2]);
     tracing::info!(target:"test", "update rt with pruning");
     // e1 should stay - as it is fresh, but old_e2 should be removed.
     clock.advance(40 * SEC);
-    g.simple_update(vec![]).await;
+    g.simple_update(vec![]);
     g.check(std::slice::from_ref(&e1));
 
     tracing::info!(target:"test", "adding 'still old' edge to e2 should fail");
     // (as it is older than the last prune_edges_older_than)
-    g.simple_update(vec![still_old_e2.clone()]).await;
+    g.simple_update(vec![still_old_e2]);
     g.check(std::slice::from_ref(&e1));
 
     tracing::info!(target:"test", "but adding the fresh edge should work");
-    g.simple_update(vec![fresh_e2.clone()]).await;
-    g.check(&[e1.clone(), fresh_e2.clone()]);
+    g.simple_update(vec![fresh_e2.clone()]);
+    g.check(&[e1, fresh_e2]);
 
     tracing::info!(target:"test", "advance so that the edge is 'too old' and should be removed");
     clock.advance(100 * SEC);
-    g.simple_update(vec![]).await;
+    g.simple_update(vec![]);
     g.check(&[]);
 
     tracing::info!(target:"test", "let's create a removal edge");
     let e1v2 = data::make_edge(&node_key, &p1, to_active_nonce(clock.now_utc()))
         .remove_edge(peer_id(&p1), &p1);
-    g.simple_update(vec![e1v2.clone()]).await;
+    g.simple_update(vec![e1v2.clone()]);
     g.check(std::slice::from_ref(&e1v2));
 
     // Advance time a bit. The edge should stay.
     clock.advance(20 * SEC);
-    g.simple_update(vec![]).await;
+    g.simple_update(vec![]);
     g.check(std::slice::from_ref(&e1v2));
 
     // Advance time a lot. The edge should be pruned.
     clock.advance(100 * SEC);
-    g.simple_update(vec![]).await;
+    g.simple_update(vec![]);
     g.check(&[]);
 }
 
@@ -213,7 +213,7 @@ async fn source_cap_enforced() {
             data::make_edge(&node_key, &k, 1)
         })
         .collect();
-    g.remote_update(source, edges).await;
+    g.remote_update(source, edges);
 
     let snapshot = g.load();
     assert_eq!(
@@ -255,13 +255,13 @@ async fn source_cap_allows_updates() {
     let e3 = data::make_edge(&node_key, &k3, 1);
 
     // Fill source to cap.
-    g.remote_update(source.clone(), vec![e1.clone(), e2.clone(), e3.clone()]).await;
+    g.remote_update(source.clone(), vec![e1.clone(), e2, e3]);
     let snapshot = g.load();
     assert_eq!(snapshot.edges.len(), 3);
 
     // Update existing edge (higher nonce) — should succeed even though source is at cap.
     let e1_updated = data::make_edge(&node_key, &k1, 3);
-    g.remote_update(source, vec![e1_updated.clone()]).await;
+    g.remote_update(source, vec![e1_updated]);
     let snapshot = g.load();
     // Edge count stays the same (update, not new key).
     assert_eq!(snapshot.edges.len(), 3);
@@ -295,7 +295,7 @@ async fn source_cap_accumulates_across_messages() {
             data::make_edge(&node_key, &k, 1)
         })
         .collect();
-    g.remote_update(source.clone(), edges1).await;
+    g.remote_update(source.clone(), edges1);
     assert_eq!(g.load().edges.len(), 3, "first batch should be fully accepted");
 
     // Second message: send 3 more edges from the same source (total would be 6 > cap=5).
@@ -305,7 +305,7 @@ async fn source_cap_accumulates_across_messages() {
             data::make_edge(&node_key, &k, 1)
         })
         .collect();
-    g.remote_update(source, edges2).await;
+    g.remote_update(source, edges2);
     assert_eq!(
         g.load().edges.len(),
         max_per_source,
@@ -341,7 +341,7 @@ async fn global_edge_cap() {
                 data::make_edge(&node_key, &k, 1)
             })
             .collect();
-        g.remote_update(source, edges).await;
+        g.remote_update(source, edges);
     }
 
     let snapshot = g.load();
@@ -381,7 +381,7 @@ async fn global_peer_cap() {
             data::make_edge(&node_key, &k, 1)
         })
         .collect();
-    g.remote_update(source, edges).await;
+    g.remote_update(source, edges);
 
     let snapshot = g.load();
     // 3 edges fit (3 new peers + 1 existing = 4 = max), 4th edge would need 5 > 4.
@@ -416,7 +416,7 @@ async fn local_edges_obey_global_caps() {
             data::make_edge(&node_key, &k, 1)
         })
         .collect();
-    g.simple_update(edges).await;
+    g.simple_update(edges);
 
     let snapshot = g.load();
     assert_eq!(
@@ -455,7 +455,7 @@ async fn limit_drops_are_non_punitive() {
             data::make_edge(&node_key, &k, 1)
         })
         .collect();
-    let oks = g.remote_update(source, edges).await;
+    let oks = g.remote_update(source, edges);
 
     // ok must be true: limit drops are non-punitive.
     assert_eq!(oks, vec![true], "limit drops must not set ok=false");
@@ -497,19 +497,19 @@ async fn source_budget_recovery_after_prune() {
             data::make_edge(&node_key, &k, to_active_nonce(now))
         })
         .collect();
-    g.remote_update(source.clone(), edges).await;
+    g.remote_update(source.clone(), edges);
     assert_eq!(g.load().edges.len(), 3);
 
     // A 4th edge should be rejected (source cap reached).
     let extra_key = data::make_secret_key(rng);
     let extra_edge = data::make_edge(&node_key, &extra_key, to_active_nonce(now));
-    g.remote_update(source.clone(), vec![extra_edge]).await;
+    g.remote_update(source.clone(), vec![extra_edge]);
     assert_eq!(g.load().edges.len(), 3, "4th edge should be rejected");
 
     // Advance time so old edges get pruned.
     clock.advance(time::Duration::seconds(120));
     // Trigger a pruning pass by sending an empty local update.
-    g.simple_update(vec![]).await;
+    g.simple_update(vec![]);
     assert_eq!(g.load().edges.len(), 0, "all old edges should be pruned");
 
     // Now the same source should be able to introduce new edge keys again.
@@ -520,7 +520,7 @@ async fn source_budget_recovery_after_prune() {
             data::make_edge(&node_key, &k, to_active_nonce(fresh_now))
         })
         .collect();
-    g.remote_update(source, new_edges).await;
+    g.remote_update(source, new_edges);
     assert_eq!(
         g.load().edges.len(),
         max_per_source,

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -76,7 +76,7 @@ async fn one_edge() {
     let rng = &mut rng;
     let node_key = data::make_secret_key(rng);
     let cfg = test_graph_config(peer_id(&node_key));
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Graph::new(clock.clock(), cfg);
 
     let p1 = data::make_secret_key(rng);
     let e1 = data::make_edge(&node_key, &p1, 1);
@@ -125,7 +125,7 @@ async fn expired_edges() {
         prune_edges_after: Some(110 * SEC),
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Graph::new(clock.clock(), cfg);
 
     let p1 = data::make_secret_key(rng);
     let p2 = data::make_secret_key(rng);

--- a/core/async/src/lib.rs
+++ b/core/async/src/lib.rs
@@ -172,21 +172,6 @@ pub fn new_owned_future_spawner(description: &str) -> Box<dyn FutureSpawner> {
     })
 }
 
-/// Spawns a multithreaded actor which is NOT owned by any ActorSystem.
-/// Rather, the returned handle, when dropped, will stop the actor and its runtime.
-pub fn new_owned_multithread_actor<A: Actor + Send + 'static>(
-    num_threads: usize,
-    make_actor_fn: impl Fn() -> A + Sync + Send + 'static,
-) -> MultithreadRuntimeHandle<A> {
-    let (cancellation_signal, cancellation_receiver) = crossbeam_channel::bounded::<()>(0);
-    spawn_multithread_actor(
-        num_threads,
-        make_actor_fn,
-        cancellation_receiver,
-        Some(cancellation_signal), // never cancelled
-    )
-}
-
 struct OwnedFutureSpawner {
     handle: TokioRuntimeHandle<EmptyActor>,
 }


### PR DESCRIPTION
## Background

`Graph::new` spawned `GraphActor` on its own multithread tokio runtime via `new_owned_multithread_actor(1, …)`. With `num_threads = 1` that "actor" was just a serialization queue behind an extra channel hop — there is no parallelism to lose.

## What changed

- Replace `GraphActor` with a `Mutex<Inner>` held directly on `Graph`. Drop `GraphActor`, `UpdateEdges`, the `Handler` impl, and the `Weak<Graph>` / `Arc::new_cyclic` plumbing.
- `Graph::update` becomes synchronous — one-line caller change in `network_state/routing.rs`.
- Remove `new_owned_multithread_actor` from `core/async`; `GraphActor` was its only workspace caller.

## Behavior

Production behavior is unchanged. The `Mutex<Inner>` holds the lock across BFS recomputation while readers stay lock-free via `ArcSwap` for the snapshot and `RoutingTableView`. BFS at production scale (~200 peers, a few thousand edges) is sub-millisecond, so the lock isn't contended. Removing the dedicated runtime also lets the routing graph run under a single-threaded executor.
