### PR TITLE
refactor(test-loop): use TestLoopNode tx_* API in indexer tests

### DIFF
--- a/test-loop-tests/src/tests/indexer.rs
+++ b/test-loop-tests/src/tests/indexer.rs
@@ -8,7 +8,6 @@ use near_async::futures::FutureSpawnerExt;
 use near_async::time::Duration;
 use near_client::NetworkAdversarialMessage;
 use near_client::client_actor::AdvProduceChunksMode;
-use near_crypto::Signer;
 use near_indexer::{
     AwaitForNodeSyncedEnum, IndexerConfig, IndexerExecutionOutcomeWithReceipt, StreamerMessage,
     SyncModeEnum, start,
@@ -16,14 +15,12 @@ use near_indexer::{
 use near_o11y::testonly::init_test_logger;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
-use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
-use near_primitives::types::{AccountId, Balance, Finality, Nonce, NumBlocks};
+use near_primitives::types::{AccountId, Balance, Finality, NumBlocks};
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::{ActionView, ExecutionStatusView, ReceiptEnumView, ReceiptView};
 use near_store::StoreConfig;
 use std::iter::repeat_with;
-use std::sync::atomic::AtomicU64;
 use tokio::sync::mpsc;
 
 #[test]
@@ -97,16 +94,13 @@ fn test_indexer_instant_receipt() {
 
     // Step 1: Call yield_create — produces a PromiseYield instant receipt that
     // gets stored/postponed as a PromiseYield receipt (awaiting data) and persisted in DBCol::Receipts.
-    let yield_create_tx = SignedTransaction::call(
-        next_nonce(),
-        user_account(),
-        user_account(),
-        &user_signer(),
-        Balance::ZERO,
-        "call_yield_create_return_promise".to_owned(),
+    let yield_create_tx = env.rpc_node().tx_call(
+        &user_account(),
+        &user_account(),
+        "call_yield_create_return_promise",
         vec![42u8; 16],
+        Balance::ZERO,
         Gas::from_teragas(300),
-        tx_block_hash(&env),
     );
     env.rpc_node().submit_tx(yield_create_tx.clone());
     let tx_outcome = env
@@ -126,16 +120,13 @@ fn test_indexer_instant_receipt() {
 
     // Step 2: Call yield_resume — provides data for the PromiseYield, causing
     // the callback to execute in a subsequent block.
-    let resume_tx = SignedTransaction::call(
-        next_nonce(),
-        user_account(),
-        user_account(),
-        &user_signer(),
-        Balance::ZERO,
-        "call_yield_resume_read_data_id_from_storage".to_owned(),
+    let resume_tx = env.rpc_node().tx_call(
+        &user_account(),
+        &user_account(),
+        "call_yield_resume_read_data_id_from_storage",
         vec![42u8; 16],
+        Balance::ZERO,
         Gas::from_teragas(300),
-        tx_block_hash(&env),
     );
     env.rpc_runner().run_tx(resume_tx, Duration::seconds(5));
 
@@ -410,57 +401,29 @@ fn receive_indexer_message(
     ret.unwrap()
 }
 
-fn next_nonce() -> Nonce {
-    static NEXT_VALUE: AtomicU64 = AtomicU64::new(1);
-    NEXT_VALUE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-}
-
-fn tx_block_hash(env: &TestLoopEnv) -> CryptoHash {
-    let idx = env.rpc_data_idx();
-    let node_data = &env.node_datas[idx];
-    let client = &env.test_loop.data.get(&node_data.client_sender.actor_handle()).client;
-    client.chain.head().unwrap().last_block_hash
-}
-
-fn user_signer() -> Signer {
-    create_user_test_signer(&user_account())
-}
-
 fn create_local_tx(env: &TestLoopEnv) -> SignedTransaction {
-    SignedTransaction::call(
-        next_nonce(),
-        user_account(),
-        user_account(),
-        &user_signer(),
-        Balance::ZERO,
-        "does_not_matter".to_owned(),
+    env.rpc_node().tx_call(
+        &user_account(),
+        &user_account(),
+        "does_not_matter",
         vec![],
+        Balance::ZERO,
         Gas::from_teragas(100),
-        tx_block_hash(env),
     )
 }
 
 fn create_burn_gas_tx(env: &TestLoopEnv, gas_to_burn: Gas) -> SignedTransaction {
-    SignedTransaction::call(
-        next_nonce(),
-        user_account(),
-        user_account(),
-        &user_signer(),
-        Balance::ZERO,
-        "burn_gas_raw".to_owned(),
+    env.rpc_node().tx_call(
+        &user_account(),
+        &user_account(),
+        "burn_gas_raw",
         gas_to_burn.as_gas().to_le_bytes().to_vec(),
+        Balance::ZERO,
         GAS_LIMIT,
-        tx_block_hash(env),
     )
 }
 
 fn deploy_test_contract(env: &mut TestLoopEnv) {
-    let tx = SignedTransaction::deploy_contract(
-        next_nonce(),
-        &user_account(),
-        near_test_contracts::rs_contract().to_vec(),
-        &user_signer(),
-        tx_block_hash(env),
-    );
+    let tx = env.rpc_node().tx_deploy_test_contract(&user_account());
     env.rpc_runner().run_tx(tx, Duration::seconds(3));
 }


### PR DESCRIPTION
Simplify transaction construction in `tests/indexer.rs` by using the higher-level `tx_*` helpers on `TestLoopNode` (`tx_call`, `tx_deploy_test_contract`), which handle nonce, signer, and block hash automatically. Removes the `next_nonce` / `user_signer` / `tx_block_hash` boilerplate.