### PR TITLE
chore(vm-runner): remove ineffective compiler_inlining(true)

### DIFF
--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -239,13 +239,13 @@ fn test_wasmtime_artifact_output_stability() {
     ];
     let compiled_hashes = [
         // See the above comment if you want to change this
-        17467356520024489490,
-        14729060831070184139,
-        11041498883632407283,
-        12049699321754363033,
-        9906436427985886682,
-        15560032392659795845,
-        11171783944424554209,
+        4774743111553613885,
+        1597576442569865275,
+        2458663334453612687,
+        2596794912834051398,
+        914926634613848705,
+        16754245741617892699,
+        15435585184328777682,
     ];
     let mut got_prepared_hashes = Vec::with_capacity(seeds.len());
     let mut got_compiled_hashes = Vec::with_capacity(seeds.len());
@@ -327,7 +327,7 @@ fn test_wasmtime_sparse_contract_stability() {
     // sparse-data-segment case that `arbitrary_contract` does not cover.
     // See comments on that test for how to update these hashes.
     let expected_prepared_hash: u64 = 16694328674582109973;
-    let expected_compiled_hash: u64 = 8543849532946659263;
+    let expected_compiled_hash: u64 = 17665236938772967494;
 
     let contract = ContractCode::new(sparse_wasm_contract(), None);
     let config = test_vm_config(Some(VMKind::Wasmtime));

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -454,7 +454,6 @@ impl WasmtimeVM {
                 .memory_may_move(false)
                 .memory_reservation(max_memory_size.try_into().unwrap_or(u64::MAX))
                 .memory_reservation_for_growth(0)
-                .compiler_inlining(true)
                 .cranelift_nan_canonicalization(true)
                 .wasm_wide_arithmetic(true);
 

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -468,7 +468,7 @@ impl WasmtimeVM {
     pub(crate) fn vm_hash(&self) -> u64 {
         // increment the `version` when making modifications that affect the
         // artifact compatibility.
-        let version = 71;
+        let version = 72;
 
         let mut hasher = std::hash::DefaultHasher::new();
         self.engine.precompile_compatibility_hash().hash(&mut hasher);


### PR DESCRIPTION
`Config::compiler_inlining(true)` was a no-op for our contracts in wasmtime 36, so this PR removes it.

The setter only flips `tunables.inlining = Some(true)` ([config.rs:2044](https://github.com/bytecodealliance/wasmtime/blob/v36.0.7/crates/wasmtime/src/config.rs#L2044)). The actual gating happens at a separate `Tunables` field, `inlining_intra_module`, which has **no public Config setter**. Its default is `WhenUsingGc` ([tunables.rs:210](https://github.com/bytecodealliance/wasmtime/blob/v36.0.7/crates/environ/src/tunables.rs#L210)).

In [`should_inline`](https://github.com/bytecodealliance/wasmtime/blob/v36.0.7/crates/wasmtime/src/compile.rs#L1018-L1035):

```rust
if caller_module == callee_module {
    match tunables.inlining_intra_module {
        IntraModuleInlining::Yes => {}
        IntraModuleInlining::WhenUsingGc
            if caller_needs_gc_heap || callee_needs_gc_heap => {}
        IntraModuleInlining::WhenUsingGc => return false,  // <-- we land here
        IntraModuleInlining::No        => return false,
    }
}
```

A NEAR contract is a single core wasm module → `caller_module == callee_module` always. Contracts don't use WasmGC → `needs_gc_heap` is false on both sides → every intra-module call returns `false` from the inlining heuristic. The size heuristics never run.

Same picture in wasmtime 44 — fields and defaults unchanged, still no public setter.

If we ever want inlining to actually fire, we'd need to upstream a `compiler_inlining_intra_module(IntraModuleInlining)` setter (or carry a patch).

## Why the pinned artifact hashes change

Even though no inlining decisions ever fire, removing the call still flips one bit in the serialized artifact. wasmtime embeds a postcard-encoded `Metadata { tunables, .. }` blob into every artifact ([serialization.rs:175-193](https://github.com/bytecodealliance/wasmtime/blob/v36.0.7/crates/wasmtime/src/engine/serialization.rs#L175-L193)) so a second engine loading it can reject incompatible configs. The `Tunables` struct contains `inlining: bool`, and that byte gets written into the artifact verbatim.

Verified directly by compiling the same contract with two engines that differ only in `compiler_inlining(true)` vs `compiler_inlining(false)` and diffing the resulting ELF artifacts