### PR TITLE
refactor: use strict_* integer arithmetic methods

### DIFF
--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -644,7 +644,7 @@ mod tests {
         let transactions = generate_transactions("alice.near", "alice.near", 1, 100);
         // Each transaction is at least 1 byte in size, so the last transaction will not fit.
         let pool_size_limit =
-            transactions.iter().map(|tx| tx.get_size()).sum::<u64>().checked_sub(1).unwrap();
+            transactions.iter().map(|tx| tx.get_size()).sum::<u64>().strict_sub(1);
         let mut pool = TransactionPool::new(TEST_SEED, Some(pool_size_limit), "");
         for (i, tx) in transactions.iter().cloned().enumerate() {
             if i + 1 < transactions.len() {

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -12,7 +12,7 @@ use tracing::span::EnteredSpan;
 pub type ReedSolomonPart = Option<Box<[u8]>>;
 
 pub const REED_SOLOMON_MAX_PARTS: usize = reed_solomon_erasure::galois_8::Field::ORDER;
-const MAX_ENCODED_LENGTH: usize = 512usize.checked_mul(bytesize::MIB as usize).unwrap();
+const MAX_ENCODED_LENGTH: usize = 512usize.strict_mul(bytesize::MIB as usize);
 
 // Encode function takes a serializable object and returns a tuple of parts and length of encoded data
 pub fn reed_solomon_encode<T: BorshSerialize>(

--- a/core/store/src/trie/mem/node/encoding.rs
+++ b/core/store/src/trie/mem/node/encoding.rs
@@ -230,7 +230,7 @@ impl MemTrieNodeId {
         // Refcount is always encoded as the first four bytes of the node memory.
         let refcount_memory = memory.raw_slice_mut(self.pos, size_of::<u32>());
         let refcount = u32::from_le_bytes(refcount_memory.try_into().unwrap());
-        let new_refcount = refcount.checked_add(1).unwrap();
+        let new_refcount = refcount.strict_add(1);
         refcount_memory.copy_from_slice(new_refcount.to_le_bytes().as_ref());
         new_refcount
     }
@@ -247,7 +247,7 @@ impl MemTrieNodeId {
         // cspell:words unref
         let refcount_memory = arena.memory_mut().raw_slice_mut(self.pos, size_of::<u32>());
         let refcount = u32::from_le_bytes(refcount_memory.try_into().unwrap());
-        let new_refcount = refcount.checked_sub(1).unwrap();
+        let new_refcount = refcount.strict_sub(1);
         refcount_memory.copy_from_slice(new_refcount.to_le_bytes().as_ref());
         if new_refcount == 0 {
             let mut children_to_unref: SmallVec<[ArenaPos; NUM_CHILDREN]> = SmallVec::new();

--- a/runtime/near-vm/compiler-singlepass/src/machine.rs
+++ b/runtime/near-vm/compiler-singlepass/src/machine.rs
@@ -427,7 +427,7 @@ impl Machine {
         // so we won't skip the stack guard page here.
         self.locals_offset = MachineStackOffset(self.stack_offset.0 + 8); // + 8 because locals_offset is supposed to point to 1st local
         let params_size =
-            (n_params as usize).saturating_sub(Self::LOCAL_REGISTERS.len()).checked_mul(8).unwrap();
+            (n_params as usize).saturating_sub(Self::LOCAL_REGISTERS.len()).strict_mul(8);
         self.decrease_rsp(a, params_size);
         for i in 0..n_params {
             // NB: the 0th parameter is used for passing around the internal VM data (vmctx).
@@ -472,7 +472,7 @@ impl Machine {
             Self::LOCAL_REGISTERS.len().saturating_sub(n_params as usize);
         let locals_to_init = (n - n_params) as usize;
         let locals_size =
-            locals_to_init.saturating_sub(registers_remaining_for_locals).checked_mul(8).unwrap();
+            locals_to_init.saturating_sub(registers_remaining_for_locals).strict_mul(8);
 
         // Allocate the stack, without actually writing to it.
         self.decrease_rsp(a, locals_size);

--- a/runtime/near-vm/compiler/src/relocation.rs
+++ b/runtime/near-vm/compiler/src/relocation.rs
@@ -120,7 +120,7 @@ impl Relocation {
             | RelocationKind::Arm64Movw3 => {
                 let reloc_address = start + self.offset as usize;
                 let reloc_addend = self.addend as isize;
-                let reloc_abs = target_func_address.checked_add(reloc_addend as u64).unwrap();
+                let reloc_abs = target_func_address.strict_add(reloc_addend as u64);
                 (reloc_address, reloc_abs)
             }
             RelocationKind::X86PCRel4 => {

--- a/runtime/near-vm/vm/src/memory/linear_memory.rs
+++ b/runtime/near-vm/vm/src/memory/linear_memory.rs
@@ -129,7 +129,7 @@ impl LinearMemory {
             }
         };
         let minimum_bytes = minimum_pages.bytes().0;
-        let request_bytes = minimum_bytes.checked_add(offset_guard_bytes).unwrap();
+        let request_bytes = minimum_bytes.strict_add(offset_guard_bytes);
         let mapped_pages = memory.minimum;
         let mapped_bytes = mapped_pages.bytes();
 

--- a/runtime/near-vm/vm/src/vmoffsets.rs
+++ b/runtime/near-vm/vm/src/vmoffsets.rs
@@ -168,10 +168,7 @@ impl VMOffsets {
             prev_item_size: u32,
             next_item_align: usize,
         ) -> u32 {
-            align(
-                base.checked_add(num_items.checked_mul(prev_item_size).unwrap()).unwrap(),
-                next_item_align as u32,
-            )
+            align(base.strict_add(num_items.strict_mul(prev_item_size)), next_item_align as u32)
         }
 
         self.vmctx_signature_ids_begin = 0;
@@ -241,8 +238,8 @@ impl VMOffsets {
             u32::from(self.pointer_size),
             align_of::<u32>(),
         );
-        self.vmctx_stack_limit_initial_begin = self.vmctx_stack_limit_begin.checked_add(4).unwrap();
-        self.size_of_vmctx = self.vmctx_stack_limit_begin.checked_add(4).unwrap();
+        self.vmctx_stack_limit_initial_begin = self.vmctx_stack_limit_begin.strict_add(4);
+        self.size_of_vmctx = self.vmctx_stack_limit_begin.strict_add(4);
     }
 }
 


### PR DESCRIPTION
Replace `x.checked_OP(y).unwrap()` with `x.strict_OP(y)` (stable in Rust 1.91) on plain-integer types. Both panic on overflow with the same generic message; `strict_*` is more concise and signals intent.

10 sites across 7 files in `near-primitives`, `near-store`, `near-vm-*`, and `near-pool`.

Notes on scope:
- Custom wrapper types — `Balance`/`NearToken` (third-party) and our `Gas` — don't expose `strict_*` methods, so most arithmetic sites (the majority of `checked_*().unwrap()` calls in the workspace) were left alone.
- No clippy lint enforces `strict_*` over `checked_*().unwrap()`, so this isn't enforceable via workspace lints.