### PR TITLE
fix(ci): interpolate release tag in metadata dispatch

### DIFF
--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -103,7 +103,7 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.NEARONE_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/Near-One/infra-ops/dispatches \
-          -d '{"event_type":"metadata-update","client_payload":{"release":"${GITHUB_REF_NAME}"}}'
+          -d '{"event_type":"metadata-update","client_payload":{"release":"${{ github.ref_name }}"}}'
 
   docker-release:
     name: "Build and publish nearcore Docker image"


### PR DESCRIPTION
## Summary

- switch the metadata dispatch payload back to GitHub expression interpolation
- ensure the release workflow sends the actual release tag instead of the literal `${GITHUB_REF_NAME}`

## Root cause

The payload is wrapped in single-quoted JSON inside a `run` step, so `${GITHUB_REF_NAME}` is not expanded by the shell. `${{ github.ref_name }}` is resolved by GitHub Actions before the shell runs, which is what this workflow originally used.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/neard_release.yml"); puts "YAML OK"'

Closes #15801
