### PR TITLE
fix(network): check BlockHeadersRequest hash count

### DIFF
--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -1,6 +1,7 @@
 use near_async::messaging::CanSend;
 use near_async::time::{Clock, Duration, Utc};
 use near_chain::{Chain, ChainStoreAccess};
+use near_network::config::MAX_BLOCK_HEADER_HASHES;
 use near_network::types::{HighestHeightPeerInfo, NetworkRequests, PeerManagerAdapter};
 use near_network::types::{PeerManagerMessageRequest, ReasonForBan};
 use near_primitives::block::Tip;
@@ -12,9 +13,6 @@ use std::cmp::min;
 
 /// Maximum number of block headers send over the network.
 pub const MAX_BLOCK_HEADERS: u64 = 512;
-
-/// Maximum number of block header hashes to send as part of a locator.
-pub const MAX_BLOCK_HEADER_HASHES: usize = 20;
 
 pub const NS_PER_SECOND: u128 = 1_000_000_000;
 

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -40,6 +40,9 @@ pub const MAX_PEER_ADDRS: usize = 10;
 /// Maximum number of peers to include in a PeersResponse message.
 pub const PEERS_RESPONSE_MAX_PEERS: u32 = 512;
 
+/// Maximum number of block header hashes in a BlockHeadersRequest locator.
+pub const MAX_BLOCK_HEADER_HASHES: usize = 20;
+
 /// ValidatorProxies are nodes with public IP (aka proxies) that this validator trusts to be honest
 /// and willing to forward traffic to this validator. Whenever this node is a TIER1 validator
 /// (i.e. whenever it is a block producer/chunk producer/approver for the given epoch),

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1139,6 +1139,9 @@ impl NetworkState {
                 response.ok().flatten().map(|block| PeerMessage::Block(block))
             }
             PeerMessage::BlockHeadersRequest(hashes) => {
+                if hashes.len() > config::MAX_BLOCK_HEADER_HASHES {
+                    return Err(ReasonForBan::Abusive);
+                }
                 let response = self.client.send_async(BlockHeadersRequest(hashes)).await;
                 response.ok().flatten().map(PeerMessage::BlockHeaders)
             }


### PR DESCRIPTION
The `BlockHeadersRequest` handler forwarded an arbitrarily long hash list to the client without any length check. Since each hash triggers a per-hash store lookup, this caps the locator length at `MAX_BLOCK_HEADER_HASHES` (20) and bans peers that exceed it. The constant is moved to `near_network::config` so both the requester and the handler share one definition.