### PR TITLE
test(resharding): add gas-key resharding test

### DIFF
--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -70,6 +70,10 @@ pub mod col {
     pub const GLOBAL_CONTRACT_NONCE: u8 = 19;
     /// Status of a yielded receipt. Values are of type `PromiseYieldStatus`.
     pub const PROMISE_YIELD_STATUS: u8 = 20;
+    // Reserved: byte 21 is the `TrieKey::GasKeyNonce` enum discriminant.
+    // GasKeyNonce rows live on disk under `ACCESS_KEY` (extending the access-key
+    // trie key with a `NonceIndex` suffix), so no `col` constant exists for byte
+    // 21. Do not introduce one without coordinating with the `TrieKey` repr.
 
     /// All columns except those used for the delayed receipts queue, the yielded promises
     /// queue, and the outgoing receipts buffer, which are global state for the shard.

--- a/test-loop-tests/src/tests/resharding_v3.rs
+++ b/test-loop-tests/src/tests/resharding_v3.rs
@@ -9,10 +9,10 @@ use crate::utils::receipts::{
 #[cfg(feature = "test_features")]
 use crate::utils::resharding::fork_before_resharding_block;
 use crate::utils::resharding::{
-    TrackedShardSchedule, call_burn_gas_contract, call_promise_yield, check_state_cleanup,
-    delayed_receipts_repro_missing_trie_value, execute_money_transfers, execute_storage_operations,
-    promise_yield_repro_missing_trie_value, send_large_cross_shard_receipts,
-    temporary_account_during_resharding,
+    TrackedShardSchedule, assert_after_resharding, call_burn_gas_contract, call_promise_yield,
+    check_state_cleanup, delayed_receipts_repro_missing_trie_value, execute_money_transfers,
+    execute_storage_operations, gas_key_signer_for_account, promise_yield_repro_missing_trie_value,
+    send_large_cross_shard_receipts, temporary_account_during_resharding,
 };
 use crate::utils::setups::{derive_new_epoch_config_from_boundary, two_upgrades_voting_schedule};
 use crate::utils::sharding::{
@@ -29,7 +29,8 @@ use near_chain_configs::test_genesis::{TestGenesisBuilder, ValidatorsSpec};
 use near_crypto::Signer;
 use near_o11y::testonly::init_test_logger;
 use near_parameters::{RuntimeConfig, RuntimeConfigStore};
-use near_primitives::action::{GlobalContractDeployMode, GlobalContractIdentifier};
+use near_primitives::account::AccessKey;
+use near_primitives::action::{AddKeyAction, GlobalContractDeployMode, GlobalContractIdentifier};
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::{
     DynamicReshardingConfig, EpochConfig, EpochConfigStore, ShardLayoutConfig,
@@ -37,8 +38,10 @@ use near_primitives::epoch_manager::{
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{ShardLayout, shard_uids_to_ids};
 use near_primitives::test_utils::create_user_test_signer;
-use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, Balance, BlockHeightDelta, Gas, ShardId, ShardIndex};
+use near_primitives::transaction::{Action, SignedTransaction};
+use near_primitives::types::{
+    AccountId, Balance, BlockHeightDelta, Gas, NonceIndex, ShardId, ShardIndex,
+};
 use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature, ProtocolVersion};
 use std::cell::Cell;
@@ -86,6 +89,9 @@ const TRACKED_SHARD_SCHEDULE_NUM_EPOCHS_TO_WAIT: u64 = 13 + DYNAMIC_RESHARDING_E
 
 /// Account used in resharding tests as a split boundary.
 const NEW_BOUNDARY_ACCOUNT: &str = "account6";
+
+/// Number of gas-key nonce indices planted by the `gas_key_account` setup.
+const GAS_KEY_NUM_NONCES: NonceIndex = 2;
 
 #[derive(derive_builder::Builder)]
 #[builder(pattern = "owned", build_fn(skip))]
@@ -148,6 +154,9 @@ struct TestReshardingParameters {
     deploy_test_global_contract: Vec<(AccountId, GlobalContractDeployMode)>,
     #[builder(setter(custom))]
     use_test_global_contract: Vec<(AccountId, GlobalContractIdentifier)>,
+    /// For each account, add a gas key with `GAS_KEY_NUM_NONCES` nonces in setup.
+    #[builder(setter(custom))]
+    gas_key_accounts: Vec<AccountId>,
     /// Enable a stricter limit on outgoing gas to easily trigger congestion control.
     limit_outgoing_gas: bool,
     /// If non zero, split parent shard for flat state resharding will be delayed by an additional
@@ -294,6 +303,7 @@ impl TestReshardingParametersBuilder {
             deploy_test_contract: self.deploy_test_contract.unwrap_or_default(),
             deploy_test_global_contract: self.deploy_test_global_contract.unwrap_or_default(),
             use_test_global_contract: self.use_test_global_contract.unwrap_or_default(),
+            gas_key_accounts: self.gas_key_accounts.unwrap_or_default(),
             limit_outgoing_gas: self.limit_outgoing_gas.unwrap_or(false),
             delay_flat_state_resharding: self.delay_flat_state_resharding.unwrap_or(0),
             short_yield_timeout: self.short_yield_timeout.unwrap_or(false),
@@ -331,6 +341,11 @@ impl TestReshardingParametersBuilder {
         identifier: GlobalContractIdentifier,
     ) -> Self {
         self.use_test_global_contract.get_or_insert_default().push((account_id, identifier));
+        self
+    }
+
+    fn gas_key_account(mut self, account_id: AccountId) -> Self {
+        self.gas_key_accounts.get_or_insert_default().push(account_id);
         self
     }
 
@@ -718,6 +733,19 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
             2,
         );
         test_setup_transactions.push(create_account_tx);
+    }
+    for account in &params.gas_key_accounts {
+        let node = env.node_for_account(&client_account_id);
+        let gas_key = gas_key_signer_for_account(account);
+        let add_key_tx = node.tx_from_actions(
+            account,
+            account,
+            vec![Action::AddKey(Box::new(AddKeyAction {
+                public_key: gas_key.public_key(),
+                access_key: AccessKey::gas_key_full_access(GAS_KEY_NUM_NONCES),
+            }))],
+        );
+        test_setup_transactions.push(node.submit_tx(add_key_tx));
     }
     // Wait for the test setup transactions to settle and ensure they all succeeded.
     env.test_loop.run_for(Duration::milliseconds(2300));
@@ -1459,6 +1487,49 @@ fn slow_test_resharding_v3_storage_operations() {
         .all_chunks_expected(true)
         .delay_flat_state_resharding(2)
         .epoch_length(13)
+        .build();
+    test_resharding_v3_base(params);
+}
+
+/// Resharding while gas keys are live on both sides of the split boundary.
+///
+/// `TrieKey::GasKeyNonce` rows live under `col::ACCESS_KEY` with a `NonceIndex`
+/// suffix, so they should split along the same boundary as access keys. Plant
+/// a gas key on `account0` (left of `account6`) and `account7` (right), then
+/// assert both rows are still queryable on the correct child shard after the
+/// split.
+#[test]
+// Gas keys gate on `ProtocolFeature::GasKeys`, which only ships in nightly.
+#[cfg_attr(not(feature = "nightly"), ignore)]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn slow_test_resharding_v3_gas_key() {
+    let left_account: AccountId = "account0".parse().unwrap();
+    let right_account: AccountId = "account7".parse().unwrap();
+    let accounts = vec![left_account.clone(), right_account.clone()];
+    // Check the trie nodes survived a few blocks after resharding.
+    let num_blocks_after_resharding_to_check = 3;
+    let params = TestReshardingParametersBuilder::default()
+        .gas_key_account(left_account)
+        .gas_key_account(right_account)
+        .add_loop_action(assert_after_resharding(
+            num_blocks_after_resharding_to_check,
+            move |node| {
+                for account in &accounts {
+                    let gas_key = gas_key_signer_for_account(account);
+                    let nonces = node
+                        .view_gas_key_nonces_query(account, &gas_key.public_key())
+                        .unwrap_or_else(|err| {
+                            panic!("gas-key row missing after resharding for {account}: {err:?}")
+                        });
+                    assert_eq!(
+                        nonces.len(),
+                        GAS_KEY_NUM_NONCES as usize,
+                        "gas-key nonces vector shrunk across resharding for {account}",
+                    );
+                }
+            },
+        ))
         .build();
     test_resharding_v3_base(params);
 }

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -160,6 +160,21 @@ impl<'a> TestLoopNode<'a> {
         Ok(access_key_view)
     }
 
+    pub fn view_gas_key_nonces_query(
+        &self,
+        account_id: &AccountId,
+        public_key: &PublicKey,
+    ) -> Result<Vec<Nonce>, QueryError> {
+        let response = self.runtime_query(QueryRequest::ViewGasKeyNonces {
+            account_id: account_id.clone(),
+            public_key: public_key.clone(),
+        })?;
+        let QueryResponseKind::GasKeyNonces(view) = response.kind else {
+            panic!("unexpected query response type")
+        };
+        Ok(view.nonces)
+    }
+
     pub fn query_balance(&self, account_id: &AccountId) -> Balance {
         self.view_account_query(account_id).unwrap().amount
     }

--- a/test-loop-tests/src/utils/resharding.rs
+++ b/test-loop-tests/src/utils/resharding.rs
@@ -16,7 +16,7 @@ use near_chain::{ChainStoreAccess, Error};
 use near_client::Client;
 use near_client::Query;
 use near_client::client_actor::ClientActor;
-use near_crypto::Signer;
+use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_epoch_manager::shard_assignment::shard_id_to_uid;
 use near_network::client::ProcessTxRequest;
 use near_primitives::action::{Action, FunctionCallAction};
@@ -1362,6 +1362,58 @@ fn store_and_submit_tx(
     txs_vec.push((tx.get_hash(), height));
     txs.set(txs_vec);
     submit_tx(node_datas, rpc_id, tx);
+}
+
+/// Deterministic test gas-key signer for an account. Setup and verification
+/// share this helper so both sides agree on the public key.
+pub(crate) fn gas_key_signer_for_account(account_id: &AccountId) -> Signer {
+    const GAS_KEY_SIGNER_SEED: &str = "gas_key_resharding";
+    InMemorySigner::from_seed(account_id.clone(), KeyType::ED25519, GAS_KEY_SIGNER_SEED).into()
+}
+
+/// Loop action that fires its `assertion` once, `num_blocks_past_split` blocks
+/// after the resharding split block. Pass `0` to run on the split block itself.
+pub(crate) fn assert_after_resharding<F>(num_blocks_past_split: u64, assertion: F) -> LoopAction
+where
+    F: Fn(&TestLoopNode<'_>) + 'static,
+{
+    let split_height: Cell<Option<u64>> = Cell::new(None);
+    let (done, succeeded) = LoopAction::shared_success_flag();
+    let action_fn = Box::new(
+        move |node_datas: &[NodeExecutionData],
+              test_loop_data: &mut TestLoopData,
+              client_account_id: AccountId| {
+            if done.get() {
+                return;
+            }
+            let client_actor =
+                retrieve_client_actor(node_datas, test_loop_data, &client_account_id);
+            let tip = client_actor.client.chain.head().unwrap();
+            let split = match split_height.get() {
+                Some(h) => h,
+                None => {
+                    if !this_block_has_new_shard_layout(
+                        client_actor.client.epoch_manager.as_ref(),
+                        &tip,
+                    ) {
+                        return;
+                    }
+                    split_height.set(Some(tip.height));
+                    tip.height
+                }
+            };
+            if tip.height < split + num_blocks_past_split {
+                return;
+            }
+            let node = TestLoopNode {
+                data: test_loop_data,
+                node_data: get_node_data(node_datas, &client_account_id),
+            };
+            assertion(&node);
+            done.set(true);
+        },
+    );
+    LoopAction::new(action_fn, succeeded)
 }
 
 /// Checks status of the provided transactions. Panics if transaction result is an error.


### PR DESCRIPTION
Add a resharding test verifying that `TrieKey::GasKeyNonce` rows survive shard splits. Plants gas keys on both sides of the boundary account (`account0` left, `account7` right of `account6`) and asserts the nonce vectors are intact on the correct child shards post-split. Also adds a reusable `assert_after_resharding` loop action utility and a reserved-byte comment in the `col` module.