### PR TITLE
fix: readme ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@
 [![Twitter][twitter-badge]][twitter-url]
 [![Telegram Group][telegram-badge]][telegram-url]
 
-[build-badge]: https://github.com/near/nearcore/actions/workflows/ci.yml/badge.svg?branch=master
+[build-badge]: https://img.shields.io/github/check-runs/near/nearcore/master?label=CI
 [build-url]: https://github.com/near/nearcore/actions
 [stable-release]: https://img.shields.io/github/v/release/nearprotocol/nearcore?label=stable
 [prerelease]: https://img.shields.io/github/v/release/nearprotocol/nearcore?include_prereleases&label=prerelease
-[ci-badge-master]: https://badge.buildkite.com/a81147cb62c585cc434459eedd1d25e521453120ead9ee6c64.svg?branch=master
-[ci-url]: https://buildkite.com/nearprotocol/nearcore
 [codecov-badge]: https://codecov.io/gh/near/nearcore/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/near/nearcore
 [discord-badge]: https://img.shields.io/discord/490367152054992913.svg

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Reference implementation of NEAR Protocol
 
-[![Build][build-badge]][build-url]
+[![CI][ci-badge]][ci-url]
 ![Stable Status][stable-release]
 ![Prerelease Status][prerelease]
 [![codecov][codecov-badge]][codecov-url]
@@ -19,8 +19,8 @@
 [![Twitter][twitter-badge]][twitter-url]
 [![Telegram Group][telegram-badge]][telegram-url]
 
-[build-badge]: https://img.shields.io/github/check-runs/near/nearcore/master?label=CI
-[build-url]: https://github.com/near/nearcore/actions
+[ci-badge]: https://img.shields.io/github/check-runs/near/nearcore/master?label=CI
+[ci-url]: https://github.com/near/nearcore/actions
 [stable-release]: https://img.shields.io/github/v/release/nearprotocol/nearcore?label=stable
 [prerelease]: https://img.shields.io/github/v/release/nearprotocol/nearcore?include_prereleases&label=prerelease
 [codecov-badge]: https://codecov.io/gh/near/nearcore/branch/master/graph/badge.svg


### PR DESCRIPTION
Replace the GitHub Actions workflow badge with a shields.io check-runs
badge for master. The previous badge filtered by `branch=master`, but
`ci.yml` only triggers on `pull_request` and `merge_group` — neither
produces a run attributed to master for badge purposes — so the badge
always rendered as "no status" (red), even when CI was green.

The check-runs badge reflects the aggregated status of master's tip
commit, which includes the merge-queue results, so it now matches
actual CI health.

Also drops two unused Buildkite link references