### PR TITLE
feat(params-estimator): more vm benchmarks

### DIFF
--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -2,7 +2,14 @@
 
 use arbitrary::Arbitrary;
 use rand::{Fill, SeedableRng};
+use std::borrow::Cow;
 use std::sync::OnceLock;
+use wasm_encoder::{
+    BlockType, CodeSection, ConstExpr, DataSection, ElementSection, Elements, EntityType,
+    ExportKind, ExportSection, Function, FunctionSection, GlobalSection, GlobalType, Ieee64,
+    ImportSection, Instruction, MemorySection, MemoryType, Module, RefType, TableSection,
+    TableType, TypeSection, ValType,
+};
 
 /// Parse a WASM contract from WAT representation.
 pub fn wat_contract(wat: &str) -> Vec<u8> {
@@ -178,11 +185,6 @@ impl LargeContract {
     ///
     /// Exports a function called `main` that does nothing.
     pub fn make(&self) -> Vec<u8> {
-        use wasm_encoder::{
-            CodeSection, EntityType, ExportKind, ExportSection, Function, FunctionSection,
-            ImportSection, Instruction, Module, TypeSection, ValType,
-        };
-
         // Won't generate a valid WASM without functions.
         assert!(self.functions >= 1, "must specify at least 1 function to be generated");
         let mut module = Module::new();
@@ -224,10 +226,6 @@ impl LargeContract {
 ///
 /// This is particularly useful for testing how gas instrumentation works and its corner cases.
 pub fn function_with_a_lot_of_nop(nops: u64) -> Vec<u8> {
-    use wasm_encoder::{
-        CodeSection, ExportKind, ExportSection, Function, FunctionSection, Instruction, Module,
-        TypeSection,
-    };
     let mut module = Module::new();
     let mut type_section = TypeSection::new();
     type_section.ty().function([], []);
@@ -251,10 +249,6 @@ pub fn function_with_a_lot_of_nop(nops: u64) -> Vec<u8> {
 
 /// Many zero-initialized globals.
 pub fn contract_with_num_globals(num_globals: u32) -> Vec<u8> {
-    use wasm_encoder::{
-        CodeSection, ConstExpr, ExportKind, ExportSection, Function, FunctionSection,
-        GlobalSection, GlobalType, Instruction, Module, TypeSection, ValType,
-    };
     let mut module = Module::new();
     let mut types = TypeSection::new();
     types.ty().function([], []);
@@ -275,6 +269,191 @@ pub fn contract_with_num_globals(num_globals: u32) -> Vec<u8> {
     module.section(&exports);
     let mut code = CodeSection::new();
     let mut f = Function::new([]);
+    f.instruction(&Instruction::End);
+    code.function(&f);
+    module.section(&code);
+    module.finish()
+}
+
+/// Many tiny active data segments, each writing 1 byte to memory offset 0.
+pub fn many_data_segments_contract(num_segments: u32) -> Vec<u8> {
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+    let mut memories = MemorySection::new();
+    memories.memory(MemoryType {
+        minimum: 1,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+    module.section(&memories);
+    let mut exports = ExportSection::new();
+    exports.export("main", ExportKind::Func, 0);
+    module.section(&exports);
+    let mut data = DataSection::new();
+    for i in 0..num_segments {
+        data.active(0, &ConstExpr::i32_const(0), [i as u8]);
+    }
+    module.section(&data);
+    let mut code = CodeSection::new();
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::End);
+    code.function(&f);
+    module.section(&code);
+    module.finish()
+}
+
+/// Many active element segments, each writing function 0 into table slot 0.
+pub fn many_element_segments_contract(num_segments: u32) -> Vec<u8> {
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+    let mut tables = TableSection::new();
+    tables.table(TableType {
+        element_type: RefType::FUNCREF,
+        minimum: 1,
+        maximum: Some(1),
+        table64: false,
+        shared: false,
+    });
+    module.section(&tables);
+    let mut exports = ExportSection::new();
+    exports.export("main", ExportKind::Func, 0);
+    module.section(&exports);
+    let mut elements = ElementSection::new();
+    for _ in 0..num_segments {
+        elements.active(
+            Some(0),
+            &ConstExpr::i32_const(0),
+            Elements::Functions(Cow::Borrowed(&[0u32])),
+        );
+    }
+    module.section(&elements);
+    let mut code = CodeSection::new();
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::End);
+    code.function(&f);
+    module.section(&code);
+    module.finish()
+}
+
+/// A contract with many nested blocks approaching protocol limits, maximizing
+/// gas-instrumentation overhead and Winch compilation work.
+pub fn max_blocks_contract(num_functions: u32, blocks_per_function: u32) -> Vec<u8> {
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    for _ in 0..num_functions {
+        funcs.function(0);
+    }
+    module.section(&funcs);
+    let mut exports = ExportSection::new();
+    exports.export("main", ExportKind::Func, 0);
+    module.section(&exports);
+    let mut code = CodeSection::new();
+    for _ in 0..num_functions {
+        let mut f = Function::new([]);
+        for _ in 0..blocks_per_function {
+            f.instruction(&Instruction::Block(BlockType::Empty));
+            f.instruction(&Instruction::End);
+        }
+        f.instruction(&Instruction::End);
+        code.function(&f);
+    }
+    module.section(&code);
+    module.finish()
+}
+
+/// Tight f64.add infinite loop for NaN-canonicalization measurement.
+pub fn float_nan_loop_contract() -> Vec<u8> {
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+    let mut exports = ExportSection::new();
+    exports.export("main", ExportKind::Func, 0);
+    module.section(&exports);
+    let mut code = CodeSection::new();
+    let mut f = Function::new([(1, ValType::F64)]);
+    f.instruction(&Instruction::Loop(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::F64Const(Ieee64::from(1.5_f64)));
+    f.instruction(&Instruction::F64Add);
+    f.instruction(&Instruction::LocalSet(0));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+    code.function(&f);
+    module.section(&code);
+    module.finish()
+}
+
+/// Tight i64.div_u infinite loop for wide-arithmetic calibration measurement.
+pub fn wide_arithmetic_loop_contract() -> Vec<u8> {
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+    let mut exports = ExportSection::new();
+    exports.export("main", ExportKind::Func, 0);
+    module.section(&exports);
+    let mut code = CodeSection::new();
+    let mut f = Function::new([(1, ValType::I64)]);
+    f.instruction(&Instruction::Loop(BlockType::Empty));
+    // local += 7, then divide by 3; the value cycles and stays non-zero (never div-by-zero)
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I64Const(7));
+    f.instruction(&Instruction::I64Add);
+    f.instruction(&Instruction::I64Const(3));
+    f.instruction(&Instruction::I64DivU);
+    f.instruction(&Instruction::LocalSet(0));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+    code.function(&f);
+    module.section(&code);
+    module.finish()
+}
+
+/// Tight i64.add infinite loop — baseline for NaN-canonicalization comparison.
+pub fn int_baseline_loop_contract() -> Vec<u8> {
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+    let mut exports = ExportSection::new();
+    exports.export("main", ExportKind::Func, 0);
+    module.section(&exports);
+    let mut code = CodeSection::new();
+    let mut f = Function::new([(1, ValType::I64)]);
+    f.instruction(&Instruction::Loop(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I64Const(1));
+    f.instruction(&Instruction::I64Add);
+    f.instruction(&Instruction::LocalSet(0));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
     f.instruction(&Instruction::End);
     code.function(&f);
     module.section(&code);

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -706,6 +706,23 @@ pub enum Cost {
     /// produces the steepest line.
     ContractCompileBaseV2,
     ContractCompileBytesV2,
+    /// Compile a contract at the maximum block limit (10 functions with 4999 blocks).
+    AdversarialCompileMaxBlocks,
+    /// Invocation cost with 100k zero-initialized globals.
+    /// Exposes unbounded per-call Wasmtime global re-initialization not covered by gas.
+    AdversarialLoadManyGlobals,
+    /// Invocation cost with 50k active data segments.
+    /// Exposes unbounded per-call data-segment initialization not covered by gas.
+    AdversarialLoadManyDataSegments,
+    /// Invocation cost with 10k active element segments.
+    /// Exposes unbounded per-call table-initialization work not covered by gas.
+    AdversarialLoadManyElementSegments,
+    /// Wasm instruction cost for float ops, including NaN Canonicalization cost.
+    OpFloat,
+    /// Wasm instruction cost for integer ops.
+    OpInt,
+    /// Wasm instruction cost for wide division cost.
+    OpWideArithmetic,
     /// The cost of contract deployment per byte, without the compilation cost.
     ///
     /// Estimation: Measure the deployment costs of two data-only contracts,

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -68,7 +68,9 @@ fn compute_function_call_cost(
     let protocol_version = ProtocolVersion::MAX;
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(protocol_version).as_ref();
-    let vm_config = runtime_config.wasm_config.clone();
+    let mut vm_config = runtime_config.wasm_config.as_ref().clone();
+    vm_config.vm_kind = vm_kind;
+    let vm_config = Arc::new(vm_config);
     let fees = runtime_config.fees.clone();
     let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
     let fake_context = create_context(vec![]);

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -129,7 +129,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let cache: Option<&dyn ContractRuntimeCache> = Some(&cache_store);
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
-    let vm_config_gas = runtime_config.wasm_config.clone();
+    let vm_config_gas = Arc::new({
+        let mut cfg = runtime_config.wasm_config.as_ref().clone();
+        cfg.vm_kind = vm_kind;
+        cfg
+    });
     let vm_config_free = Arc::new({
         let mut cfg = near_parameters::vm::Config::clone(&vm_config_gas);
         cfg.make_free();

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -250,6 +250,9 @@ static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     ),
     (Cost::HostFunctionCall, host_function_call),
     (Cost::WasmInstruction, wasm_instruction),
+    (Cost::OpFloat, adversarial_float_nan_canonicalization),
+    (Cost::OpInt, op_int),
+    (Cost::OpWideArithmetic, op_wide_arithmetic),
     (Cost::DataReceiptCreationBase, data_receipt_creation_base),
     (Cost::DataReceiptCreationPerByte, data_receipt_creation_per_byte),
     (Cost::ReadMemoryBase, read_memory_base),
@@ -306,8 +309,12 @@ static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     (Cost::ContractCompileBaseV2, contract_compile_base_v2),
     (Cost::ContractCompileBytesV2, contract_compile_bytes_v2),
     (Cost::DeployBytes, pure_deploy_bytes),
+    (Cost::AdversarialCompileMaxBlocks, adversarial_compile_max_blocks),
     (Cost::ContractLoadingBase, contract_loading_base),
     (Cost::ContractLoadingPerByte, contract_loading_per_byte),
+    (Cost::AdversarialLoadManyGlobals, adversarial_load_many_globals),
+    (Cost::AdversarialLoadManyDataSegments, adversarial_load_many_data_segments),
+    (Cost::AdversarialLoadManyElementSegments, adversarial_load_many_element_segments),
     (Cost::FunctionCallPerStorageByte, function_call_per_storage_byte),
     (Cost::GasMeteringBase, gas_metering_base),
     (Cost::GasMeteringOp, gas_metering_op),
@@ -729,6 +736,35 @@ fn contract_compile_base(ctx: &mut EstimatorContext) -> GasCost {
 fn contract_compile_bytes(ctx: &mut EstimatorContext) -> GasCost {
     compilation_cost_base_per_byte(ctx).1
 }
+
+fn adversarial_compile_max_blocks(ctx: &mut EstimatorContext) -> GasCost {
+    vm_estimator::adversarial_compile_max_blocks(ctx.config.metric, ctx.config.vm_kind)
+}
+
+fn adversarial_load_many_globals(ctx: &mut EstimatorContext) -> GasCost {
+    vm_estimator::adversarial_load_many_globals(ctx.config.metric, ctx.config.vm_kind)
+}
+
+fn adversarial_load_many_data_segments(ctx: &mut EstimatorContext) -> GasCost {
+    vm_estimator::adversarial_load_many_data_segments(ctx.config.metric, ctx.config.vm_kind)
+}
+
+fn adversarial_load_many_element_segments(ctx: &mut EstimatorContext) -> GasCost {
+    vm_estimator::adversarial_load_many_element_segments(ctx.config.metric, ctx.config.vm_kind)
+}
+
+fn adversarial_float_nan_canonicalization(ctx: &mut EstimatorContext) -> GasCost {
+    vm_estimator::op_float_nan_canonicalization(ctx.config.metric, ctx.config.vm_kind)
+}
+
+fn op_int(ctx: &mut EstimatorContext) -> GasCost {
+    vm_estimator::op_int_baseline(ctx.config.metric, ctx.config.vm_kind)
+}
+
+fn op_wide_arithmetic(ctx: &mut EstimatorContext) -> GasCost {
+    vm_estimator::op_wide_arithmetic(ctx.config.metric, ctx.config.vm_kind)
+}
+
 fn compilation_cost_base_per_byte(ctx: &mut EstimatorContext) -> (GasCost, GasCost) {
     if let Some(base_byte_cost) = ctx.cached.compile_cost_base_per_byte.clone() {
         return base_byte_cost;
@@ -1023,6 +1059,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let config_store = RuntimeConfigStore::new(None);
     let mut config = config_store.get_config(PROTOCOL_VERSION).wasm_config.as_ref().clone();
+    config.vm_kind = vm_kind;
     // The soak test contract is a finite loop that must exhaust gas to abort.
     // Cap max_gas_burnt so it reliably runs out of gas.
     config.limit_config.max_gas_burnt = Gas::from_teragas(300);

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -286,7 +286,7 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
     rocksdb_test_config.debug_rocksdb = cli_args.debug;
     rocksdb_test_config.drop_os_cache = cli_args.drop_os_cache;
     let iter_per_block = cli_args.iters;
-    let active_accounts = cli_args.accounts_num;
+    let active_accounts = cli_args.accounts_num.min(cli_args.additional_accounts_num as usize);
     let metric = match cli_args.metric.as_str() {
         "icount" => GasMetric::ICount,
         "time" => GasMetric::Time,

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -1,15 +1,17 @@
 use crate::config::GasMetric;
 use crate::gas_cost::{GasCost, LeastSquaresTolerance};
 use crate::{REAL_CONTRACTS_SAMPLE, utils::read_resource};
-use near_parameters::RuntimeConfigStore;
 use near_parameters::vm::VMKind;
+use near_parameters::{RuntimeConfigStore, RuntimeFeesConfig};
 use near_primitives::types::{Balance, Gas};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_runner::internal::VMKindExt;
 use near_vm_runner::logic::VMContext;
 use near_vm_runner::{
-    ContractCode, ContractRuntimeCache, FilesystemContractRuntimeCache, NoContractRuntimeCache,
+    ContractCode, ContractRuntimeCache, FilesystemContractRuntimeCache, MockContractRuntimeCache,
+    NoContractRuntimeCache,
 };
+use std::sync::Arc;
 
 const CURRENT_ACCOUNT_ID: &str = "alice";
 const SIGNER_ACCOUNT_ID: &str = "bob";
@@ -156,4 +158,138 @@ pub(crate) fn compute_compile_cost_vm(
         );
     }
     (a, b)
+}
+
+pub(crate) fn adversarial_compile_max_blocks(metric: GasMetric, vm_kind: VMKind) -> GasCost {
+    let code = near_test_contracts::max_blocks_contract(10, 4_999);
+    compile_single_contract_cost(metric, vm_kind, &code)
+}
+
+pub(crate) fn adversarial_load_many_globals(metric: GasMetric, vm_kind: VMKind) -> GasCost {
+    let code = near_test_contracts::contract_with_num_globals(50_000);
+    measure_instantiation_overhead(metric, vm_kind, &code)
+}
+
+pub(crate) fn adversarial_load_many_data_segments(metric: GasMetric, vm_kind: VMKind) -> GasCost {
+    let code = near_test_contracts::many_data_segments_contract(50_000);
+    measure_instantiation_overhead(metric, vm_kind, &code)
+}
+
+pub(crate) fn adversarial_load_many_element_segments(
+    metric: GasMetric,
+    vm_kind: VMKind,
+) -> GasCost {
+    let code = near_test_contracts::many_element_segments_contract(10_000);
+    measure_instantiation_overhead(metric, vm_kind, &code)
+}
+
+/// Warm the compile cache, then measure N invocations (instantiation + trivial execution).
+/// The function body is a bare `end`, so execution cost is negligible.
+fn measure_instantiation_overhead(
+    metric: GasMetric,
+    vm_kind: VMKind,
+    contract_bytes: &[u8],
+) -> GasCost {
+    let config_store = RuntimeConfigStore::new(None);
+    let mut config = config_store.get_config(PROTOCOL_VERSION).wasm_config.as_ref().clone();
+    config.vm_kind = vm_kind;
+    let config = Arc::new(config);
+    let fees = Arc::new(RuntimeFeesConfig::test());
+    let code = ContractCode::new(contract_bytes.to_vec(), None);
+    let cache = MockContractRuntimeCache::default();
+    let mut fake_external = near_vm_runner::logic::mocks::mock_external::MockedExternal::with_code(
+        code.clone_for_tests(),
+    );
+
+    let mut run_once = || {
+        let context = create_context(vec![]);
+        let gas_counter = context.make_gas_counter(&config);
+        vm_kind
+            .runtime(config.clone())
+            .unwrap()
+            .prepare(&fake_external, Some(&cache), gas_counter, "main")
+            .run(&mut fake_external, &context, Arc::clone(&fees))
+            .expect("fatal_error")
+    };
+
+    // Warm: compiles and caches the module; subsequent calls only instantiate + execute.
+    run_once();
+
+    let n = 10_usize;
+    let start = GasCost::measure(metric);
+    for _ in 0..n {
+        run_once();
+    }
+    start.elapsed() / n as u64
+}
+
+pub(crate) fn op_float_nan_canonicalization(metric: GasMetric, vm_kind: VMKind) -> GasCost {
+    let code = near_test_contracts::float_nan_loop_contract();
+    measure_op_loop(metric, vm_kind, &code)
+}
+
+pub(crate) fn op_int_baseline(metric: GasMetric, vm_kind: VMKind) -> GasCost {
+    let code = near_test_contracts::int_baseline_loop_contract();
+    measure_op_loop(metric, vm_kind, &code)
+}
+
+pub(crate) fn op_wide_arithmetic(metric: GasMetric, vm_kind: VMKind) -> GasCost {
+    let code = near_test_contracts::wide_arithmetic_loop_contract();
+    measure_op_loop(metric, vm_kind, &code)
+}
+
+/// Compile + run an infinite loop until gas exhaustion (100 Tgas), return ns
+/// per WASM instruction.
+fn measure_op_loop(metric: GasMetric, vm_kind: VMKind, contract_bytes: &[u8]) -> GasCost {
+    let config_store = RuntimeConfigStore::new(None);
+    let mut config = config_store.get_config(PROTOCOL_VERSION).wasm_config.as_ref().clone();
+    let gas_limit = Gas::from_teragas(100);
+    config.limit_config.max_gas_burnt = gas_limit;
+    config.vm_kind = vm_kind;
+    let config = Arc::new(config);
+    let fees = Arc::new(RuntimeFeesConfig::test());
+    let code = ContractCode::new(contract_bytes.to_vec(), None);
+    let cache = MockContractRuntimeCache::default();
+    let mut fake_external = near_vm_runner::logic::mocks::mock_external::MockedExternal::with_code(
+        code.clone_for_tests(),
+    );
+
+    let mut run_once = || {
+        let mut context = create_context(vec![]);
+        context.prepaid_gas = gas_limit;
+        let gas_counter = context.make_gas_counter(&config);
+        let result = vm_kind
+            .runtime(config.clone())
+            .unwrap()
+            .prepare(&fake_external, Some(&cache), gas_counter, "main")
+            .run(&mut fake_external, &context, Arc::clone(&fees))
+            .expect("fatal_error");
+        assert!(result.aborted.is_some(), "expected gas exhaustion but contract finished cleanly");
+        result
+    };
+
+    let warmup = run_once();
+    let burnt_gas = warmup.burnt_gas.as_gas();
+    assert!(
+        burnt_gas > 0,
+        "loop burnt 0 gas — method not found or gas budget exhausted before first instruction; \
+         aborted={:?}",
+        warmup.aborted,
+    );
+    let instructions = burnt_gas / u64::from(config.regular_op_cost);
+    assert!(
+        instructions > 0,
+        "gas budget too small: burnt {} gas but regular_op_cost={} gas/op — \
+         increase max_gas_burnt in measure_op_loop",
+        burnt_gas,
+        config.regular_op_cost,
+    );
+
+    let n = 5_usize;
+    let start = GasCost::measure(metric);
+    for _ in 0..n {
+        run_once();
+    }
+    let result = start.elapsed() / (instructions * n as u64);
+    result
 }


### PR DESCRIPTION
Add several new Wasm VM benchmarks for comparing the performance of NearVM with Wasmtime + Winch.

- `OpFloat`, `OpInt`, `OpWideArithmetic`: These are more specific versions of `WasmInstruction`. They show what the per op cost for regular instructions should be.
- `AdversarialCompileMaxBlocks` measures a specific case of contract compilation that we know can become slower with Wasmtime compared to NearVM.
- `AdversarialLoadManyGlobals`, `AdversarialLoadManyDataSegments`, `AdversarialLoadManyElementSegments` are contracts crafted to be slow to load, creating a high per-function-call overhead.