### PR TITLE
test(test-loop): widen stake gap between block producers and chunk validators

### DIFF
--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -424,6 +424,6 @@ mod test {
 
         // In case this test fails, please make sure the changes do not change the structure of the genesis block.
         let hash = genesis_block.hash().to_string();
-        assert_eq!(hash, "93CRibQrTXr4eGB1zBCdVqrCNS3jFwwmx8oQ6wFxsx5j");
+        assert_eq!(hash, "3j2i6euhGGm8UG7avGhDnxiDftD2HW42kyTa14jbuKtQ");
     }
 }

--- a/core/chain-configs/src/test_genesis.rs
+++ b/core/chain-configs/src/test_genesis.rs
@@ -657,9 +657,7 @@ fn derive_validator_setup(specs: ValidatorsSpec) -> DerivedValidatorSetup {
                 let account_info = AccountInfo {
                     public_key: create_test_signer(account_id.as_str()).public_key(),
                     account_id,
-                    amount: Balance::from_near(
-                        10000 - i as u128 - num_block_and_chunk_producer_seats as u128,
-                    ),
+                    amount: Balance::from_near((1000 - i).try_into().unwrap()),
                 };
                 validators.push(account_info);
             }

--- a/core/chain-configs/src/test_genesis.rs
+++ b/core/chain-configs/src/test_genesis.rs
@@ -649,7 +649,7 @@ fn derive_validator_setup(specs: ValidatorsSpec) -> DerivedValidatorSetup {
                 let account_info = AccountInfo {
                     public_key: create_test_signer(account_id.as_str()).public_key(),
                     account_id,
-                    amount: Balance::from_near((10000 - i).try_into().unwrap()),
+                    amount: Balance::from_near((11_000 - i).try_into().unwrap()),
                 };
                 validators.push(account_info);
             }
@@ -657,7 +657,9 @@ fn derive_validator_setup(specs: ValidatorsSpec) -> DerivedValidatorSetup {
                 let account_info = AccountInfo {
                     public_key: create_test_signer(account_id.as_str()).public_key(),
                     account_id,
-                    amount: Balance::from_near((1000 - i).try_into().unwrap()),
+                    amount: Balance::from_near(
+                        10_000 - i as u128 - num_block_and_chunk_producer_seats as u128,
+                    ),
                 };
                 validators.push(account_info);
             }


### PR DESCRIPTION
In `ValidatorsSpec::DesiredRoles`, block-and-chunk-producer stakes start at 10000 NEAR and decrement by 1 per validator, while chunk-validators-only continue the same sequence (e.g. with 3 BPs and 2 CVs: 10000, 9999, 9998, 9997, 9996). Stakes between the two role tiers differ by only 1 NEAR, which leaves the role ordering vulnerable to flipping if reward distributions become asymmetric (eg, CV is rewarded but BP gets partial reward or misses reward).

This change bumps the BP base from 10_000 to 11_000 while keeping the CV formula unchanged. The result is a constant ~1001 NEAR gap between the lowest BP and the highest CV, regardless of validator count. Stakes stay in the same order of magnitude across tiers so stake-weighted mandate allocation behaves the same as before (important for tests like `chunk_validator_kickout`).