### PR TITLE
feat(debug-ui): add lightweight epoch_info endpoint for Recent Epochs

### DIFF
--- a/chain/client-primitives/src/debug.rs
+++ b/chain/client-primitives/src/debug.rs
@@ -256,6 +256,10 @@ pub enum DebugStatus {
     TrackedShards,
     // Detailed information about last couple epochs.
     EpochInfo(Option<EpochId>),
+    // Same as EpochInfo, but omits the expensive per-validator `validator_info`.
+    // Used by debug-ui views that only need epoch metadata and producer/validator
+    // counts (recent epochs, epoch shards, current peers).
+    EpochInfoLight(Option<EpochId>),
     // Detailed information about last couple blocks.
     BlockStatus(DebugBlockStatusQuery),
     // Consensus related information.

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -55,6 +55,16 @@ const DEBUG_MAX_BLOCKS_TO_FETCH: u64 = 1000;
 // Number of epochs to fetch when displaying epoch info.
 const DEBUG_EPOCHS_TO_FETCH: u32 = 5;
 
+/// Controls how much detail `get_recent_epoch_info` / `get_epoch_info_view` include.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EpochInfoMode {
+    /// Include the per-validator `validator_info`. This is expensive: computing it
+    /// can traverse the whole epoch via the epoch info aggregator.
+    Full,
+    /// Omit `validator_info`; only epoch metadata and producer/validator counts.
+    Lite,
+}
+
 // How many old blocks (before HEAD) should be shown in debug page.
 const DEBUG_PRODUCTION_OLD_BLOCKS_TO_SHOW: u64 = 50;
 
@@ -178,9 +188,12 @@ impl Handler<DebugStatus, Result<DebugStatusResponse, StatusError>> for ClientAc
             DebugStatus::TrackedShards => {
                 Ok(DebugStatusResponse::TrackedShards(self.get_tracked_shards_view()?))
             }
-            DebugStatus::EpochInfo(epoch_id) => {
-                Ok(DebugStatusResponse::EpochInfo(self.get_recent_epoch_info(epoch_id)?))
-            }
+            DebugStatus::EpochInfo(epoch_id) => Ok(DebugStatusResponse::EpochInfo(
+                self.get_recent_epoch_info(epoch_id, EpochInfoMode::Full)?,
+            )),
+            DebugStatus::EpochInfoLight(epoch_id) => Ok(DebugStatusResponse::EpochInfo(
+                self.get_recent_epoch_info(epoch_id, EpochInfoMode::Lite)?,
+            )),
             DebugStatus::BlockStatus(query) => {
                 Ok(DebugStatusResponse::BlockStatus(self.get_last_blocks_info(query)?))
             }
@@ -330,6 +343,7 @@ impl ClientActor {
     fn get_epoch_info_view(
         &self,
         epoch_identifier: &ValidatorInfoIdentifier,
+        mode: EpochInfoMode,
     ) -> Result<EpochInfoView, Error> {
         let epoch_start_height =
             get_epoch_start_height(self.client.epoch_manager.as_ref(), epoch_identifier)?;
@@ -406,8 +420,14 @@ impl ClientActor {
             .map(|((a, b), c)| (*a, *b, *c))
             .collect();
 
-        let validator_info =
-            self.client.epoch_manager.get_validator_info(epoch_identifier.clone())?;
+        // `get_validator_info` is expensive (it can traverse the whole epoch via the
+        // epoch info aggregator), so only compute it in `Full` mode.
+        let validator_info = match mode {
+            EpochInfoMode::Lite => None,
+            EpochInfoMode::Full => {
+                Some(self.client.epoch_manager.get_validator_info(epoch_identifier.clone())?)
+            }
+        };
         let epoch_height =
             self.client.epoch_manager.get_epoch_info(&epoch_id).map(|info| info.epoch_height())?;
         Ok(EpochInfoView {
@@ -421,7 +441,7 @@ impl ClientActor {
             block_producers,
             chunk_producers,
             chunk_validators,
-            validator_info: Some(validator_info),
+            validator_info,
             protocol_version: self
                 .client
                 .epoch_manager
@@ -485,6 +505,7 @@ impl ClientActor {
     fn get_recent_epoch_info(
         &self,
         epoch_id: Option<EpochId>,
+        mode: EpochInfoMode,
     ) -> Result<Vec<EpochInfoView>, near_chain_primitives::Error> {
         let mut epochs_info: Vec<EpochInfoView> = Vec::new();
 
@@ -505,7 +526,7 @@ impl ClientActor {
 
         let mut current_epoch_identifier = epoch_identifier;
         for _ in 0..DEBUG_EPOCHS_TO_FETCH {
-            let Ok(epoch_view) = self.get_epoch_info_view(&current_epoch_identifier) else {
+            let Ok(epoch_view) = self.get_epoch_info_view(&current_epoch_identifier, mode) else {
                 break;
             };
             let first_block = epoch_view.first_block.map(|(hash, _)| hash);

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1133,6 +1133,9 @@ impl JsonRpcHandler {
                     "/debug/api/epoch_info" => {
                         self.client_send(DebugStatus::EpochInfo(None)).await?.rpc_into()
                     }
+                    "/debug/api/epoch_info_light" => {
+                        self.client_send(DebugStatus::EpochInfoLight(None)).await?.rpc_into()
+                    }
                     "/debug/api/block_status" => self
                         .client_send(DebugStatus::BlockStatus(DebugBlockStatusQuery::default()))
                         .await?
@@ -1213,6 +1216,23 @@ impl JsonRpcHandler {
         } else {
             Ok(None)
         }
+    }
+
+    pub async fn debug_epoch_info_light(
+        &self,
+        epoch_id: Option<near_primitives::types::EpochId>,
+    ) -> Result<
+        Option<near_jsonrpc_primitives::types::status::RpcDebugStatusResponse>,
+        near_jsonrpc_primitives::types::status::RpcStatusError,
+    > {
+        if !self.enable_debug_rpc {
+            return Ok(None);
+        }
+        let debug_status =
+            self.client_send(DebugStatus::EpochInfoLight(epoch_id)).await?.rpc_into();
+        Ok(Some(near_jsonrpc_primitives::types::status::RpcDebugStatusResponse {
+            status_response: debug_status,
+        }))
     }
 
     pub fn instrumented_threads(
@@ -2821,6 +2841,19 @@ async fn debug_epoch_info_handler(
         Err(_) => StatusCode::SERVICE_UNAVAILABLE.into_response(),
     }
 }
+async fn debug_epoch_info_light_handler(
+    State(handler): State<Arc<JsonRpcHandler>>,
+    Path(epoch_id_str): Path<String>,
+) -> Response {
+    let Ok(epoch_id) = epoch_id_str.parse::<near_primitives::types::EpochId>() else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    match handler.debug_epoch_info_light(Some(epoch_id)).await {
+        Ok(Some(value)) => (StatusCode::OK, Json(value)).into_response(),
+        Ok(None) => StatusCode::METHOD_NOT_ALLOWED.into_response(),
+        Err(_) => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
 
 async fn health_handler(State(handler): State<Arc<JsonRpcHandler>>) -> Response {
     match handler.health().await {
@@ -2988,6 +3021,7 @@ pub fn create_jsonrpc_app(
             )
             .route("/debug/api/block_status", get(debug_block_status_handler))
             .route("/debug/api/epoch_info/{epoch_id}", get(debug_epoch_info_handler))
+            .route("/debug/api/epoch_info_light/{epoch_id}", get(debug_epoch_info_light_handler))
             .route("/debug/api/instrumented_threads", get(debug_instrumented_threads_handler))
             .route("/debug/api/{*api_path}", get(debug_handler))
             .route("/debug/client_config", get(client_config_handler))

--- a/test-loop-tests/src/tests/debug_epoch_info.rs
+++ b/test-loop-tests/src/tests/debug_epoch_info.rs
@@ -1,0 +1,62 @@
+use crate::setup::builder::TestLoopBuilder;
+use near_async::messaging::Handler;
+use near_client::client_actor::ClientActor;
+use near_client_primitives::debug::{DebugStatus, DebugStatusResponse, EpochInfoView};
+use near_o11y::testonly::init_test_logger;
+
+const EPOCH_LENGTH: u64 = 5;
+
+fn get_recent_epochs(client_actor: &mut ClientActor, request: DebugStatus) -> Vec<EpochInfoView> {
+    match client_actor.handle(request).unwrap() {
+        DebugStatusResponse::EpochInfo(epochs) => epochs,
+        other => panic!("expected EpochInfo response, got {other:?}"),
+    }
+}
+
+/// The `EpochInfoLight` debug request must return the same recent-epoch list as
+/// `EpochInfo`, only with the expensive per-validator `validator_info` omitted.
+#[test]
+fn test_debug_epoch_info_light_omits_validator_info() {
+    init_test_logger();
+
+    let mut env = TestLoopBuilder::new().epoch_length(EPOCH_LENGTH).build();
+    // Advance past the first epoch so the recent-epoch list contains at least one
+    // finalized epoch whose `validator_info` is populated in the full response.
+    env.node_runner(0).run_until_new_epoch();
+    env.node_runner(0).run_until_new_epoch();
+
+    let handle = env.node_datas[0].client_sender.actor_handle();
+    let client_actor = env.test_loop.data.get_mut(&handle);
+    let full = get_recent_epochs(client_actor, DebugStatus::EpochInfo(None));
+    let lite = get_recent_epochs(client_actor, DebugStatus::EpochInfoLight(None));
+
+    assert_eq!(full.len(), lite.len(), "lite response must list the same epochs as the full one");
+
+    for (full_epoch, lite_epoch) in full.iter().zip(lite.iter()) {
+        // Everything except validator_info must be identical between the two.
+        assert_eq!(full_epoch.epoch_id, lite_epoch.epoch_id);
+        assert_eq!(full_epoch.epoch_height, lite_epoch.epoch_height);
+        assert_eq!(full_epoch.height, lite_epoch.height);
+        assert_eq!(full_epoch.protocol_version, lite_epoch.protocol_version);
+        assert_eq!(full_epoch.first_block, lite_epoch.first_block);
+        assert_eq!(full_epoch.block_producers.len(), lite_epoch.block_producers.len());
+        assert_eq!(full_epoch.chunk_producers, lite_epoch.chunk_producers);
+        assert_eq!(full_epoch.chunk_validators, lite_epoch.chunk_validators);
+        assert_eq!(full_epoch.shards_size_and_parts, lite_epoch.shards_size_and_parts);
+
+        // The lite response never carries validator_info.
+        assert!(
+            lite_epoch.validator_info.is_none(),
+            "lite epoch {} must not include validator_info",
+            lite_epoch.epoch_id
+        );
+    }
+
+    // Sanity check that the full response actually does compute validator_info for a
+    // finalized epoch, otherwise the assertions above would pass vacuously. The "next
+    // epoch" entry (the first one) legitimately has no validator_info, so look past it.
+    let full_has_validator_info = full.iter().any(|epoch| {
+        epoch.validator_info.as_ref().is_some_and(|info| !info.current_validators.is_empty())
+    });
+    assert!(full_has_validator_info, "full response should populate validator_info");
+}

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod contract_distribution_cross_shard;
 mod contract_distribution_simple;
 mod create_delete_account;
 mod cross_shard_tx;
+mod debug_epoch_info;
 mod deploy_compute_cost;
 mod deterministic_account_id;
 #[cfg(feature = "test_features")]

--- a/tools/debug-ui/src/CurrentPeersView.tsx
+++ b/tools/debug-ui/src/CurrentPeersView.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { MouseEvent, useCallback, useMemo, useState } from 'react';
-import { PeerInfoView, fetchEpochInfo, fetchFullStatus } from './api';
+import { PeerInfoView, fetchEpochInfoLight, fetchFullStatus } from './api';
 import './CurrentPeersView.scss';
 import { addDebugPortLink, formatDurationInMillis, formatTraffic } from './utils';
 
@@ -55,7 +55,7 @@ export const CurrentPeersView = ({ addr }: NetworkInfoViewProps) => {
         data: epochInfo,
         error: epochInfoError,
         isLoading: epochInfoLoading,
-    } = useQuery(['epochInfo', addr], () => fetchEpochInfo(addr, null));
+    } = useQuery(['epochInfoLight', addr], () => fetchEpochInfoLight(addr, null));
 
     const { blockProducers, chunkProducers, knownSet, reachableSet, numPeersByStatus, peers } =
         useMemo(() => {

--- a/tools/debug-ui/src/EpochShardsView.tsx
+++ b/tools/debug-ui/src/EpochShardsView.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchEpochInfo } from './api';
+import { fetchEpochInfoLight } from './api';
 import './EpochShardsView.scss';
 
 function humanFileSize(bytes: number, si = false, dp = 1): string {
@@ -32,7 +32,7 @@ export const EpochShardsView = ({ addr }: EpochShardsViewProps) => {
         data: epochData,
         error: epochError,
         isLoading: epochIsLoading,
-    } = useQuery(['epochInfo', addr], () => fetchEpochInfo(addr, null));
+    } = useQuery(['epochInfoLight', addr], () => fetchEpochInfoLight(addr, null));
 
     if (epochIsLoading) {
         return <div>Loading...</div>;

--- a/tools/debug-ui/src/RecentEpochsView.tsx
+++ b/tools/debug-ui/src/RecentEpochsView.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { parse } from 'date-fns';
-import { EpochInfoView, fetchEpochInfo, fetchFullStatus } from './api';
+import { EpochInfoView, fetchEpochInfoLight, fetchFullStatus } from './api';
 import './RecentEpochsView.scss';
 import { formatDurationInMillis } from './utils';
 
@@ -13,7 +13,7 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
         data: epochData,
         error: epochError,
         isLoading: epochIsLoading,
-    } = useQuery(['epochInfo', addr], () => fetchEpochInfo(addr, null));
+    } = useQuery(['epochInfoLight', addr], () => fetchEpochInfoLight(addr, null));
     const {
         data: statusData,
         error: statusError,

--- a/tools/debug-ui/src/RecentEpochsView.tsx
+++ b/tools/debug-ui/src/RecentEpochsView.tsx
@@ -104,11 +104,11 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
                             <td>{epochStartColumn}</td>
                             <td>{epochInfo.block_producers.length}</td>
                             <td>
-                                {epochInfo.chunk_producers?.length ||
+                                {epochInfo.chunk_producers?.length ??
                                     getChunkProducersTotal(epochInfo)}
                             </td>
                             <td>
-                                {epochInfo.chunk_validators?.length ||
+                                {epochInfo.chunk_validators?.length ??
                                     getChunkValidatorsTotal(epochInfo)}
                             </td>
                         </tr>

--- a/tools/debug-ui/src/RecentEpochsView.tsx
+++ b/tools/debug-ui/src/RecentEpochsView.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { parse } from 'date-fns';
-import { EpochInfoView, fetchEpochInfoLight, fetchFullStatus } from './api';
+import { fetchEpochInfoLight, fetchFullStatus } from './api';
 import './RecentEpochsView.scss';
 import { formatDurationInMillis } from './utils';
 
@@ -103,14 +103,8 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
                             <td>{firstBlockColumn}</td>
                             <td>{epochStartColumn}</td>
                             <td>{epochInfo.block_producers.length}</td>
-                            <td>
-                                {epochInfo.chunk_producers?.length ??
-                                    getChunkProducersTotal(epochInfo)}
-                            </td>
-                            <td>
-                                {epochInfo.chunk_validators?.length ??
-                                    getChunkValidatorsTotal(epochInfo)}
-                            </td>
+                            <td>{epochInfo.chunk_producers.length}</td>
+                            <td>{epochInfo.chunk_validators.length}</td>
                         </tr>
                     );
                 })}
@@ -118,27 +112,3 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
         </table>
     );
 };
-
-// TODO(2.6): remove as superseded by chunk_producers field.
-function getChunkProducersTotal(epochInfo: EpochInfoView) {
-    return (
-        epochInfo.validator_info?.current_validators.reduce((acc, it) => {
-            if (it.num_expected_chunks > 0) {
-                acc = acc + 1;
-            }
-            return acc;
-        }, 0) ?? 'N/A'
-    );
-}
-
-// TODO(2.6): remove as superseded by chunk_validators field.
-function getChunkValidatorsTotal(epochInfo: EpochInfoView) {
-    return (
-        epochInfo.validator_info?.current_validators.reduce((acc, it) => {
-            if (it.num_expected_endorsements > 0) {
-                acc = acc + 1;
-            }
-            return acc;
-        }, 0) ?? 'N/A'
-    );
-}

--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -481,6 +481,30 @@ export function fetchEpochInfo(
     return fetchJson(getTargetUrl(addr, `debug/api/epoch_info${trailing}`));
 }
 
+// Lightweight variant of the recent-epochs list that omits the heavy per-validator
+// `validator_info`. Use this for views that only need epoch metadata and
+// producer/validator counts (recent epochs, epoch shards, current peers).
+//
+// The debug-ui is released ahead of the node side, so this gracefully falls back to
+// the full `epoch_info` endpoint when talking to a node that predates
+// `epoch_info_light` (it returns 405 for the unknown path / 404 for the id route).
+// The fallback is correct, just heavier.
+// TODO: remove the fallback once all nodes expose `epoch_info_light`.
+export async function fetchEpochInfoLight(
+    addr: string,
+    epochId: string | null
+): Promise<EpochInfoResponse> {
+    const trailing = epochId ? `/${epochId}` : '';
+    try {
+        return await fetchJson(getTargetUrl(addr, `debug/api/epoch_info_light${trailing}`));
+    } catch (error) {
+        if (error instanceof HttpError && (error.status === 404 || error.status === 405)) {
+            return fetchEpochInfo(addr, epochId);
+        }
+        throw error;
+    }
+}
+
 export function fetchPeerStore(addr: string): Promise<PeerStoreResponse> {
     return fetchJson(getTargetUrl(addr, 'debug/api/peer_store'));
 }

--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -113,15 +113,15 @@ export type SyncStatusView =
     | 'NoSync'
     | {
         EpochSync:
-            | 'NotStarted'
-            | {
-                  InProgress: {
-                      source_peer_height: number;
-                      source_peer_id: string;
-                      attempt_time: string;
-                  };
-              }
-            | 'Done';
+        | 'NotStarted'
+        | {
+            InProgress: {
+                source_peer_height: number;
+                source_peer_id: string;
+                attempt_time: string;
+            };
+        }
+        | 'Done';
     }
     | {
         HeaderSync: {
@@ -401,8 +401,8 @@ function getTargetUrl(addr: string, endpoint: string): string {
 
     if (protocol === 'https:') {
         return getProxyUrl(addr, endpoint);
-    } 
-    
+    }
+
     if (protocol === 'http:') {
         return `http://${addr}/${endpoint}`;
     }
@@ -487,8 +487,9 @@ export function fetchEpochInfo(
 //
 // The debug-ui is released ahead of the node side, so this gracefully falls back to
 // the full `epoch_info` endpoint when talking to a node that predates
-// `epoch_info_light` (it returns 405 for the unknown path / 404 for the id route).
-// The fallback is correct, just heavier.
+// `epoch_info_light`. Such a node has no route for either form, so both fall through
+// to the `/debug/api/{*path}` catch-all and return 405 (we also treat 404 as missing
+// for safety, e.g. behind a proxy).
 // TODO: remove the fallback once all nodes expose `epoch_info_light`.
 export async function fetchEpochInfoLight(
     addr: string,


### PR DESCRIPTION
The Recent Epochs view (and Epoch Shards / Current Peers) only render epoch metadata and producer/validator counts, but they fetch `debug/api/epoch_info`, whose response is ~95% `validator_info` (full per-validator stats for ~5 recent epochs). On mainnet this is a ~2 MB payload, and building it calls the explicitly-expensive `EpochManager::get_validator_info` (epoch-info aggregator traversal) up to 5 times per request.

Add a new `debug/api/epoch_info_light` endpoint that returns the same `EpochInfoView` list with `validator_info` omitted, and repoint the three count-only debug-ui views at it. The existing `epoch_info` endpoint is left unchanged (still used by the Validators view, which needs the full per-validator stats).

Result: the Recent Epochs payload drops from ~2 MB to ~100 KB and the node skips the expensive validator-info computation.