### PR TITLE
fix(sync): check final block headers are in the expected epoch

### DIFF
--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -335,6 +335,12 @@ impl EpochSync {
                 "invalid block producers for second epoch after genesis".to_string(),
             ));
         }
+        if all_epochs[0].last_final_block_header.epoch_id() != &second_next_epoch_id_after_genesis {
+            return Err(Error::InvalidEpochSyncProof(
+                "last final block header for the first epoch is not in the expected epoch"
+                    .to_string(),
+            ));
+        }
         Self::verify_final_block_endorsement(&all_epochs[0])?;
 
         // Verify the data of each epoch, in chronological order. When verifying each epoch,
@@ -359,6 +365,14 @@ impl EpochSync {
             )? {
                 return Err(Error::InvalidEpochSyncProof(format!(
                     "invalid block producer handoff to epoch index {}",
+                    epoch_index
+                )));
+            }
+            if epoch.last_final_block_header.epoch_id()
+                != prev_epoch.last_final_block_header.next_epoch_id()
+            {
+                return Err(Error::InvalidEpochSyncProof(format!(
+                    "last final block header for epoch index {} is not in the expected epoch",
                     epoch_index
                 )));
             }

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -312,7 +312,7 @@ impl EpochSync {
         Ok(())
     }
 
-    fn verify_proof(
+    pub fn verify_proof(
         &self,
         proof: &EpochSyncProofV1,
         epoch_manager: &dyn EpochManagerAdapter,

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -336,10 +336,11 @@ impl EpochSync {
             ));
         }
         if all_epochs[0].last_final_block_header.epoch_id() != &second_next_epoch_id_after_genesis {
-            return Err(Error::InvalidEpochSyncProof(
-                "last final block header for the first epoch is not in the expected epoch"
-                    .to_string(),
-            ));
+            return Err(Error::InvalidEpochSyncProof(format!(
+                "epoch_id mismatch for all_epochs[0] last final block header: expected {:?}, got {:?}",
+                second_next_epoch_id_after_genesis,
+                all_epochs[0].last_final_block_header.epoch_id(),
+            )));
         }
         Self::verify_final_block_endorsement(&all_epochs[0])?;
 
@@ -372,8 +373,10 @@ impl EpochSync {
                 != prev_epoch.last_final_block_header.next_epoch_id()
             {
                 return Err(Error::InvalidEpochSyncProof(format!(
-                    "last final block header for epoch index {} is not in the expected epoch",
-                    epoch_index
+                    "epoch_id mismatch at all_epochs[{}]: expected {:?}, got {:?}",
+                    epoch_index,
+                    prev_epoch.last_final_block_header.next_epoch_id(),
+                    epoch.last_final_block_header.epoch_id(),
                 )));
             }
             Self::verify_final_block_endorsement(epoch)?;

--- a/test-loop-tests/src/tests/sync/epoch_sync.rs
+++ b/test-loop-tests/src/tests/sync/epoch_sync.rs
@@ -6,6 +6,7 @@ use crate::utils::transactions::{BalanceMismatchError, execute_money_transfers};
 use itertools::Itertools;
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
+use near_chain::Error;
 use near_chain_configs::GenesisConfig;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_epoch_manager::epoch_sync::{
@@ -338,4 +339,64 @@ fn slow_test_epoch_sync_proof_sanity_zero_transaction_validity_period() {
     let final_head_height = env.chain_final_head_height(0);
     // The proof should still be for the previous epoch, for state sync purposes.
     sanity_check_epoch_sync_proof(&proof, final_head_height, &env.shared_state.genesis.config, 1);
+}
+
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn slow_test_epoch_sync_proof_rejects_wrong_epoch_id() {
+    init_test_logger();
+    let env = setup_initial_blockchain(20);
+
+    let client_handle = env.node_datas[0].client_sender.actor_handle();
+    let client = &env.test_loop.data.get(&client_handle).client;
+    let epoch_sync = &client.sync_handler.epoch_sync;
+    let epoch_manager = client.epoch_manager.as_ref();
+
+    let proof = env.derive_epoch_sync_proof(0).into_v1();
+    epoch_sync.verify_proof(&proof, epoch_manager).unwrap();
+
+    // A last final block header taken from a different epoch must be rejected.
+    let mut tampered = proof;
+    assert!(tampered.all_epochs.len() >= 2);
+    tampered.all_epochs[0].last_final_block_header =
+        tampered.all_epochs[1].last_final_block_header.clone();
+
+    let err = epoch_sync.verify_proof(&tampered, epoch_manager).unwrap_err();
+    match &err {
+        Error::InvalidEpochSyncProof(msg) => {
+            assert!(msg.contains("epoch_id mismatch"), "unexpected message: {msg}");
+        }
+        _ => panic!("expected InvalidEpochSyncProof, got: {err}"),
+    }
+}
+
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn slow_test_epoch_sync_proof_rejects_wrong_epoch_id_middle_epoch() {
+    init_test_logger();
+    let env = setup_initial_blockchain(20);
+
+    let client_handle = env.node_datas[0].client_sender.actor_handle();
+    let client = &env.test_loop.data.get(&client_handle).client;
+    let epoch_sync = &client.sync_handler.epoch_sync;
+    let epoch_manager = client.epoch_manager.as_ref();
+
+    let proof = env.derive_epoch_sync_proof(0).into_v1();
+    epoch_sync.verify_proof(&proof, epoch_manager).unwrap();
+
+    // The same must hold for an epoch in the middle of the chain, not just the first.
+    let mut tampered = proof;
+    assert!(tampered.all_epochs.len() >= 3);
+    tampered.all_epochs[1].last_final_block_header =
+        tampered.all_epochs[2].last_final_block_header.clone();
+
+    let err = epoch_sync.verify_proof(&tampered, epoch_manager).unwrap_err();
+    match &err {
+        Error::InvalidEpochSyncProof(msg) => {
+            assert!(msg.contains("epoch_id mismatch"), "unexpected message: {msg}");
+        }
+        _ => panic!("expected InvalidEpochSyncProof, got: {err}"),
+    }
 }


### PR DESCRIPTION
Adds two epoch_id checks in `EpochSync::verify_proof`:

- Verify that the first epoch's `last_final_block_header` belongs to the expected second-epoch-after-genesis id.
- Verify epoch_id continuity through the inductive loop, so each epoch's `last_final_block_header` chains from the previous epoch's `next_epoch_id`.

This complements the existing first-block epoch check (#15530). With a stable validator set, the block-producer handoff and endorsement checks alone don't catch an epoch substitution, so these add explicit epoch_id validation at each step.