### PR TITLE
feat(cloud-archive): reader-side cold-column completion

### DIFF
--- a/chain/client/src/archive/cloud_archival_reader.rs
+++ b/chain/client/src/archive/cloud_archival_reader.rs
@@ -1,5 +1,6 @@
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::shard_layout::get_block_shard_uid;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
@@ -85,12 +86,16 @@ pub fn save_shard_data(
 ) {
     let shard_id = shard_uid.shard_id();
     let block_shard_id_key = get_block_shard_id(block_hash, shard_id);
-    let block_shard_uid_key = borsh::to_vec(&(*block_hash, shard_uid)).unwrap();
+    let block_shard_uid_key = get_block_shard_uid(block_hash, &shard_uid);
+    let chunk = shard_data.chunk();
+    // Chunks presence marks (block, shard) already saved; reruns would inflate refcounts.
+    if store.exists(DBCol::Chunks, chunk.chunk_hash().as_ref()) {
+        return;
+    }
     let mut update = store.store_update();
 
     // Chunks, ReceiptToTx, and TransactionResultForBlock are content-addressed;
     // use insert_ser to keep the columns insert-only.
-    let chunk = shard_data.chunk();
     update.insert_ser(DBCol::Chunks, chunk.chunk_hash().as_ref(), chunk);
 
     let chunk_extra: &ChunkExtra = shard_data.chunk_extra();
@@ -203,6 +208,8 @@ pub fn bootstrap_range(
         height = last_in_batch + 1;
     }
 
+    // TODO(cloud_archival): support resharding. Layout is captured once;
+    // a mid-range layout change would write under the wrong ShardUId.
     for shard_id in shard_layout.shard_ids() {
         let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
         save_shard_range(store, cloud_storage, shard_uid, start_height, end_height)?;

--- a/chain/client/src/archive/cloud_archival_reader.rs
+++ b/chain/client/src/archive/cloud_archival_reader.rs
@@ -1,9 +1,14 @@
+use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::sharding::ChunkHash;
+use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
-use near_primitives::utils::index_to_bytes;
-use near_store::archive::cloud_storage::{BlockData, CloudRetrievalError, CloudStorage, EpochData};
-use near_store::{DBCol, Store};
-use std::collections::HashSet;
+use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
+use near_store::archive::cloud_storage::{
+    BlockData, CloudRetrievalError, CloudStorage, EpochData, ShardData,
+};
+use near_store::{DBCol, KeyForStateChanges, ShardUId, Store};
+use std::collections::{HashMap, HashSet};
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
 #[derive(thiserror::Error, Debug)]
@@ -16,13 +21,8 @@ pub enum CloudArchivalReaderError {
 
 /// Writes block-level data from cloud storage into the local store.
 ///
-/// The merkle tree is updated incrementally: the previous block's tree is read,
-/// extended with prev_hash, and saved under the current block's hash. The
-/// initial tree for each epoch must be written by `save_epoch_data` first.
-///
-/// Block, BlockHeader, BlockInfo use `insert_ser` (insert-only, content-addressed
-/// by hash). BlockHeight and BlockMerkleTree use `set_ser` (regular columns,
-/// keyed by height or hash, safe to overwrite).
+/// `save_epoch_data` must run first for the current epoch to seed the merkle
+/// tree at the epoch start; this function then extends the tree incrementally.
 pub fn save_block_data(store: &Store, block_data: &BlockData) {
     let block = block_data.block();
     let header = block.header();
@@ -31,12 +31,35 @@ pub fn save_block_data(store: &Store, block_data: &BlockData) {
 
     let mut update = store.store_update();
 
+    // BlockHeader, Block, BlockInfo are content-addressed by hash; use
+    // insert_ser to keep the column insert-only.
     update.insert_ser(DBCol::BlockHeader, block_hash.as_ref(), header);
     update.insert_ser(DBCol::Block, block_hash.as_ref(), block);
     update.insert_ser(DBCol::BlockInfo, block_hash.as_ref(), block_data.block_info());
     update.set_ser(DBCol::BlockHeight, &index_to_bytes(height), &block_hash);
 
-    // Update block merkle tree incrementally.
+    // Archive only carries canonical blocks, so one hash per height per epoch.
+    let mut block_per_height: HashMap<EpochId, HashSet<CryptoHash>> = HashMap::new();
+    block_per_height.insert(*header.epoch_id(), HashSet::from([block_hash]));
+    update.set_ser(DBCol::BlockPerHeight, &index_to_bytes(height), &block_per_height);
+
+    update.set_ser(DBCol::NextBlockHashes, block_hash.as_ref(), block_data.next_block_hash());
+
+    let mut chunk_hashes: HashSet<ChunkHash> = HashSet::new();
+    for chunk_header in block.chunks().iter_raw() {
+        if chunk_header.is_new_chunk(height) {
+            chunk_hashes.insert(chunk_header.chunk_hash().clone());
+        }
+    }
+    // Skip the write when no shard has a new chunk so the on-disk shape
+    // matches what the chain store produces at apply time.
+    if !chunk_hashes.is_empty() {
+        update.set_ser(DBCol::ChunkHashesByHeight, &index_to_bytes(height), &chunk_hashes);
+    }
+
+    // Update the block merkle tree incrementally: read the previous block's
+    // tree, extend with prev_hash, and save under the current block's hash.
+    // save_epoch_data must run first to seed the tree at the epoch start.
     if header.is_genesis() {
         update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), &PartialMerkleTree::default());
     } else {
@@ -46,6 +69,67 @@ pub fn save_block_data(store: &Store, block_data: &BlockData) {
         let mut tree = prev_tree;
         tree.insert(*header.prev_hash());
         update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), &tree);
+    }
+
+    update.commit();
+}
+
+/// Writes shard-level data for one `(block_hash, shard_uid)` into the local
+/// store. Mirrors the chain store's column shapes so reader queries hit the
+/// same code paths as a normal node.
+pub fn save_shard_data(
+    store: &Store,
+    block_hash: &CryptoHash,
+    shard_uid: ShardUId,
+    shard_data: &ShardData,
+) {
+    let shard_id = shard_uid.shard_id();
+    let block_shard_id_key = get_block_shard_id(block_hash, shard_id);
+    let block_shard_uid_key = borsh::to_vec(&(*block_hash, shard_uid)).unwrap();
+    let mut update = store.store_update();
+
+    // Chunks, ReceiptToTx, and TransactionResultForBlock are content-addressed;
+    // use insert_ser to keep the columns insert-only.
+    let chunk = shard_data.chunk();
+    update.insert_ser(DBCol::Chunks, chunk.chunk_hash().as_ref(), chunk);
+
+    let chunk_extra: &ChunkExtra = shard_data.chunk_extra();
+    update.set_ser(DBCol::ChunkExtra, &block_shard_uid_key, chunk_extra);
+
+    update.set_ser(DBCol::ChunkApplyStats, &block_shard_id_key, shard_data.chunk_apply_stats());
+
+    // Transactions and Receipts are reference-counted; bump the refcount once
+    // per stored value, matching what a chunk-applying node would write.
+    for tx in chunk.to_transactions() {
+        let bytes = borsh::to_vec(tx).expect("borsh cannot fail on SignedTransaction");
+        update.increment_refcount(DBCol::Transactions, tx.get_hash().as_ref(), &bytes);
+    }
+    for receipt in chunk.prev_outgoing_receipts() {
+        let bytes = borsh::to_vec(receipt).expect("borsh cannot fail on Receipt");
+        update.increment_refcount(DBCol::Receipts, receipt.get_hash().as_ref(), &bytes);
+    }
+
+    let outcome_ids: Vec<CryptoHash> =
+        shard_data.transaction_result_for_block().iter().map(|(id, _)| *id).collect();
+    update.set_ser(DBCol::OutcomeIds, &block_shard_id_key, &outcome_ids);
+
+    for (outcome_id, outcome_with_proof) in shard_data.transaction_result_for_block() {
+        update.insert_ser(
+            DBCol::TransactionResultForBlock,
+            &get_outcome_id_block_hash(outcome_id, block_hash),
+            outcome_with_proof,
+        );
+    }
+    for (receipt_id, info) in shard_data.receipt_to_tx() {
+        update.insert_ser(DBCol::ReceiptToTx, receipt_id.as_ref(), info);
+    }
+
+    update.set_ser(DBCol::IncomingReceipts, &block_shard_id_key, shard_data.incoming_receipts());
+    update.set_ser(DBCol::OutgoingReceipts, &block_shard_id_key, shard_data.outgoing_receipts());
+
+    for change in shard_data.state_changes() {
+        let key_for_changes = KeyForStateChanges::from_trie_key(block_hash, &change.trie_key);
+        update.set_ser(DBCol::StateChanges, key_for_changes.as_ref(), change);
     }
 
     update.commit();
@@ -69,13 +153,13 @@ pub fn save_epoch_data(store: &Store, epoch_id: &EpochId, epoch_data: &EpochData
     update.commit();
 }
 
-/// Downloads block and epoch data for [start_height, end_height] from cloud
-/// storage and writes it into the local store.
+/// Downloads block + epoch + per-shard data for `[start_height, end_height]`
+/// from cloud storage and writes the cold columns into the local store.
 ///
 /// When `start_height` falls mid-epoch, blocks from the epoch start are
-/// backfilled automatically so the merkle tree chain is complete.
-///
-/// TODO(cloud_archival): Also download and apply shard (state) data per block.
+/// backfilled automatically so the merkle tree chain is complete. Shard data
+/// is saved only for `[start_height, end_height]` because earlier heights are
+/// just block-level backfill for the merkle chain.
 pub fn bootstrap_range(
     store: &Store,
     cloud_storage: &CloudStorage,
@@ -91,6 +175,7 @@ pub fn bootstrap_range(
     let (start_height, first_epoch_data) =
         backfill_epoch_start(store, cloud_storage, start_height)?;
     saved_epochs.insert(*first_epoch_data.epoch_id());
+    let shard_layout = first_epoch_data.shard_layout().clone();
 
     let range_length = end_height - start_height + 1;
     let epoch_length = end_height - first_epoch_data.epoch_start_height();
@@ -118,6 +203,42 @@ pub fn bootstrap_range(
         height = last_in_batch + 1;
     }
 
+    for shard_id in shard_layout.shard_ids() {
+        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+        save_shard_range(store, cloud_storage, shard_uid, start_height, end_height)?;
+    }
+
+    Ok(())
+}
+
+/// Writes shard-level data for one shard across `[start_height, end_height]`.
+fn save_shard_range(
+    store: &Store,
+    cloud_storage: &CloudStorage,
+    shard_uid: ShardUId,
+    start_height: BlockHeight,
+    end_height: BlockHeight,
+) -> anyhow::Result<()> {
+    // TODO(cloud_archival): download and apply the state snapshot for this
+    // shard before this loop, and apply per-block state deltas alongside the
+    // column saves so the reader's trie advances with the saved data.
+    let shard_id = shard_uid.shard_id();
+    let mut height = start_height;
+    while height <= end_height {
+        let batch = cloud_storage.get_shard_batch_for_height(height, shard_id)?;
+        let last_in_batch = std::cmp::min(batch.end_height(), end_height);
+        for h in height..=last_in_batch {
+            let Some(shard_data) = batch.get_shard_at_height(h) else {
+                continue;
+            };
+            // save_block_data above writes BlockHeight at every present height.
+            let block_hash: CryptoHash = store
+                .get_ser(DBCol::BlockHeight, &index_to_bytes(h))
+                .expect("BlockHeight saved earlier in bootstrap_range");
+            save_shard_data(store, &block_hash, shard_uid, shard_data);
+        }
+        height = last_in_batch + 1;
+    }
     Ok(())
 }
 

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -177,9 +177,9 @@ mod tests {
 
     /// Cold columns intentionally not carried by batch blobs.
     const CLOUD_NON_BATCH_COLUMNS: &[DBCol] = &[
-        // TODO(cloud_archival): reconstruct from BlockHeight in the reader.
+        // Reconstructed from BlockData by the reader at save time.
         DBCol::BlockPerHeight,
-        // TODO(cloud_archival): reconstruct from Block in the reader.
+        // Reconstructed from BlockData by the reader at save time.
         DBCol::ChunkHashesByHeight,
         // Per-epoch state snapshots cover state, not per-block deltas.
         DBCol::State,

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -205,6 +205,18 @@ impl ShardData {
         }
     }
 
+    pub fn incoming_receipts(&self) -> &[ReceiptProof] {
+        match self {
+            ShardData::V1(data) => &data.incoming_receipts,
+        }
+    }
+
+    pub fn outgoing_receipts(&self) -> &[Receipt] {
+        match self {
+            ShardData::V1(data) => &data.outgoing_receipts,
+        }
+    }
+
     pub fn chunk_apply_stats(&self) -> &ChunkApplyStats {
         match self {
             ShardData::V1(data) => &data.chunk_apply_stats,
@@ -301,6 +313,7 @@ impl ShardBatch {
     /// the height is a skipped slot or the shard's chunk at that height is
     /// not new. `height` must be within the batch range - passing an
     /// out-of-range height is a programmer error and panics.
+    // TODO(cloud_archival): rename to `get_data_at_height` to read better.
     pub fn get_shard_at_height(&self, height: BlockHeight) -> Option<&ShardData> {
         let ShardBatch::V1(batch) = self;
         assert!(

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -23,6 +23,7 @@ use near_primitives::transaction::ExecutionOutcomeWithProof;
 use near_primitives::types::{AccountId, Balance, BlockHeight, BlockHeightDelta, ShardId};
 use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
 use near_store::adapter::StoreAdapter;
+use near_store::archive::cloud_storage::CloudStorage;
 use near_store::archive::cloud_storage::bucket_config::BucketConfig;
 use near_store::flat::FlatStorageManager;
 use near_store::{
@@ -77,10 +78,10 @@ impl CloudArchiveHarnessBuilder {
         self
     }
 
-    /// Sets the number of block-and-chunk-producer validators.
+    /// Sets the number of block-and-chunk-producer validators. Tests that
+    /// call `drop_blocks_at` or `drop_chunks` get this set to >= 4
+    /// automatically; see `build()`.
     fn validators(mut self, count: usize) -> Self {
-        // `drop_blocks_at` / `drop_chunks` need count >= 4 to be observable on
-        // the chain; see `block_dropper_by_height` in `test-loop-tests/src/utils/network.rs`.
         assert!(count > 0);
         self.num_validators = Some(count);
         self
@@ -125,8 +126,22 @@ impl CloudArchiveHarnessBuilder {
                     snapshot_every_n_epochs,
                 );
             });
+        // `drop_blocks_at` / `drop_chunks` need >= 4 validators to be
+        // observable on the chain; see `block_dropper_by_height` in
+        // `test-loop-tests/src/utils/network.rs`. Tests that opt into drops
+        // get this minimum automatically; an explicit lower count panics.
+        const MIN_VALIDATORS_FOR_DROPS: usize = 4;
         if let Some(count) = self.num_validators {
+            if has_drops {
+                assert!(
+                    count >= MIN_VALIDATORS_FOR_DROPS,
+                    "drop_blocks_at / drop_chunks need >= {MIN_VALIDATORS_FOR_DROPS} validators, \
+                     got {count}",
+                );
+            }
             builder = builder.validators(count, 0);
+        } else if has_drops {
+            builder = builder.validators(MIN_VALIDATORS_FOR_DROPS, 0);
         }
         // Drop conditions must be registered after build but before warmup;
         // delay_warmup splits build/warmup so we can call drop() in between.
@@ -309,6 +324,15 @@ impl CloudArchiveHarness {
     fn shutdown(mut self) {
         self.env.test_loop.run_for(Duration::seconds(5));
     }
+}
+
+/// Reads the block at `probe_height` from cloud and returns the start height
+/// of its epoch. Used to anchor per-epoch offsets to absolute heights when
+/// the chain's genesis epoch is shorter than `epoch_length`.
+fn epoch_start_at_height(cloud_storage: &CloudStorage, probe_height: BlockHeight) -> BlockHeight {
+    let epoch_id =
+        *cloud_storage.get_block_data(probe_height).unwrap().unwrap().block().header().epoch_id();
+    cloud_storage.get_epoch_data(epoch_id).unwrap().epoch_start_height()
 }
 
 /// Verifies that `cloud_head` progresses without crashes.
@@ -642,7 +666,6 @@ fn test_cloud_archival_find_snapshot_with_missing_epoch_boundary() {
     assert_eq!(CloudArchiveHarness::DEFAULT_EPOCH_LENGTH, 10);
     let dropped_height: BlockHeight = 29;
     let mut h = CloudArchiveHarness::builder()
-        .validators(4)
         .snapshot_every_n_epochs(2)
         .drop_blocks_at(&[dropped_height])
         .build();
@@ -675,8 +698,7 @@ fn test_cloud_archival_find_snapshot_with_missing_epoch_boundary() {
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_single_skipped_slot() {
     let dropped_height: BlockHeight = 13;
-    let mut h =
-        CloudArchiveHarness::builder().validators(4).drop_blocks_at(&[dropped_height]).build();
+    let mut h = CloudArchiveHarness::builder().drop_blocks_at(&[dropped_height]).build();
     h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
 
     let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
@@ -737,7 +759,6 @@ fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
     chunk_pattern[5] = false;
 
     let mut h = CloudArchiveHarness::builder()
-        .validators(4)
         .drop_blocks_at(&[start, target])
         .drop_chunks(dropped_shard, chunk_pattern)
         .build();
@@ -757,11 +778,7 @@ fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
     }
     // The chunk-drop pattern is applied per epoch; assert that offset 5 of
     // the target's epoch is missing in cloud for the dropped shard.
-    let target_epoch_id =
-        *cloud_storage.get_block_data(25).unwrap().unwrap().block().header().epoch_id();
-    let target_epoch_start =
-        cloud_storage.get_epoch_data(target_epoch_id).unwrap().epoch_start_height();
-    let chunk_drop_height = target_epoch_start + 5;
+    let chunk_drop_height = epoch_start_at_height(&cloud_storage, 25) + 5;
     assert!(
         cloud_storage.get_shard_data(chunk_drop_height, dropped_shard).unwrap().is_none(),
         "shard {dropped_shard} chunk at h={chunk_drop_height} must be None in cloud"
@@ -798,16 +815,13 @@ fn test_cloud_archival_missing_chunks_one_shard() {
     for offset in dropped_offsets {
         pattern[offset as usize] = false;
     }
-    let mut h =
-        CloudArchiveHarness::builder().validators(4).drop_chunks(dropped_shard, pattern).build();
+    let mut h = CloudArchiveHarness::builder().drop_chunks(dropped_shard, pattern).build();
     h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
 
     let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
     for epoch in [1u64, 2] {
         let probe = epoch * h.epoch_length + h.epoch_length / 2;
-        let epoch_id =
-            *cloud_storage.get_block_data(probe).unwrap().unwrap().block().header().epoch_id();
-        let epoch_start = cloud_storage.get_epoch_data(epoch_id).unwrap().epoch_start_height();
+        let epoch_start = epoch_start_at_height(&cloud_storage, probe);
         for offset in dropped_offsets {
             let height = epoch_start + offset;
             let dropped = cloud_storage.get_shard_data(height, dropped_shard).unwrap();
@@ -943,9 +957,7 @@ fn test_cloud_archival_outcomes_and_receipts() {
 /// the per-block cold columns the reader reconstructs from cloud data:
 /// `BlockPerHeight`, `ChunkHashesByHeight`, and `NextBlockHashes`.
 #[test]
-// TODO(cloud_archival): un-ignore once the reader reconstructs per-block cold columns.
-#[ignore]
-fn test_cloud_archival_reader_reconstructs_per_block_columns() {
+fn test_cloud_archival_reader_per_block_columns() {
     let mut h = CloudArchiveHarness::builder().build();
     h.run_until_epoch(3 + MIN_GC_NUM_EPOCHS_TO_KEEP);
     let start = h.epoch_length / 2;
@@ -978,14 +990,57 @@ fn test_cloud_archival_reader_reconstructs_per_block_columns() {
     h.shutdown();
 }
 
+/// At a height where every shard's chunk is missing but the block itself is
+/// present, the reader writes no `ChunkHashesByHeight` entry, matching what
+/// the chain store does at apply time.
+#[test]
+fn test_cloud_archival_block_present_all_chunks_missing() {
+    let epoch_length = CloudArchiveHarness::DEFAULT_EPOCH_LENGTH;
+    let dropped_offset = epoch_length / 2;
+    let mut pattern = vec![true; epoch_length as usize];
+    pattern[dropped_offset as usize] = false;
+    let mut builder = CloudArchiveHarness::builder();
+    for shard_id in CloudArchiveHarness::all_shard_ids() {
+        builder = builder.drop_chunks(shard_id, pattern.clone());
+    }
+    let mut h = builder.build();
+    h.run_until_epoch(2 + MIN_GC_NUM_EPOCHS_TO_KEEP);
+
+    let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
+    let dropped_height = epoch_start_at_height(&cloud_storage, 2 * epoch_length) + dropped_offset;
+
+    let start = dropped_height - 2;
+    let target = dropped_height + 2;
+    h.bootstrap_reader(start, target);
+
+    let store = h.reader_store();
+    let block_hash: CryptoHash = store
+        .get_ser(DBCol::BlockHeight, &index_to_bytes(dropped_height))
+        .expect("block must be present");
+    let block: Block = store.get_ser(DBCol::Block, block_hash.as_ref()).unwrap();
+    for chunk_header in block.chunks().iter_raw() {
+        assert!(
+            !chunk_header.is_new_chunk(dropped_height),
+            "shard {} chunk is new at h={dropped_height}; test setup did not produce \
+             the all-chunks-missing state",
+            chunk_header.shard_id(),
+        );
+    }
+    assert!(
+        !store.exists(DBCol::ChunkHashesByHeight, &index_to_bytes(dropped_height)),
+        "ChunkHashesByHeight unexpectedly set at h={dropped_height} with no new chunks",
+    );
+
+    h.kill_reader();
+    h.shutdown();
+}
+
 /// Verifies that after reader bootstrap, the local store has entries in
 /// the always-populated per-shard cold columns: `Chunks`, `ChunkExtra`,
 /// `ChunkApplyStats`, `IncomingReceipts`, `OutgoingReceipts`, and
 /// `OutcomeIds`.
 #[test]
-// TODO(cloud_archival): un-ignore once the reader reconstructs per-shard cold columns.
-#[ignore]
-fn test_cloud_archival_reader_reconstructs_per_shard_columns() {
+fn test_cloud_archival_reader_per_shard_columns() {
     let mut h = CloudArchiveHarness::builder().build();
     h.run_until_epoch(3 + MIN_GC_NUM_EPOCHS_TO_KEEP);
     let start = h.epoch_length / 2;
@@ -1046,9 +1101,7 @@ fn test_cloud_archival_reader_reconstructs_per_shard_columns() {
 /// `ReceiptToTx`, and `StateChanges`. The test submits a cross-shard
 /// transfer before the bootstrap range to populate them.
 #[test]
-// TODO(cloud_archival): un-ignore once the reader reconstructs per-shard cold columns.
-#[ignore]
-fn test_cloud_archival_reader_reconstructs_per_shard_data_columns() {
+fn test_cloud_archival_reader_per_shard_chunk_apply_columns() {
     let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
     let mut h = CloudArchiveHarness::builder().build();
     let tx = h.env.validator().tx_send_money(
@@ -1134,7 +1187,7 @@ fn test_cloud_archival_reader_reconstructs_per_shard_data_columns() {
 // TODO(cloud_archival): un-ignore once the reader reconstructs per-shard cold columns
 // and applies per-block state deltas with insertion-only trie updates.
 #[ignore]
-fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
+fn test_cloud_archival_reader_state_through_missing_chunk() {
     let dropped_shard = CloudArchiveHarness::all_shard_ids()[0];
     let dropped_shard_uid = CloudArchiveHarness::all_shard_uids()[0];
     let epoch_length = CloudArchiveHarness::DEFAULT_EPOCH_LENGTH;
@@ -1145,8 +1198,7 @@ fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
     let mut pattern = vec![true; epoch_length as usize];
     pattern[dropped_height as usize] = false;
 
-    let mut h =
-        CloudArchiveHarness::builder().validators(4).drop_chunks(dropped_shard, pattern).build();
+    let mut h = CloudArchiveHarness::builder().drop_chunks(dropped_shard, pattern).build();
     h.run_until_epoch(3 + MIN_GC_NUM_EPOCHS_TO_KEEP);
     let start = h.epoch_length / 2;
     let target = h.epoch_length + h.epoch_length / 2;

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -957,6 +957,7 @@ fn test_cloud_archival_outcomes_and_receipts() {
 /// the per-block cold columns the reader reconstructs from cloud data:
 /// `BlockPerHeight`, `ChunkHashesByHeight`, and `NextBlockHashes`.
 #[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_reader_per_block_columns() {
     let mut h = CloudArchiveHarness::builder().build();
     h.run_until_epoch(3 + MIN_GC_NUM_EPOCHS_TO_KEEP);
@@ -998,6 +999,7 @@ fn test_cloud_archival_reader_per_block_columns() {
 /// present, the reader writes no `ChunkHashesByHeight` entry, matching what
 /// the chain store does at apply time.
 #[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_block_present_all_chunks_missing() {
     let epoch_length = CloudArchiveHarness::DEFAULT_EPOCH_LENGTH;
     let dropped_offset = epoch_length / 2;
@@ -1044,6 +1046,7 @@ fn test_cloud_archival_block_present_all_chunks_missing() {
 /// `ChunkApplyStats`, `IncomingReceipts`, `OutgoingReceipts`, and
 /// `OutcomeIds`.
 #[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_reader_per_shard_columns() {
     let mut h = CloudArchiveHarness::builder().build();
     h.run_until_epoch(3 + MIN_GC_NUM_EPOCHS_TO_KEEP);
@@ -1105,6 +1108,7 @@ fn test_cloud_archival_reader_per_shard_columns() {
 /// `ReceiptToTx`, and `StateChanges`. The test submits a cross-shard
 /// transfer before the bootstrap range to populate them.
 #[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_reader_per_shard_chunk_apply_columns() {
     let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
     let mut h = CloudArchiveHarness::builder().build();

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -970,13 +970,17 @@ fn test_cloud_archival_reader_per_block_columns() {
         let block_hash: CryptoHash = store
             .get_ser(DBCol::BlockHeight, &index_to_bytes(height))
             .expect("BlockHeight missing");
+        let block: Block = store.get_ser(DBCol::Block, block_hash.as_ref()).unwrap();
         assert!(
             store.exists(DBCol::BlockPerHeight, &index_to_bytes(height)),
             "BlockPerHeight missing at h={height}"
         );
-        assert!(
+        // ChunkHashesByHeight is written only when a block has new chunks.
+        let has_new_chunk = block.chunks().iter_raw().any(|c| c.is_new_chunk(height));
+        assert_eq!(
             store.exists(DBCol::ChunkHashesByHeight, &index_to_bytes(height)),
-            "ChunkHashesByHeight missing at h={height}"
+            has_new_chunk,
+            "ChunkHashesByHeight presence at h={height} should match has_new_chunk={has_new_chunk}"
         );
         if height < target {
             assert!(


### PR DESCRIPTION
After `bootstrap_range` runs, the reader holds every cold column a chunk-applying node would have, so archival queries work for the bootstrapped range.

## What changes

`save_block_data` writes the per-block cold columns at apply time, matching the chain store.

New `save_shard_data` writes the per-shard cold columns a chunk-applying node would write.

`bootstrap_range` iterates the shard layout and calls a new `save_shard_range` helper per shard.

## Tests

Un-ignores four scaffold tests from the data-completion test PR, plus a new `test_cloud_archival_block_present_all_chunks_missing`. Small harness refactor on the side.