### PR TITLE
feat(forknet): parametrize wasm stress test with contract and tps

### DIFF
--- a/pytest/tests/mocknet/forknet_scenario.py
+++ b/pytest/tests/mocknet/forknet_scenario.py
@@ -4,6 +4,7 @@ This script is used to run a forknet scenario.
 
 from argparse import ArgumentParser, ArgumentTypeError, FileType
 import json
+import math
 import sys
 import pathlib
 import subprocess
@@ -90,13 +91,18 @@ def handle_destroy(test_setup, dump_workflow_params=None):
     bucket_path = f"{MOCKNET_STORE_PATH}/{mocknet_id}"
     logger.info(f"Removing mocknet bucket folder: {bucket_path}")
 
-    cmd = ['gsutil', 'rm', '-r', bucket_path]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        logger.warning(
-            f"Failed to remove bucket directory {bucket_path}: {result.stderr}")
+    cmd = ['gcloud', 'storage', 'rm', '--recursive', bucket_path]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError as e:
+        logger.warning(f"Failed to remove bucket directory {bucket_path}: {e}")
     else:
-        logger.info(f"Successfully removed bucket directory {bucket_path}")
+        if result.returncode != 0:
+            logger.warning(
+                f"Failed to remove bucket directory {bucket_path}: {result.stderr}"
+            )
+        else:
+            logger.info(f"Successfully removed bucket directory {bucket_path}")
 
     workflow_params = {
         "action": Action.DESTROY.value,
@@ -140,6 +146,23 @@ def validate_unique_id(value):
             f"'{value}' is not a valid unique ID. Must match pattern: {pattern}"
         )
     return value
+
+
+def positive_float(value):
+    """argparse type for --tps. Matches LoadTestRunner's float --tps but
+    requires a positive value: the forknet scenarios sweep block delays under
+    a known throughput, so LoadTestRunner's `0 = no throttle` mode doesn't
+    fit. Rejects nan/inf so downstream arithmetic (concurrency sizing, sleep
+    intervals) doesn't blow up."""
+    try:
+        parsed = float(value)
+    except ValueError:
+        raise ArgumentTypeError(f"'{value}' is not a number")
+    if not math.isfinite(parsed):
+        raise ArgumentTypeError(f"--tps must be finite, got {parsed}")
+    if parsed <= 0:
+        raise ArgumentTypeError(f"--tps must be > 0, got {parsed}")
+    return parsed
 
 
 def main():
@@ -215,6 +238,22 @@ def main():
         type=int,
         help=
         'Genesis protocol version to use. Used as default if test case class does not set it.',
+        required=False,
+    )
+
+    start_parser.add_argument(
+        '--contract',
+        help=
+        'WASM source spec forwarded to the stress-test script (alias / http(s) URL / local path). Overrides the test case default when set.',
+        required=False,
+    )
+
+    start_parser.add_argument(
+        '--tps',
+        type=positive_float,
+        default=1.0,
+        help=
+        'Per-signer deploys-per-second for the stress-test script (positive float).',
         required=False,
     )
 

--- a/pytest/tests/mocknet/forknet_scenarios/base.py
+++ b/pytest/tests/mocknet/forknet_scenarios/base.py
@@ -3,6 +3,7 @@ This script is used to define release tests for forknet.
 """
 
 import copy
+import os
 import pathlib
 import sys
 import tempfile
@@ -15,7 +16,7 @@ from mirror import (CommandContext, amend_binaries_cmd, clear_scheduled_cmds,
                     get_nodes_pending_new_test, hard_reset_cmd, new_test_cmd,
                     run_remote_cmd, run_remote_download_file,
                     run_remote_upload_file, start_nodes_cmd, start_traffic_cmd,
-                    stop_nodes_cmd, update_config_cmd)
+                    stop_nodes_cmd, update_config_cmd, upload_local_neard)
 from utils import ScheduleMode, PartitionSelector
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
@@ -119,12 +120,38 @@ class TestSetup:
         """
         return self.neard_upgrade_binary_url is not None and self.neard_upgrade_binary_url != ''
 
+    # Remote root for binaries shipped from the workflow runner. Each slot
+    # lives in its own subdir so two artifacts named `neard` don't collide.
+    _LOCAL_BINARY_REMOTE_ROOT = '/home/ubuntu/forknet-binaries'
+
+    def _materialize_local_binary(self, url, slot):
+        """If `url` points to a local file on this runner, scp it to every
+        targeted node under a per-slot subdir and return the remote path the
+        neard-runner should symlink. Otherwise return `url` unchanged."""
+        if not url or not os.path.isfile(url):
+            return url
+        remote_dir = f'{self._LOCAL_BINARY_REMOTE_ROOT}/{slot}'
+        logger.info(
+            f"local neard detected for slot '{slot}' at {url}; uploading to {remote_dir} on all nodes"
+        )
+        remote_path = upload_local_neard(self.args, url, remote_dir)
+        logger.info(f"slot '{slot}' neard remote path: {remote_path}")
+        return remote_path
+
     def init_env(self):
         """
         Setup the forknet environment for the test.
         """
         logger.info(
             f"Initializing environment for test case {self.args.test_case}")
+        # When the workflow ships a freshly-built binary as a GHA artifact, the
+        # URL is actually a path on the runner. Push it to the nodes first so
+        # the neard-runner's local-path branch (os.path.isfile → symlink) picks
+        # it up at hard_reset time.
+        self.neard_binary_url = self._materialize_local_binary(
+            self.neard_binary_url, 'start')
+        self.neard_upgrade_binary_url = self._materialize_local_binary(
+            self.neard_upgrade_binary_url, 'upgrade')
         # Load test state orchestrator
         init_args = copy.deepcopy(self.args)
         init_args.neard_binary_url = self.neard_binary_url

--- a/pytest/tests/mocknet/forknet_scenarios/test_wasm_release.py
+++ b/pytest/tests/mocknet/forknet_scenarios/test_wasm_release.py
@@ -58,10 +58,14 @@ class TestWasmCandidate(TestSetup):
         self.stress_signers = [
             ("astro-stakers.poolv1.near", None, None),
         ]
-        self.tps = 1  # set the number of contract deploy actions per signer per second.
+        # Per-signer deploys-per-second for the stress-test script. Default
+        # and validation live on the `start` subparser; getattr keeps this
+        # safe for create/destroy subcommands that don't define --tps.
+        self.tps = getattr(args, 'tps', 1.0)
         # Value passed via --contract to the stress-test script. When None
         # the flag is omitted and the script uses its built-in default.
-        self.contract = None
+        # CLI --contract overrides; otherwise None.
+        self.contract = getattr(args, 'contract', None)
 
     def amend_epoch_config(self):
         """
@@ -194,8 +198,12 @@ class TestWasmCandidate(TestSetup):
             extra_flags.append(f"--signer {shlex.quote(csv)}")
         if self.contract:
             extra_flags.append(f"--contract {shlex.quote(self.contract)}")
-        if self.tps:
-            extra_flags.append(f"--tps {shlex.quote(str(self.tps))}")
+        extra_flags.append(f"--tps {shlex.quote(str(self.tps))}")
+
+        # Scale workers with TPS so the per-signer queue (size = 2*concurrency)
+        # has ~2s of slack before the ticker starts dropping.
+        max_concurrency = 16
+        concurrency = int(min(max(4, self.tps * 2), max_concurrency))
 
         run_cmd_args = copy.deepcopy(self.args)
         run_cmd_args.host_type = "traffic"
@@ -203,7 +211,7 @@ class TestWasmCandidate(TestSetup):
             "cd /home/ubuntu/nearcore "
             "&& /home/ubuntu/.near/target/neard-runner/venv/bin/python pytest/tests/mocknet/wasm_stress_test.py "
             "--rpc-url http://localhost:3030 "
-            "--concurrency 5 " + " ".join(extra_flags))
+            f"--concurrency {concurrency} " + " ".join(extra_flags))
         run_cmd_args.on = ScheduleMode(mode="calendar",
                                        value=time_to_str(run_at))
         run_cmd_args.schedule_id = schedule_id

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -3,6 +3,7 @@
 Cli tool for managing the mocknet instances.
 """
 from argparse import ArgumentParser, Action
+import copy
 import datetime
 import pathlib
 import json
@@ -673,6 +674,25 @@ def run_remote_upload_file(ctx: CommandContext):
         node, node.upload_file(ctx.args.src, ctx.args.dst)),
          targeted,
          on_exception="")
+
+
+def upload_local_neard(args, local_path: str, remote_dir: str) -> str:
+    """Upload a local neard binary to remote_dir on every targeted node.
+
+    `scp` does not create destination directories, so this first runs
+    `mkdir -p remote_dir` on every target, then uploads the file. Returns the
+    absolute path on the remote where the binary now lives.
+    """
+    mkdir_args = copy.deepcopy(args)
+    mkdir_args.cmd = f'mkdir -p {remote_dir}'
+    run_remote_cmd(CommandContext(mkdir_args))
+
+    upload_args = copy.deepcopy(args)
+    upload_args.src = local_path
+    upload_args.dst = remote_dir
+    run_remote_upload_file(CommandContext(upload_args))
+
+    return os.path.join(remote_dir, os.path.basename(local_path))
 
 
 def add_node_name_to_path(node, path: str, prefix_if_path_is_dir: str) -> str:

--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -19,7 +19,7 @@ from rc import pmap
 from types import SimpleNamespace
 from mirror import CommandContext, get_nodes_status, init_cmd, new_test_cmd, \
     reset_cmd, run_env_cmd, run_remote_cmd, run_remote_download_file, run_remote_upload_file, \
-    start_nodes_cmd, stop_nodes_cmd, update_binaries_cmd
+    start_nodes_cmd, stop_nodes_cmd, update_binaries_cmd, upload_local_neard
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from configured_logger import logger
@@ -130,20 +130,6 @@ def upload_ft_contract(args):
     run_remote_cmd(CommandContext(run_cmd_args))
 
 
-def upload_local_neard(args):
-    """
-    uploads the local `neard` binary to every node to the ${BENCHNET_DIR}.
-    @return the absolute path (local to the remote node) to the uploaded `neard`
-
-    """
-    logger.info("uploading the neard ")
-    upload_file_args = copy.deepcopy(args)
-    upload_file_args.src = args.neard_binary_url
-    upload_file_args.dst = BENCHNET_DIR
-    run_remote_upload_file(CommandContext(upload_file_args))
-    return os.path.join(BENCHNET_DIR, "neard")
-
-
 def upload_json_patches(args):
     """Upload the json patches to the benchmark directory."""
     upload_file_args = copy.deepcopy(args)
@@ -181,8 +167,8 @@ def handle_init(args):
     is_local_neard = os.path.isfile(args.neard_binary_url)
     if is_local_neard:
         logger.info(f"handling local `neard` at {args.neard_binary_url}")
-        local_path_on_remote = upload_local_neard(args)
-        args.neard_binary_url = local_path_on_remote
+        args.neard_binary_url = upload_local_neard(args, args.neard_binary_url,
+                                                   BENCHNET_DIR)
         logger.info(f"`neard` local path on remote: {args.neard_binary_url}")
     else:
         logger.info("no local `neard` found, continue assuming the remote url")


### PR DESCRIPTION
This is to make the mirror infra-ops [pull](https://github.com/Near-One/infra-ops/pull/748) work.

- Add `--contract` and `--tps` to `forknet_scenario_start.py `. The previous workflow required editing test_wasm_release.py to point at a different WASM source or change throughput.
- Auto-scale stress-test worker concurrency with target TPS  inside `_schedule_slow_compile_stress_test`, replacing the hardcoded `--concurrency 5`. The per-signer queue is sized concurrency * 2, so a fixed 5 workers can't keep up at higher TPS and drops ticks with queue full warnings.
- Replace `gsutil rm -r` with `gcloud storage rm --recursive` in handle_destroy and handle errors too.