### PR TITLE
fix(chunk_application): detect memtrie cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [unreleased]
-
-### Protocol Changes
-* New opt-in strict nonce mode for transactions added in nightly. When enabled, each transaction must use a nonce exactly equal to the previous nonce for that access key plus one; nonces that repeat or skip values are rejected. ([#15361](https://github.com/near/nearcore/pull/15361), [#15402](https://github.com/near/nearcore/pull/15402))
-* Ensure delegate action returns the correct error consistently. ([#15458](https://github.com/near/nearcore/pull/15458))
-
 ## [2.12.0]
 
 ### Protocol Changes

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3378,6 +3378,20 @@ impl Chain {
             return Ok(None);
         }
 
+        // Register this in-flight apply_chunk job so memtrie GC can cancel us if the
+        // prev_block memtrie root we depend on is about to be pruned. We register at
+        // `prev_block.header().height()` — the height at which the memtrie root we
+        // need was inserted — NOT `block.height`, since they differ when heights are
+        // skipped and the cancel predicate must match `MemTries::delete_until_height`'s
+        // boundary exactly. The handle is moved into the spawned closure so it
+        // deregisters on completion; its `flag()` is plumbed into apply_chunk as a
+        // separate parameter so two competing forks each see only their own flag.
+        let cancel_handle = self
+            .runtime_adapter
+            .get_tries()
+            .register_apply_chunk(shard_uid, prev_block.header().height());
+        let cancel_flag = cancel_handle.flag();
+
         let chunk_header = chunk_headers.get(shard_index).ok_or(Error::InvalidShardId(shard_id))?;
         let is_new_chunk = chunk_header.is_new_chunk(block_height);
 
@@ -3484,12 +3498,17 @@ impl Chain {
             shard_id,
             cached_shard_update_key,
             Box::new(move |parent_span| -> Result<ShardUpdateResult, Error> {
+                // The cancel handle is moved into this closure so it lives exactly as
+                // long as the worker job; on closure return its slot is removed from
+                // the `ShardTries` registry.
+                let _cancel_handle = cancel_handle;
                 Ok(process_shard_update(
                     parent_span,
                     runtime.as_ref(),
                     shard_update_reason,
                     shard_context,
                     on_post_state_ready,
+                    Some(cancel_flag),
                 )?)
             }),
         )))

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -560,6 +560,7 @@ impl<'a> ChainUpdate<'a> {
             },
             &receipts,
             transactions,
+            None,
         )?;
 
         let (_, outcome_proofs) = ApplyChunkResult::compute_outcomes_proof(&apply_result.outcomes);
@@ -675,6 +676,7 @@ impl<'a> ChainUpdate<'a> {
             ),
             &[],
             SignedValidPeriodTransactions::empty(),
+            None,
         )?;
         let flat_storage_manager = self.runtime_adapter.get_flat_storage_manager();
         let store_update = flat_storage_manager.save_flat_state_changes(

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1155,11 +1155,25 @@ impl RuntimeAdapter for NightshadeRuntime {
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
         transactions: SignedValidPeriodTransactions,
+        cancel: Option<Arc<AtomicBool>>,
     ) -> Result<ApplyChunkResult, Error> {
         let shard_id = chunk.shard_id;
         let _timer = metrics::APPLYING_CHUNKS_TIME
             .with_label_values(&[&apply_reason.to_string(), &shard_id.to_string()])
             .start_timer();
+
+        // The `cancel` flag (if any) is flipped by
+        // `ShardTries::delete_memtrie_roots_up_to_height` when the prev_block
+        // memtrie root we depend on is about to be pruned. Each apply_chunk job
+        // owns its own `Arc<AtomicBool>` (registered in `get_update_shard_job`),
+        // so two distinct jobs at the same `(shard, height)` (e.g. competing
+        // forks) see only their own state.
+        let cancelled = || cancel.as_ref().is_some_and(|c| c.load(Ordering::Acquire));
+        if cancelled() {
+            return Err(Error::StorageError(StorageError::StorageInconsistentState(
+                "apply_chunk cancelled: memtrie root pruned by GC".into(),
+            )));
+        }
 
         let mut trie = match storage_config.source {
             StorageDataSource::Db => self.get_trie_for_shard(
@@ -1212,6 +1226,14 @@ impl RuntimeAdapter for NightshadeRuntime {
                 Error::StorageError(err) => match &err {
                     StorageError::FlatStorageBlockNotSupported(_)
                     | StorageError::MissingTrieValue(..) => Err(err.into()),
+                    // The memtrie root for prev_block can be pruned by
+                    // `delete_memtrie_roots_up_to_height` while a slow apply_chunk
+                    // job is still in flight (e.g. during a cold Wasmtime compile).
+                    // The GC site signals cancellation via the per-job flag in
+                    // `block.cancel`; if our flag was flipped, treat the storage
+                    // error as recoverable instead of panicking. Covers
+                    // optimistic, fork, and catchup workers uniformly.
+                    StorageError::StorageInconsistentState(_) if cancelled() => Err(err.into()),
                     _ => panic!("{err}"),
                 },
                 _ => Err(e),

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -279,6 +279,7 @@ impl TestEnv {
                 },
                 receipts,
                 transactions,
+                None,
             )
             .unwrap()
     }

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -584,6 +584,7 @@ pub fn validate_chunk_state_witness_impl(
                     ShardContext { shard_uid, should_apply_chunk: true },
                     runtime_adapter,
                     None,
+                    None,
                 )?;
                 let outgoing_receipts = std::mem::take(&mut main_apply_result.outgoing_receipts);
                 let chunk_extra = main_apply_result.to_chunk_extra(chunk_gas_limit);
@@ -666,6 +667,7 @@ pub fn validate_chunk_state_witness_impl(
                     old_chunk_data,
                     shard_context,
                     runtime_adapter,
+                    None,
                 )?;
                 let congestion_info = chunk_extra.congestion_info();
                 (shard_uid, apply_result.new_root, congestion_info)

--- a/chain/chain/src/stateless_validation/spice_chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/spice_chunk_validation.rs
@@ -214,6 +214,7 @@ pub fn spice_validate_chunk_state_witness(
             ShardContext { shard_uid, should_apply_chunk: true },
             runtime_adapter,
             None,
+            None,
         )?;
         let outgoing_receipts = std::mem::take(&mut main_apply_result.outgoing_receipts);
         let chunk_extra = main_apply_result.to_chunk_extra(gas_limit);
@@ -1504,6 +1505,7 @@ mod tests {
                 new_chunk_data,
                 ShardContext { shard_uid, should_apply_chunk: true },
                 self.chain.runtime_adapter.as_ref(),
+                None,
                 None,
             )
             .unwrap();

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -599,6 +599,13 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Apply transactions and receipts to given state root and return store update
     /// and new state root.
     /// Also returns transaction result for each transaction and new receipts.
+    ///
+    /// `cancel`, if `Some`, is an out-of-band cancellation flag flipped by
+    /// `ShardTries::delete_memtrie_roots_up_to_height` when the prev_block memtrie
+    /// root this apply depends on is about to be pruned. The runtime polls it and
+    /// bails with a recoverable error rather than panicking on missing memtrie
+    /// state. `None` for paths that don't register with `ShardTries`
+    /// (state-viewer tools, tests, code outside the live apply_chunks pool).
     fn apply_chunk(
         &self,
         storage: RuntimeStorageConfig,
@@ -607,6 +614,7 @@ pub trait RuntimeAdapter: Send + Sync {
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
         transactions: SignedValidPeriodTransactions,
+        cancel: Option<Arc<AtomicBool>>,
     ) -> Result<ApplyChunkResult, Error>;
 
     /// Query runtime with given `path` and `data`.

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -14,6 +14,8 @@ use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use near_primitives::types::{Gas, StateRoot};
 use node_runtime::{PostStateReadyCallback, SignedValidPeriodTransactions};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 /// Result of updating a shard for some block when it has a new chunk for this
 /// shard.
@@ -89,12 +91,19 @@ pub struct StorageContext {
 
 /// Processes shard update with given block and shard.
 /// Doesn't modify chain, only produces result to be applied later.
+///
+/// `cancel`, if `Some`, is the per-job cancellation flag flipped by
+/// `ShardTries::delete_memtrie_roots_up_to_height` when the prev_block memtrie
+/// root this update depends on is about to be pruned. The runtime polls it and
+/// returns a recoverable error rather than panicking. Pass `None` from paths
+/// that don't register with `ShardTries` (state-viewer tools, tests).
 pub fn process_shard_update(
     parent_span: &tracing::Span,
     runtime: &dyn RuntimeAdapter,
     shard_update_reason: ShardUpdateReason,
     shard_context: ShardContext,
     on_post_state_ready: Option<PostStateReadyCallback>,
+    cancel: Option<Arc<AtomicBool>>,
 ) -> Result<ShardUpdateResult, Error> {
     Ok(match shard_update_reason {
         ShardUpdateReason::NewChunk(data) => ShardUpdateResult::NewChunk(apply_new_chunk(
@@ -104,6 +113,7 @@ pub fn process_shard_update(
             shard_context,
             runtime,
             on_post_state_ready,
+            cancel,
         )?),
         ShardUpdateReason::OldChunk(data) => ShardUpdateResult::OldChunk(apply_old_chunk(
             ApplyChunkReason::UpdateTrackedShard,
@@ -111,6 +121,7 @@ pub fn process_shard_update(
             data,
             shard_context,
             runtime,
+            cancel,
         )?),
     })
 }
@@ -124,6 +135,7 @@ pub fn apply_new_chunk(
     shard_context: ShardContext,
     runtime: &dyn RuntimeAdapter,
     on_post_state_ready: Option<PostStateReadyCallback>,
+    cancel: Option<Arc<AtomicBool>>,
 ) -> Result<NewChunkResult, Error> {
     let NewChunkData {
         gas_limit,
@@ -170,6 +182,7 @@ pub fn apply_new_chunk(
         block,
         &receipts,
         transactions,
+        cancel,
     ) {
         Ok(apply_result) => {
             Ok(NewChunkResult { gas_limit, shard_uid: shard_context.shard_uid, apply_result })
@@ -187,6 +200,7 @@ pub fn apply_old_chunk(
     data: OldChunkData,
     shard_context: ShardContext,
     runtime: &dyn RuntimeAdapter,
+    cancel: Option<Arc<AtomicBool>>,
 ) -> Result<OldChunkResult, Error> {
     let OldChunkData { prev_chunk_extra, block, storage_context } = data;
     let shard_id = shard_context.shard_uid.shard_id();
@@ -220,6 +234,7 @@ pub fn apply_old_chunk(
         block,
         &[],
         SignedValidPeriodTransactions::empty(),
+        cancel,
     ) {
         Ok(apply_result) => Ok(OldChunkResult { shard_uid: shard_context.shard_uid, apply_result }),
         Err(err) => Err(err),

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -912,6 +912,7 @@ impl ChunkExecutorActor {
                     shard_update_reason,
                     ShardContext { shard_uid, should_apply_chunk: true },
                     None,
+                    None,
                 )?)
             }),
         ))

--- a/chain/client/src/tests/spice_chunk_validator_actor.rs
+++ b/chain/client/src/tests/spice_chunk_validator_actor.rs
@@ -526,6 +526,7 @@ fn simulate_chunk_application(
             },
             &TEST_RECEIPTS,
             transactions,
+            None,
         )
         .unwrap();
 

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -552,7 +552,7 @@ pub fn assert_supported_protocol_version(current_protocol_version: ProtocolVersi
 }
 
 /// Current protocol version used on the mainnet with all stable features.
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 85;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 84;
 
 // On nightly, pick big enough version to support all features.
 const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 153;

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -26,6 +26,7 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::instrument;
 
 /// Result of a background memtrie loading: the loaded memtries and the
@@ -71,10 +72,57 @@ struct ShardTriesInner {
     /// the memtrie is being loaded in a background thread. The receiver will yield the loaded
     /// `MemTries` once the thread completes.
     memtries_loading: Mutex<HashMap<ShardUId, MemtrieLoadingEntry>>,
+    /// In-flight apply_chunk jobs registered for cancellation when memtrie roots they
+    /// depend on are about to be pruned. Each entry is
+    /// `(shard_uid, prev_block_height, flag)`, where `prev_block_height` is the
+    /// height at which the memtrie root the job reads was inserted — i.e. the
+    /// `prev_block`'s height, NOT the height of the block being applied (these
+    /// differ when heights are skipped). The cancel predicate mirrors
+    /// `MemTries::delete_until_height` exactly: a job is cancelled when its
+    /// `prev_block_height` is strictly less than the pruning threshold. On drop,
+    /// the corresponding `ApplyChunkCancelHandle` removes its slot. Linear scan
+    /// is fine — at any moment the registry holds at most a handful of entries.
+    apply_chunk_cancel_flags: Mutex<Vec<(ShardUId, BlockHeight, Arc<AtomicBool>)>>,
 }
 
 #[derive(Clone)]
 pub struct ShardTries(Arc<ShardTriesInner>);
+
+/// RAII guard for an `apply_chunk` job registered with [`ShardTries::register_apply_chunk`].
+///
+/// While this handle is alive, the registry knows about the
+/// `(shard_uid, prev_block_height)` job and `delete_memtrie_roots_up_to_height`
+/// can signal cancellation to it. On `Drop`, the handle removes its slot from
+/// the registry. Workers don't query the registry directly — they hold a clone
+/// of [`flag`](Self::flag) and load that atomic, so two distinct registrations
+/// at the same key (e.g. two competing forks whose prev_block is at the same
+/// height) each see only their own state.
+pub struct ApplyChunkCancelHandle {
+    shard_uid: ShardUId,
+    prev_block_height: BlockHeight,
+    flag: Arc<AtomicBool>,
+    inner: Arc<ShardTriesInner>,
+}
+
+impl ApplyChunkCancelHandle {
+    /// Clone of the cancel flag for this job. Pass to workers (e.g. via
+    /// `ApplyChunkBlockContext::cancel`) so they can check their own state without
+    /// going through the shared registry.
+    pub fn flag(&self) -> Arc<AtomicBool> {
+        self.flag.clone()
+    }
+}
+
+impl Drop for ApplyChunkCancelHandle {
+    fn drop(&mut self) {
+        let mut flags = self.inner.apply_chunk_cancel_flags.lock();
+        if let Some(pos) = flags.iter().position(|(uid, h, f)| {
+            *uid == self.shard_uid && *h == self.prev_block_height && Arc::ptr_eq(f, &self.flag)
+        }) {
+            flags.swap_remove(pos);
+        }
+    }
+}
 
 impl ShardTries {
     pub fn new(
@@ -96,6 +144,7 @@ impl ShardTries {
             state_snapshot_config,
             temp_split_shard_map: Default::default(),
             memtries_loading: Default::default(),
+            apply_chunk_cancel_flags: Default::default(),
         }))
     }
 
@@ -637,10 +686,48 @@ impl ShardTries {
 
     /// Garbage collects the in-memory tries for the shard up to (and including) the given
     /// height.
+    ///
+    /// Before pruning, signal cancellation to any in-flight `apply_chunk` jobs whose
+    /// memtrie root is about to disappear. The cancel predicate
+    /// (`prev_block_height < height`) mirrors `MemTries::delete_until_height`'s
+    /// own deletion predicate (`inserted_height < height`) so the boundary is
+    /// computed identically — this is robust to skipped heights, where a job's
+    /// `prev_block_height` is not simply `block.height - 1`.
     pub fn delete_memtrie_roots_up_to_height(&self, shard_uid: ShardUId, height: BlockHeight) {
+        {
+            let flags = self.0.apply_chunk_cancel_flags.lock();
+            for (uid, prev_block_height, flag) in flags.iter() {
+                if *uid == shard_uid && *prev_block_height < height {
+                    flag.store(true, Ordering::Release);
+                }
+            }
+        }
         if let Some(memtries) = self.get_memtries(shard_uid) {
             memtries.write().delete_until_height(height);
         }
+    }
+
+    /// Register an in-flight `apply_chunk` job.
+    ///
+    /// `prev_block_height` is the height at which the memtrie root the job will
+    /// read was inserted — i.e. `prev_block.header().height()`. **Do not pass
+    /// the height of the block being applied**: with skipped heights they are
+    /// not equal, and the cancel predicate would miss the prune.
+    ///
+    /// The returned [`ApplyChunkCancelHandle`] is a RAII guard: hold it for the
+    /// duration of the job (e.g. by capturing it in the closure spawned on the
+    /// apply_chunks worker pool). When dropped, its slot is removed from the
+    /// registry. While the slot is alive, [`delete_memtrie_roots_up_to_height`]
+    /// can flip its flag, and the worker observes the flip by loading from a
+    /// clone of [`ApplyChunkCancelHandle::flag`].
+    pub fn register_apply_chunk(
+        &self,
+        shard_uid: ShardUId,
+        prev_block_height: BlockHeight,
+    ) -> ApplyChunkCancelHandle {
+        let flag = Arc::new(AtomicBool::new(false));
+        self.0.apply_chunk_cancel_flags.lock().push((shard_uid, prev_block_height, flag.clone()));
+        ApplyChunkCancelHandle { shard_uid, prev_block_height, flag, inner: self.0.clone() }
     }
 
     /// Freezes in-memory trie for parent shard and copies reference from it to children shards.
@@ -1101,5 +1188,66 @@ mod test {
         let insert_ops = Vec::from([(&key, Some(val.as_slice()))]);
         trie.update_cache(insert_ops, shard_uid);
         assert!(trie_caches.lock().get(&shard_uid).unwrap().get(&key).is_none());
+    }
+
+    #[test]
+    fn test_apply_chunk_cancel_signal() {
+        let tries = create_trie();
+        let shard_a = ShardUId { version: 1, shard_id: 0 };
+        let shard_b = ShardUId { version: 1, shard_id: 1 };
+
+        // Each handle is registered with its `prev_block_height` — the height
+        // at which the memtrie root the job reads was inserted.
+        let prev10 = tries.register_apply_chunk(shard_a, 10);
+        let prev11 = tries.register_apply_chunk(shard_a, 11);
+        let prev12_b = tries.register_apply_chunk(shard_b, 12);
+
+        // Initially nothing is cancelled.
+        assert!(!prev10.flag().load(Ordering::Acquire));
+        assert!(!prev11.flag().load(Ordering::Acquire));
+        assert!(!prev12_b.flag().load(Ordering::Acquire));
+
+        // `delete_memtrie_roots_up_to_height(shard_a, 11)` deletes memtrie
+        // entries inserted at heights `< 11`, i.e. height 10 (and below).
+        // The cancel predicate uses the same `<` boundary, so:
+        //   - prev10 (depends on root at 10): cancelled ✓
+        //   - prev11 (depends on root at 11): NOT cancelled (11 is still there)
+        //   - prev12_b: different shard, untouched
+        tries.delete_memtrie_roots_up_to_height(shard_a, 11);
+        assert!(prev10.flag().load(Ordering::Acquire));
+        assert!(!prev11.flag().load(Ordering::Acquire));
+        assert!(!prev12_b.flag().load(Ordering::Acquire));
+
+        // Pruning at 12 does delete root 11, so prev11 is cancelled now.
+        tries.delete_memtrie_roots_up_to_height(shard_a, 12);
+        assert!(prev11.flag().load(Ordering::Acquire));
+        assert!(!prev12_b.flag().load(Ordering::Acquire));
+
+        // Skipped-height case: a fork block whose prev_block is at height 8
+        // (i.e. heights 9, 10 skipped). Pruning at height 9 must cancel it,
+        // because the dep root at 8 is freed (`8 < 9`). With the buggy
+        // `block_height <= prune_height` predicate, registering by the block's
+        // own height (say 11) and pruning at 9 would incorrectly skip it.
+        let skipped_dep = tries.register_apply_chunk(shard_a, 8);
+        tries.delete_memtrie_roots_up_to_height(shard_a, 9);
+        assert!(skipped_dep.flag().load(Ordering::Acquire));
+
+        // Fork-collision: two distinct registrations at the same key see only
+        // their own flag. Re-register at prev_block_height=12 (still alive
+        // since we only pruned up to 12 — heights `< 12`).
+        let prev12_a_fresh = tries.register_apply_chunk(shard_a, 12);
+        assert!(!prev12_a_fresh.flag().load(Ordering::Acquire));
+
+        // Pruning at 13 cancels both shard_a entries at height 12.
+        tries.delete_memtrie_roots_up_to_height(shard_a, 13);
+        assert!(prev12_a_fresh.flag().load(Ordering::Acquire));
+        assert!(!prev12_b.flag().load(Ordering::Acquire), "shard_b unaffected");
+
+        drop(prev10);
+        drop(prev11);
+        drop(prev12_b);
+        drop(skipped_dep);
+        drop(prev12_a_fresh);
+        assert_eq!(tries.0.apply_chunk_cancel_flags.lock().len(), 0);
     }
 }

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -336,8 +336,14 @@ impl ReplayController {
             })
         };
 
-        let shard_update_result =
-            process_shard_update(&span, self.runtime.as_ref(), update_reason, shard_context, None)?;
+        let shard_update_result = process_shard_update(
+            &span,
+            self.runtime.as_ref(),
+            update_reason,
+            shard_context,
+            None,
+            None,
+        )?;
 
         let output = match shard_update_result {
             ShardUpdateResult::NewChunk(NewChunkResult {

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -112,6 +112,7 @@ fn apply_chunk_from_input(
             block_context,
             &receipts,
             transactions,
+            None,
         )
         .unwrap()
 }

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -190,6 +190,7 @@ pub fn apply_chunk(
             },
             &receipts,
             SignedValidPeriodTransactions::new(transactions, valid_txs),
+            None,
         )?,
         chunk_header.gas_limit(),
     ))

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -118,6 +118,7 @@ pub(crate) fn apply_block(
                 ),
                 &receipts,
                 SignedValidPeriodTransactions::new(transactions, valid_txs),
+                None,
             )
             .unwrap()
     } else {
@@ -144,6 +145,7 @@ pub(crate) fn apply_block(
                 ),
                 &[],
                 SignedValidPeriodTransactions::empty(),
+                None,
             )
             .unwrap()
     };


### PR DESCRIPTION
This fix sends a per-job cancellation signal from ShardTries::delete_memtrie_roots_up_to_height to the in-flight worker so it bails with a recoverable error.