### PR TITLE
test(cloud-archive): inverse-walk scaffold for cross-resharding bootstrap

### DIFF
--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -127,7 +127,9 @@ pub mod col {
     ];
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, ProtocolSchema)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, BorshDeserialize, BorshSerialize, ProtocolSchema,
+)]
 #[borsh(use_discriminant = true)]
 #[repr(u8)]
 pub enum GlobalContractCodeIdentifier {
@@ -165,7 +167,9 @@ impl From<GlobalContractIdentifier> for GlobalContractCodeIdentifier {
 }
 
 /// Describes the key of a specific key-value record in a state trie.
-#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, ProtocolSchema)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, BorshDeserialize, BorshSerialize, ProtocolSchema,
+)]
 #[borsh(use_discriminant = true)]
 #[repr(u8)]
 pub enum TrieKey {

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -5,7 +5,7 @@ pub use crate::archive::cloud_storage::blocks::{BlockBatch, BlockData};
 pub use crate::archive::cloud_storage::bucket_config::BucketConfig;
 pub use crate::archive::cloud_storage::epoch_data::EpochData;
 pub use crate::archive::cloud_storage::retrieve::CloudRetrievalError;
-pub use crate::archive::cloud_storage::shards::{ShardBatch, ShardData};
+pub use crate::archive::cloud_storage::shards::{InverseStateChanges, ShardBatch, ShardData};
 use near_external_storage::ExternalConnection;
 use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -16,11 +16,12 @@ use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, RawStateChangesWithTrieKey};
 use near_primitives::utils::get_block_shard_id;
 use near_schema_checker_lib::ProtocolSchema;
+use std::collections::BTreeMap;
 
 /// Earlier value of each key changed in one block. `None` = key did not exist.
-/// One entry per key, sorted by trie key byte order, so the serialized blob bytes
-/// are deterministic.
-pub type InverseStateChanges = Vec<(TrieKey, Option<Vec<u8>>)>;
+/// A `BTreeMap` keeps entries ordered by key, so the serialized blob bytes are
+/// deterministic across writers.
+pub type InverseStateChanges = BTreeMap<TrieKey, Option<Vec<u8>>>;
 
 /// Versioned container for shard-related data stored in the cloud archive.
 /// This is for a single block height (taken from the file path).

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -10,11 +10,17 @@ use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptSource,
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::sharding::{ReceiptProof, ShardChunk};
 use near_primitives::transaction::ExecutionOutcomeWithProof;
+use near_primitives::trie_key::TrieKey;
 use near_primitives::types::ShardId;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, RawStateChangesWithTrieKey};
 use near_primitives::utils::get_block_shard_id;
 use near_schema_checker_lib::ProtocolSchema;
+
+/// Earlier value of each key changed in one block. `None` = key did not exist.
+/// One entry per key, sorted by trie key byte order, so the serialized blob bytes
+/// are deterministic.
+pub type InverseStateChanges = Vec<(TrieKey, Option<Vec<u8>>)>;
 
 /// Versioned container for shard-related data stored in the cloud archive.
 /// This is for a single block height (taken from the file path).
@@ -274,6 +280,13 @@ impl ShardData {
         match self {
             ShardData::V1(ShardDataV1::NewChunk(d)) => Some(&d.outgoing_receipts),
             ShardData::V1(ShardDataV1::Carried(_)) => None,
+        }
+    }
+
+    // TODO(cloud_archival): return the stored field once the writer attaches it.
+    pub fn inverse_state_changes(&self) -> Option<&InverseStateChanges> {
+        match self {
+            ShardData::V1(_) => None,
         }
     }
 }

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -4,9 +4,9 @@ use crate::setup::env::TestLoopEnv;
 use crate::utils::account::archival_account_id;
 use crate::utils::cloud_archival::{
     ReshardingInfo, WriterConfig, add_writer_node, apply_writer_settings,
-    assert_reader_writer_parity, bootstrap_reader, check_account_balance,
+    assert_reader_writer_parity, bootstrap_reader, build_shard_tries, check_account_balance,
     check_data_at_height_for_shards, gc_and_heads_sanity_checks, get_cloud_head, get_cloud_storage,
-    get_writer_handle, run_node_until, run_until_one_epoch_after_resharding,
+    get_writer_handle, has_state_root, run_node_until, run_until_one_epoch_after_resharding,
     simulate_lagging_shard, snapshots_sanity_check, stop_and_restart_node,
 };
 use crate::utils::setups::derive_new_epoch_config_from_boundary;
@@ -30,10 +30,7 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::bucket_config::BucketConfig;
 use near_store::db::cloud_shard_head_key;
-use near_store::flat::FlatStorageManager;
-use near_store::{
-    DBCol, KeyForStateChanges, ShardTries, ShardUId, StateSnapshotConfig, Store, TrieConfig,
-};
+use near_store::{DBCol, KeyForStateChanges, ShardUId, Store};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
@@ -1340,12 +1337,7 @@ fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
     h.bootstrap_reader(start, target);
 
     let store = h.reader_store();
-    let tries = ShardTries::new(
-        store.trie_store(),
-        TrieConfig::default(),
-        FlatStorageManager::new(store.flat_store()),
-        StateSnapshotConfig::Disabled,
-    );
+    let tries = build_shard_tries(&store);
 
     // For each height read the block, take dropped_shard's chunk header
     // `prev_state_root` as the state at that height for that shard, and check
@@ -1365,9 +1357,8 @@ fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
             );
         }
         let state_root = chunk_header.prev_state_root();
-        let trie = tries.get_trie_for_shard(dropped_shard_uid, state_root);
         assert!(
-            trie.retrieve_root_node().is_ok(),
+            has_state_root(&tries, dropped_shard_uid, state_root),
             "state unreachable for shard {dropped_shard} at h={h_check}"
         );
     }
@@ -1472,4 +1463,48 @@ fn test_cloud_archival_writer_resharding_known_shard_layout_versions() {
     match CloudArchiveHarness::default_shard_layout() {
         ShardLayout::V0(_) | ShardLayout::V1(_) | ShardLayout::V2(_) | ShardLayout::V3(_) => {}
     }
+}
+
+/// Bootstraps a reader across a resharding boundary and asserts the reader trie
+/// holds every base (old-layout) shard's state at the resharding block, and
+/// every new-layout shard's state both inside the resharding gap (reached by
+/// inverse walk) and at the snapshot (reached by forward replay).
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+// TODO(cloud_archival): un-ignore when resharding support is implemented.
+#[ignore]
+fn test_cloud_archival_resharding_gap_inverse_walk() {
+    let boundary_account: AccountId = "boundary".parse().unwrap();
+    let mut h = CloudArchiveHarness::builder().with_resharding(boundary_account).build();
+
+    let r = h.run_until_one_epoch_after_resharding();
+    let checkpoints: [(&str, BlockHeight, &[ShardUId]); 3] = [
+        ("base (old layout)", r.resharding_block_height, r.base_shard_uids.as_slice()),
+        ("new layout (gap)", r.new_epoch_first_height, r.new_shard_uids.as_slice()),
+        ("new layout (snapshot)", r.sync_block_height, r.new_shard_uids.as_slice()),
+    ];
+
+    h.bootstrap_reader(r.resharding_block_height, r.sync_block_height);
+
+    let reader_tries = build_shard_tries(&h.reader_store());
+    // Expected state roots are the writer's own chunk extras; each must resolve
+    // to a reachable root in the reader trie.
+    for (label, height, shard_uids) in checkpoints {
+        let block_hash = h.writer_store().chain_store().get_block_hash_by_height(height).unwrap();
+        for uid in shard_uids {
+            let state_root = *h
+                .writer_store()
+                .chunk_store()
+                .get_chunk_extra(&block_hash, uid)
+                .unwrap()
+                .state_root();
+            assert!(
+                has_state_root(&reader_tries, *uid, state_root),
+                "{label} shard {uid} state at h={height} unreachable in reader trie"
+            );
+        }
+    }
+
+    h.kill_reader();
+    h.shutdown();
 }

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -1470,7 +1470,6 @@ fn test_cloud_archival_writer_resharding_known_shard_layout_versions() {
 /// every new-layout shard's state both inside the resharding gap (reached by
 /// inverse walk) and at the snapshot (reached by forward replay).
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 // TODO(cloud_archival): un-ignore when resharding support is implemented.
 #[ignore]
 fn test_cloud_archival_resharding_gap_inverse_walk() {

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -96,10 +96,10 @@ pub fn run_until_one_epoch_after_resharding(
     let resharding_block_height = epoch_manager.get_block_info(&resharding_block).unwrap().height();
     let new_epoch_first_height = epoch_manager.get_block_info(&epoch_first).unwrap().height();
 
-    run_node_until(env, archival_id, resharding_block_height + epoch_length);
+    // Advance one epoch from the resharding epoch's first produced block so the
+    // resharding epoch fully elapses and its sync_hash gets recorded.
+    run_node_until(env, archival_id, new_epoch_first_height + epoch_length);
 
-    // The resharding epoch's sync_hash is recorded by the time the chain is a
-    // full epoch past it.
     let node = env.node_for_account(archival_id);
     let chain_store = node.client().chain.chain_store().store().chain_store();
     let sync_hash = chain_store

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -51,6 +51,15 @@ pub fn run_node_until(env: &mut TestLoopEnv, account_id: &AccountId, target_heig
 pub struct ReshardingInfo {
     /// The last block of the epoch before the split.
     pub resharding_block_height: BlockHeight,
+    /// The resharding epoch's first block, a produced block inside the gap.
+    pub new_epoch_first_height: BlockHeight,
+    /// The resharding epoch's sync_hash block height: the reader's snapshot
+    /// anchor, above the gap the inverse walk must cover.
+    pub sync_block_height: BlockHeight,
+    /// Shard UIds of the pre-split layout.
+    pub base_shard_uids: Vec<ShardUId>,
+    /// Shard UIds of the post-split layout.
+    pub new_shard_uids: Vec<ShardUId>,
     /// The shard the resharding removes.
     pub parent_shard: ShardId,
     /// One of the new child shards.
@@ -77,6 +86,7 @@ pub fn run_until_one_epoch_after_resharding(
         timeout,
     );
     let node = env.node_for_account(archival_id);
+    let resharding_epoch_id = node.head().epoch_id;
     let epoch_manager = &node.client().epoch_manager;
     let head = node.head().last_block_hash;
     // Follow prev_hash to the old epoch's last block; it can sit below
@@ -84,16 +94,37 @@ pub fn run_until_one_epoch_after_resharding(
     let epoch_first = *epoch_manager.get_block_info(&head).unwrap().epoch_first_block();
     let resharding_block = *epoch_manager.get_block_info(&epoch_first).unwrap().prev_hash();
     let resharding_block_height = epoch_manager.get_block_info(&resharding_block).unwrap().height();
+    let new_epoch_first_height = epoch_manager.get_block_info(&epoch_first).unwrap().height();
 
     run_node_until(env, archival_id, resharding_block_height + epoch_length);
 
+    // The resharding epoch's sync_hash is recorded by the time the chain is a
+    // full epoch past it.
+    let node = env.node_for_account(archival_id);
+    let chain_store = node.client().chain.chain_store().store().chain_store();
+    let sync_hash = chain_store
+        .get_current_epoch_sync_hash(&resharding_epoch_id)
+        .expect("resharding epoch sync_hash recorded one epoch past the split");
+    let sync_block_height = chain_store.get_block_header(&sync_hash).unwrap().height();
+
+    let base_shard_uids: Vec<ShardUId> = base_layout.shard_uids().collect();
+    let new_shard_uids: Vec<ShardUId> = new_layout.shard_uids().collect();
     let parent_shard = base_layout.account_id_to_shard_id(boundary);
     let child_shard = new_layout.account_id_to_shard_id(boundary);
     let carried_shard = base_layout
         .shard_ids()
         .find(|shard_id| *shard_id != parent_shard)
         .expect("layout has a shard other than the resharding parent");
-    ReshardingInfo { resharding_block_height, parent_shard, child_shard, carried_shard }
+    ReshardingInfo {
+        resharding_block_height,
+        new_epoch_first_height,
+        sync_block_height,
+        base_shard_uids,
+        new_shard_uids,
+        parent_shard,
+        child_shard,
+        carried_shard,
+    }
 }
 
 fn execute_future<F: Future>(fut: F) -> F::Output {
@@ -396,12 +427,7 @@ pub fn bootstrap_reader(
 
     let chain = &env.node_for_account(reader_id).client().chain;
     let store = chain.chain_store.store();
-    let tries = ShardTries::new(
-        store.trie_store(),
-        TrieConfig::default(),
-        FlatStorageManager::new(store.flat_store()),
-        StateSnapshotConfig::Disabled,
-    );
+    let tries = build_shard_tries(&store);
 
     // TODO(cloud_archival): support resharding; the shard layout can change
     // between the snapshot epoch and the target, which this loop assumes constant.
@@ -458,7 +484,22 @@ pub fn bootstrap_reader(
     }
 }
 
-fn has_state_root(tries: &ShardTries, shard_uid: ShardUId, state_root: CryptoHash) -> bool {
+/// Builds a `ShardTries` over `store` with state snapshots disabled.
+pub(crate) fn build_shard_tries(store: &Store) -> ShardTries {
+    ShardTries::new(
+        store.trie_store(),
+        TrieConfig::default(),
+        FlatStorageManager::new(store.flat_store()),
+        StateSnapshotConfig::Disabled,
+    )
+}
+
+/// Whether `state_root` resolves to a reachable root node in `shard_uid`'s trie.
+pub(crate) fn has_state_root(
+    tries: &ShardTries,
+    shard_uid: ShardUId,
+    state_root: CryptoHash,
+) -> bool {
     let trie = tries.get_trie_for_shard(shard_uid, state_root);
     trie.retrieve_root_node().is_ok()
 }


### PR DESCRIPTION
Test scaffold for the resharding-gap reader bootstrap that lands in two follow-up PRs.

- `InverseStateChanges` type + `ShardData::inverse_state_changes()` accessor stub (returns `None`).
- `run_until_one_epoch_after_resharding` returns the gap and snapshot block heights and each layout's shard uids; shared `build_shard_tries` helper.
- `test_cloud_archival_resharding_gap_inverse_walk`, `#[ignore]`'d.

Stacked PRs that follow:
- writer attaches inverse state changes, chain force-fires the resharding-epoch snapshot, `apply_inverse_state_changes_range` lands.
- cross-resharding multi-snapshot `bootstrap_reader`; un-ignores the test.