### PR TITLE
chore(ci): bump doomslug fuzz timeout to 12m

### DIFF
--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -30,9 +30,9 @@ expensive --timeout=10m test-loop-tests test_loop_tests tests::cross_shard_tx::u
 expensive --timeout=10m test-loop-tests test_loop_tests tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_with_validator_rotation_drop_chunks --features nightly,protocol_feature_spice
 
 # consensus tests
-expensive --timeout=10m near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety
-expensive --timeout=10m near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety --features nightly
-expensive --timeout=10m near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety --features nightly,protocol_feature_spice
+expensive --timeout=12m near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety
+expensive --timeout=12m near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety --features nightly
+expensive --timeout=12m near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety --features nightly,protocol_feature_spice
 expensive --timeout=10m test-loop-tests test_loop_tests tests::consensus::ultra_slow_test_consensus_with_epoch_switches
 expensive --timeout=10m test-loop-tests test_loop_tests tests::consensus::ultra_slow_test_consensus_with_epoch_switches --features nightly
 expensive --timeout=10m test-loop-tests test_loop_tests tests::consensus::ultra_slow_test_consensus_with_epoch_switches --features nightly,protocol_feature_spice


### PR DESCRIPTION
The `ultra_slow_test_fuzzy_doomslug_liveness_and_safety` nightly was skirting its 10m (600s) cap: last 30 nightlies on master have mean=467s, median=442s, stdev=59s, max=573s — only 27s of headroom. Bumping to 12m=720s gives ~150s over the observed max while staying well below the existing 30m extremes (`sanity/docker.py`, `full_estimator`).

This is causing random failures & retries on CI. For now this seems a good enough band-aid. We could also split the test into smaller ones, it appears to try different values in a loop.

Recent step-up of ~120s (399s → 519s) appears to be the Rust 1.93 toolchain bump (#15681); none of the test's own code path changed in that window.