### PR TITLE
fix: don't panic on wasmtime loading errors

### DIFF
--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -250,7 +250,7 @@ pub fn function_with_a_lot_of_nop(nops: u64) -> Vec<u8> {
 }
 
 /// Many zero-initialized globals.
-pub fn global_bomb_contract(num_globals: u32) -> Vec<u8> {
+pub fn contract_with_num_globals(num_globals: u32) -> Vec<u8> {
     use wasm_encoder::{
         CodeSection, ConstExpr, ExportKind, ExportSection, Function, FunctionSection,
         GlobalSection, GlobalType, Instruction, Module, TypeSection, ValType,

--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -281,47 +281,6 @@ pub fn global_bomb_contract(num_globals: u32) -> Vec<u8> {
     module.finish()
 }
 
-/// Many tiny active data segments, each writing 1 byte to memory offset 0.
-/// Tests whether per-segment instantiation cost is covered by gas.
-///
-/// Binary size ≈ num_segments * 8 bytes. Requires a WASM-internal memory.
-pub fn data_segment_bomb_contract(num_segments: u32) -> Vec<u8> {
-    use wasm_encoder::{
-        CodeSection, ConstExpr, DataSection, ExportKind, ExportSection, Function, FunctionSection,
-        Instruction, MemorySection, MemoryType, Module, TypeSection,
-    };
-    let mut module = Module::new();
-    let mut types = TypeSection::new();
-    types.ty().function([], []);
-    module.section(&types);
-    let mut funcs = FunctionSection::new();
-    funcs.function(0);
-    module.section(&funcs);
-    let mut memories = MemorySection::new();
-    memories.memory(MemoryType {
-        minimum: 1,
-        maximum: None,
-        memory64: false,
-        shared: false,
-        page_size_log2: None,
-    });
-    module.section(&memories);
-    let mut exports = ExportSection::new();
-    exports.export("main", ExportKind::Func, 0);
-    module.section(&exports);
-    let mut data = DataSection::new();
-    for i in 0..num_segments {
-        data.active(0, &ConstExpr::i32_const(0), [i as u8]);
-    }
-    module.section(&data);
-    let mut code = CodeSection::new();
-    let mut f = Function::new([]);
-    f.instruction(&Instruction::End);
-    code.function(&f);
-    module.section(&code);
-    module.finish()
-}
-
 /// Wrapper to get more useful Debug.
 pub struct ArbitraryModule(pub wasm_smith::Module);
 

--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -249,6 +249,79 @@ pub fn function_with_a_lot_of_nop(nops: u64) -> Vec<u8> {
     module.finish()
 }
 
+/// Many zero-initialized globals.
+pub fn global_bomb_contract(num_globals: u32) -> Vec<u8> {
+    use wasm_encoder::{
+        CodeSection, ConstExpr, ExportKind, ExportSection, Function, FunctionSection,
+        GlobalSection, GlobalType, Instruction, Module, TypeSection, ValType,
+    };
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+    let mut globals = GlobalSection::new();
+    for _ in 0..num_globals {
+        globals.global(
+            GlobalType { val_type: ValType::I32, mutable: false, shared: false },
+            &ConstExpr::i32_const(0),
+        );
+    }
+    module.section(&globals);
+    let mut exports = ExportSection::new();
+    exports.export("main", ExportKind::Func, 0);
+    module.section(&exports);
+    let mut code = CodeSection::new();
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::End);
+    code.function(&f);
+    module.section(&code);
+    module.finish()
+}
+
+/// Many tiny active data segments, each writing 1 byte to memory offset 0.
+/// Tests whether per-segment instantiation cost is covered by gas.
+///
+/// Binary size ≈ num_segments * 8 bytes. Requires a WASM-internal memory.
+pub fn data_segment_bomb_contract(num_segments: u32) -> Vec<u8> {
+    use wasm_encoder::{
+        CodeSection, ConstExpr, DataSection, ExportKind, ExportSection, Function, FunctionSection,
+        Instruction, MemorySection, MemoryType, Module, TypeSection,
+    };
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+    let mut memories = MemorySection::new();
+    memories.memory(MemoryType {
+        minimum: 1,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+    module.section(&memories);
+    let mut exports = ExportSection::new();
+    exports.export("main", ExportKind::Func, 0);
+    module.section(&exports);
+    let mut data = DataSection::new();
+    for i in 0..num_segments {
+        data.active(0, &ConstExpr::i32_const(0), [i as u8]);
+    }
+    module.section(&data);
+    let mut code = CodeSection::new();
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::End);
+    code.function(&f);
+    module.section(&code);
+    module.finish()
+}
+
 /// Wrapper to get more useful Debug.
 pub struct ArbitraryModule(pub wasm_smith::Module);
 

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -54,6 +54,11 @@ pub enum FunctionCallError {
     /// A trap happened during execution of a binary
     WasmTrap(WasmTrap),
     HostError(HostError),
+    /// The compiled module was rejected by the VM host when instantiating it.
+    /// This covers host-side resource limits.
+    LoadingError {
+        msg: String,
+    },
 }
 
 impl FunctionCallError {
@@ -61,7 +66,9 @@ impl FunctionCallError {
         const BASE_SIZE: usize = 4; // to roughly accommodate for static parts of the enum
         match self {
             FunctionCallError::CompilationError(e) => e.size_bytes_approximate(),
-            FunctionCallError::LinkError { msg } => BASE_SIZE + msg.len(),
+            FunctionCallError::LinkError { msg } | FunctionCallError::LoadingError { msg } => {
+                BASE_SIZE + msg.len()
+            }
             FunctionCallError::MethodResolveError(_)
             | FunctionCallError::WasmTrap(_)
             | FunctionCallError::HostError(_) => BASE_SIZE,
@@ -449,6 +456,7 @@ impl fmt::Display for FunctionCallError {
             FunctionCallError::MethodResolveError(e) => e.fmt(f),
             FunctionCallError::HostError(e) => e.fmt(f),
             FunctionCallError::LinkError { msg } => write!(f, "{}", msg),
+            FunctionCallError::LoadingError { msg } => write!(f, "Loading error: {}", msg),
             FunctionCallError::WasmTrap(trap) => write!(f, "WebAssembly trap: {}", trap),
         }
     }

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -3,6 +3,55 @@ use expect_test::expect;
 use near_primitives_core::types::Gas;
 use std::fmt::Write;
 
+/// Compile and load a contract with 100k globals.
+///
+/// Each global produces 8 bytes of instance data, so globals alone add 800kB.
+/// In total, that breaches the (default) limit of 1MiB for
+/// `max_core_instance_size` for the Wasmtime pooling allocator.
+///
+/// This must return `VMRunnerError::LoadingError` and not panic / crash the node.
+///
+/// Other VM backends don't use a pooling allocator with this limit, so they should
+/// run the contract successfully.
+#[test]
+fn test_max_core_instance_size_breached() {
+    use crate::logic::errors::VMRunnerError;
+    use crate::logic::mocks::mock_external::MockedExternal;
+    use crate::runner::VMKindExt;
+    use near_parameters::RuntimeFeesConfig;
+    use near_parameters::vm::VMKind;
+    use near_primitives_core::code::ContractCode;
+    use std::sync::Arc;
+
+    let wasm = near_test_contracts::global_bomb_contract(100_000);
+
+    super::with_vm_variants(|vm_kind| {
+        let code = ContractCode::new(wasm.clone(), None);
+        let config = Arc::new(super::test_vm_config(Some(vm_kind)));
+        let fees = Arc::new(RuntimeFeesConfig::test());
+        let mut ext = MockedExternal::with_code(code.clone_for_tests());
+        let context = super::create_context(vec![]);
+        let gas_counter = context.make_gas_counter(&config);
+
+        let result = vm_kind
+            .runtime(config)
+            .unwrap()
+            .prepare(&ext, None, gas_counter, "main")
+            .run(&mut ext, &context, fees);
+
+        match vm_kind {
+            VMKind::Wasmtime => assert!(
+                matches!(result, Err(VMRunnerError::LoadingError(_))),
+                "Wasmtime: expected LoadingError for oversized instance, got: {result:?}",
+            ),
+            _ => assert!(
+                result.as_ref().is_ok_and(|outcome| outcome.aborted.is_none()),
+                "{vm_kind:?}: expected clean success for many-globals contract, got: {result:?}",
+            ),
+        }
+    });
+}
+
 const FIX_CONTRACT_LOADING_COST: u32 = 129;
 
 static INFINITE_INITIALIZER_CONTRACT: &str = r#"

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -1,7 +1,14 @@
 use super::test_builder::test_builder;
+use crate::logic::errors::VMRunnerError;
+use crate::logic::mocks::mock_external::MockedExternal;
+use crate::runner::VMKindExt;
 use expect_test::expect;
+use near_parameters::RuntimeFeesConfig;
+use near_parameters::vm::VMKind;
+use near_primitives_core::code::ContractCode;
 use near_primitives_core::types::Gas;
 use std::fmt::Write;
+use std::sync::Arc;
 
 /// Compile and load a contract with 100k globals.
 ///
@@ -15,15 +22,7 @@ use std::fmt::Write;
 /// run the contract successfully.
 #[test]
 fn test_max_core_instance_size_breached() {
-    use crate::logic::errors::VMRunnerError;
-    use crate::logic::mocks::mock_external::MockedExternal;
-    use crate::runner::VMKindExt;
-    use near_parameters::RuntimeFeesConfig;
-    use near_parameters::vm::VMKind;
-    use near_primitives_core::code::ContractCode;
-    use std::sync::Arc;
-
-    let wasm = near_test_contracts::global_bomb_contract(100_000);
+    let wasm = near_test_contracts::contract_with_num_globals(100_000);
 
     super::with_vm_variants(|vm_kind| {
         let code = ContractCode::new(wasm.clone(), None);

--- a/runtime/runtime/src/conversions.rs
+++ b/runtime/runtime/src/conversions.rs
@@ -80,6 +80,9 @@ mod function_call_error {
                 // on specific types in Rust code.
                 From::HostError(ref _e) => Self::ExecutionError(outer_err.to_string()),
                 From::LinkError { msg } => Self::ExecutionError(format!("Link Error: {}", msg)),
+                From::LoadingError { msg } => {
+                    Self::ExecutionError(format!("Loading Error: {}", msg))
+                }
                 From::WasmTrap(ref _e) => Self::ExecutionError(outer_err.to_string()),
             }
         }

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -108,7 +108,7 @@ pub(crate) fn action_function_call(
                     .with_label_values::<&str>(&[err.into()])
                     .inc();
             }
-            FunctionCallError::LinkError { .. } => (),
+            FunctionCallError::LinkError { .. } | FunctionCallError::LoadingError { .. } => (),
             FunctionCallError::MethodResolveError(err) => {
                 metrics::FUNCTION_CALL_PROCESSED_METHOD_RESOLVE_ERRORS
                     .with_label_values::<&str>(&[err.into()])
@@ -323,9 +323,7 @@ pub(crate) fn execute_function_call(
             return Err(StorageError::StorageInconsistentState(err.to_string()).into());
         }
         Err(VMRunnerError::LoadingError(msg)) => {
-            // Loading the WASM failed, despite passing compilation. `LinkError`
-            // isn't 100% accurate but it can be treated as such.
-            return Ok(VMOutcome::nop_outcome(FunctionCallError::LinkError { msg }));
+            return Ok(VMOutcome::nop_outcome(FunctionCallError::LoadingError { msg }));
         }
         Err(VMRunnerError::Nondeterministic(msg)) => {
             panic!("Contract runner returned non-deterministic error '{}', aborting", msg)

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -108,7 +108,12 @@ pub(crate) fn action_function_call(
                     .with_label_values::<&str>(&[err.into()])
                     .inc();
             }
-            FunctionCallError::LinkError { .. } | FunctionCallError::LoadingError { .. } => (),
+            FunctionCallError::LinkError { .. } => {
+                metrics::FUNCTION_CALL_PROCESSED_LINK_ERRORS.inc();
+            }
+            FunctionCallError::LoadingError { .. } => {
+                metrics::FUNCTION_CALL_PROCESSED_LOADING_ERRORS.inc();
+            }
             FunctionCallError::MethodResolveError(err) => {
                 metrics::FUNCTION_CALL_PROCESSED_METHOD_RESOLVE_ERRORS
                     .with_label_values::<&str>(&[err.into()])

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -323,7 +323,9 @@ pub(crate) fn execute_function_call(
             return Err(StorageError::StorageInconsistentState(err.to_string()).into());
         }
         Err(VMRunnerError::LoadingError(msg)) => {
-            panic!("Contract runtime failed to load a contract: {msg}")
+            // Loading the WASM failed, despite passing compilation. `LinkError`
+            // isn't 100% accurate but it can be treated as such.
+            return Ok(VMOutcome::nop_outcome(FunctionCallError::LinkError { msg }));
         }
         Err(VMRunnerError::Nondeterministic(msg)) => {
             panic!("Contract runner returned non-deterministic error '{}', aborting", msg)

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -266,6 +266,20 @@ pub static FUNCTION_CALL_PROCESSED_HOST_ERRORS: LazyLock<IntCounterVec> = LazyLo
     )
     .unwrap()
 });
+pub static FUNCTION_CALL_PROCESSED_LINK_ERRORS: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_function_call_processed_link_errors",
+        "The number of function calls resulting in link errors, since starting this node",
+    )
+    .unwrap()
+});
+pub static FUNCTION_CALL_PROCESSED_LOADING_ERRORS: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_function_call_processed_loading_errors",
+        "The number of function calls resulting in loading errors, since starting this node",
+    )
+    .unwrap()
+});
 pub static FUNCTION_CALL_PROCESSED_CACHE_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     try_create_int_counter_vec(
         "near_function_call_processed_cache_errors",


### PR DESCRIPTION
Wasmer didn't have cases where loading could fail after compilation was successful.

Wasmtime may run into resource limits at load time. We should not panic on those and instead treat them as deterministic execution errors.