### PR TITLE
feat(gas-keys): don't burn remaining gas on DepositFailed

### DIFF
--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1938,6 +1938,7 @@ impl Runtime {
                         "gas key transaction failed deposit check, charging gas"
                     );
                     // All gas used for converting the transaction to a receipt is burnt.
+                    let outcome = ExecutionOutcomeWithId::failed_with_gas_burnt(
                         tx,
                         error,
                         cost.gas_burnt,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1937,13 +1937,12 @@ impl Runtime {
                         error = &error as &dyn std::error::Error,
                         "gas key transaction failed deposit check, charging gas"
                     );
-                    // All prepaid gas is burnt (no receipt created to refund remaining gas).
-                    let total_gas = cost.gas_burnt.checked_add_result(cost.gas_remaining)?;
+                    // All the gas used for converting the transaction to a receipt burnt.
                     let outcome = ExecutionOutcomeWithId::failed_with_gas_burnt(
                         tx,
                         error,
-                        total_gas,
-                        cost.gas_cost,
+                        cost.gas_burnt,
+                        cost.burnt_amount,
                     );
                     (outcome, result)
                 }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1937,8 +1937,7 @@ impl Runtime {
                         error = &error as &dyn std::error::Error,
                         "gas key transaction failed deposit check, charging gas"
                     );
-                    // All the gas used for converting the transaction to a receipt burnt.
-                    let outcome = ExecutionOutcomeWithId::failed_with_gas_burnt(
+                    // All gas used for converting the transaction to a receipt is burnt.
                         tx,
                         error,
                         cost.gas_burnt,

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -3979,9 +3979,8 @@ fn test_gas_key_tx_deposit_insufficient_charges_gas() {
         }
         other => panic!("expected NotEnoughBalanceForDeposit, got {:?}", other),
     }
-    let total_gas = transaction_cost.gas_burnt.checked_add(transaction_cost.gas_remaining).unwrap();
-    assert_eq!(outcome.outcome.gas_burnt, total_gas);
-    assert_eq!(outcome.outcome.tokens_burnt, transaction_cost.gas_cost);
+    assert_eq!(outcome.outcome.gas_burnt, transaction_cost.gas_burnt);
+    assert_eq!(outcome.outcome.tokens_burnt, transaction_cost.burnt_amount);
 
     // Commit and verify state
     let root = commit_apply_result(&apply_result, &mut apply_state, &tries, shard_uid);
@@ -3992,7 +3991,7 @@ fn test_gas_key_tx_deposit_insufficient_charges_gas() {
         get_access_key(&state, &alice_account(), &gas_key_signer.public_key()).unwrap().unwrap();
     assert_eq!(
         access_key.gas_key_info().unwrap().balance,
-        gas_key_balance.checked_sub(transaction_cost.gas_cost).unwrap()
+        gas_key_balance.checked_sub(transaction_cost.burnt_amount).unwrap()
     );
 
     // Account balance was NOT deducted

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -459,22 +459,40 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
     }
     let new_gas_key_balance = gas_key_info.balance.checked_sub(gas_cost).unwrap();
 
+    // Calculate new key balance in case of deposit failure. Charges only for the gas burned on
+    // converting the transaction to a receipt.
+    let Some(new_key_balance_on_deposit_failure) = gas_key_info.balance.checked_sub(burnt_amount)
+    else {
+        return TxVerdict::Failed(InvalidTxError::NotEnoughGasKeyBalance {
+            signer_id: account_id.clone(),
+            balance: gas_key_info.balance,
+            cost: burnt_amount,
+        });
+    };
+
     // Validate FunctionCall permission constraints if applicable
     if let Some(function_call_permission) = access_key.permission.function_call_permission()
         && let Err(e) = verify_function_call_permission(function_call_permission, tx)
     {
         return TxVerdict::Failed(e);
     }
-    let gas_key_update =
-        AccessKeyUpdate::GasKey { new_balance: new_gas_key_balance, nonce_index, nonce: tx_nonce };
-    let make_result = move |new_account_amount| VerificationResult {
+    let make_result = move |new_account_amount, new_key_amount| VerificationResult {
         gas_burnt,
         compute_burnt,
         gas_remaining,
         receipt_gas_price,
         burnt_amount,
         new_account_amount,
-        access_key_update: gas_key_update,
+        access_key_update: AccessKeyUpdate::GasKey {
+            new_balance: new_key_amount,
+            nonce_index,
+            nonce: tx_nonce,
+        },
+    };
+    let make_success_result =
+        move |new_account_amount| make_result(new_account_amount, new_gas_key_balance);
+    let make_deposit_failed_result = move |new_account_amount| {
+        make_result(new_account_amount, new_key_balance_on_deposit_failure)
     };
 
     // Check account has enough balance for deposits, accounting for
@@ -485,7 +503,7 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
     let available_balance = account.amount().saturating_sub(pending.paid_from_balance);
     if available_balance < deposit_cost {
         return TxVerdict::DepositFailed {
-            result: make_result(account.amount()),
+            result: make_deposit_failed_result(account.amount()),
             error: InvalidTxError::NotEnoughBalanceForDeposit {
                 signer_id: account_id.clone(),
                 balance: available_balance,
@@ -501,7 +519,7 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
         Ok(()) => {}
         Err(StorageStakingError::LackBalanceForStorageStaking(amount)) => {
             return TxVerdict::DepositFailed {
-                result: make_result(account.amount()),
+                result: make_deposit_failed_result(account.amount()),
                 error: InvalidTxError::NotEnoughBalanceForDeposit {
                     signer_id: account_id.clone(),
                     balance: new_account_amount,
@@ -515,7 +533,7 @@ pub fn verify_and_charge_gas_key_tx_ephemeral(
         }
     };
 
-    TxVerdict::Success(make_result(new_account_amount))
+    TxVerdict::Success(make_success_result(new_account_amount))
 }
 
 /// Validates a given receipt. Checks validity of the Action or Data receipt.
@@ -2401,7 +2419,7 @@ mod tests {
         assert_eq!(
             result.access_key_update,
             AccessKeyUpdate::GasKey {
-                new_balance: TESTING_GAS_KEY_BALANCE.checked_sub(cost.gas_cost).unwrap(),
+                new_balance: TESTING_GAS_KEY_BALANCE.checked_sub(cost.burnt_amount).unwrap(),
                 nonce_index: 0,
                 nonce: initial_nonce + 1,
             }

--- a/test-loop-tests/src/tests/gas_keys.rs
+++ b/test-loop-tests/src/tests/gas_keys.rs
@@ -394,7 +394,7 @@ fn test_gas_key_deposit_failed() {
         outcome.outcome_with_id.outcome.status,
     );
 
-    // Verify: all prepaid gas was burnt and tokens_burnt matches gas_burnt * gas_price
+    // Verify: gas was burnt for transaction processing and tokens_burnt matches gas_burnt * gas_price
     let gas_burnt = outcome.outcome_with_id.outcome.gas_burnt;
     let tokens_burnt = outcome.outcome_with_id.outcome.tokens_burnt;
     assert!(gas_burnt.as_gas() > 0);


### PR DESCRIPTION
Currently when a gas key transaction fails with `DepositFailed` (not enough balance to cover attached deposit), all the gas in the transaction is burned without refunds. This includes both the gas burned on converting the transaction to a receipt, and the gas that would be attached to the new receipt.

This PR changes it so that the gas attached to the receipt is not burned. The user only pays for the gas that was burned on converting the transaction to a receipt.

Not sure if I need to guard it behind a protocol feature. Maybe not?