### PR TITLE
refactor(crt): add exhaustive wasmtime trap classification

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -466,6 +466,7 @@
         "wasmprinter",
         "wasms",
         "wasmtime",
+        "Waitable",
         "webfonts",
         "webrtc",
         "welford",

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -37,6 +37,7 @@ use wasmtime::{
 mod logic;
 #[cfg(test)]
 pub(crate) mod test_logic;
+mod trap_classification;
 
 /// The maximum amount of concurrent calls this engine can handle.
 /// If this limit is reached, invocations will block until an execution slot is available.
@@ -378,23 +379,30 @@ impl IntoVMError for wasmtime::Error {
             };
         }
         if let Some(trap) = cause.downcast_ref::<wasmtime::Trap>() {
-            use wasmtime::Trap as T;
+            use trap_classification::TrapClassification as C;
+            let classification = C::from(*trap);
             let nondeterministic_message = 'nondet: {
-                return Ok(FunctionCallError::WasmTrap(match *trap {
-                    T::StackOverflow => WasmTrap::StackOverflow,
-                    T::MemoryOutOfBounds => WasmTrap::MemoryOutOfBounds,
-                    T::TableOutOfBounds => WasmTrap::MemoryOutOfBounds,
-                    T::IndirectCallToNull => WasmTrap::IndirectCallToNull,
-                    T::BadSignature => WasmTrap::IncorrectCallIndirectSignature,
-                    T::IntegerOverflow => WasmTrap::IllegalArithmetic,
-                    T::IntegerDivisionByZero => WasmTrap::IllegalArithmetic,
-                    T::BadConversionToInteger => WasmTrap::IllegalArithmetic,
-                    T::UnreachableCodeReached => WasmTrap::Unreachable,
-                    T::Interrupt => break 'nondet "interrupt",
-                    T::HeapMisaligned => break 'nondet "heap misaligned",
-                    t => {
+                return Ok(FunctionCallError::WasmTrap(match classification {
+                    C::StackOverflow => WasmTrap::StackOverflow,
+                    C::MemoryOutOfBounds => WasmTrap::MemoryOutOfBounds,
+                    C::TableOutOfBounds => WasmTrap::MemoryOutOfBounds,
+                    C::IndirectCallToNull => WasmTrap::IndirectCallToNull,
+                    C::BadSignature => WasmTrap::IncorrectCallIndirectSignature,
+                    C::IntegerOverflow => WasmTrap::IllegalArithmetic,
+                    C::IntegerDivisionByZero => WasmTrap::IllegalArithmetic,
+                    C::BadConversionToInteger => WasmTrap::IllegalArithmetic,
+                    C::UnreachableCodeReached => WasmTrap::Unreachable,
+                    C::Interrupt => break 'nondet "interrupt",
+                    C::HeapMisaligned => break 'nondet "heap misaligned",
+                    C::Unreachable { trap } => {
+                        panic!(
+                            "contract produced a trap that should be unreachable \
+                                under NEAR's engine configuration: {trap:?}"
+                        );
+                    }
+                    C::Unknown { trap } => {
                         return Err(VMRunnerError::WasmUnknownError {
-                            debug_message: format!("unhandled trap type: {:?}", t),
+                            debug_message: format!("unhandled trap type: {trap:?}"),
                         });
                     }
                 }));

--- a/runtime/near-vm-runner/src/wasmtime_runner/trap_classification.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/trap_classification.rs
@@ -1,0 +1,114 @@
+use wasmtime::Trap;
+
+/// Mirror of [`wasmtime::Trap`] that we own, so we can match exhaustively.
+///
+/// When a Wasmtime upgrade adds a new trap variant, `From<Trap>` maps it to
+/// `Unknown` and the `test_all_wasmtime_traps_classified` test fails, forcing
+/// explicit classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrapClassification {
+    StackOverflow,
+    MemoryOutOfBounds,
+    HeapMisaligned,
+    TableOutOfBounds,
+    IndirectCallToNull,
+    BadSignature,
+    IntegerOverflow,
+    IntegerDivisionByZero,
+    BadConversionToInteger,
+    UnreachableCodeReached,
+    Interrupt,
+    /// Trap codes that exist in Wasmtime but should never be produced by a core
+    /// Wasm module running under NEAR's engine configuration (GC, component
+    /// model, threads, fuel, etc.).
+    Unreachable {
+        trap: Trap,
+    },
+    Unknown {
+        trap: Trap,
+    },
+}
+
+impl From<Trap> for TrapClassification {
+    fn from(trap: Trap) -> Self {
+        match trap {
+            Trap::StackOverflow => Self::StackOverflow,
+            Trap::MemoryOutOfBounds => Self::MemoryOutOfBounds,
+            Trap::HeapMisaligned => Self::HeapMisaligned,
+            Trap::TableOutOfBounds => Self::TableOutOfBounds,
+            Trap::IndirectCallToNull => Self::IndirectCallToNull,
+            Trap::BadSignature => Self::BadSignature,
+            Trap::IntegerOverflow => Self::IntegerOverflow,
+            Trap::IntegerDivisionByZero => Self::IntegerDivisionByZero,
+            Trap::BadConversionToInteger => Self::BadConversionToInteger,
+            Trap::UnreachableCodeReached => Self::UnreachableCodeReached,
+            Trap::Interrupt => Self::Interrupt,
+
+            // fuel (not used; NEAR meters gas via instrumentation)
+            Trap::OutOfFuel
+            // threads proposal
+            | Trap::AtomicWaitNonSharedMemory
+            // GC / function-references proposals
+            | Trap::NullReference
+            | Trap::ArrayOutOfBounds
+            | Trap::AllocationTooLarge
+            | Trap::CastFailure
+            // component model
+            | Trap::CannotEnterComponent
+            | Trap::CannotLeaveComponent
+            | Trap::CannotBlockSyncTask
+            | Trap::InvalidChar
+            | Trap::StringOutOfBounds
+            | Trap::ListOutOfBounds
+            | Trap::InvalidDiscriminant
+            | Trap::UnalignedPointer
+            | Trap::DebugAssertStringEncodingFinished
+            | Trap::DebugAssertEqualCodeUnits
+            | Trap::DebugAssertPointerAligned
+            | Trap::DebugAssertUpperBitsUnset
+            // component-model async
+            | Trap::NoAsyncResult
+            | Trap::AsyncDeadlock
+            | Trap::TaskCancelNotCancelled
+            | Trap::TaskCancelOrReturnTwice
+            | Trap::SubtaskCancelAfterTerminal
+            | Trap::TaskReturnInvalid
+            | Trap::WaitableSetDropHasWaiters
+            | Trap::SubtaskDropNotResolved
+            | Trap::BackpressureOverflow
+            | Trap::UnsupportedCallbackCode
+            | Trap::ConcurrentFutureStreamOp
+            | Trap::ReferenceCountOverflow
+            | Trap::StreamOpTooBig
+            // stack switching / continuations
+            | Trap::UnhandledTag
+            | Trap::ContinuationAlreadyConsumed
+            | Trap::CannotResumeThread
+            | Trap::ThreadNewIndirectInvalidType
+            | Trap::ThreadNewIndirectUninitialized
+            // pulley interpreter
+            | Trap::DisabledOpcode => Self::Unreachable { trap },
+
+            _ => Self::Unknown { trap },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_wasmtime_traps_classified() {
+        for byte in 0..=u8::MAX {
+            let Some(trap) = Trap::from_u8(byte) else {
+                continue;
+            };
+            let classification = TrapClassification::from(trap);
+            assert!(
+                !matches!(classification, TrapClassification::Unknown { .. }),
+                "unclassified wasmtime trap variant: {trap:?} (discriminant {byte})",
+            );
+        }
+    }
+}

--- a/runtime/near-vm-runner/src/wasmtime_runner/trap_classification.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/trap_classification.rs
@@ -45,7 +45,7 @@ impl From<Trap> for TrapClassification {
             Trap::Interrupt => Self::Interrupt,
 
             // fuel (not used; NEAR meters gas via instrumentation)
-            Trap::OutOfFuel
+            t @ (Trap::OutOfFuel
             // threads proposal
             | Trap::AtomicWaitNonSharedMemory
             // GC / function-references proposals
@@ -87,9 +87,9 @@ impl From<Trap> for TrapClassification {
             | Trap::ThreadNewIndirectInvalidType
             | Trap::ThreadNewIndirectUninitialized
             // pulley interpreter
-            | Trap::DisabledOpcode => Self::Unreachable { trap },
+            | Trap::DisabledOpcode) => Self::Unreachable { trap: t },
 
-            _ => Self::Unknown { trap },
+            t => Self::Unknown { trap: t },
         }
     }
 }


### PR DESCRIPTION
Introduces a `TrapClassification` mirror enum that we own, replacing the raw `wasmtime::Trap` match in `into_vm_error`. Since `wasmtime::Trap` is `#[non_exhaustive]`, the catch-all arm silently swallows new variants on Wasmtime upgrades. The new `From<Trap>` impl explicitly classifies every current variant, and a unit test iterates all discriminants via `Trap::from_u8` to ensure no variant lands in `Unknown`. Each disabled-proposal variant is annotated with the Wasm proposal it belongs to (fuel, threads, GC/function-references, component model, component-model async, stack switching, pulley).