### PR TITLE
fix(memtrie): return MissingTrieValue, not StorageInconsistentState, on missing root

### DIFF
--- a/core/store/src/trie/mem/iter.rs
+++ b/core/store/src/trie/mem/iter.rs
@@ -14,23 +14,25 @@ use near_primitives::state::FlatStateValue;
 pub struct MemTrieIteratorInner<'a> {
     memtrie: &'a MemTries,
     trie: &'a Trie,
+    // Pre-resolved at construction so the infallible `get_root` on the trait
+    // doesn't have to panic if the root went missing concurrently.
+    root: Option<MemTrieNodeId>,
 }
 
 impl<'a> MemTrieIteratorInner<'a> {
-    pub fn new(memtrie: &'a MemTries, trie: &'a Trie) -> Self {
-        Self { memtrie, trie }
+    pub fn new(memtrie: &'a MemTries, trie: &'a Trie) -> Result<Self, StorageError> {
+        let root = if trie.root == CryptoHash::default() {
+            None
+        } else {
+            Some(memtrie.get_root(&trie.root)?.id())
+        };
+        Ok(Self { memtrie, trie, root })
     }
 }
 
 impl<'a> GenericTrieInternalStorage<MemTrieNodeId, FlatStateValue> for MemTrieIteratorInner<'a> {
     fn get_root(&self) -> Option<MemTrieNodeId> {
-        let root_hash = self.trie.root;
-        if root_hash == CryptoHash::default() {
-            return None;
-        }
-        let root_node = self.memtrie.get_root(&root_hash).unwrap();
-        let root_ptr = root_node.id();
-        Some(root_ptr)
+        self.root
     }
 
     fn get_node_with_size(

--- a/core/store/src/trie/mem/memtrie_update.rs
+++ b/core/store/src/trie/mem/memtrie_update.rs
@@ -1259,18 +1259,12 @@ mod tests {
         memtrie.delete_until_height(10);
 
         // state_root2 should still exist in snapshot, however state_root should be gone
-        assert!(matches!(
-            memtrie.get_root(&state_root),
-            Err(StorageError::StorageInconsistentState { .. })
-        ));
+        assert!(matches!(memtrie.get_root(&state_root), Err(StorageError::MissingTrieValue(..))));
         let hash = memtrie.get_root(&state_root2).unwrap().view().node_hash().to_string();
         assert_eq!(hash, "87gK6ZaJBgtuBLL3MZ5GB1rVKJmpJ1gYBLusRbTHyZuu");
 
         // delete snapshot, state_root2 should be gone
         memtrie.delete_snapshot();
-        assert!(matches!(
-            memtrie.get_root(&state_root2),
-            Err(StorageError::StorageInconsistentState { .. })
-        ));
+        assert!(matches!(memtrie.get_root(&state_root2), Err(StorageError::MissingTrieValue(..))));
     }
 }

--- a/core/store/src/trie/mem/memtries.rs
+++ b/core/store/src/trie/mem/memtries.rs
@@ -12,7 +12,7 @@ use crate::trie::MemTrieChanges;
 use crate::trie::mem::arena::ArenaMut;
 use crate::trie::mem::metrics::MEMTRIE_NUM_ROOTS;
 use itertools::Itertools;
-use near_primitives::errors::StorageError;
+use near_primitives::errors::{MissingTrieValue, MissingTrieValueContext, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::types::{BlockHeight, StateRoot};
@@ -156,12 +156,16 @@ impl MemTries {
         state_root: &CryptoHash,
     ) -> Result<MemTrieNodePtr<'_, HybridArenaMemory>, StorageError> {
         assert_ne!(state_root, &CryptoHash::default());
-        self.roots.get(state_root).map(|ids| ids[0].as_ptr(self.arena.memory())).ok_or_else(|| {
-            StorageError::StorageInconsistentState(format!(
-                "Failed to find root node {:?} in memtrie",
-                state_root
-            ))
-        })
+        // Memtrie root may be missing due to an in-flight chunk application
+        // which goes past the memtrie GC or over the resharding boundary.
+        // Return MissingTrieValue, not StorageInconsistentState, which
+        // callers may decide to panic on.
+        self.roots.get(state_root).map(|ids| ids[0].as_ptr(self.arena.memory())).ok_or(
+            StorageError::MissingTrieValue(MissingTrieValue {
+                context: MissingTrieValueContext::TrieStorage,
+                hash: *state_root,
+            }),
+        )
     }
 
     /// Expires all trie roots corresponding to a height smaller than
@@ -209,7 +213,7 @@ impl MemTries {
 
     /// Returns an iterator over the memtrie for the given trie root.
     pub fn get_iter<'a>(&'a self, trie: &'a Trie) -> Result<STMemTrieIterator<'a>, StorageError> {
-        let iter_storage = MemTrieIteratorInner::new(self, trie);
+        let iter_storage = MemTrieIteratorInner::new(self, trie)?;
         STMemTrieIterator::new(iter_storage, None)
     }
 

--- a/core/store/src/trie/ops/tests.rs
+++ b/core/store/src/trie/ops/tests.rs
@@ -119,7 +119,7 @@ fn run(initial_entries: Vec<(Vec<u8>, Vec<u8>)>, retain_multi_ranges: Vec<Range<
     let entries = if mem_state_root != StateRoot::default() {
         let trie =
             Trie::new(Arc::new(TrieMemoryPartialStorage::<false>::default()), mem_state_root, None);
-        STMemTrieIterator::new(MemTrieIteratorInner::new(&memtries, &trie), None)
+        STMemTrieIterator::new(MemTrieIteratorInner::new(&memtries, &trie).unwrap(), None)
             .unwrap()
             .map(|e| e.unwrap())
             .collect_vec()

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -946,10 +946,15 @@ impl KeyForStateChanges {
 mod test {
     use super::*;
     use crate::adapter::StoreAdapter;
+    use crate::test_utils::{TestTriesBuilder, test_populate_trie};
+    use crate::trie::AccessOptions;
     use crate::{
         TrieConfig, config::TrieCacheConfig, test_utils::create_test_store,
         trie::DEFAULT_SHARD_CACHE_TOTAL_SIZE_LIMIT,
     };
+    use near_primitives::errors::{MissingTrieValueContext, StorageError};
+    use std::sync::mpsc::sync_channel;
+    use std::thread;
     use std::{assert_eq, str::FromStr};
 
     fn create_trie() -> ShardTries {
@@ -1101,5 +1106,51 @@ mod test {
         let insert_ops = Vec::from([(&key, Some(val.as_slice()))]);
         trie.update_cache(insert_ops, shard_uid);
         assert!(trie_caches.lock().get(&shard_uid).unwrap().get(&key).is_none());
+    }
+
+    /// A `Trie` reader racing with `freeze_parent_memtrie` should get
+    /// `MissingTrieValue` (non-fatal), not `StorageInconsistentState` (fatal
+    /// at `runtime/mod.rs`).
+    #[test]
+    fn test_freeze_during_apply_returns_missing_trie_value() {
+        let tries =
+            TestTriesBuilder::new().with_flat_storage(true).with_in_memory_tries(true).build();
+        let parent = ShardUId::single_shard();
+        let children =
+            vec![ShardUId { version: 2, shard_id: 0 }, ShardUId { version: 2, shard_id: 1 }];
+
+        let state_root = test_populate_trie(
+            &tries,
+            &Trie::EMPTY_ROOT,
+            parent,
+            vec![(b"key".to_vec(), Some(b"value".to_vec()))],
+        );
+
+        let (apply_paused_tx, apply_paused_rx) = sync_channel::<()>(0);
+        let (freeze_done_tx, freeze_done_rx) = sync_channel::<()>(0);
+
+        let tries_for_apply = tries.clone();
+        let apply_thread = thread::spawn(move || {
+            let trie = tries_for_apply.get_trie_for_shard(parent, state_root);
+            let first = trie.get(b"key", AccessOptions::DEFAULT).unwrap();
+            assert_eq!(first, Some(b"value".to_vec()));
+
+            apply_paused_tx.send(()).unwrap();
+            freeze_done_rx.recv().unwrap();
+
+            trie.get(b"key", AccessOptions::DEFAULT)
+        });
+
+        apply_paused_rx.recv().unwrap();
+        tries.freeze_parent_memtrie(parent, children).unwrap();
+        freeze_done_tx.send(()).unwrap();
+
+        let result = apply_thread.join().unwrap();
+        assert_matches::assert_matches!(
+            result,
+            Err(StorageError::MissingTrieValue(missing))
+                if missing.context == MissingTrieValueContext::TrieStorage
+                    && missing.hash == state_root
+        );
     }
 }

--- a/core/store/src/trie/split.rs
+++ b/core/store/src/trie/split.rs
@@ -590,7 +590,7 @@ fn extension_to_nibbles(extension: &[u8]) -> SmallVec<[u8; MAX_NIBBLES]> {
 pub fn find_trie_split(trie: &Trie) -> FindSplitResult<TrieSplit> {
     match trie.lock_memtries() {
         Some(memtries) => {
-            let trie_storage = MemTrieIteratorInner::new(&memtries, trie);
+            let trie_storage = MemTrieIteratorInner::new(&memtries, trie)?;
             TrieDescent::new(trie_storage)?.find_mem_usage_split()
         }
         None => {
@@ -605,7 +605,7 @@ pub fn find_trie_split(trie: &Trie) -> FindSplitResult<TrieSplit> {
 pub fn total_mem_usage(trie: &Trie) -> FindSplitResult<u64> {
     match trie.lock_memtries() {
         Some(memtries) => {
-            let trie_storage = MemTrieIteratorInner::new(&memtries, trie);
+            let trie_storage = MemTrieIteratorInner::new(&memtries, trie)?;
             let root_id = trie_storage.get_root().ok_or(FindSplitError::NoRoot)?;
             let root_node = trie_storage.get_node_with_size(root_id, AccessOptions::DEFAULT)?;
             Ok(root_node.memory_usage)
@@ -1177,7 +1177,7 @@ mod tests {
         ) -> FindSplitResult<TrieSplit> {
             let key_bytes = boundary_account.as_bytes();
             let memtries = trie.lock_memtries().unwrap();
-            let trie_storage = MemTrieIteratorInner::new(&memtries, trie);
+            let trie_storage = MemTrieIteratorInner::new(&memtries, trie)?;
             TrieDescent::new(trie_storage)?.get_split(key_bytes)
         }
 


### PR DESCRIPTION
- `MemTries::get_root` returned `StorageInconsistentState` when the requested root wasn't in the in-memory roots map. That error variant hits the catch-all panic in `chain/chain/src/runtime/mod.rs:1232`, so a missing root during an in-flight apply (e.g. `freeze_parent_memtrie` replacing the parent MemTries, or GC freeing a root the apply was racing) would crash the node under `panic = "abort"`.
- Switch the error to `StorageError::MissingTrieValue { context: TrieStorage, hash: state_root }`. `MissingTrieValue` is already in the non-panic arm at `runtime/mod.rs:1230`, so the apply now fails gracefully and the result is discarded as a normal retryable miss.
- No new variants, no protocol schema change. The `snapshot()` path keeps `StorageInconsistentState` since that's caller-driven, not a race.
- Includes `test_freeze_during_apply_returns_missing_trie_value`: threaded unit test that pauses an apply between two reads, runs `freeze_parent_memtrie`, and asserts the second read returns `MissingTrieValue` with the right hash.