### PR TITLE
test(spice): wire spice actors in jsonrpc test setup

### DIFF
--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -1,12 +1,18 @@
 use axum::Router;
 use axum_test::TestServer;
 use near_async::ActorSystem;
-use near_async::messaging::{IntoMultiSender, IntoSender, noop};
-use near_chain::ChainGenesis;
+use near_async::messaging::{IntoMultiSender, IntoSender, LateBoundSender, noop};
+use near_chain::spice_core::SpiceCoreReader;
+use near_chain::spice_core_writer_actor::SpiceCoreWriterActor;
+use near_chain::types::RuntimeAdapter;
+use near_chain::{ApplyChunksSpawner, ChainGenesis};
 use near_chain_configs::test_utils::TestClientConfigParams;
 use near_chain_configs::{ClientConfig, Genesis, MutableConfigValue, TrackedShardsConfig};
 use near_client::adversarial::Controls;
+use near_client::chunk_executor_actor::{ChunkExecutorActor, ChunkExecutorConfig};
 use near_client::client_actor::SpiceClientConfig;
+use near_client::spice_chunk_validator_actor::SpiceChunkValidatorActor;
+use near_client::spice_data_distributor_actor::SpiceDataDistributorActor;
 use near_client::{RpcHandlerConfig, ViewClientActor, spawn_rpc_handler_actor, start_client};
 use near_crypto::{KeyType, PublicKey};
 use near_epoch_manager::{EpochManager, shard_tracker::ShardTracker};
@@ -18,6 +24,7 @@ use near_primitives::epoch_info::RngSeed;
 use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{AccountId, NumSeats};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_store::adapter::StoreAdapter as _;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::create_test_store;
@@ -144,11 +151,30 @@ pub fn create_test_setup_with_accounts_and_validity(
     );
 
     // 7. Create ClientActor
+    let chunk_executor_adapter = LateBoundSender::new();
+    let spice_chunk_validator_adapter = LateBoundSender::new();
+    let spice_data_distributor_adapter = LateBoundSender::new();
+    let spice_core_writer_adapter = LateBoundSender::new();
+    let spice_client_config = if cfg!(feature = "protocol_feature_spice") {
+        SpiceClientConfig {
+            chunk_executor_sender: chunk_executor_adapter.as_sender(),
+            spice_chunk_validator_sender: spice_chunk_validator_adapter.as_sender(),
+            spice_data_distributor_sender: spice_data_distributor_adapter.as_sender(),
+            spice_core_writer_sender: spice_core_writer_adapter.as_sender(),
+        }
+    } else {
+        SpiceClientConfig {
+            chunk_executor_sender: noop().into_sender(),
+            spice_chunk_validator_sender: noop().into_sender(),
+            spice_data_distributor_sender: noop().into_sender(),
+            spice_core_writer_sender: noop().into_sender(),
+        }
+    };
     let client_result = start_client(
         Clock::real(),
         actor_system.clone(),
         client_config.clone(),
-        chain_genesis,
+        chain_genesis.clone(),
         epoch_manager.clone(),
         shard_tracker.clone(),
         runtime.clone(),
@@ -167,13 +193,75 @@ pub fn create_test_setup_with_accounts_and_validity(
         Some(TEST_SEED),
         noop().into_multi_sender(),
         block_notification_watch_sender,
-        SpiceClientConfig {
-            chunk_executor_sender: noop().into_sender(),
-            spice_chunk_validator_sender: noop().into_sender(),
-            spice_data_distributor_sender: noop().into_sender(),
-            spice_core_writer_sender: noop().into_sender(),
-        },
+        spice_client_config,
     );
+
+    if cfg!(feature = "protocol_feature_spice") {
+        let spice_core_reader = SpiceCoreReader::new(
+            runtime.store().chain_store(),
+            epoch_manager.clone(),
+            chain_genesis.gas_limit,
+        );
+        let spice_core_writer_actor = SpiceCoreWriterActor::new(
+            runtime.store().chain_store(),
+            epoch_manager.clone(),
+            spice_core_reader.clone(),
+            chunk_executor_adapter.as_sender(),
+            spice_chunk_validator_adapter.as_sender(),
+        );
+        let spice_core_writer_addr = actor_system.spawn_tokio_actor(spice_core_writer_actor);
+        spice_core_writer_adapter.bind(spice_core_writer_addr);
+
+        let spice_data_distributor_actor = SpiceDataDistributorActor::new(
+            epoch_manager.clone(),
+            runtime.store().chain_store(),
+            signer.clone(),
+            shard_tracker.clone(),
+            spice_core_reader,
+            noop().into_multi_sender(),
+            chunk_executor_adapter.as_sender(),
+            spice_chunk_validator_adapter.as_sender(),
+            spice_chunk_validator_adapter.as_sender(),
+            spice_chunk_validator_adapter.as_sender(),
+        );
+        let spice_data_distributor_addr =
+            actor_system.spawn_tokio_actor(spice_data_distributor_actor);
+        spice_data_distributor_adapter.bind(spice_data_distributor_addr);
+
+        let chunk_executor_actor = ChunkExecutorActor::new(
+            runtime.store().clone(),
+            &chain_genesis,
+            runtime.clone(),
+            epoch_manager.clone(),
+            shard_tracker.clone(),
+            noop().into_multi_sender(),
+            signer.clone(),
+            {
+                let thread_limit = runtime.get_shard_limit(PROTOCOL_VERSION) as usize * 3;
+                ApplyChunksSpawner::default().into_spawner(thread_limit)
+            },
+            chunk_executor_adapter.as_sender(),
+            spice_core_writer_adapter.as_sender(),
+            spice_data_distributor_adapter.as_multi_sender(),
+            ChunkExecutorConfig::default(),
+        );
+        let chunk_executor_addr = actor_system.spawn_tokio_actor(chunk_executor_actor);
+        chunk_executor_adapter.bind(chunk_executor_addr);
+
+        let spice_chunk_validator_actor = SpiceChunkValidatorActor::new(
+            runtime.store().clone(),
+            &chain_genesis,
+            runtime.clone(),
+            epoch_manager.clone(),
+            noop().into_multi_sender(),
+            signer.clone(),
+            spice_core_writer_adapter.as_sender(),
+            ApplyChunksSpawner::default(),
+        );
+        let spice_chunk_validator_addr =
+            actor_system.spawn_tokio_actor(spice_chunk_validator_actor);
+        spice_chunk_validator_adapter.bind(spice_chunk_validator_addr);
+    }
 
     // 8. Create RpcHandlerActor
     let rpc_handler_config = RpcHandlerConfig {

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -24,7 +24,7 @@ use near_primitives::epoch_info::RngSeed;
 use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{AccountId, NumSeats};
-use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::adapter::StoreAdapter as _;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::create_test_store;
@@ -155,7 +155,7 @@ pub fn create_test_setup_with_accounts_and_validity(
     let spice_chunk_validator_adapter = LateBoundSender::new();
     let spice_data_distributor_adapter = LateBoundSender::new();
     let spice_core_writer_adapter = LateBoundSender::new();
-    let spice_client_config = if cfg!(feature = "protocol_feature_spice") {
+    let spice_client_config = if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
         SpiceClientConfig {
             chunk_executor_sender: chunk_executor_adapter.as_sender(),
             spice_chunk_validator_sender: spice_chunk_validator_adapter.as_sender(),
@@ -196,7 +196,7 @@ pub fn create_test_setup_with_accounts_and_validity(
         spice_client_config,
     );
 
-    if cfg!(feature = "protocol_feature_spice") {
+    if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
         let spice_core_reader = SpiceCoreReader::new(
             runtime.store().chain_store(),
             epoch_manager.clone(),

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -358,8 +358,6 @@ async fn test_query_state() {
 
 /// Connect to json rpc and call function
 #[tokio::test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 async fn test_query_call_function() {
     let setup = create_test_setup_with_node_type(NodeType::Validator);
     let client = new_client(&setup.server_addr);
@@ -393,8 +391,6 @@ async fn test_query_call_function() {
 
 /// query contract code
 #[tokio::test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 async fn test_query_contract_code() {
     let setup = create_test_setup_with_node_type(NodeType::Validator);
     let client = new_client(&setup.server_addr);
@@ -745,15 +741,11 @@ async fn test_get_chunk_with_object_in_params() {
 }
 
 #[tokio::test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 async fn test_query_global_contract_code_by_hash() {
     test_query_global_contract_code(GlobalContractDeployMode::CodeHash).await;
 }
 
 #[tokio::test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 async fn test_query_global_contract_code_by_account_id() {
     test_query_global_contract_code(GlobalContractDeployMode::AccountId).await;
 }
@@ -953,8 +945,6 @@ async fn test_experimental_view_account_missing_account() {
 }
 
 /// Test EXPERIMENTAL_view_code method
-// TODO(spice): Fix test setup to support SPICE's async chunk execution.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 #[tokio::test]
 async fn test_experimental_view_code() {
     let setup = create_test_setup_with_node_type(NodeType::Validator);
@@ -1134,8 +1124,6 @@ async fn test_experimental_view_access_key_list_unknown_block() {
 }
 
 /// Test EXPERIMENTAL_call_function method
-// TODO(spice): Fix test setup to support SPICE's async chunk execution.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 #[tokio::test]
 async fn test_experimental_call_function() {
     let setup = create_test_setup_with_node_type(NodeType::Validator);
@@ -1162,8 +1150,6 @@ async fn test_experimental_call_function() {
 }
 
 /// Test EXPERIMENTAL_call_function error on missing method (MethodNotFound)
-// TODO(spice): Fix test setup to support SPICE's async chunk execution.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 #[tokio::test]
 async fn test_experimental_call_function_nonexisting_method() {
     let setup = create_test_setup_with_node_type(NodeType::Validator);

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -14,8 +14,6 @@ use std::ops::ControlFlow;
 
 /// Test sending transaction via json rpc without waiting.
 #[tokio::test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 async fn test_send_tx_async() {
     let setup = create_test_setup_with_node_type(NodeType::Validator);
     let client = new_client(&setup.server_addr);
@@ -68,8 +66,6 @@ async fn test_send_tx_async() {
 
 /// Test sending transaction and waiting for it to be committed to a block.
 #[tokio::test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 async fn test_send_tx_commit() {
     let setup = create_test_setup_with_node_type(NodeType::Validator);
     let client = new_client(&setup.server_addr);
@@ -103,8 +99,6 @@ async fn test_send_tx_commit() {
 
 /// Test that expired transaction should be rejected
 #[tokio::test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 async fn test_expired_tx() {
     // Create setup with very short transaction validity period (1 block)
     let accounts = vec!["test1".parse().unwrap(), "test2".parse().unwrap()];


### PR DESCRIPTION
- Mirror `nearcore::spawn_spice_actors`: when the feature is on, wire `LateBoundSender` adapters into `SpiceClientConfig`, then after `start_client` spawn the four SPICE actors (`ChunkExecutorActor`, `SpiceChunkValidatorActor`, `SpiceDataDistributorActor`, `SpiceCoreWriterActor`) and bind them. 
- The network adapter for these stays `noop` since the test runs a single validator. 
- With the feature off, the original noop wiring is preserved.