### PR TITLE
refactor(test-loop): dedupe contract selection by protocol version

### DIFF
--- a/test-loop-tests/src/tests/cache_warming.rs
+++ b/test-loop-tests/src/tests/cache_warming.rs
@@ -3,6 +3,7 @@
 
 use crate::setup::builder::TestLoopBuilder;
 use crate::utils::account::create_account_id;
+use crate::utils::contracts::rs_contract_for_protocol_version;
 use near_async::time::Duration;
 use near_o11y::testonly::init_test_logger;
 use near_parameters::{RuntimeConfig, RuntimeConfigStore};
@@ -58,12 +59,9 @@ fn slow_test_cache_warming_across_vm_config_change() {
         .build();
 
     // Deploy during the old-protocol epoch, exercising the deploy warming hook.
-    // Uses the backwards-compatible contract since this runs below the latest
-    // protocol version, where `rs_contract`'s newest host-fn imports are absent.
-    let deploy_tx = env.rpc_node().tx_deploy_contract(
-        &user,
-        near_test_contracts::backwards_compatible_rs_contract().to_vec(),
-    );
+    let deploy_tx = env
+        .rpc_node()
+        .tx_deploy_contract(&user, rs_contract_for_protocol_version(old_protocol).to_vec());
     env.rpc_runner().run_tx(deploy_tx, Duration::seconds(10));
 
     // Calls exercise the pipelining warming path on receipt preparation.
@@ -95,7 +93,7 @@ fn slow_test_cache_warming_across_vm_config_change() {
     // The contract must already be cached under the new protocol's wasm_config.
     // No contract activity has run under new_protocol yet, so this can only
     // have been populated by pre-upgrade warming.
-    let code_hash = CryptoHash::hash_bytes(near_test_contracts::backwards_compatible_rs_contract());
+    let code_hash = CryptoHash::hash_bytes(rs_contract_for_protocol_version(old_protocol));
     let client = &env.test_loop.data.get(&client_handle).client;
     let next_runtime_config = client.runtime_adapter.get_runtime_config(new_protocol);
     let cache = client.runtime_adapter.compiled_contract_cache();

--- a/test-loop-tests/src/tests/deterministic_account_id.rs
+++ b/test-loop-tests/src/tests/deterministic_account_id.rs
@@ -27,6 +27,7 @@ use crate::setup::env::TestLoopEnv;
 use crate::utils::account::{
     create_account_ids, create_validators_spec, validators_spec_clients_with_rpc,
 };
+use crate::utils::contracts::rs_contract_for_protocol_version;
 use crate::utils::transactions;
 use assert_matches::assert_matches;
 use near_async::time::Duration;
@@ -983,14 +984,7 @@ impl TestEnv {
             .runtime_config_store(runtime_config_store.clone())
             .build();
 
-        // `rs_contract` declares host-fn imports for the latest protocol that are
-        // not available at older versions; use the backwards-compatible contract
-        // when the test runs below the latest protocol version.
-        let contract_code = if protocol_version < PROTOCOL_VERSION {
-            near_test_contracts::backwards_compatible_rs_contract()
-        } else {
-            near_test_contracts::rs_contract()
-        };
+        let contract_code = rs_contract_for_protocol_version(protocol_version);
 
         Self {
             env,

--- a/test-loop-tests/src/tests/yield_resume.rs
+++ b/test-loop-tests/src/tests/yield_resume.rs
@@ -4,6 +4,7 @@ use crate::tests::yield_timeouts::{
     assert_no_promise_yield_status_in_state, get_yield_data_ids_in_latest_state,
 };
 use crate::utils::account::validators_spec_clients;
+use crate::utils::contracts::rs_contract_for_protocol_version;
 use assert_matches::assert_matches;
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
@@ -552,7 +553,7 @@ fn test_yield_resume_across_protocol_upgrade() {
     let deploy_contract_tx = SignedTransaction::deploy_contract(
         1,
         &test_account,
-        near_test_contracts::backwards_compatible_rs_contract().into(),
+        rs_contract_for_protocol_version(old_protocol).into(),
         &test_account_signer,
         start_head.last_block_hash,
     );

--- a/test-loop-tests/src/tests/yield_resume.rs
+++ b/test-loop-tests/src/tests/yield_resume.rs
@@ -109,7 +109,7 @@ fn prepare_env() -> TestLoopEnv {
     let deploy_contract_tx = SignedTransaction::deploy_contract(
         1,
         &test_account,
-        near_test_contracts::backwards_compatible_rs_contract().into(),
+        near_test_contracts::rs_contract().into(),
         &test_account_signer,
         *genesis_block.hash(),
     );

--- a/test-loop-tests/src/utils/contracts.rs
+++ b/test-loop-tests/src/utils/contracts.rs
@@ -1,0 +1,14 @@
+use near_primitives::version::{PROTOCOL_VERSION, ProtocolVersion};
+
+/// Returns the rust test contract appropriate for `protocol_version`.
+///
+/// `rs_contract` imports the newest host functions (gated by `latest_protocol`)
+/// and only links at the latest protocol version; below it we fall back to
+/// `backwards_compatible_rs_contract`, which omits those imports.
+pub(crate) fn rs_contract_for_protocol_version(protocol_version: ProtocolVersion) -> &'static [u8] {
+    if protocol_version < PROTOCOL_VERSION {
+        near_test_contracts::backwards_compatible_rs_contract()
+    } else {
+        near_test_contracts::rs_contract()
+    }
+}

--- a/test-loop-tests/src/utils/mod.rs
+++ b/test-loop-tests/src/utils/mod.rs
@@ -8,6 +8,7 @@ use near_primitives::types::{AccountId, BlockHeight};
 pub(crate) mod account;
 pub(crate) mod cloud_archival;
 pub(crate) mod contract_distribution;
+pub(crate) mod contracts;
 pub(crate) mod loop_action;
 pub(crate) mod network;
 pub(crate) mod node;


### PR DESCRIPTION
`rs_contract` imports the newest host functions and only links at the latest protocol version, so protocol-upgrade tests that deploy it pre-upgrade fall back to `backwards_compatible_rs_contract`. That choice, along with its explanatory comment, was duplicated across `cache_warming`, `deterministic_account_id`, and `yield_resume`.

Introduce `utils::contracts::rs_contract_for_protocol_version(protocol_version)`, which returns the appropriate contract for a given protocol version, and use it at the three version-keyed sites. No behavior change.

Separately, `yield_resume::prepare_env` is switched back to `rs_contract`. It runs at the latest `PROTOCOL_VERSION`, where `rs_contract` links fine, so the `backwards_compatible_rs_contract` switch it picked up (the same change as in #15183, whose target was genuinely-pre-upgrade deploy sites) was unnecessary here. Verified the four `prepare_env`-based tests pass.