### PR TITLE
feat(cloud-archive): reader cross-resharding bootstrap

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3696,9 +3696,23 @@ impl Chain {
         let epoch_height =
             self.epoch_manager.get_epoch_height_from_prev_block(&head.prev_block_hash)?;
         if epoch_height % snapshot_every_n_epochs != 0 {
-            return Ok(SnapshotAction::None);
+            // Cloud-archive readers anchor the resharding-gap backward walk
+            // at this snapshot; the cadence skip would drop the only anchor
+            // for the new layout. Cadence=1 nodes never reach this branch.
+            if !self.is_resharding_epoch(&head)? {
+                return Ok(SnapshotAction::None);
+            }
         }
         Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
+    }
+
+    /// True when `head`'s epoch's shard layout differs from the previous epoch's.
+    fn is_resharding_epoch(&self, head: &Tip) -> Result<bool, Error> {
+        let cur_layout = self.epoch_manager.get_shard_layout(&head.epoch_id)?;
+        let prev_epoch_id =
+            self.epoch_manager.get_prev_epoch_id_from_prev_block(&head.prev_block_hash)?;
+        let prev_layout = self.epoch_manager.get_shard_layout(&prev_epoch_id)?;
+        Ok(cur_layout != prev_layout)
     }
 
     pub fn transaction_validity_period(&self) -> BlockHeightDelta {

--- a/chain/client/src/archive/cloud_archival_reader.rs
+++ b/chain/client/src/archive/cloud_archival_reader.rs
@@ -1,8 +1,13 @@
+use near_primitives::errors::StorageError;
+use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::index_to_bytes;
+use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::{BlockData, CloudRetrievalError, CloudStorage, EpochData};
-use near_store::{DBCol, Store};
+use near_store::trie::AccessOptions;
+use near_store::{DBCol, ShardTries, Store};
 use std::collections::HashSet;
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
@@ -12,6 +17,8 @@ pub enum CloudArchivalReaderError {
     Retrieval(#[from] CloudRetrievalError),
     #[error("walked back to genesis without finding a state snapshot")]
     NoSnapshotFound,
+    #[error(transparent)]
+    Storage(#[from] StorageError),
 }
 
 /// Writes block-level data from cloud storage into the local store.
@@ -225,4 +232,52 @@ fn save_new_epoch(
         "saved epoch data"
     );
     Ok(epoch_data)
+}
+
+/// Walks inverse state changes from `anchor_height` down to `target_height`
+/// for `shard_uid`, applying each block's entries via `Trie::update` +
+/// `tries.apply_all`. Heights with no `ShardData` or no inverse entries
+/// are silently skipped.
+pub fn apply_inverse_state_changes_range(
+    store: &Store,
+    cloud_storage: &CloudStorage,
+    tries: &ShardTries,
+    shard_uid: ShardUId,
+    anchor_state_root: CryptoHash,
+    anchor_height: BlockHeight,
+    target_height: BlockHeight,
+) -> Result<CryptoHash, CloudArchivalReaderError> {
+    assert!(target_height <= anchor_height);
+    let shard_id = shard_uid.shard_id();
+    let mut state_root = anchor_state_root;
+    let mut h = anchor_height;
+    while h > target_height {
+        let batch = cloud_storage.get_shard_batch_for_height(h, shard_id)?;
+        let batch_lo = std::cmp::max(batch.start_height(), target_height + 1);
+        for hh in (batch_lo..=h).rev() {
+            let Some(shard_data) = batch.get_shard_at_height(hh) else {
+                continue;
+            };
+            let Some(inverse) = shard_data.inverse_state_changes() else {
+                continue;
+            };
+            let trie = tries.get_trie_for_shard(shard_uid, state_root);
+            let trie_changes = trie.update(
+                inverse.iter().map(|(trie_key, pre)| (trie_key.to_vec(), pre.clone())),
+                AccessOptions::NO_SIDE_EFFECTS,
+            )?;
+            let mut store_update = store.trie_store().store_update();
+            // Insertions only; decrementing anchor-unique nodes here would
+            // remove the trie state at heights above the inverse walk that
+            // a subsequent forward apply (or sibling query) still needs.
+            tries.apply_insertions(&trie_changes, shard_uid, &mut store_update);
+            state_root = trie_changes.new_root;
+            store_update.commit();
+        }
+        if batch_lo == 0 {
+            break;
+        }
+        h = batch_lo - 1;
+    }
+    Ok(state_root)
 }

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -10,7 +10,7 @@ use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::types::{BlockHeight, EpochId, ShardId};
 use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::CloudStorage;
 use near_store::archive::cloud_storage::archive::CloudArchivingError;
@@ -316,12 +316,12 @@ impl CloudArchivalWriter {
         &self,
         batch_range: &BatchRange,
     ) -> Result<(), CloudArchivingError> {
-        // TODO(cloud_archival): support resharding.
         let prev_epoch_end = self.get_local_prev_epoch_end()?;
         let epoch_id = self.epoch_manager.get_next_epoch_id(&prev_epoch_end)?;
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         let tracked_shards =
             self.shard_tracker.get_tracked_shards_for_non_validator_in_epoch(&epoch_id)?;
+        let inverse_ceiling = self.resharding_inverse_ceiling(&epoch_id, &prev_epoch_end)?;
 
         let block_advanced = if self.config.archive_block_data {
             self.archive_block_batch_if_lagging(batch_range).await?
@@ -329,7 +329,12 @@ impl CloudArchivalWriter {
             false
         };
         let advanced_shards = self
-            .archive_shard_batches_if_lagging(batch_range, &shard_layout, &tracked_shards)
+            .archive_shard_batches_if_lagging(
+                batch_range,
+                &shard_layout,
+                &tracked_shards,
+                inverse_ceiling,
+            )
             .await?;
         let new_prev_epoch_end = self.find_epoch_ending_in_batch(batch_range)?;
         if self.config.archive_block_data {
@@ -400,11 +405,14 @@ impl CloudArchivalWriter {
 
     /// Archives shard batches for tracked shards whose local head is behind
     /// `batch_range.end()`. Returns the shard IDs that were advanced.
+    /// `inverse_ceiling`: passed to `archive_shard_batch` to enable inverse
+    /// state-change attachment in a resharding epoch.
     async fn archive_shard_batches_if_lagging(
         &self,
         batch_range: &BatchRange,
         shard_layout: &ShardLayout,
         tracked_shards: &[ShardUId],
+        inverse_ceiling: Option<BlockHeight>,
     ) -> Result<Vec<ShardId>, CloudArchivingError> {
         let mut advanced_shards = Vec::new();
         for shard_uid in tracked_shards {
@@ -429,12 +437,42 @@ impl CloudArchivalWriter {
                     shard_layout,
                     batch_range,
                     *shard_uid,
+                    inverse_ceiling,
                 )
                 .await?;
             self.cloud_storage.update_cloud_shard_head(shard_id, batch_range.end()).await?;
             advanced_shards.push(shard_id);
         }
         Ok(advanced_shards)
+    }
+
+    /// Highest block height that should carry inverse state changes. `None`
+    /// for non-resharding epochs. `Some(sync_prev_prev_height)` when
+    /// sync_hash for the new epoch is recorded; `Some(BlockHeight::MAX)`
+    /// while it isn't (finality-plus-atomic `FINAL_HEAD` + `StateSyncHashes`
+    /// write in `ChainStoreUpdate::finalize` guarantees the writer can only
+    /// be at gap blocks until sync_hash lands).
+    fn resharding_inverse_ceiling(
+        &self,
+        epoch_id: &EpochId,
+        prev_epoch_end: &CryptoHash,
+    ) -> Result<Option<BlockHeight>, near_chain_primitives::Error> {
+        let prev_epoch_id = self.epoch_manager.get_epoch_id(prev_epoch_end)?;
+        let cur_layout = self.epoch_manager.get_shard_layout(epoch_id)?;
+        let prev_layout = self.epoch_manager.get_shard_layout(&prev_epoch_id)?;
+        if cur_layout == prev_layout {
+            return Ok(None);
+        }
+        let Some(sync_hash) =
+            self.hot_store.get_ser::<CryptoHash>(DBCol::StateSyncHashes, epoch_id.as_ref())
+        else {
+            return Ok(Some(BlockHeight::MAX));
+        };
+        let chain_store = self.hot_store.chain_store();
+        let sync_header = chain_store.get_block_header(&sync_hash)?;
+        let sync_prev_header = chain_store.get_block_header(sync_header.prev_hash())?;
+        let sync_prev_prev_header = chain_store.get_block_header(sync_prev_header.prev_hash())?;
+        Ok(Some(sync_prev_prev_header.height()))
     }
 
     /// Initializes the cloud archive writer: validates bucket config and

--- a/core/store/src/archive/cloud_storage/archive.rs
+++ b/core/store/src/archive/cloud_storage/archive.rs
@@ -118,6 +118,8 @@ impl CloudStorage {
 
     /// Builds and uploads a shard batch covering `range`. The caller must
     /// ensure that all heights in the batch share the same `shard_layout`.
+    /// `inverse_ceiling`: when `Some(h)`, attaches inverse state changes
+    /// for present blocks with height `<= h`.
     pub async fn archive_shard_batch(
         &self,
         hot_store: &Store,
@@ -125,9 +127,16 @@ impl CloudStorage {
         shard_layout: &ShardLayout,
         range: &BatchRange,
         shard_uid: ShardUId,
+        inverse_ceiling: Option<BlockHeight>,
     ) -> Result<(), CloudArchivingError> {
-        let shard_batch =
-            build_shard_batch(hot_store, genesis_height, shard_layout, range, shard_uid)?;
+        let shard_batch = build_shard_batch(
+            hot_store,
+            genesis_height,
+            shard_layout,
+            range,
+            shard_uid,
+            inverse_ceiling,
+        )?;
         let batch_id = compute_batch_id(range.start(), self.batch_size());
         let file_id = CloudStorageFileID::ShardBatch(shard_uid.shard_id(), batch_id);
         let blob = borsh::to_vec(&shard_batch).unwrap();

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -4,7 +4,7 @@ pub use crate::archive::cloud_storage::blocks::{BlockBatch, BlockData};
 pub use crate::archive::cloud_storage::bucket_config::BucketConfig;
 pub use crate::archive::cloud_storage::epoch_data::EpochData;
 pub use crate::archive::cloud_storage::retrieve::CloudRetrievalError;
-pub use crate::archive::cloud_storage::shards::{ShardBatch, ShardData};
+pub use crate::archive::cloud_storage::shards::{InverseStateChanges, ShardBatch, ShardData};
 use near_external_storage::ExternalConnection;
 use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -10,10 +10,14 @@ use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptSource,
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::sharding::{ReceiptProof, ShardChunk};
 use near_primitives::transaction::{ExecutionOutcomeWithProof, SignedTransaction};
+use near_primitives::trie_key::TrieKey;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, RawStateChangesWithTrieKey};
 use near_primitives::utils::get_block_shard_id;
 use near_schema_checker_lib::ProtocolSchema;
+
+/// Earlier value of each key changed in one block. `None` = key did not exist.
+pub type InverseStateChanges = Vec<(TrieKey, Option<Vec<u8>>)>;
 
 /// Versioned container for shard-related data stored in the cloud archive.
 /// This is for a single block height (taken from the file path).
@@ -220,6 +224,13 @@ impl ShardData {
     pub fn receipt_to_tx(&self) -> &[(CryptoHash, ReceiptToTxInfo)] {
         match self {
             ShardData::V1(data) => &data.receipt_to_tx,
+        }
+    }
+
+    // TODO(cloud_archival): return the stored field once the writer attaches it.
+    pub fn inverse_state_changes(&self) -> Option<&InverseStateChanges> {
+        match self {
+            ShardData::V1(_) => None,
         }
     }
 }

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -1,7 +1,11 @@
 use crate::adapter::StoreAdapter;
 use crate::adapter::chain_store::option_to_not_found;
 use crate::archive::cloud_storage::batch::BatchRange;
-use crate::{DBCol, KeyForStateChanges, Store};
+use crate::flat::FlatStorageManager;
+use crate::trie::AccessOptions;
+use crate::{
+    DBCol, KeyForStateChanges, ShardTries, StateSnapshotConfig, Store, TrieConfig,
+};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_chain_primitives::Error;
 use near_primitives::chunk_apply_stats::ChunkApplyStats;
@@ -51,6 +55,9 @@ pub struct ShardDataV1 {
     /// Read from `DBCol::ProcessedReceiptIds` (entries tagged
     /// `ReceiptSource::ReceiptToTxGc`) and `DBCol::ReceiptToTx`.
     receipt_to_tx: Vec<(CryptoHash, ReceiptToTxInfo)>,
+
+    /// Earlier value of each key in `state_changes`. `None` if not computed.
+    inverse_state_changes: Option<InverseStateChanges>,
 }
 
 /// Builds a `ShardData` object for the given block height and shard ID by
@@ -64,6 +71,7 @@ pub fn build_shard_data(
     shard_layout: &ShardLayout,
     block_height: BlockHeight,
     shard_uid: ShardUId,
+    inverse_state_changes: Option<InverseStateChanges>,
 ) -> Result<Option<ShardData>, Error> {
     let chain_store = store.chain_store();
     let chunk_store = store.chunk_store();
@@ -156,8 +164,33 @@ pub fn build_shard_data(
         chunk_apply_stats,
         transaction_result_for_block,
         receipt_to_tx,
+        inverse_state_changes,
     };
     Ok(Some(ShardData::V1(shard_data)))
+}
+
+/// For each key changed in this block, reads its value at `prev_state_root`.
+/// Output sorted by `TrieKey` bytes so every writer produces the same blob.
+pub fn build_inverse_state_changes(
+    store: &Store,
+    tries: &ShardTries,
+    shard_layout: &ShardLayout,
+    shard_uid: ShardUId,
+    block_hash: &CryptoHash,
+    prev_state_root: CryptoHash,
+) -> Result<InverseStateChanges, Error> {
+    let forward = get_state_changes(store, shard_layout, block_hash, shard_uid)?;
+    let trie = tries.get_trie_for_shard(shard_uid, prev_state_root);
+    let mut entries = Vec::with_capacity(forward.len());
+    for change in &forward {
+        let key_bytes = change.trie_key.to_vec();
+        let pre_value = trie
+            .get(&key_bytes, AccessOptions::DEFAULT)
+            .map_err(|e| Error::Other(format!("inverse lookup failed: {e}")))?;
+        entries.push((change.trie_key.clone(), pre_value));
+    }
+    entries.sort_by(|(a, _), (b, _)| a.to_vec().cmp(&b.to_vec()));
+    Ok(entries)
 }
 
 // TODO(cloud_archival) Consider calling this function once per block height instead for each shard.
@@ -227,10 +260,9 @@ impl ShardData {
         }
     }
 
-    // TODO(cloud_archival): return the stored field once the writer attaches it.
     pub fn inverse_state_changes(&self) -> Option<&InverseStateChanges> {
         match self {
-            ShardData::V1(_) => None,
+            ShardData::V1(data) => data.inverse_state_changes.as_ref(),
         }
     }
 }
@@ -252,20 +284,81 @@ pub struct ShardBatchV1 {
 
 /// Builds a `ShardBatch` by reading shard data for each height in `range`.
 /// Pushes `None` for skipped slots and for heights where this shard's chunk
-/// is not new.
+/// is not new. If `inverse_ceiling` is `Some(h)`, fills `inverse_state_changes`
+/// on each present block with height `<= h`.
 pub fn build_shard_batch(
     store: &Store,
     genesis_height: BlockHeight,
     shard_layout: &ShardLayout,
     range: &BatchRange,
     shard_uid: ShardUId,
+    inverse_ceiling: Option<BlockHeight>,
 ) -> Result<ShardBatch, Error> {
+    let tries = inverse_ceiling.map(|_| {
+        ShardTries::new(
+            store.trie_store(),
+            TrieConfig::default(),
+            FlatStorageManager::new(store.flat_store()),
+            StateSnapshotConfig::Disabled,
+        )
+    });
     let count = (range.end() - range.start() + 1) as usize;
     let mut data = Vec::with_capacity(count);
     for height in range.start()..=range.end() {
-        data.push(build_shard_data(store, genesis_height, shard_layout, height, shard_uid)?);
+        let inverse = build_inverse_at_height(
+            store,
+            tries.as_ref(),
+            shard_layout,
+            shard_uid,
+            height,
+            inverse_ceiling,
+        )?;
+        data.push(build_shard_data(
+            store,
+            genesis_height,
+            shard_layout,
+            height,
+            shard_uid,
+            inverse,
+        )?);
     }
     Ok(ShardBatch::new(range.start(), range.end(), data))
+}
+
+/// Inverse entries for `(height, shard_uid)`, or `None` if `height` is
+/// above `inverse_ceiling` or there is no block at `height`.
+fn build_inverse_at_height(
+    store: &Store,
+    tries: Option<&ShardTries>,
+    shard_layout: &ShardLayout,
+    shard_uid: ShardUId,
+    height: BlockHeight,
+    inverse_ceiling: Option<BlockHeight>,
+) -> Result<Option<InverseStateChanges>, Error> {
+    let Some(ceiling) = inverse_ceiling else {
+        return Ok(None);
+    };
+    if height > ceiling {
+        return Ok(None);
+    }
+    let tries = tries.expect("tries are built whenever inverse_ceiling is Some");
+    let chain_store = store.chain_store();
+    let block_hash = match chain_store.get_block_hash_by_height(height) {
+        Ok(hash) => hash,
+        Err(Error::DBNotFoundErr(_)) => return Ok(None),
+        Err(other) => return Err(other),
+    };
+    let header = chain_store.get_block_header(&block_hash)?;
+    let prev_chunk_extra = store.chunk_store().get_chunk_extra(header.prev_hash(), &shard_uid)?;
+    let prev_state_root = *prev_chunk_extra.state_root();
+    Ok(Some(build_inverse_state_changes(
+        store,
+        tries,
+        shard_layout,
+        shard_uid,
+        &block_hash,
+        prev_state_root,
+    )?))
 }
 
 impl ShardBatch {

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -1268,8 +1268,6 @@ fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
 /// trie holds state for parent shards before the boundary, new-layout
 /// shards inside the resharding gap, and new-layout shards at target.
 #[test]
-// TODO(cloud_archival): un-ignore when resharding support is implemented.
-#[ignore]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_resharding_gap_inverse_walk() {
     let mut h = CloudArchiveHarness::builder()

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -5,16 +5,22 @@ use crate::utils::account::archival_account_id;
 use crate::utils::cloud_archival::{
     WriterConfig, add_writer_node, apply_writer_settings, bootstrap_reader, check_account_balance,
     check_data_at_height_for_shards, gc_and_heads_sanity_checks, get_cloud_head, get_cloud_storage,
-    get_writer_handle, run_node_until, simulate_lagging_shard, snapshots_sanity_check,
-    stop_and_restart_node, verify_block_range,
+    get_writer_handle, resharding_gap_window, run_node_until,
+    run_until_cloud_head_above, run_until_resharding_sync_hash_recorded, simulate_lagging_shard,
+    snapshots_sanity_check, stop_and_restart_node, verify_block_range,
 };
+use crate::utils::setups::derive_new_epoch_config_from_boundary;
 use borsh::to_vec;
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
-use near_chain_configs::MIN_GC_NUM_EPOCHS_TO_KEEP;
+use near_chain_configs::test_genesis::TestEpochConfigBuilder;
+use near_chain_configs::{
+    CloudArchivalWriterConfig, MIN_GC_NUM_EPOCHS_TO_KEEP, TrackedShardsConfig,
+};
 use near_client::archive::cloud_archival_reader::find_snapshot_at_or_before;
 use near_primitives::block::Block;
 use near_primitives::chunk_apply_stats::ChunkApplyStats;
+use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{Receipt, ReceiptOrigin, ReceiptToTxInfo};
 use near_primitives::shard_layout::{ShardLayout, get_block_shard_uid};
@@ -22,13 +28,15 @@ use near_primitives::sharding::ShardChunk;
 use near_primitives::transaction::ExecutionOutcomeWithProof;
 use near_primitives::types::{AccountId, Balance, BlockHeight, BlockHeightDelta, ShardId};
 use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::bucket_config::BucketConfig;
 use near_store::flat::FlatStorageManager;
 use near_store::{
     DBCol, KeyForStateChanges, ShardTries, ShardUId, StateSnapshotConfig, Store, TrieConfig,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
 /// Test harness for cloud archival tests. Owns the `TestLoopEnv` and exposes
 /// composable action and assertion methods so each test reads as an explicit
@@ -45,6 +53,8 @@ struct CloudArchiveHarness {
     snapshot_every_n_epochs: u64,
     /// Account ID of the reader node, set after `bootstrap_reader()`.
     reader_id: Option<AccountId>,
+    /// Post-resharding shard layout when `with_resharding` was used.
+    new_shard_layout: Option<ShardLayout>,
 }
 
 struct CloudArchiveHarnessBuilder {
@@ -54,6 +64,10 @@ struct CloudArchiveHarnessBuilder {
     dropped_block_heights: HashSet<BlockHeight>,
     /// Per-shard chunk-production schedule applied every epoch.
     dropped_chunks_by_shard: HashMap<ShardId, Vec<bool>>,
+    /// Boundary account for a static resharding split.
+    resharding_boundary: Option<AccountId>,
+    epoch_length: Option<BlockHeightDelta>,
+    batch_size: Option<u32>,
 }
 
 impl CloudArchiveHarnessBuilder {
@@ -97,6 +111,23 @@ impl CloudArchiveHarnessBuilder {
         self
     }
 
+    /// Schedules a static resharding split at `boundary_account` in the
+    /// successor protocol version.
+    fn with_resharding(mut self, boundary_account: AccountId) -> Self {
+        self.resharding_boundary = Some(boundary_account);
+        self
+    }
+
+    fn epoch_length(mut self, length: BlockHeightDelta) -> Self {
+        self.epoch_length = Some(length);
+        self
+    }
+
+    fn batch_size(mut self, size: u32) -> Self {
+        self.batch_size = Some(size);
+        self
+    }
+
     fn build(self) -> CloudArchiveHarness {
         let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
         let archival_kind =
@@ -105,26 +136,58 @@ impl CloudArchiveHarnessBuilder {
         let snapshot_every_n_epochs = self.writer.snapshot_every_n_epochs;
         let has_drops =
             !self.dropped_block_heights.is_empty() || !self.dropped_chunks_by_shard.is_empty();
+        let epoch_length = self.epoch_length.unwrap_or(CloudArchiveHarness::DEFAULT_EPOCH_LENGTH);
+        let batch_size = self.batch_size.unwrap_or(CloudArchiveHarness::TEST_BATCH_SIZE);
+        let base_shard_layout = CloudArchiveHarness::default_shard_layout();
+        let resharding_boundary = self.resharding_boundary.clone();
+        let writer_archive_block_data = self.writer.archive_block_data;
+        let writer_tracked_shards = self.writer.tracked_shards.clone();
         let mut builder = TestLoopBuilder::new()
-            .shard_layout(CloudArchiveHarness::default_shard_layout())
-            .epoch_length(CloudArchiveHarness::DEFAULT_EPOCH_LENGTH)
+            .shard_layout(base_shard_layout.clone())
+            .epoch_length(epoch_length)
             .add_user_account(&user_account, CloudArchiveHarness::USER_BALANCE)
             .enable_archival_node(archival_kind)
             .gc_num_epochs_to_keep(MIN_GC_NUM_EPOCHS_TO_KEEP)
-            .bucket_config(BucketConfig::with_batch_size_for_test(
-                CloudArchiveHarness::TEST_BATCH_SIZE,
-            ))
+            .bucket_config(BucketConfig::with_batch_size_for_test(batch_size))
             .config_modifier(move |config, _client_index| {
                 if !config.archive {
                     return;
                 }
-                apply_writer_settings(
-                    config,
-                    self.writer.archive_block_data,
-                    &self.writer.tracked_shards,
-                    snapshot_every_n_epochs,
-                );
+                if resharding_boundary.is_some() {
+                    // Child shards added by resharding aren't known at startup,
+                    // so track everything in the current epoch's layout.
+                    config.cloud_archival_writer = Some(CloudArchivalWriterConfig {
+                        archive_block_data: writer_archive_block_data,
+                        snapshot_every_n_epochs,
+                        ..Default::default()
+                    });
+                    config.tracked_shards_config = TrackedShardsConfig::AllShards;
+                } else {
+                    apply_writer_settings(
+                        config,
+                        writer_archive_block_data,
+                        &writer_tracked_shards,
+                        snapshot_every_n_epochs,
+                    );
+                }
             });
+        let mut new_shard_layout = None;
+        if let Some(boundary) = &self.resharding_boundary {
+            let base_epoch_config = TestEpochConfigBuilder::new()
+                .shard_layout(base_shard_layout.clone())
+                .epoch_length(epoch_length)
+                .build();
+            let (new_epoch_config, derived_layout) =
+                derive_new_epoch_config_from_boundary(&base_epoch_config, boundary);
+            new_shard_layout = Some(derived_layout);
+            let epoch_config_store = EpochConfigStore::test(BTreeMap::from_iter([
+                (PROTOCOL_VERSION - 1, Arc::new(base_epoch_config)),
+                (PROTOCOL_VERSION, Arc::new(new_epoch_config)),
+            ]));
+            builder = builder
+                .protocol_version(PROTOCOL_VERSION - 1)
+                .epoch_config_store(epoch_config_store);
+        }
         if let Some(count) = self.num_validators {
             builder = builder.validators(count, 0);
         }
@@ -147,10 +210,11 @@ impl CloudArchiveHarnessBuilder {
         CloudArchiveHarness {
             env,
             archival_id,
-            epoch_length: CloudArchiveHarness::DEFAULT_EPOCH_LENGTH,
+            epoch_length,
             cold_storage_enabled: self.cold_storage,
             snapshot_every_n_epochs,
             reader_id: None,
+            new_shard_layout,
         }
     }
 }
@@ -173,6 +237,9 @@ impl CloudArchiveHarness {
             num_validators: None,
             dropped_block_heights: HashSet::new(),
             dropped_chunks_by_shard: HashMap::new(),
+            resharding_boundary: None,
+            epoch_length: None,
+            batch_size: None,
         }
     }
 
@@ -199,6 +266,11 @@ impl CloudArchiveHarness {
         let reader_id: AccountId = "reader".parse().unwrap();
         bootstrap_reader(&mut self.env, &reader_id, start_height, target_height);
         self.reader_id = Some(reader_id);
+    }
+
+    /// Post-resharding shard layout. Requires `with_resharding` on the builder.
+    fn new_shard_layout(&self) -> &ShardLayout {
+        self.new_shard_layout.as_ref().expect("with_resharding required")
     }
 
     fn kill_reader(&mut self) {
@@ -1187,6 +1259,80 @@ fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
             "state unreachable for shard {dropped_shard} at h={h_check}"
         );
     }
+
+    h.kill_reader();
+    h.shutdown();
+}
+
+/// Bootstraps a reader across a resharding boundary and asserts the reader
+/// trie holds state for parent shards before the boundary, new-layout
+/// shards inside the resharding gap, and new-layout shards at target.
+#[test]
+// TODO(cloud_archival): un-ignore when resharding support is implemented.
+#[ignore]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_resharding_gap_inverse_walk() {
+    let mut h = CloudArchiveHarness::builder()
+        .epoch_length(6)
+        .batch_size(1)
+        .with_resharding("boundary".parse().unwrap())
+        .build();
+    let new_layout = h.new_shard_layout().clone();
+    let base_layout = CloudArchiveHarness::default_shard_layout();
+    let timeout = Duration::seconds((6 * h.epoch_length) as i64);
+
+    run_until_resharding_sync_hash_recorded(&mut h.env, &h.archival_id, &new_layout, timeout);
+    let (epoch_start, sync_prev_prev) = resharding_gap_window(&h.env, &h.archival_id);
+    // Target sits past sync_block in the new epoch (forward-replay region).
+    let target = sync_prev_prev + 4;
+    run_until_cloud_head_above(&mut h.env, &h.archival_id, target, timeout);
+    // Freeze the writer so the chain blocks the assertions read aren't GC'd.
+    get_writer_handle(&h.env, &h.archival_id).0.stop();
+
+    // Capture expected state roots from the writer's chain at three heights:
+    // start (in old epoch, parent shards), gap_height (in the resharding
+    // gap, new layout - reached via inverse walk), and target (past the
+    // gap, new layout - reached via forward replay).
+    let start = epoch_start - 1; // resharding block (last of old epoch)
+    let gap_height = epoch_start; // first block of new epoch, inside gap
+
+    let writer_store = h.writer_store();
+    let writer_chain = writer_store.chain_store();
+    let writer_chunks = writer_store.chunk_store();
+    let expected_at = |height: BlockHeight, uids: &[ShardUId]| -> HashMap<ShardUId, CryptoHash> {
+        let hash = writer_chain.get_block_hash_by_height(height).unwrap();
+        uids.iter()
+            .map(|uid| (*uid, *writer_chunks.get_chunk_extra(&hash, uid).unwrap().state_root()))
+            .collect()
+    };
+    let parent_uids: Vec<ShardUId> = base_layout.shard_uids().collect();
+    let new_uids: Vec<ShardUId> = new_layout.shard_uids().collect();
+    let expected_parent_at_start = expected_at(start, &parent_uids);
+    let expected_new_at_gap = expected_at(gap_height, &new_uids);
+    let expected_new_at_target = expected_at(target, &new_uids);
+
+    h.bootstrap_reader(start, target);
+
+    let reader_store = h.reader_store();
+    let reader_tries = ShardTries::new(
+        reader_store.trie_store(),
+        TrieConfig::default(),
+        FlatStorageManager::new(reader_store.flat_store()),
+        StateSnapshotConfig::Disabled,
+    );
+    let assert_reachable =
+        |expected: &HashMap<ShardUId, CryptoHash>, height: BlockHeight, label: &str| {
+            for (uid, state_root) in expected {
+                let trie = reader_tries.get_trie_for_shard(*uid, *state_root);
+                assert!(
+                    trie.retrieve_root_node().is_ok(),
+                    "{label} shard {uid} state at h={height} unreachable in reader trie"
+                );
+            }
+        };
+    assert_reachable(&expected_parent_at_start, start, "parent");
+    assert_reachable(&expected_new_at_gap, gap_height, "new-layout (gap)");
+    assert_reachable(&expected_new_at_target, target, "new-layout (target)");
 
     h.kill_reader();
     h.shutdown();

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -16,8 +16,10 @@ use near_primitives::block_header::BlockHeader;
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
+use near_async::time::Duration;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId,
 };
@@ -44,6 +46,67 @@ pub(crate) struct WriterConfig {
 
 pub fn run_node_until(env: &mut TestLoopEnv, account_id: &AccountId, target_height: BlockHeight) {
     env.runner_for_account(account_id).run_until_head_height(target_height);
+}
+
+/// Runs until head's epoch has layout `new_layout` and its sync_hash is recorded.
+pub fn run_until_resharding_sync_hash_recorded(
+    env: &mut TestLoopEnv,
+    archival_id: &AccountId,
+    new_layout: &ShardLayout,
+    timeout: Duration,
+) {
+    let new_layout = new_layout.clone();
+    env.runner_for_account(archival_id).run_until(
+        move |node| {
+            let epoch_id = node.head().epoch_id;
+            let layout = node.client().epoch_manager.get_shard_layout(&epoch_id).unwrap();
+            if layout != new_layout {
+                return false;
+            }
+            let store = node.client().chain.chain_store().store();
+            store.exists(DBCol::StateSyncHashes, epoch_id.as_ref())
+        },
+        timeout,
+    );
+}
+
+/// `(epoch_start_height, sync_prev_prev_height)` for the head's epoch.
+/// Caller must ensure the sync_hash is already recorded.
+pub fn resharding_gap_window(
+    env: &TestLoopEnv,
+    archival_id: &AccountId,
+) -> (BlockHeight, BlockHeight) {
+    let node = env.node_for_account(archival_id);
+    let client = node.client();
+    let store = client.chain.chain_store().store();
+    let epoch_id = node.head().epoch_id;
+    let sync_hash: CryptoHash =
+        store.get_ser(DBCol::StateSyncHashes, epoch_id.as_ref()).unwrap();
+    let chain_store = store.chain_store();
+    let sync_header = chain_store.get_block_header(&sync_hash).unwrap();
+    let sync_prev_header = chain_store.get_block_header(sync_header.prev_hash()).unwrap();
+    let sync_prev_prev_header =
+        chain_store.get_block_header(sync_prev_header.prev_hash()).unwrap();
+    let epoch_start_height = client.epoch_manager.get_epoch_start_height(&sync_hash).unwrap();
+    (epoch_start_height, sync_prev_prev_header.height())
+}
+
+/// Runs until `CLOUD_MIN_HEAD` exceeds `min_height`.
+pub fn run_until_cloud_head_above(
+    env: &mut TestLoopEnv,
+    archival_id: &AccountId,
+    min_height: BlockHeight,
+    timeout: Duration,
+) {
+    env.runner_for_account(archival_id).run_until(
+        move |node| {
+            let store = node.client().chain.chain_store().store();
+            let cloud_head: BlockHeight =
+                store.get_ser(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY).unwrap_or(0);
+            cloud_head > min_height
+        },
+        timeout,
+    );
 }
 
 fn execute_future<F: Future>(fut: F) -> F::Output {

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -5,7 +5,7 @@ use near_chain::types::Tip;
 use near_chain::{Chain, ChainStoreAccess};
 use near_chain_configs::{ClientConfig, CloudArchivalWriterConfig, TrackedShardsConfig};
 use near_client::archive::cloud_archival_reader::{
-    bootstrap_range, find_present_block_at_or_below,
+    apply_inverse_state_changes_range, bootstrap_range, find_present_block_at_or_below,
 };
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::sync::external::{
@@ -392,27 +392,15 @@ pub fn bootstrap_reader(
 
     let cloud_storage = get_cloud_storage(env, reader_id);
 
-    // Download all blocks in the range into the reader's store.
     {
         let store = env.node_for_account(reader_id).client().chain.chain_store.store();
         bootstrap_range(&store, &cloud_storage, start_height, target_block_height)
             .expect("bootstrap_range should succeed");
     }
 
-    // If `target_block_height` is a skipped slot the height carries no data,
-    // so reconstructing state at the nearest present block at-or-below it is
-    // equivalent (no state changes between them).
-    let (target_block_height, target_block_data) =
+    let (target_block_height, _) =
         find_present_block_at_or_below(&cloud_storage, target_block_height).unwrap();
-    let epoch_id = target_block_data.block().header().epoch_id();
-    let epoch_data = cloud_storage.get_epoch_data(*epoch_id).unwrap();
-    let epoch_height = epoch_data.epoch_info().epoch_height();
-
-    // Sync block is in the new epoch, after the prefix of blocks needed to
-    // reach two chunks per shard, and saved only once final - so present.
-    let sync_block = cloud_storage.get_block_data(epoch_data.sync_block_height()).unwrap().unwrap();
-    let sync_hash = sync_block.block().hash();
-    let sync_prev_block_height = sync_block.block().header().prev_height().unwrap();
+    let segments = find_epoch_segments(&cloud_storage, start_height, target_block_height);
 
     let chain = &env.node_for_account(reader_id).client().chain;
     let store = chain.chain_store.store();
@@ -423,47 +411,158 @@ pub fn bootstrap_reader(
         StateSnapshotConfig::Disabled,
     );
     let state_sync_connection = StateSyncConnection::from_cloud_storage(&cloud_storage);
+    // Tracks the state root each shard reached at the end of the last
+    // segment it appeared in. Inherited shards continue forward from this
+    // root instead of re-downloading a snapshot.
+    let mut shard_state: std::collections::HashMap<ShardUId, CryptoHash> =
+        std::collections::HashMap::new();
 
-    for shard_id in epoch_data.shard_layout().shard_ids() {
-        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, epoch_data.shard_layout());
-        let target_block_shard_data =
-            cloud_storage.get_shard_data(target_block_height, shard_id).unwrap().unwrap();
-        let target_state_root = *target_block_shard_data.chunk_extra().state_root();
-        let state_header =
-            cloud_storage.get_state_header(epoch_height, *epoch_id, shard_id).unwrap();
-        let state_sync_state_root = state_header.chunk_prev_state_root();
-
-        chain.state_sync_adapter.set_state_header(shard_id, *sync_hash, state_header).unwrap();
-
-        assert!(!has_state_root(&tries, shard_uid, state_sync_state_root));
-        execute_future(load_state_snapshot(
+    for (epoch_id, range_low, range_high) in segments {
+        bootstrap_one_epoch(
             chain,
             &state_sync_connection,
-            cloud_storage.chain_id(),
-            epoch_id,
-            epoch_height,
-            *sync_hash,
-            shard_id,
-            state_sync_state_root,
-        ));
-        assert!(has_state_root(&tries, shard_uid, state_sync_state_root));
-
-        assert!(!has_state_root(&tries, shard_uid, target_state_root));
-        apply_state_changes(
             &cloud_storage,
             &store,
             &tries,
-            state_sync_state_root,
-            sync_prev_block_height,
-            target_block_height,
-            shard_uid,
+            epoch_id,
+            range_low,
+            range_high,
+            &mut shard_state,
         );
-        assert!(has_state_root(&tries, shard_uid, target_state_root));
+    }
+}
 
-        // Validate the restored state by reading from the trie.
-        let trie = tries.get_trie_for_shard(shard_uid, target_state_root);
-        let item_count = trie.disk_iter().unwrap().count();
-        assert!(item_count > 0, "trie for shard {shard_id} should not be empty after bootstrap");
+/// Walks `[start_height, target_block_height]` block-by-block in cloud and
+/// returns one `(epoch_id, range_low, range_high)` per epoch covered, in
+/// ascending height order.
+fn find_epoch_segments(
+    cloud_storage: &CloudStorage,
+    start_height: BlockHeight,
+    target_block_height: BlockHeight,
+) -> Vec<(EpochId, BlockHeight, BlockHeight)> {
+    let mut segments: Vec<(EpochId, BlockHeight, BlockHeight)> = Vec::new();
+    let mut current: Option<(EpochId, BlockHeight, BlockHeight)> = None;
+    let mut h = start_height;
+    while h <= target_block_height {
+        let batch = cloud_storage.get_block_batch_for_height(h).unwrap();
+        let last_in_batch = std::cmp::min(batch.end_height(), target_block_height);
+        for hh in h..=last_in_batch {
+            let Some(block_data) = batch.get_block_at_height(hh) else {
+                continue;
+            };
+            let epoch_id = *block_data.block().header().epoch_id();
+            match current.as_mut() {
+                None => current = Some((epoch_id, hh, hh)),
+                Some(seg) if seg.0 == epoch_id => seg.2 = hh,
+                Some(_) => {
+                    segments.push(current.take().unwrap());
+                    current = Some((epoch_id, hh, hh));
+                }
+            }
+        }
+        h = last_in_batch + 1;
+    }
+    if let Some(seg) = current {
+        segments.push(seg);
+    }
+    segments
+}
+
+/// For each shard in `epoch_id`'s layout, either state-syncs at this
+/// epoch's snapshot anchor (new shards) or continues forward from the
+/// state root the shard reached in the previous segment (inherited
+/// shards). Applies forward state changes up to `range_high` and inverse
+/// state changes down to `range_low` (or the epoch start, if higher).
+/// Updates `shard_state` with the resulting state root for each shard.
+fn bootstrap_one_epoch(
+    chain: &Chain,
+    state_sync_connection: &StateSyncConnection,
+    cloud_storage: &CloudStorage,
+    store: &Store,
+    tries: &ShardTries,
+    epoch_id: EpochId,
+    range_low: BlockHeight,
+    range_high: BlockHeight,
+    shard_state: &mut std::collections::HashMap<ShardUId, CryptoHash>,
+) {
+    let epoch_data = cloud_storage.get_epoch_data(epoch_id).unwrap();
+    let epoch_height = epoch_data.epoch_info().epoch_height();
+    let sync_block_height = epoch_data.sync_block_height();
+    let sync_block = cloud_storage.get_block_data(sync_block_height).unwrap().unwrap();
+    let sync_hash = *sync_block.block().hash();
+    let sync_prev_block_height = sync_block.block().header().prev_height().unwrap();
+    let sync_prev_block =
+        cloud_storage.get_block_data(sync_prev_block_height).unwrap().unwrap();
+    let sync_prev_prev_height = sync_prev_block.block().header().prev_height().unwrap();
+    let epoch_start_height = epoch_data.epoch_start_height();
+
+    for shard_id in epoch_data.shard_layout().shard_ids() {
+        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, epoch_data.shard_layout());
+        if let Some(&prev_state_root) = shard_state.get(&shard_uid) {
+            // Inherited shard: continue forward from where the previous
+            // segment left off; no fresh snapshot needed.
+            apply_state_changes(
+                cloud_storage,
+                store,
+                tries,
+                prev_state_root,
+                epoch_start_height,
+                range_high,
+                shard_uid,
+            );
+        } else {
+            // New shard for this segment: state-sync at the anchor, then
+            // forward and (if needed) inverse from there.
+            let state_header =
+                cloud_storage.get_state_header(epoch_height, epoch_id, shard_id).unwrap();
+            let state_sync_state_root = state_header.chunk_prev_state_root();
+
+            chain.state_sync_adapter.set_state_header(shard_id, sync_hash, state_header).unwrap();
+            assert!(!has_state_root(tries, shard_uid, state_sync_state_root));
+            execute_future(load_state_snapshot(
+                chain,
+                state_sync_connection,
+                cloud_storage.chain_id(),
+                &epoch_id,
+                epoch_height,
+                sync_hash,
+                shard_id,
+                state_sync_state_root,
+            ));
+            assert!(has_state_root(tries, shard_uid, state_sync_state_root));
+
+            // Inverse first, so its `apply_insertions` increments the
+            // shared anchor/inverse-chain trie nodes before forward's
+            // `apply_all` decrements anchor-unique ones.
+            let inverse_low = std::cmp::max(range_low, epoch_start_height);
+            if inverse_low <= sync_prev_prev_height {
+                apply_inverse_state_changes_range(
+                    store,
+                    cloud_storage,
+                    tries,
+                    shard_uid,
+                    state_sync_state_root,
+                    sync_prev_prev_height,
+                    inverse_low,
+                )
+                .unwrap();
+            }
+            if range_high >= sync_prev_block_height {
+                apply_state_changes(
+                    cloud_storage,
+                    store,
+                    tries,
+                    state_sync_state_root,
+                    sync_prev_block_height,
+                    range_high,
+                    shard_uid,
+                );
+            }
+        }
+        // State at `range_high` is now in the trie. Record it so the
+        // next segment that inherits this shard can continue from here.
+        let shard_data = cloud_storage.get_shard_data(range_high, shard_id).unwrap().unwrap();
+        shard_state.insert(shard_uid, *shard_data.chunk_extra().state_root());
     }
 }
 
@@ -537,7 +636,11 @@ fn apply_state_changes(
             )
             .unwrap();
         let mut store_update = store.trie_store().store_update();
-        state_root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
+        // Insertions only: forward apply preserves every intermediate state
+        // root reached so a sibling query (or another walk from the same
+        // anchor) can still read those heights.
+        tries.apply_insertions(&trie_changes, shard_uid, &mut store_update);
+        state_root = trie_changes.new_root;
         store_update.commit();
         assert!(has_state_root(&tries, shard_uid, state_root));
     }


### PR DESCRIPTION
Reader-side cross-resharding bootstrap: `bootstrap_reader` walks every epoch in `[start, target]` and runs one snapshot+state-sync+apply cycle per layout, forward up to each segment's high end and inverse down to the low end. Inherited shards continue forward without re-snapshot.

- `apply_inverse_state_changes_range` public reader primitive in `cloud_archival_reader.rs`.
- `CloudArchivalReaderError::Storage(StorageError)` for trie errors surfaced from `apply_all`.
- `find_epoch_segments` + `bootstrap_one_epoch` in `utils/cloud_archival.rs`.
- `bootstrap_reader` switches from single-epoch to multi-segment.

`apply_state_changes` and `apply_inverse_state_changes_range` switch from `apply_all` to `apply_insertions`: the reader walks forward AND inverse from the same anchor, and `apply_all`'s deletions would remove anchor-unique trie nodes the sibling walk still needs. Insertions-only keeps every intermediate state root reachable.

Un-ignores the scaffold test from #15806; parent shards at start, new-layout at gap (inverse walk), and new-layout at target all resolve from the reader trie.