### PR TITLE
chore: more lint fixes for Rust 1.92

### DIFF
--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -319,7 +319,7 @@ impl BlocksDelayTracker {
                 ChunkTrackingStats::new(chunk_header)
             })
             .completed_timestamp
-            .get_or_insert(self.clock.now_utc());
+            .get_or_insert_with(|| self.clock.now_utc());
     }
 
     pub fn mark_chunk_requested(&mut self, chunk_header: &ShardChunkHeader) {
@@ -331,7 +331,7 @@ impl BlocksDelayTracker {
                 ChunkTrackingStats::new(chunk_header)
             })
             .requested_timestamp
-            .get_or_insert(self.clock.now_utc());
+            .get_or_insert_with(|| self.clock.now_utc());
     }
 
     fn update_head(&mut self, head_height: BlockHeight) {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1452,7 +1452,7 @@ impl Chain {
         (accepted_blocks, errors)
     }
 
-    fn chain_update(&mut self) -> ChainUpdate {
+    fn chain_update(&mut self) -> ChainUpdate<'_> {
         ChainUpdate::new(
             &mut self.chain_store,
             self.epoch_manager.clone(),

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -159,10 +159,12 @@ impl ChainStore {
         // because they get accumulated too quickly for regular gc process.
         // If clearing state transition data or witnesses fails there's no reason not to try
         // cleaning old blocks.
+        #[allow(clippy::or_fun_call)]
         let result = self
             .clear_state_transition_data(epoch_manager.as_ref())
             .and(self.clear_witnesses_data());
 
+        #[allow(clippy::or_fun_call)]
         result.and(self.clear_old_blocks_data(
             gc_config,
             runtime_adapter,

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -30,7 +30,8 @@ impl<T: BlockLike> PartialEq for HeightOrdered<T> {
 impl<T: BlockLike> Eq for HeightOrdered<T> {}
 impl<T: BlockLike> PartialOrd for HeightOrdered<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.0.height().cmp(&other.0.height()))
+        // use cmp defined a few lines below
+        Some(HeightOrdered::cmp(&self, other))
     }
 }
 impl<T: BlockLike> Ord for HeightOrdered<T> {

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -939,7 +939,7 @@ impl ChunkExecutorActor {
         self.get_chunk_extra(block_hash, shard_id).map(|option| option.is_some())
     }
 
-    fn chain_update(&mut self) -> ChainUpdate {
+    fn chain_update(&mut self) -> ChainUpdate<'_> {
         ChainUpdate::new(
             &mut self.chain_store,
             self.epoch_manager.clone(),

--- a/chain/client/src/prepare_transactions.rs
+++ b/chain/client/src/prepare_transactions.rs
@@ -58,6 +58,9 @@ impl PrepareTransactionsJobInputs {
     }
 }
 
+// Lint: `PrepareTransactionsJobInputs` is 1280 bytes
+// while `PreparedTransactions` is only 48 bytes.
+#[allow(clippy::large_enum_variant)]
 enum PrepareTransactionsJobState {
     /// Job created, but not running yet
     NotStarted(PrepareTransactionsJobInputs),

--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -216,7 +216,7 @@ pub fn part_filename(part_id: u64, num_parts: u64) -> String {
     format!("state_part_{:06}_of_{:06}", part_id, num_parts)
 }
 
-pub fn match_filename(s: &str) -> Option<regex::Captures> {
+pub fn match_filename(s: &str) -> Option<regex::Captures<'_>> {
     let re = regex::Regex::new(r"^state_part_(\d{6})_of_(\d{6})$").unwrap();
     re.captures(s)
 }

--- a/chain/client/src/sync/state/downloader.rs
+++ b/chain/client/src/sync/state/downloader.rs
@@ -50,7 +50,7 @@ impl StateSyncDownloader {
         shard_id: ShardId,
         sync_hash: CryptoHash,
         cancel: CancellationToken,
-    ) -> BoxFuture<Result<ShardStateSyncResponseHeader, near_chain::Error>> {
+    ) -> BoxFuture<'_, Result<ShardStateSyncResponseHeader, near_chain::Error>> {
         let store = self.store.clone();
         let validation_sender = self.header_validation_sender.clone();
         let preferred_source = self.preferred_source.clone();

--- a/chain/client/src/sync/state/external.rs
+++ b/chain/client/src/sync/state/external.rs
@@ -75,7 +75,7 @@ impl StateSyncDownloadSource for StateSyncDownloadSourceExternal {
         sync_hash: CryptoHash,
         handle: Arc<TaskHandle>,
         cancel: CancellationToken,
-    ) -> BoxFuture<Result<ShardStateSyncResponseHeader, near_chain::Error>> {
+    ) -> BoxFuture<'_, Result<ShardStateSyncResponseHeader, near_chain::Error>> {
         let clock = self.clock.clone();
         let timeout = self.timeout;
         let chain_id = self.chain_id.clone();
@@ -121,7 +121,7 @@ impl StateSyncDownloadSource for StateSyncDownloadSourceExternal {
         part_id: u64,
         handle: Arc<TaskHandle>,
         cancel: CancellationToken,
-    ) -> BoxFuture<Result<StatePart, near_chain::Error>> {
+    ) -> BoxFuture<'_, Result<StatePart, near_chain::Error>> {
         let clock = self.clock.clone();
         let timeout = self.timeout;
         let chain_id = self.chain_id.clone();

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -504,7 +504,7 @@ pub(self) trait StateSyncDownloadSource: Send + Sync + 'static {
         sync_hash: CryptoHash,
         handle: Arc<TaskHandle>,
         cancel: CancellationToken,
-    ) -> BoxFuture<Result<ShardStateSyncResponseHeader, near_chain::Error>>;
+    ) -> BoxFuture<'_, Result<ShardStateSyncResponseHeader, near_chain::Error>>;
 
     fn download_shard_part(
         &self,
@@ -513,7 +513,7 @@ pub(self) trait StateSyncDownloadSource: Send + Sync + 'static {
         part_id: u64,
         handle: Arc<TaskHandle>,
         cancel: CancellationToken,
-    ) -> BoxFuture<Result<StatePart, near_chain::Error>>;
+    ) -> BoxFuture<'_, Result<StatePart, near_chain::Error>>;
 }
 
 /// Find the hash of the first block on the same epoch (and chain) of block with hash `sync_hash`.

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -325,17 +325,14 @@ impl ViewClientActor {
         for block_height in head.height..next_epoch_start_height {
             let bp = epoch_info.sample_block_producer(block_height);
             let bp = epoch_info.get_validator(bp).account_id().clone();
-            let cps: Vec<AccountId> = shard_ids
-                .iter()
-                .map(|&shard_id| {
-                    let cp = epoch_info
-                        .sample_chunk_producer(&shard_layout, shard_id, block_height)
-                        .unwrap();
-                    let cp = epoch_info.get_validator(cp).account_id().clone();
-                    cp
-                })
-                .collect();
-            if account_id != bp && !cps.iter().any(|a| *a == account_id) {
+            let mut cps = shard_ids.iter().map(|&shard_id| {
+                let cp = epoch_info
+                    .sample_chunk_producer(&shard_layout, shard_id, block_height)
+                    .unwrap();
+                let cp = epoch_info.get_validator(cp).account_id().clone();
+                cp
+            });
+            if account_id != bp && !cps.any(|a| *a == account_id) {
                 if let Some(start) = start_block_of_window {
                     if block_height == last_block_of_epoch {
                         windows.push(start..block_height + 1);

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -73,11 +73,11 @@ pub struct EpochManagerHandle {
 }
 
 impl EpochManagerHandle {
-    pub fn write(&self) -> RwLockWriteGuard<EpochManager> {
+    pub fn write(&self) -> RwLockWriteGuard<'_, EpochManager> {
         self.inner.write()
     }
 
-    pub fn read(&self) -> RwLockReadGuard<EpochManager> {
+    pub fn read(&self) -> RwLockReadGuard<'_, EpochManager> {
         self.inner.read()
     }
 }

--- a/chain/epoch-manager/src/shard_assignment.rs
+++ b/chain/epoch-manager/src/shard_assignment.rs
@@ -36,21 +36,6 @@ struct ValidatorsFirstShardAssignmentItem {
 
 type ValidatorsFirstShardAssignment = MinHeap<ValidatorsFirstShardAssignmentItem>;
 
-/// A helper struct to maintain the shard assignment sorted by the stake
-/// assigned to each shard.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct StakeFirstShardAssignmentItem {
-    stake: Balance,
-    validators: usize,
-    shard_index: ShardIndex,
-}
-
-impl From<ValidatorsFirstShardAssignmentItem> for StakeFirstShardAssignmentItem {
-    fn from(v: ValidatorsFirstShardAssignmentItem) -> Self {
-        Self { validators: v.validators, stake: v.stake, shard_index: v.shard_index }
-    }
-}
-
 fn assign_to_satisfy_shards_inner<T: HasStake + Eq, I: Iterator<Item = (usize, T)>>(
     shard_assignment: &mut ValidatorsFirstShardAssignment,
     result: &mut Vec<Vec<T>>,

--- a/chain/network/src/announce_accounts/tests.rs
+++ b/chain/network/src/announce_accounts/tests.rs
@@ -72,7 +72,7 @@ fn dont_load_on_build() {
     announcements_cache.add_accounts(vec![announce0.clone()]);
     announcements_cache.add_accounts(vec![announce1.clone()]);
     let accounts: Vec<AnnounceAccount> = announcements_cache.get_announcements();
-    assert!(vec![announce0, announce1].iter().all(|announce| { accounts.contains(&announce) }));
+    assert!([announce0, announce1].iter().all(|announce| { accounts.contains(&announce) }));
     assert_eq!(accounts.len(), 2);
 
     let announcements_cache1 = AnnounceAccountCache::new(store);

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -85,7 +85,7 @@ impl ValidatorConfig {
         self.signer.get().map(|s| s.validator_id().clone())
     }
 
-    pub fn frozen_view(&self) -> FrozenValidatorConfig {
+    pub fn frozen_view(&self) -> FrozenValidatorConfig<'_> {
         FrozenValidatorConfig { signer: self.signer.get(), proxies: &self.proxies }
     }
 }

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -22,7 +22,7 @@ impl super::NetworkState {
     fn tier1_validator_config(
         &self,
         accounts_data: &AccountDataCacheSnapshot,
-    ) -> Option<FrozenValidatorConfig> {
+    ) -> Option<FrozenValidatorConfig<'_>> {
         let signer = self.config.validator.signer.get();
         if signer
             .as_ref()

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -85,17 +85,17 @@ async fn one_edge() {
     tracing::info!(target:"test", "add an active edge, update rt with pruning");
     // NOOP, since p1 is reachable.
     g.simple_update(vec![e1.clone()]).await;
-    g.check(&[e1.clone()]);
+    g.check(std::slice::from_ref(&e1));
 
     tracing::info!(target:"test", "override with an inactive edge");
     g.simple_update(vec![e1v2.clone()]).await;
-    g.check(&[e1v2.clone()]);
+    g.check(std::slice::from_ref(&e1v2));
 
     tracing::info!(target:"test", "after 2s, simple_update rt with pruning unreachable for 3s");
     // NOOP, since p1 is unreachable for 2s.
     clock.advance(2 * SEC);
     g.simple_update(vec![]).await;
-    g.check(&[e1v2.clone()]);
+    g.check(std::slice::from_ref(&e1v2));
 
     tracing::info!(target:"test", "update rt with pruning unreachable for 1s");
     // p1 should be moved to DB.
@@ -143,12 +143,12 @@ async fn expired_edges() {
     // e1 should stay - as it is fresh, but old_e2 should be removed.
     clock.advance(40 * SEC);
     g.simple_update(vec![]).await;
-    g.check(&[e1.clone()]);
+    g.check(std::slice::from_ref(&e1));
 
     tracing::info!(target:"test", "adding 'still old' edge to e2 should fail");
     // (as it is older than the last prune_edges_older_than)
     g.simple_update(vec![still_old_e2.clone()]).await;
-    g.check(&[e1.clone()]);
+    g.check(std::slice::from_ref(&e1));
 
     tracing::info!(target:"test", "but adding the fresh edge should work");
     g.simple_update(vec![fresh_e2.clone()]).await;
@@ -163,12 +163,12 @@ async fn expired_edges() {
     let e1v2 = data::make_edge(&node_key, &p1, to_active_nonce(clock.now_utc()))
         .remove_edge(peer_id(&p1), &p1);
     g.simple_update(vec![e1v2.clone()]).await;
-    g.check(&[e1v2.clone()]);
+    g.check(std::slice::from_ref(&e1v2));
 
     // Advance time a bit. The edge should stay.
     clock.advance(20 * SEC);
     g.simple_update(vec![]).await;
-    g.check(&[e1v2.clone()]);
+    g.check(std::slice::from_ref(&e1v2));
 
     // Advance time a lot. The edge should be pruned.
     clock.advance(100 * SEC);

--- a/chain/network/src/store/schema/mod.rs
+++ b/chain/network/src/store/schema/mod.rs
@@ -4,9 +4,8 @@ use crate::types as primitives;
 /// of the DB columns. For high level access see store.rs.
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_async::time;
-use near_crypto::Signature;
 use near_primitives::account::id::AccountId;
-use near_primitives::network::{AnnounceAccount, PeerId};
+use near_primitives::network::AnnounceAccount;
 use near_schema_checker_lib::ProtocolSchema;
 use near_store::DBCol;
 use std::io;
@@ -55,33 +54,6 @@ impl BorshRepr for ConnectionInfoRepr {
             )
             .map_err(invalid_data)?,
         })
-    }
-}
-
-#[derive(BorshSerialize, BorshDeserialize, ProtocolSchema)]
-pub(super) struct EdgeRepr {
-    key: (PeerId, PeerId),
-    nonce: u64,
-    signature0: Signature,
-    signature1: Signature,
-    removal_info: Option<(bool, Signature)>,
-}
-
-impl BorshRepr for EdgeRepr {
-    type T = primitives::Edge;
-
-    fn to_repr(e: &Self::T) -> Self {
-        Self {
-            key: e.key().clone(),
-            nonce: e.nonce(),
-            signature0: e.signature0().clone(),
-            signature1: e.signature1().clone(),
-            removal_info: e.removal_info().cloned(),
-        }
-    }
-    fn from_repr(e: Self) -> Result<Self::T, Error> {
-        Ok(primitives::Edge::new(e.key.0, e.key.1, e.nonce, e.signature0, e.signature1)
-            .with_removal_info(e.removal_info))
     }
 }
 
@@ -171,18 +143,6 @@ impl<R: BorshRepr> BorshRepr for Vec<R> {
     }
     fn from_repr(a: Vec<R>) -> Result<Self::T, Error> {
         a.into_iter().map(R::from_repr).collect()
-    }
-}
-
-// Little endian representation for u64.
-pub struct U64LE;
-impl Format for U64LE {
-    type T = u64;
-    fn encode<W: io::Write>(a: &u64, w: &mut W) -> io::Result<()> {
-        w.write_all(&a.to_le_bytes())
-    }
-    fn decode(a: &[u8]) -> Result<u64, Error> {
-        a.try_into().map(u64::from_le_bytes).map_err(invalid_data)
     }
 }
 

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -1083,12 +1083,6 @@ pub(crate) struct SubNetworkIdentifier {
      * pub metadata: Option<serde_json::Value>, */
 }
 
-/// The timestamp of the block in milliseconds since the Unix Epoch. The
-/// timestamp is stored in milliseconds because some blockchains produce blocks
-/// more often than once a second.
-#[derive(Debug, Clone, PartialEq, PartialOrd, ToSchema, serde::Serialize, serde::Deserialize)]
-pub(crate) struct Timestamp(i64);
-
 /// Transactions contain an array of Operations that are attributable to the
 /// same TransactionIdentifier.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
@@ -1381,13 +1375,6 @@ pub(crate) enum Nep141EventKind {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
-pub(crate) struct FtMintData {
-    pub owner_id: String,
-    pub amount: String,
-    pub memo: Option<String>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub(crate) struct FtTransferData {
     pub old_owner_id: String,
     pub new_owner_id: String,
@@ -1395,12 +1382,6 @@ pub(crate) struct FtTransferData {
     pub memo: Option<String>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
-pub(crate) struct FtBurnData {
-    pub owner_id: String,
-    pub amount: String,
-    pub memo: Option<String>,
-}
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct FungibleTokenEvent {
     pub standard: String,
@@ -1436,21 +1417,6 @@ pub(crate) struct FtEvent {
     pub decimals: u32,
     pub cause: String,
     pub memo: Option<String>,
-}
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
-pub(crate) struct FTMetadataResponse {
-    pub spec: String,
-    pub name: String,
-    pub symbol: String,
-    pub icon: Option<String>,
-    pub reference: Option<String>,
-    pub reference_hash: Option<String>,
-    pub decimals: u32,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
-pub(crate) struct FTAccountBalanceResponse {
-    pub amount: u128,
 }
 
 #[cfg(test)]

--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -87,7 +87,7 @@ impl TrieStoreAdapter {
     }
 
     #[cfg(test)]
-    pub fn iter_raw_bytes(&self) -> crate::db::DBIterator {
+    pub fn iter_raw_bytes(&self) -> crate::db::DBIterator<'_> {
         self.store.iter_raw_bytes(DBCol::State)
     }
 }

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -157,6 +157,7 @@ pub enum FlatStorageCreationStatus {
 /// background and could take significant time.
 /// After all elements have been copied the new flat storages will be behind the chain head. To remediate this issue
 /// they will enter a catching up phase. The parent shard, instead, must be removed and cleaned up.
+#[allow(clippy::large_enum_variant)]
 #[derive(
     BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, serde::Serialize, ProtocolSchema,
 )]

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -999,7 +999,7 @@ mod tests {
         let part_id = PartId::new(1, 2);
         let trie = tries.get_trie_for_shard(shard_uid, Trie::EMPTY_ROOT);
 
-        let state_items = vec![
+        let state_items = [
             (b"a".to_vec(), vec![1]),
             (b"aa".to_vec(), vec![2]),
             (b"ab".to_vec(), vec![3]),

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -626,7 +626,7 @@ impl Config {
     pub fn set_rpc_addr(&mut self, addr: tcp::ListenerAddr) {
         #[cfg(feature = "json_rpc")]
         {
-            self.rpc.get_or_insert(Default::default()).addr = addr;
+            self.rpc.get_or_insert_with(Default::default).addr = addr;
         }
     }
 
@@ -1388,7 +1388,7 @@ fn create_localnet_config(
         std::cmp::min(num_validators as usize - 1, config.consensus.min_num_peers);
 
     // Configure networking and RPC endpoint. Enable debug-RPC by default for all nodes.
-    config.rpc.get_or_insert(Default::default()).enable_debug_rpc = true;
+    config.rpc.get_or_insert_with(Default::default).enable_debug_rpc = true;
     config.network.addr = network_config.0.to_string();
     config.network.public_addrs = vec![PeerAddr {
         addr: network_config.0,
@@ -1407,10 +1407,12 @@ fn create_localnet_config(
     // Configure archival node with split storage (hot + cold DB).
     if params.is_archival {
         config.archive = true;
-        config.cold_store.get_or_insert(config.store.clone()).path =
+        config.cold_store.get_or_insert_with(|| config.store.clone()).path =
             Some(PathBuf::from("cold-data"));
-        config.split_storage.get_or_insert(Default::default()).enable_split_storage_view_client =
-            true;
+        config
+            .split_storage
+            .get_or_insert_with(Default::default)
+            .enable_split_storage_view_client = true;
         config.save_trie_changes = Some(true);
     }
 

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -519,11 +519,11 @@ impl RunCmd {
             near_config.rpc_config = None;
         } else {
             if let Some(rpc_addr) = self.rpc_addr {
-                near_config.rpc_config.get_or_insert(Default::default()).addr =
+                near_config.rpc_config.get_or_insert_with(Default::default).addr =
                     tcp::ListenerAddr::new(rpc_addr.parse().unwrap());
             }
             if let Some(rpc_prometheus_addr) = self.rpc_prometheus_addr {
-                near_config.rpc_config.get_or_insert(Default::default()).prometheus_addr =
+                near_config.rpc_config.get_or_insert_with(Default::default).prometheus_addr =
                     Some(rpc_prometheus_addr);
             }
         }

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -872,7 +872,7 @@ impl<'a> DelayedReceiptQueueWrapper<'a> {
         &mut self,
         trie_update: &mut TrieUpdate,
         config: &RuntimeConfig,
-    ) -> Result<Option<ReceiptOrStateStoredReceipt>, RuntimeError> {
+    ) -> Result<Option<ReceiptOrStateStoredReceipt<'_>>, RuntimeError> {
         // While processing receipts, we need to keep track of the gas and bytes
         // even for receipts that may be filtered out due to a resharding event
         loop {

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -2396,7 +2396,7 @@ fn test_contract_accesses_when_validating_chunk() {
             tries.get_trie_for_shard(ShardUId::single_shard(), root).recording_reads_new_recorder(),
             &None,
             &apply_state,
-            &[call_receipt.clone()],
+            std::slice::from_ref(&call_receipt),
             SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),

--- a/test-loop-tests/src/tests/processed_receipts_gc.rs
+++ b/test-loop-tests/src/tests/processed_receipts_gc.rs
@@ -163,7 +163,10 @@ fn test_receipt_to_tx_saved_and_gced() {
         .epoch_length(EPOCH_LENGTH)
         .shard_layout(ShardLayout::single_shard())
         .validators_spec(validators_spec)
-        .add_user_accounts_simple(&[user_account.clone()], Balance::from_near(1_000_000))
+        .add_user_accounts_simple(
+            std::slice::from_ref(&user_account),
+            Balance::from_near(1_000_000),
+        )
         .build();
 
     let mut env = TestLoopBuilder::new()
@@ -268,7 +271,10 @@ fn test_receipt_to_tx_gc_with_outcomes_disabled() {
         .epoch_length(EPOCH_LENGTH)
         .shard_layout(ShardLayout::single_shard())
         .validators_spec(validators_spec)
-        .add_user_accounts_simple(&[user_account.clone()], Balance::from_near(1_000_000))
+        .add_user_accounts_simple(
+            std::slice::from_ref(&user_account),
+            Balance::from_near(1_000_000),
+        )
         .build();
 
     let mut env = TestLoopBuilder::new()

--- a/tools/protocol-schema-check/res/protocol_schema.toml
+++ b/tools/protocol-schema-check/res/protocol_schema.toml
@@ -120,7 +120,6 @@ Direction = 2170775249
 ED25519PublicKey = 213018126
 Edge = 2761011518
 EdgeInner = 548982790
-EdgeRepr = 854595132
 EdgeState = 833218820
 EncodedChunkStateWitness = 329848903
 EncodedShardChunk = 4186697988

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -116,6 +116,7 @@ fn apply_chunk_from_input(
         .unwrap()
 }
 
+#[allow(clippy::large_enum_variant)]
 /// Result of `get_chunk_application_input` - either input for chunk application or a reason why we can't apply the chunk and should skip it.
 enum ApplicationInputOrSkip {
     Input(ChunkApplicationInput),


### PR DESCRIPTION
This is another batch of straight-forward fixes for lints, plus a few lint ignores.
They will start firing once we upgrade the Rust toolchain.

Commit 1 combines easy fixes for these lints:

- mismatched_lifetime_syntaxes
- clippy::cloned_ref_to_slice_refs
- clippy::useless_vec
- clippy::needless_collect
- clippy::non_canonical_partial_ord_impl

Commit 2 allows some more large enum variants.
They look all non performance critical to me but could be worth looking into.

Commit 3 allows two cases of functions inside an `and` where fixing it would change the deliberate behaviour.

Commit 4: remove various structs in the code base that are completely unused.