### PR TITLE
fix(memtrie): preserve frozen data in parent Arc on resharding

### DIFF
--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -675,6 +675,12 @@ impl ShardTries {
         let mut guard = memtries.write();
         let memtries = std::mem::replace(&mut *guard, MemTries::new(parent_shard_uid));
         let frozen_memtries = memtries.freeze();
+        // Put a clone of the frozen MemTries back into the *old* Arc so that any
+        // in-flight apply task that already cloned this Arc (before the new ones
+        // below are inserted) can still resolve its prev_state_root. Without this,
+        // such an apply would hit an empty MemTries and panic on `get_root`.
+        *guard = MemTries::from_frozen_memtries(parent_shard_uid, frozen_memtries.clone());
+        drop(guard);
 
         // Create hybrid memtrie for both parent and children shards.
         for shard_uid in [vec![parent_shard_uid], children_shard_uids.clone()].concat() {

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -952,10 +952,14 @@ impl KeyForStateChanges {
 mod test {
     use super::*;
     use crate::adapter::StoreAdapter;
+    use crate::test_utils::{TestTriesBuilder, test_populate_trie};
+    use crate::trie::AccessOptions;
     use crate::{
         TrieConfig, config::TrieCacheConfig, test_utils::create_test_store,
         trie::DEFAULT_SHARD_CACHE_TOTAL_SIZE_LIMIT,
     };
+    use std::sync::mpsc::sync_channel;
+    use std::thread;
     use std::{assert_eq, str::FromStr};
 
     fn create_trie() -> ShardTries {
@@ -1107,5 +1111,49 @@ mod test {
         let insert_ops = Vec::from([(&key, Some(val.as_slice()))]);
         trie.update_cache(insert_ops, shard_uid);
         assert!(trie_caches.lock().get(&shard_uid).unwrap().get(&key).is_none());
+    }
+
+    /// Holds a `Trie` for the parent shard, pauses between two reads while
+    /// the main thread runs `freeze_parent_memtrie`, and verifies that the
+    /// second read still succeeds. Without preserving the frozen data in the
+    /// old parent Arc, the second read would hit an empty MemTries and fail
+    /// with `StorageInconsistentState` (panicking in production via the
+    /// catch-all in `chain/chain/src/runtime/mod.rs`).
+    #[test]
+    fn test_freeze_during_apply_keeps_in_flight_reads_alive() {
+        let tries =
+            TestTriesBuilder::new().with_flat_storage(true).with_in_memory_tries(true).build();
+        let parent = ShardUId::single_shard();
+        let children =
+            vec![ShardUId { version: 2, shard_id: 0 }, ShardUId { version: 2, shard_id: 1 }];
+
+        let state_root = test_populate_trie(
+            &tries,
+            &Trie::EMPTY_ROOT,
+            parent,
+            vec![(b"key".to_vec(), Some(b"value".to_vec()))],
+        );
+
+        let (apply_paused_tx, apply_paused_rx) = sync_channel::<()>(0);
+        let (freeze_done_tx, freeze_done_rx) = sync_channel::<()>(0);
+
+        let tries_for_apply = tries.clone();
+        let apply_thread = thread::spawn(move || {
+            let trie = tries_for_apply.get_trie_for_shard(parent, state_root);
+            let first = trie.get(b"key", AccessOptions::DEFAULT).unwrap();
+            assert_eq!(first, Some(b"value".to_vec()));
+
+            apply_paused_tx.send(()).unwrap();
+            freeze_done_rx.recv().unwrap();
+
+            trie.get(b"key", AccessOptions::DEFAULT)
+        });
+
+        apply_paused_rx.recv().unwrap();
+        tries.freeze_parent_memtrie(parent, children).unwrap();
+        freeze_done_tx.send(()).unwrap();
+
+        let result = apply_thread.join().unwrap();
+        assert_eq!(result.unwrap(), Some(b"value".to_vec()));
     }
 }


### PR DESCRIPTION
- `freeze_parent_memtrie` was leaving an empty `MemTries` inside the parent's old `Arc<RwLock<MemTries>>` after moving its data out to freeze it. Any in-flight apply task holding that Arc would then hit `get_root` → `StorageInconsistentState` → fatal panic via the catch-all in `chain/chain/src/runtime/mod.rs:1232`.
- Fix: put a `MemTries::from_frozen_memtries(parent_shard_uid, frozen_memtries.clone())` back into the old Arc. This reuses the same arena via `HybridArena::from_frozen`, so in-flight readers see the same view the new parent/children Arcs get.
- Includes `test_freeze_during_apply_keeps_in_flight_reads_alive`: a threaded unit test that pauses an apply between two reads, runs `freeze_parent_memtrie` on the main thread, and asserts the second read still succeeds. Fails on master, passes with this change.