### PR TITLE
refactor(crypto): turn the ML-DSA-65 hash domain tag into a HashDomainTag enum

### DIFF
--- a/core/crypto/src/hash_domain.rs
+++ b/core/crypto/src/hash_domain.rs
@@ -1,7 +1,7 @@
 /// Domain-separation tags for hashing in the protocol. The tag is prepended
 /// to the input bytes before hashing, so a digest from one domain can never
 /// collide with a digest from another. Each variant is one domain; uses that
-/// deliberately share a digest share a variant.
+/// are meant to produce the same digest must use the same variant.
 #[derive(Debug, Clone, Copy)]
 pub enum HashDomainTag {
     /// `MlDsa65PublicKey`-to-digest derivation. The digest serves as the

--- a/core/crypto/src/hash_domain.rs
+++ b/core/crypto/src/hash_domain.rs
@@ -1,0 +1,21 @@
+/// Domain-separation tags for hashing in the protocol. The tag is prepended
+/// to the input bytes before hashing, so a digest from one domain can never
+/// collide with a digest from another. Each variant is one domain; uses that
+/// deliberately share a digest share a variant.
+#[derive(Debug, Clone, Copy)]
+pub enum HashDomainTag {
+    /// `MlDsa65PublicKey`-to-digest derivation. The digest serves as the
+    /// on-trie access-key identifier (`MlDsa65PublicKeyHandle`) and is
+    /// expected to also serve as the account-id payload for universal
+    /// implicit accounts when that feature lands - the same digest in both
+    /// roles, by design.
+    MlDsa65PubkeyHash,
+}
+
+impl HashDomainTag {
+    pub const fn as_bytes(self) -> &'static [u8] {
+        match self {
+            HashDomainTag::MlDsa65PubkeyHash => b"near:ml-dsa-65-pubkey-hash:v1",
+        }
+    }
+}

--- a/core/crypto/src/hash_domain.rs
+++ b/core/crypto/src/hash_domain.rs
@@ -1,21 +1,19 @@
-/// Domain-separation tags for hashing in the protocol. The tag is prepended
-/// to the input bytes before hashing, so a digest from one domain can never
+/// Domain-separation tags for hashing in the protocol. The tag is prepended to
+/// the input bytes before hashing, so a digest from one domain can never
 /// collide with a digest from another. Each variant is one domain; uses that
 /// are meant to produce the same digest must use the same variant.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum HashDomainTag {
     /// `MlDsa65PublicKey`-to-digest derivation. The digest serves as the
-    /// on-trie access-key identifier (`MlDsa65PublicKeyHandle`) and is
-    /// expected to also serve as the account-id payload for universal
-    /// implicit accounts when that feature lands - the same digest in both
-    /// roles, by design.
-    MlDsa65PubkeyHash,
+    /// on-trie access-key identifier (`MlDsa65PublicKeyHandle`).
+    MlDsa65PubkeyV1,
 }
 
 impl HashDomainTag {
     pub const fn as_bytes(self) -> &'static [u8] {
         match self {
-            HashDomainTag::MlDsa65PubkeyHash => b"near:ml-dsa-65-pubkey-hash:v1",
+            HashDomainTag::MlDsa65PubkeyV1 => b"near:ml-dsa-65-pubkey-hash:v1",
         }
     }
 }

--- a/core/crypto/src/lib.rs
+++ b/core/crypto/src/lib.rs
@@ -16,6 +16,7 @@ mod traits;
 mod util;
 
 mod errors;
+pub mod hash_domain;
 pub mod key_conversion;
 mod key_file;
 mod signature;

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -166,7 +166,7 @@ impl MlDsa65PublicKey {
     pub fn to_public_key_handle(&self) -> MlDsa65PublicKeyHandle {
         use sha3::{Digest, Sha3_256};
         let mut hasher = Sha3_256::new();
-        hasher.update(HashDomainTag::MlDsa65PubkeyHash.as_bytes());
+        hasher.update(HashDomainTag::MlDsa65PubkeyV1.as_bytes());
         hasher.update(&self.0[..]);
         let mut out = [0u8; ML_DSA_65_HASH_LENGTH];
         out.copy_from_slice(&hasher.finalize());

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -1,3 +1,4 @@
+use crate::hash_domain::HashDomainTag;
 use crate::util::try_fixed_array;
 use aws_lc_rs::signature::UnparsedPublicKey;
 use aws_lc_rs::unstable::signature::{ML_DSA_65, ML_DSA_65_SIGNING, PqdsaKeyPair};
@@ -30,10 +31,6 @@ pub const ML_DSA_65_SEED_LENGTH: usize = 32;
 /// the account-id payload for ML-DSA-65 implicit accounts when that
 /// feature lands; update this comment then.
 pub const ML_DSA_65_HASH_LENGTH: usize = 32;
-/// Domain-separation tag for `MlDsa65PublicKey`-to-hash derivation.
-/// Prepended to the raw pubkey bytes before SHA3-256, so an ML-DSA-65
-/// hash can never collide with another use of SHA3 in the protocol.
-const ML_DSA_65_HASH_DOMAIN_TAG: &[u8] = b"near:ml-dsa-65-pubkey-hash:v1";
 /// Wire-format prefix for an ML-DSA-65 access-key identifier (the SHA3-256
 /// digest, not the full pubkey). Used in `view_access_key_list` responses
 /// and accepted by `PublicKeyHandle::from_str`.
@@ -169,7 +166,7 @@ impl MlDsa65PublicKey {
     pub fn to_public_key_handle(&self) -> MlDsa65PublicKeyHandle {
         use sha3::{Digest, Sha3_256};
         let mut hasher = Sha3_256::new();
-        hasher.update(ML_DSA_65_HASH_DOMAIN_TAG);
+        hasher.update(HashDomainTag::MlDsa65PubkeyHash.as_bytes());
         hasher.update(&self.0[..]);
         let mut out = [0u8; ML_DSA_65_HASH_LENGTH];
         out.copy_from_slice(&hasher.finalize());


### PR DESCRIPTION
Replace the fixed ML_DSA_65_HASH_DOMAIN_TAG string constant with a general-purpose HashDomainTag enum in a new public hash_domain module, so future hash domains (e.g. universal implicit account ids) can be added as variants. Tag bytes are unchanged, so existing digests and handles are unaffected.

Please note there are a few options on how to implement this. The tag could be the default number assigned to each variant (0, 1, ..). I chose to preserve the long tag mostly due to being paranoid. The backwards compatibility doesn't matter since the previous tag was not yet released. 

The tag is also made into general purpose thing so that it can later be reused for universal implicit account ids. 