### PR TITLE
chore(ci): split and upload debug info for release binaries

### DIFF
--- a/scripts/binary_release.sh
+++ b/scripts/binary_release.sh
@@ -140,16 +140,23 @@ function upload_binary {
 # Build with full DWARF debug info, then split it into a separate file and
 # strip the binary. The shipped binary stays nearly the same size as before;
 # the .debug sibling is uploaded so post-mortem investigations have symbols.
-export CARGO_PROFILE_RELEASE_DEBUG=2
-export CARGO_PROFILE_RELEASE_STRIP=none
+#
+# Only do this on platforms where we have GNU objcopy + strip available —
+# otherwise the binary would ship with debug info inline (huge) and unstripped.
+# macOS uses a different toolchain (dsymutil + .dSYM bundles) and is left at
+# the default release profile.
+if command -v objcopy >/dev/null 2>&1 && command -v strip >/dev/null 2>&1; then
+  export CARGO_PROFILE_RELEASE_DEBUG=2
+  export CARGO_PROFILE_RELEASE_STRIP=none
+  SPLIT_DEBUG_INFO=1
+fi
+
 run_cmd make $release_type
 
-# Always split debug info — applies to all release types (release,
-# nightly-release, assertions-release, test-features-release). The
-# split_debug_info function is a no-op when the target binary doesn't exist
-# or when objcopy/strip aren't available (mac builds).
-split_debug_info "target/release/neard"
-split_debug_info "target/release/near-sandbox"
+if [[ -n "${SPLIT_DEBUG_INFO:-}" ]]; then
+  split_debug_info "target/release/neard"
+  split_debug_info "target/release/near-sandbox"
+fi
 
 if [ "$upload_action" = "upload-release" ]
 then

--- a/scripts/binary_release.sh
+++ b/scripts/binary_release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# cspell:words czvf objcopy debuglink
+# cspell:words czvf objcopy debuglink dsymutil
 set -xeo pipefail
 
 release_type="${1:?Release type is required as the first argument}"

--- a/scripts/binary_release.sh
+++ b/scripts/binary_release.sh
@@ -51,6 +51,24 @@ run_cmd() {
   fi
 }
 
+# Split debug info out of a release binary into a `.debug` sibling file, then
+# strip the original. Adds a gnu-debuglink so gdb auto-finds the debug file
+# when both are alongside each other.
+function split_debug_info {
+  local binary_path="$1"
+  if [[ ! -x "${binary_path}" ]]; then
+    return 0
+  fi
+  if ! command -v objcopy >/dev/null 2>&1 || ! command -v strip >/dev/null 2>&1; then
+    echo "objcopy/strip not available; skipping debug-info split for ${binary_path}" >&2
+    return 0
+  fi
+  run_cmd objcopy --only-keep-debug "${binary_path}" "${binary_path}.debug"
+  run_cmd strip --strip-debug --strip-unneeded "${binary_path}"
+  run_cmd objcopy --add-gnu-debuglink="${binary_path}.debug" "${binary_path}"
+  run_cmd chmod 644 "${binary_path}.debug"
+}
+
 # cspell:words czvf
 function tar_binary {
   local src="$1"
@@ -88,6 +106,11 @@ function upload_release_binary {
 
   local sources=("target/release/${binary}" "${tar_file}")
   local destinations=("${binary}" "${tar_file}")
+  # Include the split-out debug file if it exists (for post-mortem debugging).
+  if [[ -f "target/release/${binary}.debug" ]]; then
+    sources+=("target/release/${binary}.debug")
+    destinations+=("${binary}.debug")
+  fi
 
   for i in "${!sources[@]}"; do
     local src=${sources[$i]}
@@ -106,10 +129,17 @@ function upload_binary {
   upload_s3 "target/release/${binary}" "${os_and_arch}/${branch}/${commit}/${folder}/${binary}"
 }
 
+# Build with full DWARF debug info, then split it into a separate file and
+# strip the binary. The shipped binary stays nearly the same size as before;
+# the .debug sibling is uploaded so post-mortem investigations have symbols.
+export CARGO_PROFILE_RELEASE_DEBUG=2
+export CARGO_PROFILE_RELEASE_STRIP=none
 run_cmd make $release_type
 
 if [ "$upload_action" = "upload-release" ]
 then
+  split_debug_info "target/release/neard"
+  split_debug_info "target/release/near-sandbox"
   upload_release_binary neard
   # near-sandbox is used by near-workspaces which is an SDK for end-to-end contracts testing that automatically 
   # spins up localnet using near-sandbox (neard with extra features useful for testing - state patching, time travel). 

--- a/scripts/binary_release.sh
+++ b/scripts/binary_release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# cspell:words czvf objcopy debuglink
 set -xeo pipefail
 
 release_type="${1:?Release type is required as the first argument}"
@@ -69,7 +70,6 @@ function split_debug_info {
   run_cmd chmod 644 "${binary_path}.debug"
 }
 
-# cspell:words czvf
 function tar_binary {
   local src="$1"
 
@@ -125,8 +125,16 @@ function upload_binary {
   local binary="$1"
   local folder="${release_type%-release}"
 
-  upload_s3 "target/release/${binary}" "${os_and_arch}/${branch}/${folder}/${binary}"
-  upload_s3 "target/release/${binary}" "${os_and_arch}/${branch}/${commit}/${folder}/${binary}"
+  local sources=("target/release/${binary}")
+  local destinations=("${binary}")
+  if [[ -f "target/release/${binary}.debug" ]]; then
+    sources+=("target/release/${binary}.debug")
+    destinations+=("${binary}.debug")
+  fi
+  for i in "${!sources[@]}"; do
+    upload_s3 "${sources[$i]}" "${os_and_arch}/${branch}/${folder}/${destinations[$i]}"
+    upload_s3 "${sources[$i]}" "${os_and_arch}/${branch}/${commit}/${folder}/${destinations[$i]}"
+  done
 }
 
 # Build with full DWARF debug info, then split it into a separate file and
@@ -136,10 +144,15 @@ export CARGO_PROFILE_RELEASE_DEBUG=2
 export CARGO_PROFILE_RELEASE_STRIP=none
 run_cmd make $release_type
 
+# Always split debug info — applies to all release types (release,
+# nightly-release, assertions-release, test-features-release). The
+# split_debug_info function is a no-op when the target binary doesn't exist
+# or when objcopy/strip aren't available (mac builds).
+split_debug_info "target/release/neard"
+split_debug_info "target/release/near-sandbox"
+
 if [ "$upload_action" = "upload-release" ]
 then
-  split_debug_info "target/release/neard"
-  split_debug_info "target/release/near-sandbox"
   upload_release_binary neard
   # near-sandbox is used by near-workspaces which is an SDK for end-to-end contracts testing that automatically 
   # spins up localnet using near-sandbox (neard with extra features useful for testing - state patching, time travel). 


### PR DESCRIPTION
Build release binaries with full debug info, then split it into a separate `.debug` file via `objcopy --only-keep-debug` + `strip --strip-debug`, and upload the `.debug` sibling alongside each binary to the same S3 paths.

`objcopy --add-gnu-debuglink` lets gdb auto-load symbols when a `.debug` is placed next to the binary, which makes post-mortem debugging on production binaries faster.