### PR TITLE
test(spice): re-enable passing tests under spice

### DIFF
--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -22,8 +22,6 @@ use near_primitives::transaction::{Action, DeployContractAction, SignedTransacti
 ///
 /// In ths benchmark, we construct a large with a bunch of deploy_code txes
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn benchmark_large_chunk_production_time() {
     let mb = 1024usize.pow(2);
 

--- a/integration-tests/src/tests/features/wallet_contract.rs
+++ b/integration-tests/src/tests/features/wallet_contract.rs
@@ -157,8 +157,6 @@ fn test_eth_implicit_account_creation() {
 
 /// Test that transactions from ETH-implicit accounts are rejected.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_transaction_from_eth_implicit_account_fail() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();

--- a/integration-tests/src/tests/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/features/zero_balance_account.rs
@@ -118,8 +118,6 @@ fn test_zero_balance_account_creation() {
 /// it has to pay for storage cost of the account structure and the keys that
 /// it didn't have to pay while it was a zero balance account.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_zero_balance_account_add_key() {
     let epoch_length = 1000;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);

--- a/test-loop-tests/src/tests/consensus.rs
+++ b/test-loop-tests/src/tests/consensus.rs
@@ -30,8 +30,6 @@ use std::sync::Arc;
 /// Periodically verify finality is not violated.
 /// This test is designed to reproduce finality bugs on the epoch boundaries.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn ultra_slow_test_consensus_with_epoch_switches() {
     init_test_logger();
 

--- a/test-loop-tests/src/tests/max_receipt_size.rs
+++ b/test-loop-tests/src/tests/max_receipt_size.rs
@@ -16,12 +16,11 @@ use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV0};
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{Balance, Gas};
+use near_primitives::version::ProtocolFeature;
 use near_primitives::views::FinalExecutionStatus;
 
 /// Generating receipts larger than the size limit should cause the transaction to fail.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_max_receipt_size() {
     init_test_logger();
 
@@ -128,8 +127,6 @@ fn test_max_receipt_size() {
 // isn't because of a bug (See https://github.com/near/nearcore/issues/12606)
 // Runtime shouldn't die when it encounters a receipt with size above `max_receipt_size`.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_max_receipt_size_promise_return() {
     init_test_logger();
 
@@ -216,8 +213,6 @@ fn test_max_receipt_size_promise_return() {
 /// Creates the following promise DAG:
 /// A[self.return_large_value()] -then-> B[self.mark_test_completed()]
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_max_receipt_size_value_return() {
     init_test_logger();
 
@@ -359,69 +354,76 @@ fn assert_oversized_receipt_occurred(node: &TestLoopNode<'_>) {
     let epoch_manager = &*client.epoch_manager;
 
     let tip = chain.head().unwrap();
-    let mut block = chain.get_block(&tip.last_block_hash).unwrap();
-    let mut prev_block = chain.get_block(&block.header().prev_hash()).unwrap();
-
-    let epoch_id = epoch_manager.get_epoch_id(block.hash()).unwrap();
+    let epoch_id = epoch_manager.get_epoch_id(&tip.last_block_hash).unwrap();
     let protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id).unwrap();
     let runtime_config = client.runtime_adapter.get_runtime_config(protocol_version);
+    let max_receipt_size = runtime_config.wasm_config.limit_config.max_receipt_size;
 
-    // Go over all blocks in the range
+    let mut block = chain.get_block(&tip.last_block_hash).unwrap();
+
+    // Go over all blocks down to genesis looking for a receipt above max_receipt_size.
     loop {
         if block.header().is_genesis() {
             panic!("Didn't find receipt with size above max_receipt_size!");
         }
+        let prev_block = chain.get_block(block.header().prev_hash()).unwrap();
 
-        let cur_shard_layout = client
-            .epoch_manager
-            .get_shard_layout(&epoch_manager.get_epoch_id(&block.hash()).unwrap())
+        let shard_layout = epoch_manager
+            .get_shard_layout(&epoch_manager.get_epoch_id(block.hash()).unwrap())
             .unwrap();
 
-        // Go over all new chunks in a block
-        for new_chunk in block.chunks().iter_new() {
-            let shard_id = new_chunk.shard_id();
-            let prev_shard_index = epoch_manager
-                .get_prev_shard_id_from_prev_hash(block.header().prev_hash(), shard_id)
-                .unwrap()
-                .2;
-            let prev_height_included =
-                prev_block.chunks().get(prev_shard_index).unwrap().height_included();
+        let oversized = if ProtocolFeature::Spice.enabled(protocol_version) {
+            // With spice chunks are executed asynchronously and their produced receipts are
+            // persisted as receipt proofs keyed by the block in which the chunk was applied,
+            // rather than as incoming receipts on the following block.
+            shard_layout.shard_ids().any(|shard_id| {
+                chain
+                    .chain_store()
+                    .iter_receipt_proofs_for_shard(block.hash(), shard_id)
+                    .iter()
+                    .flat_map(|proof| proof.0.iter())
+                    .any(|receipt| receipt_is_oversized(receipt, max_receipt_size))
+            })
+        } else {
+            block.chunks().iter_new().any(|new_chunk| {
+                let shard_id = new_chunk.shard_id();
+                let prev_shard_index = epoch_manager
+                    .get_prev_shard_id_from_prev_hash(block.header().prev_hash(), shard_id)
+                    .unwrap()
+                    .2;
+                let prev_height_included =
+                    prev_block.chunks().get(prev_shard_index).unwrap().height_included();
+                let incoming_receipts_proofs = get_incoming_receipts_for_shard(
+                    &chain.chain_store,
+                    epoch_manager,
+                    shard_id,
+                    &shard_layout,
+                    *block.hash(),
+                    prev_height_included,
+                    ReceiptFilter::TargetShard,
+                )
+                .unwrap();
+                incoming_receipts_proofs
+                    .iter()
+                    .flat_map(|response| response.1.iter())
+                    .flat_map(|proof| proof.0.iter())
+                    .any(|receipt| receipt_is_oversized(receipt, max_receipt_size))
+            })
+        };
 
-            // Fetch incoming receipts for this chunk
-            let incoming_receipts_proofs = get_incoming_receipts_for_shard(
-                &chain.chain_store,
-                epoch_manager,
-                shard_id,
-                &cur_shard_layout,
-                *block.hash(),
-                prev_height_included,
-                ReceiptFilter::TargetShard,
-            )
-            .unwrap();
-
-            // Look for receipt with size above max_receipt_size
-            for response in incoming_receipts_proofs {
-                for proof in response.1.iter() {
-                    for receipt in &proof.0 {
-                        let receipt_size: u64 =
-                            borsh::object_length(receipt).unwrap().try_into().unwrap();
-                        let max_receipt_size =
-                            runtime_config.wasm_config.limit_config.max_receipt_size;
-                        if receipt_size > max_receipt_size {
-                            // Success! found receipt above max size
-                            tracing::info!(
-                                %receipt_size,
-                                %max_receipt_size,
-                                "found receipt above max size"
-                            );
-                            return;
-                        }
-                    }
-                }
-            }
+        if oversized {
+            return;
         }
 
         block = prev_block;
-        prev_block = chain.get_block(block.header().prev_hash()).unwrap();
     }
+}
+
+fn receipt_is_oversized(receipt: &Receipt, max_receipt_size: u64) -> bool {
+    let receipt_size: u64 = borsh::object_length(receipt).unwrap().try_into().unwrap();
+    if receipt_size > max_receipt_size {
+        tracing::info!(%receipt_size, %max_receipt_size, "found receipt above max size");
+        return true;
+    }
+    false
 }

--- a/test-loop-tests/src/tests/yield_resume.rs
+++ b/test-loop-tests/src/tests/yield_resume.rs
@@ -399,8 +399,6 @@ fn test_yield_then_resume_two_actions() {
 /// When processing the receipt fails, the yielded receipt should be cancelled and there should be
 /// no PromiseYieldStatus in the state, even though it was written by the first action.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_yield_then_resume_two_actions_failure() {
     let mut env = prepare_env();
     let signer = create_user_test_signer(&AccountId::from_str("test0").unwrap());

--- a/test-loop-tests/src/tests/yield_timeouts.rs
+++ b/test-loop-tests/src/tests/yield_timeouts.rs
@@ -371,8 +371,6 @@ fn test_simple_yield_timeout() {
 /// In this test, we introduce congestion and verify that the timeout execution is
 /// delayed as expected, but ultimately succeeds without error.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_yield_timeout_under_congestion() {
     let (mut env, yield_tx_hash, _) = prepare_env_with_yield(vec![], Some(10_000_000_000_000));
     assert!(NEXT_BLOCK_HEIGHT_AFTER_SETUP < YIELD_TIMEOUT_HEIGHT);
@@ -476,8 +474,6 @@ fn test_yield_resume_just_before_timeout() {
 /// In this test we introduce congestion to delay the yield timeout so that we can invoke
 /// yield resume after the timeout height has passed.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_yield_resume_after_timeout_height() {
     let yield_payload = vec![6u8; 16];
     let (mut env, yield_tx_hash, data_id) =


### PR DESCRIPTION
Passing as-is (only the spice `ignore` gate removed):
- `ultra_slow_test_consensus_with_epoch_switches` — consensus/finality machinery is unchanged by SPICE.
- `test_yield_then_resume_two_actions_failure`, `test_yield_timeout_under_congestion`, `test_yield_resume_after_timeout_height`.
- `benchmark_large_chunk_production_time`, `test_transaction_from_eth_implicit_account_fail`, `test_zero_balance_account_add_key`.

With a fix:
- `test_max_receipt_size`, `test_max_receipt_size_promise_return`, `test_max_receipt_size_value_return` — the shared `assert_oversized_receipt_occurred` helper looked for the oversized receipt in block incoming-receipts, which are empty under SPICE since execution is decoupled from consensus. It now reads from the `receipt_proofs` column via `iter_receipt_proofs_for_shard` when SPICE is enabled; the non-SPICE path is unchanged.