### PR TITLE
feat(database): bucket-ETL ReceiptToTx backfill prototype

### DIFF
--- a/chain/chain/src/backfill_receipt_to_tx.rs
+++ b/chain/chain/src/backfill_receipt_to_tx.rs
@@ -8,7 +8,7 @@ use near_primitives::receipt::{
     ReceiptToTxInfoV1,
 };
 use near_primitives::transaction::ExecutionOutcomeWithProof;
-use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::types::{AccountId, BlockHeight, ShardId};
 use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash};
 use near_store::{DBCol, NodeStorage, Store};
 use rayon::prelude::*;
@@ -169,6 +169,54 @@ struct StagedOutcome {
     outcome_id: CryptoHash,
     shard_id: ShardId,
     outcome: ExecutionOutcomeWithProof,
+}
+
+/// Resolved primitives needed to assemble a `ReceiptToTxInfo`.
+///
+/// Both `process_height` (single-height MultiGet path) and the bucket-ETL
+/// pipeline produce these by their own routes; the kernel
+/// [`build_receipt_to_tx_info`] consumes them and produces byte-identical
+/// output. Skipping (missing parent / child / outcome) is decided by the
+/// caller — once a `BuiltOriginInputs` is constructed, an entry will be
+/// produced.
+pub struct BuiltOriginInputs {
+    pub outcome_id: CryptoHash,
+    pub shard_id: ShardId,
+    pub child_receiver_id: AccountId,
+    pub origin: BuiltOrigin,
+}
+
+pub enum BuiltOrigin {
+    FromTransaction { sender_id: AccountId },
+    FromReceipt { parent_predecessor_id: AccountId },
+}
+
+/// Assemble a `ReceiptToTxInfo` from already-resolved primitives.
+///
+/// This is the shared kernel between `process_height` and the bucket-ETL
+/// pipeline. Producing the same `BuiltOriginInputs` from either path is the
+/// guarantee the equivalence tests rely on.
+pub fn build_receipt_to_tx_info(inputs: BuiltOriginInputs) -> ReceiptToTxInfo {
+    let BuiltOriginInputs { outcome_id, shard_id, child_receiver_id, origin } = inputs;
+    let origin = match origin {
+        BuiltOrigin::FromTransaction { sender_id } => {
+            ReceiptOrigin::FromTransaction(ReceiptOriginTransaction {
+                tx_hash: outcome_id,
+                sender_account_id: sender_id,
+            })
+        }
+        BuiltOrigin::FromReceipt { parent_predecessor_id } => {
+            ReceiptOrigin::FromReceipt(ReceiptOriginReceipt {
+                parent_receipt_id: outcome_id,
+                parent_predecessor_id,
+            })
+        }
+    };
+    ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+        origin,
+        receiver_account_id: child_receiver_id,
+        shard_id,
+    })
 }
 
 /// Process a single height: read all execution outcomes and build ReceiptToTxInfo entries.
@@ -355,15 +403,8 @@ pub fn process_height(
             }
         };
 
-        let info = if is_tx {
-            ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
-                origin: ReceiptOrigin::FromTransaction(ReceiptOriginTransaction {
-                    tx_hash: s.outcome_id,
-                    sender_account_id: outcome.executor_id.clone(),
-                }),
-                receiver_account_id: child_receipt.receiver_id().clone(),
-                shard_id: s.shard_id,
-            })
+        let origin = if is_tx {
+            BuiltOrigin::FromTransaction { sender_id: outcome.executor_id.clone() }
         } else {
             let parent = match parent_by_staged_idx.get(staged_idx) {
                 Some(r) => r,
@@ -377,16 +418,15 @@ pub fn process_height(
                     continue;
                 }
             };
-            ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
-                origin: ReceiptOrigin::FromReceipt(ReceiptOriginReceipt {
-                    parent_receipt_id: s.outcome_id,
-                    parent_predecessor_id: parent.predecessor_id().clone(),
-                }),
-                receiver_account_id: child_receipt.receiver_id().clone(),
-                shard_id: s.shard_id,
-            })
+            BuiltOrigin::FromReceipt { parent_predecessor_id: parent.predecessor_id().clone() }
         };
 
+        let info = build_receipt_to_tx_info(BuiltOriginInputs {
+            outcome_id: s.outcome_id,
+            shard_id: s.shard_id,
+            child_receiver_id: child_receipt.receiver_id().clone(),
+            origin,
+        });
         entries.push((*child_receipt_id, info));
     }
 

--- a/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -42,12 +42,12 @@ use near_primitives::transaction::ExecutionOutcomeWithProof;
 use near_primitives::types::{AccountId, BlockHeight, ShardId};
 use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash};
 use near_store::DBCol;
+use parking_lot::Mutex;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 
 /// Strict upper bound the SST ingest path enforces; mirrored here so Pass D
 /// rejects any output bucket the Phase 3 ingest would refuse.
@@ -770,7 +770,8 @@ fn pass_b_worker(
     let mut seg = list_existing_segments(scratch, worker);
 
     let marker_interval = opts.marker_block_interval.max(1);
-    let mut last_marker_height = resume_height.unwrap_or(slice_start.saturating_sub(1));
+    let mut last_marker_height =
+        resume_height.unwrap_or_else(|| slice_start.saturating_sub(1));
 
     let mut h = start;
     while h <= slice_end {
@@ -976,11 +977,11 @@ fn pass_c_resolve_parents(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)>
 
             for (zz, rows) in local_zz.into_iter().enumerate() {
                 if !rows.is_empty() {
-                    zz_buffers[zz].lock().unwrap().extend(rows);
+                    zz_buffers[zz].lock().extend(rows);
                 }
             }
-            *missing_total.lock().unwrap() += local_missing;
-            *total_rows.lock().unwrap() += local_emitted;
+            *missing_total.lock() += local_missing;
+            *total_rows.lock() += local_emitted;
             Ok(())
         })
     })?;
@@ -992,14 +993,14 @@ fn pass_c_resolve_parents(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)>
         if out.exists() {
             return Ok(());
         }
-        let mut rows = std::mem::take(&mut *zz_buffers[zz as usize].lock().unwrap());
+        let mut rows = std::mem::take(&mut *zz_buffers[zz as usize].lock());
         rows.sort_by(|a, b| a.child_id.as_ref().cmp(b.child_id.as_ref()));
         write_bucket(&out, &rows)?;
         Ok(())
     })?;
 
-    let total = *total_rows.lock().unwrap();
-    let missing = *missing_total.lock().unwrap();
+    let total = *total_rows.lock();
+    let missing = *missing_total.lock();
     Ok((total, missing))
 }
 
@@ -1077,14 +1078,14 @@ fn pass_d_final_join(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)> {
             let count = validated.len() as u64;
             write_bucket(&out_path, &validated)?;
 
-            *total_rows.lock().unwrap() += count;
-            *missing_children.lock().unwrap() += local_missing;
+            *total_rows.lock() += count;
+            *missing_children.lock() += local_missing;
             Ok(())
         })
     })?;
 
-    let total = *total_rows.lock().unwrap();
-    let missing = *missing_children.lock().unwrap();
+    let total = *total_rows.lock();
+    let missing = *missing_children.lock();
     Ok((total, missing))
 }
 

--- a/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -581,9 +581,12 @@ fn pass_a_receipts_extract(
                         });
                     }
                     // iter_range delivers in sorted order, so rows are already
-                    // sorted by receipt_id. Belt-and-braces sort to defend against
-                    // future iter changes.
-                    rows.sort_by(|a, b| a.receipt_id.as_ref().cmp(b.receipt_id.as_ref()));
+                    // sorted by receipt_id. Cheap debug_assert keeps a regression
+                    // net without paying for a full sort on every prefix in prod.
+                    debug_assert!(
+                        rows.windows(2).all(|w| w[0].receipt_id.as_ref() < w[1].receipt_id.as_ref()),
+                        "Pass A: iter_range broke its sorted-output contract for prefix {prefix:#04x}"
+                    );
                     let count = rows.len() as u64;
                     write_bucket(&out_path, &rows)?;
                     Ok(acc + count)

--- a/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -1,0 +1,1321 @@
+//! Bucket-ETL pipeline that rebuilds `DBCol::ReceiptToTx` from cold-store data
+//! without random reads.
+//!
+//! Four parallel-by-prefix passes with a deterministic shuffle:
+//!
+//! - **Pass A**: scan `DBCol::Receipts` partitioned by first byte; emit
+//!   `(receipt_id, receiver_id, predecessor_id)` per receipt to per-prefix files.
+//! - **Pass B**: parallel block walk; per outcome emit either a tx-origin
+//!   demand row (bucketed by `child_id_first_byte`) or a needs-parent row
+//!   (bucketed by `parent_receipt_id_first_byte`).
+//! - **Pass C**: per `parent_id` prefix, join needs-parent rows against the
+//!   receipts extract for that prefix to fill in `parent.predecessor_id`.
+//!   Output is re-bucketed by `child_id_first_byte` (the deterministic
+//!   shuffle that eliminates cross-prefix lookups in Pass D).
+//! - **Pass D**: per `child_id` prefix, join tx-origin demands (Pass B) +
+//!   resolved receipt-origin demands (Pass C) against the receipts extract
+//!   to fill in `child.receiver_id`. Build `ReceiptToTxInfo` via the shared
+//!   kernel, sort+dedupe with `BackfillError::ValueDivergence` quarantine,
+//!   validate SST invariants, write per-prefix output files.
+//!
+//! Restart machinery:
+//! - per-stage `.done` markers in `{scratch_dir}/.markers/`
+//! - per-Pass-B-worker height marker; on restart, each worker resumes from
+//!   its last marker rather than slice-start.
+//! - `options.json` records the invocation; mismatched options on resume
+//!   abort with a clear error.
+//!
+//! Phase 1 prototype: in-memory sort within each prefix is sufficient at
+//! expected scale (per-prefix bucket << RAM). External-sort is Phase 3.
+
+use crate::backfill_receipt_to_tx::{
+    BackfillError, BackfillStorage, BuiltOrigin, BuiltOriginInputs, build_receipt_to_tx_info,
+    process_height,
+};
+use crate::{ChainStore, ChainStoreAccess, Error};
+use anyhow::{Context, bail};
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_o11y::tracing;
+use near_primitives::hash::CryptoHash;
+use near_primitives::receipt::{Receipt, ReceiptToTxInfo};
+use near_primitives::transaction::ExecutionOutcomeWithProof;
+use near_primitives::types::{AccountId, BlockHeight, ShardId};
+use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash};
+use near_store::DBCol;
+use rayon::prelude::*;
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Strict upper bound the SST ingest path enforces; mirrored here so Pass D
+/// rejects any output bucket the Phase 3 ingest would refuse.
+pub const MAX_BUCKET_SERIALIZED_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Production default for Pass B per-worker height marker cadence. Tests
+/// override to small values to exercise the resume path on small ranges.
+const DEFAULT_MARKER_BLOCK_INTERVAL: u64 = 100_000;
+
+const STAGE_A: &str = "pass_a";
+const STAGE_B: &str = "pass_b";
+const STAGE_C: &str = "pass_c";
+const STAGE_D: &str = "pass_d";
+
+#[derive(Clone)]
+pub struct BucketEtlOptions {
+    pub from_height: Option<BlockHeight>,
+    pub to_height: Option<BlockHeight>,
+    pub num_threads: usize,
+    pub scratch_dir: PathBuf,
+    pub output_mode: BucketEtlOutputMode,
+    /// Block interval at which Pass B workers persist a height marker and
+    /// flush accumulated buffers. Tests override to small values.
+    pub marker_block_interval: u64,
+    /// Test-only knob: cause Pass B to abort once any worker reaches this
+    /// height. Drives `test_bucket_etl_resumes_after_simulated_crash`.
+    #[cfg(feature = "test_features")]
+    pub crash_after_pass_b_height: Option<BlockHeight>,
+}
+
+impl BucketEtlOptions {
+    pub fn measure_only(scratch_dir: PathBuf) -> Self {
+        Self {
+            from_height: None,
+            to_height: None,
+            num_threads: 4,
+            scratch_dir,
+            output_mode: BucketEtlOutputMode::MeasureOnly,
+            marker_block_interval: DEFAULT_MARKER_BLOCK_INTERVAL,
+            #[cfg(feature = "test_features")]
+            crash_after_pass_b_height: None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum BucketEtlOutputMode {
+    /// Validate output buckets but don't write to any store. Operational mode
+    /// used on the production VM to gate the run.
+    MeasureOnly,
+    /// Test-only mode: write the validated output to `BackfillStorage.write_store`
+    /// via the legacy per-key insert path. Not exposed via the CLI.
+    WriteToStore,
+    /// Run `process_height` over `[from_height, to_height]` after Pass D and
+    /// byte-compare resulting `ReceiptToTx` entries.
+    CompareAgainstActor { from_height: BlockHeight, to_height: BlockHeight },
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct BucketEtlStats {
+    pub pass_a_rows: u64,
+    pub pass_b_tx_origin_rows: u64,
+    pub pass_b_needs_parent_rows: u64,
+    pub pass_c_rows: u64,
+    pub pass_d_rows: u64,
+    pub blocks_processed: u64,
+    pub heights_skipped: u64,
+    pub missing_outcomes: u64,
+    pub missing_child_receipts: u64,
+    pub missing_parent_receipts: u64,
+    pub compare_divergences: u64,
+}
+
+// ===== Bucket file row types =====
+
+/// Pass A output: per receipt, the primitives needed by Pass C (predecessor)
+/// and Pass D (receiver) joins.
+#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
+pub struct ReceiptExtractRow {
+    pub receipt_id: CryptoHash,
+    pub receiver_id: AccountId,
+    pub predecessor_id: AccountId,
+}
+
+/// Pass B output (bucketed by `child_id` first byte): tx-origin demand row.
+/// Carries everything Pass D needs for tx-origin entries (no parent lookup).
+#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
+pub struct TxOriginDemandRow {
+    pub child_id: CryptoHash,
+    pub shard_id: ShardId,
+    pub tx_hash: CryptoHash,
+    pub sender_account_id: AccountId,
+}
+
+/// Pass B output (bucketed by `parent_receipt_id` first byte): receipt-origin
+/// row pending parent.predecessor_id resolution in Pass C.
+#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
+pub struct NeedsParentRow {
+    pub child_id: CryptoHash,
+    pub shard_id: ShardId,
+    pub parent_receipt_id: CryptoHash,
+}
+
+/// Pass C output (re-bucketed by `child_id` first byte): receipt-origin demand
+/// row with parent.predecessor_id filled in from Pass A's extract.
+#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
+pub struct ReceiptOriginDemandRow {
+    pub child_id: CryptoHash,
+    pub shard_id: ShardId,
+    pub parent_receipt_id: CryptoHash,
+    pub parent_predecessor_id: AccountId,
+}
+
+/// Pass D output: the final `(child_id, ReceiptToTxInfo)` entry to ingest.
+#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
+pub struct OutputRow {
+    pub child_id: CryptoHash,
+    pub info: ReceiptToTxInfo,
+}
+
+// ===== Bucket file format =====
+
+/// Length-prefixed borsh records. `[u32 LE length][borsh bytes]...`.
+pub struct BucketWriter<W: Write> {
+    inner: W,
+    bytes_written: u64,
+}
+
+impl<W: Write> BucketWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self { inner, bytes_written: 0 }
+    }
+
+    pub fn write<T: BorshSerialize>(&mut self, row: &T) -> anyhow::Result<()> {
+        let bytes = borsh::to_vec(row).context("borsh serialize bucket row")?;
+        let len: u32 = bytes.len().try_into().context("bucket row exceeds u32::MAX")?;
+        self.inner.write_all(&len.to_le_bytes()).context("write bucket row length")?;
+        self.inner.write_all(&bytes).context("write bucket row payload")?;
+        self.bytes_written += 4 + bytes.len() as u64;
+        Ok(())
+    }
+
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+
+    pub fn finish(mut self) -> anyhow::Result<W> {
+        self.inner.flush().context("flush bucket writer")?;
+        Ok(self.inner)
+    }
+}
+
+pub struct BucketReader<R: Read> {
+    inner: R,
+}
+
+impl<R: Read> BucketReader<R> {
+    pub fn new(inner: R) -> Self {
+        Self { inner }
+    }
+}
+
+impl<R: Read> Iterator for BucketReader<R> {
+    type Item = anyhow::Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut len_bytes = [0u8; 4];
+        match self.inner.read_exact(&mut len_bytes) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return None,
+            Err(e) => return Some(Err(anyhow::Error::from(e).context("read bucket row length"))),
+        }
+        let len = u32::from_le_bytes(len_bytes) as usize;
+        let mut buf = vec![0u8; len];
+        if let Err(e) = self.inner.read_exact(&mut buf) {
+            return Some(Err(anyhow::Error::from(e).context("read bucket row payload")));
+        }
+        Some(Ok(buf))
+    }
+}
+
+/// Read a whole bucket file into a `Vec<T>`. The file must exist.
+pub fn read_bucket<T: BorshDeserialize>(path: &Path) -> anyhow::Result<Vec<T>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let f = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let reader = BucketReader::new(BufReader::new(f));
+    let mut out = Vec::new();
+    for row in reader {
+        let bytes = row?;
+        let value = T::try_from_slice(&bytes).context("borsh deserialize bucket row")?;
+        out.push(value);
+    }
+    Ok(out)
+}
+
+/// Atomic-rename based bucket writer: writes to `<path>.tmp`, fsyncs, renames.
+pub fn write_bucket<T: BorshSerialize>(path: &Path, rows: &[T]) -> anyhow::Result<u64> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("mkdir {}", parent.display()))?;
+    }
+    let tmp = with_tmp_suffix(path);
+    let f = File::create(&tmp).with_context(|| format!("create {}", tmp.display()))?;
+    let mut w = BucketWriter::new(BufWriter::new(f));
+    for row in rows {
+        w.write(row)?;
+    }
+    let bytes = w.bytes_written();
+    let bw = w.finish()?;
+    let f = bw.into_inner().context("bufwriter into_inner")?;
+    f.sync_all().context("fsync bucket")?;
+    drop(f);
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(bytes)
+}
+
+fn with_tmp_suffix(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(".tmp");
+    PathBuf::from(s)
+}
+
+/// Sort by key, surface `BackfillError::ValueDivergence` on any same-key pair
+/// whose serialized values differ, and validate the SST-ingest invariants
+/// (strictly sorted, no duplicate keys, ≤`max_bytes` total).
+///
+/// The serialized-value comparison mirrors `sort_and_dedupe_entries` in
+/// `backfill_receipt_to_tx.rs`: identical entries collapse, divergent ones
+/// quarantine the whole batch. Tests use [`finalize_output_bucket_with_max`]
+/// with a small `max_bytes` to exercise the size-limit path.
+pub fn finalize_output_bucket_with_max(
+    mut rows: Vec<OutputRow>,
+    max_bytes: u64,
+) -> anyhow::Result<Vec<OutputRow>> {
+    rows.sort_by(|a, b| a.child_id.as_ref().cmp(b.child_id.as_ref()));
+    let mut deduped: Vec<OutputRow> = Vec::with_capacity(rows.len());
+    let mut total_bytes: u64 = 0;
+    for row in rows {
+        match deduped.last() {
+            Some(prev) if prev.child_id == row.child_id => {
+                let prev_bytes =
+                    borsh::to_vec(&prev.info).context("serialize prev ReceiptToTxInfo")?;
+                let new_bytes =
+                    borsh::to_vec(&row.info).context("serialize new ReceiptToTxInfo")?;
+                if prev_bytes != new_bytes {
+                    return Err(BackfillError::ValueDivergence {
+                        key: row.child_id,
+                        prev_value: prev_bytes,
+                        new_value: new_bytes,
+                    }
+                    .into());
+                }
+                // identical: collapse
+            }
+            _ => {
+                let bytes = borsh::to_vec(&row).context("serialize OutputRow")?;
+                total_bytes += 4 + bytes.len() as u64;
+                if total_bytes > max_bytes {
+                    bail!(
+                        "Pass D output bucket exceeds {} bytes (last key {}); \
+                         exceeds Store::ingest_insert_only_sst limit",
+                        max_bytes,
+                        row.child_id,
+                    );
+                }
+                deduped.push(row);
+            }
+        }
+    }
+    // Strictly-sorted check (defensive — sort_by + dedupe should guarantee, but
+    // exists to catch a regression in the validator itself).
+    for pair in deduped.windows(2) {
+        if pair[0].child_id.as_ref() >= pair[1].child_id.as_ref() {
+            bail!(
+                "Pass D output bucket is not strictly sorted: {} >= {}",
+                pair[0].child_id,
+                pair[1].child_id,
+            );
+        }
+    }
+    Ok(deduped)
+}
+
+pub fn finalize_output_bucket(rows: Vec<OutputRow>) -> anyhow::Result<Vec<OutputRow>> {
+    finalize_output_bucket_with_max(rows, MAX_BUCKET_SERIALIZED_BYTES)
+}
+
+/// Validate an already-written output bucket file against the SST-ingest
+/// invariants. Used by `test_bucket_etl_rejects_invalid_output_bucket` to
+/// confirm the validator rejects hand-corrupted files.
+pub fn validate_output_bucket_file_with_max(path: &Path, max_bytes: u64) -> anyhow::Result<()> {
+    let rows: Vec<OutputRow> = read_bucket(path)?;
+    let mut total_bytes: u64 = 0;
+    for (i, row) in rows.iter().enumerate() {
+        let bytes = borsh::to_vec(row).context("serialize OutputRow")?;
+        total_bytes += 4 + bytes.len() as u64;
+        if total_bytes > max_bytes {
+            bail!("bucket {} exceeds {} bytes serialized", path.display(), max_bytes);
+        }
+        if i > 0 {
+            let prev = &rows[i - 1];
+            if prev.child_id.as_ref() >= row.child_id.as_ref() {
+                if prev.child_id == row.child_id {
+                    bail!("bucket {} contains duplicate key {}", path.display(), row.child_id);
+                }
+                bail!(
+                    "bucket {} keys not strictly sorted: {} >= {}",
+                    path.display(),
+                    prev.child_id,
+                    row.child_id
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_output_bucket_file(path: &Path) -> anyhow::Result<()> {
+    validate_output_bucket_file_with_max(path, MAX_BUCKET_SERIALIZED_BYTES)
+}
+
+// ===== Restart helpers =====
+
+fn markers_dir(scratch: &Path) -> PathBuf {
+    scratch.join(".markers")
+}
+
+fn stage_marker_path(scratch: &Path, stage: &str) -> PathBuf {
+    markers_dir(scratch).join(format!("{stage}.done"))
+}
+
+fn stage_done(scratch: &Path, stage: &str) -> bool {
+    stage_marker_path(scratch, stage).exists()
+}
+
+fn mark_stage_done(scratch: &Path, stage: &str) -> anyhow::Result<()> {
+    let dir = markers_dir(scratch);
+    fs::create_dir_all(&dir).with_context(|| format!("mkdir {}", dir.display()))?;
+    let path = stage_marker_path(scratch, stage);
+    let tmp = with_tmp_suffix(&path);
+    fs::write(&tmp, b"").with_context(|| format!("write {}", tmp.display()))?;
+    fs::rename(&tmp, &path).context("atomic-rename stage marker")?;
+    Ok(())
+}
+
+fn options_hash_path(scratch: &Path) -> PathBuf {
+    scratch.join("options.json")
+}
+
+fn compute_options_hash(opts: &BucketEtlOptions) -> String {
+    // Hash the load-bearing fields. `output_mode` is excluded — running
+    // measure-only first then compare-mode against the same scratch is a
+    // legitimate use case.
+    let mut buf = Vec::with_capacity(64);
+    buf.extend_from_slice(&opts.from_height.unwrap_or(0).to_le_bytes());
+    buf.extend_from_slice(&opts.to_height.unwrap_or(u64::MAX).to_le_bytes());
+    buf.extend_from_slice(&(opts.num_threads as u64).to_le_bytes());
+    buf.extend_from_slice(&opts.marker_block_interval.to_le_bytes());
+    buf.extend_from_slice(opts.scratch_dir.to_string_lossy().as_bytes());
+    let hash = CryptoHash::hash_bytes(&buf);
+    hash.to_string()
+}
+
+fn check_or_write_options_hash(scratch: &Path, opts: &BucketEtlOptions) -> anyhow::Result<()> {
+    let path = options_hash_path(scratch);
+    let want = compute_options_hash(opts);
+    if path.exists() {
+        let got = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        if got.trim() != want {
+            bail!(
+                "scratch_dir {} was created with different options (hash mismatch); \
+                 either use a fresh --scratch-dir or delete the existing one",
+                scratch.display(),
+            );
+        }
+    } else {
+        fs::create_dir_all(scratch).with_context(|| format!("mkdir {}", scratch.display()))?;
+        let tmp = with_tmp_suffix(&path);
+        fs::write(&tmp, want.as_bytes()).with_context(|| format!("write {}", tmp.display()))?;
+        fs::rename(&tmp, &path).context("atomic-rename options.json")?;
+    }
+    Ok(())
+}
+
+fn worker_marker_path(scratch: &Path, worker: usize) -> PathBuf {
+    scratch.join(STAGE_B).join(format!("worker_{worker}")).join("marker")
+}
+
+fn read_resume_height(scratch: &Path, worker: usize) -> Option<BlockHeight> {
+    let path = worker_marker_path(scratch, worker);
+    let bytes = fs::read(path).ok()?;
+    if bytes.len() != 8 {
+        return None;
+    }
+    Some(u64::from_le_bytes(bytes.try_into().ok()?))
+}
+
+fn write_resume_height(scratch: &Path, worker: usize, height: BlockHeight) -> anyhow::Result<()> {
+    let path = worker_marker_path(scratch, worker);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("mkdir {}", parent.display()))?;
+    }
+    let tmp = with_tmp_suffix(&path);
+    fs::write(&tmp, height.to_le_bytes()).with_context(|| format!("write {}", tmp.display()))?;
+    fs::rename(&tmp, &path).context("atomic-rename worker marker")?;
+    Ok(())
+}
+
+// ===== Path helpers =====
+
+fn pass_a_path(scratch: &Path, prefix: u8) -> PathBuf {
+    scratch.join(STAGE_A).join(format!("prefix_{prefix:02x}.bucket"))
+}
+
+fn pass_b_seg_demand_path(scratch: &Path, worker: usize, seg: u32, prefix: u8) -> PathBuf {
+    scratch
+        .join(STAGE_B)
+        .join(format!("worker_{worker}"))
+        .join(format!("seg_{seg}"))
+        .join(format!("demand_{prefix:02x}.bucket"))
+}
+
+fn pass_b_seg_needs_parent_path(scratch: &Path, worker: usize, seg: u32, prefix: u8) -> PathBuf {
+    scratch
+        .join(STAGE_B)
+        .join(format!("worker_{worker}"))
+        .join(format!("seg_{seg}"))
+        .join(format!("needs_parent_{prefix:02x}.bucket"))
+}
+
+fn pass_b_consolidated_demand_path(scratch: &Path, prefix: u8) -> PathBuf {
+    scratch.join(STAGE_B).join("demand_by_child").join(format!("prefix_{prefix:02x}.bucket"))
+}
+
+fn pass_b_consolidated_needs_parent_path(scratch: &Path, prefix: u8) -> PathBuf {
+    scratch.join(STAGE_B).join("needs_parent_by_parent").join(format!("prefix_{prefix:02x}.bucket"))
+}
+
+fn pass_c_consolidated_path(scratch: &Path, prefix: u8) -> PathBuf {
+    scratch.join(STAGE_C).join("demand_by_child").join(format!("prefix_{prefix:02x}.bucket"))
+}
+
+pub fn pass_d_output_path(scratch: &Path, prefix: u8) -> PathBuf {
+    scratch.join(STAGE_D).join("output").join(format!("prefix_{prefix:02x}.bucket"))
+}
+
+// ===== Pass A: receipts extract =====
+
+fn pass_a_receipts_extract(
+    storage: &BackfillStorage,
+    opts: &BucketEtlOptions,
+) -> anyhow::Result<u64> {
+    let store = &storage.read_store;
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(opts.num_threads.max(1))
+        .build()
+        .context("build pass A thread pool")?;
+    let scratch = opts.scratch_dir.clone();
+    fs::create_dir_all(scratch.join(STAGE_A))
+        .with_context(|| format!("mkdir {}", scratch.join(STAGE_A).display()))?;
+
+    let total_rows: u64 = pool.install(|| {
+        (0u16..=255)
+            .into_par_iter()
+            .try_fold(
+                || 0u64,
+                |acc, prefix_u16| -> anyhow::Result<u64> {
+                    let prefix = prefix_u16 as u8;
+                    let out_path = pass_a_path(&scratch, prefix);
+                    if out_path.exists() {
+                        // Resume: prefix already done.
+                        let rows: Vec<ReceiptExtractRow> = read_bucket(&out_path)?;
+                        return Ok(acc + rows.len() as u64);
+                    }
+                    let lower = [prefix];
+                    let upper_storage: Option<[u8; 1]> =
+                        if prefix == 0xff { None } else { Some([prefix + 1]) };
+                    let upper: Option<&[u8]> = upper_storage.as_ref().map(|b| b.as_slice());
+
+                    let mut rows: Vec<ReceiptExtractRow> = Vec::new();
+                    for (key, value) in store.iter_range(DBCol::Receipts, Some(&lower), upper) {
+                        let receipt_id = CryptoHash::try_from(key.as_ref()).map_err(|e| {
+                            anyhow::anyhow!("invalid receipt id key (len={}): {e}", key.len())
+                        })?;
+                        let receipt = Receipt::try_from_slice(value.as_ref())
+                            .context("borsh deserialize Receipt during Pass A scan")?;
+                        rows.push(ReceiptExtractRow {
+                            receipt_id,
+                            receiver_id: receipt.receiver_id().clone(),
+                            predecessor_id: receipt.predecessor_id().clone(),
+                        });
+                    }
+                    // iter_range delivers in sorted order, so rows are already
+                    // sorted by receipt_id. Belt-and-braces sort to defend against
+                    // future iter changes.
+                    rows.sort_by(|a, b| a.receipt_id.as_ref().cmp(b.receipt_id.as_ref()));
+                    let count = rows.len() as u64;
+                    write_bucket(&out_path, &rows)?;
+                    Ok(acc + count)
+                },
+            )
+            .try_reduce(|| 0u64, |a, b| Ok(a + b))
+    })?;
+
+    mark_stage_done(&scratch, STAGE_A)?;
+    Ok(total_rows)
+}
+
+// ===== Pass B: parallel block walk =====
+
+#[derive(Default)]
+struct PassBHeightStats {
+    blocks_processed: u64,
+    heights_skipped: u64,
+    missing_outcomes: u64,
+}
+
+/// Replicates the per-height OutcomeIds + TransactionResultForBlock +
+/// `Transactions` `multi_exists` reads from `process_height`, but emits demand
+/// rows instead of building entries directly. Receipt MultiGet (parents +
+/// children) is replaced by Pass A's receipts extract + Pass C's resolution.
+fn pass_b_emit_for_height<TxF, RpF>(
+    chain_store: &ChainStore,
+    height: BlockHeight,
+    mut emit_tx: TxF,
+    mut emit_needs_parent: RpF,
+) -> anyhow::Result<PassBHeightStats>
+where
+    TxF: FnMut(TxOriginDemandRow),
+    RpF: FnMut(NeedsParentRow),
+{
+    let block_hash = match chain_store.get_block_hash_by_height(height) {
+        Ok(h) => h,
+        Err(Error::DBNotFoundErr(_)) => {
+            return Ok(PassBHeightStats { heights_skipped: 1, ..Default::default() });
+        }
+        Err(e) => {
+            return Err(anyhow::Error::from(e))
+                .with_context(|| format!("get block hash at height {height}"));
+        }
+    };
+
+    let read_store = chain_store.store();
+    let mut stats = PassBHeightStats { blocks_processed: 1, ..Default::default() };
+
+    let mut outcome_descriptors: Vec<(CryptoHash, ShardId)> = Vec::new();
+    for (key, outcome_ids) in
+        read_store.iter_prefix_ser::<Vec<CryptoHash>>(DBCol::OutcomeIds, block_hash.as_ref())
+    {
+        let (_, shard_id) = get_block_shard_id_rev(&key).expect("invalid OutcomeIds key");
+        for outcome_id in outcome_ids {
+            outcome_descriptors.push((outcome_id, shard_id));
+        }
+    }
+    if outcome_descriptors.is_empty() {
+        return Ok(stats);
+    }
+
+    let outcome_keys_owned: Vec<Vec<u8>> = outcome_descriptors
+        .iter()
+        .map(|(oid, _)| get_outcome_id_block_hash(oid, &block_hash))
+        .collect();
+    let outcome_key_refs: Vec<&[u8]> = outcome_keys_owned.iter().map(Vec::as_slice).collect();
+    let outcome_results = read_store.multi_get(DBCol::TransactionResultForBlock, &outcome_key_refs);
+
+    let mut staged: Vec<(CryptoHash, ShardId, ExecutionOutcomeWithProof)> = Vec::new();
+    for ((outcome_id, shard_id), result) in
+        outcome_descriptors.iter().zip(outcome_results.into_iter())
+    {
+        match result {
+            Some(bytes) => {
+                let owp = ExecutionOutcomeWithProof::try_from_slice(bytes.as_slice())
+                    .expect("borsh deserialization should not fail");
+                if owp.outcome.receipt_ids.is_empty() {
+                    continue;
+                }
+                staged.push((*outcome_id, *shard_id, owp));
+            }
+            None => {
+                stats.missing_outcomes += 1;
+            }
+        }
+    }
+    if staged.is_empty() {
+        return Ok(stats);
+    }
+
+    // RC-aware classification: tombstones in `Transactions` must be reported
+    // as absent. `multi_exists` dispatches via `multi_get` which strips refcounts.
+    let outcome_id_owned: Vec<&CryptoHash> = staged.iter().map(|(o, _, _)| o).collect();
+    let outcome_id_refs: Vec<&[u8]> = outcome_id_owned.iter().map(|h| h.as_ref()).collect();
+    let is_tx_results = read_store.multi_exists(DBCol::Transactions, &outcome_id_refs);
+
+    for (i, (outcome_id, shard_id, owp)) in staged.into_iter().enumerate() {
+        let outcome = owp.outcome;
+        let is_tx = is_tx_results[i];
+        for child_id in &outcome.receipt_ids {
+            if is_tx {
+                emit_tx(TxOriginDemandRow {
+                    child_id: *child_id,
+                    shard_id,
+                    tx_hash: outcome_id,
+                    sender_account_id: outcome.executor_id.clone(),
+                });
+            } else {
+                emit_needs_parent(NeedsParentRow {
+                    child_id: *child_id,
+                    shard_id,
+                    parent_receipt_id: outcome_id,
+                });
+            }
+        }
+    }
+    Ok(stats)
+}
+
+struct PassBWorkerOutcome {
+    tx_origin_rows: u64,
+    needs_parent_rows: u64,
+    blocks_processed: u64,
+    heights_skipped: u64,
+    missing_outcomes: u64,
+}
+
+#[cfg(feature = "test_features")]
+#[derive(Debug)]
+pub struct CrashAfterPassBHeight(pub BlockHeight);
+#[cfg(feature = "test_features")]
+impl std::fmt::Display for CrashAfterPassBHeight {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "test-only crash_after_pass_b_height triggered at {}", self.0)
+    }
+}
+#[cfg(feature = "test_features")]
+impl std::error::Error for CrashAfterPassBHeight {}
+
+fn pass_b_block_walk(
+    chain_store: &ChainStore,
+    opts: &BucketEtlOptions,
+    from_height: BlockHeight,
+    to_height: BlockHeight,
+) -> anyhow::Result<(BucketEtlStats, Vec<PassBWorkerOutcome>)> {
+    let num_workers = opts.num_threads.max(1);
+    let total_heights = to_height.saturating_sub(from_height) + 1;
+    let per_worker = total_heights.div_ceil(num_workers as u64).max(1);
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(num_workers)
+        .build()
+        .context("build pass B thread pool")?;
+
+    // Compute each worker's height slice up front.
+    let slices: Vec<(usize, BlockHeight, BlockHeight)> = (0..num_workers)
+        .map(|w| {
+            let start = from_height + per_worker * w as u64;
+            let end = (start + per_worker - 1).min(to_height);
+            (w, start, end)
+        })
+        .filter(|(_, start, _)| *start <= to_height)
+        .collect();
+
+    let outcomes: Vec<anyhow::Result<PassBWorkerOutcome>> = pool.install(|| {
+        slices
+            .par_iter()
+            .map(|(w, start, end)| pass_b_worker(chain_store, opts, *w, *start, *end))
+            .collect()
+    });
+
+    let mut worker_outcomes: Vec<PassBWorkerOutcome> = Vec::with_capacity(outcomes.len());
+    for o in outcomes {
+        worker_outcomes.push(o?);
+    }
+
+    // Aggregate stats; consolidation happens after this fn returns.
+    let mut stats = BucketEtlStats::default();
+    for o in &worker_outcomes {
+        stats.pass_b_tx_origin_rows += o.tx_origin_rows;
+        stats.pass_b_needs_parent_rows += o.needs_parent_rows;
+        stats.blocks_processed += o.blocks_processed;
+        stats.heights_skipped += o.heights_skipped;
+        stats.missing_outcomes += o.missing_outcomes;
+    }
+    Ok((stats, worker_outcomes))
+}
+
+fn pass_b_worker(
+    chain_store: &ChainStore,
+    opts: &BucketEtlOptions,
+    worker: usize,
+    slice_start: BlockHeight,
+    slice_end: BlockHeight,
+) -> anyhow::Result<PassBWorkerOutcome> {
+    let scratch = &opts.scratch_dir;
+    let resume_height = read_resume_height(scratch, worker);
+    let start = match resume_height {
+        Some(h) if h >= slice_start && h <= slice_end => h + 1,
+        _ => slice_start,
+    };
+    if start > slice_end {
+        // Already done.
+        return Ok(PassBWorkerOutcome {
+            tx_origin_rows: 0,
+            needs_parent_rows: 0,
+            blocks_processed: 0,
+            heights_skipped: 0,
+            missing_outcomes: 0,
+        });
+    }
+
+    let mut tx_origin_rows: u64 = 0;
+    let mut needs_parent_rows: u64 = 0;
+    let mut blocks_processed: u64 = 0;
+    let mut heights_skipped: u64 = 0;
+    let mut missing_outcomes: u64 = 0;
+
+    // Per-prefix in-memory buffers; flushed on marker boundary or at end of slice.
+    let mut tx_buf: Vec<Vec<TxOriginDemandRow>> = (0..256).map(|_| Vec::new()).collect();
+    let mut np_buf: Vec<Vec<NeedsParentRow>> = (0..256).map(|_| Vec::new()).collect();
+    let mut seg = list_existing_segments(scratch, worker);
+
+    let marker_interval = opts.marker_block_interval.max(1);
+    let mut last_marker_height = resume_height.unwrap_or(slice_start.saturating_sub(1));
+
+    let mut h = start;
+    while h <= slice_end {
+        #[cfg(feature = "test_features")]
+        if let Some(crash_h) = opts.crash_after_pass_b_height {
+            if h == crash_h {
+                // Flush whatever we have so the partial segment is durable, then
+                // bail. The next run will pick up at h based on the marker.
+                flush_segment(scratch, worker, seg, &mut tx_buf, &mut np_buf)?;
+                return Err(CrashAfterPassBHeight(h).into());
+            }
+        }
+
+        let stats = pass_b_emit_for_height(
+            chain_store,
+            h,
+            |row| {
+                let p = row.child_id.as_ref()[0];
+                tx_buf[p as usize].push(row);
+                tx_origin_rows += 1;
+            },
+            |row| {
+                let p = row.parent_receipt_id.as_ref()[0];
+                np_buf[p as usize].push(row);
+                needs_parent_rows += 1;
+            },
+        )?;
+        blocks_processed += stats.blocks_processed;
+        heights_skipped += stats.heights_skipped;
+        missing_outcomes += stats.missing_outcomes;
+
+        // Marker boundary: if we've crossed an interval boundary, flush + advance marker.
+        if h - last_marker_height >= marker_interval {
+            flush_segment(scratch, worker, seg, &mut tx_buf, &mut np_buf)?;
+            seg += 1;
+            write_resume_height(scratch, worker, h)?;
+            last_marker_height = h;
+        }
+        h += 1;
+    }
+
+    // End of slice: flush final segment + advance marker to slice_end.
+    flush_segment(scratch, worker, seg, &mut tx_buf, &mut np_buf)?;
+    write_resume_height(scratch, worker, slice_end)?;
+
+    Ok(PassBWorkerOutcome {
+        tx_origin_rows,
+        needs_parent_rows,
+        blocks_processed,
+        heights_skipped,
+        missing_outcomes,
+    })
+}
+
+/// List existing segment counter for a worker. The next-to-write segment index
+/// is the max(seg_S directories) + 1, or 0 if none exist.
+fn list_existing_segments(scratch: &Path, worker: usize) -> u32 {
+    let dir = scratch.join(STAGE_B).join(format!("worker_{worker}"));
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return 0;
+    };
+    let mut max_seg: Option<u32> = None;
+    for e in entries.flatten() {
+        let Some(name) = e.file_name().to_str().map(str::to_owned) else { continue };
+        if let Some(rest) = name.strip_prefix("seg_") {
+            if let Ok(n) = rest.parse::<u32>() {
+                max_seg = Some(max_seg.map_or(n, |m| m.max(n)));
+            }
+        }
+    }
+    max_seg.map(|m| m + 1).unwrap_or(0)
+}
+
+fn flush_segment(
+    scratch: &Path,
+    worker: usize,
+    seg: u32,
+    tx_buf: &mut [Vec<TxOriginDemandRow>],
+    np_buf: &mut [Vec<NeedsParentRow>],
+) -> anyhow::Result<()> {
+    for prefix_idx in 0..256u16 {
+        let prefix = prefix_idx as u8;
+        let txs = std::mem::take(&mut tx_buf[prefix as usize]);
+        if !txs.is_empty() {
+            let mut sorted = txs;
+            sorted.sort_by(|a, b| a.child_id.as_ref().cmp(b.child_id.as_ref()));
+            write_bucket(&pass_b_seg_demand_path(scratch, worker, seg, prefix), &sorted)?;
+        }
+        let nps = std::mem::take(&mut np_buf[prefix as usize]);
+        if !nps.is_empty() {
+            let mut sorted = nps;
+            sorted.sort_by(|a, b| a.parent_receipt_id.as_ref().cmp(b.parent_receipt_id.as_ref()));
+            write_bucket(&pass_b_seg_needs_parent_path(scratch, worker, seg, prefix), &sorted)?;
+        }
+    }
+    Ok(())
+}
+
+/// After all Pass B workers complete, k-way merge per-prefix segment files
+/// into a single sorted `pass_b/{demand_by_child,needs_parent_by_parent}/prefix_XX.bucket`.
+fn pass_b_consolidate(scratch: &Path, num_workers: usize) -> anyhow::Result<()> {
+    // Discover number of segments per worker.
+    let segs_per_worker: Vec<u32> =
+        (0..num_workers).map(|w| list_existing_segments(scratch, w)).collect();
+
+    // Consolidate demand-by-child.
+    (0u16..=255).into_par_iter().try_for_each(|prefix_idx| -> anyhow::Result<()> {
+        let prefix = prefix_idx as u8;
+        let out = pass_b_consolidated_demand_path(scratch, prefix);
+        if out.exists() {
+            return Ok(());
+        }
+        let mut all: Vec<TxOriginDemandRow> = Vec::new();
+        for (w, segs) in segs_per_worker.iter().enumerate() {
+            for s in 0..*segs {
+                let p = pass_b_seg_demand_path(scratch, w, s, prefix);
+                if p.exists() {
+                    let rows: Vec<TxOriginDemandRow> = read_bucket(&p)?;
+                    all.extend(rows);
+                }
+            }
+        }
+        all.sort_by(|a, b| a.child_id.as_ref().cmp(b.child_id.as_ref()));
+        write_bucket(&out, &all)?;
+        Ok(())
+    })?;
+
+    // Consolidate needs-parent-by-parent.
+    (0u16..=255).into_par_iter().try_for_each(|prefix_idx| -> anyhow::Result<()> {
+        let prefix = prefix_idx as u8;
+        let out = pass_b_consolidated_needs_parent_path(scratch, prefix);
+        if out.exists() {
+            return Ok(());
+        }
+        let mut all: Vec<NeedsParentRow> = Vec::new();
+        for (w, segs) in segs_per_worker.iter().enumerate() {
+            for s in 0..*segs {
+                let p = pass_b_seg_needs_parent_path(scratch, w, s, prefix);
+                if p.exists() {
+                    let rows: Vec<NeedsParentRow> = read_bucket(&p)?;
+                    all.extend(rows);
+                }
+            }
+        }
+        all.sort_by(|a, b| a.parent_receipt_id.as_ref().cmp(b.parent_receipt_id.as_ref()));
+        write_bucket(&out, &all)?;
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// ===== Pass C: resolve parent predecessors =====
+
+fn pass_c_resolve_parents(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)> {
+    let scratch = &opts.scratch_dir;
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(opts.num_threads.max(1))
+        .build()
+        .context("build pass C thread pool")?;
+
+    // Each YY worker writes its per-ZZ output into a global locked buffer; we
+    // serialize per-ZZ in a final consolidation step. For the prototype this
+    // keeps the file-descriptor count bounded.
+    let zz_buffers: Vec<Mutex<Vec<ReceiptOriginDemandRow>>> =
+        (0..256).map(|_| Mutex::new(Vec::new())).collect();
+    let missing_total: Mutex<u64> = Mutex::new(0);
+    let total_rows: Mutex<u64> = Mutex::new(0);
+
+    pool.install(|| {
+        (0u16..=255).into_par_iter().try_for_each(|yy| -> anyhow::Result<()> {
+            let yy = yy as u8;
+            let extract_path = pass_a_path(scratch, yy);
+            let needs_parent_path = pass_b_consolidated_needs_parent_path(scratch, yy);
+            let extract_rows: Vec<ReceiptExtractRow> = read_bucket(&extract_path)?;
+            // Build hashmap for parent lookup.
+            let map: HashMap<CryptoHash, &ReceiptExtractRow> =
+                extract_rows.iter().map(|r| (r.receipt_id, r)).collect();
+
+            let needs_parent_rows: Vec<NeedsParentRow> = read_bucket(&needs_parent_path)?;
+            let mut local_missing: u64 = 0;
+            let mut local_emitted: u64 = 0;
+            // Local per-ZZ buffer to minimize lock contention.
+            let mut local_zz: Vec<Vec<ReceiptOriginDemandRow>> =
+                (0..256).map(|_| Vec::new()).collect();
+
+            for np in needs_parent_rows {
+                match map.get(&np.parent_receipt_id) {
+                    Some(extract) => {
+                        let zz = np.child_id.as_ref()[0] as usize;
+                        local_zz[zz].push(ReceiptOriginDemandRow {
+                            child_id: np.child_id,
+                            shard_id: np.shard_id,
+                            parent_receipt_id: np.parent_receipt_id,
+                            parent_predecessor_id: extract.predecessor_id.clone(),
+                        });
+                        local_emitted += 1;
+                    }
+                    None => {
+                        local_missing += 1;
+                    }
+                }
+            }
+
+            for (zz, rows) in local_zz.into_iter().enumerate() {
+                if !rows.is_empty() {
+                    zz_buffers[zz].lock().unwrap().extend(rows);
+                }
+            }
+            *missing_total.lock().unwrap() += local_missing;
+            *total_rows.lock().unwrap() += local_emitted;
+            Ok(())
+        })
+    })?;
+
+    // Sort + flush per-ZZ.
+    (0u16..=255).into_par_iter().try_for_each(|zz| -> anyhow::Result<()> {
+        let zz = zz as u8;
+        let out = pass_c_consolidated_path(scratch, zz);
+        if out.exists() {
+            return Ok(());
+        }
+        let mut rows = std::mem::take(&mut *zz_buffers[zz as usize].lock().unwrap());
+        rows.sort_by(|a, b| a.child_id.as_ref().cmp(b.child_id.as_ref()));
+        write_bucket(&out, &rows)?;
+        Ok(())
+    })?;
+
+    let total = *total_rows.lock().unwrap();
+    let missing = *missing_total.lock().unwrap();
+    Ok((total, missing))
+}
+
+// ===== Pass D: final per-prefix join =====
+
+fn pass_d_final_join(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)> {
+    let scratch = &opts.scratch_dir;
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(opts.num_threads.max(1))
+        .build()
+        .context("build pass D thread pool")?;
+
+    let total_rows: Mutex<u64> = Mutex::new(0);
+    let missing_children: Mutex<u64> = Mutex::new(0);
+
+    pool.install(|| {
+        (0u16..=255).into_par_iter().try_for_each(|prefix_idx| -> anyhow::Result<()> {
+            let prefix = prefix_idx as u8;
+            let out_path = pass_d_output_path(scratch, prefix);
+            if out_path.exists() {
+                return Ok(());
+            }
+
+            // Load receipts extract for this prefix; build a child_id → receiver_id map.
+            let extract_rows: Vec<ReceiptExtractRow> = read_bucket(&pass_a_path(scratch, prefix))?;
+            let receiver_map: HashMap<CryptoHash, AccountId> =
+                extract_rows.into_iter().map(|r| (r.receipt_id, r.receiver_id)).collect();
+
+            let mut output: Vec<OutputRow> = Vec::new();
+            let mut local_missing: u64 = 0;
+
+            // Tx-origin demands (Pass B).
+            let demand_b: Vec<TxOriginDemandRow> =
+                read_bucket(&pass_b_consolidated_demand_path(scratch, prefix))?;
+            for d in demand_b {
+                let receiver = match receiver_map.get(&d.child_id) {
+                    Some(r) => r.clone(),
+                    None => {
+                        local_missing += 1;
+                        continue;
+                    }
+                };
+                let info = build_receipt_to_tx_info(BuiltOriginInputs {
+                    outcome_id: d.tx_hash,
+                    shard_id: d.shard_id,
+                    child_receiver_id: receiver,
+                    origin: BuiltOrigin::FromTransaction { sender_id: d.sender_account_id },
+                });
+                output.push(OutputRow { child_id: d.child_id, info });
+            }
+
+            // Receipt-origin demands (Pass C resolved).
+            let demand_c: Vec<ReceiptOriginDemandRow> =
+                read_bucket(&pass_c_consolidated_path(scratch, prefix))?;
+            for d in demand_c {
+                let receiver = match receiver_map.get(&d.child_id) {
+                    Some(r) => r.clone(),
+                    None => {
+                        local_missing += 1;
+                        continue;
+                    }
+                };
+                let info = build_receipt_to_tx_info(BuiltOriginInputs {
+                    outcome_id: d.parent_receipt_id,
+                    shard_id: d.shard_id,
+                    child_receiver_id: receiver,
+                    origin: BuiltOrigin::FromReceipt {
+                        parent_predecessor_id: d.parent_predecessor_id,
+                    },
+                });
+                output.push(OutputRow { child_id: d.child_id, info });
+            }
+
+            let validated = finalize_output_bucket(output)?;
+            let count = validated.len() as u64;
+            write_bucket(&out_path, &validated)?;
+
+            *total_rows.lock().unwrap() += count;
+            *missing_children.lock().unwrap() += local_missing;
+            Ok(())
+        })
+    })?;
+
+    let total = *total_rows.lock().unwrap();
+    let missing = *missing_children.lock().unwrap();
+    Ok((total, missing))
+}
+
+// ===== Output-mode handlers =====
+
+fn write_outputs_to_store(
+    storage: &BackfillStorage,
+    opts: &BucketEtlOptions,
+) -> anyhow::Result<()> {
+    let scratch = &opts.scratch_dir;
+    for prefix_idx in 0..256u16 {
+        let prefix = prefix_idx as u8;
+        let path = pass_d_output_path(scratch, prefix);
+        if !path.exists() {
+            continue;
+        }
+        let rows: Vec<OutputRow> = read_bucket(&path)?;
+        if rows.is_empty() {
+            continue;
+        }
+        let mut update = storage.write_store.store_update();
+        for row in rows {
+            let value = borsh::to_vec(&row.info).context("serialize ReceiptToTxInfo for write")?;
+            update.insert(DBCol::ReceiptToTx, row.child_id.as_ref().to_vec(), value);
+        }
+        update.commit();
+    }
+    Ok(())
+}
+
+pub fn compare_against_actor(
+    chain_store: &ChainStore,
+    opts: &BucketEtlOptions,
+    from_height: BlockHeight,
+    to_height: BlockHeight,
+) -> anyhow::Result<u64> {
+    let scratch = &opts.scratch_dir;
+
+    // Run process_height over the range and collect entries.
+    let mut actor_entries: HashMap<CryptoHash, Vec<u8>> = HashMap::new();
+    for h in from_height..=to_height {
+        let result = process_height(chain_store, h)?;
+        if let Some(hr) = result {
+            for (child_id, info) in hr.entries {
+                let bytes = borsh::to_vec(&info).context("serialize actor entry")?;
+                if let Some(prev) = actor_entries.insert(child_id, bytes.clone()) {
+                    // Same key seen at multiple heights: must agree (otherwise
+                    // the actor itself would diverge).
+                    if prev != bytes {
+                        bail!(
+                            "actor produced divergent values for receipt {} across heights",
+                            child_id
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Read bucket-ETL outputs.
+    let mut etl_entries: HashMap<CryptoHash, Vec<u8>> = HashMap::new();
+    for prefix_idx in 0..256u16 {
+        let prefix = prefix_idx as u8;
+        let path = pass_d_output_path(scratch, prefix);
+        if !path.exists() {
+            continue;
+        }
+        let rows: Vec<OutputRow> = read_bucket(&path)?;
+        for row in rows {
+            let bytes = borsh::to_vec(&row.info).context("serialize etl entry")?;
+            etl_entries.insert(row.child_id, bytes);
+        }
+    }
+
+    let mut divergences: Vec<(CryptoHash, &'static str)> = Vec::new();
+    let mut printed = 0usize;
+
+    // Keys present in actor but missing or different in ETL.
+    for (k, v) in &actor_entries {
+        match etl_entries.get(k) {
+            None => {
+                if printed < 10 {
+                    tracing::error!(receipt = %k, "compare: present in actor, missing in bucket-ETL");
+                    printed += 1;
+                }
+                divergences.push((*k, "missing_in_etl"));
+            }
+            Some(ev) if ev != v => {
+                if printed < 10 {
+                    tracing::error!(
+                        receipt = %k,
+                        "compare: value divergence between actor and bucket-ETL"
+                    );
+                    printed += 1;
+                }
+                divergences.push((*k, "value_diff"));
+            }
+            _ => {}
+        }
+    }
+    // Keys present in ETL but missing in actor.
+    for k in etl_entries.keys() {
+        if !actor_entries.contains_key(k) {
+            if printed < 10 {
+                tracing::error!(receipt = %k, "compare: present in bucket-ETL, missing in actor");
+                printed += 1;
+            }
+            divergences.push((*k, "missing_in_actor"));
+        }
+    }
+    Ok(divergences.len() as u64)
+}
+
+// ===== Top-level driver =====
+
+pub fn run_bucket_etl(
+    chain_store: &ChainStore,
+    storage: &BackfillStorage,
+    opts: BucketEtlOptions,
+) -> anyhow::Result<BucketEtlStats> {
+    fs::create_dir_all(&opts.scratch_dir)
+        .with_context(|| format!("mkdir {}", opts.scratch_dir.display()))?;
+    check_or_write_options_hash(&opts.scratch_dir, &opts)?;
+
+    let mut stats = BucketEtlStats::default();
+
+    // Resolve height range.
+    let genesis_height = chain_store.get_genesis_height();
+    let head_height = chain_store.head().context("get chain head")?.height;
+    let from = opts.from_height.unwrap_or(genesis_height).max(genesis_height);
+    let to = opts.to_height.unwrap_or(head_height).min(head_height);
+    if from > to {
+        tracing::info!(from, to, "bucket-ETL: empty height range");
+        return Ok(stats);
+    }
+
+    // Pass A.
+    if !stage_done(&opts.scratch_dir, STAGE_A) {
+        tracing::info!("bucket-ETL: starting Pass A (receipts extract)");
+        let rows = pass_a_receipts_extract(storage, &opts)?;
+        stats.pass_a_rows = rows;
+        tracing::info!(rows, "bucket-ETL: Pass A done");
+    } else {
+        tracing::info!("bucket-ETL: Pass A already complete, skipping");
+        // Recover row count for stats.
+        for prefix_idx in 0..256u16 {
+            let p = pass_a_path(&opts.scratch_dir, prefix_idx as u8);
+            if p.exists() {
+                let rows: Vec<ReceiptExtractRow> = read_bucket(&p)?;
+                stats.pass_a_rows += rows.len() as u64;
+            }
+        }
+    }
+
+    // Pass B.
+    if !stage_done(&opts.scratch_dir, STAGE_B) {
+        tracing::info!(from, to, "bucket-ETL: starting Pass B (block walk)");
+        let (b_stats, _) = pass_b_block_walk(chain_store, &opts, from, to)?;
+        stats.pass_b_tx_origin_rows = b_stats.pass_b_tx_origin_rows;
+        stats.pass_b_needs_parent_rows = b_stats.pass_b_needs_parent_rows;
+        stats.blocks_processed = b_stats.blocks_processed;
+        stats.heights_skipped = b_stats.heights_skipped;
+        stats.missing_outcomes = b_stats.missing_outcomes;
+        // Consolidate per-worker × per-segment files.
+        pass_b_consolidate(&opts.scratch_dir, opts.num_threads.max(1))?;
+        mark_stage_done(&opts.scratch_dir, STAGE_B)?;
+        tracing::info!(
+            tx_origin = stats.pass_b_tx_origin_rows,
+            needs_parent = stats.pass_b_needs_parent_rows,
+            blocks_processed = stats.blocks_processed,
+            "bucket-ETL: Pass B done"
+        );
+    } else {
+        tracing::info!("bucket-ETL: Pass B already complete, skipping");
+    }
+
+    // Pass C.
+    if !stage_done(&opts.scratch_dir, STAGE_C) {
+        tracing::info!("bucket-ETL: starting Pass C (parent resolution)");
+        let (rows, missing) = pass_c_resolve_parents(&opts)?;
+        stats.pass_c_rows = rows;
+        stats.missing_parent_receipts = missing;
+        mark_stage_done(&opts.scratch_dir, STAGE_C)?;
+        tracing::info!(rows, missing_parent_receipts = missing, "bucket-ETL: Pass C done");
+    } else {
+        tracing::info!("bucket-ETL: Pass C already complete, skipping");
+    }
+
+    // Pass D.
+    if !stage_done(&opts.scratch_dir, STAGE_D) {
+        tracing::info!("bucket-ETL: starting Pass D (final join + validate)");
+        let (rows, missing) = pass_d_final_join(&opts)?;
+        stats.pass_d_rows = rows;
+        stats.missing_child_receipts = missing;
+        mark_stage_done(&opts.scratch_dir, STAGE_D)?;
+        tracing::info!(rows, missing_child_receipts = missing, "bucket-ETL: Pass D done");
+    } else {
+        tracing::info!("bucket-ETL: Pass D already complete, skipping");
+    }
+
+    // Output mode dispatch.
+    match &opts.output_mode {
+        BucketEtlOutputMode::MeasureOnly => {
+            tracing::info!("bucket-ETL: measure-only mode, no DB writes");
+        }
+        BucketEtlOutputMode::WriteToStore => {
+            tracing::info!(
+                "bucket-ETL: WriteToStore (test-only) — writing to BackfillStorage.write_store"
+            );
+            write_outputs_to_store(storage, &opts)?;
+        }
+        BucketEtlOutputMode::CompareAgainstActor { from_height, to_height } => {
+            tracing::info!(
+                from = from_height,
+                to = to_height,
+                "bucket-ETL: comparing against actor over range"
+            );
+            stats.compare_divergences =
+                compare_against_actor(chain_store, &opts, *from_height, *to_height)?;
+            if stats.compare_divergences > 0 {
+                tracing::error!(
+                    divergences = stats.compare_divergences,
+                    "bucket-ETL: compare-mode divergences detected"
+                );
+            } else {
+                tracing::info!("bucket-ETL: compare-mode clean (zero divergences)");
+            }
+        }
+    }
+
+    Ok(stats)
+}

--- a/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -101,7 +101,10 @@ pub enum BucketEtlOutputMode {
     /// used on the production VM to gate the run.
     MeasureOnly,
     /// Test-only mode: write the validated output to `BackfillStorage.write_store`
-    /// via the legacy per-key insert path. Not exposed via the CLI.
+    /// via the legacy per-key insert path. Compile-time-gated to
+    /// `test`/`test_features` so the production CLI cannot reach this path even
+    /// by accident; production ingest is gated to Phase 3.
+    #[cfg(any(test, feature = "test_features"))]
     WriteToStore,
     /// Run `process_height` over `[from_height, to_height]` after Pass D and
     /// byte-compare resulting `ReceiptToTx` entries.
@@ -518,15 +521,19 @@ fn pass_b_seg_needs_parent_path(scratch: &Path, worker: usize, seg: u32, prefix:
         .join(format!("needs_parent_{prefix:02x}.bucket"))
 }
 
-fn pass_b_consolidated_demand_path(scratch: &Path, prefix: u8) -> PathBuf {
+pub fn pass_a_path_for_test(scratch: &Path, prefix: u8) -> PathBuf {
+    pass_a_path(scratch, prefix)
+}
+
+pub fn pass_b_consolidated_demand_path(scratch: &Path, prefix: u8) -> PathBuf {
     scratch.join(STAGE_B).join("demand_by_child").join(format!("prefix_{prefix:02x}.bucket"))
 }
 
-fn pass_b_consolidated_needs_parent_path(scratch: &Path, prefix: u8) -> PathBuf {
+pub fn pass_b_consolidated_needs_parent_path(scratch: &Path, prefix: u8) -> PathBuf {
     scratch.join(STAGE_B).join("needs_parent_by_parent").join(format!("prefix_{prefix:02x}.bucket"))
 }
 
-fn pass_c_consolidated_path(scratch: &Path, prefix: u8) -> PathBuf {
+pub fn pass_c_consolidated_path(scratch: &Path, prefix: u8) -> PathBuf {
     scratch.join(STAGE_C).join("demand_by_child").join(format!("prefix_{prefix:02x}.bucket"))
 }
 
@@ -964,7 +971,7 @@ fn pass_b_consolidate(scratch: &Path, num_workers: usize) -> anyhow::Result<()> 
 
 // ===== Pass C: resolve parent predecessors =====
 
-fn pass_c_resolve_parents(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)> {
+pub fn pass_c_resolve_parents(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)> {
     let scratch = &opts.scratch_dir;
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(opts.num_threads.max(1))
@@ -1130,6 +1137,7 @@ fn pass_d_final_join(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)> {
 
 // ===== Output-mode handlers =====
 
+#[cfg(any(test, feature = "test_features"))]
 fn write_outputs_to_store(
     storage: &BackfillStorage,
     opts: &BucketEtlOptions,
@@ -1339,6 +1347,7 @@ pub fn run_bucket_etl(
         BucketEtlOutputMode::MeasureOnly => {
             tracing::info!("bucket-ETL: measure-only mode, no DB writes");
         }
+        #[cfg(any(test, feature = "test_features"))]
         BucketEtlOutputMode::WriteToStore => {
             tracing::info!(
                 "bucket-ETL: WriteToStore (test-only) — writing to BackfillStorage.write_store"

--- a/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -915,8 +915,21 @@ fn flush_segment(
     Ok(())
 }
 
-/// After all Pass B workers complete, k-way merge per-prefix segment files
-/// into a single sorted `pass_b/{demand_by_child,needs_parent_by_parent}/prefix_XX.bucket`.
+/// After all Pass B workers complete, merge per-prefix segment files into a
+/// single sorted `pass_b/{demand_by_child,needs_parent_by_parent}/prefix_XX.bucket`.
+///
+/// Phase 1 implementation: load all (worker × segment) segments for one
+/// prefix into a single `Vec`, then `sort_by`. Inputs are pre-sorted (each
+/// segment was sorted at flush time), so a true k-way merge would be
+/// optimal — but at prototype scale this is in the noise. Memory peak is
+/// ~4× max-per-prefix-total under the default 4-thread rayon pool; on the
+/// production VM (64 GB+ RAM) this stays well within budget per the Phase
+/// 0 measurements.
+///
+/// TODO(phase-3): replace concat-then-sort with k-way merge over
+/// `BucketReader` streams (`BinaryHeap<Reverse<(Key, ReaderIdx)>>`).
+/// Eliminates the per-prefix in-memory peak and lets external-sort
+/// fallback land naturally if any prefix outgrows RAM.
 fn pass_b_consolidate(scratch: &Path, num_workers: usize) -> anyhow::Result<()> {
     // Discover number of segments per worker.
     let segs_per_worker: Vec<u32> =
@@ -1052,6 +1065,18 @@ pub fn pass_c_resolve_parents(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u
 
 // ===== Pass D: final per-prefix join =====
 
+/// Per-prefix join of (Pass A extract for receiver) ⨝ (Pass B tx-origin
+/// demands ∪ Pass C resolved receipt-origin demands) → `OutputRow`.
+///
+/// Phase 1 implementation: build a `HashMap<CryptoHash, AccountId>` from the
+/// Pass A extract for receiver lookup, iterate the demand streams. Both
+/// inputs are sorted by `child_id` (Pass A naturally; demand buckets via
+/// `pass_b_consolidate`/`pass_c_resolve_parents`), so a sort-merge join
+/// would not need the receiver map at all — saving ~5 GB per prefix per
+/// thread on mainnet. Acceptable at prototype scale; flagged for measurement.
+///
+/// TODO(phase-3): replace HashMap-based receiver join with sort-merge over
+/// pre-sorted child_id-keyed streams.
 fn pass_d_final_join(opts: &BucketEtlOptions) -> anyhow::Result<(u64, u64)> {
     let scratch = &opts.scratch_dir;
     let pool = rayon::ThreadPoolBuilder::new()
@@ -1163,6 +1188,19 @@ fn write_outputs_to_store(
     Ok(())
 }
 
+/// Run `process_height` over `[from_height, to_height]` and byte-compare
+/// against the bucket-ETL output bucket files.
+///
+/// **Memory:** materializes both sides as `HashMap<CryptoHash, Vec<u8>>` over
+/// the full height range. For ~1M blocks this is ~4 GB per side; for full
+/// mainnet (~150M blocks) it is well outside a single VM's RAM. Use against
+/// bounded ranges only — the CLI's `--compare-from-height`/`--compare-to-height`
+/// flags exist so the operator can sweep the chain in chunks.
+///
+/// TODO(phase-3): replace with a sort-merge walk over both streams. Both
+/// sides are naturally sortable by `child_id` (the bucket-ETL output is
+/// per-prefix-sorted; the actor side can be sorted incrementally per height
+/// then merged across heights), eliminating the `HashMap` entirely.
 pub fn compare_against_actor(
     chain_store: &ChainStore,
     opts: &BucketEtlOptions,

--- a/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -73,8 +73,11 @@ pub struct BucketEtlOptions {
     /// flush accumulated buffers. Tests override to small values.
     pub marker_block_interval: u64,
     /// Test-only knob: cause Pass B to abort once any worker reaches this
-    /// height. Drives `test_bucket_etl_resumes_after_simulated_crash`.
-    #[cfg(feature = "test_features")]
+    /// height. Drives `test_bucket_etl_resumes_after_simulated_crash`. The
+    /// field is unconditional (rather than `cfg(feature = "test_features")`)
+    /// to avoid feature-mismatch initializer errors in callers that don't
+    /// declare a `test_features` feature themselves; `None` is the
+    /// production default and is checked at the only use site.
     pub crash_after_pass_b_height: Option<BlockHeight>,
 }
 
@@ -87,7 +90,6 @@ impl BucketEtlOptions {
             scratch_dir,
             output_mode: BucketEtlOutputMode::MeasureOnly,
             marker_block_interval: DEFAULT_MARKER_BLOCK_INTERVAL,
-            #[cfg(feature = "test_features")]
             crash_after_pass_b_height: None,
         }
     }
@@ -674,16 +676,13 @@ struct PassBWorkerOutcome {
     missing_outcomes: u64,
 }
 
-#[cfg(feature = "test_features")]
 #[derive(Debug)]
 pub struct CrashAfterPassBHeight(pub BlockHeight);
-#[cfg(feature = "test_features")]
 impl std::fmt::Display for CrashAfterPassBHeight {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "test-only crash_after_pass_b_height triggered at {}", self.0)
     }
 }
-#[cfg(feature = "test_features")]
 impl std::error::Error for CrashAfterPassBHeight {}
 
 fn pass_b_block_walk(
@@ -775,7 +774,6 @@ fn pass_b_worker(
 
     let mut h = start;
     while h <= slice_end {
-        #[cfg(feature = "test_features")]
         if let Some(crash_h) = opts.crash_after_pass_b_height {
             if h == crash_h {
                 // Flush whatever we have so the partial segment is durable, then

--- a/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/chain/chain/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -401,23 +401,40 @@ fn options_hash_path(scratch: &Path) -> PathBuf {
     scratch.join("options.json")
 }
 
-fn compute_options_hash(opts: &BucketEtlOptions) -> String {
-    // Hash the load-bearing fields. `output_mode` is excluded — running
-    // measure-only first then compare-mode against the same scratch is a
-    // legitimate use case.
+/// Hash the load-bearing fields of an invocation. Takes the *resolved*
+/// `from`/`to` heights (after `genesis`/`head` defaults are applied) so a
+/// no-arg run that picks up new heights between invocations does NOT match
+/// the previous fingerprint and silently skip Pass B. `output_mode` is
+/// excluded — running measure-only first then compare-mode against the
+/// same scratch is a legitimate use case.
+///
+/// Path bytes go in via `as_os_str().as_encoded_bytes()` so non-UTF-8 paths
+/// fingerprint distinctly (`to_string_lossy` would collapse them).
+fn compute_options_hash(
+    scratch_dir: &Path,
+    from: BlockHeight,
+    to: BlockHeight,
+    num_threads: usize,
+    marker_block_interval: u64,
+) -> String {
     let mut buf = Vec::with_capacity(64);
-    buf.extend_from_slice(&opts.from_height.unwrap_or(0).to_le_bytes());
-    buf.extend_from_slice(&opts.to_height.unwrap_or(u64::MAX).to_le_bytes());
-    buf.extend_from_slice(&(opts.num_threads as u64).to_le_bytes());
-    buf.extend_from_slice(&opts.marker_block_interval.to_le_bytes());
-    buf.extend_from_slice(opts.scratch_dir.to_string_lossy().as_bytes());
-    let hash = CryptoHash::hash_bytes(&buf);
-    hash.to_string()
+    buf.extend_from_slice(&from.to_le_bytes());
+    buf.extend_from_slice(&to.to_le_bytes());
+    buf.extend_from_slice(&(num_threads as u64).to_le_bytes());
+    buf.extend_from_slice(&marker_block_interval.to_le_bytes());
+    buf.extend_from_slice(scratch_dir.as_os_str().as_encoded_bytes());
+    CryptoHash::hash_bytes(&buf).to_string()
 }
 
-fn check_or_write_options_hash(scratch: &Path, opts: &BucketEtlOptions) -> anyhow::Result<()> {
+fn check_or_write_options_hash(
+    scratch: &Path,
+    from: BlockHeight,
+    to: BlockHeight,
+    num_threads: usize,
+    marker_block_interval: u64,
+) -> anyhow::Result<()> {
     let path = options_hash_path(scratch);
-    let want = compute_options_hash(opts);
+    let want = compute_options_hash(scratch, from, to, num_threads, marker_block_interval);
     if path.exists() {
         let got = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
         if got.trim() != want {
@@ -440,13 +457,32 @@ fn worker_marker_path(scratch: &Path, worker: usize) -> PathBuf {
     scratch.join(STAGE_B).join(format!("worker_{worker}")).join("marker")
 }
 
-fn read_resume_height(scratch: &Path, worker: usize) -> Option<BlockHeight> {
+/// Read the per-worker height marker.
+///
+/// Returns `Ok(None)` when the marker file is missing (legitimate first run).
+/// Returns `Err(...)` when the file exists but its contents are invalid —
+/// silently re-doing all of Pass B's work for a worker because of a corrupt
+/// 8-byte file would erase the resume guarantee, so we fail loudly instead.
+fn read_resume_height(scratch: &Path, worker: usize) -> anyhow::Result<Option<BlockHeight>> {
     let path = worker_marker_path(scratch, worker);
-    let bytes = fs::read(path).ok()?;
+    let bytes = match fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(anyhow::Error::from(e))
+                .with_context(|| format!("read worker {worker} marker at {}", path.display()));
+        }
+    };
     if bytes.len() != 8 {
-        return None;
+        bail!(
+            "worker {worker} marker at {} has {} bytes; expected 8 — corruption suspected, \
+             refusing to re-do completed work",
+            path.display(),
+            bytes.len()
+        );
     }
-    Some(u64::from_le_bytes(bytes.try_into().ok()?))
+    let arr: [u8; 8] = bytes.try_into().expect("checked length above");
+    Ok(Some(u64::from_le_bytes(arr)))
 }
 
 fn write_resume_height(scratch: &Path, worker: usize, height: BlockHeight) -> anyhow::Result<()> {
@@ -742,7 +778,7 @@ fn pass_b_worker(
     slice_end: BlockHeight,
 ) -> anyhow::Result<PassBWorkerOutcome> {
     let scratch = &opts.scratch_dir;
-    let resume_height = read_resume_height(scratch, worker);
+    let resume_height = read_resume_height(scratch, worker)?;
     let start = match resume_height {
         Some(h) if h >= slice_start && h <= slice_end => h + 1,
         _ => slice_start,
@@ -1208,11 +1244,13 @@ pub fn run_bucket_etl(
 ) -> anyhow::Result<BucketEtlStats> {
     fs::create_dir_all(&opts.scratch_dir)
         .with_context(|| format!("mkdir {}", opts.scratch_dir.display()))?;
-    check_or_write_options_hash(&opts.scratch_dir, &opts)?;
 
     let mut stats = BucketEtlStats::default();
 
-    // Resolve height range.
+    // Resolve the height range *before* writing the options-hash so the
+    // fingerprint pins to concrete heights. Otherwise a no-arg run that
+    // resumes after the chain head moves would match the previous hash and
+    // silently skip the new heights via `STAGE_B.done`.
     let genesis_height = chain_store.get_genesis_height();
     let head_height = chain_store.head().context("get chain head")?.height;
     let from = opts.from_height.unwrap_or(genesis_height).max(genesis_height);
@@ -1221,6 +1259,13 @@ pub fn run_bucket_etl(
         tracing::info!(from, to, "bucket-ETL: empty height range");
         return Ok(stats);
     }
+    check_or_write_options_hash(
+        &opts.scratch_dir,
+        from,
+        to,
+        opts.num_threads,
+        opts.marker_block_interval,
+    )?;
 
     // Pass A.
     if !stage_done(&opts.scratch_dir, STAGE_A) {

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -25,6 +25,7 @@ pub use types::{Block, BlockHeader, BlockStatus, ChainGenesis, LatestKnown, Prov
 
 mod approval_verification;
 pub mod backfill_receipt_to_tx;
+pub mod backfill_receipt_to_tx_bucket_etl;
 mod block_processing_utils;
 pub mod blocks_delay_tracker;
 pub mod chain;

--- a/chain/client/src/backfill_receipt_to_tx_actor.rs
+++ b/chain/client/src/backfill_receipt_to_tx_actor.rs
@@ -166,7 +166,7 @@ impl BackfillReceiptToTxActor {
     /// Halting is permanent for the life of this process: no further
     /// `run_later` is scheduled. An operator restart with the underlying
     /// fault resolved is required to resume backfill.
-    fn record_error_and_maybe_halt(&mut self, e: &anyhow::Error) -> bool {
+    fn record_error_and_maybe_halt(&self, e: &anyhow::Error) -> bool {
         if let Some(BackfillError::ValueDivergence { key, prev_value, new_value }) =
             e.downcast_ref::<BackfillError>()
         {

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/bucket_etl.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/bucket_etl.rs
@@ -32,7 +32,6 @@ fn default_etl_opts(scratch_dir: PathBuf) -> BucketEtlOptions {
         scratch_dir,
         output_mode: BucketEtlOutputMode::WriteToStore,
         marker_block_interval: 1_000_000,
-        #[cfg(feature = "test_features")]
         crash_after_pass_b_height: None,
     }
 }

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/bucket_etl.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/bucket_etl.rs
@@ -1,0 +1,725 @@
+use super::common::{EPOCH_LENGTH, generate_diverse_traffic, shared_storage};
+use crate::setup::builder::TestLoopBuilder;
+use crate::utils::account::create_account_id;
+use borsh::BorshSerialize;
+use near_chain::backfill_receipt_to_tx::{
+    BuiltOrigin, BuiltOriginInputs, build_receipt_to_tx_info, process_height,
+};
+use near_chain::backfill_receipt_to_tx_bucket_etl::{
+    BucketEtlOptions, BucketEtlOutputMode, BucketReader, BucketWriter, NeedsParentRow, OutputRow,
+    ReceiptExtractRow, ReceiptOriginDemandRow, TxOriginDemandRow, compare_against_actor,
+    finalize_output_bucket_with_max, pass_d_output_path, run_bucket_etl,
+    validate_output_bucket_file, validate_output_bucket_file_with_max,
+};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
+use near_primitives::receipt::{ReceiptOrigin, ReceiptToTxInfo, ReceiptToTxInfoV1};
+use near_primitives::types::{AccountId, Balance};
+use near_store::DBCol;
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::str::FromStr;
+use tempfile::TempDir;
+
+/// Default test options. Big marker interval so most tests don't trigger
+/// segment flushes mid-run; the resume test overrides.
+fn default_etl_opts(scratch_dir: PathBuf) -> BucketEtlOptions {
+    BucketEtlOptions {
+        from_height: None,
+        to_height: None,
+        num_threads: 2,
+        scratch_dir,
+        output_mode: BucketEtlOutputMode::WriteToStore,
+        marker_block_interval: 1_000_000,
+        #[cfg(feature = "test_features")]
+        crash_after_pass_b_height: None,
+    }
+}
+
+fn build_env_with_traffic() -> crate::setup::env::TestLoopEnv {
+    let user_account = create_account_id("account0");
+    let receiver_account = create_account_id("account1");
+
+    // Non-zero gas price → unspent gas refund receipts get created, which
+    // makes the receipt-origin (`FromReceipt`) code path actually exercise
+    // during diverse_traffic. With the default (zero) gas price, function
+    // calls produce no refund receipts and the `FromReceipt` codepath is
+    // never reached. See `test_refund_receipt_has_receipt_to_tx`.
+    let min_gas_price = Balance::from_yoctonear(100_000_000);
+    let mut env = TestLoopBuilder::new()
+        .add_user_account(&user_account, Balance::from_near(1_000_000))
+        .add_user_account(&receiver_account, Balance::from_near(1_000_000))
+        .epoch_length(EPOCH_LENGTH)
+        .gas_prices(min_gas_price, min_gas_price)
+        .gc_num_epochs_to_keep(20)
+        .build();
+    generate_diverse_traffic(&mut env);
+    env
+}
+
+fn collect_organic_entries(store: &near_store::Store) -> Vec<(CryptoHash, ReceiptToTxInfo)> {
+    let mut entries: Vec<(CryptoHash, ReceiptToTxInfo)> = store
+        .iter_ser::<ReceiptToTxInfo>(DBCol::ReceiptToTx)
+        .map(|(k, v)| (CryptoHash::try_from(k.as_ref()).unwrap(), v))
+        .collect();
+    entries.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
+    entries
+}
+
+fn wipe_receipt_to_tx(store: &near_store::Store) {
+    let keys: Vec<Vec<u8>> = store.iter(DBCol::ReceiptToTx).map(|(k, _)| k.to_vec()).collect();
+    let mut update = store.store_update();
+    for k in &keys {
+        update.delete(DBCol::ReceiptToTx, k);
+    }
+    update.commit();
+    assert_eq!(store.iter(DBCol::ReceiptToTx).count(), 0);
+}
+
+/// Baseline: bucket-ETL output equals the entries written organically when
+/// `save_receipt_to_tx = true`. Mirrors `test_backfill_matches_normal_processing`.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_bucket_etl_matches_actor_output() {
+    init_test_logger();
+    let env = build_env_with_traffic();
+    let store = env.validator().store();
+
+    let original = collect_organic_entries(&store);
+    assert!(
+        original.len() > 10,
+        "expected many ReceiptToTx entries from diverse traffic, got {}",
+        original.len()
+    );
+    let has_from_tx = original.iter().any(|(_, info)| {
+        let ReceiptToTxInfo::V1(v1) = info;
+        matches!(&v1.origin, ReceiptOrigin::FromTransaction(_))
+    });
+    assert!(has_from_tx, "expected FromTransaction entries");
+
+    wipe_receipt_to_tx(&store);
+
+    let scratch = TempDir::new().unwrap();
+    let storage = shared_storage(&store, None);
+    let chain_store = env.validator().client().chain.chain_store();
+    let stats = run_bucket_etl(chain_store, &storage, default_etl_opts(scratch.path().to_owned()))
+        .expect("bucket-ETL should succeed");
+    assert_eq!(stats.pass_d_rows as usize, original.len());
+
+    let backfilled = collect_organic_entries(&store);
+    assert_eq!(backfilled.len(), original.len(), "row count must match");
+    for ((k1, v1), (k2, v2)) in original.iter().zip(backfilled.iter()) {
+        assert_eq!(k1, k2, "key mismatch");
+        assert_eq!(v1, v2, "value mismatch for key {k1}");
+    }
+}
+
+/// Bucket-ETL stats agree with `process_height` when a parent receipt is missing.
+/// We delete one receipt-origin outcome's outcome_id from `Receipts` and confirm
+/// both the actor and the bucket-ETL count it as `missing_parent_receipts`.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_bucket_etl_handles_missing_parent_receipt() {
+    init_test_logger();
+    let env = build_env_with_traffic();
+    let store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+
+    // Find a receipt-origin outcome's outcome_id (also a receipt id in DBCol::Receipts).
+    let parent = pick_receipt_origin_outcome_id(chain_store).expect("need at least one");
+    let mut update = store.store_update();
+    update.decrement_refcount(DBCol::Receipts, parent.as_ref());
+    update.commit();
+    // Confirm Pass A scan won't see it.
+    assert!(
+        store
+            .get_ser::<near_primitives::receipt::Receipt>(DBCol::Receipts, parent.as_ref())
+            .is_none()
+    );
+
+    let genesis = chain_store.get_genesis_height();
+    let head = env.validator().head().height;
+
+    // Baseline via process_height (after deletion).
+    let mut actor_missing_parent: u64 = 0;
+    let mut actor_entries: HashMap<CryptoHash, ReceiptToTxInfo> = HashMap::new();
+    for h in genesis..=head {
+        if let Some(hr) = process_height(chain_store, h).expect("process_height ok") {
+            actor_missing_parent += hr.missing_parent_receipts;
+            for (k, v) in hr.entries {
+                actor_entries.insert(k, v);
+            }
+        }
+    }
+    assert!(actor_missing_parent > 0, "expected at least one missing parent");
+
+    wipe_receipt_to_tx(&store);
+
+    let scratch = TempDir::new().unwrap();
+    let stats = run_bucket_etl(
+        chain_store,
+        &shared_storage(&store, None),
+        default_etl_opts(scratch.path().to_owned()),
+    )
+    .expect("bucket-ETL should succeed");
+
+    assert_eq!(
+        stats.missing_parent_receipts, actor_missing_parent,
+        "bucket-ETL missing_parent_receipts must match actor"
+    );
+
+    let etl_entries: HashMap<CryptoHash, ReceiptToTxInfo> = store
+        .iter_ser::<ReceiptToTxInfo>(DBCol::ReceiptToTx)
+        .map(|(k, v)| (CryptoHash::try_from(k.as_ref()).unwrap(), v))
+        .collect();
+    assert_eq!(etl_entries.len(), actor_entries.len());
+    for (k, v) in &actor_entries {
+        assert_eq!(etl_entries.get(k), Some(v));
+    }
+}
+
+/// Symmetric to the parent test: when a child receipt is missing, both the
+/// actor and the bucket-ETL count it as `missing_child_receipts`.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_bucket_etl_handles_missing_child_receipt() {
+    init_test_logger();
+    let env = build_env_with_traffic();
+    let store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+
+    // Pick a receipt that appears as a child in some outcome's `receipt_ids`.
+    let child = pick_child_receipt_id(chain_store).expect("need at least one");
+    let mut update = store.store_update();
+    update.decrement_refcount(DBCol::Receipts, child.as_ref());
+    update.commit();
+    assert!(
+        store
+            .get_ser::<near_primitives::receipt::Receipt>(DBCol::Receipts, child.as_ref())
+            .is_none()
+    );
+
+    let genesis = chain_store.get_genesis_height();
+    let head = env.validator().head().height;
+    let mut actor_missing_child: u64 = 0;
+    for h in genesis..=head {
+        if let Some(hr) = process_height(chain_store, h).expect("process_height ok") {
+            actor_missing_child += hr.missing_child_receipts;
+        }
+    }
+    assert!(actor_missing_child > 0, "expected at least one missing child");
+
+    wipe_receipt_to_tx(&store);
+    let scratch = TempDir::new().unwrap();
+    let stats = run_bucket_etl(
+        chain_store,
+        &shared_storage(&store, None),
+        default_etl_opts(scratch.path().to_owned()),
+    )
+    .expect("bucket-ETL should succeed");
+    assert_eq!(
+        stats.missing_child_receipts, actor_missing_child,
+        "bucket-ETL missing_child_receipts must match actor"
+    );
+}
+
+/// `missing_outcomes` is incremented when an outcome key is absent from
+/// `TransactionResultForBlock`. Delete one and confirm both paths agree.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_bucket_etl_handles_missing_outcome() {
+    init_test_logger();
+    let env = build_env_with_traffic();
+    let store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+
+    // Pick the first key in TransactionResultForBlock and delete it.
+    let key: Vec<u8> =
+        store.iter(DBCol::TransactionResultForBlock).next().expect("non-empty").0.to_vec();
+    let mut update = store.store_update();
+    update.delete(DBCol::TransactionResultForBlock, &key);
+    update.commit();
+
+    let genesis = chain_store.get_genesis_height();
+    let head = env.validator().head().height;
+    let mut actor_missing_outcomes: u64 = 0;
+    for h in genesis..=head {
+        if let Some(hr) = process_height(chain_store, h).expect("process_height ok") {
+            actor_missing_outcomes += hr.missing_outcomes;
+        }
+    }
+    assert!(actor_missing_outcomes > 0, "expected at least one missing outcome");
+
+    wipe_receipt_to_tx(&store);
+    let scratch = TempDir::new().unwrap();
+    let stats = run_bucket_etl(
+        chain_store,
+        &shared_storage(&store, None),
+        default_etl_opts(scratch.path().to_owned()),
+    )
+    .expect("bucket-ETL should succeed");
+    assert_eq!(
+        stats.missing_outcomes, actor_missing_outcomes,
+        "bucket-ETL missing_outcomes must match actor"
+    );
+}
+
+/// `finalize_output_bucket` quarantines the batch when two entries share a key
+/// but disagree on the serialized payload. Mirrors the actor's
+/// `BackfillError::ValueDivergence` path.
+#[test]
+fn test_bucket_etl_quarantines_value_divergence() {
+    init_test_logger();
+    let key = CryptoHash([0x11; 32]);
+    let row_a = OutputRow {
+        child_id: key,
+        info: ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+            origin: ReceiptOrigin::FromTransaction(
+                near_primitives::receipt::ReceiptOriginTransaction {
+                    tx_hash: CryptoHash([0xaa; 32]),
+                    sender_account_id: AccountId::from_str("alice.near").unwrap(),
+                },
+            ),
+            receiver_account_id: AccountId::from_str("bob.near").unwrap(),
+            shard_id: 0u64.into(),
+        }),
+    };
+    let row_b = OutputRow {
+        child_id: key,
+        info: ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+            origin: ReceiptOrigin::FromTransaction(
+                near_primitives::receipt::ReceiptOriginTransaction {
+                    tx_hash: CryptoHash([0xbb; 32]), // different tx hash → divergent payload
+                    sender_account_id: AccountId::from_str("alice.near").unwrap(),
+                },
+            ),
+            receiver_account_id: AccountId::from_str("bob.near").unwrap(),
+            shard_id: 0u64.into(),
+        }),
+    };
+    let err = finalize_output_bucket_with_max(vec![row_a, row_b], 1024 * 1024)
+        .expect_err("divergent values must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("two different ReceiptToTxInfo")
+            || msg.contains("ValueDivergence")
+            || msg.contains("non-determinism"),
+        "expected ValueDivergence error, got: {msg}"
+    );
+}
+
+/// The deterministic shuffle (Pass B → Pass C) must correctly handle
+/// receipt-origin parents whose `parent_receipt_id` first byte differs from
+/// the child's. We verify byte-equivalence with `process_height` end-to-end;
+/// any cross-prefix shuffle bug would surface as a missing or divergent entry.
+/// (The actor under test reads from a single-shard chain whose traffic mix may
+/// or may not include FromReceipt entries; equivalence is the load-bearing
+/// invariant either way.)
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_bucket_etl_resolves_cross_prefix_parents() {
+    init_test_logger();
+    let env = build_env_with_traffic();
+    let store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+
+    // Count how many cross-prefix parent→child cases the chain produced —
+    // logged for diagnostic value, not asserted. The equivalence check below
+    // is the actual safety net for the cross-prefix shuffle.
+    let mut cross_prefix = 0usize;
+    let genesis = chain_store.get_genesis_height();
+    let head = env.validator().head().height;
+    for h in genesis..=head {
+        if let Some(hr) = process_height(chain_store, h).expect("process_height ok") {
+            for (child_id, info) in &hr.entries {
+                let ReceiptToTxInfo::V1(v1) = info;
+                if let ReceiptOrigin::FromReceipt(o) = &v1.origin {
+                    if o.parent_receipt_id.as_ref()[0] != child_id.as_ref()[0] {
+                        cross_prefix += 1;
+                    }
+                }
+            }
+        }
+    }
+    eprintln!("test_bucket_etl_resolves_cross_prefix_parents: cross_prefix cases = {cross_prefix}");
+
+    // Equivalence end-to-end.
+    let original = collect_organic_entries(&store);
+    wipe_receipt_to_tx(&store);
+    let scratch = TempDir::new().unwrap();
+    run_bucket_etl(
+        chain_store,
+        &shared_storage(&store, None),
+        default_etl_opts(scratch.path().to_owned()),
+    )
+    .expect("bucket-ETL should succeed");
+    let backfilled = collect_organic_entries(&store);
+    assert_eq!(backfilled.len(), original.len());
+    for ((k1, v1), (k2, v2)) in original.iter().zip(backfilled.iter()) {
+        assert_eq!(k1, k2);
+        assert_eq!(v1, v2);
+    }
+}
+
+/// Pure unit test: each of the 5 row types roundtrips through
+/// `BucketWriter` → `BucketReader` byte-for-byte.
+#[test]
+fn test_bucket_writer_reader_roundtrip() {
+    init_test_logger();
+    let receipt_extract = ReceiptExtractRow {
+        receipt_id: CryptoHash([0x01; 32]),
+        receiver_id: AccountId::from_str("alice.near").unwrap(),
+        predecessor_id: AccountId::from_str("system").unwrap(),
+    };
+    let tx_demand = TxOriginDemandRow {
+        child_id: CryptoHash([0x02; 32]),
+        shard_id: 1u64.into(),
+        tx_hash: CryptoHash([0x03; 32]),
+        sender_account_id: AccountId::from_str("bob.near").unwrap(),
+    };
+    let needs_parent = NeedsParentRow {
+        child_id: CryptoHash([0x04; 32]),
+        shard_id: 2u64.into(),
+        parent_receipt_id: CryptoHash([0x05; 32]),
+    };
+    let receipt_demand = ReceiptOriginDemandRow {
+        child_id: CryptoHash([0x06; 32]),
+        shard_id: 3u64.into(),
+        parent_receipt_id: CryptoHash([0x07; 32]),
+        parent_predecessor_id: AccountId::from_str("carol.near").unwrap(),
+    };
+    let output = OutputRow {
+        child_id: CryptoHash([0x08; 32]),
+        info: ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+            origin: ReceiptOrigin::FromTransaction(
+                near_primitives::receipt::ReceiptOriginTransaction {
+                    tx_hash: CryptoHash([0x09; 32]),
+                    sender_account_id: AccountId::from_str("alice.near").unwrap(),
+                },
+            ),
+            receiver_account_id: AccountId::from_str("bob.near").unwrap(),
+            shard_id: 0u64.into(),
+        }),
+    };
+
+    fn roundtrip<T: BorshSerialize + borsh::BorshDeserialize + PartialEq + std::fmt::Debug>(
+        row: T,
+    ) {
+        let mut buf = Vec::new();
+        let mut w = BucketWriter::new(&mut buf);
+        w.write(&row).unwrap();
+        let _ = w.finish().unwrap();
+        let mut reader = BucketReader::new(Cursor::new(&buf));
+        let bytes = reader.next().unwrap().unwrap();
+        let decoded = T::try_from_slice(&bytes).unwrap();
+        assert_eq!(decoded, row);
+        // No more rows after.
+        assert!(reader.next().is_none());
+    }
+
+    roundtrip(receipt_extract);
+    roundtrip(tx_demand);
+    roundtrip(needs_parent);
+    roundtrip(receipt_demand);
+    roundtrip(output);
+}
+
+/// `validate_output_bucket_file` rejects (a) out-of-order keys, (b) duplicates,
+/// and (c) buckets exceeding the size cap.
+#[test]
+fn test_bucket_etl_rejects_invalid_output_bucket() {
+    init_test_logger();
+    let dir = TempDir::new().unwrap();
+
+    // Helper to write rows raw (skipping finalize_output_bucket so we can craft invalid files).
+    fn write_raw(path: &std::path::Path, rows: &[OutputRow]) {
+        let f = std::fs::File::create(path).unwrap();
+        let mut w = BucketWriter::new(std::io::BufWriter::new(f));
+        for r in rows {
+            w.write(r).unwrap();
+        }
+        let _ = w.finish().unwrap();
+    }
+
+    let mk_row = |k: u8, tx: u8| OutputRow {
+        child_id: CryptoHash([k; 32]),
+        info: ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+            origin: ReceiptOrigin::FromTransaction(
+                near_primitives::receipt::ReceiptOriginTransaction {
+                    tx_hash: CryptoHash([tx; 32]),
+                    sender_account_id: AccountId::from_str("alice.near").unwrap(),
+                },
+            ),
+            receiver_account_id: AccountId::from_str("bob.near").unwrap(),
+            shard_id: 0u64.into(),
+        }),
+    };
+
+    // (a) out-of-order
+    let path = dir.path().join("out_of_order.bucket");
+    write_raw(&path, &[mk_row(0x05, 1), mk_row(0x02, 2)]);
+    let err = validate_output_bucket_file(&path).expect_err("out-of-order must error");
+    assert!(
+        format!("{err:#}").contains("not strictly sorted"),
+        "expected out-of-order error: {err:#}"
+    );
+
+    // (b) duplicates
+    let path = dir.path().join("dup.bucket");
+    write_raw(&path, &[mk_row(0x03, 1), mk_row(0x03, 2)]);
+    let err = validate_output_bucket_file(&path).expect_err("duplicate keys must error");
+    assert!(format!("{err:#}").contains("duplicate key"), "expected duplicate error: {err:#}");
+
+    // (c) size > limit (use a small max so we don't need 256 MiB of data).
+    let path = dir.path().join("toolarge.bucket");
+    let rows: Vec<OutputRow> = (1..30u8).map(|k| mk_row(k, 0)).collect();
+    write_raw(&path, &rows);
+    let err =
+        validate_output_bucket_file_with_max(&path, 100).expect_err("oversized bucket must error");
+    assert!(format!("{err:#}").contains("exceeds 100 bytes"), "expected size-limit error: {err:#}");
+}
+
+/// Crash mid-Pass-B at a specific height; resume with the knob unset; final
+/// output equals a clean single-shot run. Closes the load-bearing
+/// restart-correctness gap.
+#[test]
+#[cfg(feature = "test_features")]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_bucket_etl_resumes_after_simulated_crash() {
+    init_test_logger();
+    let env = build_env_with_traffic();
+    let store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+
+    let original = collect_organic_entries(&store);
+    wipe_receipt_to_tx(&store);
+
+    let head = env.validator().head().height;
+    let genesis = chain_store.get_genesis_height();
+    // Pick a crash height in the middle of the slice and a tight marker
+    // interval so workers actually persist a marker before the crash.
+    let mid = genesis + (head - genesis) / 2;
+    let scratch = TempDir::new().unwrap();
+
+    // First pass: crash at `mid`.
+    let opts_crash = BucketEtlOptions {
+        from_height: Some(genesis),
+        to_height: Some(head),
+        num_threads: 2,
+        scratch_dir: scratch.path().to_owned(),
+        output_mode: BucketEtlOutputMode::WriteToStore,
+        marker_block_interval: 3,
+        crash_after_pass_b_height: Some(mid),
+    };
+    let err = run_bucket_etl(chain_store, &shared_storage(&store, None), opts_crash)
+        .expect_err("crash knob must trigger error");
+    assert!(
+        format!("{err:#}").contains("crash_after_pass_b_height"),
+        "expected crash-knob error, got: {err:#}"
+    );
+
+    // Verify a worker actually got past at least one marker boundary
+    // (otherwise the test isn't exercising the resume path).
+    let mut any_marker = false;
+    for w in 0..2 {
+        if scratch.path().join("pass_b").join(format!("worker_{w}")).join("marker").exists() {
+            any_marker = true;
+            break;
+        }
+    }
+    assert!(any_marker, "no per-worker marker was written before the crash");
+
+    // Resume: same scratch dir, knob unset.
+    let opts_resume = BucketEtlOptions {
+        from_height: Some(genesis),
+        to_height: Some(head),
+        num_threads: 2,
+        scratch_dir: scratch.path().to_owned(),
+        output_mode: BucketEtlOutputMode::WriteToStore,
+        marker_block_interval: 3,
+        crash_after_pass_b_height: None,
+    };
+    run_bucket_etl(chain_store, &shared_storage(&store, None), opts_resume)
+        .expect("resume should succeed");
+
+    let backfilled = collect_organic_entries(&store);
+    assert_eq!(backfilled.len(), original.len(), "row count must match original");
+    for ((k1, v1), (k2, v2)) in original.iter().zip(backfilled.iter()) {
+        assert_eq!(k1, k2);
+        assert_eq!(v1, v2);
+    }
+}
+
+/// Compare-mode catches injected divergences. Run bucket-ETL to completion,
+/// overwrite ONE entry in the output bucket with a wrong receiver, then run
+/// `compare_against_actor` and assert at least one divergence is reported.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_bucket_etl_compare_mode_detects_injected_divergence() {
+    init_test_logger();
+    let env = build_env_with_traffic();
+    let store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+
+    wipe_receipt_to_tx(&store);
+    let scratch = TempDir::new().unwrap();
+    run_bucket_etl(
+        chain_store,
+        &shared_storage(&store, None),
+        default_etl_opts(scratch.path().to_owned()),
+    )
+    .expect("bucket-ETL should succeed");
+
+    // First: clean compare-mode against the same range — must report zero.
+    let genesis = chain_store.get_genesis_height();
+    let head = env.validator().head().height;
+    let opts = default_etl_opts(scratch.path().to_owned());
+    let clean = compare_against_actor(chain_store, &opts, genesis, head).expect("compare ok");
+    assert_eq!(clean, 0, "clean compare must report zero divergences");
+
+    // Find the first non-empty output bucket and corrupt one entry.
+    let mut corrupted = false;
+    for prefix in 0u16..256u16 {
+        let path = pass_d_output_path(scratch.path(), prefix as u8);
+        if !path.exists() {
+            continue;
+        }
+        // Read existing rows, mutate first one's receiver, rewrite.
+        let f = std::fs::File::open(&path).unwrap();
+        let reader = BucketReader::new(std::io::BufReader::new(f));
+        let mut rows: Vec<OutputRow> = Vec::new();
+        for row in reader {
+            rows.push(borsh::BorshDeserialize::try_from_slice(&row.unwrap()).unwrap());
+        }
+        if rows.is_empty() {
+            continue;
+        }
+        let ReceiptToTxInfo::V1(ref mut v1) = rows[0].info;
+        v1.receiver_account_id = AccountId::from_str("zzzzzzzzz.near").unwrap();
+        // Rewrite.
+        let f = std::fs::File::create(&path).unwrap();
+        let mut w = BucketWriter::new(std::io::BufWriter::new(f));
+        for r in &rows {
+            w.write(r).unwrap();
+        }
+        let _ = w.finish().unwrap();
+        corrupted = true;
+        break;
+    }
+    assert!(corrupted, "expected at least one non-empty output bucket");
+
+    let divergences = compare_against_actor(chain_store, &opts, genesis, head).expect("compare ok");
+    assert!(divergences > 0, "compare-mode must surface the injected divergence");
+}
+
+// ===== Helpers =====
+
+/// Walk the chain looking for the first outcome that:
+///   (a) is receipt-origin (`outcome_id` NOT in `Transactions`),
+///   (b) has at least one child receipt id (`receipt_ids` non-empty), so
+///       process_height actually performs the parent lookup,
+///   (c) `outcome_id` is in `Receipts` (so deletion is meaningful).
+fn pick_receipt_origin_outcome_id(chain_store: &near_chain::ChainStore) -> Option<CryptoHash> {
+    use near_chain::ChainStoreAccess;
+    use near_primitives::transaction::ExecutionOutcomeWithProof;
+    use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash};
+    let store = chain_store.store();
+    let genesis = chain_store.get_genesis_height();
+    let head = chain_store.head().ok()?.height;
+    for h in genesis..=head {
+        let block_hash = match chain_store.get_block_hash_by_height(h) {
+            Ok(h) => h,
+            Err(_) => continue,
+        };
+        for (key, outcome_ids) in
+            store.iter_prefix_ser::<Vec<CryptoHash>>(DBCol::OutcomeIds, block_hash.as_ref())
+        {
+            let _ = get_block_shard_id_rev(&key);
+            for outcome_id in outcome_ids {
+                let is_tx = store.exists(DBCol::Transactions, outcome_id.as_ref());
+                if is_tx {
+                    continue;
+                }
+                if !store.exists(DBCol::Receipts, outcome_id.as_ref()) {
+                    continue;
+                }
+                let key = get_outcome_id_block_hash(&outcome_id, &block_hash);
+                let bytes = match store.get(DBCol::TransactionResultForBlock, &key) {
+                    Some(b) => b,
+                    None => continue,
+                };
+                let owp = <ExecutionOutcomeWithProof as borsh::BorshDeserialize>::try_from_slice(
+                    bytes.as_ref(),
+                )
+                .unwrap();
+                if !owp.outcome.receipt_ids.is_empty() {
+                    return Some(outcome_id);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Pick the first receipt id that appears as a child in some outcome's
+/// `receipt_ids` AND is present in `Receipts`. Deleting it triggers
+/// `missing_child_receipts` (and may also trigger `missing_parent_receipts`
+/// if the receipt is itself an outcome_id; the missing-child test only
+/// asserts that the counts agree between the actor and the bucket-ETL,
+/// which holds either way).
+fn pick_child_receipt_id(chain_store: &near_chain::ChainStore) -> Option<CryptoHash> {
+    use near_chain::ChainStoreAccess;
+    use near_primitives::transaction::ExecutionOutcomeWithProof;
+    use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash};
+    let store = chain_store.store();
+    let genesis = chain_store.get_genesis_height();
+    let head = chain_store.head().ok()?.height;
+
+    for h in genesis..=head {
+        let block_hash = match chain_store.get_block_hash_by_height(h) {
+            Ok(h) => h,
+            Err(_) => continue,
+        };
+        for (key, outcome_ids) in
+            store.iter_prefix_ser::<Vec<CryptoHash>>(DBCol::OutcomeIds, block_hash.as_ref())
+        {
+            let _ = get_block_shard_id_rev(&key);
+            for outcome_id in outcome_ids {
+                if let Some(bytes) = store.get(
+                    DBCol::TransactionResultForBlock,
+                    &get_outcome_id_block_hash(&outcome_id, &block_hash),
+                ) {
+                    let owp =
+                        <ExecutionOutcomeWithProof as borsh::BorshDeserialize>::try_from_slice(
+                            bytes.as_ref(),
+                        )
+                        .unwrap();
+                    for child in &owp.outcome.receipt_ids {
+                        if store
+                            .get_ser::<near_primitives::receipt::Receipt>(
+                                DBCol::Receipts,
+                                child.as_ref(),
+                            )
+                            .is_some()
+                        {
+                            return Some(*child);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+// Silence unused-import warnings on configurations where some imports aren't used.
+#[allow(dead_code)]
+fn _unused_imports_silencer(_: BuiltOriginInputs, _: BuiltOrigin) -> ReceiptToTxInfo {
+    build_receipt_to_tx_info(BuiltOriginInputs {
+        outcome_id: CryptoHash::default(),
+        shard_id: 0u64.into(),
+        child_receiver_id: AccountId::from_str("a").unwrap(),
+        origin: BuiltOrigin::FromTransaction { sender_id: AccountId::from_str("a").unwrap() },
+    })
+}

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/bucket_etl.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/bucket_etl.rs
@@ -8,8 +8,9 @@ use near_chain::backfill_receipt_to_tx::{
 use near_chain::backfill_receipt_to_tx_bucket_etl::{
     BucketEtlOptions, BucketEtlOutputMode, BucketReader, BucketWriter, NeedsParentRow, OutputRow,
     ReceiptExtractRow, ReceiptOriginDemandRow, TxOriginDemandRow, compare_against_actor,
-    finalize_output_bucket_with_max, pass_d_output_path, run_bucket_etl,
-    validate_output_bucket_file, validate_output_bucket_file_with_max,
+    finalize_output_bucket_with_max, pass_a_path_for_test, pass_b_consolidated_needs_parent_path,
+    pass_c_consolidated_path, pass_c_resolve_parents, pass_d_output_path, run_bucket_etl,
+    validate_output_bucket_file, validate_output_bucket_file_with_max, write_bucket,
 };
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
@@ -342,6 +343,15 @@ fn test_bucket_etl_resolves_cross_prefix_parents() {
         }
     }
     eprintln!("test_bucket_etl_resolves_cross_prefix_parents: cross_prefix cases = {cross_prefix}");
+    // Direct coverage: with non-zero gas_prices the diverse traffic produces
+    // FromReceipt entries, and uniform hash distribution across ~30+ children
+    // makes a same-prefix-only outcome statistically negligible. If this ever
+    // flakes, build_env_with_traffic should be augmented rather than this
+    // assertion weakened — the test name promises cross-prefix coverage.
+    assert!(
+        cross_prefix > 0,
+        "test traffic must produce at least one cross-prefix parent→child case; got 0"
+    );
 
     // Equivalence end-to-end.
     let original = collect_organic_entries(&store);
@@ -479,9 +489,156 @@ fn test_bucket_etl_rejects_invalid_output_bucket() {
     assert!(format!("{err:#}").contains("exceeds 100 bytes"), "expected size-limit error: {err:#}");
 }
 
+/// Direct unit test for the Pass B → Pass C deterministic shuffle: a
+/// `NeedsParentRow` with `parent_receipt_id` first byte ≠ `child_id` first
+/// byte must end up in the ZZ bucket (child_id first byte), with
+/// `parent_predecessor_id` resolved from the YY-prefix Pass A extract.
+///
+/// Drives `pass_c_resolve_parents` against a hand-crafted scratch dir; no
+/// chain_store needed.
+#[test]
+fn test_bucket_etl_pass_c_shuffle_places_row_in_child_prefix() {
+    init_test_logger();
+    let scratch = TempDir::new().unwrap();
+
+    let parent_id = CryptoHash([0xaa; 32]); // first byte = 0xaa  (YY)
+    let mut child_bytes = [0xee; 32];
+    child_bytes[0] = 0x33; // first byte = 0x33  (ZZ ≠ YY)
+    let child_id = CryptoHash(child_bytes);
+
+    let predecessor = AccountId::from_str("predecessor.near").unwrap();
+    let receiver = AccountId::from_str("receiver.near").unwrap();
+    let shard_id = near_primitives::types::ShardId::new(0);
+
+    // Pass A extract for prefix YY=0xaa: contains the parent receipt.
+    write_bucket(
+        &pass_a_path_for_test(scratch.path(), 0xaa),
+        &[ReceiptExtractRow {
+            receipt_id: parent_id,
+            receiver_id: AccountId::from_str("ignored.near").unwrap(),
+            predecessor_id: predecessor.clone(),
+        }],
+    )
+    .unwrap();
+    // Pass A extract for prefix ZZ=0x33: contains the child receipt
+    // (Pass D will need it later, but the test only checks Pass C output).
+    write_bucket(
+        &pass_a_path_for_test(scratch.path(), 0x33),
+        &[ReceiptExtractRow {
+            receipt_id: child_id,
+            receiver_id: receiver.clone(),
+            predecessor_id: AccountId::from_str("ignored.near").unwrap(),
+        }],
+    )
+    .unwrap();
+    // Pass B consolidated needs_parent for prefix YY=0xaa: one row whose
+    // child_id is in prefix ZZ — the cross-prefix case.
+    write_bucket(
+        &pass_b_consolidated_needs_parent_path(scratch.path(), 0xaa),
+        &[NeedsParentRow { child_id, shard_id, parent_receipt_id: parent_id }],
+    )
+    .unwrap();
+
+    let opts = BucketEtlOptions {
+        from_height: None,
+        to_height: None,
+        num_threads: 1,
+        scratch_dir: scratch.path().to_owned(),
+        output_mode: BucketEtlOutputMode::MeasureOnly,
+        marker_block_interval: 1_000_000,
+        crash_after_pass_b_height: None,
+    };
+    let (rows_emitted, missing) =
+        pass_c_resolve_parents(&opts).expect("pass C should succeed");
+    assert_eq!(rows_emitted, 1, "exactly one resolved demand row expected");
+    assert_eq!(missing, 0, "parent receipt was present, no missing");
+
+    // Row landed in ZZ=0x33, NOT YY=0xaa.
+    let zz_rows: Vec<ReceiptOriginDemandRow> =
+        near_chain::backfill_receipt_to_tx_bucket_etl::read_bucket(&pass_c_consolidated_path(
+            scratch.path(),
+            0x33,
+        ))
+        .unwrap();
+    assert_eq!(zz_rows.len(), 1, "ZZ bucket must have the resolved row");
+    assert_eq!(zz_rows[0].child_id, child_id);
+    assert_eq!(zz_rows[0].parent_receipt_id, parent_id);
+    assert_eq!(
+        zz_rows[0].parent_predecessor_id, predecessor,
+        "predecessor must be resolved from the YY-prefix extract"
+    );
+    assert_eq!(zz_rows[0].shard_id, shard_id);
+
+    let yy_rows: Vec<ReceiptOriginDemandRow> =
+        near_chain::backfill_receipt_to_tx_bucket_etl::read_bucket(&pass_c_consolidated_path(
+            scratch.path(),
+            0xaa,
+        ))
+        .unwrap();
+    assert!(
+        yy_rows.is_empty(),
+        "YY (parent's prefix) bucket must NOT contain the row — shuffle keys on child_id"
+    );
+}
+
+/// `check_or_write_options_hash` rejects a resume against a scratch dir
+/// fingerprinted with different options. Without this safety net, a user
+/// could resume a partial run with a smaller height range and end up with
+/// inconsistent stage markers vs actual on-disk state.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_bucket_etl_options_hash_rejects_resume_with_different_options() {
+    init_test_logger();
+    let env = build_env_with_traffic();
+    let store = env.validator().store();
+    let chain_store = env.validator().client().chain.chain_store();
+    let genesis = chain_store.get_genesis_height();
+    let head = env.validator().head().height;
+
+    wipe_receipt_to_tx(&store);
+    let scratch = TempDir::new().unwrap();
+
+    // First run with a specific from_height.
+    let opts_first = BucketEtlOptions {
+        from_height: Some(genesis),
+        to_height: Some(head),
+        num_threads: 2,
+        scratch_dir: scratch.path().to_owned(),
+        output_mode: BucketEtlOutputMode::WriteToStore,
+        marker_block_interval: 1_000_000,
+        crash_after_pass_b_height: None,
+    };
+    run_bucket_etl(chain_store, &shared_storage(&store, None), opts_first)
+        .expect("first run should succeed");
+
+    // Re-run with a different num_threads against the same scratch dir → reject.
+    let opts_changed = BucketEtlOptions {
+        from_height: Some(genesis),
+        to_height: Some(head),
+        num_threads: 4, // different
+        scratch_dir: scratch.path().to_owned(),
+        output_mode: BucketEtlOutputMode::WriteToStore,
+        marker_block_interval: 1_000_000,
+        crash_after_pass_b_height: None,
+    };
+    let err = run_bucket_etl(chain_store, &shared_storage(&store, None), opts_changed)
+        .expect_err("hash mismatch must be rejected");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("hash mismatch") || msg.contains("different options"),
+        "expected hash-mismatch error, got: {msg}"
+    );
+}
+
 /// Crash mid-Pass-B at a specific height; resume with the knob unset; final
-/// output equals a clean single-shot run. Closes the load-bearing
-/// restart-correctness gap.
+/// output AND stats counters both equal a clean single-shot run. Closes the
+/// load-bearing restart-correctness gap.
+///
+/// Stats parity is the second-order check: a regression that under-counted by
+/// the crashed-segment delta would still pass the entry-equality assertion
+/// alone, because the resumed run *also* wrote the missing entries via
+/// `WriteToStore`. The stats comparison catches the case where Pass B's
+/// resume re-processes the wrong height set.
 #[test]
 #[cfg(feature = "test_features")]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
@@ -492,16 +649,30 @@ fn test_bucket_etl_resumes_after_simulated_crash() {
     let chain_store = env.validator().client().chain.chain_store();
 
     let original = collect_organic_entries(&store);
-    wipe_receipt_to_tx(&store);
 
     let head = env.validator().head().height;
     let genesis = chain_store.get_genesis_height();
-    // Pick a crash height in the middle of the slice and a tight marker
-    // interval so workers actually persist a marker before the crash.
     let mid = genesis + (head - genesis) / 2;
-    let scratch = TempDir::new().unwrap();
 
-    // First pass: crash at `mid`.
+    // Baseline: clean single-shot run from a fresh scratch dir, capturing stats.
+    wipe_receipt_to_tx(&store);
+    let baseline_scratch = TempDir::new().unwrap();
+    let opts_baseline = BucketEtlOptions {
+        from_height: Some(genesis),
+        to_height: Some(head),
+        num_threads: 2,
+        scratch_dir: baseline_scratch.path().to_owned(),
+        output_mode: BucketEtlOutputMode::WriteToStore,
+        marker_block_interval: 3,
+        crash_after_pass_b_height: None,
+    };
+    let baseline_stats =
+        run_bucket_etl(chain_store, &shared_storage(&store, None), opts_baseline)
+            .expect("baseline run should succeed");
+
+    // Now exercise the crash + resume path against a separate scratch dir.
+    wipe_receipt_to_tx(&store);
+    let scratch = TempDir::new().unwrap();
     let opts_crash = BucketEtlOptions {
         from_height: Some(genesis),
         to_height: Some(head),
@@ -539,7 +710,7 @@ fn test_bucket_etl_resumes_after_simulated_crash() {
         marker_block_interval: 3,
         crash_after_pass_b_height: None,
     };
-    run_bucket_etl(chain_store, &shared_storage(&store, None), opts_resume)
+    let resume_stats = run_bucket_etl(chain_store, &shared_storage(&store, None), opts_resume)
         .expect("resume should succeed");
 
     let backfilled = collect_organic_entries(&store);
@@ -548,6 +719,43 @@ fn test_bucket_etl_resumes_after_simulated_crash() {
         assert_eq!(k1, k2);
         assert_eq!(v1, v2);
     }
+
+    // Stats parity for resume-invariant counters. Stats fall into two
+    // groups depending on whether the value is computed from on-disk
+    // consolidated state (invariant across crash/resume) or from this-run
+    // emits (legitimately partial on resume):
+    //
+    //   Invariant: pass_a_rows (recovered by reading buckets on resume),
+    //              pass_c_rows, pass_d_rows, missing_child_receipts,
+    //              missing_parent_receipts (all computed from consolidated
+    //              Pass B/C input).
+    //   This-run-emits: pass_b_*_rows, blocks_processed, missing_outcomes,
+    //              heights_skipped — these reflect what Pass B did during
+    //              the call, not the cumulative total. On resume, Pass B
+    //              only re-emits heights past the marker, so the resumed
+    //              run reports only the post-crash subset. (The output
+    //              bucket files reflect the full set, which is what the
+    //              entry-equality assertion above pins.)
+    assert_eq!(
+        resume_stats.pass_a_rows, baseline_stats.pass_a_rows,
+        "resume pass_a_rows mismatch"
+    );
+    assert_eq!(
+        resume_stats.pass_c_rows, baseline_stats.pass_c_rows,
+        "resume pass_c_rows mismatch"
+    );
+    assert_eq!(
+        resume_stats.pass_d_rows, baseline_stats.pass_d_rows,
+        "resume pass_d_rows mismatch"
+    );
+    assert_eq!(
+        resume_stats.missing_child_receipts, baseline_stats.missing_child_receipts,
+        "resume missing_child_receipts mismatch"
+    );
+    assert_eq!(
+        resume_stats.missing_parent_receipts, baseline_stats.missing_parent_receipts,
+        "resume missing_parent_receipts mismatch"
+    );
 }
 
 /// Compare-mode catches injected divergences. Run bucket-ETL to completion,
@@ -712,13 +920,63 @@ fn pick_child_receipt_id(chain_store: &near_chain::ChainStore) -> Option<CryptoH
     None
 }
 
-// Silence unused-import warnings on configurations where some imports aren't used.
-#[allow(dead_code)]
-fn _unused_imports_silencer(_: BuiltOriginInputs, _: BuiltOrigin) -> ReceiptToTxInfo {
-    build_receipt_to_tx_info(BuiltOriginInputs {
-        outcome_id: CryptoHash::default(),
-        shard_id: 0u64.into(),
-        child_receiver_id: AccountId::from_str("a").unwrap(),
-        origin: BuiltOrigin::FromTransaction { sender_id: AccountId::from_str("a").unwrap() },
-    })
+/// Direct coverage of the kernel extracted in commit 1. The
+/// `process_height` path tests it transitively via the byte-equivalence
+/// suite, but the kernel is the load-bearing boundary between the actor and
+/// the bucket-ETL — so it deserves a unit test that pins both branches of
+/// `BuiltOrigin` against manually-constructed expected `ReceiptToTxInfo`.
+#[test]
+fn test_build_receipt_to_tx_info_kernel_byte_equivalence() {
+    init_test_logger();
+    let outcome_id = CryptoHash([0xaa; 32]);
+    let receiver = AccountId::from_str("bob.near").unwrap();
+    let sender = AccountId::from_str("alice.near").unwrap();
+    let predecessor = AccountId::from_str("system").unwrap();
+    let shard_id = near_primitives::types::ShardId::new(7);
+
+    // FromTransaction
+    let got_tx = build_receipt_to_tx_info(BuiltOriginInputs {
+        outcome_id,
+        shard_id,
+        child_receiver_id: receiver.clone(),
+        origin: BuiltOrigin::FromTransaction { sender_id: sender.clone() },
+    });
+    let want_tx = ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+        origin: ReceiptOrigin::FromTransaction(
+            near_primitives::receipt::ReceiptOriginTransaction {
+                tx_hash: outcome_id,
+                sender_account_id: sender.clone(),
+            },
+        ),
+        receiver_account_id: receiver.clone(),
+        shard_id,
+    });
+    assert_eq!(got_tx, want_tx, "FromTransaction kernel branch must match");
+    assert_eq!(
+        borsh::to_vec(&got_tx).unwrap(),
+        borsh::to_vec(&want_tx).unwrap(),
+        "FromTransaction byte-encoding must match"
+    );
+
+    // FromReceipt
+    let got_r = build_receipt_to_tx_info(BuiltOriginInputs {
+        outcome_id,
+        shard_id,
+        child_receiver_id: receiver.clone(),
+        origin: BuiltOrigin::FromReceipt { parent_predecessor_id: predecessor.clone() },
+    });
+    let want_r = ReceiptToTxInfo::V1(ReceiptToTxInfoV1 {
+        origin: ReceiptOrigin::FromReceipt(near_primitives::receipt::ReceiptOriginReceipt {
+            parent_receipt_id: outcome_id,
+            parent_predecessor_id: predecessor,
+        }),
+        receiver_account_id: receiver,
+        shard_id,
+    });
+    assert_eq!(got_r, want_r, "FromReceipt kernel branch must match");
+    assert_eq!(
+        borsh::to_vec(&got_r).unwrap(),
+        borsh::to_vec(&want_r).unwrap(),
+        "FromReceipt byte-encoding must match"
+    );
 }

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/bucket_etl.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/bucket_etl.rs
@@ -526,7 +526,7 @@ fn test_bucket_etl_pass_c_shuffle_places_row_in_child_prefix() {
         &pass_a_path_for_test(scratch.path(), 0x33),
         &[ReceiptExtractRow {
             receipt_id: child_id,
-            receiver_id: receiver.clone(),
+            receiver_id: receiver,
             predecessor_id: AccountId::from_str("ignored.near").unwrap(),
         }],
     )
@@ -945,7 +945,7 @@ fn test_build_receipt_to_tx_info_kernel_byte_equivalence() {
         origin: ReceiptOrigin::FromTransaction(
             near_primitives::receipt::ReceiptOriginTransaction {
                 tx_hash: outcome_id,
-                sender_account_id: sender.clone(),
+                sender_account_id: sender,
             },
         ),
         receiver_account_id: receiver.clone(),

--- a/test-loop-tests/src/tests/backfill_receipt_to_tx/mod.rs
+++ b/test-loop-tests/src/tests/backfill_receipt_to_tx/mod.rs
@@ -1,3 +1,4 @@
 mod actor;
+mod bucket_etl;
 mod cli;
 mod common;

--- a/tools/database/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/tools/database/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -51,6 +51,11 @@ pub(crate) struct BackfillReceiptToTxBucketEtlCommand {
     /// Run `process_height` over `[compare_from_height, compare_to_height]`
     /// after Pass D and byte-compare resulting `ReceiptToTx` entries against
     /// the bucket-ETL output. Mutually requires `--compare-to-height`.
+    ///
+    /// MEMORY: the comparator materializes both sides as a HashMap over
+    /// the height range — roughly 4 GB per ~1M blocks. Use bounded ranges
+    /// (e.g. 100k–1M blocks per invocation) and sweep the chain in chunks.
+    /// A streaming sort-merge is a Phase 3 follow-up.
     #[arg(long, requires = "compare_to_height")]
     compare_from_height: Option<BlockHeight>,
 

--- a/tools/database/src/backfill_receipt_to_tx_bucket_etl.rs
+++ b/tools/database/src/backfill_receipt_to_tx_bucket_etl.rs
@@ -1,0 +1,205 @@
+use anyhow::{Context, bail};
+use clap::Parser;
+use near_chain::ChainStore;
+use near_chain::backfill_receipt_to_tx::BackfillStorage;
+use near_chain::backfill_receipt_to_tx_bucket_etl::{
+    BucketEtlOptions, BucketEtlOutputMode, run_bucket_etl,
+};
+use near_chain_configs::GenesisValidationMode;
+use near_o11y::tracing;
+use near_primitives::types::BlockHeight;
+use nearcore::open_storage;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+/// Bucket-ETL backfill of `DBCol::ReceiptToTx`. Phase 1 prototype: writes
+/// validated output buckets to a scratch directory and either reports stats
+/// (`--measure-only`, default) or compares against `process_height` over a
+/// height range (`--compare-from-height` / `--compare-to-height`).
+///
+/// **No DB writes.** The CLI never writes to `DBCol::ReceiptToTx`.
+/// Production ingest is gated by Phase 3.
+#[derive(Parser)]
+pub(crate) struct BackfillReceiptToTxBucketEtlCommand {
+    /// Scratch directory for bucket files. **Must live on a different physical
+    /// filesystem than cold-data** (so Pass A's sequential scans don't
+    /// contend with Pass A/D's writes on the same HDDs). The pre-flight check
+    /// rejects same-filesystem configurations.
+    #[arg(long)]
+    scratch_dir: PathBuf,
+
+    /// Start height (inclusive). Defaults to chain genesis.
+    #[arg(long)]
+    from_block_height: Option<BlockHeight>,
+
+    /// End height (inclusive). Defaults to chain head.
+    #[arg(long)]
+    to_block_height: Option<BlockHeight>,
+
+    /// Worker count for the rayon pools used by Pass A-D. The Phase 0 spike
+    /// found 4 workers saturate the LVM-backed cold-store HDDs.
+    #[arg(long, default_value_t = 4)]
+    num_threads: usize,
+
+    /// Pass B per-worker height marker cadence. Workers flush buffers and
+    /// persist a marker every N blocks so a crash mid-Pass-B can resume
+    /// without redoing the whole slice.
+    #[arg(long, default_value_t = 100_000)]
+    marker_block_interval: u64,
+
+    /// Run `process_height` over `[compare_from_height, compare_to_height]`
+    /// after Pass D and byte-compare resulting `ReceiptToTx` entries against
+    /// the bucket-ETL output. Mutually requires `--compare-to-height`.
+    #[arg(long, requires = "compare_to_height")]
+    compare_from_height: Option<BlockHeight>,
+
+    /// See `--compare-from-height`.
+    #[arg(long, requires = "compare_from_height")]
+    compare_to_height: Option<BlockHeight>,
+}
+
+impl BackfillReceiptToTxBucketEtlCommand {
+    pub(crate) fn run(
+        &self,
+        home: &PathBuf,
+        genesis_validation: GenesisValidationMode,
+    ) -> anyhow::Result<()> {
+        let near_config = nearcore::config::load_config(home, genesis_validation)
+            .context("failed to load config")?;
+
+        // Pre-flight: scratch_dir must be on a different physical filesystem
+        // than cold-data. Pass A's sequential scans + Pass A/D's writes
+        // hammering the same HDDs would erase the cold-store throughput
+        // budget the Phase 0 spike measured.
+        if let Some(cold_store) = near_config.config.cold_store.as_ref() {
+            // The cold-store path is resolved relative to home when relative;
+            // None means the default location under home.
+            let cold_path = match cold_store.path.as_ref() {
+                Some(p) if p.is_absolute() => p.clone(),
+                Some(p) => home.join(p),
+                None => home.clone(),
+            };
+            ensure_separate_filesystems(&self.scratch_dir, &cold_path)
+                .context("scratch_dir / cold-data filesystem pre-flight check failed")?;
+        } else {
+            tracing::warn!(
+                "no cold_store configured; skipping scratch_dir filesystem check. \
+                 (This CLI is intended for cold-store backfill on archival nodes.)"
+            );
+        }
+
+        let node_storage = open_storage(home, &near_config).context("failed to open storage")?;
+        let storage = BackfillStorage::for_node(&node_storage, None);
+        let chain_store = ChainStore::new(
+            storage.read_store.clone(),
+            near_config.client_config.save_trie_changes,
+            near_config.genesis.config.transaction_validity_period,
+        );
+
+        let output_mode = match (self.compare_from_height, self.compare_to_height) {
+            (Some(from), Some(to)) => {
+                if from > to {
+                    bail!("--compare-from-height ({from}) > --compare-to-height ({to})");
+                }
+                BucketEtlOutputMode::CompareAgainstActor { from_height: from, to_height: to }
+            }
+            _ => BucketEtlOutputMode::MeasureOnly,
+        };
+
+        let opts = BucketEtlOptions {
+            from_height: self.from_block_height,
+            to_height: self.to_block_height,
+            num_threads: self.num_threads,
+            scratch_dir: self.scratch_dir.clone(),
+            output_mode,
+            marker_block_interval: self.marker_block_interval,
+            crash_after_pass_b_height: None,
+        };
+
+        let start = Instant::now();
+        let stats = run_bucket_etl(&chain_store, &storage, opts)?;
+        let elapsed = start.elapsed();
+
+        println!("bucket-ETL stats:");
+        println!("  pass_a_rows:                {}", stats.pass_a_rows);
+        println!("  pass_b_tx_origin_rows:      {}", stats.pass_b_tx_origin_rows);
+        println!("  pass_b_needs_parent_rows:   {}", stats.pass_b_needs_parent_rows);
+        println!("  pass_c_rows:                {}", stats.pass_c_rows);
+        println!("  pass_d_rows:                {}", stats.pass_d_rows);
+        println!("  blocks_processed:           {}", stats.blocks_processed);
+        println!("  heights_skipped:            {}", stats.heights_skipped);
+        println!("  missing_outcomes:           {}", stats.missing_outcomes);
+        println!("  missing_child_receipts:     {}", stats.missing_child_receipts);
+        println!("  missing_parent_receipts:    {}", stats.missing_parent_receipts);
+        if matches!(self.compare_from_height, Some(_)) {
+            println!("  compare_divergences:        {}", stats.compare_divergences);
+        }
+        println!("  wall_secs:                  {:.2}", elapsed.as_secs_f64());
+
+        if matches!(self.compare_from_height, Some(_)) && stats.compare_divergences > 0 {
+            bail!(
+                "compare-mode reported {} divergences; see logs for first 10 keys",
+                stats.compare_divergences
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Resolve each path's filesystem device via `df --output=source` and reject
+/// configurations where they share a device. The HDDs backing the cold-store
+/// LVM volume saturated under Pass A's sequential scan in the Phase 0 spike;
+/// putting scratch on the same device would block writes behind reads and
+/// destroy the throughput budget.
+fn ensure_separate_filesystems(scratch_dir: &Path, cold_path: &Path) -> anyhow::Result<()> {
+    // Materialize scratch_dir before invoking df, since df requires an
+    // existing path.
+    std::fs::create_dir_all(scratch_dir)
+        .with_context(|| format!("create scratch_dir {}", scratch_dir.display()))?;
+
+    let scratch_dev = df_source(scratch_dir)?;
+    let cold_dev = df_source(cold_path)?;
+
+    if scratch_dev == cold_dev {
+        bail!(
+            "scratch_dir ({scratch}) and cold-data path ({cold}) resolve to the same device ({dev}). \
+             scratch_dir must be on a different physical filesystem than cold-data to avoid \
+             HDD contention with Pass A reads. Either choose a different --scratch-dir or \
+             move cold-data; see plan-phase-1 §Performance for rationale.",
+            scratch = scratch_dir.display(),
+            cold = cold_path.display(),
+            dev = scratch_dev,
+        );
+    }
+    tracing::info!(
+        scratch_device = %scratch_dev,
+        cold_device = %cold_dev,
+        "filesystem pre-flight: scratch and cold are on separate devices"
+    );
+    Ok(())
+}
+
+fn df_source(path: &Path) -> anyhow::Result<String> {
+    let output = Command::new("df")
+        .arg("--output=source")
+        .arg(path)
+        .output()
+        .with_context(|| format!("invoke df on {}", path.display()))?;
+    if !output.status.success() {
+        bail!(
+            "df failed for {}: status={}, stderr={}",
+            path.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let stdout = String::from_utf8(output.stdout).context("df output is not utf-8")?;
+    // df output: header line ("Filesystem") then one source line.
+    let source = stdout.lines().nth(1).unwrap_or("").trim().to_owned();
+    if source.is_empty() {
+        bail!("df returned no source for {}", path.display());
+    }
+    Ok(source)
+}

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -5,6 +5,7 @@ use crate::analyze_delayed_receipt::AnalyzeDelayedReceiptCommand;
 use crate::analyze_gas_usage::AnalyzeGasUsageCommand;
 use crate::analyze_high_load::HighLoadStatsCommand;
 use crate::backfill_receipt_to_tx::BackfillReceiptToTxCommand;
+use crate::backfill_receipt_to_tx_bucket_etl::BackfillReceiptToTxBucketEtlCommand;
 use crate::compact::RunCompactionCommand;
 use crate::drop_column::DropColumnCommand;
 use crate::make_snapshot::MakeSnapshotCommand;
@@ -78,6 +79,11 @@ enum SubCommand {
     /// Reconstructs receipt-to-transaction mappings for the EXPERIMENTAL_receipt_to_tx RPC.
     BackfillReceiptToTx(BackfillReceiptToTxCommand),
 
+    /// Phase-1 prototype of the bucket-ETL ReceiptToTx backfill.
+    /// Validates output buckets in a scratch directory; supports a compare-mode
+    /// that runs `process_height` side-by-side. **Never writes to the DB.**
+    BackfillReceiptToTxBucketEtl(BackfillReceiptToTxBucketEtlCommand),
+
     /// Manually set database version
     SetVersion(SetVersionCommand),
 }
@@ -109,6 +115,7 @@ impl DatabaseCommand {
             SubCommand::AnalyzeDelayedReceipt(cmd) => cmd.run(home, genesis_validation),
             SubCommand::AnalyzeContractSizes(cmd) => cmd.run(home, genesis_validation),
             SubCommand::BackfillReceiptToTx(cmd) => cmd.run(home, genesis_validation),
+            SubCommand::BackfillReceiptToTxBucketEtl(cmd) => cmd.run(home, genesis_validation),
             SubCommand::SetVersion(cmd) => cmd.run(home, genesis_validation),
         }
     }

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -5,6 +5,7 @@ mod analyze_delayed_receipt;
 mod analyze_gas_usage;
 mod analyze_high_load;
 pub mod backfill_receipt_to_tx;
+pub mod backfill_receipt_to_tx_bucket_etl;
 mod block_iterators;
 pub mod commands;
 mod compact;


### PR DESCRIPTION
Phase 1 prototype of the bucket-ETL ReceiptToTx backfill (per plan-v14). Rebuilds
`DBCol::ReceiptToTx` from cold-store data via four parallel-by-prefix passes with
a deterministic shuffle, eliminating the random-read pattern that limits the
existing actor to 50–150 days for a full mainnet rebuild.

Pipeline:
- **Pass A** — sequential scan of `DBCol::Receipts` partitioned by first byte; emit
  `(id, receiver, predecessor)` per receipt.
- **Pass B** — parallel block walk; per outcome emit either a tx-origin demand
  (bucketed by `child_id`) or a needs-parent row (bucketed by `parent_receipt_id`).
- **Pass C** — per `parent_id` prefix, join needs-parent rows against the receipts
  extract for that prefix; re-bucket output by `child_id` (the deterministic
  shuffle that eliminates cross-prefix lookups in Pass D).
- **Pass D** — per `child_id` prefix, join the resolved demands against the
  receipts extract for receiver; build `ReceiptToTxInfo` via a shared kernel
  extracted from `process_height`; sort + dedupe with
  `BackfillError::ValueDivergence` quarantine; validate the SST-ingest invariants;
  write per-prefix output.

Restart machinery: per-stage `.done` markers, per-Pass-B-worker height marker,
atomic `.tmp → final` renames, options-hash check on resume.

CLI: `neard database backfill-receipt-to-tx-bucket-etl` exposes `--measure-only`
(default) and `--compare-from-height` / `--compare-to-height`. Deliberately no
`--write-to-store` — production ingest is gated to Phase 3, and the
`WriteToStore` library variant is `cfg(any(test, feature = \"test_features\"))`.

Pre-flight: `df --output=source` rejects same-device scratch/cold configurations
so Pass A's read budget isn't sunk into write contention on the cold-data HDDs.

13 bucket-ETL tests cover equivalence vs `process_height`, four failure modes
(missing parent / child / outcome, value-divergence quarantine), bucket-format
roundtrip, SST-invariant rejection, simulated mid-Pass-B crash + resume (entries
and stats parity), compare-mode divergence detection, the deterministic Pass C
shuffle in isolation, and options-hash mismatch rejection.
\`cargo clippy --all-features --all-targets\` is clean.

Drafted because this is the prototype gate; production rebuild against the cold
store is a separate follow-up after operational measurement on the production VM.

Based on \`stedfn/backfill-sst-ingest\` so the diff shows only the 9 new commits;
that PR should land first.