### PR TITLE
feat(store): improve diagnostics when a RocksDB instance fails to open

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -143,7 +143,7 @@ pub enum MigrationSnapshot {
 }
 
 /// Mode in which to open the storage.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum Mode {
     /// Open an existing database in read-only mode.  Fail if it doesn’t exist.
     ReadOnly,

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -125,9 +125,12 @@ impl RocksDB {
         let cache = guard
             .entry(path.to_path_buf())
             .or_insert_with(|| Arc::new(deserialized_column::Cache::enabled()));
-        let counter = instance_tracker::InstanceTracker::try_new(store_config.max_open_files)
+        let mut counter = instance_tracker::InstanceTracker::try_new(store_config.max_open_files)
             .map_err(io::Error::other)?;
         let (db, db_opt) = Self::open_db(path, store_config, mode, temp, columns)?;
+        // Reaching here means the open succeeded, so log it. On failure the `?`
+        // above returns early and drops `counter` without logging open or close.
+        counter.mark_opened();
         let cf_handles = Self::get_cf_handles(&db, columns);
         Ok(Self { db, db_opt, cf_handles, _instance_tracker: counter, cache: Arc::clone(cache) })
     }
@@ -147,7 +150,15 @@ impl RocksDB {
         } else {
             DB::open_cf_descriptors(&options, path, cfs)
         }
-        .map_err(io::Error::other)?;
+        .map_err(|error| {
+            // RocksDB only surfaces a terse low level error here (e.g.
+            // `While reading file sequentially: <dir>/: Is a directory`). Log the
+            // CURRENT/MANIFEST pointers before returning, since a failed start is
+            // often rolled back to an older binary whose successful open rewrites
+            // them and heals whatever tripped us up.
+            log_rocksdb_open_failure(path, mode, &error);
+            io::Error::other(error)
+        })?;
         if cfg!(feature = "single_thread_rocksdb") {
             // These have to be set after open db
             let mut env = Env::new().unwrap();
@@ -554,6 +565,36 @@ impl Database for RocksDB {
             .ingest_external_file_cf_opts(&cf, &opts, paths.to_vec())
             .with_context(|| format!("failed to ingest SST files into {col:?}"))
     }
+}
+
+/// Logs the `CURRENT` pointer and the `MANIFEST` it references after
+/// [`RocksDB::open_db`] fails to open the instance.
+///
+/// RocksDB's own error is a terse low level IO error (for example
+/// `While reading file sequentially: <dir>/: Is a directory`) that doesn't say
+/// what is broken on disk, and a failed start is often rolled back to an older
+/// binary whose successful open rewrites `CURRENT`/`MANIFEST` - healing the bad
+/// state before anyone can inspect it. `CURRENT` is a tiny file naming the live
+/// manifest, so reading it (and stat-ing that manifest) is cheap regardless of
+/// database size and is the usual explanation for a failed open.
+fn log_rocksdb_open_failure(path: &Path, mode: Mode, error: &::rocksdb::Error) {
+    let current = std::fs::read_to_string(path.join("CURRENT"));
+    let manifest = current.as_ref().ok().map(|content| {
+        let name = content.trim_end_matches('\n');
+        match std::fs::metadata(path.join(name)) {
+            Ok(meta) => format!("{name:?} (len={}, is_file={})", meta.len(), meta.is_file()),
+            Err(err) => format!("{name:?} (unreadable: {err})"),
+        }
+    });
+    tracing::error!(
+        target: "db",
+        path = %path.display(),
+        ?mode,
+        %error,
+        current = ?current,
+        ?manifest,
+        "failed to open rocksdb instance",
+    );
 }
 
 fn cf_descriptors(

--- a/core/store/src/db/rocksdb/instance_tracker.rs
+++ b/core/store/src/db/rocksdb/instance_tracker.rs
@@ -44,25 +44,32 @@ impl State {
         Self { inner: Mutex::new(inner), zero_cvar: Condvar::new() }
     }
 
-    /// Registers a new RocksDB instance and checks if limits are enough for
-    /// given max_open_files configuration option.
+    /// Reserves capacity for a new RocksDB instance and checks if limits are
+    /// enough for given max_open_files configuration option.
     ///
     /// Returns an error if process’ resource limits are too low to allow
     /// max_open_files open file descriptors for the new database instance.
-    fn try_new_instance(&self, max_open_files: u32) -> Result<(), String> {
-        let num_instances = {
-            let mut inner = self.inner.lock();
-            let max_open_files = inner.max_open_files + u64::from(max_open_files);
-            ensure_max_open_files_limit(RealNoFile, max_open_files)?;
-            inner.max_open_files = max_open_files;
-            inner.count += 1;
-            inner.count
-        };
-        tracing::info!(target: "db", num_instances, "opened a new rocksdb instance");
+    ///
+    /// This intentionally does not log.  The "opened a new rocksdb instance"
+    /// message is emitted separately via [`Self::log_opened`] once the RocksDB
+    /// open actually succeeds, so that a failed open (which reserves then
+    /// immediately releases) doesn't produce a misleading "opened"/"closed" pair.
+    fn reserve_instance(&self, max_open_files: u32) -> Result<(), String> {
+        let mut inner = self.inner.lock();
+        let max_open_files = inner.max_open_files + u64::from(max_open_files);
+        ensure_max_open_files_limit(RealNoFile, max_open_files)?;
+        inner.max_open_files = max_open_files;
+        inner.count += 1;
         Ok(())
     }
 
-    fn close_instance(&self, max_open_files: u32) {
+    /// Logs that a reserved instance has finished opening successfully.
+    fn log_opened(&self) {
+        let num_instances = self.inner.lock().count;
+        tracing::info!(target: "db", num_instances, "opened a new rocksdb instance");
+    }
+
+    fn close_instance(&self, max_open_files: u32, opened: bool) {
         let num_instances = {
             let mut inner = self.inner.lock();
             inner.max_open_files = inner.max_open_files.saturating_sub(max_open_files.into());
@@ -72,7 +79,11 @@ impl State {
             }
             inner.count
         };
-        tracing::info!(target: "db", num_instances, "closed a rocksdb instance");
+        // Only announce the close for instances whose open we announced, so a
+        // failed open (reserved then dropped) stays silent on both sides.
+        if opened {
+            tracing::info!(target: "db", num_instances, "closed a rocksdb instance");
+        }
     }
 
     /// Blocks until all RocksDB instances (usually 0 or 1) shut down.
@@ -103,11 +114,16 @@ pub(super) fn block_until_all_instances_are_closed() {
 pub(super) struct InstanceTracker {
     /// max_open_files configuration of given RocksDB instance.
     max_open_files: u32,
+
+    /// Whether the RocksDB open succeeded.  Open and close are only logged for
+    /// instances that actually opened, so a failed open doesn't emit a
+    /// misleading "opened"/"closed" pair.
+    opened: bool,
 }
 
 impl InstanceTracker {
-    /// Registers a new RocksDB instance and checks if limits are enough for
-    /// given max_open_files configuration option.
+    /// Reserves capacity for a new RocksDB instance and checks if limits are
+    /// enough for given max_open_files configuration option.
     ///
     /// Returns an error if process’ resource limits are too low to allow
     /// max_open_files open file descriptors for the new database instance.  On
@@ -115,22 +131,27 @@ impl InstanceTracker {
     /// that creating more instances will take into account the sum of all the
     /// max_open_files options.
     ///
-    /// The instance is unregistered once this object is dropped.
+    /// Call [`Self::mark_opened`] once the RocksDB open succeeds so the instance
+    /// is logged.  The reservation is released once this object is dropped.
     pub(super) fn try_new(max_open_files: u32) -> Result<Self, String> {
-        STATE.try_new_instance(max_open_files)?;
-        Ok(Self { max_open_files })
+        STATE.reserve_instance(max_open_files)?;
+        Ok(Self { max_open_files, opened: false })
+    }
+
+    /// Marks the instance as successfully opened and logs it.  Call once the
+    /// RocksDB open returns successfully.
+    pub(super) fn mark_opened(&mut self) {
+        self.opened = true;
+        STATE.log_opened();
     }
 }
 
 impl Drop for InstanceTracker {
     /// Deregisters a RocksDB instance and frees its reserved NOFILE limit.
     ///
-    /// Returns an error if process’ resource limits are too low to allow
-    /// max_open_files open file descriptors for the new database instance.
-    ///
     /// The instance is unregistered once this object is dropped.
     fn drop(&mut self) {
-        STATE.close_instance(self.max_open_files);
+        STATE.close_instance(self.max_open_files, self.opened);
     }
 }
 

--- a/core/store/src/node_storage/opener.rs
+++ b/core/store/src/node_storage/opener.rs
@@ -441,6 +441,7 @@ impl<'a> StoreOpener<'a> {
 
     // Creates the DB if it doesn't exist.
     fn ensure_created(mode: Mode, opener: &DBOpener) -> Result<(), StoreOpenerError> {
+        tracing::debug!(target: "db_opener", path=%opener.path.display(), ?mode, "reading database metadata to check existence");
         let meta = opener.get_metadata()?;
         match meta {
             Some(_) if !mode.must_create() => {


### PR DESCRIPTION
## Background

When a node fails to open its RocksDB storage at startup, neard panics with only RocksDB's raw, low-level error and no surrounding context. A 2.12.0 mainnet report ([Zulip thread](https://near.zulipchat.com/#narrow/channel/531275-releases.2F2.2E12-wasmtime/topic/2.2E12.2E0.20mainnet.20release.20issues/with/600114903)) showed how unhelpful this is: a validator crash-looped with

```
IO error: While reading file sequentially: /home/near/mainnet/data/: Is a directory
```

and we could not determine the root cause. The logs showed storage being opened, an instance being opened and immediately closed, and then a panic — with no indication of *which* step failed or what state the data directory was actually in. By the time the operator shared their data directory it looked healthy, because they had already rolled back to an older binary whose successful open rewrote the on-disk metadata (`CURRENT`/`MANIFEST`) and healed whatever had tripped up the newer binary. The evidence we needed was already gone.

The investigation concluded this was an environment / on-disk-state problem on a single node, not a code regression — but we had no way to confirm the on-disk state at the time of failure. This PR closes that gap and removes a log line that actively misled the investigation.

## What this changes

**1. Capture the data directory state when a RocksDB open fails.** On a failed open, neard now logs the `CURRENT` pointer and whether the `MANIFEST` it references actually exists. These are the first bookkeeping files RocksDB reads and the usual explanation for an open failure; they are tiny, so capturing them is cheap regardless of database size. Critically, this records the state *before* a restart on another binary can heal it.

**2. Stop logging "opened a new rocksdb instance" before the open actually happens.** This message was previously emitted as soon as we reserved capacity for an instance — before RocksDB was opened. A failed open therefore logged a misleading "opened" immediately followed by "closed", implying an open had succeeded. The open/close messages are now emitted only for instances that genuinely opened.

**3. Make the existence/metadata check a distinct, visible step** so the open sequence stays legible in the logs even when an early step fails.

## Why

- **The current behavior is undebuggable after the fact.** The most useful evidence — the `CURRENT`/`MANIFEST` state at the moment of failure — is exactly what gets destroyed when an operator restarts on a working binary. Logging it at failure time is the only reliable way to capture it.
- **The misleading instance log cost us investigation time.** The "opened then closed" pair was read as "the database opened fine, then something else broke", when the open itself never succeeded. Aligning the log with reality removes that false signal.
- **No behavior change.** This is purely observability — the open path, error propagation, and file-descriptor accounting are unchanged, and the new logging only runs on the failure path.