### PR TITLE
fix(dynamic-resharding): enforce min_epochs_between_resharding > 0

### DIFF
--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -2436,7 +2436,7 @@ mod check_dynamic_resharding {
             memory_usage_threshold,
             min_child_memory_usage,
             max_number_of_shards,
-            min_epochs_between_resharding: 0,
+            min_epochs_between_resharding: 1.try_into().unwrap(),
             force_split_shards,
             block_split_shards,
         }

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -13,8 +13,8 @@ use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, ApprovalStake, BlockHeight, EpochHeight, EpochId, ShardId, ShardIndex,
-    ValidatorInfoIdentifier,
+    AccountId, ApprovalStake, BlockHeight, EpochHeight, EpochId, NonZeroEpochHeight, ShardId,
+    ShardIndex, ValidatorInfoIdentifier,
 };
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views::EpochValidatorInfo;
@@ -128,11 +128,13 @@ pub trait EpochManagerAdapter: Send + Sync {
     /// Checks if resharding can be scheduled in 2 epochs from now (assuming `block_hash` belongs
     /// to the current epoch), based on `min_epochs_between_resharding`.
     ///
-    /// Returns `true` if no resharding occurred in the last N epochs (including the next one).
+    /// Returns `true` if no resharding occurred in the last `min_epochs_between_resharding`
+    /// epochs (including the next one). The cooldown is non-zero by type: allowing
+    /// back-to-back reshardings is unsafe (see `DynamicReshardingConfig`).
     fn can_reshard(
         &self,
         block_hash: &CryptoHash,
-        min_epochs_between_resharding: u64,
+        min_epochs_between_resharding: NonZeroEpochHeight,
     ) -> Result<bool, EpochError>;
 
     /// Get epoch id given hash of previous block.
@@ -881,7 +883,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
     fn can_reshard(
         &self,
         block_hash: &CryptoHash,
-        min_epochs_between_resharding: u64,
+        min_epochs_between_resharding: NonZeroEpochHeight,
     ) -> Result<bool, EpochError> {
         let epoch_manager = self.read();
         epoch_manager.can_reshard(block_hash, min_epochs_between_resharding)

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -21,8 +21,8 @@ use near_primitives::trie_split::TrieSplit;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockChunkValidatorStats, BlockHeight, ChunkStats, EpochId,
-    EpochInfoProvider, ProtocolVersion, ShardId, ValidatorId, ValidatorInfoIdentifier,
-    ValidatorKickoutReason, ValidatorStats,
+    EpochInfoProvider, NonZeroEpochHeight, ProtocolVersion, ShardId, ValidatorId,
+    ValidatorInfoIdentifier, ValidatorKickoutReason, ValidatorStats,
 };
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::{
@@ -732,16 +732,13 @@ impl EpochManager {
     /// Checks if resharding can be scheduled in 2 epochs from now (assuming `block_hash` belongs
     /// to the current epoch), based on `min_epochs_between_resharding`.
     ///
-    /// Returns `true` if no resharding occurred in the last N epochs (including the next one).
+    /// Returns `true` if no resharding occurred in the last `min_epochs_between_resharding`
+    /// epochs (including the next one).
     fn can_reshard(
         &self,
         block_hash: &CryptoHash,
-        min_epochs_between_resharding: u64,
+        min_epochs_between_resharding: NonZeroEpochHeight,
     ) -> Result<bool, EpochError> {
-        if min_epochs_between_resharding == 0 {
-            return Ok(true);
-        }
-
         let block_info = self.get_block_info(block_hash)?;
         let next_epoch_id = self.get_next_epoch_id_from_info(&block_info)?;
         let next_epoch_info = self.get_epoch_info(&next_epoch_id)?;
@@ -750,7 +747,7 @@ impl EpochManager {
         // has been enabled. It is theoretically possible that a static resharding was scheduled
         // right before enabling dynamic resharding, but we assume this didn't happen.
         let can_reshard = next_epoch_info.last_resharding().is_none_or(|last_resharding| {
-            next_epoch_info.epoch_height() - last_resharding >= min_epochs_between_resharding
+            next_epoch_info.epoch_height() - last_resharding >= min_epochs_between_resharding.get()
         });
         Ok(can_reshard)
     }

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -2,7 +2,7 @@
 pub use crate::account::id::AccountId;
 pub use crate::gas::Gas;
 use crate::hash::CryptoHash;
-use std::num::ParseIntError;
+use std::num::{NonZeroU64, ParseIntError};
 use std::ops::Add;
 use std::str::FromStr;
 /// Hash used by a struct implementing the Merkle tree.
@@ -23,6 +23,8 @@ pub type NonceIndex = u16;
 pub type BlockHeight = u64;
 /// Height of the epoch.
 pub type EpochHeight = u64;
+/// Non-zero epoch height. Used where `0` is semantically invalid.
+pub type NonZeroEpochHeight = NonZeroU64;
 /// Balance is type for storing amounts of tokens.
 pub type Balance = near_token::NearToken;
 /// Compute is a type for storing compute time. Measured in femtoseconds (10^-15 seconds).

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -2,7 +2,7 @@ use crate::num_rational::Rational32;
 use crate::shard_layout::ShardLayout;
 use crate::types::validator_stake::ValidatorStake;
 use crate::types::{
-    AccountId, Balance, BlockChunkValidatorStats, BlockHeightDelta, EpochHeight, NumSeats,
+    AccountId, Balance, BlockChunkValidatorStats, BlockHeightDelta, NonZeroEpochHeight, NumSeats,
     NumShards, ProtocolVersion, ShardId, ValidatorKickoutReason,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -31,8 +31,11 @@ pub struct DynamicReshardingConfig {
     /// resharding will be scheduled.
     pub max_number_of_shards: NumShards,
     /// Minimum number of epochs until next resharding can be scheduled.
-    /// The value of `0` means that resharding can happen every epoch.
-    pub min_epochs_between_resharding: EpochHeight,
+    /// Must be greater than `0`: allowing back-to-back reshardings is unsafe because
+    /// a child shard would inherit `proposed_split` from its parent's final chunk
+    /// while the child's first chunk freshly computes `proposed_split = None`,
+    /// producing an `InvalidChunkHeaderShardSplit` mismatch.
+    pub min_epochs_between_resharding: NonZeroEpochHeight,
     /// Shards that should be split even when they don't meet the regular split criteria
     /// (i.e. `memory_usage_threshold` and `min_child_memory_usage`).
     /// Keep in mind that `max_number_of_shards` still applies here.
@@ -49,7 +52,7 @@ impl Default for DynamicReshardingConfig {
             memory_usage_threshold: 999_999_999_999_999,
             min_child_memory_usage: 999_999_999_999_999,
             max_number_of_shards: 999_999_999_999_999,
-            min_epochs_between_resharding: 999_999_999_999_999,
+            min_epochs_between_resharding: NonZeroEpochHeight::new(999_999_999_999_999).unwrap(),
             force_split_shards: vec![],
             block_split_shards: vec![],
         }

--- a/docs/architecture/how/dynamic_resharding.md
+++ b/docs/architecture/how/dynamic_resharding.md
@@ -95,7 +95,7 @@ At the last block of each epoch, the block producer:
 1. Collects `proposed_split` values from all chunk headers in the block.
 2. Calls `get_upcoming_shard_split()` which:
    - Checks if dynamic resharding is enabled (via `ShardLayoutConfig::Dynamic`).
-   - Checks the resharding cooldown (`can_reshard()` -- verifies `epoch_height - last_resharding >= min_epochs_between_resharding`).
+   - Checks the resharding cooldown (`can_reshard()` -- verifies `epoch_height - last_resharding >= min_epochs_between_resharding`). `min_epochs_between_resharding` must be `> 0`: allowing back-to-back reshardings is unsafe because a freshly-created child shard would inherit `proposed_split` from the parent's final chunk while its own first chunk freshly computes `proposed_split = None`, triggering `InvalidChunkHeaderShardSplit`.
    - Calls `pick_shard_to_split()` to select the winning shard: forced shards have priority, otherwise the shard with highest `total_memory()` wins.
 3. Embeds the result as `shard_split: Option<(ShardId, AccountId)>` in `BlockHeaderInnerRestV6`.
 

--- a/test-loop-tests/src/tests/global_contracts_distribution.rs
+++ b/test-loop-tests/src/tests/global_contracts_distribution.rs
@@ -60,7 +60,7 @@ fn test_stale_global_contract_distribution_after_double_resharding() {
         memory_usage_threshold: u64::MAX,
         min_child_memory_usage: u64::MAX,
         max_number_of_shards: 100,
-        min_epochs_between_resharding: 0,
+        min_epochs_between_resharding: 1.try_into().unwrap(),
         force_split_shards: vec![first_split_shard, second_split_shard],
         block_split_shards: vec![],
     };

--- a/test-loop-tests/src/tests/resharding_v3.rs
+++ b/test-loop-tests/src/tests/resharding_v3.rs
@@ -501,7 +501,7 @@ fn build_epoch_config_store(
             memory_usage_threshold: u64::MAX,
             min_child_memory_usage: u64::MAX,
             max_number_of_shards: 100,
-            min_epochs_between_resharding: 0,
+            min_epochs_between_resharding: 1.try_into().unwrap(),
             force_split_shards,
             block_split_shards: vec![],
         };

--- a/test-loop-tests/src/tests/sharded_rpc_resharding.rs
+++ b/test-loop-tests/src/tests/sharded_rpc_resharding.rs
@@ -69,7 +69,7 @@ impl ReshardingRpcHarness {
             memory_usage_threshold: u64::MAX,
             min_child_memory_usage: u64::MAX,
             max_number_of_shards: 100,
-            min_epochs_between_resharding: 0,
+            min_epochs_between_resharding: 1.try_into().unwrap(),
             force_split_shards: vec![shard_to_split],
             block_split_shards: vec![],
         };


### PR DESCRIPTION
Allowing back-to-back reshardings is unsafe because a child shard would inherit `proposed_split` from its parent's final chunk while the child's first chunk freshly computes `proposed_split = None`, producing an `InvalidChunkHeaderShardSplit` mismatch.

Spotted here: https://github.com/near/NEPs/pull/639#discussion_r3231164160