### PR TITLE
chore(deps): clean up resolved audit ignores

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -37,6 +37,7 @@ ignore = [
     # feature is not enabled (check with `cargo tree -e features --workspace | grep 'rand feature'`)
     # and nearcore has no custom `log::Log` impl (logging goes through tracing).
     # Fixed in rand >= 0.9.3 / >= 0.10.1. rand 0.9.x in our tree is patched; remaining
-    # unpatched versions are rand 0.7.3 (via wiremock, dev-dep) and rand 0.8.5 (via ark-std).
+    # unpatched versions are rand 0.7.3 (via wiremock, dev-dep) and rand 0.8.5 (used
+    # directly across the workspace and also pulled in via ark-std).
     "RUSTSEC-2026-0097",
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,18 +18,13 @@ ignore = [
     "RUSTSEC-2024-0384",
 
     # The derivative package is unmaintained, but hard to replace right now
-    # because ark-poly depends on it.
+    # because ark-ec depends on it.
     "RUSTSEC-2024-0388",
 
     # burntsushi says the crate is feature complete and needs no maintenance, nagisa also doesn't
     # see any security risk whatsoever to keeping this crate, so we'll be letting it to upgrade out
     # of existence naturally.
     "RUSTSEC-2024-0436",
-
-    # rustls-pemfile is no longer maintained, but it's indirectly required by rust-s3,
-    # which cannot be updated without moving to Rust 1.88
-    # TODO(#14768): Remove this and updated necessary crates to get rid of rustls-pemfile
-    "RUSTSEC-2025-0134",
 
     # libsecp256k1 is unmaintained, but every version of aurora-engine-transactions pulls it in
     # (via aurora-engine-precompiles in 1.1, or aurora-engine-sdk in 1.2+). In the main workspace
@@ -41,6 +36,7 @@ ignore = [
     # custom `log::Log` logger calls `rand::rng()` on reseed. Neither applies here: the `log`
     # feature is not enabled (check with `cargo tree -e features --workspace | grep 'rand feature'`)
     # and nearcore has no custom `log::Log` impl (logging goes through tracing).
-    # Fixed in rand >= 0.9.3 / >= 0.10.1; 0.8.x has no patch and 0.7.3/0.9.0 are transitive.
+    # Fixed in rand >= 0.9.3 / >= 0.10.1. rand 0.9.x in our tree is patched; remaining
+    # unpatched versions are rand 0.7.3 (via wiremock, dev-dep) and rand 0.8.5 (via ark-std).
     "RUSTSEC-2026-0097",
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -36,8 +36,6 @@ ignore = [
     # custom `log::Log` logger calls `rand::rng()` on reseed. Neither applies here: the `log`
     # feature is not enabled (check with `cargo tree -e features --workspace | grep 'rand feature'`)
     # and nearcore has no custom `log::Log` impl (logging goes through tracing).
-    # Fixed in rand >= 0.9.3 / >= 0.10.1. rand 0.9.x in our tree is patched; remaining
-    # unpatched versions are rand 0.7.3 (via wiremock, dev-dep) and rand 0.8.5 (used
-    # directly across the workspace and also pulled in via ark-std).
+    # Fixed in rand >= 0.9.3 / >= 0.10.1; 0.8.x has no patch and 0.7.3/0.9.0 are transitive.
     "RUSTSEC-2026-0097",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.31",
 ]
 
 [[package]]
@@ -5941,7 +5941,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "percent-encoding",
  "quick-xml 0.38.4",
- "rand 0.9.4",
+ "rand 0.9.0",
  "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
@@ -6105,7 +6105,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.9.0",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -6711,7 +6711,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.1",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.9.0",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -6788,12 +6788,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -7387,7 +7388,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "mime",
- "rand 0.9.4",
+ "rand 0.9.0",
  "thiserror 2.0.18",
 ]
 
@@ -10307,7 +10308,16 @@ version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.31",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive 0.8.48",
 ]
 
 [[package]]
@@ -10315,6 +10325,17 @@ name = "zerocopy-derive"
 version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy 0.7.31",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3220,7 +3220,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.5.3",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5941,8 +5941,8 @@ dependencies = [
  "parking_lot 0.12.1",
  "percent-encoding",
  "quick-xml 0.38.4",
- "rand 0.9.0",
- "reqwest 0.12.15",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
  "serde",
@@ -6105,7 +6105,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.0",
+ "rand 0.9.4",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -6694,7 +6694,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.8",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6711,7 +6711,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.1",
  "lru-slab",
- "rand 0.9.0",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -6732,7 +6732,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6788,13 +6788,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -7060,9 +7059,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7076,18 +7075,14 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7098,13 +7093,13 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry 0.4.0",
 ]
 
 [[package]]
@@ -7392,7 +7387,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "mime",
- "rand 0.9.0",
+ "rand 0.9.4",
  "thiserror 2.0.18",
 ]
 
@@ -7419,7 +7414,7 @@ dependencies = [
  "minidom",
  "percent-encoding",
  "quick-xml 0.36.2",
- "reqwest 0.12.15",
+ "reqwest 0.12.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7502,15 +7497,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -9858,24 +9844,13 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9892,15 +9867,6 @@ name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link 0.1.3",
 ]
@@ -10341,16 +10307,7 @@ version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
- "zerocopy-derive 0.7.31",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
-dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -10358,17 +10315,6 @@ name = "zerocopy-derive"
 version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6794,7 +6794,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.48",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -10313,11 +10313,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.48",
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -10333,9 +10333,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Bump `reqwest` 0.12.15 → 0.12.28, which drops the transitive `rustls-pemfile` dependency. This resolves RUSTSEC-2025-0134, so the corresponding `cargo audit` ignore can be removed.

Also fix a comment: `derivative` is pulled in via `ark-ec`, not `ark-poly`.

Closes: https://github.com/near/nearcore/issues/14768