### PR TITLE
fix(cloud-archive): bootstrap reader at any archived height

### DIFF
--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -117,6 +117,16 @@ struct CloudArchivalWriter {
     handle: CloudArchivalWriterHandle,
 }
 
+/// State resolved during writer initialization: the block head (if blocks are
+/// archived), each tracked shard's head, the minimum across them, and the
+/// previous epoch's end used as the default for any missing component.
+struct ResolvedInitState {
+    block_head: Option<BlockHeight>,
+    shard_heads: Vec<(ShardId, BlockHeight)>,
+    min_height: BlockHeight,
+    prev_epoch_end: BlockHeight,
+}
+
 /// Creates the cloud archival writer if it is configured.
 pub fn create_cloud_archival_writer(
     clock: Clock,
@@ -432,8 +442,9 @@ impl CloudArchivalWriter {
     }
 
     /// Initializes the cloud archive writer: validates bucket config and
-    /// reconciles cloud heads with local state. Missing components start at
-    /// `hot_final_height - 1`; existing ones are clamped to that ceiling.
+    /// reconciles cloud heads with local state. Missing components start at the
+    /// previous epoch's end so the first uploaded `EpochData` reflects a
+    /// fully-archived epoch; existing ones are clamped to `hot_final_height - 1`.
     // TODO(cloud_archival) Cover this logic with tests.
     async fn initialize(
         &self,
@@ -448,12 +459,12 @@ impl CloudArchivalWriter {
         let (block_head_ext, shard_heads_ext) =
             self.read_external_heads(&tracked_shard_ids).await?;
 
-        let (block_head_local, shard_heads_local, min_height_local) =
-            self.collect_resolved_heads(hot_final_height, block_head_ext, &shard_heads_ext);
+        let init_state =
+            self.resolve_init_state(hot_final_height, block_head_ext, &shard_heads_ext)?;
 
-        self.ensure_min_cloud_head_available_for_archiving(runtime_adapter, min_height_local)?;
-        self.log_initialization_status(block_head_ext, &shard_heads_ext, hot_final_height);
-        self.set_local_heads(block_head_local, &shard_heads_local, min_height_local)?;
+        self.ensure_min_cloud_head_available_for_archiving(runtime_adapter, init_state.min_height)?;
+        self.log_initialization_status(block_head_ext, &shard_heads_ext, init_state.prev_epoch_end);
+        self.set_local_heads(&init_state)?;
 
         Ok(())
     }
@@ -479,57 +490,51 @@ impl CloudArchivalWriter {
         Ok((block_head_ext, shard_heads_ext))
     }
 
-    /// Logs the initialization status based on external head presence.
+    /// Logs, per component, whether it resumes from an external head or starts
+    /// fresh at the previous epoch's end.
     fn log_initialization_status(
         &self,
         block_head_ext: Option<BlockHeight>,
         shard_heads_ext: &[(ShardId, Option<BlockHeight>)],
-        hot_final_height: BlockHeight,
+        prev_epoch_end: BlockHeight,
     ) {
-        // block_head_ext is None both when blocks aren't tracked and when
-        // the external head is missing, so we need the config check for has_missing.
-        let has_existing =
-            block_head_ext.is_some() || shard_heads_ext.iter().any(|&(_, head)| head.is_some());
-        let has_missing = (self.config.archive_block_data && block_head_ext.is_none())
-            || shard_heads_ext.iter().any(|&(_, head)| head.is_none());
-
-        if has_missing && has_existing {
-            tracing::info!(
-                target: "cloud_archival",
-                start_height = hot_final_height - 1,
-                "some external heads missing, new components start at hot_final_height - 1",
-            );
-        } else if has_missing {
-            tracing::info!(
-                target: "cloud_archival",
-                start_height = hot_final_height - 1,
-                "no external heads found, initializing new cloud archive",
-            );
-        } else {
-            tracing::info!(
-                target: "cloud_archival",
-                "all external heads present, syncing from external",
-            );
+        let log = |component: &str, head: Option<BlockHeight>| match head {
+            Some(head) => {
+                tracing::info!(target: "cloud_archival", component, head, "resuming from external head")
+            }
+            None => {
+                tracing::info!(target: "cloud_archival", component, start = prev_epoch_end, "no external head, starting from previous epoch end")
+            }
+        };
+        if self.config.archive_block_data {
+            log("block", block_head_ext);
+        }
+        for &(shard_id, head) in shard_heads_ext {
+            log(&format!("shard {shard_id}"), head);
         }
     }
 
     /// Resolves each external head to its final local height and computes the
-    /// overall minimum. Missing components default to `hot_final_height - 1`
-    /// — the last height that can actually be archived. Callers guarantee
-    /// `hot_final_height > genesis_height` so this is always a valid height.
-    fn collect_resolved_heads(
+    /// overall minimum. Missing components default to the previous epoch's end
+    /// so the writer archives the current epoch from its start; existing ones
+    /// are clamped to `hot_final_height - 1`, the last archivable height.
+    /// Callers guarantee `hot_final_height > genesis_height`, so both are valid.
+    fn resolve_init_state(
         &self,
         hot_final_height: BlockHeight,
         block_head_ext: Option<BlockHeight>,
         shard_heads_ext: &[(ShardId, Option<BlockHeight>)],
-    ) -> (Option<BlockHeight>, Vec<(ShardId, BlockHeight)>, BlockHeight) {
+    ) -> Result<ResolvedInitState, CloudArchivalInitializationError> {
         assert!(
             hot_final_height > self.genesis_height,
-            "collect_resolved_heads called before node synced past genesis"
+            "resolve_init_state called before node synced past genesis"
         );
         // The highest archivable height is hot_final_height - 1 (the loop
         // only archives at heights strictly below hot_final_height).
         let max_archivable_height = hot_final_height - 1;
+        // Default for missing components: the previous epoch's last block, so
+        // the writer archives the current epoch from its first block.
+        let prev_epoch_end = self.prev_epoch_end_height(hot_final_height)?;
 
         let mut min_height_local: Option<BlockHeight> = None;
         let mut update_min = |height: BlockHeight| {
@@ -539,7 +544,7 @@ impl CloudArchivalWriter {
         // Clamp to max_archivable_height so the writer never fast-forwards
         // past its own chain state when another writer is ahead.
         let block_head_local = if self.config.archive_block_data {
-            let height = block_head_ext.unwrap_or(max_archivable_height).min(max_archivable_height);
+            let height = block_head_ext.unwrap_or(prev_epoch_end).min(max_archivable_height);
             update_min(height);
             Some(height)
         } else {
@@ -548,7 +553,7 @@ impl CloudArchivalWriter {
         let shard_heads_local: Vec<(ShardId, BlockHeight)> = shard_heads_ext
             .iter()
             .map(|&(shard_id, ext_head)| {
-                let height = ext_head.unwrap_or(max_archivable_height).min(max_archivable_height);
+                let height = ext_head.unwrap_or(prev_epoch_end).min(max_archivable_height);
                 update_min(height);
                 (shard_id, height)
             })
@@ -556,7 +561,41 @@ impl CloudArchivalWriter {
 
         let min_height_local = min_height_local.expect("writer must track at least one component");
 
-        (block_head_local, shard_heads_local, min_height_local)
+        Ok(ResolvedInitState {
+            block_head: block_head_local,
+            shard_heads: shard_heads_local,
+            min_height: min_height_local,
+            prev_epoch_end,
+        })
+    }
+
+    /// Hash of the last block of the epoch before the one containing
+    /// `block_hash`, or the genesis block when there is no earlier epoch.
+    fn prev_epoch_end_hash(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<CryptoHash, near_chain_primitives::Error> {
+        let chain_store = self.hot_store.chain_store();
+        let epoch_start = self.epoch_manager.get_epoch_start_height(block_hash)?;
+        // The genesis epoch has no earlier epoch; floor at the genesis block.
+        if epoch_start <= self.genesis_height {
+            return chain_store.get_block_hash_by_height(self.genesis_height);
+        }
+        let first_block_hash = chain_store.get_block_hash_by_height(epoch_start)?;
+        let first_block_header = chain_store.get_block_header(&first_block_hash)?;
+        Ok(*first_block_header.prev_hash())
+    }
+
+    /// Height of the last block of the epoch before the one containing `height`,
+    /// flooring at genesis when there is no earlier epoch.
+    fn prev_epoch_end_height(
+        &self,
+        height: BlockHeight,
+    ) -> Result<BlockHeight, near_chain_primitives::Error> {
+        let chain_store = self.hot_store.chain_store();
+        let block_hash = chain_store.get_block_hash_by_height(height)?;
+        let prev_epoch_end = self.prev_epoch_end_hash(&block_hash)?;
+        Ok(chain_store.get_block_header(&prev_epoch_end)?.height())
     }
 
     /// Returns the tracked shard IDs for the epoch at the given height.
@@ -621,7 +660,7 @@ impl CloudArchivalWriter {
             });
         }
         let hot_final_height = self.get_hot_final_head_height()?;
-        assert!(min_head < hot_final_height, "guaranteed by collect_resolved_heads");
+        assert!(min_head < hot_final_height, "guaranteed by resolve_init_state");
         let block_hash = self.hot_store.chain_store().get_block_hash_by_height(min_head)?;
         let gc_stop_height = runtime_adapter.get_gc_stop_height(&block_hash);
         // gc_stop_height at or below genesis means GC hasn't started yet.
@@ -672,14 +711,13 @@ impl CloudArchivalWriter {
 
     /// Sets local heads during initialization, each to its own resolved height.
     /// Block and shard heads are stored as `BlockHeight` (always <=
-    /// `hot_final_height - 1`, clamped during `collect_resolved_heads`).
+    /// `hot_final_height - 1`, clamped during `resolve_init_state`).
     /// `CLOUD_PREV_EPOCH_END` is derived from `min_height`.
     fn set_local_heads(
         &self,
-        block_head: Option<BlockHeight>,
-        shard_heads: &[(ShardId, BlockHeight)],
-        min_height: BlockHeight,
+        init_state: &ResolvedInitState,
     ) -> Result<(), CloudArchivalInitializationError> {
+        let &ResolvedInitState { block_head, ref shard_heads, min_height, .. } = init_state;
         let mut transaction = DBTransaction::new();
 
         if let Some(block_head) = block_head {
@@ -707,20 +745,13 @@ impl CloudArchivalWriter {
         &self,
         height: BlockHeight,
     ) -> Result<CryptoHash, near_chain_primitives::Error> {
-        let chain_store = self.hot_store.chain_store();
         // `height` may be a skipped slot, so walk down to the nearest present block.
         let block_hash = self.find_present_block_at_or_below(height)?;
         // If the block itself ends an epoch, it is the prev-epoch end.
         if self.epoch_manager.is_next_block_epoch_start(&block_hash)? {
             return Ok(block_hash);
         }
-        let epoch_start = self.epoch_manager.get_epoch_start_height(&block_hash)?;
-        if epoch_start <= self.genesis_height {
-            return chain_store.get_block_hash_by_height(self.genesis_height);
-        }
-        let first_block_hash = chain_store.get_block_hash_by_height(epoch_start)?;
-        let first_block_header = chain_store.get_block_header(&first_block_hash)?;
-        Ok(*first_block_header.prev_hash())
+        self.prev_epoch_end_hash(&block_hash)
     }
 
     fn find_present_block_at_or_below(

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -670,7 +670,9 @@ fn test_cloud_archival_find_snapshot_with_missing_epoch_boundary() {
 }
 
 /// A block at one height is lost; the batch entry there is `None` and
-/// `cloud_head` advances past it.
+/// `cloud_head` advances past it. The dropped slot pushes the epoch's sync block
+/// past a mid-epoch bootstrap target, so the reader reconstructs from the
+/// previous epoch's snapshot and replays across the gap.
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_single_skipped_slot() {
@@ -684,6 +686,29 @@ fn test_cloud_archival_single_skipped_slot() {
     assert!(batch.get_block_at_height(dropped_height).is_none());
     assert!(h.cloud_head() > dropped_height);
     h.assert_heads_and_gc_ok();
+
+    let (start, target) = (5, 15);
+    let epoch_of = |height| {
+        *cloud_storage.get_block_data(height).unwrap().unwrap().block().header().epoch_id()
+    };
+    // start and target straddle an epoch boundary, so reconstruction crosses it.
+    assert_ne!(epoch_of(start), epoch_of(target), "start and target must be in different epochs");
+    let target_epoch_data = cloud_storage.get_epoch_data(epoch_of(target)).unwrap();
+    let sync_block_height = target_epoch_data.sync_block_height();
+    // The dropped slot is in the target epoch within the bootstrap range; it
+    // pushes that epoch's sync block past the target, so the reader cannot use
+    // the target epoch's own snapshot and must walk back to an earlier one.
+    assert!(
+        target_epoch_data.epoch_start_height() <= dropped_height && dropped_height < target,
+        "dropped slot {dropped_height} must be in the target epoch and the bootstrap range"
+    );
+    assert!(
+        sync_block_height > target,
+        "sync block {sync_block_height} must be past target {target}"
+    );
+
+    h.bootstrap_reader(start, target);
+    h.kill_reader();
 
     h.shutdown();
 }

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -672,7 +672,7 @@ fn test_cloud_archival_find_snapshot_with_missing_epoch_boundary() {
 /// A block at one height is lost; the batch entry there is `None` and
 /// `cloud_head` advances past it. The dropped slot pushes the epoch's sync block
 /// past a mid-epoch bootstrap target, so the reader reconstructs from the
-/// previous epoch's snapshot and replays across the gap.
+/// previous epoch's snapshot and applies deltas across the gap.
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_single_skipped_slot() {
@@ -710,6 +710,31 @@ fn test_cloud_archival_single_skipped_slot() {
     h.bootstrap_reader(start, target);
     h.kill_reader();
 
+    h.shutdown();
+}
+
+/// At cadence 2, `start` (epoch 3) has no snapshot, so the reader resolves the
+/// snapshot to an earlier epoch whose sync block is below the downloaded block
+/// range. Reconstruction loads that snapshot from cloud state parts, so it works
+/// without the sync block being local.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_bootstrap_snapshot_in_earlier_epoch() {
+    let mut h = CloudArchiveHarness::builder().snapshot_every_n_epochs(2).build();
+    h.run_until_epoch(5);
+
+    // Pin the scenario: the resolved snapshot is in an earlier epoch than start.
+    let (start, target) = (35, 38);
+    let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
+    let shard_id = CloudArchiveHarness::all_shard_ids()[0];
+    let (_, snapshot_epoch_id) =
+        find_snapshot_at_or_before(&cloud_storage, start, shard_id).unwrap();
+    let start_epoch_id =
+        *cloud_storage.get_block_data(start).unwrap().unwrap().block().header().epoch_id();
+    assert_ne!(snapshot_epoch_id, start_epoch_id, "snapshot must resolve to an earlier epoch");
+
+    h.bootstrap_reader(start, target);
+    h.kill_reader();
     h.shutdown();
 }
 

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -1,15 +1,15 @@
 use crate::setup::env::TestLoopEnv;
 use borsh::BorshDeserialize;
 use itertools::Itertools;
+use near_chain::ChainStoreAccess;
 use near_chain::types::Tip;
-use near_chain::{Chain, ChainStoreAccess};
 use near_chain_configs::{ClientConfig, CloudArchivalWriterConfig, TrackedShardsConfig};
 use near_client::archive::cloud_archival_reader::{
     bootstrap_range, find_present_block_at_or_below, find_snapshot_at_or_before,
 };
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::sync::external::{
-    StateSyncConnection, download_and_apply_state_parts_sequentially, list_state_parts,
+    StateFileType, StateSyncConnection, external_storage_location, list_state_parts,
 };
 use near_primitives::block::Block;
 use near_primitives::block_header::BlockHeader;
@@ -18,6 +18,7 @@ use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::state_part::{PartId, StatePart};
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId,
 };
@@ -28,7 +29,7 @@ use near_store::db::{CLOUD_MIN_HEAD_KEY, CLOUD_PREV_EPOCH_END_KEY};
 use near_store::flat::FlatStorageManager;
 use near_store::trie::AccessOptions;
 use near_store::{
-    COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, StateSnapshotConfig, Store, TrieConfig,
+    COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, StateSnapshotConfig, Store, Trie, TrieConfig,
 };
 use std::collections::HashSet;
 use std::future::Future;
@@ -352,7 +353,6 @@ pub fn bootstrap_reader(
         FlatStorageManager::new(store.flat_store()),
         StateSnapshotConfig::Disabled,
     );
-    let state_sync_connection = StateSyncConnection::from_cloud_storage(&cloud_storage);
 
     // TODO(cloud_archival): support resharding; the shard layout can change
     // between the snapshot epoch and the target, which this loop assumes constant.
@@ -361,30 +361,25 @@ pub fn bootstrap_reader(
             ShardUId::from_shard_id_and_layout(shard_id, target_epoch_data.shard_layout());
 
         // Reconstruct from the nearest snapshot at or below the bootstrap start,
-        // then replay deltas forward to the target, crossing epoch boundaries if
-        // needed. That snapshot's sync block is within the downloaded range.
+        // loaded from cloud state parts, then apply deltas forward to the target.
         let (snapshot_epoch_height, snapshot_epoch_id) =
             find_snapshot_at_or_before(&cloud_storage, start_height, shard_id).unwrap();
         let snapshot_epoch_data = cloud_storage.get_epoch_data(snapshot_epoch_id).unwrap();
         let sync_block =
             cloud_storage.get_block_data(snapshot_epoch_data.sync_block_height()).unwrap().unwrap();
-        let sync_hash = *sync_block.block().hash();
         let sync_prev_block_height = sync_block.block().header().prev_height().unwrap();
-        let state_header = cloud_storage
+        let state_sync_state_root = cloud_storage
             .get_state_header(snapshot_epoch_height, snapshot_epoch_id, shard_id)
-            .unwrap();
-        let state_sync_state_root = state_header.chunk_prev_state_root();
-        chain.state_sync_adapter.set_state_header(shard_id, sync_hash, state_header).unwrap();
+            .unwrap()
+            .chunk_prev_state_root();
 
         assert!(!has_state_root(&tries, shard_uid, state_sync_state_root));
-        execute_future(load_state_snapshot(
-            chain,
-            &state_sync_connection,
-            cloud_storage.chain_id(),
+        execute_future(download_and_apply_state_snapshot(
+            &tries,
+            &cloud_storage,
             &snapshot_epoch_id,
             snapshot_epoch_height,
-            sync_hash,
-            shard_id,
+            shard_uid,
             state_sync_state_root,
         ));
         assert!(has_state_root(&tries, shard_uid, state_sync_state_root));
@@ -419,32 +414,33 @@ fn has_state_root(tries: &ShardTries, shard_uid: ShardUId, state_root: CryptoHas
     trie.retrieve_root_node().is_ok()
 }
 
-async fn load_state_snapshot(
-    chain: &Chain,
-    external: &StateSyncConnection,
-    chain_id: &str,
+/// Loads a shard's state snapshot by downloading its state parts from cloud and
+/// applying them straight into the trie.
+async fn download_and_apply_state_snapshot(
+    tries: &ShardTries,
+    cloud_storage: &CloudStorage,
     epoch_id: &EpochId,
     epoch_height: EpochHeight,
-    sync_hash: CryptoHash,
-    shard_id: ShardId,
+    shard_uid: ShardUId,
     state_root: CryptoHash,
 ) {
+    let shard_id = shard_uid.shard_id();
+    let connection = StateSyncConnection::from_cloud_storage(cloud_storage);
+    let chain_id = cloud_storage.chain_id();
     let num_parts =
-        list_state_parts(external, chain_id, epoch_id, epoch_height, shard_id).await.unwrap();
-    download_and_apply_state_parts_sequentially(
-        chain,
-        external,
-        chain_id,
-        epoch_id,
-        epoch_height,
-        sync_hash,
-        shard_id,
-        state_root,
-        0..num_parts,
-        num_parts,
-    )
-    .await
-    .unwrap();
+        list_state_parts(&connection, chain_id, epoch_id, epoch_height, shard_id).await.unwrap();
+    for part_id in 0..num_parts {
+        let file_type = StateFileType::StatePart { part_id, num_parts };
+        let location =
+            external_storage_location(chain_id, epoch_id, epoch_height, shard_id, &file_type);
+        let bytes = connection.get_file(shard_id, &location, &file_type).await.unwrap();
+        let partial_state = StatePart::from_bytes(bytes).unwrap().to_partial_state().unwrap();
+        let apply_result =
+            Trie::apply_state_part(&state_root, PartId::new(part_id, num_parts), partial_state);
+        let mut store_update = tries.store_update();
+        tries.apply_all(&apply_result.trie_changes, shard_uid, &mut store_update);
+        store_update.commit();
+    }
 }
 
 /// Applies per-block state deltas from cloud storage to advance the trie from

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -5,7 +5,7 @@ use near_chain::types::Tip;
 use near_chain::{Chain, ChainStoreAccess};
 use near_chain_configs::{ClientConfig, CloudArchivalWriterConfig, TrackedShardsConfig};
 use near_client::archive::cloud_archival_reader::{
-    bootstrap_range, find_present_block_at_or_below,
+    bootstrap_range, find_present_block_at_or_below, find_snapshot_at_or_before,
 };
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::sync::external::{
@@ -336,20 +336,13 @@ pub fn bootstrap_reader(
             .expect("bootstrap_range should succeed");
     }
 
-    // If `target_block_height` is a skipped slot the height carries no data,
-    // so reconstructing state at the nearest present block at-or-below it is
-    // equivalent (no state changes between them).
+    // Resolve the target's epoch for the shard layout. A skipped-slot target
+    // carries no data, so snap it down to the nearest present block at or below
+    // it (no state changes between them).
     let (target_block_height, target_block_data) =
         find_present_block_at_or_below(&cloud_storage, target_block_height).unwrap();
-    let epoch_id = target_block_data.block().header().epoch_id();
-    let epoch_data = cloud_storage.get_epoch_data(*epoch_id).unwrap();
-    let epoch_height = epoch_data.epoch_info().epoch_height();
-
-    // Sync block is in the new epoch, after the prefix of blocks needed to
-    // reach two chunks per shard, and saved only once final - so present.
-    let sync_block = cloud_storage.get_block_data(epoch_data.sync_block_height()).unwrap().unwrap();
-    let sync_hash = sync_block.block().hash();
-    let sync_prev_block_height = sync_block.block().header().prev_height().unwrap();
+    let target_epoch_id = *target_block_data.block().header().epoch_id();
+    let target_epoch_data = cloud_storage.get_epoch_data(target_epoch_id).unwrap();
 
     let chain = &env.node_for_account(reader_id).client().chain;
     let store = chain.chain_store.store();
@@ -361,30 +354,47 @@ pub fn bootstrap_reader(
     );
     let state_sync_connection = StateSyncConnection::from_cloud_storage(&cloud_storage);
 
-    for shard_id in epoch_data.shard_layout().shard_ids() {
-        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, epoch_data.shard_layout());
-        let target_block_shard_data =
-            cloud_storage.get_shard_data(target_block_height, shard_id).unwrap().unwrap();
-        let target_state_root = *target_block_shard_data.chunk_extra().state_root();
-        let state_header =
-            cloud_storage.get_state_header(epoch_height, *epoch_id, shard_id).unwrap();
-        let state_sync_state_root = state_header.chunk_prev_state_root();
+    // TODO(cloud_archival): support resharding; the shard layout can change
+    // between the snapshot epoch and the target, which this loop assumes constant.
+    for shard_id in target_epoch_data.shard_layout().shard_ids() {
+        let shard_uid =
+            ShardUId::from_shard_id_and_layout(shard_id, target_epoch_data.shard_layout());
 
-        chain.state_sync_adapter.set_state_header(shard_id, *sync_hash, state_header).unwrap();
+        // Reconstruct from the nearest snapshot at or below the bootstrap start,
+        // then replay deltas forward to the target, crossing epoch boundaries if
+        // needed. That snapshot's sync block is within the downloaded range.
+        let (snapshot_epoch_height, snapshot_epoch_id) =
+            find_snapshot_at_or_before(&cloud_storage, start_height, shard_id).unwrap();
+        let snapshot_epoch_data = cloud_storage.get_epoch_data(snapshot_epoch_id).unwrap();
+        let sync_block =
+            cloud_storage.get_block_data(snapshot_epoch_data.sync_block_height()).unwrap().unwrap();
+        let sync_hash = *sync_block.block().hash();
+        let sync_prev_block_height = sync_block.block().header().prev_height().unwrap();
+        let state_header = cloud_storage
+            .get_state_header(snapshot_epoch_height, snapshot_epoch_id, shard_id)
+            .unwrap();
+        let state_sync_state_root = state_header.chunk_prev_state_root();
+        chain.state_sync_adapter.set_state_header(shard_id, sync_hash, state_header).unwrap();
 
         assert!(!has_state_root(&tries, shard_uid, state_sync_state_root));
         execute_future(load_state_snapshot(
             chain,
             &state_sync_connection,
             cloud_storage.chain_id(),
-            epoch_id,
-            epoch_height,
-            *sync_hash,
+            &snapshot_epoch_id,
+            snapshot_epoch_height,
+            sync_hash,
             shard_id,
             state_sync_state_root,
         ));
         assert!(has_state_root(&tries, shard_uid, state_sync_state_root));
 
+        let target_state_root = *cloud_storage
+            .get_shard_data(target_block_height, shard_id)
+            .unwrap()
+            .unwrap()
+            .chunk_extra()
+            .state_root();
         assert!(!has_state_root(&tries, shard_uid, target_state_root));
         apply_state_changes(
             &cloud_storage,


### PR DESCRIPTION
Lets a reader bootstrap to any archived height. Two issues were blocking it:

- On fresh init, `CloudArchivalWriter::resolve_init_state` defaulted missing external heads to `hot_final_height - 1`, leaving the epoch the writer joined only partially archived. The first uploaded `EpochData` then claimed an `epoch_start_height` the writer never archived, so a reader's bootstrap panicked on the missing batch. Missing heads now default to the previous epoch's end (new `prev_epoch_end_hash` helper, shared with `compute_initial_prev_epoch_end`).

- The `bootstrap_reader` test helper reconstructed state from the *target* epoch's snapshot through the chain's `set_state_header` path, which needs the sync block in the local store. When that sync block falls outside the downloaded range - a dropped block pushing it past the target, or the snapshot resolving to an earlier epoch (`snapshot_every_n_epochs > 1`) - `set_state_header` panicked with `DBNotFoundErr`. The helper now resolves the snapshot via `find_snapshot_at_or_before(start)` and loads it by applying cloud state parts straight into the trie (no `set_state_header`), then applies per-block deltas forward to the target. Covered by `test_cloud_archival_single_skipped_slot` and `test_cloud_archival_bootstrap_snapshot_in_earlier_epoch`.
