### PR TITLE
fix(mirror): graceful shutdown and fork-network shard layout fix

### DIFF
--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -147,7 +147,15 @@ impl Indexer {
         indexer_config: &IndexerConfig,
         near_config: NearConfig,
     ) -> impl Future<Output = anyhow::Result<NearNode>> {
-        nearcore::start_with_config(&indexer_config.home_dir, near_config, ActorSystem::new())
+        Self::start_near_node_in(indexer_config, near_config, ActorSystem::new())
+    }
+
+    pub fn start_near_node_in(
+        indexer_config: &IndexerConfig,
+        near_config: NearConfig,
+        actor_system: ActorSystem,
+    ) -> impl Future<Output = anyhow::Result<NearNode>> {
+        nearcore::start_with_config(&indexer_config.home_dir, near_config, actor_system)
     }
 
     pub fn from_near_node(

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -131,7 +131,7 @@ impl Indexer {
         let near_config =
             indexer_config.load_near_config().context("failed to load near config")?;
         let nearcore::NearNode { client, view_client, shard_tracker, .. } =
-            Self::start_near_node(&indexer_config, near_config.clone())
+            Self::start_near_node(&indexer_config, near_config.clone(), ActorSystem::new())
                 .await
                 .context("failed to start near node as part of indexer")?;
         Ok(Self {
@@ -144,13 +144,6 @@ impl Indexer {
     }
 
     pub fn start_near_node(
-        indexer_config: &IndexerConfig,
-        near_config: NearConfig,
-    ) -> impl Future<Output = anyhow::Result<NearNode>> {
-        Self::start_near_node_in(indexer_config, near_config, ActorSystem::new())
-    }
-
-    pub fn start_near_node_in(
         indexer_config: &IndexerConfig,
         near_config: NearConfig,
         actor_system: ActorSystem,

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -932,10 +932,11 @@ impl ForkNetworkCommand {
                 config.num_chunk_validator_seats = *num_seats;
             }
             if let Some(shard_layout) = shard_layout_override {
-                if config.static_shard_layout().is_some() {
-                    config.shard_layout_config =
-                        ShardLayoutConfig::Static { shard_layout: shard_layout.clone() };
-                }
+                // fork-network writes a static-layout genesis, so apply the requested shard
+                // layout whether the base (mainnet) config is static or dynamic. The base is
+                // dynamic since resharding stabilized; otherwise make_and_write_genesis fails.
+                config.shard_layout_config =
+                    ShardLayoutConfig::Static { shard_layout: shard_layout.clone() };
             }
             new_epoch_configs.insert(version, Arc::new(config));
         }

--- a/tools/mirror/src/cli.rs
+++ b/tools/mirror/src/cli.rs
@@ -71,7 +71,7 @@ impl RunCmd {
             None
         };
 
-        run_async(crate::run(
+        let result = run_async(crate::run(
             self.source_home,
             self.target_home,
             self.mirror_db_path,
@@ -79,7 +79,13 @@ impl RunCmd {
             self.stop_height,
             self.online_source,
             self.config_path,
-        ))
+        ));
+        // run() aborts spawned tasks, awaits them, and calls
+        // shutdown_all_actors(). By the time we get here the tokio runtime is
+        // dropped and all Arc<DB> refs should be gone. Wait for RocksDB
+        // background threads to finish flushing.
+        near_store::db::RocksDB::block_until_all_instances_are_dropped();
+        result
     }
 }
 

--- a/tools/mirror/src/cli.rs
+++ b/tools/mirror/src/cli.rs
@@ -80,9 +80,8 @@ impl RunCmd {
             self.online_source,
             self.config_path,
         ));
-        // run() aborts spawned tasks, awaits them, and calls
-        // shutdown_all_actors(). By the time we get here the tokio runtime is
-        // dropped and all Arc<DB> refs should be gone. Wait for RocksDB
+        // run() aborts spawned tasks, awaits them, and calls actor_system.stop(). By the time we
+        // get here the tokio runtime is dropped and all Arc<DB> refs should be gone. Wait for RocksDB
         // background threads to finish flushing.
         near_store::db::RocksDB::block_until_all_instances_are_dropped();
         result

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1960,7 +1960,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let near_config =
             indexer_config.load_near_config().context("failed to load near config").unwrap();
         let near_node =
-            Indexer::start_near_node_in(&indexer_config, near_config.clone(), actor_system)
+            Indexer::start_near_node(&indexer_config, near_config.clone(), actor_system)
                 .await
                 .context("failed to start near node")
                 .unwrap();

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1948,6 +1948,7 @@ impl<T: ChainAccess> TxMirror<T> {
         accounts_to_unstake: mpsc::Sender<HashMap<(AccountId, PublicKey), AccountId>>,
         target_height: Arc<RwLock<BlockHeight>>,
         target_head: Arc<RwLock<CryptoHash>>,
+        actor_system: near_async::ActorSystem,
     ) -> anyhow::Result<()> {
         let indexer_config = near_indexer::IndexerConfig {
             home_dir,
@@ -1958,10 +1959,11 @@ impl<T: ChainAccess> TxMirror<T> {
         };
         let near_config =
             indexer_config.load_near_config().context("failed to load near config").unwrap();
-        let near_node = Indexer::start_near_node(&indexer_config, near_config.clone())
-            .await
-            .context("failed to start near node")
-            .unwrap();
+        let near_node =
+            Indexer::start_near_node_in(&indexer_config, near_config.clone(), actor_system)
+                .await
+                .context("failed to start near node")
+                .unwrap();
         let target_indexer = Indexer::from_near_node(indexer_config, near_config, &near_node);
         let mut target_stream = target_indexer.streamer();
         let NearNode { client, view_client, rpc_handler, .. } = near_node;
@@ -2130,6 +2132,7 @@ impl<T: ChainAccess> TxMirror<T> {
         self,
         stop_height: Option<BlockHeight>,
         target_home: PathBuf,
+        actor_system: near_async::ActorSystem,
     ) -> anyhow::Result<()> {
         let last_stored_height = get_last_source_height(&self.db)?;
         let last_height = last_stored_height.unwrap_or(self.target_genesis_height - 1);
@@ -2181,6 +2184,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let tx_block_queue = Arc::new(Mutex::new(VecDeque::new()));
 
         let tx_block_queue2 = tx_block_queue.clone();
+        let actor_system2 = actor_system.clone();
         let index_target_task = tokio::task::spawn(async move {
             let res = Self::index_target_loop(
                 tracker2,
@@ -2191,6 +2195,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 unstake_tx,
                 target_height2,
                 target_head2,
+                actor_system2,
             )
             .await;
             if let Err(res) = target_indexer_done_tx.send(res) {
@@ -2312,7 +2317,7 @@ impl<T: ChainAccess> TxMirror<T> {
         send_txs_task.abort();
         let _ = index_target_task.await;
         let _ = send_txs_task.await;
-        near_async::shutdown_all_actors();
+        actor_system.stop();
         result
     }
 }
@@ -2335,6 +2340,7 @@ async fn run<P: AsRef<Path>>(
         }
         None => Default::default(),
     };
+    let actor_system = near_async::ActorSystem::new();
     if !online_source {
         let source_chain_access = crate::offline::ChainAccess::new(source_home)?;
         let stop_height = stop_height.unwrap_or(
@@ -2347,17 +2353,17 @@ async fn run<P: AsRef<Path>>(
             secret,
             config,
         )?
-        .run(Some(stop_height), target_home.as_ref().to_path_buf())
+        .run(Some(stop_height), target_home.as_ref().to_path_buf(), actor_system)
         .await
     } else {
         TxMirror::new(
-            crate::online::ChainAccess::new(source_home).await?,
+            crate::online::ChainAccess::new(source_home, actor_system.clone()).await?,
             target_home.as_ref(),
             mirror_db_path.as_deref(),
             secret,
             config,
         )?
-        .run(stop_height, target_home.as_ref().to_path_buf())
+        .run(stop_height, target_home.as_ref().to_path_buf(), actor_system)
         .await
     }
 }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -2181,7 +2181,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let tx_block_queue = Arc::new(Mutex::new(VecDeque::new()));
 
         let tx_block_queue2 = tx_block_queue.clone();
-        let _index_target_task = tokio::task::spawn(async move {
+        let index_target_task = tokio::task::spawn(async move {
             let res = Self::index_target_loop(
                 tracker2,
                 tx_block_queue2,
@@ -2275,7 +2275,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let db = self.db.clone();
         let (send_txs_done_tx, send_txs_done_rx) =
             tokio::sync::oneshot::channel::<anyhow::Result<()>>();
-        let _send_txs_task = tokio::task::spawn(async move {
+        let send_txs_task = tokio::task::spawn(async move {
             let res = Self::send_txs_loop(
                 db,
                 blocks_sent_tx,
@@ -2289,13 +2289,12 @@ impl<T: ChainAccess> TxMirror<T> {
                 tracing::error!(target: "mirror", ?err, "failed send txs loop res");
             }
         });
-        tokio::select! {
+        let result = tokio::select! {
             res = self.queue_txs_loop(
                 tracker, tx_block_queue, rpc_handler, target_view_client,
                 blocks_sent_rx, unstake_rx, send_delay, target_height, target_head,
                 source_hash, stop_height.is_some(),
             ) => {
-                // TODO: cancel other threads
                 res
             }
             res = target_indexer_done_rx => {
@@ -2308,7 +2307,13 @@ impl<T: ChainAccess> TxMirror<T> {
                 tracing::error!(target: "mirror", ?res, "transaction sending thread exited");
                 res.context("target indexer thread failure")
             }
-        }
+        };
+        index_target_task.abort();
+        send_txs_task.abort();
+        let _ = index_target_task.await;
+        let _ = send_txs_task.await;
+        near_async::shutdown_all_actors();
+        result
     }
 }
 

--- a/tools/mirror/src/online.rs
+++ b/tools/mirror/src/online.rs
@@ -28,12 +28,15 @@ pub(crate) struct ChainAccess {
 }
 
 impl ChainAccess {
-    pub(crate) async fn new<P: AsRef<Path>>(home: P) -> anyhow::Result<Self> {
+    pub(crate) async fn new<P: AsRef<Path>>(
+        home: P,
+        actor_system: ActorSystem,
+    ) -> anyhow::Result<Self> {
         let config =
             nearcore::config::load_config(home.as_ref(), GenesisValidationMode::UnsafeFast)
                 .with_context(|| format!("Error loading config from {:?}", home.as_ref()))?;
 
-        let node = nearcore::start_with_config(home.as_ref(), config, ActorSystem::new())
+        let node = nearcore::start_with_config(home.as_ref(), config, actor_system)
             .await
             .context("failed to start NEAR node")?;
         Ok(Self { view_client: node.view_client })


### PR DESCRIPTION
- Abort and await spawned tasks (`index_target_task`, `send_txs_task`) before returning from `run()`, so their `Arc<DB>` clones are dropped cleanly
- Use single actor system so source/target chains can be stopped together
- Wait for all RocksDB instances to close before process exit, preventing SIGSEGV from C++ RocksDB destructors racing with async teardown
- Fix fork-network `set-validators` to apply the requested shard layout unconditionally, not only when the base config is already static (mainnet switched to dynamic after resharding stabilized)