### PR TITLE
feat(mirror): deferred tx support for keys not yet on target chain

### DIFF
--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -147,7 +147,15 @@ impl Indexer {
         indexer_config: &IndexerConfig,
         near_config: NearConfig,
     ) -> impl Future<Output = anyhow::Result<NearNode>> {
-        nearcore::start_with_config(&indexer_config.home_dir, near_config, ActorSystem::new())
+        Self::start_near_node_in(indexer_config, near_config, ActorSystem::new())
+    }
+
+    pub fn start_near_node_in(
+        indexer_config: &IndexerConfig,
+        near_config: NearConfig,
+        actor_system: ActorSystem,
+    ) -> impl Future<Output = anyhow::Result<NearNode>> {
+        nearcore::start_with_config(&indexer_config.home_dir, near_config, actor_system)
     }
 
     pub fn from_near_node(

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -131,7 +131,7 @@ impl Indexer {
         let near_config =
             indexer_config.load_near_config().context("failed to load near config")?;
         let nearcore::NearNode { client, view_client, shard_tracker, .. } =
-            Self::start_near_node(&indexer_config, near_config.clone())
+            Self::start_near_node(&indexer_config, near_config.clone(), ActorSystem::new())
                 .await
                 .context("failed to start near node as part of indexer")?;
         Ok(Self {
@@ -144,13 +144,6 @@ impl Indexer {
     }
 
     pub fn start_near_node(
-        indexer_config: &IndexerConfig,
-        near_config: NearConfig,
-    ) -> impl Future<Output = anyhow::Result<NearNode>> {
-        Self::start_near_node_in(indexer_config, near_config, ActorSystem::new())
-    }
-
-    pub fn start_near_node_in(
         indexer_config: &IndexerConfig,
         near_config: NearConfig,
         actor_system: ActorSystem,

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -932,10 +932,11 @@ impl ForkNetworkCommand {
                 config.num_chunk_validator_seats = *num_seats;
             }
             if let Some(shard_layout) = shard_layout_override {
-                if config.static_shard_layout().is_some() {
-                    config.shard_layout_config =
-                        ShardLayoutConfig::Static { shard_layout: shard_layout.clone() };
-                }
+                // fork-network writes a static-layout genesis, so apply the requested shard
+                // layout whether the base (mainnet) config is static or dynamic. The base is
+                // dynamic since resharding stabilized; otherwise make_and_write_genesis fails.
+                config.shard_layout_config =
+                    ShardLayoutConfig::Static { shard_layout: shard_layout.clone() };
             }
             new_epoch_configs.insert(version, Arc::new(config));
         }

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -1,3 +1,4 @@
+use crate::deferred_tx::{DeferredTx, DeferredTxTracker};
 use crate::{
     ChainAccess, ChainError, LatestTargetNonce, MappedBlock, MappedTx, MappedTxProvenance,
     NonceKind, NonceLookupKey, NonceUpdater, TargetChainTx, TargetNonce, TxBatch, TxRef,
@@ -152,6 +153,11 @@ pub(crate) struct TxTracker {
     recent_block_timestamps: VecDeque<u64>,
     // last source block we'll be sending transactions for
     stop_height: Option<BlockHeight>,
+    // transactions that were sent before their access key appeared on the target
+    // chain, keyed by the NonceLookupKey they're waiting on. Mirrors the DeferredTxs
+    // DB column so it survives restarts. Resent by try_set_nonces() once the nonce
+    // is known, pruned by on_target_block() after DEFERRED_TX_TTL target heights.
+    pub(crate) deferred_txs: DeferredTxTracker,
 }
 
 impl TxTracker {
@@ -163,12 +169,14 @@ impl TxTracker {
         tx_batch_interval: Option<Duration>,
         next_heights: I,
         stop_height: Option<BlockHeight>,
-    ) -> Self
+        db: &DB,
+    ) -> anyhow::Result<Self>
     where
         I: IntoIterator<Item = &'a BlockHeight>,
     {
         let next_heights = next_heights.into_iter().map(Clone::clone).collect();
-        Self {
+        let deferred_txs = DeferredTxTracker::load(db)?;
+        Ok(Self {
             min_block_production_delay,
             next_heights,
             stop_height,
@@ -182,7 +190,8 @@ impl TxTracker {
             height_popped: None,
             height_seen: None,
             recent_block_timestamps: VecDeque::new(),
-        }
+            deferred_txs,
+        })
     }
 
     pub(crate) async fn next_heights<T: ChainAccess>(
@@ -687,7 +696,7 @@ impl TxTracker {
         db: &DB,
         updated_key: UpdatedKey,
         mut nonce: Option<Nonce>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<DeferredTx>> {
         let mut n = crate::read_target_nonce(db, &updated_key.nonce_key)?.unwrap();
         n.pending_outcomes.remove(&updated_key.id);
         n.nonce = std::cmp::max(n.nonce, nonce);
@@ -696,6 +705,11 @@ impl TxTracker {
 
         let updater = NonceUpdater::ChainObjectId(updated_key.id);
         let nonce_key = updated_key.nonce_key;
+
+        // Resolve deferred txs BEFORE assigning nonces to queued txs. Deferred
+        // txs are sent immediately via the deferred_resend channel, so they
+        // must receive lower nonces than the still-queued txs sent later.
+        let deferred = self.resolve_deferred_txs(&nonce_key, &mut nonce);
 
         if let Some(info) = self.nonces.get_mut(&nonce_key) {
             info.target_nonce.pending_outcomes.remove(&updater);
@@ -740,7 +754,28 @@ impl TxTracker {
             }
             info.target_nonce.nonce = std::cmp::max(info.target_nonce.nonce, nonce);
         }
-        Ok(())
+
+        Ok(deferred)
+    }
+
+    // Once we learn the nonce for `nonce_key`, assign nonces to any txs we deferred
+    // on it and hand them back to be resent. `nonce` is the next-free nonce after
+    // accounting for any in-memory txs awaiting this key; we keep advancing it.
+    //
+    // DB updates (clearing the DeferredTxs column and advancing the stored nonce)
+    // are deferred until on_txs_sent() confirms the txs were actually sent. This
+    // prevents losing deferred txs if the process is killed between resolving and
+    // sending (e.g., during the 30-second restart).
+    pub(crate) fn resolve_deferred_txs(
+        &mut self,
+        nonce_key: &NonceLookupKey,
+        nonce: &mut Option<Nonce>,
+    ) -> Vec<DeferredTx> {
+        let txs = self.deferred_txs.resolve(nonce_key, nonce);
+        if let (Some(info), Some(n)) = (self.nonces.get_mut(nonce_key), *nonce) {
+            info.target_nonce.nonce = std::cmp::max(info.target_nonce.nonce, Some(n));
+        }
+        txs
     }
 
     fn on_outcome_finished(
@@ -853,6 +888,7 @@ impl TxTracker {
     ) -> anyhow::Result<TargetBlockInfo> {
         self.record_block_timestamp(&msg);
         self.log_target_block(&msg);
+        self.deferred_txs.prune(db, msg.block.header.height)?;
 
         let mut access_key_updates = Vec::new();
         let mut staked_accounts = HashMap::new();
@@ -961,9 +997,34 @@ impl TxTracker {
                 }
             }
             None => {
-                // if tx_ref is None, it was an extra tx we sent to unstake an unwanted validator,
-                // and there should be no access key updates
-                assert!(tx.nonce_updates.is_empty());
+                // tx_ref is None for txs we send out of band: unstake reversals (which have no
+                // access key updates) and resent deferred txs (which may add keys). Unlike the
+                // Some(_) case there's no prior TxRef updater to replace, so we just register the
+                // new outcome for any keys this tx updates. Unstake txs have empty nonce_updates,
+                // so this is a no-op for them.
+                let new_updater = NonceUpdater::ChainObjectId(hash);
+                for nonce_key in &tx.nonce_updates {
+                    let mut t = crate::read_target_nonce(db, nonce_key)?.unwrap();
+                    t.pending_outcomes.insert(hash);
+                    crate::put_target_nonce(db, nonce_key, &t)?;
+
+                    let Some(info) = self.nonces.get_mut(nonce_key) else {
+                        continue;
+                    };
+                    info.target_nonce.pending_outcomes.insert(new_updater.clone());
+                    let txs_awaiting_nonce = info.txs_awaiting_nonce.clone();
+                    if !txs_awaiting_nonce.is_empty() {
+                        let mut tx_block_queue = tx_block_queue.lock();
+                        for r in &txs_awaiting_nonce {
+                            match Self::get_tx(&mut tx_block_queue, r) {
+                                TargetChainTx::AwaitingNonce(t) => {
+                                    t.target_nonce.pending_outcomes.insert(new_updater.clone());
+                                }
+                                TargetChainTx::Ready(_) => unreachable!(),
+                            };
+                        }
+                    }
+                }
             }
         }
 
@@ -972,12 +1033,13 @@ impl TxTracker {
         let mut t = crate::read_target_nonce(db, &nonce_key)?.unwrap();
         t.nonce = std::cmp::max(t.nonce, Some(tx.target_tx.transaction.nonce().nonce()));
         crate::put_target_nonce(db, &nonce_key, &t)?;
-        let info = self.nonces.get_mut(&nonce_key).unwrap();
-        if info.last_height <= source_height {
-            keys_to_remove.insert(nonce_key);
-        }
-        if let Some(tx_ref) = tx_ref {
-            assert!(info.queued_txs.remove(&tx_ref));
+        if let Some(info) = self.nonces.get_mut(&nonce_key) {
+            if info.last_height <= source_height {
+                keys_to_remove.insert(nonce_key);
+            }
+            if let Some(tx_ref) = tx_ref {
+                assert!(info.queued_txs.remove(&tx_ref));
+            }
         }
         Ok(())
     }
@@ -1112,6 +1174,7 @@ impl TxTracker {
         let mut total_sent = 0;
         let now = Instant::now();
         let mut keys_to_remove = HashSet::new();
+        let mut resolved_deferred_sent: Vec<(NonceLookupKey, Nonce)> = Vec::new();
 
         let (txs_sent, provenance) = match sent_batch {
             SentBatch::MappedBlock(b) => {
@@ -1142,6 +1205,12 @@ impl TxTracker {
             match tx {
                 crate::TargetChainTx::Ready(t) => {
                     if t.sent_successfully {
+                        let is_deferred_resend = tx_ref.is_none();
+                        if is_deferred_resend {
+                            let nonce_key = NonceLookupKey::from_tx(&t.target_tx.transaction);
+                            let nonce = t.target_tx.transaction.nonce().nonce();
+                            resolved_deferred_sent.push((nonce_key, nonce));
+                        }
                         self.on_tx_sent(
                             tx_block_queue,
                             db,
@@ -1170,8 +1239,12 @@ impl TxTracker {
                         &t.nonce_updates,
                         &mut keys_to_remove,
                     )?;
+                    self.deferred_txs.push(db, t, target_height)?;
                 }
             }
+        }
+        if !resolved_deferred_sent.is_empty() {
+            DeferredTxTracker::commit_sent(db, &resolved_deferred_sent)?;
         }
 
         for nonce_key in keys_to_remove {

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -1174,7 +1174,7 @@ impl TxTracker {
         let mut total_sent = 0;
         let now = Instant::now();
         let mut keys_to_remove = HashSet::new();
-        let mut resolved_deferred_sent: Vec<(NonceLookupKey, Nonce)> = Vec::new();
+        let mut resolved_deferred_keys: Vec<NonceLookupKey> = Vec::new();
 
         let (txs_sent, provenance) = match sent_batch {
             SentBatch::MappedBlock(b) => {
@@ -1207,9 +1207,8 @@ impl TxTracker {
                     if t.sent_successfully {
                         let is_deferred_resend = tx_ref.is_none();
                         if is_deferred_resend {
-                            let nonce_key = NonceLookupKey::from_tx(&t.target_tx.transaction);
-                            let nonce = t.target_tx.transaction.nonce().nonce();
-                            resolved_deferred_sent.push((nonce_key, nonce));
+                            resolved_deferred_keys
+                                .push(NonceLookupKey::from_tx(&t.target_tx.transaction));
                         }
                         self.on_tx_sent(
                             tx_block_queue,
@@ -1243,8 +1242,8 @@ impl TxTracker {
                 }
             }
         }
-        if !resolved_deferred_sent.is_empty() {
-            DeferredTxTracker::commit_sent(db, &resolved_deferred_sent)?;
+        if !resolved_deferred_keys.is_empty() {
+            DeferredTxTracker::commit_sent(db, &resolved_deferred_keys)?;
         }
 
         for nonce_key in keys_to_remove {

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -108,7 +108,8 @@ struct NonceInfo {
 
 pub(crate) enum SentBatch {
     MappedBlock(TxBatch),
-    ExtraTxs(Vec<TargetChainTx>),
+    UnstakeTxs(Vec<TargetChainTx>),
+    DeferredResendTxs(Vec<TargetChainTx>),
 }
 
 // a nonce lookup key along with the id of the tx or receipt that might have updated it
@@ -156,7 +157,7 @@ pub(crate) struct TxTracker {
     // transactions that were sent before their access key appeared on the target
     // chain, keyed by the NonceLookupKey they're waiting on. Mirrors the DeferredTxs
     // DB column so it survives restarts. Resent by try_set_nonces() once the nonce
-    // is known, pruned by on_target_block() after DEFERRED_TX_TTL target heights.
+    // is known, pruned in the steady-state index loop after DEFERRED_TX_TTL target heights.
     pub(crate) deferred_txs: DeferredTxTracker,
 }
 
@@ -228,6 +229,7 @@ impl TxTracker {
             Some(_) => {
                 self.height_popped >= self.stop_height
                     && self.height_seen >= self.nonempty_height_queued
+                    && self.deferred_txs.is_empty()
             }
             None => false,
         }
@@ -888,7 +890,6 @@ impl TxTracker {
     ) -> anyhow::Result<TargetBlockInfo> {
         self.record_block_timestamp(&msg);
         self.log_target_block(&msg);
-        self.deferred_txs.prune(db, msg.block.header.height)?;
 
         let mut access_key_updates = Vec::new();
         let mut staked_accounts = HashMap::new();
@@ -1176,6 +1177,7 @@ impl TxTracker {
         let mut keys_to_remove = HashSet::new();
         let mut resolved_deferred_keys: Vec<NonceLookupKey> = Vec::new();
 
+        let mut is_deferred_resend = false;
         let (txs_sent, provenance) = match sent_batch {
             SentBatch::MappedBlock(b) => {
                 self.height_popped = Some(b.source_height);
@@ -1196,16 +1198,22 @@ impl TxTracker {
                     b.txs.into_iter().map(|(tx_ref, tx)| (Some(tx_ref), tx)).collect::<Vec<_>>();
                 (txs, format!("source #{}", b.source_height))
             }
-            SentBatch::ExtraTxs(txs) => (
+            SentBatch::UnstakeTxs(txs) => (
                 txs.into_iter().map(|tx| (None, tx)).collect::<Vec<_>>(),
                 String::from("extra unstake transactions"),
             ),
+            SentBatch::DeferredResendTxs(txs) => {
+                is_deferred_resend = true;
+                (
+                    txs.into_iter().map(|tx| (None, tx)).collect::<Vec<_>>(),
+                    String::from("deferred resend transactions"),
+                )
+            }
         };
         for (tx_ref, tx) in txs_sent {
             match tx {
                 crate::TargetChainTx::Ready(t) => {
                     if t.sent_successfully {
-                        let is_deferred_resend = tx_ref.is_none();
                         if is_deferred_resend {
                             resolved_deferred_keys
                                 .push(NonceLookupKey::from_tx(&t.target_tx.transaction));

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -155,9 +155,9 @@ pub(crate) struct TxTracker {
     // last source block we'll be sending transactions for
     stop_height: Option<BlockHeight>,
     // transactions that were sent before their access key appeared on the target
-    // chain, keyed by the NonceLookupKey they're waiting on. Mirrors the DeferredTxs
-    // DB column so it survives restarts. Resent by try_set_nonces() once the nonce
-    // is known, pruned in the steady-state index loop after DEFERRED_TX_TTL target heights.
+    // chain, keyed by the NonceLookupKey they're waiting on. Held in memory only.
+    // Resent by try_set_nonces() once the nonce is known, pruned in the steady-state
+    // index loop after DEFERRED_TX_TTL target heights.
     pub(crate) deferred_txs: DeferredTxTracker,
 }
 
@@ -170,14 +170,12 @@ impl TxTracker {
         tx_batch_interval: Option<Duration>,
         next_heights: I,
         stop_height: Option<BlockHeight>,
-        db: &DB,
-    ) -> anyhow::Result<Self>
+    ) -> Self
     where
         I: IntoIterator<Item = &'a BlockHeight>,
     {
         let next_heights = next_heights.into_iter().map(Clone::clone).collect();
-        let deferred_txs = DeferredTxTracker::load(db)?;
-        Ok(Self {
+        Self {
             min_block_production_delay,
             next_heights,
             stop_height,
@@ -191,8 +189,8 @@ impl TxTracker {
             height_popped: None,
             height_seen: None,
             recent_block_timestamps: VecDeque::new(),
-            deferred_txs,
-        })
+            deferred_txs: DeferredTxTracker::new(),
+        }
     }
 
     pub(crate) async fn next_heights<T: ChainAccess>(
@@ -1175,9 +1173,7 @@ impl TxTracker {
         let mut total_sent = 0;
         let now = Instant::now();
         let mut keys_to_remove = HashSet::new();
-        let mut resolved_deferred_keys: Vec<NonceLookupKey> = Vec::new();
 
-        let mut is_deferred_resend = false;
         let (txs_sent, provenance) = match sent_batch {
             SentBatch::MappedBlock(b) => {
                 self.height_popped = Some(b.source_height);
@@ -1202,22 +1198,15 @@ impl TxTracker {
                 txs.into_iter().map(|tx| (None, tx)).collect::<Vec<_>>(),
                 String::from("extra unstake transactions"),
             ),
-            SentBatch::DeferredResendTxs(txs) => {
-                is_deferred_resend = true;
-                (
-                    txs.into_iter().map(|tx| (None, tx)).collect::<Vec<_>>(),
-                    String::from("deferred resend transactions"),
-                )
-            }
+            SentBatch::DeferredResendTxs(txs) => (
+                txs.into_iter().map(|tx| (None, tx)).collect::<Vec<_>>(),
+                String::from("deferred resend transactions"),
+            ),
         };
         for (tx_ref, tx) in txs_sent {
             match tx {
                 crate::TargetChainTx::Ready(t) => {
                     if t.sent_successfully {
-                        if is_deferred_resend {
-                            resolved_deferred_keys
-                                .push(NonceLookupKey::from_tx(&t.target_tx.transaction));
-                        }
                         self.on_tx_sent(
                             tx_block_queue,
                             db,
@@ -1246,12 +1235,9 @@ impl TxTracker {
                         &t.nonce_updates,
                         &mut keys_to_remove,
                     )?;
-                    self.deferred_txs.push(db, t, target_height)?;
+                    self.deferred_txs.push(t, target_height);
                 }
             }
-        }
-        if !resolved_deferred_keys.is_empty() {
-            DeferredTxTracker::commit_sent(db, &resolved_deferred_keys)?;
         }
 
         for nonce_key in keys_to_remove {

--- a/tools/mirror/src/cli.rs
+++ b/tools/mirror/src/cli.rs
@@ -71,7 +71,7 @@ impl RunCmd {
             None
         };
 
-        run_async(crate::run(
+        let result = run_async(crate::run(
             self.source_home,
             self.target_home,
             self.mirror_db_path,
@@ -79,7 +79,13 @@ impl RunCmd {
             self.stop_height,
             self.online_source,
             self.config_path,
-        ))
+        ));
+        // run() aborts spawned tasks, awaits them, and calls
+        // shutdown_all_actors(). By the time we get here the tokio runtime is
+        // dropped and all Arc<DB> refs should be gone. Wait for RocksDB
+        // background threads to finish flushing.
+        near_store::db::RocksDB::block_until_all_instances_are_dropped();
+        result
     }
 }
 

--- a/tools/mirror/src/deferred_tx.rs
+++ b/tools/mirror/src/deferred_tx.rs
@@ -1,23 +1,19 @@
-use crate::{
-    DBCol, MappedTx, MappedTxProvenance, NonceLookupKey, SignedTransaction, TxAwaitingNonce,
-};
-use borsh::{BorshDeserialize, BorshSerialize};
+use crate::{MappedTx, MappedTxProvenance, NonceLookupKey, SignedTransaction, TxAwaitingNonce};
 use near_crypto::SecretKey;
 use near_primitives::transaction::Transaction;
 use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives_core::types::Nonce;
-use rocksdb::DB;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
 const DEFERRED_TX_TTL: BlockHeight = 50;
 
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug)]
 pub(crate) struct DeferredTx {
     source_signer_id: AccountId,
     source_receiver_id: AccountId,
     provenance: MappedTxProvenance,
-    target_secret_key: String,
+    target_secret_key: SecretKey,
     pub(crate) target_tx: Transaction,
     nonce_updates: HashSet<NonceLookupKey>,
     deferred_at: BlockHeight,
@@ -29,7 +25,7 @@ impl DeferredTx {
             source_signer_id: tx.source_signer_id,
             source_receiver_id: tx.source_receiver_id,
             provenance: tx.provenance,
-            target_secret_key: tx.target_secret_key.to_string(),
+            target_secret_key: tx.target_secret_key,
             target_tx: tx.target_tx,
             nonce_updates: tx.nonce_updates,
             deferred_at,
@@ -41,10 +37,8 @@ impl DeferredTx {
     }
 
     pub(crate) fn into_ready(self) -> MappedTx {
-        let target_secret_key: SecretKey =
-            self.target_secret_key.parse().expect("serialized our own target secret key");
         let target_tx = SignedTransaction::new(
-            target_secret_key.sign(&self.target_tx.get_hash_and_size().0.as_ref()),
+            self.target_secret_key.sign(&self.target_tx.get_hash_and_size().0.as_ref()),
             self.target_tx,
         );
         MappedTx {
@@ -63,17 +57,8 @@ pub(crate) struct DeferredTxTracker {
 }
 
 impl DeferredTxTracker {
-    pub(crate) fn load(db: &DB) -> anyhow::Result<Self> {
-        let mut txs = HashMap::new();
-        let handle = db.cf_handle(DBCol::DeferredTxs.name()).unwrap();
-        for item in db.iterator_cf(handle, rocksdb::IteratorMode::Start) {
-            let (key, value) = item?;
-            txs.insert(
-                NonceLookupKey::try_from_slice(&key).unwrap(),
-                Vec::<DeferredTx>::try_from_slice(&value).unwrap(),
-            );
-        }
-        Ok(Self { txs })
+    pub(crate) fn new() -> Self {
+        Self { txs: HashMap::new() }
     }
 
     pub(crate) fn keys(&self) -> Vec<NonceLookupKey> {
@@ -84,19 +69,11 @@ impl DeferredTxTracker {
         self.txs.is_empty()
     }
 
-    pub(crate) fn push(
-        &mut self,
-        db: &DB,
-        tx: TxAwaitingNonce,
-        target_height: BlockHeight,
-    ) -> anyhow::Result<()> {
+    pub(crate) fn push(&mut self, tx: TxAwaitingNonce, target_height: BlockHeight) {
         let deferred = DeferredTx::new(tx, target_height);
         let nonce_key = deferred.nonce_key();
-        let entry = self.txs.entry(nonce_key.clone()).or_default();
-        entry.push(deferred);
-        Self::db_put(db, &nonce_key, entry)?;
+        self.txs.entry(nonce_key.clone()).or_default().push(deferred);
         tracing::debug!(target: "mirror", ?nonce_key, "deferred tx until its access key appears on the target chain");
-        Ok(())
     }
 
     pub(crate) fn resolve(
@@ -118,50 +95,23 @@ impl DeferredTxTracker {
         txs
     }
 
-    pub(crate) fn prune(&mut self, db: &DB, target_height: BlockHeight) -> anyhow::Result<()> {
-        let mut emptied_keys = Vec::new();
-        for (nonce_key, txs) in &mut self.txs {
+    pub(crate) fn prune(&mut self, target_height: BlockHeight) {
+        self.txs.retain(|nonce_key, txs| {
             let before = txs.len();
             txs.retain(|tx| target_height.saturating_sub(tx.deferred_at) <= DEFERRED_TX_TTL);
             let dropped = before - txs.len();
             if dropped > 0 {
                 tracing::warn!(target: "mirror", ?nonce_key, dropped, "dropping deferred txs whose access key never appeared on the target chain");
-                Self::db_put(db, nonce_key, txs)?;
             }
-            if txs.is_empty() {
-                emptied_keys.push(nonce_key.clone());
-            }
-        }
-        for nonce_key in emptied_keys {
-            self.txs.remove(&nonce_key);
-        }
-        Ok(())
-    }
-
-    // Clear the DeferredTxs column for keys whose txs were resent and confirmed
-    // sent. The stored target nonce is already advanced by on_tx_sent().
-    pub(crate) fn commit_sent(db: &DB, keys: &[NonceLookupKey]) -> anyhow::Result<()> {
-        for nonce_key in keys {
-            Self::db_put(db, nonce_key, &[])?;
-        }
-        Ok(())
-    }
-
-    fn db_put(db: &DB, key: &NonceLookupKey, txs: &[DeferredTx]) -> anyhow::Result<()> {
-        let handle = db.cf_handle(DBCol::DeferredTxs.name()).unwrap();
-        if txs.is_empty() {
-            db.delete_cf(handle, &key.db_key())?;
-        } else {
-            db.put_cf(handle, &key.db_key(), &borsh::to_vec(txs).unwrap())?;
-        }
-        Ok(())
+            !txs.is_empty()
+        });
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{TargetNonce, open_db};
+    use crate::TargetNonce;
     use near_crypto::KeyType;
     use near_primitives::hash::CryptoHash;
     use near_primitives::types::ShardId;
@@ -193,25 +143,11 @@ mod test {
     }
 
     #[test]
-    fn push_persists_across_reload() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = open_db(dir.path()).unwrap();
-        let tx = awaiting_nonce("alice.near", 0);
-        let key = NonceLookupKey::from_tx(&tx.target_tx);
-
-        DeferredTxTracker::load(&db).unwrap().push(&db, tx, 5).unwrap();
-
-        assert_eq!(DeferredTxTracker::load(&db).unwrap().keys(), vec![key]);
-    }
-
-    #[test]
     fn resolve_assigns_increasing_nonces() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = open_db(dir.path()).unwrap();
-        let mut tracker = DeferredTxTracker::load(&db).unwrap();
+        let mut tracker = DeferredTxTracker::new();
         let key = NonceLookupKey::from_tx(&awaiting_nonce("alice.near", 0).target_tx);
-        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
-        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
+        tracker.push(awaiting_nonce("alice.near", 0), 5);
+        tracker.push(awaiting_nonce("alice.near", 0), 5);
 
         let mut nonce = Some(10);
         let resolved = tracker.resolve(&key, &mut nonce);
@@ -223,47 +159,24 @@ mod test {
 
     #[test]
     fn resolve_without_known_nonce_keeps_txs() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = open_db(dir.path()).unwrap();
-        let mut tracker = DeferredTxTracker::load(&db).unwrap();
+        let mut tracker = DeferredTxTracker::new();
         let key = NonceLookupKey::from_tx(&awaiting_nonce("alice.near", 0).target_tx);
-        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
+        tracker.push(awaiting_nonce("alice.near", 0), 5);
 
         let mut nonce = None;
         assert!(tracker.resolve(&key, &mut nonce).is_empty());
         assert_eq!(tracker.keys(), vec![key]);
     }
 
-    // resolve() removes txs from memory but intentionally leaves the DB rows so a crash
-    // between resolving and sending can't lose them; commit_sent() clears them afterwards.
-    #[test]
-    fn resolve_leaves_db_for_commit_sent() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = open_db(dir.path()).unwrap();
-        let mut tracker = DeferredTxTracker::load(&db).unwrap();
-        let key = NonceLookupKey::from_tx(&awaiting_nonce("alice.near", 0).target_tx);
-        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
-
-        let mut nonce = Some(10);
-        tracker.resolve(&key, &mut nonce);
-        assert_eq!(DeferredTxTracker::load(&db).unwrap().keys(), vec![key.clone()]);
-
-        DeferredTxTracker::commit_sent(&db, &[key]).unwrap();
-        assert!(DeferredTxTracker::load(&db).unwrap().keys().is_empty());
-    }
-
     #[test]
     fn prune_drops_after_ttl() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = open_db(dir.path()).unwrap();
-        let mut tracker = DeferredTxTracker::load(&db).unwrap();
-        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
+        let mut tracker = DeferredTxTracker::new();
+        tracker.push(awaiting_nonce("alice.near", 0), 5);
 
-        tracker.prune(&db, 5 + DEFERRED_TX_TTL).unwrap();
+        tracker.prune(5 + DEFERRED_TX_TTL);
         assert_eq!(tracker.keys().len(), 1);
 
-        tracker.prune(&db, 5 + DEFERRED_TX_TTL + 1).unwrap();
+        tracker.prune(5 + DEFERRED_TX_TTL + 1);
         assert!(tracker.keys().is_empty());
-        assert!(DeferredTxTracker::load(&db).unwrap().keys().is_empty());
     }
 }

--- a/tools/mirror/src/deferred_tx.rs
+++ b/tools/mirror/src/deferred_tx.rs
@@ -100,13 +100,12 @@ impl DeferredTxTracker {
         nonce_key: &NonceLookupKey,
         nonce: &mut Option<Nonce>,
     ) -> Vec<DeferredTx> {
-        if self.txs.get(nonce_key).is_none_or(|txs| txs.is_empty()) {
-            return Vec::new();
-        }
         let Some(next_nonce) = nonce.as_mut() else {
             return Vec::new();
         };
-        let mut txs = self.txs.remove(nonce_key).unwrap();
+        let Some(mut txs) = self.txs.remove(nonce_key) else {
+            return Vec::new();
+        };
         for tx in &mut txs {
             *next_nonce += 1;
             *tx.target_tx.nonce_mut() = *next_nonce;
@@ -117,7 +116,7 @@ impl DeferredTxTracker {
 
     pub(crate) fn prune(&mut self, db: &DB, target_height: BlockHeight) -> anyhow::Result<()> {
         let mut emptied_keys = Vec::new();
-        for (nonce_key, txs) in self.txs.iter_mut() {
+        for (nonce_key, txs) in &mut self.txs {
             let before = txs.len();
             txs.retain(|tx| target_height.saturating_sub(tx.deferred_at) <= TTL);
             let dropped = before - txs.len();
@@ -135,19 +134,11 @@ impl DeferredTxTracker {
         Ok(())
     }
 
-    pub(crate) fn commit_sent(db: &DB, sent: &[(NonceLookupKey, Nonce)]) -> anyhow::Result<()> {
-        let mut by_key: HashMap<&NonceLookupKey, Nonce> = HashMap::new();
-        for (nonce_key, nonce) in sent {
-            by_key
-                .entry(nonce_key)
-                .and_modify(|n| *n = std::cmp::max(*n, *nonce))
-                .or_insert(*nonce);
-        }
-        for (nonce_key, max_nonce) in &by_key {
+    // Clear the DeferredTxs column for keys whose txs were resent and confirmed
+    // sent. The stored target nonce is already advanced by on_tx_sent().
+    pub(crate) fn commit_sent(db: &DB, keys: &[NonceLookupKey]) -> anyhow::Result<()> {
+        for nonce_key in keys {
             Self::db_put(db, nonce_key, &[])?;
-            let mut stored = crate::read_target_nonce(db, nonce_key)?.unwrap();
-            stored.nonce = std::cmp::max(stored.nonce, Some(*max_nonce));
-            crate::put_target_nonce(db, nonce_key, &stored)?;
         }
         Ok(())
     }

--- a/tools/mirror/src/deferred_tx.rs
+++ b/tools/mirror/src/deferred_tx.rs
@@ -80,6 +80,10 @@ impl DeferredTxTracker {
         self.txs.keys().cloned().collect()
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+    }
+
     pub(crate) fn push(
         &mut self,
         db: &DB,

--- a/tools/mirror/src/deferred_tx.rs
+++ b/tools/mirror/src/deferred_tx.rs
@@ -1,0 +1,164 @@
+use crate::{
+    DBCol, MappedTx, MappedTxProvenance, NonceLookupKey, SignedTransaction, TxAwaitingNonce,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_crypto::SecretKey;
+use near_primitives::transaction::Transaction;
+use near_primitives::types::{AccountId, BlockHeight};
+use near_primitives_core::types::Nonce;
+use rocksdb::DB;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+const TTL: BlockHeight = 50;
+
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+pub(crate) struct DeferredTx {
+    source_signer_id: AccountId,
+    source_receiver_id: AccountId,
+    provenance: MappedTxProvenance,
+    target_secret_key: String,
+    pub(crate) target_tx: Transaction,
+    nonce_updates: HashSet<NonceLookupKey>,
+    deferred_at: BlockHeight,
+}
+
+impl DeferredTx {
+    pub(crate) fn new(tx: TxAwaitingNonce, deferred_at: BlockHeight) -> Self {
+        Self {
+            source_signer_id: tx.source_signer_id,
+            source_receiver_id: tx.source_receiver_id,
+            provenance: tx.provenance,
+            target_secret_key: tx.target_secret_key.to_string(),
+            target_tx: tx.target_tx,
+            nonce_updates: tx.nonce_updates,
+            deferred_at,
+        }
+    }
+
+    pub(crate) fn nonce_key(&self) -> NonceLookupKey {
+        NonceLookupKey::from_tx(&self.target_tx)
+    }
+
+    pub(crate) fn into_ready(self) -> MappedTx {
+        let target_secret_key: SecretKey =
+            self.target_secret_key.parse().expect("serialized our own target secret key");
+        let target_tx = SignedTransaction::new(
+            target_secret_key.sign(&self.target_tx.get_hash_and_size().0.as_ref()),
+            self.target_tx,
+        );
+        MappedTx {
+            source_signer_id: self.source_signer_id,
+            source_receiver_id: self.source_receiver_id,
+            provenance: self.provenance,
+            target_tx,
+            nonce_updates: self.nonce_updates,
+            sent_successfully: false,
+        }
+    }
+}
+
+pub(crate) struct DeferredTxTracker {
+    txs: HashMap<NonceLookupKey, Vec<DeferredTx>>,
+}
+
+impl DeferredTxTracker {
+    pub(crate) fn load(db: &DB) -> anyhow::Result<Self> {
+        let mut txs = HashMap::new();
+        let handle = db.cf_handle(DBCol::DeferredTxs.name()).unwrap();
+        for item in db.iterator_cf(handle, rocksdb::IteratorMode::Start) {
+            let (key, value) = item?;
+            txs.insert(
+                NonceLookupKey::try_from_slice(&key).unwrap(),
+                Vec::<DeferredTx>::try_from_slice(&value).unwrap(),
+            );
+        }
+        Ok(Self { txs })
+    }
+
+    pub(crate) fn keys(&self) -> Vec<NonceLookupKey> {
+        self.txs.keys().cloned().collect()
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        db: &DB,
+        tx: TxAwaitingNonce,
+        target_height: BlockHeight,
+    ) -> anyhow::Result<()> {
+        let deferred = DeferredTx::new(tx, target_height);
+        let nonce_key = deferred.nonce_key();
+        let entry = self.txs.entry(nonce_key.clone()).or_default();
+        entry.push(deferred);
+        Self::db_put(db, &nonce_key, entry)?;
+        tracing::debug!(target: "mirror", ?nonce_key, "deferred tx until its access key appears on the target chain");
+        Ok(())
+    }
+
+    pub(crate) fn resolve(
+        &mut self,
+        nonce_key: &NonceLookupKey,
+        nonce: &mut Option<Nonce>,
+    ) -> Vec<DeferredTx> {
+        if self.txs.get(nonce_key).is_none_or(|txs| txs.is_empty()) {
+            return Vec::new();
+        }
+        let Some(next_nonce) = nonce.as_mut() else {
+            return Vec::new();
+        };
+        let mut txs = self.txs.remove(nonce_key).unwrap();
+        for tx in &mut txs {
+            *next_nonce += 1;
+            *tx.target_tx.nonce_mut() = *next_nonce;
+        }
+        tracing::debug!(target: "mirror", ?nonce_key, count = txs.len(), "resending deferred txs");
+        txs
+    }
+
+    pub(crate) fn prune(&mut self, db: &DB, target_height: BlockHeight) -> anyhow::Result<()> {
+        let mut emptied_keys = Vec::new();
+        for (nonce_key, txs) in self.txs.iter_mut() {
+            let before = txs.len();
+            txs.retain(|tx| target_height.saturating_sub(tx.deferred_at) <= TTL);
+            let dropped = before - txs.len();
+            if dropped > 0 {
+                tracing::warn!(target: "mirror", ?nonce_key, dropped, "dropping deferred txs whose access key never appeared on the target chain");
+                Self::db_put(db, nonce_key, txs)?;
+            }
+            if txs.is_empty() {
+                emptied_keys.push(nonce_key.clone());
+            }
+        }
+        for nonce_key in emptied_keys {
+            self.txs.remove(&nonce_key);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn commit_sent(db: &DB, sent: &[(NonceLookupKey, Nonce)]) -> anyhow::Result<()> {
+        let mut by_key: HashMap<&NonceLookupKey, Nonce> = HashMap::new();
+        for (nonce_key, nonce) in sent {
+            by_key
+                .entry(nonce_key)
+                .and_modify(|n| *n = std::cmp::max(*n, *nonce))
+                .or_insert(*nonce);
+        }
+        for (nonce_key, max_nonce) in &by_key {
+            Self::db_put(db, nonce_key, &[])?;
+            let mut stored = crate::read_target_nonce(db, nonce_key)?.unwrap();
+            stored.nonce = std::cmp::max(stored.nonce, Some(*max_nonce));
+            crate::put_target_nonce(db, nonce_key, &stored)?;
+        }
+        Ok(())
+    }
+
+    fn db_put(db: &DB, key: &NonceLookupKey, txs: &[DeferredTx]) -> anyhow::Result<()> {
+        let handle = db.cf_handle(DBCol::DeferredTxs.name()).unwrap();
+        if txs.is_empty() {
+            db.delete_cf(handle, &key.db_key())?;
+        } else {
+            db.put_cf(handle, &key.db_key(), &borsh::to_vec(txs).unwrap())?;
+        }
+        Ok(())
+    }
+}

--- a/tools/mirror/src/deferred_tx.rs
+++ b/tools/mirror/src/deferred_tx.rs
@@ -10,7 +10,7 @@ use rocksdb::DB;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-const TTL: BlockHeight = 50;
+const DEFERRED_TX_TTL: BlockHeight = 50;
 
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub(crate) struct DeferredTx {
@@ -118,7 +118,7 @@ impl DeferredTxTracker {
         let mut emptied_keys = Vec::new();
         for (nonce_key, txs) in &mut self.txs {
             let before = txs.len();
-            txs.retain(|tx| target_height.saturating_sub(tx.deferred_at) <= TTL);
+            txs.retain(|tx| target_height.saturating_sub(tx.deferred_at) <= DEFERRED_TX_TTL);
             let dropped = before - txs.len();
             if dropped > 0 {
                 tracing::warn!(target: "mirror", ?nonce_key, dropped, "dropping deferred txs whose access key never appeared on the target chain");
@@ -151,5 +151,115 @@ impl DeferredTxTracker {
             db.put_cf(handle, &key.db_key(), &borsh::to_vec(txs).unwrap())?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{TargetNonce, open_db};
+    use near_crypto::KeyType;
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::types::ShardId;
+
+    fn awaiting_nonce(signer: &str, nonce: Nonce) -> TxAwaitingNonce {
+        let target_secret_key = SecretKey::from_seed(KeyType::ED25519, signer);
+        let signer_id: AccountId = signer.parse().unwrap();
+        let receiver_id: AccountId = "receiver.near".parse().unwrap();
+        let target_tx = Transaction::new_v0(
+            signer_id.clone(),
+            target_secret_key.public_key(),
+            receiver_id.clone(),
+            nonce,
+            CryptoHash::default(),
+        );
+        TxAwaitingNonce {
+            source_signer_id: signer_id,
+            source_receiver_id: receiver_id,
+            provenance: MappedTxProvenance::MappedSourceTx(1, ShardId::new(0), 0),
+            target_secret_key,
+            target_tx,
+            nonce_updates: HashSet::new(),
+            target_nonce: TargetNonce::default(),
+        }
+    }
+
+    fn assigned_nonce(tx: &DeferredTx) -> Nonce {
+        tx.target_tx.nonce().nonce()
+    }
+
+    #[test]
+    fn push_persists_across_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_db(dir.path()).unwrap();
+        let tx = awaiting_nonce("alice.near", 0);
+        let key = NonceLookupKey::from_tx(&tx.target_tx);
+
+        DeferredTxTracker::load(&db).unwrap().push(&db, tx, 5).unwrap();
+
+        assert_eq!(DeferredTxTracker::load(&db).unwrap().keys(), vec![key]);
+    }
+
+    #[test]
+    fn resolve_assigns_increasing_nonces() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_db(dir.path()).unwrap();
+        let mut tracker = DeferredTxTracker::load(&db).unwrap();
+        let key = NonceLookupKey::from_tx(&awaiting_nonce("alice.near", 0).target_tx);
+        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
+        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
+
+        let mut nonce = Some(10);
+        let resolved = tracker.resolve(&key, &mut nonce);
+
+        assert_eq!(resolved.iter().map(assigned_nonce).collect::<Vec<_>>(), vec![11, 12]);
+        assert_eq!(nonce, Some(12));
+        assert!(tracker.keys().is_empty());
+    }
+
+    #[test]
+    fn resolve_without_known_nonce_keeps_txs() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_db(dir.path()).unwrap();
+        let mut tracker = DeferredTxTracker::load(&db).unwrap();
+        let key = NonceLookupKey::from_tx(&awaiting_nonce("alice.near", 0).target_tx);
+        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
+
+        let mut nonce = None;
+        assert!(tracker.resolve(&key, &mut nonce).is_empty());
+        assert_eq!(tracker.keys(), vec![key]);
+    }
+
+    // resolve() removes txs from memory but intentionally leaves the DB rows so a crash
+    // between resolving and sending can't lose them; commit_sent() clears them afterwards.
+    #[test]
+    fn resolve_leaves_db_for_commit_sent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_db(dir.path()).unwrap();
+        let mut tracker = DeferredTxTracker::load(&db).unwrap();
+        let key = NonceLookupKey::from_tx(&awaiting_nonce("alice.near", 0).target_tx);
+        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
+
+        let mut nonce = Some(10);
+        tracker.resolve(&key, &mut nonce);
+        assert_eq!(DeferredTxTracker::load(&db).unwrap().keys(), vec![key.clone()]);
+
+        DeferredTxTracker::commit_sent(&db, &[key]).unwrap();
+        assert!(DeferredTxTracker::load(&db).unwrap().keys().is_empty());
+    }
+
+    #[test]
+    fn prune_drops_after_ttl() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_db(dir.path()).unwrap();
+        let mut tracker = DeferredTxTracker::load(&db).unwrap();
+        tracker.push(&db, awaiting_nonce("alice.near", 0), 5).unwrap();
+
+        tracker.prune(&db, 5 + DEFERRED_TX_TTL).unwrap();
+        assert_eq!(tracker.keys().len(), 1);
+
+        tracker.prune(&db, 5 + DEFERRED_TX_TTL + 1).unwrap();
+        assert!(tracker.keys().is_empty());
+        assert!(DeferredTxTracker::load(&db).unwrap().keys().is_empty());
     }
 }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1960,7 +1960,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let near_config =
             indexer_config.load_near_config().context("failed to load near config").unwrap();
         let near_node =
-            Indexer::start_near_node_in(&indexer_config, near_config.clone(), actor_system)
+            Indexer::start_near_node(&indexer_config, near_config.clone(), actor_system)
                 .await
                 .context("failed to start near node")
                 .unwrap();

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -2272,8 +2272,8 @@ impl<T: ChainAccess> TxMirror<T> {
         // always locked first.
         let tx_block_queue = Arc::new(Mutex::new(VecDeque::new()));
 
-        let actor_system2 = actor_system.clone();
         let tx_block_queue2 = tx_block_queue.clone();
+        let actor_system2 = actor_system.clone();
         let index_target_task = tokio::task::spawn(async move {
             let res = Self::index_target_loop(
                 tracker2,
@@ -2407,8 +2407,6 @@ impl<T: ChainAccess> TxMirror<T> {
         send_txs_task.abort();
         let _ = index_target_task.await;
         let _ = send_txs_task.await;
-        // Shut down actors while we're still inside the async context so that
-        // the target chain's RocksDB instances are closed before self drops.
         actor_system.stop();
         result
     }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1948,6 +1948,7 @@ impl<T: ChainAccess> TxMirror<T> {
         accounts_to_unstake: mpsc::Sender<HashMap<(AccountId, PublicKey), AccountId>>,
         target_height: Arc<RwLock<BlockHeight>>,
         target_head: Arc<RwLock<CryptoHash>>,
+        actor_system: near_async::ActorSystem,
     ) -> anyhow::Result<()> {
         let indexer_config = near_indexer::IndexerConfig {
             home_dir,
@@ -1958,10 +1959,11 @@ impl<T: ChainAccess> TxMirror<T> {
         };
         let near_config =
             indexer_config.load_near_config().context("failed to load near config").unwrap();
-        let near_node = Indexer::start_near_node(&indexer_config, near_config.clone())
-            .await
-            .context("failed to start near node")
-            .unwrap();
+        let near_node =
+            Indexer::start_near_node_in(&indexer_config, near_config.clone(), actor_system)
+                .await
+                .context("failed to start near node")
+                .unwrap();
         let target_indexer = Indexer::from_near_node(indexer_config, near_config, &near_node);
         let mut target_stream = target_indexer.streamer();
         let NearNode { client, view_client, rpc_handler, .. } = near_node;
@@ -2130,6 +2132,7 @@ impl<T: ChainAccess> TxMirror<T> {
         self,
         stop_height: Option<BlockHeight>,
         target_home: PathBuf,
+        actor_system: near_async::ActorSystem,
     ) -> anyhow::Result<()> {
         let last_stored_height = get_last_source_height(&self.db)?;
         let last_height = last_stored_height.unwrap_or(self.target_genesis_height - 1);
@@ -2181,6 +2184,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let tx_block_queue = Arc::new(Mutex::new(VecDeque::new()));
 
         let tx_block_queue2 = tx_block_queue.clone();
+        let actor_system2 = actor_system.clone();
         let index_target_task = tokio::task::spawn(async move {
             let res = Self::index_target_loop(
                 tracker2,
@@ -2191,6 +2195,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 unstake_tx,
                 target_height2,
                 target_head2,
+                actor_system2,
             )
             .await;
             if let Err(res) = target_indexer_done_tx.send(res) {
@@ -2312,7 +2317,7 @@ impl<T: ChainAccess> TxMirror<T> {
         send_txs_task.abort();
         let _ = index_target_task.await;
         let _ = send_txs_task.await;
-        near_async::shutdown_all_actors();
+        actor_system.stop();
         result
     }
 }
@@ -2335,6 +2340,7 @@ async fn run<P: AsRef<Path>>(
         }
         None => Default::default(),
     };
+    let actor_system = near_async::ActorSystem::new();
     if !online_source {
         let source_chain_access = crate::offline::ChainAccess::new(source_home)?;
         let stop_height = stop_height.unwrap_or(
@@ -2347,17 +2353,17 @@ async fn run<P: AsRef<Path>>(
             secret,
             config,
         )?
-        .run(Some(stop_height), target_home.as_ref().to_path_buf())
+        .run(Some(stop_height), target_home.as_ref().to_path_buf(), actor_system)
         .await
     } else {
         TxMirror::new(
-            crate::online::ChainAccess::new(source_home).await?,
+            crate::online::ChainAccess::new(source_home, actor_system.clone()).await?,
             target_home.as_ref(),
             mirror_db_path.as_deref(),
             secret,
             config,
         )?
-        .run(stop_height, target_home.as_ref().to_path_buf())
+        .run(stop_height, target_home.as_ref().to_path_buf(), actor_system)
         .await
     }
 }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -2181,7 +2181,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let tx_block_queue = Arc::new(Mutex::new(VecDeque::new()));
 
         let tx_block_queue2 = tx_block_queue.clone();
-        let _index_target_task = tokio::task::spawn(async move {
+        let index_target_task = tokio::task::spawn(async move {
             let res = Self::index_target_loop(
                 tracker2,
                 tx_block_queue2,
@@ -2275,7 +2275,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let db = self.db.clone();
         let (send_txs_done_tx, send_txs_done_rx) =
             tokio::sync::oneshot::channel::<anyhow::Result<()>>();
-        let _send_txs_task = tokio::task::spawn(async move {
+        let send_txs_task = tokio::task::spawn(async move {
             let res = Self::send_txs_loop(
                 db,
                 blocks_sent_tx,
@@ -2289,13 +2289,12 @@ impl<T: ChainAccess> TxMirror<T> {
                 tracing::error!(target: "mirror", ?err, "failed send txs loop res");
             }
         });
-        tokio::select! {
+        let result = tokio::select! {
             res = self.queue_txs_loop(
                 tracker, tx_block_queue, rpc_handler, target_view_client,
                 blocks_sent_rx, unstake_rx, send_delay, target_height, target_head,
                 source_hash, stop_height.is_some(),
             ) => {
-                // TODO: cancel other threads
                 res
             }
             res = target_indexer_done_rx => {
@@ -2308,7 +2307,13 @@ impl<T: ChainAccess> TxMirror<T> {
                 tracing::error!(target: "mirror", ?res, "transaction sending thread exited");
                 res.context("target indexer thread failure")
             }
-        }
+        };
+        index_target_task.abort();
+        send_txs_task.abort();
+        let _ = index_target_task.await;
+        let _ = send_txs_task.await;
+        near_async::shutdown_all_actors();
+        result
     }
 }
 

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1907,9 +1907,7 @@ impl<T: ChainAccess> TxMirror<T> {
             resolved += 1;
         }
         let unresolved = deferred_keys.len() - resolved;
-        if resolved > 0 || unresolved > 0 {
-            tracing::info!(target: "mirror", resolved, unresolved, resend_count = resend.len(), tag, "deferred tx poll complete");
-        }
+        tracing::info!(target: "mirror", resolved, unresolved, resend_count = resend.len(), tag, "deferred tx poll complete");
         Ok(resend)
     }
 

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -41,6 +41,7 @@ use tokio::sync::mpsc;
 
 mod chain_tracker;
 pub mod cli;
+mod deferred_tx;
 pub mod genesis;
 pub mod key_mapping;
 mod key_util;
@@ -50,6 +51,7 @@ mod online;
 pub mod secret;
 
 pub use cli::MirrorCommand;
+use deferred_tx::DeferredTx;
 use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::tokio::TokioRuntimeHandle;
@@ -66,6 +68,11 @@ enum DBCol {
     // state. Otherwise, we map tx nonces according to the values in this column.
     Nonces,
     AccessKeyOutcomes,
+    // Transactions whose access key had not yet appeared on the target chain by
+    // the time their source block was sent, so we couldn't assign a nonce. Keyed
+    // by the NonceLookupKey they're waiting on, they're resent once that key's
+    // nonce becomes known, or dropped after DEFERRED_TX_TTL target heights.
+    DeferredTxs,
 }
 
 impl DBCol {
@@ -74,6 +81,7 @@ impl DBCol {
             Self::Misc => "miscellaneous",
             Self::Nonces => "nonces",
             Self::AccessKeyOutcomes => "access_key_outcomes",
+            Self::DeferredTxs => "deferred_txs",
         }
     }
 }
@@ -471,7 +479,7 @@ fn open_db<P: AsRef<Path>>(home: P) -> anyhow::Result<DB> {
     Ok(DB::open_cf_descriptors(&options, home.as_ref(), cf_descriptors)?)
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, BorshSerialize, BorshDeserialize)]
 enum MappedTxProvenance {
     MappedSourceTx(BlockHeight, ShardId, usize),
     TxAddKey(BlockHeight, ShardId, usize),
@@ -1873,6 +1881,38 @@ impl<T: ChainAccess> TxMirror<T> {
         Ok(())
     }
 
+    // Query the target chain for all deferred tx keys and resolve any whose
+    // access key has appeared. Returns the resolved txs ready to resend.
+    async fn poll_deferred_txs(
+        tracker: &Mutex<crate::chain_tracker::TxTracker>,
+        view_client: &MultithreadRuntimeHandle<ViewClientActor>,
+        tag: &str,
+    ) -> anyhow::Result<Vec<DeferredTx>> {
+        let deferred_keys = tracker.lock().deferred_txs.keys();
+        if deferred_keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut resend = Vec::new();
+        let mut resolved = 0;
+        for nonce_key in &deferred_keys {
+            let mut nonce = crate::fetch_nonce(view_client, nonce_key).await?;
+            if nonce.is_none() {
+                continue;
+            }
+            let txs = tracker.lock().resolve_deferred_txs(nonce_key, &mut nonce);
+            if !txs.is_empty() {
+                tracing::info!(target: "mirror", ?nonce_key, count = txs.len(), tag, "resolved deferred txs");
+                resend.extend(txs);
+            }
+            resolved += 1;
+        }
+        let unresolved = deferred_keys.len() - resolved;
+        if resolved > 0 || unresolved > 0 {
+            tracing::info!(target: "mirror", resolved, unresolved, resend_count = resend.len(), tag, "deferred tx poll complete");
+        }
+        Ok(resend)
+    }
+
     async fn send_txs_loop(
         db: Arc<DB>,
         blocks_sent: mpsc::Sender<TxBatch>,
@@ -1946,6 +1986,7 @@ impl<T: ChainAccess> TxMirror<T> {
             MultithreadRuntimeHandle<RpcHandlerActor>,
         )>,
         accounts_to_unstake: mpsc::Sender<HashMap<(AccountId, PublicKey), AccountId>>,
+        deferred_resend: mpsc::Sender<Vec<DeferredTx>>,
         target_height: Arc<RwLock<BlockHeight>>,
         target_head: Arc<RwLock<CryptoHash>>,
         actor_system: near_async::ActorSystem,
@@ -1983,10 +2024,18 @@ impl<T: ChainAccess> TxMirror<T> {
             .send((client.clone(), view_client.clone(), rpc_handler.clone()))
             .map_err(|_| anyhow::anyhow!("failed to send clients"))?;
 
+        {
+            let resend = Self::poll_deferred_txs(&tracker, &view_client, "restart").await?;
+            if !resend.is_empty() {
+                deferred_resend.send(resend).await?;
+            }
+        }
+
         loop {
             let msg = target_stream.recv().await.unwrap();
+            let msg_height = msg.block.header.height;
             *target_head.write() = msg.block.header.hash;
-            *target_height.write() = msg.block.header.height;
+            *target_height.write() = msg_height;
             let target_block_info = {
                 let mut tracker = tracker.lock();
                 tracker.on_target_block(&tx_block_queue, db.as_ref(), msg)?
@@ -1994,10 +2043,23 @@ impl<T: ChainAccess> TxMirror<T> {
             if !target_block_info.staked_accounts.is_empty() {
                 accounts_to_unstake.send(target_block_info.staked_accounts).await?;
             }
+            let mut resend = if msg_height % 10 == 0 {
+                Self::poll_deferred_txs(&tracker, &view_client, "poll").await?
+            } else {
+                Vec::new()
+            };
             for access_key_update in target_block_info.access_key_updates {
                 let nonce = crate::fetch_nonce(&view_client, &access_key_update.nonce_key).await?;
                 let mut tracker = tracker.lock();
-                tracker.try_set_nonces(&tx_block_queue, db.as_ref(), access_key_update, nonce)?;
+                resend.extend(tracker.try_set_nonces(
+                    &tx_block_queue,
+                    db.as_ref(),
+                    access_key_update,
+                    nonce,
+                )?);
+            }
+            if !resend.is_empty() {
+                deferred_resend.send(resend).await?;
             }
         }
     }
@@ -2010,6 +2072,7 @@ impl<T: ChainAccess> TxMirror<T> {
         target_view_client: MultithreadRuntimeHandle<ViewClientActor>,
         mut blocks_sent: mpsc::Receiver<TxBatch>,
         mut accounts_to_unstake: mpsc::Receiver<HashMap<(AccountId, PublicKey), AccountId>>,
+        mut deferred_resend: mpsc::Receiver<Vec<DeferredTx>>,
         send_delay: Arc<Mutex<Duration>>,
         target_height: Arc<RwLock<BlockHeight>>,
         target_head: Arc<RwLock<CryptoHash>>,
@@ -2056,6 +2119,22 @@ impl<T: ChainAccess> TxMirror<T> {
                         &target_view_client, staked_accounts, &source_hash,
                         &target_head, target_height
                     ).await?;
+                }
+                msg = deferred_resend.recv() => {
+                    let deferred = msg.unwrap();
+                    let mut txs = deferred
+                        .into_iter()
+                        .map(|tx| TargetChainTx::Ready(tx.into_ready()))
+                        .collect::<Vec<_>>();
+                    Self::send_transactions(&target_client, txs.iter_mut()).await?;
+                    let target_height = *target_height.read();
+                    let mut tracker = tracker.lock();
+                    tracker.on_txs_sent(
+                        &tx_block_queue,
+                        &self.db,
+                        crate::chain_tracker::SentBatch::ExtraTxs(txs),
+                        target_height,
+                    )?;
                 }
             };
             // TODO: this locking of the mutex before continuing the loop is kind of unnecessary since we should be able to tell
@@ -2137,6 +2216,16 @@ impl<T: ChainAccess> TxMirror<T> {
         let last_stored_height = get_last_source_height(&self.db)?;
         let last_height = last_stored_height.unwrap_or(self.target_genesis_height - 1);
 
+        // When resuming after having already sent everything up to --stop-height (e.g. a
+        // restart of a finished mirror over a finite source), there are no more blocks to
+        // send and we're done. Without this we'd bail below as if the source were broken.
+        if let Some(stop_height) = stop_height {
+            if last_height >= stop_height {
+                tracing::info!(target: "mirror", stop_height, last_height, "already sent all transactions up to --stop-height");
+                return Ok(());
+            }
+        }
+
         let next_heights =
             self.source_chain_access.init(last_height, CREATE_ACCOUNT_DELTA + 1).await?;
 
@@ -2165,13 +2254,15 @@ impl<T: ChainAccess> TxMirror<T> {
             self.config.tx_batch_interval,
             next_heights.iter(),
             stop_height,
-        )));
+            &self.db,
+        )?));
         let target_height = Arc::new(RwLock::new(0));
         let target_head = Arc::new(RwLock::new(CryptoHash::default()));
         let (clients_tx, clients_rx) = tokio::sync::oneshot::channel();
         let (target_indexer_done_tx, target_indexer_done_rx) =
             tokio::sync::oneshot::channel::<anyhow::Result<()>>();
         let (unstake_tx, unstake_rx) = mpsc::channel(10);
+        let (deferred_resend_tx, deferred_resend_rx) = mpsc::channel(10);
 
         let db = self.db.clone();
         let target_height2 = target_height.clone();
@@ -2183,8 +2274,8 @@ impl<T: ChainAccess> TxMirror<T> {
         // always locked first.
         let tx_block_queue = Arc::new(Mutex::new(VecDeque::new()));
 
-        let tx_block_queue2 = tx_block_queue.clone();
         let actor_system2 = actor_system.clone();
+        let tx_block_queue2 = tx_block_queue.clone();
         let index_target_task = tokio::task::spawn(async move {
             let res = Self::index_target_loop(
                 tracker2,
@@ -2193,6 +2284,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 db,
                 clients_tx,
                 unstake_tx,
+                deferred_resend_tx,
                 target_height2,
                 target_head2,
                 actor_system2,
@@ -2297,7 +2389,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let result = tokio::select! {
             res = self.queue_txs_loop(
                 tracker, tx_block_queue, rpc_handler, target_view_client,
-                blocks_sent_rx, unstake_rx, send_delay, target_height, target_head,
+                blocks_sent_rx, unstake_rx, deferred_resend_rx, send_delay, target_height, target_head,
                 source_hash, stop_height.is_some(),
             ) => {
                 res
@@ -2317,6 +2409,8 @@ impl<T: ChainAccess> TxMirror<T> {
         send_txs_task.abort();
         let _ = index_target_task.await;
         let _ = send_txs_task.await;
+        // Shut down actors while we're still inside the async context so that
+        // the target chain's RocksDB instances are closed before self drops.
         actor_system.stop();
         result
     }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -68,11 +68,6 @@ enum DBCol {
     // state. Otherwise, we map tx nonces according to the values in this column.
     Nonces,
     AccessKeyOutcomes,
-    // Transactions whose access key had not yet appeared on the target chain by
-    // the time their source block was sent, so we couldn't assign a nonce. Keyed
-    // by the NonceLookupKey they're waiting on, they're resent once that key's
-    // nonce becomes known, or dropped after DEFERRED_TX_TTL target heights.
-    DeferredTxs,
 }
 
 impl DBCol {
@@ -81,7 +76,6 @@ impl DBCol {
             Self::Misc => "miscellaneous",
             Self::Nonces => "nonces",
             Self::AccessKeyOutcomes => "access_key_outcomes",
-            Self::DeferredTxs => "deferred_txs",
         }
     }
 }
@@ -479,7 +473,7 @@ fn open_db<P: AsRef<Path>>(home: P) -> anyhow::Result<DB> {
     Ok(DB::open_cf_descriptors(&options, home.as_ref(), cf_descriptors)?)
 }
 
-#[derive(Clone, Copy, Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Copy, Debug)]
 enum MappedTxProvenance {
     MappedSourceTx(BlockHeight, ShardId, usize),
     TxAddKey(BlockHeight, ShardId, usize),
@@ -1886,7 +1880,6 @@ impl<T: ChainAccess> TxMirror<T> {
     async fn poll_deferred_txs(
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         view_client: &MultithreadRuntimeHandle<ViewClientActor>,
-        tag: &str,
     ) -> anyhow::Result<Vec<DeferredTx>> {
         let deferred_keys = tracker.lock().deferred_txs.keys();
         if deferred_keys.is_empty() {
@@ -1901,13 +1894,13 @@ impl<T: ChainAccess> TxMirror<T> {
             }
             let txs = tracker.lock().resolve_deferred_txs(nonce_key, &mut nonce);
             if !txs.is_empty() {
-                tracing::info!(target: "mirror", ?nonce_key, count = txs.len(), tag, "resolved deferred txs");
+                tracing::info!(target: "mirror", ?nonce_key, count = txs.len(), "resolved deferred txs");
                 resend.extend(txs);
             }
             resolved += 1;
         }
         let unresolved = deferred_keys.len() - resolved;
-        tracing::info!(target: "mirror", resolved, unresolved, resend_count = resend.len(), tag, "deferred tx poll complete");
+        tracing::info!(target: "mirror", resolved, unresolved, resend_count = resend.len(), "deferred tx poll complete");
         Ok(resend)
     }
 
@@ -2022,13 +2015,6 @@ impl<T: ChainAccess> TxMirror<T> {
             .send((client.clone(), view_client.clone(), rpc_handler.clone()))
             .map_err(|_| anyhow::anyhow!("failed to send clients"))?;
 
-        {
-            let resend = Self::poll_deferred_txs(&tracker, &view_client, "restart").await?;
-            if !resend.is_empty() {
-                deferred_resend.send(resend).await?;
-            }
-        }
-
         loop {
             let msg = target_stream.recv().await.unwrap();
             let msg_height = msg.block.header.height;
@@ -2042,7 +2028,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 accounts_to_unstake.send(target_block_info.staked_accounts).await?;
             }
             let mut resend = if msg_height % 10 == 0 {
-                Self::poll_deferred_txs(&tracker, &view_client, "poll").await?
+                Self::poll_deferred_txs(&tracker, &view_client).await?
             } else {
                 Vec::new()
             };
@@ -2059,10 +2045,9 @@ impl<T: ChainAccess> TxMirror<T> {
             if !resend.is_empty() {
                 deferred_resend.send(resend).await?;
             }
-            // Prune only after this block's access-key updates have been resolved, and only
-            // in the steady-state loop (not during index_target_chain catch-up), so a key that
-            // appeared while we were down is resolved by the restart poll before we drop its txs.
-            tracker.lock().deferred_txs.prune(db.as_ref(), msg_height)?;
+            // Prune after this block's access-key updates have been resolved, so a key that
+            // appears in this block resolves its deferred txs before we'd drop them.
+            tracker.lock().deferred_txs.prune(msg_height);
         }
     }
 
@@ -2256,8 +2241,7 @@ impl<T: ChainAccess> TxMirror<T> {
             self.config.tx_batch_interval,
             next_heights.iter(),
             stop_height,
-            &self.db,
-        )?));
+        )));
         let target_height = Arc::new(RwLock::new(0));
         let target_head = Arc::new(RwLock::new(CryptoHash::default()));
         let (clients_tx, clients_rx) = tokio::sync::oneshot::channel();

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1874,7 +1874,7 @@ impl<T: ChainAccess> TxMirror<T> {
             tracker.on_txs_sent(
                 tx_block_queue,
                 &self.db,
-                crate::chain_tracker::SentBatch::ExtraTxs(txs),
+                crate::chain_tracker::SentBatch::UnstakeTxs(txs),
                 target_height,
             )?;
         }
@@ -2059,6 +2059,10 @@ impl<T: ChainAccess> TxMirror<T> {
             if !resend.is_empty() {
                 deferred_resend.send(resend).await?;
             }
+            // Prune only after this block's access-key updates have been resolved, and only
+            // in the steady-state loop (not during index_target_chain catch-up), so a key that
+            // appeared while we were down is resolved by the restart poll before we drop its txs.
+            tracker.lock().deferred_txs.prune(db.as_ref(), msg_height)?;
         }
     }
 
@@ -2130,7 +2134,7 @@ impl<T: ChainAccess> TxMirror<T> {
                     tracker.on_txs_sent(
                         &tx_block_queue,
                         &self.db,
-                        crate::chain_tracker::SentBatch::ExtraTxs(txs),
+                        crate::chain_tracker::SentBatch::DeferredResendTxs(txs),
                         target_height,
                     )?;
                 }

--- a/tools/mirror/src/online.rs
+++ b/tools/mirror/src/online.rs
@@ -28,12 +28,15 @@ pub(crate) struct ChainAccess {
 }
 
 impl ChainAccess {
-    pub(crate) async fn new<P: AsRef<Path>>(home: P) -> anyhow::Result<Self> {
+    pub(crate) async fn new<P: AsRef<Path>>(
+        home: P,
+        actor_system: ActorSystem,
+    ) -> anyhow::Result<Self> {
         let config =
             nearcore::config::load_config(home.as_ref(), GenesisValidationMode::UnsafeFast)
                 .with_context(|| format!("Error loading config from {:?}", home.as_ref()))?;
 
-        let node = nearcore::start_with_config(home.as_ref(), config, ActorSystem::new())
+        let node = nearcore::start_with_config(home.as_ref(), config, actor_system)
             .await
             .context("failed to start NEAR node")?;
         Ok(Self { view_client: node.view_client })


### PR DESCRIPTION
Transactions whose access key hasn't appeared on the target chain by the time their source block is sent are now deferred and persisted in a new `DeferredTxs` DB column. They are resent once the key's nonce becomes known.

- **Nonce ordering**: deferred txs get lower nonces than queued txs, since they're sent immediately via the `deferred_resend` channel
- **Restart safety**: DB cleanup happens in `on_txs_sent` after confirmed send, not in `resolve_deferred_txs`, so deferred txs survive process restarts
- **Periodic polling**: every 10 target blocks, all deferred tx keys are queried against the target chain, catching keys whose pending-outcome was consumed by a previous mirror instance
- **Startup resolution**: on restart, all deferred keys loaded from DB are checked against the target chain
- **TTL pruning**: deferred txs whose key never appears are dropped after `DEFERRED_TX_TTL` (50) target blocks