### PR TITLE
fix(network): route NetworkState/Graph runtimes through ActorSystem

### DIFF
--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -93,6 +93,7 @@ impl PeerHandle {
         });
         let network_state = Arc::new(NetworkState::new(
             &clock,
+            &actor_system,
             &*actor_system.new_future_spawner("network demux"),
             store,
             peer_store::PeerStore::new(&clock, network_cfg.peer_store.clone()).unwrap(),

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -47,9 +47,10 @@ use crate::types::{
 };
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
+use near_async::ActorSystem;
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{CanSend, CanSendAsync, Sender};
-use near_async::{new_owned_future_spawner, time};
+use near_async::time;
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_primitives::genesis::GenesisId;
 use near_primitives::hash::CryptoHash;
@@ -263,6 +264,7 @@ impl From<&connection::Connection> for PeerDisconnectInfo {
 impl NetworkState {
     pub fn new(
         clock: &time::Clock,
+        actor_system: &ActorSystem,
         future_spawner: &dyn FutureSpawner,
         store: store::Store,
         peer_store: peer_store::PeerStore,
@@ -278,7 +280,7 @@ impl NetworkState {
         spice_core_writer_adapter: Sender<SpiceChunkEndorsementMessage>,
     ) -> Self {
         Self {
-            ops_spawner: new_owned_future_spawner("NetworkState ops"),
+            ops_spawner: actor_system.new_future_spawner("NetworkState ops"),
             graph: crate::routing::Graph::new(
                 clock.clone(),
                 crate::routing::GraphConfig {
@@ -289,6 +291,7 @@ impl NetworkState {
                     max_total_edges: config.routing_graph_max_edges,
                     max_graph_peers: config.routing_graph_max_peers,
                 },
+                actor_system,
             ),
             genesis_id,
             client,

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -332,9 +332,10 @@ impl NetworkState {
     }
 
     /// Spawn a future on the runtime which has the same lifetime as the NetworkState instance.
-    /// In particular if the future contains the NetworkState handler, it will be run until
-    /// completion. It is safe to self.spawn(...).await.unwrap(), since runtime will be kept alive
-    /// by the reference to self.
+    /// During normal operation a captured `Arc<NetworkState>` keeps the runtime alive, so the
+    /// returned receiver resolves to the future's output. On `ActorSystem` shutdown the runtime
+    /// is cancelled and the receiver may resolve to `Err(RecvError)`; callers should treat
+    /// that as a no-op rather than `.unwrap()`-ing.
     ///
     /// It should be used to make the public methods cancellable: you spawn the
     /// noncancellable logic on self.runtime and just await it: in case the call is cancelled,
@@ -1330,7 +1331,8 @@ impl NetworkState {
             err
         })
         .await
-        .unwrap()
+        .ok()
+        .flatten()
     }
 
     pub async fn add_snapshot_hosts(
@@ -1373,7 +1375,8 @@ impl NetworkState {
             err
         })
         .await
-        .unwrap()
+        .ok()
+        .flatten()
     }
 
     /// a) there is a peer we should be connected to, but we aren't

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1326,11 +1326,12 @@ impl NetworkState {
                 })
                 .collect();
             for t in tasks {
-                let _ = t.await;
+                let _ = t.await.inspect_err(|err| tracing::debug!(target: "network", ?err, "send_accounts_data task cancelled"));
             }
             err
         })
         .await
+        .inspect_err(|err| tracing::debug!(target: "network", ?err, "add_accounts_data cancelled, likely shutdown"))
         .ok()
         .flatten()
     }
@@ -1370,11 +1371,12 @@ impl NetworkState {
                 })
                 .collect();
             for t in tasks {
-                let _ = t.await;
+                let _ = t.await.inspect_err(|err| tracing::debug!(target: "network", ?err, "send_snapshot_hosts task cancelled"));
             }
             err
         })
         .await
+        .inspect_err(|err| tracing::debug!(target: "network", ?err, "add_snapshot_hosts cancelled, likely shutdown"))
         .ok()
         .flatten()
     }

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1326,7 +1326,7 @@ impl NetworkState {
                 })
                 .collect();
             for t in tasks {
-                t.await.unwrap();
+                let _ = t.await;
             }
             err
         })
@@ -1370,7 +1370,7 @@ impl NetworkState {
                 })
                 .collect();
             for t in tasks {
-                t.await.unwrap();
+                let _ = t.await;
             }
             err
         })

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -38,7 +38,7 @@ impl NetworkState {
         transport: Arc<dyn NetworkTransport>,
     ) {
         let this = self.clone();
-        self.spawn("add_accounts", async move {
+        let _ = self.spawn("add_accounts", async move {
             let new_accounts = this.account_announcements.add_accounts(accounts);
             tracing::debug!(target: "network", account_id = ?this.config.validator.account_id(), ?new_accounts, "received new accounts");
             #[cfg(test)]
@@ -46,7 +46,7 @@ impl NetworkState {
             this.broadcast_routing_table_update(RoutingTableUpdate::from_accounts(
                 new_accounts,
             ), &*transport);
-        }).await.unwrap()
+        }).await;
     }
 
     /// Constructs a partial edge to the given peer with the nonce specified.

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -46,7 +46,9 @@ impl NetworkState {
             this.broadcast_routing_table_update(RoutingTableUpdate::from_accounts(
                 new_accounts,
             ), &*transport);
-        }).await;
+        })
+        .await
+        .inspect_err(|err| tracing::debug!(target: "network", ?err, "add_accounts cancelled, likely shutdown"));
     }
 
     /// Constructs a partial edge to the given peer with the nonce specified.

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -117,7 +117,9 @@ impl super::NetworkState {
                 });
                 let mut node_ips = vec![];
                 for q in queries {
-                    node_ips.extend(q.await.unwrap());
+                    if let Ok(ips) = q.await {
+                        node_ips.extend(ips);
+                    }
                 }
                 // Check that we have received non-zero responses and that they are consistent.
                 if node_ips.is_empty() {

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -117,7 +117,7 @@ impl super::NetworkState {
                 });
                 let mut node_ips = vec![];
                 for q in queries {
-                    if let Ok(ips) = q.await {
+                    if let Ok(ips) = q.await.inspect_err(|err| tracing::debug!(target: "network", ?err, "stun lookup_host cancelled")) {
                         node_ips.extend(ips);
                     }
                 }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -367,6 +367,7 @@ impl PeerManagerActor {
         let clock = clock;
         let state = Arc::new(NetworkState::new(
             &clock,
+            &actor_system,
             &*handle.future_spawner(),
             store,
             peer_store,

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -397,7 +397,9 @@ impl Graph {
     /// because just the last edge was invalid. Instead, we accept all the edges verified so
     /// far and return an error only afterwards.
     pub async fn update(&self, edges: Vec<EdgesWithSource>) -> (Vec<Edge>, Vec<bool>) {
-        self.updater.send_async(UpdateEdges(edges)).await.unwrap()
+        // On shutdown the GraphActor worker may exit before the request is processed,
+        // returning an `AsyncSendError`. Treat that as "no edges accepted".
+        self.updater.send_async(UpdateEdges(edges)).await.unwrap_or_default()
     }
 }
 

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -397,9 +397,11 @@ impl Graph {
     /// because just the last edge was invalid. Instead, we accept all the edges verified so
     /// far and return an error only afterwards.
     pub async fn update(&self, edges: Vec<EdgesWithSource>) -> (Vec<Edge>, Vec<bool>) {
-        // On shutdown the GraphActor worker may exit before the request is processed,
-        // returning an `AsyncSendError`. Treat that as "no edges accepted".
-        self.updater.send_async(UpdateEdges(edges)).await.unwrap_or_default()
+        self.updater
+            .send_async(UpdateEdges(edges))
+            .await
+            .inspect_err(|err| tracing::warn!(target: "network", ?err, "GraphActor update dropped, worker unavailable"))
+            .unwrap_or_default()
     }
 }
 

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -5,10 +5,11 @@ use crate::routing::routing_table_view::RoutingTableView;
 use crate::stats::metrics;
 use ::time::ext::InstantExt as _;
 use arc_swap::ArcSwap;
+use near_async::ActorSystem;
 use near_async::messaging::{Actor, CanSendAsync, Handler};
 use near_async::multithread::MultithreadRuntimeHandle;
+use near_async::time;
 use near_async::time::Clock;
-use near_async::{new_owned_multithread_actor, time};
 use near_primitives::network::PeerId;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
@@ -348,10 +349,10 @@ pub(crate) struct Graph {
 }
 
 impl Graph {
-    pub fn new(clock: Clock, config: GraphConfig) -> Arc<Self> {
+    pub fn new(clock: Clock, config: GraphConfig, actor_system: &ActorSystem) -> Arc<Self> {
         Arc::new_cyclic(|weak| {
             let weak = weak.clone();
-            let updater = new_owned_multithread_actor(1, move || GraphActor {
+            let updater = actor_system.spawn_multithread_actor(1, move || GraphActor {
                 clock: clock.clone(),
                 graph: weak.clone(),
                 inner: Inner {

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -7,6 +7,7 @@ use crate::network_protocol::Edge;
 use crate::network_protocol::testonly as data;
 use crate::peer_manager::network_state::EdgesWithSource;
 use crate::testonly::make_rng;
+use near_async::ActorSystem;
 use near_async::time;
 use near_crypto::SecretKey;
 use near_o11y::testonly::init_test_logger;
@@ -62,7 +63,7 @@ async fn empty() {
     let node_key = data::make_secret_key(rng);
     let cfg = test_graph_config(peer_id(&node_key));
     let clock = time::FakeClock::default();
-    let g = Graph::new(clock.clock(), cfg);
+    let g = Graph::new(clock.clock(), cfg, &ActorSystem::new());
     g.check(&[]);
 }
 
@@ -76,7 +77,7 @@ async fn one_edge() {
     let rng = &mut rng;
     let node_key = data::make_secret_key(rng);
     let cfg = test_graph_config(peer_id(&node_key));
-    let g = Arc::new(Graph::new(clock.clock(), cfg.clone()));
+    let g = Arc::new(Graph::new(clock.clock(), cfg.clone(), &ActorSystem::new()));
 
     let p1 = data::make_secret_key(rng);
     let e1 = data::make_edge(&node_key, &p1, 1);
@@ -125,7 +126,7 @@ async fn expired_edges() {
         prune_edges_after: Some(110 * SEC),
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg.clone()));
+    let g = Arc::new(Graph::new(clock.clock(), cfg.clone(), &ActorSystem::new()));
 
     let p1 = data::make_secret_key(rng);
     let p2 = data::make_secret_key(rng);
@@ -200,7 +201,7 @@ async fn source_cap_enforced() {
         max_graph_peers: 1_000,
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Arc::new(Graph::new(clock.clock(), cfg, &ActorSystem::new()));
 
     let source_key = data::make_secret_key(rng);
     let source = peer_id(&source_key);
@@ -239,7 +240,7 @@ async fn source_cap_allows_updates() {
         max_graph_peers: 1_000,
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Arc::new(Graph::new(clock.clock(), cfg, &ActorSystem::new()));
 
     let source_key = data::make_secret_key(rng);
     let source = peer_id(&source_key);
@@ -283,7 +284,7 @@ async fn source_cap_accumulates_across_messages() {
         max_graph_peers: 1_000,
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Arc::new(Graph::new(clock.clock(), cfg, &ActorSystem::new()));
 
     let source_key = data::make_secret_key(rng);
     let source = peer_id(&source_key);
@@ -329,7 +330,7 @@ async fn global_edge_cap() {
         max_graph_peers: 1_000,
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Arc::new(Graph::new(clock.clock(), cfg, &ActorSystem::new()));
 
     // Send edges from multiple sources exceeding global cap.
     for _ in 0..3 {
@@ -370,7 +371,7 @@ async fn global_peer_cap() {
         max_graph_peers: 4,
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Arc::new(Graph::new(clock.clock(), cfg, &ActorSystem::new()));
 
     let source_key = data::make_secret_key(rng);
     let source = peer_id(&source_key);
@@ -407,7 +408,7 @@ async fn local_edges_obey_global_caps() {
         max_graph_peers: 1_000,
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Arc::new(Graph::new(clock.clock(), cfg, &ActorSystem::new()));
 
     // Local edges should also obey max_total_edges.
     let edges: Vec<Edge> = (0..max_total + 5)
@@ -443,7 +444,7 @@ async fn limit_drops_are_non_punitive() {
         max_graph_peers: 4,
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Arc::new(Graph::new(clock.clock(), cfg, &ActorSystem::new()));
 
     let source_key = data::make_secret_key(rng);
     let source = peer_id(&source_key);
@@ -484,7 +485,7 @@ async fn source_budget_recovery_after_prune() {
         prune_edges_after: Some(time::Duration::seconds(60)),
         ..test_graph_config(peer_id(&node_key))
     };
-    let g = Arc::new(Graph::new(clock.clock(), cfg));
+    let g = Arc::new(Graph::new(clock.clock(), cfg, &ActorSystem::new()));
 
     let source_key = data::make_secret_key(rng);
     let source = peer_id(&source_key);

--- a/core/async/src/lib.rs
+++ b/core/async/src/lib.rs
@@ -187,65 +187,47 @@ pub fn shutdown_all_actors() {
 mod tests {
     use super::*;
     use crate::futures::FutureSpawnerExt;
-    use std::time::{Duration, Instant};
+    use std::sync::mpsc;
+    use std::time::Duration;
 
-    /// Regression test for the shutdown deadlock that wedged forknet nodes:
-    /// a struct holds a `Box<dyn FutureSpawner>` AND tasks spawned on that
-    /// spawner capture `Arc<Self>` to keep the runtime alive while running.
-    /// That forms an Arc cycle whose only exit is external cancellation.
-    /// `ActorSystem::new_future_spawner` plus `stop()` must break the cycle.
+    /// `ActorSystem::stop` must cancel pending futures spawned via
+    /// `new_future_spawner`, otherwise tasks that capture an `Arc` of their
+    /// owner form a self-pin cycle that wedges shutdown indefinitely.
     #[test]
-    fn actor_system_future_spawner_breaks_self_pin_on_stop() {
-        struct SelfPinning {
-            spawner: Box<dyn FutureSpawner>,
-        }
-
+    fn future_spawner_cancels_pending_tasks_on_stop() {
         let actor_system = ActorSystem::new();
-        let outer =
-            Arc::new(SelfPinning { spawner: actor_system.new_future_spawner("test self-pin") });
-        let weak = Arc::downgrade(&outer);
+        let spawner = actor_system.new_future_spawner("test");
 
-        let captured = outer.clone();
-        outer.spawner.spawn("self-pin", async move {
-            let _hold = captured;
+        let (tx, rx) = mpsc::channel::<()>();
+        spawner.spawn("pending", async move {
+            let _tx = tx; // dropped iff this future is cancelled
             std::future::pending::<()>().await;
         });
 
-        drop(outer);
-        // The captured clone keeps strong count >= 1.
-        assert!(weak.strong_count() > 0, "spawned task should still hold an Arc clone");
-
         actor_system.stop();
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while weak.strong_count() > 0 && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        assert_eq!(weak.strong_count(), 0, "stop() should cancel the task and drop the Arc");
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(5)),
+            Err(mpsc::RecvTimeoutError::Disconnected)
+        );
     }
 
-    /// Same property for multithread actors: tasks running on
-    /// `ActorSystem::spawn_multithread_actor` exit when the system is stopped,
-    /// even if the actor's worker thread closure captured an `Arc<Self>` style
-    /// keepalive (modeled here via `Arc::downgrade` after wiring).
+    /// Same property for multithread actors: `stop()` causes the worker thread
+    /// to exit and the actor instance to drop.
     #[test]
-    fn actor_system_multithread_actor_breaks_self_pin_on_stop() {
-        struct Holder {
-            _handle: crate::multithread::MultithreadRuntimeHandle<EmptyActor>,
-        }
+    fn multithread_actor_dropped_on_stop() {
+        struct DropProbe(#[allow(dead_code)] mpsc::Sender<()>);
+        impl Actor for DropProbe {}
 
         let actor_system = ActorSystem::new();
-        let handle = actor_system.spawn_multithread_actor(1, || EmptyActor);
-        let outer = Arc::new(Holder { _handle: handle });
-        let weak = Arc::downgrade(&outer);
+        let (tx, rx) = mpsc::channel::<()>();
+        let _handle = actor_system.spawn_multithread_actor(1, move || DropProbe(tx.clone()));
 
-        drop(outer);
         actor_system.stop();
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while weak.strong_count() > 0 && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        assert_eq!(weak.strong_count(), 0);
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(5)),
+            Err(mpsc::RecvTimeoutError::Disconnected)
+        );
     }
 }

--- a/core/async/src/lib.rs
+++ b/core/async/src/lib.rs
@@ -164,45 +164,6 @@ impl ActorSystem {
     }
 }
 
-/// Spawns a future spawner that is NOT owned by any ActorSystem.
-/// Rather, the returned FutureSpawner, when dropped, will stop the runtime.
-pub fn new_owned_future_spawner(description: &str) -> Box<dyn FutureSpawner> {
-    Box::new(OwnedFutureSpawner {
-        handle: spawn_tokio_actor(EmptyActor, description.to_string(), CancellationToken::new()),
-    })
-}
-
-/// Spawns a multithreaded actor which is NOT owned by any ActorSystem.
-/// Rather, the returned handle, when dropped, will stop the actor and its runtime.
-pub fn new_owned_multithread_actor<A: Actor + Send + 'static>(
-    num_threads: usize,
-    make_actor_fn: impl Fn() -> A + Sync + Send + 'static,
-) -> MultithreadRuntimeHandle<A> {
-    let (cancellation_signal, cancellation_receiver) = crossbeam_channel::bounded::<()>(0);
-    spawn_multithread_actor(
-        num_threads,
-        make_actor_fn,
-        cancellation_receiver,
-        Some(cancellation_signal), // never cancelled
-    )
-}
-
-struct OwnedFutureSpawner {
-    handle: TokioRuntimeHandle<EmptyActor>,
-}
-
-impl FutureSpawner for OwnedFutureSpawner {
-    fn spawn_boxed(&self, description: &'static str, f: crate::futures::BoxFuture<'static, ()>) {
-        self.handle.future_spawner().spawn_boxed(description, f);
-    }
-}
-
-impl Drop for OwnedFutureSpawner {
-    fn drop(&mut self) {
-        self.handle.stop();
-    }
-}
-
 /// Used to determine whether shutdown_all_actors is being used properly. If there are multiple
 /// ActorSystems, shutdown_all_actors shall not be used, but instead the test needs to manage
 /// the shutdown of each ActorSystem individually.
@@ -219,5 +180,72 @@ pub fn shutdown_all_actors() {
         if let Some(system) = systems.first() {
             system.stop();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::futures::FutureSpawnerExt;
+    use std::time::{Duration, Instant};
+
+    /// Regression test for the shutdown deadlock that wedged forknet nodes:
+    /// a struct holds a `Box<dyn FutureSpawner>` AND tasks spawned on that
+    /// spawner capture `Arc<Self>` to keep the runtime alive while running.
+    /// That forms an Arc cycle whose only exit is external cancellation.
+    /// `ActorSystem::new_future_spawner` plus `stop()` must break the cycle.
+    #[test]
+    fn actor_system_future_spawner_breaks_self_pin_on_stop() {
+        struct SelfPinning {
+            spawner: Box<dyn FutureSpawner>,
+        }
+
+        let actor_system = ActorSystem::new();
+        let outer =
+            Arc::new(SelfPinning { spawner: actor_system.new_future_spawner("test self-pin") });
+        let weak = Arc::downgrade(&outer);
+
+        let captured = outer.clone();
+        outer.spawner.spawn("self-pin", async move {
+            let _hold = captured;
+            std::future::pending::<()>().await;
+        });
+
+        drop(outer);
+        // The captured clone keeps strong count >= 1.
+        assert!(weak.strong_count() > 0, "spawned task should still hold an Arc clone");
+
+        actor_system.stop();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while weak.strong_count() > 0 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(weak.strong_count(), 0, "stop() should cancel the task and drop the Arc");
+    }
+
+    /// Same property for multithread actors: tasks running on
+    /// `ActorSystem::spawn_multithread_actor` exit when the system is stopped,
+    /// even if the actor's worker thread closure captured an `Arc<Self>` style
+    /// keepalive (modeled here via `Arc::downgrade` after wiring).
+    #[test]
+    fn actor_system_multithread_actor_breaks_self_pin_on_stop() {
+        struct Holder {
+            _handle: crate::multithread::MultithreadRuntimeHandle<EmptyActor>,
+        }
+
+        let actor_system = ActorSystem::new();
+        let handle = actor_system.spawn_multithread_actor(1, || EmptyActor);
+        let outer = Arc::new(Holder { _handle: handle });
+        let weak = Arc::downgrade(&outer);
+
+        drop(outer);
+        actor_system.stop();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while weak.strong_count() > 0 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(weak.strong_count(), 0);
     }
 }


### PR DESCRIPTION
`NetworkState` owns `ops_spawner: Box<dyn FutureSpawner>`, a standalone tokio runtime created via `new_owned_future_spawner`. The cancellation token for that runtime was `CancellationToken::new()` — a fresh token only signaled by `Drop`. Tasks spawned on the runtime follow the pattern `let this = self.clone(); self.spawn("...", async move { /* use this */ })`, intentionally capturing `Arc<NetworkState>` to keep the runtime alive while the future runs.

This forms a self-pin cycle: `NetworkState` owns the spawner, the spawner's futures hold clones of `Arc<NetworkState>`. Normally, futures finish quickly, drop their captures, and the refcount returns to baseline. But if a single future is stuck on an `.await` that never completes, its captured `Arc` clone holds `NetworkState` alive forever, the runtime never drops, and the wedged future never gets cancelled (the cancellation token lives inside the runtime that can't be dropped).

The wedged process blocks indefinitely in `RocksDB::block_until_all_instances_are_dropped`, since `NetworkState` transitively holds the only `Arc<dyn Database>` via `connection_store` and `account_announcements`.

The same pattern applied to `Graph::updater` via `new_owned_multithread_actor`.


Route both spawners through `ActorSystem` so `stop()` cancels them externally — captured Arcs drop, the cycle resolves, shutdown completes. The now-unused `new_owned_*` helpers are removed.

Followup commits handle `RecvError` in outer `.spawn(...).await` callers that can now observe cancellation, and log on cancellation instead of silently dropping. Regression tests in `core/async`.