### PR TITLE
fix(openrpc): strip required from config schemas

### DIFF
--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -306,10 +306,6 @@
             "description": "The account ID of the account registrar. This account ID allowed to create top-level\naccounts of any valid length."
           }
         },
-        "required": [
-          "min_allowed_top_level_account_length",
-          "registrar_account_id"
-        ],
         "title": "AccountCreationConfigView",
         "type": "object"
       },
@@ -495,19 +491,6 @@
             "description": "Base cost of making a transfer."
           }
         },
-        "required": [
-          "create_account_cost",
-          "deploy_contract_cost",
-          "deploy_contract_cost_per_byte",
-          "function_call_cost",
-          "function_call_cost_per_byte",
-          "transfer_cost",
-          "stake_cost",
-          "add_key_cost",
-          "delete_key_cost",
-          "delete_account_cost",
-          "delegate_cost"
-        ],
         "title": "ActionCreationConfigView",
         "type": "object"
       },
@@ -2576,10 +2559,6 @@
             "$ref": "#/components/schemas/ChunkDistributionUris"
           }
         },
-        "required": [
-          "enabled",
-          "uris"
-        ],
         "title": "ChunkDistributionNetworkConfig",
         "type": "object"
       },
@@ -2595,10 +2574,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "get",
-          "set"
-        ],
         "title": "ChunkDistributionUris",
         "type": "object"
       },
@@ -2914,20 +2889,6 @@
             "type": "number"
           }
         },
-        "required": [
-          "max_congestion_incoming_gas",
-          "max_congestion_outgoing_gas",
-          "max_congestion_memory_consumption",
-          "max_congestion_missed_chunks",
-          "max_outgoing_gas",
-          "min_outgoing_gas",
-          "allowed_shard_outgoing_gas",
-          "max_tx_gas",
-          "min_tx_gas",
-          "reject_tx_congestion_threshold",
-          "outgoing_receipts_usual_size_limit",
-          "outgoing_receipts_big_size_limit"
-        ],
         "title": "CongestionControlConfigView",
         "type": "object"
       },
@@ -3127,10 +3088,6 @@
             "description": "Additional cost per byte sent.\nBoth `send` and `exec` costs are burned when a function call finishes execution and returns\n`N` bytes of data to every output dependency. For each output dependency the cost is\n`(send(sir) + exec()) * N`."
           }
         },
-        "required": [
-          "base_cost",
-          "cost_per_byte"
-        ],
         "title": "DataReceiptCreationConfigView",
         "type": "object"
       },
@@ -3416,9 +3373,6 @@
             ]
           }
         },
-        "required": [
-          "location"
-        ],
         "title": "DumpConfig",
         "type": "object"
       },
@@ -3467,9 +3421,6 @@
             "description": "Timeout for epoch sync requests. The node will continue retrying indefinitely even\nif this timeout is exceeded."
           }
         },
-        "required": [
-          "timeout_for_epoch_sync"
-        ],
         "title": "EpochSyncConfig",
         "type": "object"
       },
@@ -4263,97 +4214,6 @@
             "description": "Per byte cost of resume payload."
           }
         },
-        "required": [
-          "base",
-          "contract_loading_base",
-          "contract_loading_bytes",
-          "read_memory_base",
-          "read_memory_byte",
-          "write_memory_base",
-          "write_memory_byte",
-          "read_register_base",
-          "read_register_byte",
-          "write_register_base",
-          "write_register_byte",
-          "utf8_decoding_base",
-          "utf8_decoding_byte",
-          "utf16_decoding_base",
-          "utf16_decoding_byte",
-          "sha256_base",
-          "sha256_byte",
-          "keccak256_base",
-          "keccak256_byte",
-          "keccak512_base",
-          "keccak512_byte",
-          "ripemd160_base",
-          "ripemd160_block",
-          "ed25519_verify_base",
-          "ed25519_verify_byte",
-          "ecrecover_base",
-          "p256_verify_base",
-          "p256_verify_byte",
-          "log_base",
-          "log_byte",
-          "storage_write_base",
-          "storage_write_key_byte",
-          "storage_write_value_byte",
-          "storage_write_evicted_byte",
-          "storage_read_base",
-          "storage_read_key_byte",
-          "storage_read_value_byte",
-          "storage_large_read_overhead_base",
-          "storage_large_read_overhead_byte",
-          "storage_remove_base",
-          "storage_remove_key_byte",
-          "storage_remove_ret_value_byte",
-          "storage_has_key_base",
-          "storage_has_key_byte",
-          "storage_iter_create_prefix_base",
-          "storage_iter_create_prefix_byte",
-          "storage_iter_create_range_base",
-          "storage_iter_create_from_byte",
-          "storage_iter_create_to_byte",
-          "storage_iter_next_base",
-          "storage_iter_next_key_byte",
-          "storage_iter_next_value_byte",
-          "touching_trie_node",
-          "read_cached_trie_node",
-          "promise_and_base",
-          "promise_and_per_promise",
-          "promise_return",
-          "validator_stake_base",
-          "validator_total_stake_base",
-          "contract_compile_base",
-          "contract_compile_bytes",
-          "alt_bn128_g1_multiexp_base",
-          "alt_bn128_g1_multiexp_element",
-          "alt_bn128_g1_sum_base",
-          "alt_bn128_g1_sum_element",
-          "alt_bn128_pairing_check_base",
-          "alt_bn128_pairing_check_element",
-          "yield_create_base",
-          "yield_create_byte",
-          "yield_resume_base",
-          "yield_resume_byte",
-          "bls12381_p1_sum_base",
-          "bls12381_p1_sum_element",
-          "bls12381_p2_sum_base",
-          "bls12381_p2_sum_element",
-          "bls12381_g1_multiexp_base",
-          "bls12381_g1_multiexp_element",
-          "bls12381_g2_multiexp_base",
-          "bls12381_g2_multiexp_element",
-          "bls12381_map_fp_to_g1_base",
-          "bls12381_map_fp_to_g1_element",
-          "bls12381_map_fp2_to_g2_base",
-          "bls12381_map_fp2_to_g2_element",
-          "bls12381_pairing_base",
-          "bls12381_pairing_element",
-          "bls12381_p1_decompress_base",
-          "bls12381_p1_decompress_element",
-          "bls12381_p2_decompress_base",
-          "bls12381_p2_decompress_element"
-        ],
         "title": "ExtCostsConfigView",
         "type": "object"
       },
@@ -4391,9 +4251,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "location"
-        ],
         "title": "ExternalStorageConfig",
         "type": "object"
       },
@@ -6784,34 +6641,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "max_gas_burnt",
-          "max_stack_height",
-          "initial_memory_pages",
-          "max_memory_pages",
-          "registers_memory_limit",
-          "max_register_size",
-          "max_number_registers",
-          "max_number_logs",
-          "max_total_log_length",
-          "max_total_prepaid_gas",
-          "max_actions_per_receipt",
-          "max_deploy_actions_per_receipt",
-          "max_number_bytes_method_names",
-          "max_length_method_name",
-          "max_arguments_length",
-          "max_length_returned_data",
-          "max_contract_size",
-          "max_transaction_size",
-          "max_receipt_size",
-          "max_length_storage_key",
-          "max_length_storage_value",
-          "max_promises_per_function_call_action",
-          "max_number_input_data_dependencies",
-          "yield_timeout_length_in_blocks",
-          "max_yield_payload_size",
-          "per_receipt_storage_proof_size_limit"
-        ],
         "title": "LimitConfig",
         "type": "object"
       },
@@ -8568,73 +8397,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "version",
-          "chain_id",
-          "expected_shutdown",
-          "block_production_tracking_delay",
-          "min_block_production_delay",
-          "max_block_production_delay",
-          "max_block_wait_delay",
-          "chunk_wait_mult",
-          "skip_sync_wait",
-          "sync_check_period",
-          "sync_step_period",
-          "sync_height_threshold",
-          "sync_max_block_requests",
-          "header_sync_initial_timeout",
-          "header_sync_progress_timeout",
-          "header_sync_stall_ban_timeout",
-          "header_sync_expected_height_per_second",
-          "state_sync_external_timeout",
-          "state_sync_p2p_timeout",
-          "state_sync_retry_backoff",
-          "state_sync_external_backoff",
-          "min_num_peers",
-          "log_summary_period",
-          "log_summary_style",
-          "produce_empty_blocks",
-          "epoch_length",
-          "num_block_producer_seats",
-          "ttl_account_id_router",
-          "block_fetch_horizon",
-          "catchup_step_period",
-          "chunk_request_retry_period",
-          "doomslug_step_period",
-          "block_header_fetch_horizon",
-          "gc",
-          "tracked_shards_config",
-          "archive",
-          "save_trie_changes",
-          "save_tx_outcomes",
-          "save_receipt_to_tx",
-          "save_state_changes",
-          "save_untracked_partial_chunks_parts",
-          "view_client_threads",
-          "chunk_validation_threads",
-          "state_request_throttle_period",
-          "state_requests_per_throttle_period",
-          "state_request_server_threads",
-          "enable_statistics_export",
-          "client_background_migration_threads",
-          "state_sync_enabled",
-          "state_sync",
-          "epoch_sync",
-          "transaction_pool_strict_nonce_ttl_blocks",
-          "enable_multiline_logging",
-          "resharding_config",
-          "tx_routing_height_horizon",
-          "disable_tx_routing",
-          "produce_chunk_add_transactions_time_limit",
-          "orphan_state_witness_pool_size",
-          "orphan_state_witness_max_size",
-          "save_latest_witnesses",
-          "save_invalid_witnesses",
-          "transaction_request_handler_threads",
-          "protocol_version_check",
-          "enable_early_prepare_transactions",
-          "chunks_cache_height_horizon"
-        ],
         "title": "RpcClientConfigResponse",
         "type": "object"
       },
@@ -9283,39 +9045,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "protocol_version",
-          "genesis_time",
-          "chain_id",
-          "genesis_height",
-          "num_block_producer_seats",
-          "dynamic_resharding",
-          "protocol_upgrade_stake_threshold",
-          "epoch_length",
-          "gas_limit",
-          "min_gas_price",
-          "max_gas_price",
-          "block_producer_kickout_threshold",
-          "chunk_producer_kickout_threshold",
-          "chunk_validator_only_kickout_threshold",
-          "target_validator_mandates_per_shard",
-          "online_min_threshold",
-          "online_max_threshold",
-          "gas_price_adjustment_rate",
-          "runtime_config",
-          "transaction_validity_period",
-          "protocol_reward_rate",
-          "max_inflation_rate",
-          "num_blocks_per_year",
-          "protocol_treasury_account",
-          "fishermen_threshold",
-          "minimum_stake_divisor",
-          "max_kickout_stake_perc",
-          "minimum_stake_ratio",
-          "shuffle_shard_assignment_for_chunk_producers",
-          "minimum_validators_per_shard",
-          "shard_layout"
-        ],
         "title": "RpcProtocolConfigResponse",
         "type": "object"
       },
@@ -10473,14 +10202,6 @@
             "description": "Configuration specific to ChunkStateWitness."
           }
         },
-        "required": [
-          "storage_amount_per_byte",
-          "transaction_costs",
-          "wasm_config",
-          "account_creation_config",
-          "congestion_control_config",
-          "witness_config"
-        ],
         "title": "RuntimeConfigView",
         "type": "object"
       },
@@ -10540,14 +10261,6 @@
             "description": "Describes fees for storage."
           }
         },
-        "required": [
-          "action_receipt_creation_config",
-          "data_receipt_creation_config",
-          "action_creation_config",
-          "storage_usage_config",
-          "burnt_gas_reward",
-          "pessimistic_gas_price_inflation_ratio"
-        ],
         "title": "RuntimeFeesConfigView",
         "type": "object"
       },
@@ -11878,10 +11591,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "num_bytes_account",
-          "num_extra_bytes_record"
-        ],
         "title": "StorageUsageConfigView",
         "type": "object"
       },
@@ -11936,12 +11645,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "apply",
-          "apply_during_catchup",
-          "peer_downloads",
-          "per_shard"
-        ],
         "title": "SyncConcurrency",
         "type": "object"
       },
@@ -12326,27 +12029,6 @@
             "description": "See [VMConfig::vm_kind](crate::vm::Config::vm_kind)."
           }
         },
-        "required": [
-          "ext_costs",
-          "grow_mem_cost",
-          "regular_op_cost",
-          "linear_op_base_cost",
-          "linear_op_unit_cost",
-          "vm_kind",
-          "discard_custom_sections",
-          "global_contract_host_fns",
-          "reftypes_bulk_memory",
-          "deterministic_account_ids",
-          "gas_key_host_fns",
-          "one_yocto_on_promise",
-          "p256_verify_host_fn",
-          "storage_get_mode",
-          "fix_contract_loading_cost",
-          "implicit_account_creation",
-          "eth_implicit_accounts",
-          "eth_implicit_global_contract",
-          "limit_config"
-        ],
         "title": "VMConfigView",
         "type": "object"
       },
@@ -12745,11 +12427,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "main_storage_proof_size_soft_limit",
-          "combined_transactions_size_limit",
-          "new_transactions_validation_state_size_soft_limit"
-        ],
         "title": "WitnessConfigView",
         "type": "object"
       }

--- a/chain/jsonrpc/openapi/src/main.rs
+++ b/chain/jsonrpc/openapi/src/main.rs
@@ -348,14 +348,43 @@ fn add_title_to_allof(
     }
 }
 
+/// Schemas whose `required` list is stripped so generated clients stay
+/// compatible across networks (testnet/mainnet may expose different fields)
+/// and nearcore versions where fields may be added or removed.
+/// Shared between the OpenAPI and OpenRPC generators.
+pub(crate) const SCHEMAS_TO_REMOVE_REQUIRED_FROM: &[&str] = &[
+    "RpcClientConfigResponse",
+    "GCConfig",
+    "CloudArchivalWriterConfig",
+    "StateSyncConfig",
+    "DumpConfig",
+    "ExternalStorageConfig",
+    "SyncConcurrency",
+    "EpochSyncConfig",
+    "ChunkDistributionNetworkConfig",
+    "ChunkDistributionUris",
+    "RpcProtocolConfigResponse",
+    "RuntimeConfigView",
+    "RuntimeFeesConfigView",
+    "DataReceiptCreationConfigView",
+    "ActionCreationConfigView",
+    "StorageUsageConfigView",
+    "VMConfigView",
+    "LimitConfig",
+    "ExtCostsConfigView",
+    "AccountCreationConfigView",
+    "CongestionControlConfigView",
+    "WitnessConfigView",
+];
+
 /// Removes the "required" list from specific schemas
 #[derive(Debug, Clone)]
 pub struct RemoveRequiredFrom {
-    schemas: Vec<String>,
+    schemas: &'static [&'static str],
 }
 
 impl RemoveRequiredFrom {
-    pub fn new(schemas: Vec<String>) -> Self {
+    pub fn new(schemas: &'static [&'static str]) -> Self {
         Self { schemas }
     }
 }
@@ -364,8 +393,8 @@ impl schemars::transform::Transform for RemoveRequiredFrom {
     fn transform(&mut self, schema: &mut schemars::Schema) {
         // Check in $defs for all target schemas (schemas are in $defs at this point in the pipeline)
         if let Some(serde_json::Value::Object(defs)) = schema.get_mut("$defs") {
-            for schema_name in &self.schemas {
-                if let Some(target_schema) = defs.get_mut(schema_name) {
+            for schema_name in self.schemas {
+                if let Some(target_schema) = defs.get_mut(*schema_name) {
                     if let serde_json::Value::Object(schema_obj) = target_schema {
                         schema_obj.remove("required");
                     }
@@ -426,33 +455,8 @@ fn interchange_one_ofs_and_all_ofs(
 }
 
 fn schemas_map<T: JsonSchema>() -> SchemasMap {
-    let config_schemas_to_remove_required = vec![
-        "RpcClientConfigResponse".to_string(),
-        "GCConfig".to_string(),
-        "CloudArchivalWriterConfig".to_string(),
-        "StateSyncConfig".to_string(),
-        "DumpConfig".to_string(),
-        "ExternalStorageConfig".to_string(),
-        "SyncConcurrency".to_string(),
-        "EpochSyncConfig".to_string(),
-        "ChunkDistributionNetworkConfig".to_string(),
-        "ChunkDistributionUris".to_string(),
-        "RpcProtocolConfigResponse".to_string(),
-        "RuntimeConfigView".to_string(),
-        "RuntimeFeesConfigView".to_string(),
-        "DataReceiptCreationConfigView".to_string(),
-        "ActionCreationConfigView".to_string(),
-        "StorageUsageConfigView".to_string(),
-        "VMConfigView".to_string(),
-        "LimitConfig".to_string(),
-        "ExtCostsConfigView".to_string(),
-        "AccountCreationConfigView".to_string(),
-        "CongestionControlConfigView".to_string(),
-        "WitnessConfigView".to_string(),
-    ];
-
     let mut settings = schemars::generate::SchemaSettings::openapi3();
-    settings.transforms.push(Box::new(RemoveRequiredFrom::new(config_schemas_to_remove_required)));
+    settings.transforms.push(Box::new(RemoveRequiredFrom::new(SCHEMAS_TO_REMOVE_REQUIRED_FROM)));
 
     settings.transforms.insert(
         0,

--- a/chain/jsonrpc/openapi/src/openrpc.rs
+++ b/chain/jsonrpc/openapi/src/openrpc.rs
@@ -8,6 +8,7 @@
 //! Usage:
 //!   cargo run -p near-jsonrpc-openapi-spec --bin near-openrpc > openrpc.json
 
+use crate::SCHEMAS_TO_REMOVE_REQUIRED_FROM;
 use near_chain_configs::GenesisConfig;
 use near_jsonrpc_primitives::types::blocks::{RpcBlockRequest, RpcBlockResponse};
 use near_jsonrpc_primitives::types::call_function::{
@@ -60,7 +61,6 @@ use near_primitives::hash::CryptoHash;
 use schemars::JsonSchema;
 use schemars::transform::transform_subschemas;
 use serde_json::{Value, json};
-use crate::SCHEMAS_TO_REMOVE_REQUIRED_FROM;
 
 // Request types that are just empty structs
 #[derive(JsonSchema)]

--- a/chain/jsonrpc/openapi/src/openrpc.rs
+++ b/chain/jsonrpc/openapi/src/openrpc.rs
@@ -59,7 +59,9 @@ use near_jsonrpc_primitives::types::view_state::{RpcViewStateRequest, RpcViewSta
 use near_primitives::hash::CryptoHash;
 use schemars::JsonSchema;
 use schemars::transform::transform_subschemas;
-use serde_json::json;
+use serde_json::{Value, json};
+
+use crate::SCHEMAS_TO_REMOVE_REQUIRED_FROM;
 
 // Request types that are just empty structs
 #[derive(JsonSchema)]
@@ -599,37 +601,9 @@ const CARTESIAN_COLLAPSE_CONFIGS: &[CartesianCollapseConfig] = &[CartesianCollap
     ],
 }];
 
-/// Schemas whose `required` list is stripped so generated clients stay
-/// compatible across networks (testnet/mainnet may expose different fields).
-/// Mirrors the patch applied to the OpenAPI generator.
-const SCHEMAS_TO_REMOVE_REQUIRED_FROM: &[&str] = &[
-    "RpcClientConfigResponse",
-    "GCConfig",
-    "CloudArchivalWriterConfig",
-    "StateSyncConfig",
-    "DumpConfig",
-    "ExternalStorageConfig",
-    "SyncConcurrency",
-    "EpochSyncConfig",
-    "ChunkDistributionNetworkConfig",
-    "ChunkDistributionUris",
-    "RpcProtocolConfigResponse",
-    "RuntimeConfigView",
-    "RuntimeFeesConfigView",
-    "DataReceiptCreationConfigView",
-    "ActionCreationConfigView",
-    "StorageUsageConfigView",
-    "VMConfigView",
-    "LimitConfig",
-    "ExtCostsConfigView",
-    "AccountCreationConfigView",
-    "CongestionControlConfigView",
-    "WitnessConfigView",
-];
-
-fn remove_required_from_config_schemas(schemas: &mut serde_json::Map<String, serde_json::Value>) {
+fn remove_required_from_config_schemas(schemas: &mut serde_json::Map<String, Value>) {
     for name in SCHEMAS_TO_REMOVE_REQUIRED_FROM {
-        if let Some(serde_json::Value::Object(obj)) = schemas.get_mut(*name) {
+        if let Some(Value::Object(obj)) = schemas.get_mut(*name) {
             obj.remove("required");
         }
     }

--- a/chain/jsonrpc/openapi/src/openrpc.rs
+++ b/chain/jsonrpc/openapi/src/openrpc.rs
@@ -599,6 +599,42 @@ const CARTESIAN_COLLAPSE_CONFIGS: &[CartesianCollapseConfig] = &[CartesianCollap
     ],
 }];
 
+/// Schemas whose `required` list is stripped so generated clients stay
+/// compatible across networks (testnet/mainnet may expose different fields).
+/// Mirrors the patch applied to the OpenAPI generator.
+const SCHEMAS_TO_REMOVE_REQUIRED_FROM: &[&str] = &[
+    "RpcClientConfigResponse",
+    "GCConfig",
+    "CloudArchivalWriterConfig",
+    "StateSyncConfig",
+    "DumpConfig",
+    "ExternalStorageConfig",
+    "SyncConcurrency",
+    "EpochSyncConfig",
+    "ChunkDistributionNetworkConfig",
+    "ChunkDistributionUris",
+    "RpcProtocolConfigResponse",
+    "RuntimeConfigView",
+    "RuntimeFeesConfigView",
+    "DataReceiptCreationConfigView",
+    "ActionCreationConfigView",
+    "StorageUsageConfigView",
+    "VMConfigView",
+    "LimitConfig",
+    "ExtCostsConfigView",
+    "AccountCreationConfigView",
+    "CongestionControlConfigView",
+    "WitnessConfigView",
+];
+
+fn remove_required_from_config_schemas(schemas: &mut serde_json::Map<String, serde_json::Value>) {
+    for name in SCHEMAS_TO_REMOVE_REQUIRED_FROM {
+        if let Some(serde_json::Value::Object(obj)) = schemas.get_mut(*name) {
+            obj.remove("required");
+        }
+    }
+}
+
 /// Collapse cartesian product explosions in the schema.
 fn collapse_cartesian_products(schemas: &mut serde_json::Map<String, serde_json::Value>) {
     for config in CARTESIAN_COLLAPSE_CONFIGS {
@@ -1383,6 +1419,8 @@ pub fn generate_openrpc() -> serde_json::Value {
     // the cartesian product (e.g., 3 × 8 = 24 variants). We detect these patterns
     // and collapse them back to `allOf[BlockReference, StateChangesRequestView]`.
     collapse_cartesian_products(&mut all_schemas);
+
+    remove_required_from_config_schemas(&mut all_schemas);
 
     // Build final OpenRPC document
     let mut openrpc = json!({

--- a/chain/jsonrpc/openapi/src/openrpc.rs
+++ b/chain/jsonrpc/openapi/src/openrpc.rs
@@ -60,7 +60,6 @@ use near_primitives::hash::CryptoHash;
 use schemars::JsonSchema;
 use schemars::transform::transform_subschemas;
 use serde_json::{Value, json};
-
 use crate::SCHEMAS_TO_REMOVE_REQUIRED_FROM;
 
 // Request types that are just empty structs


### PR DESCRIPTION
Mirrors the OpenAPI patch from #14621. The config schemas have different fields on testnet vs mainnet, so listing them as `required` made generated clients incompatible across networks. OpenRPC was missing the equivalent step — this adds it and regenerates `openrpc.json` (pure deletions).