### PR TITLE
chore(vm-runner): trampoline-only regression tests + use typed lookup

### DIFF
--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -310,6 +310,40 @@ fn test_guest_panic() {
 }
 
 #[test]
+fn test_trampoline_only_start_section() {
+    test_builder()
+        .wat(
+            r#"
+(module
+  (import "env" "panic" (func $panic))
+  (start $panic)
+  (export "main" (func $panic))
+)"#,
+        )
+        .expect(&expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 364482479 used gas 364482479
+            Err: Smart contract panicked: explicit guest panic
+        "#]]);
+}
+
+#[test]
+fn test_trampoline_only_remaining_gas_global() {
+    test_builder()
+        .wat(
+            r#"
+(module
+  (import "env" "panic" (func $panic))
+  (global $g i32 (i32.const 0))
+  (export "main" (func $panic))
+)"#,
+        )
+        .expect(&expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 376464724 used gas 376464724
+            Err: Smart contract panicked: explicit guest panic
+        "#]]);
+}
+
+#[test]
 fn test_panic_re_export() {
     test_builder()
         .wat(

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -902,20 +902,18 @@ impl crate::PreparedContract for VMResult<PreparedContract> {
                 return Ok(VMOutcome::abort(result_state, err));
             }
         };
-        // Pre-resolve the memory export so that host functions don't need to
-        // resolve it lazily via Caller::get_module_export (which can fail when
-        // the Caller's instance is a host-side trampoline for re-exported
-        // host functions). It may already be resolved if a start function
-        // triggered a host import during instantiation.
+        // Pre-resolve the memory export here (on the real, post-instantiation
+        // instance) so host functions don't need to resolve it lazily.
         //
-        // Uses string-based instance.get_memory instead of
-        // instance.get_module_export due to a wasmtime issue: for modules
-        // whose only compiled functions are trampolines (no user-defined
-        // function bodies), LoadedCode::push_module stores the module in
-        // modules_with_only_trampolines, but LoadedCode::module() only
-        // searches self.modules, causing module_for_instance to panic.
-        if let Export::Unresolved(_) = store.data().memory {
-            if let Some(memory) = instance.get_memory(&mut store, MEMORY_EXPORT) {
+        // The lazy Caller::get_module_export → module_for_instance().unwrap()
+        // path panics when the Caller's instance is a Dummy host-side
+        // trampoline for a re-exported host function (module_for_instance
+        // returns None for Dummy instances). See test_panic_re_export and
+        // test_trampoline_only_* for regression coverage.
+        if let Export::Unresolved(memory_export) = store.data().memory {
+            if let Some(Extern::Memory(memory)) =
+                instance.get_module_export(&mut store, &memory_export)
+            {
                 store.data_mut().memory = Export::Resolved(memory);
             }
         }


### PR DESCRIPTION
Adding the regression tests from: https://github.com/near/nearcore/pull/15654, but the fix itself is not needed with wasmtime 45.

Additionally, update the comment to reflect the new reason the prior workaround is still needed in case of memory lookup. However, we can switch to the indexed lookup instead of a string based lookup.