### PR TITLE
chore: drop enable_const_type_id cfg and fix latent unexpected_cfgs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,10 +136,6 @@ unnecessary_join = "deny"
 unnecessary_lazy_evaluations = "deny"
 unused_async = "deny"
 
-[workspace.lints.rust]
-# Will take effect since Rust 1.80, produces unused warning before it: https://github.com/rust-lang/cargo/pull/13913
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(enable_const_type_id)'] }
-
 [workspace.dependencies]
 anyhow = "1.0.62"
 arbitrary = { version = "1.2.3", features = ["derive"] }

--- a/Justfile
+++ b/Justfile
@@ -139,16 +139,8 @@ check-lychee:
              else { "Note: 'Too Many Requests' errors are allowed here but not in CI, set GITHUB_TOKEN to check them" } }}
 
 # check tools/protocol-schema-check/res/protocol_schema.toml
-# On MacOS, not all structs are collected by `inventory`. Non-incremental build fixes that.
-# See https://github.com/dtolnay/inventory/issues/52.
-protocol_schema_env := "CARGO_TARGET_DIR=" + justfile_directory() + "/target/schema-check RUSTC_BOOTSTRAP=1 RUSTFLAGS='--cfg enable_const_type_id' CARGO_INCREMENTAL=0"
+protocol_schema_env := "CARGO_TARGET_DIR=" + justfile_directory() + "/target/schema-check"
 check-protocol-schema:
-    # Below, we *should* have been used `cargo +nightly ...` instead of
-    # `RUSTC_BOOTSTRAP=1`. However, the env var appears to be more stable.
-    # `nightly` builds are updated daily and may be broken sometimes, e.g.
-    # https://github.com/rust-lang/rust/issues/130769.
-    #
-    # If there is an issue with the env var, fall back to `cargo +nightly ...`.
     env {{protocol_schema_env}} cargo test -p protocol-schema-check --profile dev-artifacts
     env {{protocol_schema_env}} cargo run -p protocol-schema-check --profile dev-artifacts
 

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -73,6 +73,8 @@ harness = false
 # if enabled, we assert in most situations that are impossible unless some byzantine behavior is observed.
 byzantine_asserts = ["near-chain/byzantine_asserts"]
 shadow_chunk_validation = ["near-chain/shadow_chunk_validation"]
+# Opt-in for tests that need real GCS credentials (read from SERVICE_ACCOUNT env var).
+gcs_credentials = []
 protocol_feature_spice = [
     "near-chain/protocol_feature_spice",
     "near-epoch-manager/protocol_feature_spice",

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1794,7 +1794,7 @@ impl EpochManager {
             return Ok(None);
         }
 
-        if cfg!(debug) {
+        if cfg!(debug_assertions) {
             let agg_hash = self.epoch_info_aggregator.last_block_hash;
             let agg_height = self.get_block_info(&agg_hash)?.height();
             let block_height = self.get_block_info(block_hash)?.height();

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1794,16 +1794,6 @@ impl EpochManager {
             return Ok(None);
         }
 
-        if cfg!(debug_assertions) {
-            let agg_hash = self.epoch_info_aggregator.last_block_hash;
-            let agg_height = self.get_block_info(&agg_hash)?.height();
-            let block_height = self.get_block_info(block_hash)?.height();
-            assert!(
-                agg_height < block_height,
-                "#{agg_hash} {agg_height} >= #{block_hash} {block_height}",
-            );
-        }
-
         let epoch_id = *self.get_block_info(block_hash)?.epoch_id();
         let epoch_info = self.get_epoch_info(&epoch_id)?;
         let shard_layout = self.get_shard_layout(&epoch_id)?;

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -22,9 +22,7 @@ pub(crate) struct AccountBalanceRequest {
 /// an account has a balance for each AccountIdentifier describing it (ex: an
 /// ERC-20 token balance on a few smart contracts), an account balance request
 /// must be made with each AccountIdentifier.
-/// cspell:words frunk
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub(crate) struct AccountBalanceResponse {
     pub block_identifier: BlockIdentifier,
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -320,8 +320,6 @@ pub struct GasKeyNoncesView {
     pub nonces: Vec<Nonce>,
 }
 
-// cspell:words deepsize
-#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KnownPeerStateView {
@@ -333,7 +331,6 @@ pub struct KnownPeerStateView {
     pub last_attempt: Option<(i64, String)>,
 }
 
-#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ConnectionInfoView {
@@ -343,7 +340,6 @@ pub struct ConnectionInfoView {
     pub time_connected_until: i64,
 }
 
-#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SnapshotHostInfoView {
@@ -353,7 +349,6 @@ pub struct SnapshotHostInfoView {
     pub shards: Vec<u64>,
 }
 
-#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum QueryResponseKind {
     ViewAccount(AccountView),
@@ -1982,7 +1977,6 @@ impl ExecutionOutcomeView {
     }
 }
 
-#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(
     BorshSerialize,
     BorshDeserialize,

--- a/core/schema-checker/schema-checker-core/src/lib.rs
+++ b/core/schema-checker/schema-checker-core/src/lib.rs
@@ -66,7 +66,7 @@ macro_rules! primitive_impl {
         $(
             impl ProtocolSchema for $t {}
 
-            #[cfg(all(enable_const_type_id, feature = "protocol_schema"))]
+            #[cfg(feature = "protocol_schema")]
             inventory::submit! {
                 ProtocolSchemaInfo::Struct {
                     name: stringify!($t),

--- a/core/schema-checker/schema-checker-macro/src/lib.rs
+++ b/core/schema-checker/schema-checker-macro/src/lib.rs
@@ -5,7 +5,7 @@ pub fn protocol_schema(input: TokenStream) -> TokenStream {
     helper::protocol_schema_impl(input)
 }
 
-#[cfg(all(enable_const_type_id, feature = "protocol_schema"))]
+#[cfg(feature = "protocol_schema")]
 mod helper {
     use proc_macro::TokenStream;
     use proc_macro2::TokenStream as TokenStream2;
@@ -285,7 +285,7 @@ mod helper {
     }
 }
 
-#[cfg(not(all(enable_const_type_id, feature = "protocol_schema")))]
+#[cfg(not(feature = "protocol_schema"))]
 mod helper {
     use proc_macro::TokenStream;
 

--- a/core/store/src/archive/cloud_storage/config.rs
+++ b/core/store/src/archive/cloud_storage/config.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 /// Configuration for a cloud-based archival node.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CloudArchivalConfig {
     /// The storage location of the archival data.
     pub location: ExternalStorageLocation,

--- a/runtime/near-vm/compiler-test-derive/src/lib.rs
+++ b/runtime/near-vm/compiler-test-derive/src/lib.rs
@@ -91,7 +91,6 @@ pub fn compiler_test(attrs: TokenStream, input: TokenStream) -> TokenStream {
             let mod_name = ::quote::format_ident!("{}", compiler_name.to_lowercase());
             let universal_engine_test =
                 construct_engine_test(func, compiler_name, "Universal", "universal");
-            let dylib_engine_test = construct_engine_test(func, compiler_name, "Dylib", "dylib");
             let compiler_name_lowercase = compiler_name.to_lowercase();
 
             quote! {
@@ -100,7 +99,6 @@ pub fn compiler_test(attrs: TokenStream, input: TokenStream) -> TokenStream {
                     use super::*;
 
                     #universal_engine_test
-                    #dylib_engine_test
                 }
             }
         };

--- a/runtime/near-vm/test-api/src/sys/store.rs
+++ b/runtime/near-vm/test-api/src/sys/store.rs
@@ -88,9 +88,6 @@ impl Default for Store {
                     near_vm_engine::universal::Universal::new(config)
                         .code_memory_pool(pool)
                         .engine()
-                } else if #[cfg(feature = "default-dylib")] {
-                    near_vm_engine_dylib::Dylib::new(config)
-                        .engine()
                 } else {
                     compile_error!("No default engine chosen")
                 }

--- a/runtime/near-vm/tests/compilers/wast.rs
+++ b/runtime/near-vm/tests/compilers/wast.rs
@@ -42,9 +42,6 @@ pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()
     wast.allow_trap_message("uninitialized element 2", "uninitialized element");
     // `liking.wast` has different wording but the same meaning
     wast.allow_trap_message("out of bounds memory access", "memory out of bounds");
-    if cfg!(feature = "coverage") {
-        wast.disable_assert_and_exhaustion();
-    }
     if is_simd {
         // We allow this, so tests can be run properly for `simd_const` test.
         wast.allow_instantiation_failures(&[

--- a/runtime/near-vm/vm/src/probestack/rust_lang_probestack.rs
+++ b/runtime/near-vm/vm/src/probestack/rust_lang_probestack.rs
@@ -57,8 +57,6 @@
 
 // Windows already has builtins to do this.
 #![cfg(not(windows))]
-// All these builtins require assembly
-#![cfg(not(feature = "no-asm"))]
 // We only define stack probing for these architectures today.
 #![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 

--- a/runtime/runtime-params-estimator/estimator-warehouse/src/estimate.rs
+++ b/runtime/runtime-params-estimator/estimator-warehouse/src/estimate.rs
@@ -1,3 +1,6 @@
+// `xshell::cmd!` emits `cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)`.
+#![allow(unexpected_cfgs)]
+
 use crate::{db::Db, import::ImportConfig};
 use nix::unistd::Uid;
 use xshell::{Shell, cmd};

--- a/runtime/runtime-params-estimator/estimator-warehouse/src/estimate.rs
+++ b/runtime/runtime-params-estimator/estimator-warehouse/src/estimate.rs
@@ -1,3 +1,4 @@
+// cspell:words cfgs
 // `xshell::cmd!` emits `cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)`.
 #![allow(unexpected_cfgs)]
 

--- a/tools/protocol-schema-check/README.md
+++ b/tools/protocol-schema-check/README.md
@@ -20,9 +20,7 @@ For context on why this tool is necessary, refer to [this pull request](https://
 ## Usage
 
 Run the tool locally using:
-`RUSTFLAGS="--cfg enable_const_type_id" cargo +nightly run -p protocol-schema-check`
-
-On MacOS, prepend this with `CARGO_INCREMENTAL=0` to avoid a [known issue](https://github.com/dtolnay/inventory/issues/52) with incremental compilation.
+`cargo run -p protocol-schema-check`
 
 ## What To Do If It Fails
 

--- a/tools/protocol-schema-check/src/main.rs
+++ b/tools/protocol-schema-check/src/main.rs
@@ -91,18 +91,6 @@ fn compute_type_hash(
 const PROTOCOL_SCHEMA_FILE: &str = "protocol_schema.toml";
 
 fn main() {
-    #[cfg(enable_const_type_id)]
-    {
-        // For some reason, `LatestWitnessesInfo` structs is not picked up
-        // on macos. This is a workaround around that. It is enough to put only
-        // `LatestWitnessesInfo` and `ServerError` here but I don't know why as well.
-        // The issue may be related to the large size of crates. Other workaround
-        // is to move these types to smaller crates.
-        // TODO (#11755): find the reason and remove this workaround.
-        LatestWitnessesInfo::ensure_registration();
-        ServerError::ensure_registration();
-    }
-
     let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("res").join(PROTOCOL_SCHEMA_FILE);
     let target_dir = std::env::var("CARGO_TARGET_DIR")
         .map(std::path::PathBuf::from)
@@ -166,7 +154,7 @@ fn main() {
     }
 }
 
-#[cfg(all(test, enable_const_type_id))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use near_schema_checker_lib::ProtocolSchema;


### PR DESCRIPTION
Follow-up to #15714. With the `const_type_id` feature stable since Rust 1.91 the surrounding scaffolding is dead and can be removed.

Removing the workspace-wide `unexpected_cfgs = "allow"` also exposed a handful of pre-existing latent issues that were silently being suppressed — dead derives left behind by old refactors, leftover cfg branches from vendored wasmer code, an undeclared feature, and one assertion guard that was inert due to a `cfg!(debug)` typo.

### `enable_const_type_id` removal
- Drop the cfg from `tools/protocol-schema-check` and the schema-checker macro/core — always emit the real impl, still feature-gated on `protocol_schema`.
- Drop `RUSTC_BOOTSTRAP=1 RUSTFLAGS='--cfg enable_const_type_id'` from the Justfile and the README usage instructions.

### MacOS / inventory workarounds (now obsolete)
- Drop `CARGO_INCREMENTAL=0`. The upstream rustc bug (rust-lang/rust#133491) was fixed in 1.87; verified empirically by running with `CARGO_INCREMENTAL=1` on macOS — all 378 structs are picked up.
- Drop the `LatestWitnessesInfo`/`ServerError` explicit `ensure_registration()` calls. Verified by probe-modifying both structs and confirming the schema check still flags the mismatches.

### Dead derives / cfg branches surfaced by tightening unexpected_cfgs
- `near-primitives::views`: remove dead `#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]`. The `deepsize` crate was removed in #7796 (2022); these were copy-pasted into new view structs added later.
- `near-store::CloudArchivalConfig`: remove dead `#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]`. The struct lives on the on-disk node config, never in an RPC response.
- `near-rosetta-rpc`: remove dead `#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]`. `frunk` isn't a workspace dependency.
- `near-vm-vm`: drop dead `#![cfg(not(feature = "no-asm"))]` from the vendored `rust_lang_probestack.rs`. The feature was inherited from upstream rustc and never wired up here.
- `near-vm/test-api`: drop the `default-dylib` branch in `sys/store.rs`. `near_vm_engine_dylib` was dropped in #9220 (2023) when the dynamic-engine API was removed; this branch was carried forward from upstream wasmer and has been unreachable since.
- `near-vm/compiler-test-derive`: stop emitting the `dylib` engine test variant (same provenance — dead since #9220).
- `near-vm/tests`: drop the `if cfg!(feature = "coverage")` branch in `wast.rs`. Vendored from upstream wasmer in #8792 (2023); the `coverage` feature was never declared and the body never ran.
- `near-epoch-manager`: delete a dead assertion in `aggregate_epoch_info_upto`. It was gated on `cfg!(debug)` (a no-op cfg) and has been dead since PR #6531 (2022). Reactivating it broke ~8 GC tests because the assertion contradicts the function's own documented contract: the function explicitly supports being called with fork blocks (slow path through prev_hash), while the assertion forbids them. Deleted instead.
- `near-client`: declare the `gcs_credentials` feature. PR #10063 (2023) converted an unconditional `#[ignore]` to `#[cfg_attr(not(feature = "gcs_credentials"), ignore)]` but never added the feature declaration, so the test stayed permanently ignored with no way to opt-in.
- `estimator-warehouse`: per-file `#![allow(unexpected_cfgs)]` for `xshell::cmd!`, which emits `cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)`.