### PR TITLE
chore: update rust toolchain to 1.93

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0"                               # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
-rust-version = "1.86.0"
+rust-version = "1.93.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 
@@ -129,7 +129,7 @@ needless_pass_by_ref_mut = "deny"
 redundant_clone = "deny"
 same_functions_in_if_condition = "deny"
 or_fun_call = "deny"
-unchecked_duration_subtraction = "deny"
+unchecked_time_subtraction = "deny"
 unnecessary_box_returns = "deny"
 unnecessary_join = "deny"
 unnecessary_lazy_evaluations = "deny"

--- a/runtime/near-vm/vm/src/probestack/rust_lang_probestack.rs
+++ b/runtime/near-vm/vm/src/probestack/rust_lang_probestack.rs
@@ -106,10 +106,6 @@ macro_rules! define_rust_probestack {
     };
 }
 
-// FIXME(rust-lang/rust#126984): Remove allow once lint is fixed
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use define_rust_probestack;
-
 // Our goal here is to touch each page between %rsp+8 and %rsp+8-%rax,
 // ensuring that if any pages are unmapped we'll make a page fault.
 //

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -9,6 +9,6 @@
 # their contracts.  See
 # https://near.zulipchat.com/#narrow/channel/295306-contract-runtime/topic/bulk.20memory.20support
 # for more details.
-channel = "1.86.0"
+channel = "1.93.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This bumps the MSRV to 1.93.0 for all crates in the repository.

As far as possible, necessary code changes have been applied in previous PRs.

- #15664
- #15665
- #15667
- #15668
- #15672
- #15673
- #15675

On top of that, two changes are in this PR:

- removes a `use` statement that was necessary with old Rust versions and is now marked by clippy as unused
- rename clippy::unchecked_duration_subtraction to clippy::unchecked_time_subtraction following the renaming in clippy