### PR TITLE
feat: cap operand stack size per function at 8 KiB

### DIFF
--- a/core/parameters/res/runtime_configs/84.yaml
+++ b/core/parameters/res/runtime_configs/84.yaml
@@ -10,3 +10,4 @@ max_types_per_contract: { new: 1024 }
 max_deploy_actions_per_receipt: { old: 100, new: 10 }
 max_params_per_contract: { new: 50_000 }
 max_params_per_function: { new: 64 }
+max_operand_stack_per_function: { new: 8_192 }

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -234,6 +234,7 @@ max_blocks_per_contract                               50_000
 max_types_per_contract                                 1_024
 max_params_per_function                                   64
 max_params_per_contract                               50_000
+max_operand_stack_per_function                         8_192
 flat_storage_reads                      true
 fix_contract_loading_cost               false
 vm_kind                                 Wasmtime

--- a/core/parameters/src/parameter.rs
+++ b/core/parameters/src/parameter.rs
@@ -214,6 +214,7 @@ pub enum Parameter {
     MaxTypesPerContract,
     MaxParamsPerFunction,
     MaxParamsPerContract,
+    MaxOperandStackPerFunction,
 
     // Contract runtime features
     FlatStorageReads,
@@ -353,6 +354,7 @@ impl Parameter {
             Parameter::MaxTypesPerContract,
             Parameter::MaxParamsPerFunction,
             Parameter::MaxParamsPerContract,
+            Parameter::MaxOperandStackPerFunction,
         ]
         .iter()
     }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -241,6 +241,7 @@ expression: config_view
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__149.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__149.json.snap
@@ -241,6 +241,7 @@ expression: config_view
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__84.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__84.json.snap
@@ -241,6 +241,7 @@ expression: config_view
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__85.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__85.json.snap
@@ -241,6 +241,7 @@ expression: config_view
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -241,6 +241,7 @@ expression: config_view
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_149.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_149.json.snap
@@ -241,6 +241,7 @@ expression: config_view
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_84.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_84.json.snap
@@ -241,6 +241,7 @@ expression: config_view
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_85.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_85.json.snap
@@ -241,6 +241,7 @@ expression: config_view
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -241,6 +241,7 @@ expression: "&view"
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -127,6 +127,11 @@ pub struct LimitConfig {
     pub max_params_per_contract: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_params_per_function: Option<u64>,
+    /// If present, stores the max operand stack size (in bytes) at any point
+    /// during the execution of a single function. Per-function: not summed
+    /// across recursion. Computed by `finite_wasm::max_stack`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_operand_stack_per_function: Option<u64>,
     /// If present, stores max number of tables declared globally in one contract
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tables_per_contract: Option<u32>,

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -1338,6 +1338,9 @@ pub enum PrepareError {
     TooManyParamsPerFunction = 16,
     /// A function has more than `max_params_per_function` parameters.
     TooManyParamsPerContract = 17,
+    /// A function's max operand-stack size (in bytes) exceeds
+    /// `max_operand_stack_per_function`.
+    OperandStackTooLarge = 18,
 }
 
 /// A kind of a trap happened during execution of a binary

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -241,6 +241,7 @@ expression: "&view"
       "max_locals_per_contract": 1000000,
       "max_params_per_contract": 50000,
       "max_params_per_function": 64,
+      "max_operand_stack_per_function": 8192,
       "max_tables_per_contract": 1,
       "max_elements_per_contract_table": 10000,
       "max_function_body_size": 196608,

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -197,6 +197,9 @@ pub enum PrepareError {
     TooManyParamsPerContract = 16,
     /// A function has more than `max_params_per_function` parameters.
     TooManyParamsPerFunction = 17,
+    /// A function's max operand-stack size (in bytes) exceeds
+    /// `max_operand_stack_per_function`.
+    OperandStackTooLarge = 18,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, strum::IntoStaticStr)]
@@ -434,6 +437,7 @@ impl fmt::Display for PrepareError {
             TooManyTypes => "Too many type-section entries declared in the contract.",
             TooManyParamsPerContract => "Too many function parameters in the contract",
             TooManyParamsPerFunction => "Too many parameters in a single function",
+            OperandStackTooLarge => "A function uses too much operand stack.",
         })
     }
 }

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -471,4 +471,33 @@ mod tests {
             })
         }
     }
+
+    /// Reject contracts whose static operand-stack size (bytes) in any single
+    /// function exceeds `max_operand_stack_per_function`. NearVm doesn't run
+    /// the instrumentation pass and so doesn't enforce this cap.
+    #[test]
+    fn operand_stack_too_large() {
+        with_vm_variants(|kind| {
+            if kind == VMKind::NearVm {
+                return;
+            }
+            // 16 i64 pushes leave 128 bytes on the operand stack at peak.
+            // Cap of 127 should reject; cap of 128 should accept.
+            let push_then_drop = "(i64.const 0) ".repeat(16) + &"(drop) ".repeat(16);
+            let wat = format!(
+                r#"(module
+                    (func (export "main") {push_then_drop})
+                )"#
+            );
+
+            let mut config = test_vm_config(Some(kind));
+            config.limit_config.max_operand_stack_per_function = Some(127);
+            let r = parse_and_prepare_wat(&config, kind, &wat);
+            assert_matches!(r, Err(PrepareError::OperandStackTooLarge));
+
+            config.limit_config.max_operand_stack_per_function = Some(128);
+            let r = parse_and_prepare_wat(&config, kind, &wat);
+            assert_matches!(r, Ok(_));
+        })
+    }
 }

--- a/runtime/near-vm-runner/src/prepare/instrument_v3.rs
+++ b/runtime/near-vm-runner/src/prepare/instrument_v3.rs
@@ -97,6 +97,8 @@ pub enum Error {
     TooManyParamsPerContract,
     #[error("too many parameters in a function")]
     TooManyParamsPerFunction,
+    #[error("a function uses too much operand stack")]
+    OperandStackTooLarge,
 }
 
 pub(crate) struct InstrumentContext<'a> {
@@ -110,6 +112,7 @@ pub(crate) struct InstrumentContext<'a> {
     max_blocks_per_contract: u64,
     max_params_per_function: u64,
     max_params_per_contract: u64,
+    max_operand_stack_per_function: u64,
 
     type_section: we::TypeSection,
     import_section: we::ImportSection,
@@ -238,6 +241,7 @@ impl<'a> InstrumentContext<'a> {
         max_blocks_per_contract: u64,
         max_params_per_function: u64,
         max_params_per_contract: u64,
+        max_operand_stack_per_function: u64,
     ) -> Self {
         Self {
             analysis,
@@ -250,6 +254,7 @@ impl<'a> InstrumentContext<'a> {
             max_blocks_per_contract,
             max_params_per_function,
             max_params_per_contract,
+            max_operand_stack_per_function,
 
             type_section: we::TypeSection::new(),
             import_section: we::ImportSection::new(),
@@ -519,6 +524,9 @@ impl<'a> InstrumentContext<'a> {
         let gas_kinds = get_idx!(analysis.gas_kinds)?;
         let gas_offsets = get_idx!(analysis.gas_offsets)?;
         let stack_sz = *get_idx!(analysis.function_operand_stack_sizes)?;
+        if stack_sz > self.max_operand_stack_per_function {
+            return Err(Error::OperandStackTooLarge);
+        }
         let frame_sz = *get_idx!(analysis.function_frame_sizes)?;
 
         let mut instrumentation_points =

--- a/runtime/near-vm-runner/src/prepare/prepare_v3.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v3.rs
@@ -438,6 +438,7 @@ pub(crate) fn prepare_contract(
         config.limit_config.max_blocks_per_contract.unwrap_or(u64::MAX),
         config.limit_config.max_params_per_function.unwrap_or(u64::MAX),
         config.limit_config.max_params_per_contract.unwrap_or(u64::MAX),
+        config.limit_config.max_operand_stack_per_function.unwrap_or(u64::MAX),
     )
     .run()
     .map_err(|err| {
@@ -447,6 +448,7 @@ pub(crate) fn prepare_contract(
             Error::TooManyBlocksPerContract => PrepareError::TooManyBlocksPerContract,
             Error::TooManyParamsPerFunction => PrepareError::TooManyParamsPerFunction,
             Error::TooManyParamsPerContract => PrepareError::TooManyParamsPerContract,
+            Error::OperandStackTooLarge => PrepareError::OperandStackTooLarge,
             err => {
                 tracing::error!(target: "vm", ?err, ?kind, "instrumentation failed");
                 PrepareError::Serialization

--- a/runtime/runtime/src/conversions.rs
+++ b/runtime/runtime/src/conversions.rs
@@ -43,6 +43,7 @@ mod prepare_error {
                 From::TooManyTypes => Self::TooManyTypes,
                 From::TooManyParamsPerFunction => Self::TooManyParamsPerFunction,
                 From::TooManyParamsPerContract => Self::TooManyParamsPerContract,
+                From::OperandStackTooLarge => Self::OperandStackTooLarge,
             }
         }
     }


### PR DESCRIPTION
Introduce `max_operand_stack_per_function` (bytes), enforced at
`prepare_contract` time. Set to 8192 starting at protocol version 84,
alongside the related contract-shape caps from #15611.

Caps the **per-function** static operand-stack size that `finite_wasm`
computes (`function_operand_stack_sizes[i]`). Independent of the existing
`max_stack_height` (which is a runtime cumulative cap over operand stack +
locals frame summed across recursion).

A function whose operand stack exceeds the cap is rejected with
`PrepareError::OperandStackTooLarge` rather than being allowed and trapping
at runtime.

### Why 8 KiB

A full scan of mainnet (3,745 wasms, block 196,141,659) and testnet
(77,425 wasms, block 247,993,407) snapshots from 2026-04-29 measured the
worst real-world per-function operand-stack size:

|                                            | mainnet | testnet |
|--------------------------------------------|---------|---------|
| `max_operand_stack_bytes_per_fn` max       | 276 B   | 560 B   |
| p999                                       | 236 B   | 196 B   |

8 KiB leaves **14.6× margin** to the worst testnet contract and **29.7×**
to the worst mainnet contract. Pairs cleanly with the proposed
`max_operand_depth_per_function = 1024` from the nearcore-private
`wasmtime_chains.rs` PoC (at the observed typical ratio of ~7–8 B/value,
depth 1024 × 8 B ≈ 8 KiB).

### Why not `max_stack_height`

An earlier draft of this PR tightened `max_stack_height` from 256 KiB to
8 KiB. That parameter is the runtime cumulative budget covering operand
stack + locals frame, summed across the call stack. Lowering it 32× would
have broken legitimately-recursive contracts. The current approach caps
**only** the per-function operand-stack size, which has nothing to do with
recursion. (Backup of the previous attempt:
[darioush/cap-max-stack-height-attempt1](https://github.com/darioush/nearcore/tree/darioush/cap-max-stack-height-attempt1).)

### Test

`prepare::tests::operand_stack_too_large` — builds a function with 128 B
peak operand stack, verifies it rejects at cap=127 and accepts at cap=128.