### PR TITLE
refactor(test-utils): route Block::produce calls through TestBlockBuilder

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -1,15 +1,12 @@
 use crate::near_chain_primitives::error::BlockKnownError;
 use crate::test_utils::{setup, wait_for_all_blocks_in_processing};
-use crate::{Block, BlockProcessingArtifact, ChainStoreAccess, Error};
+use crate::{BlockProcessingArtifact, ChainStoreAccess, Error};
 use assert_matches::assert_matches;
 use near_async::time::{Clock, Duration, FakeClock, Utc};
 use near_o11y::testonly::init_test_logger;
 #[cfg(feature = "test_features")]
 use near_primitives::optimistic_block::OptimisticBlock;
-use near_primitives::{
-    hash::CryptoHash, test_utils::TestBlockBuilder, types::Balance, version::PROTOCOL_VERSION,
-};
-use num_rational::Ratio;
+use near_primitives::{hash::CryptoHash, test_utils::TestBlockBuilder, types::Balance};
 use std::sync::Arc;
 
 #[test]
@@ -78,31 +75,11 @@ fn build_chain_with_orphans() {
         blocks.push(block);
     }
     let last_block = &blocks[blocks.len() - 1];
-    let block = Arc::new(Block::produce(
-        PROTOCOL_VERSION,
-        PROTOCOL_VERSION,
-        last_block.header(),
-        10,
-        last_block.header().block_ordinal() + 1,
-        last_block.chunks().iter_raw().cloned().collect(),
-        vec![vec![]; last_block.chunks().len()],
-        *last_block.header().epoch_id(),
-        *last_block.header().next_epoch_id(),
-        None,
-        vec![],
-        Ratio::from_integer(0),
-        Balance::ZERO,
-        Balance::from_yoctonear(100),
-        Some(Balance::ZERO),
-        &*signer,
-        *last_block.header().next_bp_hash(),
-        CryptoHash::default(),
-        clock,
-        None,
-        None,
-        None,
-        None,
-    ));
+    let block = TestBlockBuilder::from_prev_block(clock, last_block, signer)
+        .height(10)
+        .max_gas_price(Balance::from_yoctonear(100))
+        .block_merkle_root(CryptoHash::default())
+        .build();
     assert_matches!(chain.process_block_test(block).unwrap_err(), Error::Orphan);
     assert_matches!(chain.process_block_test(blocks.pop().unwrap()).unwrap_err(), Error::Orphan);
     assert_matches!(chain.process_block_test(blocks.pop().unwrap()).unwrap_err(), Error::Orphan);

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -11,11 +11,11 @@ use near_primitives::block::{Block, BlockHeader};
 use near_primitives::genesis::{genesis_block, genesis_chunks};
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
-use near_primitives::num_rational::Ratio;
 use near_primitives::reed_solomon::reed_solomon_encode;
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunkBody, PartialEncodedChunkPart, ShardChunk,
 };
+use near_primitives::test_utils::TestBlockBuilder;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, Balance, BlockHeight, EpochId, Gas, StateRoot};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
@@ -35,39 +35,6 @@ pub fn make_genesis_block(clock: &time::Clock, chunks: Vec<ShardChunk>) -> Arc<B
         Balance::from_yoctonear(1000),
         Balance::from_yoctonear(1000),
         &vec![],
-    ))
-}
-
-pub fn make_block(
-    clock: time::Clock,
-    signer: &ValidatorSigner,
-    prev: &Block,
-    chunks: Vec<ShardChunk>,
-) -> Arc<Block> {
-    Arc::new(Block::produce(
-        version::PROTOCOL_VERSION,
-        version::PROTOCOL_VERSION,
-        prev.header(),
-        prev.header().height() + 5,
-        prev.header().block_ordinal() + 1,
-        chunks.iter().cloned().map(|c| c.take_header()).collect(),
-        vec![vec![]; chunks.len()],
-        EpochId::default(),
-        EpochId::default(),
-        None,
-        vec![],
-        Ratio::from_integer(0),
-        Balance::ZERO,
-        Balance::ZERO,
-        Some(Balance::ZERO),
-        signer,
-        CryptoHash::default(),
-        CryptoHash::default(),
-        clock,
-        None,
-        None,
-        None,
-        None,
     ))
 }
 
@@ -233,10 +200,20 @@ impl Chain {
         let mut chunks = ChunkSet::new();
         let mut blocks = vec![];
         blocks.push(make_genesis_block(&clock.clock(), chunks.make()));
-        let signer = make_validator_signer(rng);
+        let signer = Arc::new(make_validator_signer(rng));
         for _ in 1..block_count {
             clock.advance(time::Duration::seconds(15));
-            blocks.push(make_block(clock.clock(), &signer, blocks.last().unwrap(), chunks.make()));
+            let prev = blocks.last().unwrap();
+            let chunk_set = chunks.make();
+            let block = TestBlockBuilder::from_prev_block(clock.clock(), prev, signer.clone())
+                .chunks(chunk_set.iter().map(ShardChunk::cloned_header))
+                .height(prev.header().height() + 5)
+                .epoch_id(EpochId::default())
+                .next_epoch_id(EpochId::default())
+                .next_bp_hash(CryptoHash::default())
+                .block_merkle_root(CryptoHash::default())
+                .build();
+            blocks.push(block);
         }
         Chain {
             genesis_id: GenesisId {

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -869,6 +869,7 @@ pub struct TestBlockBuilder {
     block_merkle_root: CryptoHash,
     chunks: Vec<ShardChunkHeader>,
     chunk_endorsements: Vec<ChunkEndorsementSignatures>,
+    timestamp_nanos: Option<u64>,
     // TODO(spice): Once spice is released remove Option.
     /// Iff `Some` spice block will be created.
     spice_core_statements: Option<crate::block_body::SpiceCoreStatements>,
@@ -903,6 +904,7 @@ impl TestBlockBuilder {
             block_merkle_root: tree.root(),
             chunks: prev_chunks,
             chunk_endorsements: vec![vec![]; chunks_len],
+            timestamp_nanos: None,
             prev_header,
             spice_core_statements: if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
                 Some(crate::block_body::SpiceCoreStatements::new(vec![]))
@@ -975,8 +977,13 @@ impl TestBlockBuilder {
         self
     }
 
-    pub fn chunks(mut self, chunks: Vec<ShardChunkHeader>) -> Self {
-        self.chunks = chunks;
+    pub fn block_merkle_root(mut self, block_merkle_root: CryptoHash) -> Self {
+        self.block_merkle_root = block_merkle_root;
+        self
+    }
+
+    pub fn chunks(mut self, chunks: impl IntoIterator<Item = ShardChunkHeader>) -> Self {
+        self.chunks = chunks.into_iter().collect();
         self
     }
 
@@ -1005,9 +1012,19 @@ impl TestBlockBuilder {
         self
     }
 
+    /// Override the produced block's timestamp and resign the header.
+    pub fn timestamp_nanos(mut self, timestamp_nanos: u64) -> Self {
+        self.timestamp_nanos = Some(timestamp_nanos);
+        self
+    }
+
     pub fn build(self) -> Arc<Block> {
+        Arc::new(self.build_owned())
+    }
+
+    pub fn build_owned(self) -> Block {
         tracing::debug!(target: "test", height=self.height, ?self.epoch_id, "produce block");
-        Arc::new(Block::produce(
+        let mut block = Block::produce(
             PROTOCOL_VERSION,
             PROTOCOL_VERSION,
             &self.prev_header,
@@ -1037,7 +1054,12 @@ impl TestBlockBuilder {
                         .newly_certified_block_execution_results,
                 }
             }),
-        ))
+        );
+        if let Some(ts) = self.timestamp_nanos {
+            block.mut_header().set_timestamp(ts);
+            block.mut_header().resign(self.signer.as_ref());
+        }
+        block
     }
 }
 

--- a/integration-tests/src/tests/client/query_client.rs
+++ b/integration-tests/src/tests/client/query_client.rs
@@ -11,14 +11,12 @@ use near_network::client::{BlockResponse, ProcessTxRequest, ProcessTxResponse};
 use near_network::types::PeerInfo;
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_o11y::testonly::init_test_logger;
-use near_primitives::block::{Block, BlockHeader};
 use near_primitives::merkle::PartialMerkleTree;
-use near_primitives::test_utils::create_test_signer;
+use near_primitives::test_utils::{TestBlockBuilder, create_test_signer};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{Balance, BlockReference, EpochId, ShardId};
-use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{QueryRequest, QueryResponseKind};
-use num_rational::Ratio;
+use std::sync::Arc;
 
 /// Query account from view client
 #[tokio::test]
@@ -61,48 +59,26 @@ async fn query_status_not_crash() {
         true,
         false,
     );
-    let signer = create_test_signer("test");
+    let signer = Arc::new(create_test_signer("test"));
     let res = actor_handles.view_client_actor.send_async(GetBlockWithMerkleTree::latest()).await;
     let (block, block_merkle_tree) = res.unwrap().unwrap();
     let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
-    let header: BlockHeader = block.header.clone().into();
-    block_merkle_tree.insert(*header.hash());
-    let mut next_block = Block::produce(
-        PROTOCOL_VERSION,
-        PROTOCOL_VERSION,
-        &header,
-        block.header.height + 1,
-        header.block_ordinal() + 1,
-        block.chunks.iter().cloned().map(|c| c.into()).collect(),
-        vec![vec![]; block.chunks.len()],
-        EpochId(block.header.next_epoch_id),
-        EpochId(block.header.hash),
-        None,
-        vec![],
-        Ratio::from_integer(0),
-        Balance::ZERO,
-        Balance::from_yoctonear(100),
-        None,
-        &signer,
-        block.header.next_bp_hash,
-        block_merkle_tree.root(),
-        Clock::real(),
-        None,
-        None,
-        None,
-        None,
-    );
-    let timestamp = next_block.header().timestamp();
-    next_block
-        .mut_header()
-        .set_timestamp((timestamp + Duration::seconds(60)).unix_timestamp_nanos() as u64);
-    next_block.mut_header().resign(&signer);
+    let future_timestamp_nanos =
+        (Clock::real().now_utc() + Duration::seconds(60)).unix_timestamp_nanos() as u64;
+    let next_block = TestBlockBuilder::from_prev_block_view(Clock::real(), &block, signer)
+        .epoch_id(EpochId(block.header.next_epoch_id))
+        .next_epoch_id(EpochId(block.header.hash))
+        .next_bp_hash(block.header.next_bp_hash)
+        .block_merkle_tree(&mut block_merkle_tree)
+        .max_gas_price(Balance::from_yoctonear(100))
+        .timestamp_nanos(future_timestamp_nanos)
+        .build();
 
     let _ = actor_handles
         .client_actor
         .send_async(
             BlockResponse {
-                block: next_block.into(),
+                block: next_block,
                 peer_id: PeerInfo::random().id,
                 was_requested: false,
             }

--- a/nearcore/benches/serialization.rs
+++ b/nearcore/benches/serialization.rs
@@ -6,7 +6,7 @@ use near_primitives::block::Block;
 use near_primitives::genesis::{genesis_block, genesis_chunks};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::combine_hash;
-use near_primitives::test_utils::account_new;
+use near_primitives::test_utils::{TestBlockBuilder, account_new};
 use near_primitives::transaction::{
     Action, SignedTransaction, Transaction, TransactionV0, TransferAction,
 };
@@ -15,7 +15,7 @@ use near_primitives::types::{Balance, EpochId, Gas, ShardId, StateRoot};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_time::Clock;
-use num_rational::Rational32;
+use std::sync::Arc;
 
 fn create_transaction() -> SignedTransaction {
     let mut actions = vec![];
@@ -56,32 +56,16 @@ fn create_block() -> Block {
         Balance::from_yoctonear(1_000),
         &vec![],
     );
-    let signer = InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519);
-    Block::produce(
-        PROTOCOL_VERSION,
-        PROTOCOL_VERSION,
-        genesis.header(),
-        10,
-        genesis.header().block_ordinal() + 1,
-        vec![genesis.chunks()[0].clone()],
-        vec![vec![]; shard_ids.len()],
-        EpochId::default(),
-        EpochId::default(),
-        None,
-        vec![],
-        Rational32::from_integer(0),
-        Balance::ZERO,
-        Balance::ZERO,
-        Some(Balance::ZERO),
-        &signer,
-        CryptoHash::default(),
-        CryptoHash::default(),
-        Clock::real(),
-        None,
-        None,
-        None,
-        None,
-    )
+    let signer =
+        Arc::new(InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519));
+    TestBlockBuilder::from_prev_block(Clock::real(), &genesis, signer)
+        .chunks([genesis.chunks()[0].clone()])
+        .height(10)
+        .epoch_id(EpochId::default())
+        .next_epoch_id(EpochId::default())
+        .next_bp_hash(CryptoHash::default())
+        .block_merkle_root(CryptoHash::default())
+        .build_owned()
 }
 
 fn create_account() -> Account {


### PR DESCRIPTION
Routes ad-hoc `Block::produce` calls in `simple_chain.rs`, `network/testonly.rs`, `query_client.rs`, and `serialization.rs` through the existing `TestBlockBuilder`. Adds a few small setters (`block_merkle_root`, `timestamp_nanos`, `IntoIterator` for `chunks`) and a `build_owned()` variant to keep all four migrations byte-identical.

Preparation for spice-specific header version.