### PR TITLE
fix(primitives): add #[repr(u8)] to TxExecutionStatus

### DIFF
--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -2056,6 +2056,7 @@ pub struct TxStatusView {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[borsh(use_discriminant = true)]
+#[repr(u8)]
 pub enum TxExecutionStatus {
     /// Transaction is waiting to be included into the block
     None = 0,


### PR DESCRIPTION
All other Borsh-serialized enums in `core/primitives/src/views.rs` pair `#[borsh(use_discriminant = true)]` with `#[repr(u8)]`. `TxExecutionStatus` was the only one missing the repr attribute. Adding it pins the discriminant to a single byte (matching Borsh's wire format) and makes the compiler reject out-of-range discriminants. The wire format itself is unchanged, so this is backward compatible.