### PR TITLE
refactor: collapse nested if-let into let chains

### DIFF
--- a/chain/network/src/peer_manager/peer_store/mod.rs
+++ b/chain/network/src/peer_manager/peer_store/mod.rs
@@ -161,10 +161,10 @@ impl Inner {
     /// Deletes peers from the internal cache
     fn delete_peers(&mut self, peer_ids: &[PeerId]) {
         for peer_id in peer_ids {
-            if let Some(peer_state) = self.peer_states.pop(peer_id) {
-                if let Some(addr) = peer_state.peer_info.addr {
-                    self.addr_peers.remove(&addr);
-                }
+            if let Some(peer_state) = self.peer_states.pop(peer_id)
+                && let Some(addr) = peer_state.peer_info.addr
+            {
+                self.addr_peers.remove(&addr);
             }
         }
     }
@@ -197,10 +197,10 @@ impl Inner {
         }
 
         // If this peer already has an address, remove that pair from the index.
-        if let Some(peer_state) = self.peer_states.get_mut(&peer_info.id) {
-            if let Some(cur_addr) = peer_state.peer_info.addr.take() {
-                self.addr_peers.remove(&cur_addr);
-            }
+        if let Some(peer_state) = self.peer_states.get_mut(&peer_info.id)
+            && let Some(cur_addr) = peer_state.peer_info.addr.take()
+        {
+            self.addr_peers.remove(&cur_addr);
         }
 
         // Add new address

--- a/core/primitives/src/action/delegate.rs
+++ b/core/primitives/src/action/delegate.rs
@@ -128,17 +128,17 @@ impl schemars::JsonSchema for NonDelegateAction {
         let mut action_schema = Action::json_schema(generator);
 
         // Find and filter the oneOf array directly on the Schema object
-        if let Some(one_of) = action_schema.get_mut("oneOf") {
-            if let Some(arr) = one_of.as_array_mut() {
-                // Remove the Delegate variant
-                arr.retain(|variant| {
-                    !variant
-                        .get("properties")
-                        .and_then(|p| p.as_object())
-                        .map(|p| p.contains_key("Delegate"))
-                        .unwrap_or(false)
-                });
-            }
+        if let Some(one_of) = action_schema.get_mut("oneOf")
+            && let Some(arr) = one_of.as_array_mut()
+        {
+            // Remove the Delegate variant
+            arr.retain(|variant| {
+                !variant
+                    .get("properties")
+                    .and_then(|p| p.as_object())
+                    .map(|p| p.contains_key("Delegate"))
+                    .unwrap_or(false)
+            });
         }
 
         // Update description to be more client-friendly

--- a/core/store/src/contract.rs
+++ b/core/store/src/contract.rs
@@ -109,10 +109,10 @@ impl ContractStorage {
             // Note that this does not cause any correctness issue, because the pipeline stops processing when
             // it hits a new deployment, so the contract requested by the pipeline will not be in the committed or
             // uncommitted deployment list.
-            if let Some(tracker) = guard.as_ref() {
-                if let Some(contract) = tracker.get(code_hash.into()) {
-                    return Some(ContractCode::new(contract.code().to_vec(), Some(code_hash)));
-                }
+            if let Some(tracker) = guard.as_ref()
+                && let Some(contract) = tracker.get(code_hash.into())
+            {
+                return Some(ContractCode::new(contract.code().to_vec(), Some(code_hash)));
             }
         }
 

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -365,10 +365,10 @@ pub fn verify_and_charge_tx_ephemeral(
     };
 
     // Validate FunctionCall permission constraints if applicable
-    if let Some(function_call_permission) = access_key.permission.function_call_permission() {
-        if let Err(e) = verify_function_call_permission(function_call_permission, tx) {
-            return TxVerdict::Failed(e);
-        }
+    if let Some(function_call_permission) = access_key.permission.function_call_permission()
+        && let Err(e) = verify_function_call_permission(function_call_permission, tx)
+    {
+        return TxVerdict::Failed(e);
     }
 
     TxVerdict::Success(VerificationResult {
@@ -469,10 +469,10 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
     let new_gas_key_balance = gas_key_info.balance.checked_sub(gas_cost).unwrap();
 
     // Validate FunctionCall permission constraints if applicable
-    if let Some(function_call_permission) = access_key.permission.function_call_permission() {
-        if let Err(e) = verify_function_call_permission(function_call_permission, tx) {
-            return TxVerdict::Failed(e);
-        }
+    if let Some(function_call_permission) = access_key.permission.function_call_permission()
+        && let Err(e) = verify_function_call_permission(function_call_permission, tx)
+    {
+        return TxVerdict::Failed(e);
     }
     let gas_key_update =
         AccessKeyUpdate::GasKey { new_balance: new_gas_key_balance, nonce_index, nonce: tx_nonce };


### PR DESCRIPTION
Rust 1.88 stabilized let chains, allowing multiple let-bindings and boolean conditions to be combined in a single if expression. Apply this to a handful of two-level nested if-let blocks.