### PR TITLE
feat(post-quantum): hash ML-DSA-65 access keys with SHA3-256 instead of SHA3-384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Protocol Changes
 * New opt-in strict nonce mode for transactions added in nightly. When enabled, each transaction must use a nonce exactly equal to the previous nonce for that access key plus one; nonces that repeat or skip values are rejected. ([#15361](https://github.com/near/nearcore/pull/15361), [#15402](https://github.com/near/nearcore/pull/15402))
-* Added FIPS 204 ML-DSA-65 post-quantum signature scheme for access keys in nightly. Public keys are stored on-trie as a 48-byte SHA3-384 hash rather than the full 1952 bytes. ([#15731](https://github.com/near/nearcore/pull/15731))
+* Added FIPS 204 ML-DSA-65 post-quantum signature scheme for access keys in nightly. Public keys are stored on-trie as a 32-byte SHA3-256 hash rather than the full 1952 bytes. ([#15731](https://github.com/near/nearcore/pull/15731))
 * Ensure delegate action returns the correct error consistently. ([#15458](https://github.com/near/nearcore/pull/15458))
 * Fix `action_delete_account` not accounting for the global contract identifier when checking the account deletion storage limit. For accounts using a global contract, the check overcounted storage usage by the identifier size (32 bytes, or the account id length for `GlobalByAccount`), so they were slightly harder to delete. ([#15752](https://github.com/near/nearcore/pull/15752))
 * Fix a bug in `receiver` verification for a `DeterministicStateInitAction` inside a `DelegateAction` that made it impossible to create deterministic accounts through meta transactions. ([#15812](https://github.com/near/nearcore/pull/15812))

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -1132,7 +1132,7 @@
         "type": "object"
       },
       "AccessKeyInfoView": {
-        "description": "Describes information about an access key including its on-trie\nidentifier. For ed25519/secp256k1 access keys the `public_key` field\nis the full public key (string form unchanged from before); for\nML-DSA-65 access keys it is a `ml-dsa-65-hash:...` SHA3-384 digest\n(the full pubkey is not stored on-chain).",
+        "description": "Describes information about an access key including its on-trie\nidentifier. For ed25519/secp256k1 access keys the `public_key` field\nis the full public key (string form unchanged from before); for\nML-DSA-65 access keys it is a `ml-dsa-65-hash:...` SHA3-256 digest\n(the full pubkey is not stored on-chain).",
         "properties": {
           "access_key": {
             "$ref": "#/components/schemas/AccessKeyView"

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -63,7 +63,7 @@
         "type": "object"
       },
       "AccessKeyInfoView": {
-        "description": "Describes information about an access key including its on-trie\nidentifier. For ed25519/secp256k1 access keys the `public_key` field\nis the full public key (string form unchanged from before); for\nML-DSA-65 access keys it is a `ml-dsa-65-hash:...` SHA3-384 digest\n(the full pubkey is not stored on-chain).",
+        "description": "Describes information about an access key including its on-trie\nidentifier. For ed25519/secp256k1 access keys the `public_key` field\nis the full public key (string form unchanged from before); for\nML-DSA-65 access keys it is a `ml-dsa-65-hash:...` SHA3-256 digest\n(the full pubkey is not stored on-chain).",
         "properties": {
           "access_key": {
             "$ref": "#/components/schemas/AccessKeyView"

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -25,16 +25,16 @@ pub const ML_DSA_65_SIGNATURE_LENGTH: usize = 3309;
 /// FIPS 204 seed length in bytes (used to derive an ML-DSA private key).
 #[cfg(feature = "rand")]
 pub const ML_DSA_65_SEED_LENGTH: usize = 32;
-/// SHA3-384 output length used as the on-trie identifier for an
+/// SHA3-256 output length used as the on-trie identifier for an
 /// ML-DSA-65 access key. The same digest is expected to be reused as
 /// the account-id payload for ML-DSA-65 implicit accounts when that
 /// feature lands; update this comment then.
-pub const ML_DSA_65_HASH_LENGTH: usize = 48;
+pub const ML_DSA_65_HASH_LENGTH: usize = 32;
 /// Domain-separation tag for `MlDsa65PublicKey`-to-hash derivation.
-/// Prepended to the raw pubkey bytes before SHA3-384, so an ML-DSA-65
+/// Prepended to the raw pubkey bytes before SHA3-256, so an ML-DSA-65
 /// hash can never collide with another use of SHA3 in the protocol.
 const ML_DSA_65_HASH_DOMAIN_TAG: &[u8] = b"near:ml-dsa-65-pubkey-hash:v1";
-/// Wire-format prefix for an ML-DSA-65 access-key identifier (the SHA3-384
+/// Wire-format prefix for an ML-DSA-65 access-key identifier (the SHA3-256
 /// digest, not the full pubkey). Used in `view_access_key_list` responses
 /// and accepted by `PublicKeyHandle::from_str`.
 const ML_DSA_65_HASH_PREFIX: &str = "ml-dsa-65-hash:";
@@ -160,15 +160,15 @@ pub struct MlDsa65PublicKey(pub Box<[u8; ML_DSA_65_PUBLIC_KEY_LENGTH]>);
 
 impl MlDsa65PublicKey {
     /// Compute the on-trie [`MlDsa65PublicKeyHandle`] for this public key -
-    /// the SHA3-384 of (domain-separation tag || raw pubkey bytes).
+    /// the SHA3-256 of (domain-separation tag || raw pubkey bytes).
     ///
     /// This is the form an ML-DSA-65 access key takes inside the trie: the
     /// full pubkey lives only on the wire (in transactions and actions),
     /// never in state. The full pubkey can be derived from the handle only
     /// by brute force.
     pub fn to_public_key_handle(&self) -> MlDsa65PublicKeyHandle {
-        use sha3::{Digest, Sha3_384};
-        let mut hasher = Sha3_384::new();
+        use sha3::{Digest, Sha3_256};
+        let mut hasher = Sha3_256::new();
         hasher.update(ML_DSA_65_HASH_DOMAIN_TAG);
         hasher.update(&self.0[..]);
         let mut out = [0u8; ML_DSA_65_HASH_LENGTH];
@@ -203,7 +203,7 @@ impl bolero::TypeGenerator for MlDsa65PublicKey {
 }
 
 /// On-trie identifier of an ML-DSA-65 access key - and, in the future,
-/// the basis for ML-DSA-65 implicit-account ids. Stored as the SHA3-384
+/// the basis for ML-DSA-65 implicit-account ids. Stored as the SHA3-256
 /// digest of (domain-tag || raw pubkey) because the full 1952-byte pubkey
 /// would be prohibitive to keep in state. Cannot sign or verify; only
 /// appears as a lookup key and in view-API responses.
@@ -265,7 +265,7 @@ impl PublicKey {
     /// discriminant tag (the leading `+ 1` in each arm).
     ///
     /// For storage-fee accounting use [`PublicKey::trie_id_len`] instead;
-    /// for ML-DSA-65 those two diverge (1953 wire vs 49 on-trie).
+    /// for ML-DSA-65 those two diverge (1953 wire vs 33 on-trie).
     // `is_empty` always returns false, so there is no point in adding it
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
@@ -320,7 +320,7 @@ impl PublicKey {
 
     /// Length, in bytes, of the on-trie identifier for an access-key
     /// entry owned by this public key. For ed25519/secp256k1 this matches
-    /// `len()`; for ML-DSA-65 the trie stores a SHA3-384 hash (49 bytes
+    /// `len()`; for ML-DSA-65 the trie stores a SHA3-256 hash (33 bytes
     /// including the type tag), not the 1953-byte borsh-encoded pubkey.
     /// Used by storage-fee calculations on the runtime side; cheap to call
     /// (no hashing) - for ML-DSA-65 this returns the size of the digest
@@ -481,7 +481,7 @@ impl From<MlDsa65PublicKey> for PublicKey {
 /// How an access-key entry is referred to in the trie.
 ///
 /// The trie stores ed25519 and secp256k1 access keys as their full
-/// public keys, but ML-DSA-65 access keys as a SHA3-384 hash of the
+/// public keys, but ML-DSA-65 access keys as a SHA3-256 hash of the
 /// pubkey (storage-efficiency optimization - see
 /// `docs/architecture/how/post_quantum_signatures.md`).
 ///
@@ -493,7 +493,7 @@ impl From<MlDsa65PublicKey> for PublicKey {
 ///
 /// The variant set mirrors [`PublicKey`] for schemes that store the
 /// full key in the trie (ed25519, secp256k1), and replaces ML-DSA-65's
-/// full-key variant with the SHA3-384 hash actually stored. This makes
+/// full-key variant with the SHA3-256 hash actually stored. This makes
 /// "a full ML-DSA-65 key in the trie" unrepresentable in the type
 /// system - the encoding/decoding round-trip becomes lossless and
 /// invalid combinations cannot be constructed.
@@ -503,7 +503,7 @@ pub enum PublicKeyHandle {
     ED25519(ED25519PublicKey),
     /// Full secp256k1 public key, as stored in the trie.
     SECP256K1(Secp256K1PublicKey),
-    /// SHA3-384 hash of an ML-DSA-65 public key. The full pubkey is not
+    /// SHA3-256 hash of an ML-DSA-65 public key. The full pubkey is not
     /// stored on-chain; only this hash appears in the trie.
     MlDsa65(MlDsa65PublicKeyHandle),
 }
@@ -536,8 +536,8 @@ impl Hash for PublicKeyHandle {
 impl PublicKeyHandle {
     /// Length, in bytes, of this handle's on-trie borsh encoding: the raw
     /// handle bytes plus a 1-byte borsh discriminant tag (the leading
-    /// `+ 1` in each arm). For ML-DSA-65 the handle is the 48-byte
-    /// SHA3-384 digest, not the full 1952-byte pubkey.
+    /// `+ 1` in each arm). For ML-DSA-65 the handle is the 32-byte
+    /// SHA3-256 digest, not the full 1952-byte pubkey.
     pub fn trie_id_len(&self) -> usize {
         match self {
             Self::ED25519(_) => 1 + ed25519_dalek::PUBLIC_KEY_LENGTH,
@@ -1638,7 +1638,7 @@ mod tests {
         assert!(matches!(pk2, PublicKey::ED25519(_)));
     }
 
-    /// `MlDsa65PublicKey::to_public_key_handle()` must be deterministic, 48 bytes,
+    /// `MlDsa65PublicKey::to_public_key_handle()` must be deterministic, 32 bytes,
     /// and distinct between different keys.
     #[cfg(feature = "rand")]
     #[test]
@@ -1688,7 +1688,7 @@ mod tests {
     }
 
     /// Borsh roundtrip of `PublicKeyHandle::MlDsa65`. Bytes must be tag 3
-    /// followed by the 48-byte hash so that the trie encoding matches.
+    /// followed by the 32-byte hash so that the trie encoding matches.
     #[test]
     fn test_key_handle_hash_borsh_roundtrip() {
         use super::PublicKeyHandle;
@@ -1713,7 +1713,7 @@ mod tests {
         let pq: PublicKeyHandle = SecretKey::from_seed(KeyType::MLDSA65, "x").public_key().into();
         assert_eq!(ed.trie_id_len(), 33);
         assert_eq!(sk.trie_id_len(), 65);
-        assert_eq!(pq.trie_id_len(), 49); // 1 + 48
+        assert_eq!(pq.trie_id_len(), 33); // 1 + 32
     }
 
     /// Backwards-compat: borsh-encoded `PublicKeyHandle::ED25519`/`SECP256K1`

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -169,7 +169,7 @@ pub enum TrieKey {
     /// Used to store `primitives::account::AccessKey` struct for a given `AccountId` and
     /// a given key handle (the on-trie identifier of the access key - for
     /// ed25519/secp256k1 this is the full public key; for ML-DSA-65 it is
-    /// a SHA3-384 hash of the public key).
+    /// a SHA3-256 hash of the public key).
     AccessKey {
         account_id: AccountId,
         key_handle: PublicKeyHandle,
@@ -302,7 +302,7 @@ pub fn gas_key_nonce_key_len(account_id: &AccountId, key_handle: &PublicKeyHandl
 /// The on-trie bytes are exactly `PublicKeyHandle`'s borsh encoding, so we
 /// delegate to `BorshSerialize` rather than duplicating the layout here.
 /// For ed25519 / secp256k1 the identifier is the full `PublicKey`; for
-/// ML-DSA-65 it is `[tag=3] || sha3_384(domain || raw_pubkey)` - the
+/// ML-DSA-65 it is `[tag=3] || sha3_256(domain || raw_pubkey)` - the
 /// full ML-DSA-65 pubkey never enters the trie.
 fn append_key_handle_trie_id(
     buf: &mut impl trie_key_buffer::TrieKeyBuffer,
@@ -940,7 +940,7 @@ mod tests {
     }
 
     /// Encoding an `AccessKey` trie key with a full `MLDSA65` pubkey must
-    /// write the SHA3-384 hash form, not the 1953-byte raw bytes. Parsing
+    /// write the SHA3-256 hash form, not the 1953-byte raw bytes. Parsing
     /// the resulting raw key returns `PublicKeyHandle::MlDsa65` carrying the
     /// matching hash.
     #[cfg(feature = "rand")]

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -298,7 +298,7 @@ pub struct QueryError {
 /// Describes information about an access key including its on-trie
 /// identifier. For ed25519/secp256k1 access keys the `public_key` field
 /// is the full public key (string form unchanged from before); for
-/// ML-DSA-65 access keys it is a `ml-dsa-65-hash:...` SHA3-384 digest
+/// ML-DSA-65 access keys it is a `ml-dsa-65-hash:...` SHA3-256 digest
 /// (the full pubkey is not stored on-chain).
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/docs/architecture/how/post_quantum_signatures.md
+++ b/docs/architecture/how/post_quantum_signatures.md
@@ -70,8 +70,8 @@ responses:
   `PublicKey::ED25519`'s encoding.
 - `PublicKeyHandle::SECP256K1(Secp256K1PublicKey)` - borsh tag `1`, byte-identical
   to `PublicKey::SECP256K1`'s encoding.
-- `PublicKeyHandle::MlDsa65Hash(MlDsa65PublicKeyHandle)` - borsh tag `3`, 48-byte
-  SHA3-384 digest. Appears only as a result of parsing a trie key (e.g.
+- `PublicKeyHandle::MlDsa65Hash(MlDsa65PublicKeyHandle)` - borsh tag `3`, 32-byte
+  SHA3-256 digest. Appears only as a result of parsing a trie key (e.g.
   `view_access_key_list`) or constructed via `From<&PublicKey>` from a known
   full ML-DSA-65 pubkey. Cannot sign, cannot verify, never appears in
   transactions or actions.
@@ -96,19 +96,20 @@ encoding for an `AccessKey` entry is:
 |------------|----------------------------------------------------------------------|
 | ED25519    | `[tag=0] \|\| 32-byte raw pubkey`                                    |
 | SECP256K1  | `[tag=1] \|\| 64-byte raw pubkey`                                    |
-| ML-DSA-65  | `[tag=3] \|\| sha3_384(domain_tag \|\| raw_pubkey)` (49 bytes total) |
+| ML-DSA-65  | `[tag=3] \|\| sha3_256(domain_tag \|\| raw_pubkey)` (33 bytes total) |
 
 Domain tag: `b"near:ml-dsa-65-pubkey-hash:v1"`, hashed before the pubkey
 bytes. Prevents collisions with other SHA-3 uses in the protocol.
 
-Choice of SHA3-384 (not SHA3-256): an attacker forging an access key needs
-second-preimage on the hash. Grover gives `O(2^(H/2))` quantum cost; to match
-ML-DSA-65's Category-3 (~192-bit) security level, the hash needs `H ≥ 384`
-bits. SHA3-256 would leave the access-key lookup at Category 2, one level
-under the keypair.
+Choice of SHA3-256: a 256-bit digest has been decided to be secure enough for
+the access-key lookup. The decisive property is that the digest is short enough
+to be encoded into a NEAR account id, so the hash can be used directly as an
+(implicit) account id. This keeps the door open to creating ML-DSA-65 access
+keys for implicit accounts in the future from the account id alone - without
+having to carry or store the full 1952-byte pubkey.
 
-Storage impact: an ML-DSA-65 access key occupies 49 bytes in the trie key
-portion versus 1953 if stored raw - about a 96% reduction. Storage stake
+Storage impact: an ML-DSA-65 access key occupies 33 bytes in the trie key
+portion versus 1953 if stored raw - about a 98% reduction. Storage stake
 drops from ~0.0195 NEAR to ~0.0005 NEAR per key.
 
 UX consequence: `view_access_key_list` returns `ml-dsa-65-hash:<bs58>` for
@@ -128,7 +129,7 @@ gas-key fee helpers (`gas_key_*_fee` in `runtime/runtime/src/config.rs`) use
 
 - `len()` reports the borsh-encoded length (33 / 65 / 1953 across the
   three `PublicKey` variants).
-- `trie_id_len()` reports the on-trie length (33 / 65 / **49**).
+- `trie_id_len()` reports the on-trie length (33 / 65 / **33**).
 
 The two diverge only for `PublicKey::MLDSA65`. Every storage-stake and
 trie-byte-priced fee path was updated to call `trie_id_len()`.
@@ -289,5 +290,5 @@ items the team should resolve before stabilizing in 2.13.
 
 7. **Implicit-account derivation for PQ keys.** Briefing's open question
     (1). Not part of this feature, but the access-key hashing here has set
-    the precedent (SHA3-384, domain-separated) that implicit-account
+    the precedent (SHA3-256, domain-separated) that implicit-account
     derivation should probably follow.

--- a/runtime/runtime/src/access_keys.rs
+++ b/runtime/runtime/src/access_keys.rs
@@ -21,8 +21,8 @@ fn access_key_storage_usage(
 ) -> StorageUsage {
     let storage_usage_config = &fee_config.storage_usage_config;
     // Use the on-trie identifier length, not the borsh-serialized pubkey
-    // length: ML-DSA-65 access keys live in the trie as a SHA3-384 hash
-    // (49 bytes incl. type tag), not as a 1953-byte full pubkey.
+    // length: ML-DSA-65 access keys live in the trie as a SHA3-256 hash
+    // (33 bytes incl. type tag), not as a 1953-byte full pubkey.
     public_key.trie_id_len() as u64
         + borsh::object_length(access_key).unwrap() as u64
         + storage_usage_config.num_extra_bytes_record
@@ -1193,10 +1193,11 @@ mod tests {
     }
 
     /// `access_key_storage_usage` uses `public_key.trie_id_len()`, which for
-    /// ML-DSA-65 is the SHA3-384 hash form (1 tag + 48 bytes = 49 bytes),
-    /// not the 1953-byte borsh-encoded full pubkey. Verify that the
-    /// post-hashing storage delta vs an ed25519 key is just the hash-vs-raw
-    /// difference (~16 bytes), not the full-pubkey gap (~1920 bytes).
+    /// ML-DSA-65 is the SHA3-256 hash form (1 tag + 32 bytes = 33 bytes),
+    /// not the 1953-byte borsh-encoded full pubkey. The 32-byte digest is the
+    /// same size as an ed25519 key, so the storage usage of an ML-DSA-65
+    /// access key matches an ed25519 one exactly - rather than the
+    /// ~1920-byte-larger figure a raw pubkey would produce.
     #[test]
     fn test_ml_dsa_65_access_key_storage_scales() {
         let config = RuntimeConfig::test();
@@ -1212,16 +1213,16 @@ mod tests {
         let ed_usage = access_key_storage_usage(&config.fees, &ed_pk, &access_key);
         let pq_usage = access_key_storage_usage(&config.fees, &pq_pk, &access_key);
 
-        assert!(
-            pq_usage > ed_usage,
-            "ML-DSA storage usage ({pq_usage}) must exceed ed25519 ({ed_usage})"
+        // The trie-id encoded lengths are identical:
+        // ML-DSA-65: [tag=3] + 32-byte SHA3-256 hash = 33 bytes.
+        // ED25519:   [tag=0] + 32-byte raw pubkey    = 33 bytes.
+        // So storage usage matches exactly. Stored raw, the ML-DSA-65 pubkey
+        // would be 1953 bytes and the usage would be ~1920 bytes larger.
+        assert_eq!(
+            pq_usage, ed_usage,
+            "ML-DSA-65 storage usage ({pq_usage}) must match ed25519 ({ed_usage}); \
+             both are 33-byte trie ids"
         );
-        // Difference reduces to the trie-id encoded length delta:
-        // ML-DSA-65: [tag=3] + 48-byte SHA3-384 hash = 49 bytes.
-        // ED25519:   [tag=0] + 32-byte raw pubkey   = 33 bytes.
-        // Expected delta: 49 - 33 = 16 bytes.
-        let delta = pq_usage - ed_usage;
-        assert_eq!(delta, 16, "expected exactly +16-byte storage delta (hash form), got {delta}");
     }
 
     /// Pre-hash sanity: the borsh-serialized full pubkey for ML-DSA-65 is
@@ -1232,7 +1233,7 @@ mod tests {
         let pq_pk: PublicKey =
             near_crypto::SecretKey::from_seed(near_crypto::KeyType::MLDSA65, "trie-id-len")
                 .public_key();
-        assert_eq!(pq_pk.trie_id_len(), 1 + 48);
+        assert_eq!(pq_pk.trie_id_len(), 1 + 32);
         assert_eq!(pq_pk.len(), 1 + 1952); // borsh form still reports full
     }
 }


### PR DESCRIPTION
Changes the on-trie identifier for ML-DSA-65 access keys from a 48-byte SHA3-384 digest to a 32-byte SHA3-256 digest.

A 256-bit digest has been decided to be secure enough for the access-key lookup. The decisive property is that the digest is short enough to be encoded into a NEAR account id, so the hash can be used directly as an (implicit) account id. This keeps the door open to creating ML-DSA-65 access keys for implicit accounts in the future from the account id alone, without carrying or storing the full 1952-byte pubkey.

Updates the hashing, the dependent comments and tests, the post-quantum design doc, and the CHANGELOG. Confined to the nightly post-quantum feature.