### PR TITLE
feat(cloud-archive): classify retained columns, reframe per-column GC policy

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -22,7 +22,7 @@ use near_primitives::utils::{
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::adapter::trie_store::maybe_get_shard_uid_mapping;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
-use near_store::{DBCol, GcMethod, KeyForStateChanges, ShardTries, ShardUId};
+use near_store::{DBCol, GcPolicy, KeyForStateChanges, ShardTries, ShardUId};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
@@ -1038,23 +1038,17 @@ impl<'a> ChainStoreUpdate<'a> {
 
     fn gc_col(&mut self, col: DBCol, key: &[u8]) {
         let mut store_update = self.store().store_update();
-        // Dispatch on the per-column GC method. Columns with a dedicated GC
-        // path, and columns that are never GC-ed, must not reach this generic
-        // path.
-        match col.gc_method() {
-            GcMethod::Delete => {
+        // Dispatch on the per-column GC policy. `Permanent` and `Other` columns
+        // are never collected through this generic path.
+        match col.gc_policy() {
+            GcPolicy::Delete => {
                 store_update.delete(col, key);
             }
-            GcMethod::DecrementRefcount => {
+            GcPolicy::DecrementRefcount => {
                 store_update.decrement_refcount(col, key);
             }
-            GcMethod::Dedicated => {
-                panic!(
-                    "{col:?} is garbage collected by a dedicated method or subsystem, not gc_col"
-                );
-            }
-            GcMethod::NotGced => {
-                unreachable!("gc_col called on non-GC column {col:?}");
+            GcPolicy::Permanent | GcPolicy::Other => {
+                unreachable!("gc_col called on a column it does not collect: {col:?}");
             }
         }
         self.merge(store_update);

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use crate::DBCol;
 use crate::archive::cloud_storage::batch::compute_batch_id;
 pub use crate::archive::cloud_storage::batch::{BatchId, BatchRange, compute_next_batch};

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -143,7 +143,8 @@ fn block_on_future<F: Future>(fut: F) -> F::Output {
 }
 
 /// Columns the cloud-archive reader reproduces from cloud data.
-pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
+#[cfg(test)]
+fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
     matches!(
         col,
         // From BlockData.
@@ -183,7 +184,8 @@ pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
 }
 
 /// Columns the cloud-archive reader does not reproduce.
-pub fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
+#[cfg(test)]
+fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
     // TODO(spice): decide how the reader handles spice columns.
     #[cfg(feature = "protocol_feature_spice")]
     if col == DBCol::ReceiptProofs {

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -153,9 +153,9 @@ pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
             // Reconstructed from BlockData.
             | DBCol::BlockHeader
             | DBCol::BlockHeight
-            // TODO(cloud-archival): reconstruct from BlockHeight in the reader.
+            // TODO(cloud_archival): reconstruct from BlockHeight in the reader.
             | DBCol::BlockPerHeight
-            // TODO(cloud-archival): reconstruct from Block in the reader.
+            // TODO(cloud_archival): reconstruct from Block in the reader.
             | DBCol::ChunkHashesByHeight
 
             // From ShardData.
@@ -191,13 +191,16 @@ pub fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
     }
     matches!(
         col,
-        // State-sync header, used only transiently for State bootstrap, not persisted.
-        DBCol::StateHeaders
+        // DB-level metadata; the reader maintains its own.
+        DBCol::DbVersion
+            | DBCol::BlockMisc
+            // State-sync header, used only transiently for State bootstrap, not persisted.
+            | DBCol::StateHeaders
             // Resharding bookkeeping; the reader bootstraps State from per-epoch snapshots instead.
             | DBCol::StateChangesForSplitStates
             | DBCol::StateShardUIdMapping
 
-            // TODO(cloud-archival): the reader may need the following for validator /
+            // TODO(cloud_archival): the reader may need the following for validator /
             // light-client / block-ordinal / epoch-sync queries; confirm, and reproduce if so.
             | DBCol::BlockOrdinal
             | DBCol::EpochLightClientBlocks
@@ -220,13 +223,13 @@ mod tests {
     use strum::IntoEnumIterator;
 
     /// A cloud-bootstrapped reader must reproduce every column an archival node
-    /// keeps long-term (in the cold or hot database). Each such column must be in
-    /// exactly one of the two predicates above, so a new one fails this test until
-    /// a cloud-archive decision is made.
+    /// keeps long-term, i.e. `is_in_colddb() || gc_policy() == GcPolicy::Permanent`.
+    /// Each such column must be in exactly one of the two predicates above, so a new
+    /// one fails this test until a cloud-archive decision is made.
     #[test]
     fn every_retained_column_is_classified_for_cloud_archive() {
         for col in DBCol::iter() {
-            let retained = col.is_cold() || matches!(col.gc_policy(), GcPolicy::Permanent);
+            let retained = col.is_in_colddb() || matches!(col.gc_policy(), GcPolicy::Permanent);
             if !retained {
                 continue;
             }

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -1,3 +1,4 @@
+use crate::DBCol;
 use crate::archive::cloud_storage::batch::compute_batch_id;
 pub use crate::archive::cloud_storage::batch::{BatchId, BatchRange, compute_next_batch};
 pub use crate::archive::cloud_storage::blocks::{BlockBatch, BlockData};
@@ -141,71 +142,101 @@ fn block_on_future<F: Future>(fut: F) -> F::Output {
     futures::executor::block_on(fut)
 }
 
+/// Columns the cloud-archive reader reproduces from cloud data.
+pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
+    matches!(
+        col,
+        // From BlockData.
+        DBCol::Block
+            | DBCol::BlockInfo
+            | DBCol::NextBlockHashes
+            // Reconstructed from BlockData.
+            | DBCol::BlockHeader
+            | DBCol::BlockHeight
+            // TODO(cloud-archival): reconstruct from BlockHeight in the reader.
+            | DBCol::BlockPerHeight
+            // TODO(cloud-archival): reconstruct from Block in the reader.
+            | DBCol::ChunkHashesByHeight
+
+            // From ShardData.
+            | DBCol::Chunks
+            | DBCol::OutcomeIds
+            | DBCol::TransactionResultForBlock
+            | DBCol::ReceiptToTx
+            | DBCol::IncomingReceipts
+            | DBCol::OutgoingReceipts
+            | DBCol::ChunkExtra
+            | DBCol::ChunkApplyStats
+            | DBCol::StateChanges
+            // Reconstructed from ShardData.
+            | DBCol::Receipts
+            | DBCol::Transactions
+
+            // From EpochData.
+            | DBCol::EpochInfo
+            | DBCol::EpochStart
+            | DBCol::BlockMerkleTree
+
+            // From a state snapshot.
+            | DBCol::State
+    )
+}
+
+/// Columns the cloud-archive reader does not reproduce.
+pub fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
+    // TODO(spice): decide how the reader handles spice columns.
+    #[cfg(feature = "protocol_feature_spice")]
+    if col == DBCol::ReceiptProofs {
+        return true;
+    }
+    matches!(
+        col,
+        // State-sync header, used only transiently for State bootstrap, not persisted.
+        DBCol::StateHeaders
+            // Resharding bookkeeping; the reader bootstraps State from per-epoch snapshots instead.
+            | DBCol::StateChangesForSplitStates
+            | DBCol::StateShardUIdMapping
+
+            // TODO(cloud-archival): the reader may need the following for validator /
+            // light-client / block-ordinal / epoch-sync queries; confirm, and reproduce if so.
+            | DBCol::BlockOrdinal
+            | DBCol::EpochLightClientBlocks
+            | DBCol::EpochSyncProof
+            | DBCol::EpochValidatorInfo
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::CloudStorage;
     use super::batch::BatchId;
     use super::file_id::CloudStorageFileID;
-    use crate::DBCol;
     use crate::archive::cloud_storage::bucket_config::BucketConfig;
+    use crate::archive::cloud_storage::{
+        is_cloud_archive_reader_bootstrapped, is_cloud_archive_reader_skipped,
+    };
+    use crate::{DBCol, GcPolicy};
     use near_external_storage::ExternalConnection;
     use strum::IntoEnumIterator;
 
-    /// Cold columns whose data is carried by per-block-height batch blobs in cloud
-    /// archive, either as a direct field of `BlockData` / `ShardData` or extracted
-    /// from one of those at read time.
-    const CLOUD_BATCH_COLUMNS: &[DBCol] = &[
-        // Carried by BlockData (one entry per block).
-        DBCol::Block,
-        DBCol::BlockHeader,
-        DBCol::BlockInfo,
-        DBCol::NextBlockHashes,
-        // Carried by ShardData (one entry per (block, shard)).
-        DBCol::Chunks,
-        DBCol::Transactions,
-        DBCol::Receipts,
-        DBCol::OutcomeIds,
-        DBCol::TransactionResultForBlock,
-        DBCol::ReceiptToTx,
-        DBCol::IncomingReceipts,
-        DBCol::OutgoingReceipts,
-        DBCol::ChunkExtra,
-        DBCol::ChunkApplyStats,
-        DBCol::StateChanges,
-    ];
-
-    /// Cold columns intentionally not carried by batch blobs.
-    const CLOUD_NON_BATCH_COLUMNS: &[DBCol] = &[
-        // TODO(cloud_archival): reconstruct from BlockHeight in the reader.
-        DBCol::BlockPerHeight,
-        // TODO(cloud_archival): reconstruct from Block in the reader.
-        DBCol::ChunkHashesByHeight,
-        // Per-epoch state snapshots cover state, not per-block deltas.
-        DBCol::State,
-        // Per-epoch state snapshots cover the shard-layout mapping that keys state.
-        DBCol::StateShardUIdMapping,
-        // Uploaded as a separate StateHeader file per (epoch_height, shard_id).
-        DBCol::StateHeaders,
-        // Not GC-ed; cloud archive only handles GC-ed data.
-        DBCol::StateChangesForSplitStates,
-        // Spice cold columns - cloud-archive integration is a separate task.
-        #[cfg(feature = "protocol_feature_spice")]
-        DBCol::ReceiptProofs,
-    ];
-
-    /// Every cold column must be classified as either batch-carried or
-    /// intentionally non-batch. A new cold column fails this test until
-    /// classified with a rationale.
+    /// A cloud-bootstrapped reader must reproduce every column an archival node
+    /// keeps long-term (in the cold or hot database). Each such column must be in
+    /// exactly one of the two predicates above, so a new one fails this test until
+    /// a cloud-archive decision is made.
     #[test]
-    fn every_cold_column_is_classified_for_cloud_archive() {
+    fn every_retained_column_is_classified_for_cloud_archive() {
         for col in DBCol::iter() {
-            if !col.is_cold() {
+            let retained = col.is_cold() || matches!(col.gc_policy(), GcPolicy::Permanent);
+            if !retained {
                 continue;
             }
-            assert!(
-                CLOUD_BATCH_COLUMNS.contains(&col) ^ CLOUD_NON_BATCH_COLUMNS.contains(&col),
-                "cold column {col:?} must be classified as batch or non-batch \
-                 (with a rationale)"
+            let categories =
+                [is_cloud_archive_reader_bootstrapped(col), is_cloud_archive_reader_skipped(col)];
+            assert_eq!(
+                categories.iter().filter(|x| **x).count(),
+                1,
+                "retained column {col:?} must be in exactly one of \
+                 is_cloud_archive_reader_bootstrapped / is_cloud_archive_reader_skipped",
             );
         }
     }

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -439,17 +439,19 @@ pub enum DBKeyType {
     ChunkExecutionResultHash,
 }
 
-/// The way garbage collection handles a column.
+/// Garbage-collection policy of a column.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-pub enum GcMethod {
-    /// GC deletes the key.
+pub enum GcPolicy {
+    /// Deletes the key.
     Delete,
-    /// GC decrements the key's refcount.
+    /// Decrements the key's refcount.
     DecrementRefcount,
-    /// Garbage-collected by a dedicated method or its own subsystem.
-    Dedicated,
-    /// Not garbage-collected; kept for the node's lifetime.
-    NotGced,
+    /// Never collected; kept for the node's lifetime as canonical chain data.
+    Permanent,
+    /// Neither generically collected nor permanent: either collected through a
+    /// dedicated path (e.g. state, flat storage), or node-local / operational /
+    /// legacy data (networking, caches, deprecated).
+    Other,
 }
 
 impl DBCol {
@@ -656,8 +658,8 @@ impl DBCol {
         }
     }
 
-    /// This column's GC method, which garbage collection dispatches on.
-    pub const fn gc_method(&self) -> GcMethod {
+    /// This column's garbage-collection policy.
+    pub const fn gc_policy(&self) -> GcPolicy {
         match self {
             DBCol::Block
             | DBCol::BlockHeader
@@ -690,7 +692,7 @@ impl DBCol {
             | DBCol::StateSyncNewChunks
             | DBCol::StateTransitionData
             | DBCol::TransactionResultForBlock
-            | DBCol::TrieChanges => GcMethod::Delete,
+            | DBCol::TrieChanges => GcPolicy::Delete,
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::AllNextBlockHashes
             | DBCol::ContractAccesses
@@ -699,57 +701,56 @@ impl DBCol {
             | DBCol::ReceiptProofs
             | DBCol::UncertifiedChunks
             | DBCol::UncertifiedExecutionResults
-            | DBCol::Witnesses => GcMethod::Delete,
+            | DBCol::Witnesses => GcPolicy::Delete,
 
-            DBCol::Receipts | DBCol::Transactions => GcMethod::DecrementRefcount,
+            DBCol::Receipts | DBCol::Transactions => GcPolicy::DecrementRefcount,
 
-            DBCol::BlockPerHeight  // gc_col_block_per_height
-            | DBCol::FlatState  // flat storage
-            | DBCol::FlatStateChanges  // flat storage
-            | DBCol::FlatStateDeltaMetadata  // flat storage
-            | DBCol::FlatStorageStatus  // flat storage
-            | DBCol::OutgoingReceipts  // gc_outgoing_receipts
-            | DBCol::State  // gc_state
-            | DBCol::StateShardUIdMapping  // resharding
-            // Unneeded keys are removed as new ones are added.
-            | DBCol::StateSyncHashes  // state sync
-            => GcMethod::Dedicated,
-
-            DBCol::AccountAnnouncements
-            | DBCol::_BlockExtra
-            | DBCol::BlockHeight  // block sync needs it + genesis should be accessible
+            DBCol::BlockHeight  // block sync needs it + genesis should be accessible
             | DBCol::BlockMerkleTree
-            | DBCol::BlockMisc
             | DBCol::BlockOrdinal
-            | DBCol::CachedContractCode
-            | DBCol::_ChunkPerHeightShard
-            | DBCol::ComponentEdges
-            | DBCol::DbVersion
             // https://github.com/nearprotocol/nearcore/pull/2952
             | DBCol::EpochInfo
             | DBCol::EpochLightClientBlocks
             | DBCol::EpochStart
             | DBCol::EpochSyncProof
-            | DBCol::EpochValidatorInfo
+            | DBCol::EpochValidatorInfo => GcPolicy::Permanent,
+
+            DBCol::AccountAnnouncements
+            | DBCol::_BlockExtra
+            | DBCol::BlockMisc
+            | DBCol::BlockPerHeight  // gc_col_block_per_height
+            | DBCol::CachedContractCode
+            | DBCol::_ChunkPerHeightShard
+            | DBCol::ComponentEdges
+            | DBCol::DbVersion
+            | DBCol::FlatState
+            | DBCol::FlatStateChanges
+            | DBCol::FlatStateDeltaMetadata
+            | DBCol::FlatStorageStatus
             | DBCol::_GCCount
             | DBCol::_LastBlockWithNewChunk
             | DBCol::LastComponentNonce
             | DBCol::Misc
             | DBCol::_NextBlockWithNewChunk
+            | DBCol::OutgoingReceipts  // gc_outgoing_receipts
             | DBCol::PeerComponent
             | DBCol::_Peers
             | DBCol::_ReceiptIdToShardId
             | DBCol::RecentOutboundConnections
+            | DBCol::State
             | DBCol::StateChangesForSplitStates
+            | DBCol::StateShardUIdMapping
+            // Unneeded keys are removed as new ones are added.
+            | DBCol::StateSyncHashes
             | DBCol::_TransactionRefCount
-            | DBCol::_TransactionResult => GcMethod::NotGced,
+            | DBCol::_TransactionResult => GcPolicy::Other,
             // ChunkProducers is not garbage collected. Once dynamic chunk producer
             // sampling ships, historical assignments cannot be recomputed.
             // TODO(early-kickout): before moving to stable, add a GC strategy
             // (e.g. retain only canonical-chain entries or entries within a sliding window)
             // to prevent unbounded disk growth on long-running nodes.
             #[cfg(feature = "nightly")]
-            DBCol::ChunkProducers => GcMethod::NotGced,
+            DBCol::ChunkProducers => GcPolicy::Other,
         }
     }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -1,4 +1,4 @@
-pub use crate::columns::{DBCol, GcMethod};
+pub use crate::columns::{DBCol, GcPolicy};
 pub use crate::config::{Mode, StoreConfig};
 pub use crate::db::{
     CHUNK_TAIL_KEY, COLD_HEAD_KEY, FINAL_HEAD_KEY, FORK_TAIL_KEY, GENESIS_STATE_ROOTS_KEY,


### PR DESCRIPTION
Reframes the per-column GC classifier and uses it to enumerate the columns a cloud-bootstrapped reader must reproduce.

## `GcPolicy` (`columns.rs`)

Renames `GcMethod` to `GcPolicy` and reframes its variants into `{ Delete, DecrementRefcount, Permanent, Other }`:

- `Delete` / `DecrementRefcount`: what the generic `gc_col` dispatches on.
- `Permanent`: never collected; kept for the node's lifetime as canonical chain data.
- `Other`: neither generically collected nor permanent. Collected through a dedicated path (state, flat storage), or node-local / operational / legacy (networking, caches, deprecated).

`gc_col` dispatches `Delete` / `DecrementRefcount` and is `unreachable!()` for `Permanent` / `Other`. GC behavior is unchanged.

## Cloud-archive column classification (`cloud_storage/mod.rs`)

A cloud reader has to reproduce every column an archival node retains long-term (cold cols + `GcPolicy::Permanent` hot cols). Two predicates split that set:

- `is_cloud_archive_reader_bootstrapped`: reader writes the column itself, either verbatim from a cloud file or reconstructed.
- `is_cloud_archive_reader_skipped`: reader doesn't reproduce it; handled outside the per-column bootstrap (state snapshot / header), or not yet handled (TODO).

A unit test enforces exactly-one classification, so any new retained column forces a decision.