### PR TITLE
fix(params-estimator): improve gas metering estimation

### DIFF
--- a/core/parameters/src/parameter_table.rs
+++ b/core/parameters/src/parameter_table.rs
@@ -457,6 +457,7 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                 gas_key_host_fns: params.get(Parameter::GasKeyHostFns)?,
                 one_yocto_on_promise: params.get(Parameter::OneYoctoOnPromise)?,
                 p256_verify_host_fn: params.get(Parameter::P256VerifyHostFn)?,
+                skip_gas_instrumentation: false,
             }),
             account_creation_config: AccountCreationConfig {
                 min_allowed_top_level_account_length: params

--- a/core/parameters/src/view.rs
+++ b/core/parameters/src/view.rs
@@ -300,6 +300,8 @@ impl From<VMConfigView> for crate::vm::Config {
             gas_key_host_fns: view.gas_key_host_fns,
             one_yocto_on_promise: view.one_yocto_on_promise,
             p256_verify_host_fn: view.p256_verify_host_fn,
+            // Not exposed on the view, only used in benchmarks
+            skip_gas_instrumentation: false,
         }
     }
 }

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -230,6 +230,10 @@ pub struct Config {
     /// NEP-635: <https://github.com/near/NEPs/pull/635>
     pub p256_verify_host_fn: bool,
 
+    /// Skip finite-wasm gas instrumentation when preparing contracts.
+    /// Used for benchmarks, keep this `false` in production.
+    pub skip_gas_instrumentation: bool,
+
     /// Describes limits for VM and Runtime.
     pub limit_config: LimitConfig,
 }

--- a/runtime/near-vm-runner/src/prepare/prepare_v2.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v2.rs
@@ -401,6 +401,10 @@ pub(crate) fn prepare_contract(
         VMKind::Wasmer0 | VMKind::Wasmtime | VMKind::Wasmer2 => {}
     }
 
+    if config.skip_gas_instrumentation {
+        return Ok(lightly_steamed);
+    }
+
     let res = finite_wasm::Analysis::new()
         .with_stack(Box::new(SimpleMaxStackCfg))
         .with_gas(Box::new(SimpleGasCostCfg(u64::from(config.regular_op_cost))))

--- a/runtime/near-vm-runner/src/prepare/prepare_v3.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v3.rs
@@ -415,6 +415,16 @@ pub(crate) fn prepare_contract(
         VMKind::Wasmer0 | VMKind::Wasmtime | VMKind::Wasmer2 => {}
     }
 
+    if config.skip_gas_instrumentation {
+        if let Some(max_size) = config.limit_config.max_instrumented_code_size {
+            if lightly_steamed.len() as u64 > max_size {
+                tracing::debug!(target: "vm", size=lightly_steamed.len(), ?kind, "instrumented code too large");
+                return Err(PrepareError::InstrumentedCodeTooLarge);
+            }
+        }
+        return Ok(lightly_steamed);
+    }
+
     let analysis = finite_wasm_6::Analysis::new()
         .with_stack(SimpleMaxStackCfg)
         .with_gas(SimpleGasCostCfg {

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -138,6 +138,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
         let mut cfg = near_parameters::vm::Config::clone(&vm_config_gas);
         cfg.make_free();
         cfg.enable_all_features();
+        cfg.skip_gas_instrumentation = true;
         cfg
     });
     let fees = runtime_config.fees.clone();


### PR DESCRIPTION
This commit allows the benchmark to disable gas metering in Wasmtime and updates the params-estimator code to use that.

The benchmark-based estimation for the overhead the gas metering was not working properly for Wasmtime. The baseline was not actually skipping gas metering at all.

What was measured previously was, more or less, the difference between cold and warm  CPU caches. Running that old setup with --warmup-iters 3 showed that runs after always show a noisy, near-zero, sometimes negative cost for gas metering.