### PR TITLE
refactor(network): drop owned-spawner concept from NetworkState (1/n)

### DIFF
--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -93,7 +93,7 @@ impl PeerHandle {
         });
         let network_state = Arc::new(NetworkState::new(
             &clock,
-            &*actor_system.new_future_spawner("network demux"),
+            Arc::from(actor_system.new_future_spawner("network demux")),
             store,
             peer_store::PeerStore::new(&clock, network_cfg.peer_store.clone()).unwrap(),
             network_cfg.verify().unwrap(),

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -49,7 +49,7 @@ use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{CanSend, CanSendAsync, Sender};
-use near_async::{new_owned_future_spawner, time};
+use near_async::time;
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_primitives::genesis::GenesisId;
 use near_primitives::hash::CryptoHash;
@@ -106,8 +106,12 @@ pub(crate) struct WhitelistNode {
 }
 
 pub(crate) struct NetworkState {
-    /// Single-threaded tokio runtime for NetworkState operations
-    ops_spawner: Box<dyn FutureSpawner>,
+    /// Spawner for NetworkState's background operations (gossip
+    /// processing, edge correction, send-to-self delivery). The
+    /// spawner's runtime lifetime is the caller's responsibility;
+    /// callers of `self.spawn(..).await` should treat the result as
+    /// best-effort (cancellation propagates from the runtime).
+    ops_spawner: Arc<dyn FutureSpawner>,
     /// PeerManager config.
     pub config: config::VerifiedConfig,
     /// When network state has been constructed.
@@ -263,7 +267,7 @@ impl From<&connection::Connection> for PeerDisconnectInfo {
 impl NetworkState {
     pub fn new(
         clock: &time::Clock,
-        future_spawner: &dyn FutureSpawner,
+        future_spawner: Arc<dyn FutureSpawner>,
         store: store::Store,
         peer_store: peer_store::PeerStore,
         config: config::VerifiedConfig,
@@ -278,7 +282,7 @@ impl NetworkState {
         spice_core_writer_adapter: Sender<SpiceChunkEndorsementMessage>,
     ) -> Self {
         Self {
-            ops_spawner: new_owned_future_spawner("NetworkState ops"),
+            ops_spawner: future_spawner.clone(),
             graph: crate::routing::Graph::new(
                 clock.clone(),
                 crate::routing::GraphConfig {
@@ -317,7 +321,7 @@ impl NetworkState {
             whitelist_nodes,
             add_edges_demux: demux::Demux::new(
                 config.routing_table_update_rate_limit,
-                future_spawner,
+                future_spawner.as_ref(),
             ),
             set_chain_info_mutex: Mutex::new(()),
             config,
@@ -328,14 +332,12 @@ impl NetworkState {
         }
     }
 
-    /// Spawn a future on the runtime which has the same lifetime as the NetworkState instance.
-    /// In particular if the future contains the NetworkState handler, it will be run until
-    /// completion. It is safe to self.spawn(...).await.unwrap(), since runtime will be kept alive
-    /// by the reference to self.
+    /// Spawn a future on the configured ops spawner. The returned receiver
+    /// resolves with the future's output, or `Err` if the spawner's runtime
+    /// is cancelled before the future completes (typically only at system
+    /// shutdown).
     ///
-    /// It should be used to make the public methods cancellable: you spawn the
-    /// noncancellable logic on self.runtime and just await it: in case the call is cancelled,
-    /// the noncancellable logic will be run in the background anyway.
+    /// Callers should treat `rx.await` as best-effort and not unwrap.
     pub(crate) fn spawn<R: 'static + Send>(
         &self,
         description: &'static str,
@@ -505,14 +507,14 @@ impl NetworkState {
                 peer_info.id.clone(),
                 demux::Demux::new(
                     self.config.accounts_data_broadcast_rate_limit,
-                    &*self.ops_spawner,
+                    self.ops_spawner.as_ref(),
                 ),
             );
             self.snapshot_hosts_demuxes.lock().insert(
                 peer_info.id.clone(),
                 demux::Demux::new(
                     self.config.snapshot_hosts_broadcast_rate_limit,
-                    &*self.ops_spawner,
+                    self.ops_spawner.as_ref(),
                 ),
             );
             // Broadcast the edge to other peers. The edge was already verified
@@ -1322,12 +1324,12 @@ impl NetworkState {
                 })
                 .collect();
             for t in tasks {
-                t.await.unwrap();
+                let _ = t.await;
             }
             err
         })
         .await
-        .unwrap()
+        .unwrap_or(None)
     }
 
     pub async fn add_snapshot_hosts(
@@ -1365,12 +1367,12 @@ impl NetworkState {
                 })
                 .collect();
             for t in tasks {
-                t.await.unwrap();
+                let _ = t.await;
             }
             err
         })
         .await
-        .unwrap()
+        .unwrap_or(None)
     }
 
     /// a) there is a peer we should be connected to, but we aren't
@@ -1465,7 +1467,7 @@ impl NetworkState {
             }
         })
         .await
-        .unwrap()
+        .ok();
     }
 
     pub fn update_connection_store(self: &Arc<Self>, clock: &time::Clock) {

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -46,7 +46,7 @@ impl NetworkState {
             this.broadcast_routing_table_update(RoutingTableUpdate::from_accounts(
                 new_accounts,
             ), &*transport);
-        }).await.unwrap()
+        }).await.ok();
     }
 
     /// Constructs a partial edge to the given peer with the nonce specified.

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -117,7 +117,7 @@ impl super::NetworkState {
                 });
                 let mut node_ips = vec![];
                 for q in queries {
-                    node_ips.extend(q.await.unwrap());
+                    node_ips.extend(q.await.ok().flatten());
                 }
                 // Check that we have received non-zero responses and that they are consistent.
                 if node_ips.is_empty() {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -367,7 +367,7 @@ impl PeerManagerActor {
         let clock = clock;
         let state = Arc::new(NetworkState::new(
             &clock,
-            &*handle.future_spawner(),
+            Arc::from(handle.future_spawner()),
             store,
             peer_store,
             config,

--- a/core/async/src/lib.rs
+++ b/core/async/src/lib.rs
@@ -164,14 +164,6 @@ impl ActorSystem {
     }
 }
 
-/// Spawns a future spawner that is NOT owned by any ActorSystem.
-/// Rather, the returned FutureSpawner, when dropped, will stop the runtime.
-pub fn new_owned_future_spawner(description: &str) -> Box<dyn FutureSpawner> {
-    Box::new(OwnedFutureSpawner {
-        handle: spawn_tokio_actor(EmptyActor, description.to_string(), CancellationToken::new()),
-    })
-}
-
 /// Spawns a multithreaded actor which is NOT owned by any ActorSystem.
 /// Rather, the returned handle, when dropped, will stop the actor and its runtime.
 pub fn new_owned_multithread_actor<A: Actor + Send + 'static>(
@@ -185,22 +177,6 @@ pub fn new_owned_multithread_actor<A: Actor + Send + 'static>(
         cancellation_receiver,
         Some(cancellation_signal), // never cancelled
     )
-}
-
-struct OwnedFutureSpawner {
-    handle: TokioRuntimeHandle<EmptyActor>,
-}
-
-impl FutureSpawner for OwnedFutureSpawner {
-    fn spawn_boxed(&self, description: &'static str, f: crate::futures::BoxFuture<'static, ()>) {
-        self.handle.future_spawner().spawn_boxed(description, f);
-    }
-}
-
-impl Drop for OwnedFutureSpawner {
-    fn drop(&mut self) {
-        self.handle.stop();
-    }
 }
 
 /// Used to determine whether shutdown_all_actors is being used properly. If there are multiple


### PR DESCRIPTION
## Summary

Drop the workaround that gave `NetworkState` its own tokio runtime
(`new_owned_future_spawner`) and replace `.unwrap()` calls on the
spawn-receiver with graceful handling.

## Background

`NetworkState::ops_spawner` previously called `new_owned_future_spawner("NetworkState ops")`,
constructing a tokio runtime whose `CancellationToken` was NOT wired
to the `ActorSystem` stop signal. The runtime survived
`actor_system.stop()` and only stopped when the last `Arc<NetworkState>`
dropped.

The intent was to keep these callers panic-free at shutdown:

- `add_accounts`, `add_accounts_data`, `add_snapshot_hosts`,
  `fix_local_edges`, and the STUN lookup all call
  `self.spawn(...).await.unwrap()`. If the underlying runtime is
  cancelled mid-flight, the spawned task is dropped, the
  `oneshot::Sender` drops without sending, `rx.await` returns `Err`,
  and `.unwrap()` panics.

The owned runtime kicked the can down the road, but is itself a
workaround. Auditing each caller shows none of them are
correctness-critical — all are best-effort gossip or self-healing
periodic work. The only thing the owned runtime buys us is
preventing panic logs at shutdown.

## What changes

- `NetworkState::new` now takes `Arc<dyn FutureSpawner>` and uses it
  directly for both `add_edges_demux` and the `ops_spawner` field.
- `new_owned_future_spawner` and `OwnedFutureSpawner` removed from
  `core/async/src/lib.rs` (no other workspace caller).
- `add_accounts`, `fix_local_edges`: `.spawn(..).await.unwrap()` →
  `.spawn(..).await.ok();` (functions return `()`).
- `add_accounts_data`, `add_snapshot_hosts`: outer `.unwrap()` →
  `.unwrap_or(None)`. Inner per-peer `t.await.unwrap()` →
  `let _ = t.await;`.
- STUN lookup (`tier1.rs`): `q.await.unwrap()` → `q.await.ok().flatten()`
  (preserves `Option<IpAddr>` semantics).
- `NetworkState::spawn` doc rewritten to reflect the new contract:
  the receiver returns `Err` on cancellation and callers should not
  unwrap.
- Production callers (`PeerManagerActor`, `peer/testonly.rs`) pass
  the actor system's spawner via `Arc::from(handle.future_spawner())`.

## Why

- All `self.spawn(...)` callers are best-effort — losing one at
  shutdown is benign (next gossip / next periodic trigger catches
  up).
- Production behavior is unchanged in steady state: the spawned
  tasks still run on the actor system's runtime; at shutdown they
  may abort cleanly instead of completing on a separate runtime.
- Stage 2 testloop integration becomes simpler: the same shape
  applies to both production and testloop paths — no second spawner.

## Stack

This is the first PR in the Stage 2 stack, inserted before the
existing T1+ work. After this lands, T2 (was "thread NetworkState
ops_spawner") simplifies to "inline Graph as Mutex" only.