### PR TITLE
fix(spice): report last certified state root in node status

### DIFF
--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -230,15 +230,75 @@ impl SpiceCoreReader {
         block_hash: &CryptoHash,
     ) -> Result<Option<CryptoHash>, Error> {
         let last_certified = get_last_certified_block_header(&self.chain_store, block_hash)?;
-        let Some(results) = self.get_block_execution_results(&last_certified)? else {
-            return Ok(None);
-        };
         let shard_layout = self.epoch_manager.get_shard_layout(last_certified.epoch_id())?;
-        let state_roots: Vec<CryptoHash> = shard_layout
-            .shard_ids()
-            .map(|shard_id| *results.0[&shard_id].chunk_extra.state_root())
-            .collect();
+
+        // Fast path: `DBCol::execution_results`, written asynchronously by
+        // `SpiceCoreWriterActor`. By the time a block is fully certified the writer has
+        // almost always recorded its results, so this usually returns everything.
+        let mut results = self.get_execution_results_by_shard_id(&last_certified)?;
+
+        // Slow path: when the writer has not caught up yet some shards are missing. Recover
+        // them from the ancestry's block bodies, which is also the only source for shards
+        // this node does not track. Genesis carries no certifying statements, so its results
+        // only ever come from the fast path above.
+        let all_present = shard_layout.shard_ids().all(|shard_id| results.contains_key(&shard_id));
+        if !all_present && !last_certified.is_genesis() {
+            let relevant_blocks = HashSet::from([*last_certified.hash()]);
+            let mut results_by_block = HashMap::new();
+            self.collect_certified_execution_results_from_ancestry(
+                block_hash,
+                &last_certified,
+                &relevant_blocks,
+                &mut results_by_block,
+            )?;
+            for (shard_id, result) in
+                results_by_block.remove(last_certified.hash()).unwrap_or_default()
+            {
+                results.entry(shard_id).or_insert(result);
+            }
+        }
+
+        let mut state_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
+        for shard_id in shard_layout.shard_ids() {
+            let Some(result) = results.get(&shard_id) else {
+                return Ok(None);
+            };
+            state_roots.push(*result.chunk_extra.state_root());
+        }
         Ok(Some(merklize(&state_roots).0))
+    }
+
+    /// Walks the canonical ancestry backwards from `from_hash` down to (but excluding)
+    /// `stop_header`, collecting `ChunkExecutionResult` core statements whose certified
+    /// chunk belongs to a block in `relevant_blocks`, grouped by block hash and shard.
+    /// Reads block bodies because `DBCol::execution_results` is written asynchronously by
+    /// `SpiceCoreWriterActor`. Pre-existing entries in `results_by_block` take precedence.
+    fn collect_certified_execution_results_from_ancestry(
+        &self,
+        from_hash: &CryptoHash,
+        stop_header: &BlockHeader,
+        relevant_blocks: &HashSet<CryptoHash>,
+        results_by_block: &mut HashMap<CryptoHash, HashMap<ShardId, Arc<ChunkExecutionResult>>>,
+    ) -> Result<(), Error> {
+        let mut current_hash = *from_hash;
+        while current_hash != *stop_header.hash() {
+            let block = self.chain_store.get_block(&current_hash)?;
+            if block.header().height() <= stop_header.height() {
+                break;
+            }
+            for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
+                if !relevant_blocks.contains(&chunk_id.block_hash) {
+                    continue;
+                }
+                results_by_block
+                    .entry(chunk_id.block_hash)
+                    .or_default()
+                    .entry(chunk_id.shard_id)
+                    .or_insert_with(|| Arc::new(result.clone()));
+            }
+            current_hash = *block.header().prev_hash();
+        }
+        Ok(())
     }
 
     pub fn core_statements_for_next_block(
@@ -569,27 +629,14 @@ impl SpiceCoreReader {
                 .or_insert_with(|| Arc::new(result.clone()));
         }
 
-        // Walk backwards from block_header through ancestry, collecting execution results
-        // from each block's core statements. We can't depend on DBCol::execution_results
-        // which SpiceCoreWriterActor writes asynchronously.
-        let mut current_hash = *block_header.hash();
-        while current_hash != *old_last_certified.hash() {
-            let block = self.chain_store.get_block(&current_hash)?;
-            if block.header().height() <= old_last_certified.height() {
-                break;
-            }
-            for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
-                if !newly_certified_set.contains(&chunk_id.block_hash) {
-                    continue;
-                }
-                results_by_block
-                    .entry(chunk_id.block_hash)
-                    .or_default()
-                    .entry(chunk_id.shard_id)
-                    .or_insert_with(|| Arc::new(result.clone()));
-            }
-            current_hash = *block.header().prev_hash();
-        }
+        // Collect execution results from the ancestry's block bodies, keeping any
+        // already seeded from `core_statements_for_next_block` above.
+        self.collect_certified_execution_results_from_ancestry(
+            block_header.hash(),
+            &old_last_certified,
+            &newly_certified_set,
+            &mut results_by_block,
+        )?;
 
         // Build result for each newly certified block, oldest-first.
         let mut result = Vec::with_capacity(newly_certified_hashes.len());

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -7,6 +7,7 @@ use near_primitives::block_body::{SpiceCoreStatement, SpiceCoreStatements};
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::merklize;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::spice::chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
@@ -218,6 +219,26 @@ impl SpiceCoreReader {
             results.insert(shard_id, result.clone());
         }
         Ok(Some(BlockExecutionResults(results)))
+    }
+
+    /// State root certified as of `block_hash`: the merkle root over per-shard
+    /// state roots of the last fully certified block. Mirrors the non-spice
+    /// `Chunks::compute_state_root`. Returns `None` when the certified block's
+    /// execution results are not all available yet.
+    pub fn last_certified_state_root(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<Option<CryptoHash>, Error> {
+        let last_certified = get_last_certified_block_header(&self.chain_store, block_hash)?;
+        let Some(results) = self.get_block_execution_results(&last_certified)? else {
+            return Ok(None);
+        };
+        let shard_layout = self.epoch_manager.get_shard_layout(last_certified.epoch_id())?;
+        let state_roots: Vec<CryptoHash> = shard_layout
+            .shard_ids()
+            .map(|shard_id| *results.0[&shard_id].chunk_extra.state_root())
+            .collect();
+        Ok(Some(merklize(&state_roots).0))
     }
 
     pub fn core_statements_for_next_block(

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -20,6 +20,7 @@ use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::merklize;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::ShardChunkHeader;
@@ -157,6 +158,37 @@ fn test_get_block_execution_results_with_all_execution_results_present() {
         assert!(execution_results.0.contains_key(&chunk_header.shard_id()));
     }
     assert_eq!(execution_results.0.len(), chunks.len());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_last_certified_state_root_when_execution_results_column_is_behind() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+
+    // B2 certifies B1 by carrying its endorsements and execution results in its body.
+    // We never run the core writer actor, so the `execution_results` column stays empty,
+    // simulating the asynchronous writer lagging behind certification.
+    let b2 = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, b2.clone());
+
+    assert!(core_reader.get_block_execution_results(b1.header()).unwrap().is_none());
+
+    let epoch_id = chain.epoch_manager.get_epoch_id(b1.hash()).unwrap();
+    let shard_layout = chain.epoch_manager.get_shard_layout(&epoch_id).unwrap();
+    let results = block_execution_results(&b1).0;
+    let state_roots: Vec<CryptoHash> = shard_layout
+        .shard_ids()
+        .map(|shard_id| *results[&shard_id].chunk_extra.state_root())
+        .collect();
+    let expected = merklize(&state_roots).0;
+
+    let root = core_reader.last_certified_state_root(b2.hash()).unwrap();
+    assert_eq!(root, Some(expected));
+    assert_ne!(root, Some(CryptoHash::default()));
 }
 
 #[test]

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -193,6 +193,48 @@ fn test_last_certified_state_root_when_execution_results_column_is_behind() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_last_certified_state_root_when_execution_results_column_is_partially_written() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+
+    let b2 = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, b2.clone());
+
+    // Write the column for a single shard with a distinct state root; the other shards stay
+    // unwritten and must be recovered from B2's body. The column value must win for the shard
+    // it covers, exercising the merge of the fast and slow paths.
+    let column_shard = ShardId::new(0);
+    let column_state_root = CryptoHash::hash_bytes(b"column-only-state-root");
+    let column_result = ChunkExecutionResult {
+        chunk_extra: ChunkExtra::new_with_only_state_root(&column_state_root),
+        outgoing_receipts_root: CryptoHash::default(),
+    };
+    save_execution_result_for_block(&chain, &b1, column_shard, column_result);
+
+    let epoch_id = chain.epoch_manager.get_epoch_id(b1.hash()).unwrap();
+    let shard_layout = chain.epoch_manager.get_shard_layout(&epoch_id).unwrap();
+    let walk_results = block_execution_results(&b1).0;
+    let state_roots: Vec<CryptoHash> = shard_layout
+        .shard_ids()
+        .map(|shard_id| {
+            if shard_id == column_shard {
+                column_state_root
+            } else {
+                *walk_results[&shard_id].chunk_extra.state_root()
+            }
+        })
+        .collect();
+    let expected = merklize(&state_roots).0;
+
+    let root = core_reader.last_certified_state_root(b2.hash()).unwrap();
+    assert_eq!(root, Some(expected));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_all_execution_results_exist_when_all_exist() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -783,7 +783,22 @@ impl Handler<SpanWrapped<Status>, Result<StatusResponse, StatusError>> for Clien
         let head_header =
             self.spice_chain_reader.find_first_executed_ancestor(&head.last_block_hash)?;
         let latest_block_time = head_header.raw_timestamp();
-        let latest_state_root = *head_header.prev_state_root();
+        let head_protocol_version = self
+            .client
+            .epoch_manager
+            .get_epoch_protocol_version(head_header.epoch_id())
+            .into_chain_error()?;
+        let latest_state_root = if ProtocolFeature::Spice.enabled(head_protocol_version) {
+            // Spice block headers carry a placeholder state root since execution is
+            // decoupled from consensus. Report the last certified state instead.
+            self.client
+                .chain
+                .spice_core_reader
+                .last_certified_state_root(head_header.hash())?
+                .unwrap_or_default()
+        } else {
+            *head_header.prev_state_root()
+        };
         if msg.is_health_check {
             let now = self.clock.now_utc();
             let block_timestamp =

--- a/integration-tests/src/tests/standard_cases/rpc.rs
+++ b/integration-tests/src/tests/standard_cases/rpc.rs
@@ -80,29 +80,21 @@ fn ultra_slow_test_smart_contract_bad_method_name_testnet() {
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_smart_contract_empty_method_name_with_no_tokens_testnet() {
     run_testnet_test!(test_smart_contract_empty_method_name_with_no_tokens);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_smart_contract_empty_method_name_with_tokens_testnet() {
     run_testnet_test!(test_smart_contract_empty_method_name_with_tokens);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_smart_contract_with_args_testnet() {
     run_testnet_test!(test_smart_contract_with_args);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_nonce_update_when_deploying_contract_testnet() {
     run_testnet_test!(test_nonce_update_when_deploying_contract);
 }
@@ -118,22 +110,16 @@ fn slow_test_regression_nonce_update_with_mixed_transactions_testnet() {
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_upload_contract_testnet() {
     run_testnet_test!(test_upload_contract);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_redeploy_contract_testnet() {
     run_testnet_test!(test_redeploy_contract);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_send_money_testnet() {
     run_testnet_test!(test_send_money);
 }
@@ -149,99 +135,71 @@ fn slow_test_send_money_over_balance_testnet() {
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_refund_on_send_money_to_non_existent_account_testnet() {
     run_testnet_test!(test_refund_on_send_money_to_non_existent_account);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_create_account_testnet() {
     run_testnet_test!(test_create_account);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_create_account_again_testnet() {
     run_testnet_test!(test_create_account_again);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_create_account_failure_already_exists_testnet() {
     run_testnet_test!(test_create_account_failure_already_exists);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_swap_key_testnet() {
     run_testnet_test!(test_swap_key);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_add_access_key_function_call_testnet() {
     run_testnet_test!(test_add_access_key_function_call);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_add_existing_key_testnet() {
     run_testnet_test!(test_add_existing_key);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_delete_key_testnet() {
     run_testnet_test!(test_delete_key);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_delete_key_not_owned_testnet() {
     run_testnet_test!(test_delete_key_not_owned);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_delete_key_last_testnet() {
     run_testnet_test!(test_delete_key_last);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_add_key_testnet() {
     run_testnet_test!(test_add_key);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_delete_access_key_testnet() {
     run_testnet_test!(test_delete_access_key);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_add_access_key_with_allowance_testnet() {
     run_testnet_test!(test_add_access_key_with_allowance);
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn ultra_slow_test_delete_access_key_with_allowance_testnet() {
     run_testnet_test!(test_delete_access_key_with_allowance);
 }


### PR DESCRIPTION
## Problem

Under spice, block headers carry a placeholder `prev_state_root` (`CryptoHash::default()`) because execution is decoupled from consensus (`core/primitives/src/block.rs`). The node status RPC derives `latest_state_root` from `head_header.prev_state_root()`, so `get_state_root()` always returned the all-zeros hash. Tests in `standard_cases` that assert the state root changes after a transaction (`assert_ne!(root, new_root)`) therefore failed under spice.

## Fix

Add `SpiceCoreReader::last_certified_state_root()`, which walks to the last certified block, reads its `BlockExecutionResults`, and merklizes the per-shard `chunk_extra.state_root()` (mirroring the non-spice `Chunks::compute_state_root`). The status handler reports this value under spice instead of the header placeholder.

## Tests

Re-enables 21 of the previously spice-ignored tests in `integration-tests/src/tests/standard_cases/rpc.rs`. Four smart-contract function-call tests remain ignored pending a separate fix (stacked follow-up) and are marked with a TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
