### PR TITLE
refactor: remove `PartialEq` from `VMFunction`

### DIFF
--- a/runtime/near-vm/test-api/Cargo.toml
+++ b/runtime/near-vm/test-api/Cargo.toml
@@ -35,7 +35,7 @@ wat = { workspace = true, optional = true }
 near-vm-vm.workspace = true
 near-vm-compiler.workspace = true
 near-vm-engine.workspace = true
-near-vm-types.workspace = true
+near-vm-types = { workspace = true, features = ["test_features"] }
 target-lexicon.workspace = true
 # - Optional dependencies for `sys`.
 near-vm-compiler-singlepass = { workspace = true, optional = true }

--- a/runtime/near-vm/test-api/src/sys/externals/function.rs
+++ b/runtime/near-vm/test-api/src/sys/externals/function.rs
@@ -35,7 +35,6 @@ use std::sync::Arc;
 ///   with native functions. Attempting to create a native `Function` with one will
 ///   result in a panic.
 ///   [Closures as host functions tracking issue](https://github.com/wasmerio/wasmer/issues/1840)
-#[derive(PartialEq)]
 pub struct Function {
     pub(crate) store: Store,
     pub(crate) exported: ExportFunction,

--- a/runtime/near-vm/types/Cargo.toml
+++ b/runtime/near-vm/types/Cargo.toml
@@ -20,6 +20,9 @@ indexmap.workspace = true
 num-traits.workspace = true
 rkyv = { workspace = true, features = ["indexmap-2"] }
 
+[features]
+test_features = []
+
 [dev-dependencies]
 bolero.workspace = true
 

--- a/runtime/near-vm/types/src/values.rs
+++ b/runtime/near-vm/types/src/values.rs
@@ -7,7 +7,7 @@ use crate::types::Type;
 
 /// Possible runtime values that a WebAssembly module can either consume or
 /// produce.
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub enum Value<T> {
     /// A 32-bit integer.
     ///
@@ -35,6 +35,23 @@ pub enum Value<T> {
 
     /// A 128-bit number
     V128(u128),
+}
+
+impl<T> PartialEq for Value<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::I32(a), Self::I32(b)) => a == b,
+            (Self::I64(a), Self::I64(b)) => a == b,
+            (Self::F32(a), Self::F32(b)) => a == b,
+            (Self::F64(a), Self::F64(b)) => a == b,
+            (Self::ExternRef(a), Self::ExternRef(b)) => a == b,
+            (Self::V128(a), Self::V128(b)) => a == b,
+            (Self::FuncRef(_), Self::FuncRef(_)) => {
+                panic!("function references cannot be compared for equality")
+            }
+            _ => false,
+        }
+    }
 }
 
 macro_rules! accessors {

--- a/runtime/near-vm/types/src/values.rs
+++ b/runtime/near-vm/types/src/values.rs
@@ -37,23 +37,6 @@ pub enum Value<T> {
     V128(u128),
 }
 
-impl<T> PartialEq for Value<T> {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::I32(a), Self::I32(b)) => a == b,
-            (Self::I64(a), Self::I64(b)) => a == b,
-            (Self::F32(a), Self::F32(b)) => a == b,
-            (Self::F64(a), Self::F64(b)) => a == b,
-            (Self::ExternRef(a), Self::ExternRef(b)) => a == b,
-            (Self::V128(a), Self::V128(b)) => a == b,
-            (Self::FuncRef(_), Self::FuncRef(_)) => {
-                panic!("function references cannot be compared for equality")
-            }
-            _ => false,
-        }
-    }
-}
-
 macro_rules! accessors {
     ($bind:ident $(($variant:ident($ty:ty) $get:ident $unwrap:ident $cvt:expr))*) => ($(
         /// Attempt to access the underlying value of this `Value`, returning
@@ -365,6 +348,24 @@ where
 
     fn try_from(value: Value<T>) -> Result<Self, Self::Error> {
         value.f64().ok_or(NOT_F64)
+    }
+}
+
+#[cfg(any(test, feature = "test_features"))]
+impl<T> PartialEq for Value<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::I32(a), Self::I32(b)) => a == b,
+            (Self::I64(a), Self::I64(b)) => a == b,
+            (Self::F32(a), Self::F32(b)) => a == b,
+            (Self::F64(a), Self::F64(b)) => a == b,
+            (Self::ExternRef(a), Self::ExternRef(b)) => a == b,
+            (Self::V128(a), Self::V128(b)) => a == b,
+            (Self::FuncRef(_), Self::FuncRef(_)) => {
+                panic!("function references cannot be compared for equality")
+            }
+            _ => false,
+        }
     }
 }
 

--- a/runtime/near-vm/vm/src/export/mod.rs
+++ b/runtime/near-vm/vm/src/export/mod.rs
@@ -30,7 +30,7 @@ pub enum VMExtern {
 }
 
 /// A function export value.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct VMFunction {
     /// The address of the native-code function.
     pub address: *const VMFunctionBody,

--- a/runtime/near-vm/vm/src/resolver.rs
+++ b/runtime/near-vm/vm/src/resolver.rs
@@ -49,7 +49,7 @@ impl From<VMExtern> for Export {
 ///
 /// This struct owns the original `host_env`, thus when it gets dropped
 /// it calls the `drop` function on it.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ExportFunctionMetadata {
     /// This field is stored here to be accessible by `Drop`.
     ///
@@ -125,7 +125,7 @@ impl Drop for ExportFunctionMetadata {
 
 /// A function export value with an extra function pointer to initialize
 /// host environments.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ExportFunction {
     /// The VM function, containing most of the data.
     pub vm_function: VMFunction,


### PR DESCRIPTION
Clippy with Rust 1.92 complains:

> function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique

This is a valid concern and is worth fixing.

Luckily, our current code base only uses the equality in test assertions. Even there, it is never user for comparing `Value::FuncRef`.

The fix is to manually implement PartialEq and explicitly panic when trying to compare `Value::FuncRef`. This way, we will catch it immediately if we start relying on the FuncRef comparison.