### PR TITLE
fix(estimator): ungate stable yield/resume gas costs

### DIFF
--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -58,7 +58,6 @@ pub(crate) struct CachedCosts {
     pub(crate) ed25519_verify_base: Option<GasCost>,
     pub(crate) p256_verify_base: Option<GasCost>,
     pub(crate) function_call_base: Option<GasCost>,
-    #[cfg(feature = "nightly")]
     pub(crate) yield_create_base: Option<GasCost>,
     #[cfg(feature = "nightly")]
     pub(crate) yield_create_with_id_base: Option<GasCost>,

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -320,15 +320,11 @@ static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     (Cost::GasMeteringOp, gas_metering_op),
     (Cost::RocksDbInsertValueByte, rocks_db_insert_value_byte),
     (Cost::RocksDbReadValueByte, rocks_db_read_value_byte),
-    #[cfg(feature = "nightly")]
     (Cost::YieldCreateBase, yield_create_base),
-    #[cfg(feature = "nightly")]
     (Cost::YieldCreateByte, yield_create_byte),
     #[cfg(feature = "nightly")]
     (Cost::YieldCreateWithIdBase, yield_create_with_id_base),
-    #[cfg(feature = "nightly")]
     (Cost::YieldResumeBase, yield_resume_base),
-    #[cfg(feature = "nightly")]
     (Cost::YieldResumeByte, yield_resume_byte),
     (Cost::CpuBenchmarkSha256, cpu_benchmark_sha256),
     (Cost::OneCPUInstruction, one_cpu_instruction),
@@ -1560,7 +1556,6 @@ fn rocks_db_read_value_byte(ctx: &mut EstimatorContext) -> GasCost {
     rocks_db_read_cost(&ctx.config) / total_bytes
 }
 
-#[cfg(feature = "nightly")]
 fn yield_create_base(ctx: &mut EstimatorContext) -> GasCost {
     let base_cost = noop_function_call_cost(ctx);
     let result = if let Some(cost) = &ctx.cached.yield_create_base {
@@ -1575,7 +1570,6 @@ fn yield_create_base(ctx: &mut EstimatorContext) -> GasCost {
     result.saturating_sub(&(base_cost / 1000), &NonNegativeTolerance::PER_MILLE)
 }
 
-#[cfg(feature = "nightly")]
 fn yield_create_byte(ctx: &mut EstimatorContext) -> GasCost {
     let noop_function_call = noop_function_call_cost(ctx);
     let base_cost = yield_create_base(ctx);
@@ -1609,7 +1603,6 @@ fn yield_create_with_id_base(ctx: &mut EstimatorContext) -> GasCost {
     result.saturating_sub(&(base_cost / 1000), &NonNegativeTolerance::PER_MILLE)
 }
 
-#[cfg(feature = "nightly")]
 fn yield_resume_base(ctx: &mut EstimatorContext) -> GasCost {
     fn_cost_with_setup(
         ctx,
@@ -1621,7 +1614,6 @@ fn yield_resume_base(ctx: &mut EstimatorContext) -> GasCost {
     )
 }
 
-#[cfg(feature = "nightly")]
 fn yield_resume_byte(ctx: &mut EstimatorContext) -> GasCost {
     let baseline = fn_cost_with_setup(
         ctx,


### PR DESCRIPTION
The runtime-params-estimator still gated `yield_create_base`, `yield_create_byte`, `yield_resume_base`, and `yield_resume_byte` behind `#[cfg(feature = "nightly")]`, even though yield/resume stabilized at protocol version 67 (current stable is 85). The underlying `ExtCosts`, view params, cost mapping, and estimator-contract functions were all already ungated, so the estimator was the only place still gating these, making the costs impossible to estimate on a non-nightly build.

Remove the stale gates from the cached field, the registration entries, and the estimator function definitions.

`yield_create_with_id_base` / `YieldCreateWithIdBase` stays nightly-gated since `YieldWithId` is protocol version 155 (= `NIGHTLY_PROTOCOL_VERSION`).