### PR TITLE
fix(debug-ui): handle invalid epoch ids in validators view

### DIFF
--- a/tools/debug-ui/src/EpochValidatorsView.tsx
+++ b/tools/debug-ui/src/EpochValidatorsView.tsx
@@ -246,7 +246,7 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
         error: epochError,
         isLoading: epochIsLoading,
         isFetching,
-    } = useQuery(['epochInfo', addr, currentEpochId], () => fetchEpochInfo(addr, currentEpochId), {
+    } = useQuery<EpochInfoResponse, Error>(['epochInfo', addr, currentEpochId], () => fetchEpochInfo(addr, currentEpochId), {
         onSuccess: (data) => {
             if (!isValidEpochData(data)) {
                 return;
@@ -315,8 +315,7 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
         return <div>Loading...</div>;
     }
     const isEpochNotFound = isClientError(epochError);
-    const otherError =
-        epochError != null && !isEpochNotFound ? (epochError as Error) : null;
+    const otherError = epochError != null && !isEpochNotFound ? epochError : null;
     const showNotFound = isEpochNotFound || (epochData != null && !epochs);
     const showTable = epochs !== null && epochError == null;
 

--- a/tools/debug-ui/src/EpochValidatorsView.tsx
+++ b/tools/debug-ui/src/EpochValidatorsView.tsx
@@ -268,7 +268,10 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
         },
         keepPreviousData: true,
     });
-    const epochs = isValidEpochData(epochData) ? epochData.status_response.EpochInfo : null;
+    const epochs =
+        epochError == null && isValidEpochData(epochData)
+            ? epochData.status_response.EpochInfo
+            : null;
     const { data: statusData } = useQuery(['status', addr], () => fetchBasicStatus(addr));
     const chainHeadEpochId = statusData?.sync_info.epoch_id;
     const canNavigateLeft =
@@ -317,7 +320,6 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
     const isEpochNotFound = isClientError(epochError);
     const otherError = epochError != null && !isEpochNotFound ? epochError : null;
     const showNotFound = isEpochNotFound || (epochData != null && !epochs);
-    const showTable = epochs !== null && epochError == null;
 
     const handleNavigateEpoch = async (direction: 'left' | 'right') => {
         if (!epochData?.status_response.EpochInfo) return;
@@ -567,6 +569,9 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
             {showNotFound && (
                 <div className="error">
                     Epoch {currentEpochId ? <code>{currentEpochId}</code> : ''} not found.
+                    {isEpochNotFound && epochError?.message && (
+                        <> ({epochError.message})</>
+                    )}
                 </div>
             )}
             {otherError && (
@@ -574,7 +579,7 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
                     Failed to fetch epoch info: {otherError.message}
                 </div>
             )}
-            {showTable &&
+            {epochs &&
                 renderValidatorsTable(
                     epochData,
                     validators,
@@ -589,7 +594,8 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
 };
 
 function isValidEpochData(data: EpochInfoResponse | undefined): data is EpochInfoResponse {
-    return data !== undefined && data.status_response.EpochInfo.length >= 2;
+    const epochs = data?.status_response?.EpochInfo;
+    return Array.isArray(epochs) && epochs.length >= 2;
 }
 
 function drawProducedAndExpectedBar(

--- a/tools/debug-ui/src/EpochValidatorsView.tsx
+++ b/tools/debug-ui/src/EpochValidatorsView.tsx
@@ -1,8 +1,9 @@
 import { partition } from 'lodash';
 import { useQuery } from '@tanstack/react-query';
-import { useId, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Tooltip } from 'react-tooltip';
-import { EpochInfoView, ValidatorKickoutReason, fetchEpochInfo, fetchEntity, ApiEntityDataEntry, ApiEntityData } from './api';
+import { EpochInfoResponse, EpochInfoView, HttpError, ValidatorKickoutReason, fetchBasicStatus, fetchEpochInfo, fetchEntity, ApiEntityDataEntry, ApiEntityData } from './api';
 import './EpochValidatorsView.scss';
 import { EntityQuery, EntityQueryWithParams } from './entity_debug/types';
 
@@ -217,8 +218,19 @@ type EpochValidatorViewProps = {
 };
 
 export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
-    const [enteredEpochId, setEnteredEpochId] = useState<string>('');
-    const [currentEpochId, setCurrentEpochId] = useState<string | null>(null);
+    const [searchParams, setSearchParams] = useSearchParams();
+    const currentEpochId = searchParams.get('epoch_id');
+    const [enteredEpochId, setEnteredEpochId] = useState<string>(currentEpochId ?? '');
+    useEffect(() => {
+        setEnteredEpochId(currentEpochId ?? '');
+    }, [currentEpochId]);
+    const navigateToEpoch = (epochId: string | null) => {
+        if (epochId) {
+            setSearchParams({ epoch_id: epochId });
+        } else {
+            setSearchParams({});
+        }
+    };
     const [validators, setValidators] = useState<Validators | null>(null);
     const [validatorProtocolVersion, setValidatorProtocolVersion] = useState<Map<string, string> | null>(null);
     const [maxStake, setMaxStake] = useState<number>(0);
@@ -236,6 +248,9 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
         isFetching,
     } = useQuery(['epochInfo', addr, currentEpochId], () => fetchEpochInfo(addr, currentEpochId), {
         onSuccess: (data) => {
+            if (!isValidEpochData(data)) {
+                return;
+            }
             const {
                 validators,
                 maxStake,
@@ -253,6 +268,14 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
         },
         keepPreviousData: true,
     });
+    const epochs = isValidEpochData(epochData) ? epochData.status_response.EpochInfo : null;
+    const { data: statusData } = useQuery(['status', addr], () => fetchBasicStatus(addr));
+    const chainHeadEpochId = statusData?.sync_info.epoch_id;
+    const canNavigateLeft =
+        epochs !== null &&
+        chainHeadEpochId !== undefined &&
+        epochs[1].epoch_id !== chainHeadEpochId;
+    const canNavigateRight = epochs !== null && epochs.length > 2;
 
     const {
         data: versionTrackerData,
@@ -291,9 +314,14 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
     if (epochIsLoading) {
         return <div>Loading...</div>;
     }
-    if (epochError) {
-        return <div className="error">{(epochError as Error).stack}</div>;
-    }
+    const isEpochNotFound =
+        epochError instanceof HttpError &&
+        epochError.status >= 400 &&
+        epochError.status < 500;
+    const otherError =
+        epochError != null && !isEpochNotFound ? (epochError as Error) : null;
+    const showNotFound = isEpochNotFound || (epochData != null && !epochs);
+    const showTable = epochs !== null && epochError == null;
 
     const handleNavigateEpoch = async (direction: 'left' | 'right') => {
         if (!epochData?.status_response.EpochInfo) return;
@@ -307,18 +335,11 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
             return;
         }
 
-        const targetEpochId = epochs[targetIndex].epoch_id;
-        setCurrentEpochId(targetEpochId);
-        setEnteredEpochId(targetEpochId);
+        navigateToEpoch(epochs[targetIndex].epoch_id);
     };
 
     const handleButtonClick = async () => {
-        try {
-            setCurrentEpochId(enteredEpochId || null);
-        } catch (error) {
-            console.error('Error fetching epoch data:', error);
-            alert('Failed to fetch epoch data');
-        }
+        navigateToEpoch(enteredEpochId || null);
     };
 
     const handleEpochIdInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -504,31 +525,28 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
             <div className="epoch-navigation">
                 <button
                     onClick={() => handleNavigateEpoch('left')}
-                    disabled={!epochData}
+                    disabled={!canNavigateLeft}
                     className="arrow-button">
                     ←
                 </button>
 
                 <div className="epoch-info">
-                    {epochData && (
+                    {epochs && (
                         <>
                             <div className="epoch-height">
-                                Epoch {epochData.status_response.EpochInfo[1].epoch_height}
+                                Epoch {epochs[1].epoch_height}
                                 <span className="epoch-start-height">
-                                    (starts at{' '}
-                                    {epochData.status_response.EpochInfo[1].height || 'N/A'})
+                                    (starts at {epochs[1].height || 'N/A'})
                                 </span>
                             </div>
                             <details>
                                 <summary>Recent Epochs</summary>
                                 <div className="epoch-debug">
-                                    {epochData.status_response.EpochInfo.map(
-                                        (epoch: EpochInfoView) => (
-                                            <div key={epoch.epoch_id}>
-                                                Epoch {epoch.epoch_height}: {epoch.epoch_id}
-                                            </div>
-                                        )
-                                    )}
+                                    {epochs.map((epoch: EpochInfoView) => (
+                                        <div key={epoch.epoch_id}>
+                                            Epoch {epoch.epoch_height}: {epoch.epoch_id}
+                                        </div>
+                                    ))}
                                 </div>
                             </details>
                         </>
@@ -537,12 +555,12 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
 
                 <button
                     onClick={() => handleNavigateEpoch('right')}
-                    disabled={!epochData}
+                    disabled={!canNavigateRight}
                     className="arrow-button">
                     →
                 </button>
             </div>
-            {renderVotingTracker(votingTrackerData, totalVotingStake)}
+            {epochs && renderVotingTracker(votingTrackerData, totalVotingStake)}
             <input
                 type="text"
                 placeholder="Enter Epoch ID"
@@ -550,18 +568,33 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
                 onChange={handleEpochIdInput}
             />
             <button onClick={handleButtonClick}>Show Validators</button>
-            {renderValidatorsTable(
-                epochData,
-                validators,
-                maxStake,
-                totalStake,
-                maxExpectedBlocks,
-                maxExpectedChunks,
-                maxExpectedEndorsements
+            {showNotFound && (
+                <div className="error">
+                    Epoch {currentEpochId ? <code>{currentEpochId}</code> : ''} not found.
+                </div>
             )}
+            {otherError && (
+                <div className="error">
+                    Failed to fetch epoch info: {otherError.message}
+                </div>
+            )}
+            {showTable &&
+                renderValidatorsTable(
+                    epochData,
+                    validators,
+                    maxStake,
+                    totalStake,
+                    maxExpectedBlocks,
+                    maxExpectedChunks,
+                    maxExpectedEndorsements
+                )}
         </div>
     );
 };
+
+function isValidEpochData(data: EpochInfoResponse | undefined): data is EpochInfoResponse {
+    return data !== undefined && data.status_response.EpochInfo.length >= 2;
+}
 
 function drawProducedAndExpectedBar(
     producedAndExpected: ProducedAndExpected | null,

--- a/tools/debug-ui/src/EpochValidatorsView.tsx
+++ b/tools/debug-ui/src/EpochValidatorsView.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useId, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Tooltip } from 'react-tooltip';
-import { EpochInfoResponse, EpochInfoView, HttpError, ValidatorKickoutReason, fetchBasicStatus, fetchEpochInfo, fetchEntity, ApiEntityDataEntry, ApiEntityData } from './api';
+import { EpochInfoResponse, EpochInfoView, ValidatorKickoutReason, fetchBasicStatus, fetchEpochInfo, fetchEntity, isClientError, ApiEntityDataEntry, ApiEntityData } from './api';
 import './EpochValidatorsView.scss';
 import { EntityQuery, EntityQueryWithParams } from './entity_debug/types';
 
@@ -314,10 +314,7 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
     if (epochIsLoading) {
         return <div>Loading...</div>;
     }
-    const isEpochNotFound =
-        epochError instanceof HttpError &&
-        epochError.status >= 400 &&
-        epochError.status < 500;
+    const isEpochNotFound = isClientError(epochError);
     const otherError =
         epochError != null && !isEpochNotFound ? (epochError as Error) : null;
     const showNotFound = isEpochNotFound || (epochData != null && !epochs);

--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -417,27 +417,40 @@ export interface ChainProcessingStatusResponse {
     };
 }
 
-export async function fetchBasicStatus(addr: string): Promise<StatusResponse> {
-    const response = await fetch(getTargetUrl(addr, 'status'));
-    return await response.json();
+export class HttpError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+        super(message);
+        this.status = status;
+    }
 }
 
-export async function fetchFullStatus(addr: string): Promise<StatusResponse> {
-    const response = await fetch(getTargetUrl(addr, 'debug/api/status'));
-    return await response.json();
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(url, init);
+    if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new HttpError(response.status, body || response.statusText);
+    }
+    return response.json();
 }
 
-export async function fetchSyncStatus(addr: string): Promise<SyncStatusResponse> {
-    const response = await fetch(getTargetUrl(addr, 'debug/api/sync_status'));
-    return await response.json();
+export function fetchBasicStatus(addr: string): Promise<StatusResponse> {
+    return fetchJson(getTargetUrl(addr, 'status'));
 }
 
-export async function fetchTrackedShards(addr: string): Promise<TrackedShardsResponse> {
-    const response = await fetch(getTargetUrl(addr, 'debug/api/tracked_shards'));
-    return await response.json();
+export function fetchFullStatus(addr: string): Promise<StatusResponse> {
+    return fetchJson(getTargetUrl(addr, 'debug/api/status'));
 }
 
-export async function fetchBlockStatus(
+export function fetchSyncStatus(addr: string): Promise<SyncStatusResponse> {
+    return fetchJson(getTargetUrl(addr, 'debug/api/sync_status'));
+}
+
+export function fetchTrackedShards(addr: string): Promise<TrackedShardsResponse> {
+    return fetchJson(getTargetUrl(addr, 'debug/api/tracked_shards'));
+}
+
+export function fetchBlockStatus(
     addr: string,
     height: number | null,
     mode: string | null,
@@ -453,76 +466,61 @@ export async function fetchBlockStatus(
     if (numBlocks !== null) {
         params.append('num_blocks', numBlocks.toString());
     }
-    
-    const response = await fetch(getTargetUrl(addr, `debug/api/block_status${params.toString() ? '?' + params : ''}`));
-    return await response.json();
+    const query = params.toString() ? '?' + params : '';
+    return fetchJson(getTargetUrl(addr, `debug/api/block_status${query}`));
 }
 
-export async function fetchEpochInfo(
+export function fetchEpochInfo(
     addr: string,
     epochId: string | null
 ): Promise<EpochInfoResponse> {
     const trailing = epochId ? `/${epochId}` : '';
-    const response = await fetch(getTargetUrl(addr, `debug/api/epoch_info${trailing}`));
-    if (!response.ok) {
-        throw new Error(`Failed to fetch epoch info: ${response.statusText}`);
-    }
-
-    return await response.json();
+    return fetchJson(getTargetUrl(addr, `debug/api/epoch_info${trailing}`));
 }
 
-export async function fetchPeerStore(addr: string): Promise<PeerStoreResponse> {
-    const response = await fetch(getTargetUrl(addr, 'debug/api/peer_store'));
-    return await response.json();
+export function fetchPeerStore(addr: string): Promise<PeerStoreResponse> {
+    return fetchJson(getTargetUrl(addr, 'debug/api/peer_store'));
 }
 
-export async function fetchRecentOutboundConnections(
+export function fetchRecentOutboundConnections(
     addr: string
-): Promise<RecentOutboundConnectionsResponse> {   
-    const response = await fetch(getTargetUrl(addr, 'debug/api/recent_outbound_connections'));
-    return await response.json();
+): Promise<RecentOutboundConnectionsResponse> {
+    return fetchJson(getTargetUrl(addr, 'debug/api/recent_outbound_connections'));
 }
 
-export async function fetchSnapshotHosts(addr: string): Promise<SnapshotHostsResponse> {
-    const response = await fetch(getTargetUrl(addr, 'debug/api/snapshot_hosts'));
-    return await response.json();
+export function fetchSnapshotHosts(addr: string): Promise<SnapshotHostsResponse> {
+    return fetchJson(getTargetUrl(addr, 'debug/api/snapshot_hosts'));
 }
 
-export async function fetchChainProcessingStatus(
+export function fetchChainProcessingStatus(
     addr: string
 ): Promise<ChainProcessingStatusResponse> {
-    const response = await fetch(getTargetUrl(addr, 'debug/api/chain_processing_status'));
-    return await response.json();
+    return fetchJson(getTargetUrl(addr, 'debug/api/chain_processing_status'));
 }
 
 export type ApiEntityDataEntryValue = string | ApiEntityData;
 export type ApiEntityData = { entries: ApiEntityDataEntry[] };
 export type ApiEntityDataEntry = { name: string; value: ApiEntityDataEntryValue };
 
-export async function fetchEntity(
+export function fetchEntity(
     addr: string,
     request: EntityQueryWithParams
 ): Promise<ApiEntityDataEntryValue> {
-    const response = await fetch(getTargetUrl(addr, 'debug/api/entity'), {
+    return fetchJson(getTargetUrl(addr, 'debug/api/entity'), {
         body: JSON.stringify(request),
         headers: {
             'Content-Type': 'application/json',
         },
         method: 'POST',
     });
-    if (response.status !== 200) {
-        throw await response.text();
-    }
-    return response.json();
 }
 
 export const INSTRUMENTED_WINDOW_LEN_MS = 500;
 
-export async function fetchInstrumentedThreadsView(
+export function fetchInstrumentedThreadsView(
     addr: string
 ): Promise<InstrumentedThreadsViewResponse> {
-    const response = await fetch(getTargetUrl(addr, 'debug/api/instrumented_threads'));
-    return await response.json();
+    return fetchJson(getTargetUrl(addr, 'debug/api/instrumented_threads'));
 }
 
 export interface InstrumentedThreadsViewResponse {

--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -425,6 +425,10 @@ export class HttpError extends Error {
     }
 }
 
+export function isClientError(error: unknown): boolean {
+    return error instanceof HttpError && error.status >= 400 && error.status < 500;
+}
+
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
     const response = await fetch(url, init);
     if (!response.ok) {

--- a/tools/debug-ui/src/index.tsx
+++ b/tools/debug-ui/src/index.tsx
@@ -15,12 +15,7 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
-            retry: (failureCount, error) => {
-                if (isClientError(error)) {
-                    return false;
-                }
-                return failureCount < 3;
-            },
+            retry: (failureCount, error) => !isClientError(error) && failureCount < 3,
         },
     },
 });

--- a/tools/debug-ui/src/index.tsx
+++ b/tools/debug-ui/src/index.tsx
@@ -6,7 +6,7 @@ import '@patternfly/react-core/dist/styles/base.css';
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
-import { HttpError } from './api';
+import { isClientError } from './api';
 import { LogVisualizer } from './log_visualizer/LogVisualizer';
 import { LandingPage } from './LandingPage';
 
@@ -16,7 +16,7 @@ const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
             retry: (failureCount, error) => {
-                if (error instanceof HttpError && error.status >= 400 && error.status < 500) {
+                if (isClientError(error)) {
                     return false;
                 }
                 return failureCount < 3;

--- a/tools/debug-ui/src/index.tsx
+++ b/tools/debug-ui/src/index.tsx
@@ -6,12 +6,24 @@ import '@patternfly/react-core/dist/styles/base.css';
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { HttpError } from './api';
 import { LogVisualizer } from './log_visualizer/LogVisualizer';
 import { LandingPage } from './LandingPage';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            retry: (failureCount, error) => {
+                if (error instanceof HttpError && error.status >= 400 && error.status < 500) {
+                    return false;
+                }
+                return failureCount < 3;
+            },
+        },
+    },
+});
 
 const router = createBrowserRouter([
     {


### PR DESCRIPTION
The validators view crashed with "can't access property `epoch_height`, EpochInfo[1] is undefined" when an unknown epoch id was entered, because the debug RPC returns a short / empty `EpochInfo` array for unknown epochs (and a 400 for ones that don't parse). The browser back button also didn't work between epochs since the current epoch id lived in React state.

Changes:
- Show an inline "Epoch <id> not found" banner instead of crashing when the response is short or the server returns 4xx.
- Move the current epoch id to a `?epoch_id=` URL search param so browser back/forward navigate between viewed epochs. Arrow navigation updates the URL.
- Disable ← when we're already at the chain's tip (compares `EpochInfo[1].epoch_id` to the cached basic-status `sync_info.epoch_id`). Disable → when no past epochs are present.
- Add an `HttpError` class to `api.tsx` and a small `fetchJson` helper; refactor all `fetch*` to use it. Set `QueryClient` defaults to skip retries on 4xx so bad input fails immediately instead of stalling for ~7s on the default 3-retry backoff.
- Replace the full-page `(epochError as Error).stack` fallback with inline error banners.