### PR TITLE
chore: allow large_enum_variant for FlatStorageStatus

### DIFF
--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -63,6 +63,11 @@ impl From<FlatStorageError> for StorageError {
 )]
 #[borsh(use_discriminant = true)]
 #[repr(u8)]
+// suppressed warning:
+// large size difference between variants:
+// the second-largest variant contains at least 72 bytes (FlatStorageReadyStatus)
+// the largest variant contains at least 296 bytes (FlatStorageReshardingStatus)
+#[allow(clippy::large_enum_variant)]
 pub enum FlatStorageStatus {
     /// Flat Storage is not supported.
     Disabled = 0,


### PR DESCRIPTION
Newer Rust versions will complain about this, as there is a "large size difference between variants" (72B vs 296B).

I don't think this is a real concern in how we use it, so I suggest to just ignore it.

This is in preparation to potentially upgrade to Rust 1.92.