### PR TITLE
feat(spice): adapter scaffold for chunk-executor (1/n)

### DIFF
--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -159,8 +159,9 @@ impl Chain {
         store_update.save_head(&block_head)?;
         store_update.save_final_head(&header_head)?;
         if ProtocolFeature::Spice.enabled(genesis_protocol_version) {
-            store_update.save_spice_execution_head(block_head.clone())?;
-            store_update.save_spice_final_execution_head(&block_head)?;
+            let mut spice_update = store_update.store_update().chain_store_update();
+            spice_update.set_spice_execution_head(&block_head)?;
+            spice_update.set_spice_final_execution_head(&block_head);
         }
 
         // Set the root block of flat state to be the genesis block. Later, when we

--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -159,9 +159,11 @@ impl Chain {
         store_update.save_head(&block_head)?;
         store_update.save_final_head(&header_head)?;
         if ProtocolFeature::Spice.enabled(genesis_protocol_version) {
-            let mut spice_update = store_update.store_update().chain_store_update();
-            spice_update.set_spice_execution_head(&block_head)?;
-            spice_update.set_spice_final_execution_head(&block_head);
+            let mut spice_update = store_update.store().store_update();
+            let mut adapter = spice_update.chain_store_update();
+            adapter.set_spice_execution_head(&block_head)?;
+            adapter.set_spice_final_execution_head(&block_head);
+            store_update.merge(spice_update);
         }
 
         // Set the root block of flat state to be the genesis block. Later, when we

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1938,6 +1938,21 @@ impl<'a> ChainStoreUpdate<'a> {
         self.store_updates.push(store_update);
     }
 
+    /// Returns a fresh `StoreUpdate` chained onto this `ChainStoreUpdate`. The
+    /// returned update is merged into the final commit when `finalize()` runs,
+    /// so adapter writes can be chained into the existing flow.
+    ///
+    /// CACHE-BYPASS WARNING: writes through this handle do NOT populate the
+    /// `chain_store_cache_update` write-buffer. Subsequent `ChainStoreUpdate::get_*`
+    /// reads in the same logical txn will fall through to disk and miss the
+    /// in-flight write. Callers must either (a) not read what they just wrote,
+    /// or (b) read through the adapter (which also bypasses the cache) for
+    /// consistency.
+    pub fn store_update(&mut self) -> &mut StoreUpdate {
+        self.store_updates.push(self.store().store_update());
+        self.store_updates.last_mut().expect("just pushed")
+    }
+
     fn write_col_misc<T: BorshSerialize>(
         store_update: &mut StoreUpdate,
         key: &[u8],

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -553,6 +553,13 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
     /// Forward-only: advance the SPICE final execution head to `block`'s last final
     /// block when that is higher than the current head (or none is set), writing via
     /// this update, and return the (possibly advanced) head.
+    ///
+    /// The "current head" comparison reads the committed `Store`, not pending writes
+    /// queued in this `StoreUpdate`. That's intentional: this setter is called at
+    /// most once per `apply_block_postprocessing` invocation, which owns its own
+    /// `StoreUpdate` and commits before the next finalize runs. The forward-only
+    /// check guards against inter-update races (a concurrent finalize already
+    /// committed a higher head), not intra-update races.
     pub fn update_spice_final_execution_head(
         &mut self,
         block: &Block,
@@ -584,6 +591,10 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
     /// forward by construction; this is belt-and-suspenders against an
     /// out-of-order / fork re-run. Differs from
     /// `ChainStoreUpdate::save_spice_execution_head`, which is unconditional.
+    ///
+    /// Same intra-update caveat as `update_spice_final_execution_head`: the check
+    /// reads the committed `Store`, not pending writes in this `StoreUpdate`. Safe
+    /// because callers issue at most one write per `StoreUpdate`.
     pub fn set_spice_execution_head(&mut self, tip: &Tip) -> Result<(), Error> {
         let current_height = match self.store_update.store.chain_store().spice_execution_head() {
             Ok(head) => Some(head.height),

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -7,13 +7,18 @@ use crate::{
 use near_chain_primitives::Error;
 use near_primitives::block::{Block, BlockHeader, Tip};
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptToTxInfo};
-use near_primitives::sharding::ReceiptProof;
+use near_primitives::sharding::{ReceiptProof, ShardProof};
 use near_primitives::state_sync::{ShardStateSyncResponseHeader, StateHeaderKey};
-use near_primitives::transaction::{ExecutionOutcomeWithProof, SignedTransaction};
+use near_primitives::transaction::{
+    ExecutionOutcomeWithId, ExecutionOutcomeWithProof, SignedTransaction,
+};
 use near_primitives::types::{BlockHeight, EpochId, NumBlocks, ShardId};
-use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
+use near_primitives::utils::{
+    get_block_shard_id, get_outcome_id_block_hash, get_receipt_proof_key,
+    get_receipt_proof_target_shard_prefix, index_to_bytes,
+};
 use near_primitives::views::LightClientBlockView;
 use std::collections::{HashMap, HashSet};
 use std::io;
@@ -246,6 +251,38 @@ impl ChainStoreAdapter {
         self.store.get_ser(DBCol::BlocksToCatchup, prev_hash.as_ref()).unwrap_or_default()
     }
 
+    pub fn get_receipt_proof(
+        &self,
+        block_hash: &CryptoHash,
+        to_shard_id: ShardId,
+        from_shard_id: ShardId,
+    ) -> Option<ReceiptProof> {
+        let key = get_receipt_proof_key(block_hash, from_shard_id, to_shard_id);
+        self.store.get_ser(DBCol::receipt_proofs(), &key)
+    }
+
+    pub fn iter_receipt_proofs_for_shard(
+        &self,
+        block_hash: &CryptoHash,
+        to_shard_id: ShardId,
+    ) -> Vec<ReceiptProof> {
+        let prefix = get_receipt_proof_target_shard_prefix(block_hash, to_shard_id);
+        self.store
+            .iter_prefix_ser::<ReceiptProof>(DBCol::receipt_proofs(), &prefix)
+            .map(|kv| kv.1)
+            .collect()
+    }
+
+    pub fn receipt_proof_exists(
+        &self,
+        block_hash: &CryptoHash,
+        to_shard_id: ShardId,
+        from_shard_id: ShardId,
+    ) -> bool {
+        let key = get_receipt_proof_key(block_hash, from_shard_id, to_shard_id);
+        self.store.exists(DBCol::receipt_proofs(), &key)
+    }
+
     pub fn get_transaction(&self, tx_hash: &CryptoHash) -> Option<Arc<SignedTransaction>> {
         self.store.get_ser(DBCol::Transactions, tx_hash.as_ref())
     }
@@ -433,6 +470,140 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
             self.store_update.store.chain_store().get_all_header_hashes_by_height(height);
         hash_set.insert(*header.hash());
         self.set_block_header_hashes_by_height(height, &hash_set);
+    }
+
+    pub fn set_outgoing_receipt(
+        &mut self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+        outgoing_receipts: &[Receipt],
+    ) {
+        self.store_update.set_ser(
+            DBCol::OutgoingReceipts,
+            &get_block_shard_id(block_hash, shard_id),
+            &outgoing_receipts,
+        );
+    }
+
+    /// Writes the `ProcessedReceiptIds` metadata index and increments the
+    /// refcount of each processed `Receipt` (the `DBCol::Receipts` rc-column).
+    /// The caller builds `metadata` (including any `ReceiptToTxGc` markers gated
+    /// on the `save_receipt_to_tx` config) so this stays raw I/O.
+    pub fn set_processed_receipt_ids(
+        &mut self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+        metadata: &[ProcessedReceiptMetadata],
+        receipts: &[Receipt],
+    ) {
+        self.store_update.set_ser(
+            DBCol::ProcessedReceiptIds,
+            &get_block_shard_id(block_hash, shard_id),
+            &metadata,
+        );
+        for receipt in receipts {
+            let bytes = borsh::to_vec(receipt).expect("borsh cannot fail");
+            self.store_update.increment_refcount(
+                DBCol::Receipts,
+                receipt.get_hash().as_ref(),
+                &bytes,
+            );
+        }
+    }
+
+    /// Unlike `ChainStoreUpdate::save_outcomes_with_proofs`, this method does not
+    /// consult the `save_tx_outcomes` config gate — the caller decides whether to
+    /// invoke it.
+    pub fn set_outcomes_with_proofs(
+        &mut self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+        outcomes: Vec<ExecutionOutcomeWithId>,
+        proofs: Vec<MerklePath>,
+    ) {
+        let mut outcome_ids = Vec::with_capacity(outcomes.len());
+        for (outcome_with_id, proof) in outcomes.into_iter().zip(proofs.into_iter()) {
+            outcome_ids.push(outcome_with_id.id);
+            self.store_update.insert_ser(
+                DBCol::TransactionResultForBlock,
+                &get_outcome_id_block_hash(&outcome_with_id.id, block_hash),
+                &ExecutionOutcomeWithProof { outcome: outcome_with_id.outcome, proof },
+            );
+        }
+        self.store_update.set_ser(
+            DBCol::OutcomeIds,
+            &get_block_shard_id(block_hash, shard_id),
+            &outcome_ids,
+        );
+    }
+
+    /// Unlike `ChainStoreUpdate::save_receipt_to_tx`, this method does not consult
+    /// the `save_receipt_to_tx` config gate — the caller decides whether to invoke
+    /// it.
+    pub fn set_receipt_to_tx(&mut self, receipt_to_tx: &[(CryptoHash, ReceiptToTxInfo)]) {
+        for (receipt_id, info) in receipt_to_tx {
+            self.store_update.insert_ser(DBCol::ReceiptToTx, receipt_id.as_ref(), info);
+        }
+    }
+
+    pub fn set_spice_final_execution_head(&mut self, tip: &Tip) {
+        self.store_update.set_ser(DBCol::BlockMisc, SPICE_FINAL_EXECUTION_HEAD_KEY, tip);
+    }
+
+    /// Forward-only: advance the SPICE final execution head to `block`'s last final
+    /// block when that is higher than the current head (or none is set), writing via
+    /// this update, and return the (possibly advanced) head.
+    pub fn update_spice_final_execution_head(
+        &mut self,
+        block: &Block,
+    ) -> Result<Option<Arc<Tip>>, Error> {
+        let chain_store = self.store_update.store.chain_store();
+        let current = match chain_store.spice_final_execution_head() {
+            Ok(head) => Some(head),
+            Err(Error::DBNotFoundErr(_)) => None,
+            Err(err) => return Err(err),
+        };
+        if block.header().last_final_block() == &CryptoHash::default() {
+            return Ok(current);
+        }
+        let last_final_header = chain_store.get_block_header(block.header().last_final_block())?;
+        let advance = match &current {
+            None => true,
+            Some(head) => head.height < last_final_header.height(),
+        };
+        if advance {
+            let tip = Arc::new(Tip::from_header(&last_final_header));
+            self.set_spice_final_execution_head(&tip);
+            return Ok(Some(tip));
+        }
+        Ok(current)
+    }
+
+    /// Forward-only: writes the SPICE execution head only when `tip` is higher
+    /// than the current head (or none is set). The execution-head scan only moves
+    /// forward by construction; this is belt-and-suspenders against an
+    /// out-of-order / fork re-run. Differs from
+    /// `ChainStoreUpdate::save_spice_execution_head`, which is unconditional.
+    pub fn set_spice_execution_head(&mut self, tip: &Tip) -> Result<(), Error> {
+        let current_height = match self.store_update.store.chain_store().spice_execution_head() {
+            Ok(head) => Some(head.height),
+            Err(Error::DBNotFoundErr(_)) => None,
+            Err(err) => return Err(err),
+        };
+        let should_write = match current_height {
+            None => true,
+            Some(height) => height < tip.height,
+        };
+        if should_write {
+            self.store_update.set_ser(DBCol::BlockMisc, SPICE_EXECUTION_HEAD_KEY, tip);
+        }
+        Ok(())
+    }
+
+    pub fn set_receipt_proof(&mut self, block_hash: &CryptoHash, receipt_proof: &ReceiptProof) {
+        let ShardProof { from_shard_id, to_shard_id, .. } = receipt_proof.1;
+        let key = get_receipt_proof_key(block_hash, from_shard_id, to_shard_id);
+        self.store_update.set_ser(DBCol::receipt_proofs(), &key, receipt_proof);
     }
 }
 

--- a/core/store/src/adapter/chunk_store.rs
+++ b/core/store/src/adapter/chunk_store.rs
@@ -1,15 +1,20 @@
-use super::StoreAdapter;
-use crate::{DBCol, Store};
+use super::{StoreAdapter, StoreUpdateAdapter, StoreUpdateHolder};
+use crate::{DBCol, Store, StoreUpdate};
 use near_chain_primitives::Error;
 use near_primitives::chunk_apply_stats::ChunkApplyStats;
 use near_primitives::errors::ChunkAccessError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{ShardUId, get_block_shard_uid};
 use near_primitives::sharding::{ChunkHash, EncodedShardChunk, PartialEncodedChunk, ShardChunk};
+use near_primitives::spice::state_witness::SpiceChunkStateWitness;
+use near_primitives::stateless_validation::contract_distribution::CodeHash;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, ShardId};
-use near_primitives::utils::{get_block_shard_id, index_to_bytes};
+use near_primitives::utils::{
+    get_block_shard_id, get_contract_accesses_key, get_witnesses_key, index_to_bytes,
+};
 use std::collections::HashSet;
+use std::io;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -26,6 +31,12 @@ impl StoreAdapter for ChunkStoreAdapter {
 impl ChunkStoreAdapter {
     pub fn new(store: Store) -> Self {
         Self { store }
+    }
+
+    pub fn store_update(&self) -> ChunkStoreUpdateAdapter<'static> {
+        ChunkStoreUpdateAdapter {
+            store_update: StoreUpdateHolder::Owned(self.store.store_update()),
+        }
     }
 
     pub fn get_partial_chunk(
@@ -82,6 +93,103 @@ impl ChunkStoreAdapter {
         shard_id: &ShardId,
     ) -> Option<ChunkApplyStats> {
         self.store.get_ser(DBCol::ChunkApplyStats, &get_block_shard_id(block_hash, *shard_id))
+    }
+
+    pub fn get_witness(
+        &self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+    ) -> Option<SpiceChunkStateWitness> {
+        let key = get_witnesses_key(block_hash, shard_id);
+        self.store.get_ser(DBCol::witnesses(), &key)
+    }
+
+    pub fn get_contract_accesses(
+        &self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+    ) -> Option<HashSet<CodeHash>> {
+        let key = get_contract_accesses_key(block_hash, shard_id);
+        let accesses: Arc<Vec<CodeHash>> =
+            self.store.caching_get_ser(DBCol::contract_accesses(), &key)?;
+        Some(accesses.iter().cloned().collect())
+    }
+}
+
+pub struct ChunkStoreUpdateAdapter<'a> {
+    store_update: StoreUpdateHolder<'a>,
+}
+
+impl Into<StoreUpdate> for ChunkStoreUpdateAdapter<'static> {
+    fn into(self) -> StoreUpdate {
+        self.store_update.into()
+    }
+}
+
+impl ChunkStoreUpdateAdapter<'static> {
+    pub fn commit(self) -> io::Result<()> {
+        let store_update: StoreUpdate = self.into();
+        store_update.commit();
+        Ok(())
+    }
+}
+
+impl<'a> StoreUpdateAdapter for ChunkStoreUpdateAdapter<'a> {
+    fn store_update(&mut self) -> &mut StoreUpdate {
+        &mut self.store_update
+    }
+}
+
+impl<'a> ChunkStoreUpdateAdapter<'a> {
+    pub fn new(store_update: &'a mut StoreUpdate) -> Self {
+        Self { store_update: StoreUpdateHolder::Reference(store_update) }
+    }
+
+    pub fn set_chunk_extra(
+        &mut self,
+        block_hash: &CryptoHash,
+        shard_uid: &ShardUId,
+        chunk_extra: &ChunkExtra,
+    ) {
+        self.store_update.set_ser(
+            DBCol::ChunkExtra,
+            &get_block_shard_uid(block_hash, shard_uid),
+            chunk_extra,
+        );
+    }
+
+    pub fn set_chunk_apply_stats(
+        &mut self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+        stats: &ChunkApplyStats,
+    ) {
+        self.store_update.set_ser(
+            DBCol::ChunkApplyStats,
+            &get_block_shard_id(block_hash, shard_id),
+            stats,
+        );
+    }
+
+    pub fn set_witness(
+        &mut self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+        witness: &SpiceChunkStateWitness,
+    ) {
+        let key = get_witnesses_key(block_hash, shard_id);
+        self.store_update.set_ser(DBCol::witnesses(), &key, witness);
+    }
+
+    pub fn set_contract_accesses(
+        &mut self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+        contract_accesses: &HashSet<CodeHash>,
+    ) {
+        let key = get_contract_accesses_key(block_hash, shard_id);
+        let value: Vec<CodeHash> = contract_accesses.iter().cloned().collect();
+        self.store_update.set_ser(DBCol::contract_accesses(), &key, &value);
     }
 }
 

--- a/core/store/src/adapter/mod.rs
+++ b/core/store/src/adapter/mod.rs
@@ -125,6 +125,10 @@ pub trait StoreUpdateAdapter: Sized {
         chain_store::ChainStoreUpdateAdapter::new(self.store_update())
     }
 
+    fn chunk_store_update(&mut self) -> chunk_store::ChunkStoreUpdateAdapter<'_> {
+        chunk_store::ChunkStoreUpdateAdapter::new(self.store_update())
+    }
+
     fn epoch_store_update(&mut self) -> epoch_store::EpochStoreUpdateAdapter<'_> {
         epoch_store::EpochStoreUpdateAdapter::new(self.store_update())
     }


### PR DESCRIPTION
Phase A of the chunk-executor redesign — pure-additions adapter scaffold for the spice executor. Chain-side leaf callers stay on the existing `ChainStoreUpdate::save_*` surface; the new adapter surface and the legacy surface coexist during the chain-deprecation overlap.

- New `ChunkStoreUpdateAdapter` mirrors the existing `ChainStoreUpdateAdapter` shape (`StoreUpdateHolder` pattern, plus `set_*` setters for per-shard apply columns).
- Spice-head setters are forward-only: `set_spice_execution_head` and `update_spice_final_execution_head` write only if the new tip is strictly higher than the current head. Replaces the legacy unconditional `ChainStoreUpdate::save_spice_execution_head`.
- `ChainStoreUpdate::store_update()` bridge returns ` &mut StoreUpdate ` so callers can chain adapter writes into an existing `ChainStoreUpdate`'s flow. Cache-bypass behavior is documented at the call site — adapter writes go straight to the `StoreUpdate` and miss `chain_store_cache_update`.
- Opportunistic non-spice migration: genesis spice-head writes (`chain/chain/src/genesis.rs`) switch to the adapter. The only non-spice migration in Phase A — tiny, single call site, genesis is one-shot so cache-bypass is irrelevant.