### PR TITLE
test(cloud-archive): assert reader/writer store parity over reconstructed columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8505,6 +8505,7 @@ dependencies = [
  "rlp",
  "serde_json",
  "sha3",
+ "strum",
  "tempfile",
  "testlib",
  "tokio",

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 use crate::DBCol;
 use crate::archive::cloud_storage::batch::compute_batch_id;
 pub use crate::archive::cloud_storage::batch::{BatchId, BatchRange, compute_next_batch};
@@ -144,8 +143,7 @@ fn block_on_future<F: Future>(fut: F) -> F::Output {
 }
 
 /// Columns the cloud-archive reader reproduces from cloud data.
-#[cfg(test)]
-fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
+pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
     matches!(
         col,
         // From BlockData.

--- a/test-loop-tests/Cargo.toml
+++ b/test-loop-tests/Cargo.toml
@@ -33,6 +33,7 @@ rlp.workspace = true
 axum.workspace = true
 serde_json.workspace = true
 sha3.workspace = true
+strum.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tower-service.workspace = true

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -3,10 +3,10 @@ use crate::setup::drop_condition::DropCondition;
 use crate::setup::env::TestLoopEnv;
 use crate::utils::account::archival_account_id;
 use crate::utils::cloud_archival::{
-    WriterConfig, add_writer_node, apply_writer_settings, bootstrap_reader, check_account_balance,
-    check_data_at_height_for_shards, gc_and_heads_sanity_checks, get_cloud_head, get_cloud_storage,
-    get_writer_handle, run_node_until, simulate_lagging_shard, snapshots_sanity_check,
-    stop_and_restart_node, verify_block_range,
+    WriterConfig, add_writer_node, apply_writer_settings, assert_reader_writer_parity,
+    bootstrap_reader, check_account_balance, check_data_at_height_for_shards,
+    gc_and_heads_sanity_checks, get_cloud_head, get_cloud_storage, get_writer_handle,
+    run_node_until, simulate_lagging_shard, snapshots_sanity_check, stop_and_restart_node,
 };
 use borsh::to_vec;
 use near_async::time::Duration;
@@ -51,6 +51,7 @@ struct CloudArchiveHarnessBuilder {
     cold_storage: bool,
     writer: WriterConfig,
     num_validators: Option<usize>,
+    gc_num_epochs_to_keep: u64,
     dropped_block_heights: HashSet<BlockHeight>,
     /// Per-shard chunk-production schedule applied every epoch.
     dropped_chunks_by_shard: HashMap<ShardId, Vec<bool>>,
@@ -74,6 +75,13 @@ impl CloudArchiveHarnessBuilder {
 
     fn snapshot_every_n_epochs(mut self, cadence: u64) -> Self {
         self.writer.snapshot_every_n_epochs = cadence;
+        self
+    }
+
+    /// Effectively disables GC so the writer retains the bootstrap range for
+    /// reader-writer-parity assertions.
+    fn disable_gc(mut self) -> Self {
+        self.gc_num_epochs_to_keep = 1000;
         self
     }
 
@@ -110,7 +118,7 @@ impl CloudArchiveHarnessBuilder {
             .epoch_length(CloudArchiveHarness::DEFAULT_EPOCH_LENGTH)
             .add_user_account(&user_account, CloudArchiveHarness::USER_BALANCE)
             .enable_archival_node(archival_kind)
-            .gc_num_epochs_to_keep(MIN_GC_NUM_EPOCHS_TO_KEEP)
+            .gc_num_epochs_to_keep(self.gc_num_epochs_to_keep)
             .bucket_config(BucketConfig::with_batch_size_for_test(
                 CloudArchiveHarness::TEST_BATCH_SIZE,
             ))
@@ -171,6 +179,7 @@ impl CloudArchiveHarness {
                 snapshot_every_n_epochs: 1,
             },
             num_validators: None,
+            gc_num_epochs_to_keep: MIN_GC_NUM_EPOCHS_TO_KEEP,
             dropped_block_heights: HashSet::new(),
             dropped_chunks_by_shard: HashMap::new(),
         }
@@ -246,10 +255,8 @@ impl CloudArchiveHarness {
         );
     }
 
-    fn assert_reader_blocks(&self, start_height: BlockHeight, end_height: BlockHeight) {
-        let reader_id = self.reader_id.as_ref().expect("no reader bootstrapped");
-        let store = self.env.node_for_account(reader_id).client().chain.chain_store().store();
-        verify_block_range(&store, start_height, end_height);
+    fn assert_reader_writer_parity(&self, start: BlockHeight, end: BlockHeight) {
+        assert_reader_writer_parity(&self.reader_store(), &self.writer_store(), start, end);
     }
 
     fn assert_reader_account_balance(&self, account: &AccountId, expected: Balance) {
@@ -421,20 +428,17 @@ fn test_cloud_archival_batching_blob_per_batch() {
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_use_snapshot() {
-    let mut h = CloudArchiveHarness::builder().build();
-    // Run enough epochs for the target height (mid-epoch-2) to be gc-ed
-    // locally, so the reader must bootstrap entirely from cloud.
-    let epochs = 3 + MIN_GC_NUM_EPOCHS_TO_KEEP;
-    h.run_until_epoch(epochs);
-    h.assert_heads_and_gc_ok();
+    // Reader still uses cloud: it's a fresh node with no local data.
+    let mut h = CloudArchiveHarness::builder().disable_gc().build();
+    h.run_until_epoch(3);
+    h.assert_heads_ok_before_gc();
     h.assert_snapshots_ok();
 
     // Bootstrap reader from mid-epoch-1 to mid-epoch-2, spanning an epoch boundary.
     let start = h.epoch_length / 2;
     let target = h.epoch_length + h.epoch_length / 2;
-    assert!(h.gc_tail() > target, "target height should be gc-ed");
     h.bootstrap_reader(start, target);
-    h.assert_reader_blocks(start, target);
+    h.assert_reader_writer_parity(start, target);
     h.assert_reader_account_balance(
         &CloudArchiveHarness::USER_ACCOUNT.parse().unwrap(),
         CloudArchiveHarness::USER_BALANCE,
@@ -677,15 +681,18 @@ fn test_cloud_archival_find_snapshot_with_missing_epoch_boundary() {
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_single_skipped_slot() {
     let dropped_height: BlockHeight = 13;
-    let mut h =
-        CloudArchiveHarness::builder().validators(4).drop_blocks_at(&[dropped_height]).build();
-    h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
+    let mut h = CloudArchiveHarness::builder()
+        .validators(4)
+        .drop_blocks_at(&[dropped_height])
+        .disable_gc()
+        .build();
+    h.run_until_epoch(3);
 
     let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
     let batch = cloud_storage.get_block_batch_for_height(dropped_height).unwrap();
     assert!(batch.get_block_at_height(dropped_height).is_none());
     assert!(h.cloud_head() > dropped_height);
-    h.assert_heads_and_gc_ok();
+    h.assert_heads_ok_before_gc();
 
     let (start, target) = (5, 15);
     let epoch_of = |height| {
@@ -708,6 +715,7 @@ fn test_cloud_archival_single_skipped_slot() {
     );
 
     h.bootstrap_reader(start, target);
+    h.assert_reader_writer_parity(start, target);
     h.kill_reader();
 
     h.shutdown();
@@ -748,9 +756,12 @@ fn test_cloud_archival_fully_skipped_batch() {
     let dropped_heights: Vec<BlockHeight> = vec![12, 13, 14, 15];
     // TODO(cloud_archival): drop validator count once `block_dropper_by_height`
     // also intercepts `BlockRequest` responses.
-    let mut h =
-        CloudArchiveHarness::builder().validators(12).drop_blocks_at(&dropped_heights).build();
-    h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
+    let mut h = CloudArchiveHarness::builder()
+        .validators(12)
+        .drop_blocks_at(&dropped_heights)
+        .disable_gc()
+        .build();
+    h.run_until_epoch(3);
 
     let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
     let batch = cloud_storage.get_block_batch_for_height(12).unwrap();
@@ -761,7 +772,13 @@ fn test_cloud_archival_fully_skipped_batch() {
         );
     }
     assert!(h.cloud_head() > 15, "cloud_head must advance past the gap");
-    h.assert_heads_and_gc_ok();
+    h.assert_heads_ok_before_gc();
+
+    let start = h.epoch_length / 2;
+    let target = h.epoch_length + h.epoch_length / 2;
+    h.bootstrap_reader(start, target);
+    h.assert_reader_writer_parity(start, target);
+    h.kill_reader();
 
     h.shutdown();
 }
@@ -790,10 +807,10 @@ fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
         .validators(4)
         .drop_blocks_at(&[start, target])
         .drop_chunks(dropped_shard, chunk_pattern)
+        .disable_gc()
         .build();
-    let epochs = 4 + MIN_GC_NUM_EPOCHS_TO_KEEP;
-    h.run_until_epoch(epochs);
-    h.assert_heads_and_gc_ok();
+    h.run_until_epoch(target / h.epoch_length + 2);
+    h.assert_heads_ok_before_gc();
     h.assert_snapshots_ok();
 
     // Confirm the drops actually landed in cloud storage before bootstrap.
@@ -822,8 +839,8 @@ fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
         "carried chunk at h={chunk_drop_height} must be archived with chunk=None"
     );
 
-    assert!(h.gc_tail() > target, "target height should be gc-ed");
     h.bootstrap_reader(start, target);
+    h.assert_reader_writer_parity(start, target);
     // A correct balance proves bootstrap completed without panic, the trie
     // was reconstructed up to the target's clipped height, and the
     // carried-over chunk path was traversed during state apply.
@@ -853,9 +870,12 @@ fn test_cloud_archival_missing_chunks_one_shard() {
     for offset in dropped_offsets {
         pattern[offset as usize] = false;
     }
-    let mut h =
-        CloudArchiveHarness::builder().validators(4).drop_chunks(dropped_shard, pattern).build();
-    h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
+    let mut h = CloudArchiveHarness::builder()
+        .validators(4)
+        .drop_chunks(dropped_shard, pattern)
+        .disable_gc()
+        .build();
+    h.run_until_epoch(4);
 
     let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
     let state_root_at = |height| -> CryptoHash {
@@ -893,7 +913,13 @@ fn test_cloud_archival_missing_chunks_one_shard() {
             );
         }
     }
-    h.assert_heads_and_gc_ok();
+    h.assert_heads_ok_before_gc();
+
+    let start = h.epoch_length / 2;
+    let target = 3 * h.epoch_length;
+    h.bootstrap_reader(start, target);
+    h.assert_reader_writer_parity(start, target);
+    h.kill_reader();
 
     h.shutdown();
 }
@@ -906,7 +932,7 @@ fn test_cloud_archival_missing_chunks_one_shard() {
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_outcomes_and_receipts() {
-    let mut h = CloudArchiveHarness::builder().build();
+    let mut h = CloudArchiveHarness::builder().disable_gc().build();
     let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
     // Cross-shard transfers exercise outgoing receipts; one self-transfer
     // produces a local (non-outgoing) action receipt whose ReceiptToTx the
@@ -1020,6 +1046,11 @@ fn test_cloud_archival_outcomes_and_receipts() {
     }
     assert!(total_outcomes > 0, "no outcomes were compared");
     assert!(total_receipt_to_tx > 0, "no receipt_to_tx entries were compared");
+
+    h.bootstrap_reader(start, end);
+    h.assert_reader_writer_parity(start, end);
+    h.kill_reader();
+
     h.shutdown();
 }
 

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -11,29 +11,25 @@ use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::sync::external::{
     StateFileType, StateSyncConnection, external_storage_location, list_state_parts,
 };
-use near_primitives::block::Block;
-use near_primitives::block_header::BlockHeader;
-use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::state_part::{PartId, StatePart};
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId,
 };
-use near_primitives::utils::index_to_bytes;
 use near_store::adapter::StoreAdapter;
-use near_store::archive::cloud_storage::CloudStorage;
+use near_store::archive::cloud_storage::{CloudStorage, is_cloud_archive_reader_bootstrapped};
 use near_store::db::{CLOUD_MIN_HEAD_KEY, CLOUD_PREV_EPOCH_END_KEY};
 use near_store::flat::FlatStorageManager;
 use near_store::trie::AccessOptions;
 use near_store::{
     COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, StateSnapshotConfig, Store, Trie, TrieConfig,
 };
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
+use strum::IntoEnumIterator;
 
 #[derive(Clone)]
 pub(crate) struct WriterConfig {
@@ -492,54 +488,90 @@ fn apply_state_changes(
     assert_eq!(state_root, *expected_final_state_root);
 }
 
-/// Verifies that all block and epoch columns written by bootstrap_range
-/// are present and consistent in the store.
-pub(crate) fn verify_block_range(
-    store: &Store,
-    start_height: BlockHeight,
-    end_height: BlockHeight,
+/// Asserts the reader's store equals the writer's over `[start, end]` for every
+/// column the cloud-bootstrapped reader reconstructs. Caller must `.disable_gc()`
+/// so the writer retains the bootstrap range.
+pub(crate) fn assert_reader_writer_parity(
+    reader: &Store,
+    writer: &Store,
+    start: BlockHeight,
+    end: BlockHeight,
 ) {
-    let mut prev_hash = None;
-    let mut seen_epochs = HashSet::<EpochId>::new();
-    for height in start_height..=end_height {
-        let block_hash: CryptoHash = store
-            .get_ser(DBCol::BlockHeight, &index_to_bytes(height))
-            .unwrap_or_else(|| panic!("BlockHeight entry missing at height {height}"));
+    let writer_store = writer.chain_store();
+    let in_range_hashes: HashSet<CryptoHash> =
+        (start..=end).filter_map(|h| writer_store.get_block_hash_by_height(h).ok()).collect();
+    let in_range_epoch_ids: HashSet<CryptoHash> = in_range_hashes
+        .iter()
+        .filter_map(|hash| writer_store.get_block_header(hash).ok().map(|h| h.epoch_id().0))
+        .collect();
 
-        // Verify all block-level columns exist.
-        let header: BlockHeader = store
-            .get_ser(DBCol::BlockHeader, block_hash.as_ref())
-            .unwrap_or_else(|| panic!("BlockHeader missing at height {height}"));
-        let _block: Block = store
-            .get_ser(DBCol::Block, block_hash.as_ref())
-            .unwrap_or_else(|| panic!("Block missing at height {height}"));
-        let _block_info: BlockInfo = store
-            .get_ser(DBCol::BlockInfo, block_hash.as_ref())
-            .unwrap_or_else(|| panic!("BlockInfo missing at height {height}"));
-
-        // Verify epoch-level columns exist for each epoch we encounter.
-        let epoch_id = *header.epoch_id();
-        if seen_epochs.insert(epoch_id) {
-            let _epoch_info: EpochInfo = store
-                .get_ser(DBCol::EpochInfo, epoch_id.as_ref())
-                .unwrap_or_else(|| panic!("EpochInfo missing for epoch at height {height}"));
+    for col in DBCol::iter().filter(|&c| is_cloud_archive_reader_bootstrapped(c)) {
+        match col {
+            DBCol::BlockHeight => {
+                assert_block_height_keyed_parity(reader, writer, col, start, end);
+            }
+            DBCol::Block | DBCol::BlockHeader | DBCol::BlockInfo | DBCol::BlockMerkleTree => {
+                assert_block_hash_keyed_parity(reader, writer, col, &in_range_hashes);
+            }
+            DBCol::EpochInfo | DBCol::EpochStart => {
+                assert_block_hash_keyed_parity(reader, writer, col, &in_range_epoch_ids);
+            }
+            // TODO(cloud_archival): handle these columns.
+            DBCol::NextBlockHashes
+            | DBCol::BlockPerHeight
+            | DBCol::ChunkHashesByHeight
+            | DBCol::ChunkExtra
+            | DBCol::ChunkApplyStats
+            | DBCol::IncomingReceipts
+            | DBCol::OutgoingReceipts
+            | DBCol::OutcomeIds
+            | DBCol::TransactionResultForBlock
+            | DBCol::StateChanges
+            | DBCol::Chunks
+            | DBCol::Transactions
+            | DBCol::Receipts
+            | DBCol::ReceiptToTx
+            | DBCol::State => {}
+            _ => unreachable!("{col} is reader-bootstrapped but unhandled by the parity helper"),
         }
-
-        // Verify merkle tree exists and chains correctly from the previous block.
-        let tree: PartialMerkleTree = store
-            .get_ser(DBCol::BlockMerkleTree, block_hash.as_ref())
-            .unwrap_or_else(|| panic!("BlockMerkleTree missing at height {height}"));
-        if let Some(prev) = prev_hash {
-            assert_eq!(*header.prev_hash(), prev, "prev_hash linkage broken at height {height}");
-            let prev_tree: PartialMerkleTree = store
-                .get_ser(DBCol::BlockMerkleTree, CryptoHash::as_ref(&prev))
-                .expect("prev BlockMerkleTree should exist");
-            assert_eq!(
-                tree.size(),
-                prev_tree.size() + 1,
-                "merkle tree size should increment at height {height}"
-            );
-        }
-        prev_hash = Some(block_hash);
     }
+}
+
+fn assert_block_height_keyed_parity(
+    reader: &Store,
+    writer: &Store,
+    col: DBCol,
+    start: BlockHeight,
+    end: BlockHeight,
+) {
+    let collect = |s: &Store| -> BTreeMap<Box<[u8]>, Box<[u8]>> {
+        s.iter(col)
+            .filter(|(key, _)| {
+                let height_bytes = key[..size_of::<BlockHeight>()].try_into().unwrap();
+                let height = BlockHeight::from_be_bytes(height_bytes);
+                (start..=end).contains(&height)
+            })
+            .collect()
+    };
+    assert_eq!(collect(reader), collect(writer), "{col} parity mismatch");
+}
+
+fn assert_block_hash_keyed_parity(
+    reader: &Store,
+    writer: &Store,
+    col: DBCol,
+    in_range_hashes: &HashSet<CryptoHash>,
+) {
+    let collect = |s: &Store| -> BTreeMap<Box<[u8]>, Box<[u8]>> {
+        s.iter(col)
+            .filter(|(key, _)| {
+                if key.len() < CryptoHash::LENGTH {
+                    return false;
+                }
+                let hash = CryptoHash(key[..CryptoHash::LENGTH].try_into().unwrap());
+                in_range_hashes.contains(&hash)
+            })
+            .collect()
+    };
+    assert_eq!(collect(reader), collect(writer), "{col} parity mismatch");
 }

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -18,6 +18,7 @@ use near_primitives::state_part::{PartId, StatePart};
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId,
 };
+use near_primitives::utils::index_to_bytes;
 use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::{CloudStorage, is_cloud_archive_reader_bootstrapped};
 use near_store::db::{CLOUD_MIN_HEAD_KEY, CLOUD_PREV_EPOCH_END_KEY};
@@ -26,7 +27,7 @@ use near_store::trie::AccessOptions;
 use near_store::{
     COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, StateSnapshotConfig, Store, Trie, TrieConfig,
 };
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
@@ -488,90 +489,144 @@ fn apply_state_changes(
     assert_eq!(state_root, *expected_final_state_root);
 }
 
-/// Asserts the reader's store equals the writer's over `[start, end]` for every
-/// column the cloud-bootstrapped reader reconstructs. Caller must `.disable_gc()`
-/// so the writer retains the bootstrap range.
+/// How the reader is checked against the writer over the in-range keys.
+enum Parity {
+    /// Reader must equal the in-range writer rows exactly, holding no extra rows.
+    Equality,
+    /// Reader must contain every in-range writer row, but may hold extra rows
+    /// (e.g. blocks backfilled below `start` to complete the merkle tree chain).
+    Containment,
+}
+
+/// Asserts the reader reproduces the writer's rows over `[start, end]` for every
+/// column the cloud-bootstrapped reader reconstructs today. Caller must
+/// `.disable_gc()` so the writer retains the bootstrap range.
 pub(crate) fn assert_reader_writer_parity(
     reader: &Store,
     writer: &Store,
     start: BlockHeight,
     end: BlockHeight,
 ) {
-    let writer_store = writer.chain_store();
-    let in_range_hashes: HashSet<CryptoHash> =
-        (start..=end).filter_map(|h| writer_store.get_block_hash_by_height(h).ok()).collect();
-    let in_range_epoch_ids: HashSet<CryptoHash> = in_range_hashes
-        .iter()
-        .filter_map(|hash| writer_store.get_block_header(hash).ok().map(|h| h.epoch_id().0))
+    // TODO(cloud_archival): compare the skipped columns too.
+    let cols: Vec<DBCol> = DBCol::iter()
+        .filter(|&c| {
+            is_cloud_archive_reader_bootstrapped(c)
+                && !matches!(
+                    c,
+                    // Not reconstructed yet.
+                    DBCol::NextBlockHashes
+                        | DBCol::BlockPerHeight
+                        | DBCol::ChunkHashesByHeight
+                        | DBCol::ChunkExtra
+                        | DBCol::ChunkApplyStats
+                        | DBCol::IncomingReceipts
+                        | DBCol::OutgoingReceipts
+                        | DBCol::OutcomeIds
+                        | DBCol::TransactionResultForBlock
+                        | DBCol::StateChanges
+                        | DBCol::Chunks
+                        | DBCol::Transactions
+                        | DBCol::Receipts
+                        | DBCol::ReceiptToTx
+                        | DBCol::State
+                        // Reconstructed, but keyed off-height (genesis BlockInfo under
+                        // CryptoHash::default(), EpochInfo under AGGREGATOR_KEY), so the
+                        // height walk can't reproduce their key sets.
+                        | DBCol::BlockInfo
+                        | DBCol::EpochInfo
+                        | DBCol::EpochStart
+                )
+        })
         .collect();
 
-    for col in DBCol::iter().filter(|&c| is_cloud_archive_reader_bootstrapped(c)) {
-        match col {
-            DBCol::BlockHeight => {
-                assert_block_height_keyed_parity(reader, writer, col, start, end);
+    let writer_in_range = in_range_kvs(writer, &cols, start, end);
+
+    for &col in &cols {
+        let parity = match col {
+            // The reader backfills these columns below `start` to complete the merkle
+            // tree chain, so it holds extra rows: check containment, not equality.
+            DBCol::BlockHeight | DBCol::Block | DBCol::BlockHeader | DBCol::BlockMerkleTree => {
+                Parity::Containment
             }
-            DBCol::Block | DBCol::BlockHeader | DBCol::BlockInfo | DBCol::BlockMerkleTree => {
-                assert_block_hash_keyed_parity(reader, writer, col, &in_range_hashes);
+            _ => Parity::Equality,
+        };
+        assert_keyed_parity(reader, col, &writer_in_range[&col], parity);
+    }
+}
+
+/// Compares the writer's in-range rows in `col` against the full reader.
+fn assert_keyed_parity(
+    reader: &Store,
+    col: DBCol,
+    writer_in_range_kvs: &BTreeMap<Vec<u8>, Vec<u8>>,
+    parity: Parity,
+) {
+    let reader_all_kvs: BTreeMap<Vec<u8>, Vec<u8>> =
+        reader.iter(col).map(|(k, v)| (k.into_vec(), v.into_vec())).collect();
+    match parity {
+        Parity::Equality => {
+            assert_eq!(&reader_all_kvs, writer_in_range_kvs, "{col} parity mismatch")
+        }
+        Parity::Containment => {
+            for (key, writer_value) in writer_in_range_kvs {
+                assert_eq!(
+                    reader_all_kvs.get(key),
+                    Some(writer_value),
+                    "{col}: writer key {key:?} missing or different at reader"
+                );
             }
-            DBCol::EpochInfo | DBCol::EpochStart => {
-                assert_block_hash_keyed_parity(reader, writer, col, &in_range_epoch_ids);
-            }
-            // TODO(cloud_archival): handle these columns.
-            DBCol::NextBlockHashes
-            | DBCol::BlockPerHeight
-            | DBCol::ChunkHashesByHeight
-            | DBCol::ChunkExtra
-            | DBCol::ChunkApplyStats
-            | DBCol::IncomingReceipts
-            | DBCol::OutgoingReceipts
-            | DBCol::OutcomeIds
-            | DBCol::TransactionResultForBlock
-            | DBCol::StateChanges
-            | DBCol::Chunks
-            | DBCol::Transactions
-            | DBCol::Receipts
-            | DBCol::ReceiptToTx
-            | DBCol::State => {}
-            _ => unreachable!("{col} is reader-bootstrapped but unhandled by the parity helper"),
         }
     }
 }
 
-fn assert_block_height_keyed_parity(
-    reader: &Store,
+/// Returns the writer's key-values within `[start, end]`, one map per column in `cols`.
+fn in_range_kvs(
     writer: &Store,
-    col: DBCol,
+    cols: &[DBCol],
     start: BlockHeight,
     end: BlockHeight,
-) {
-    let collect = |s: &Store| -> BTreeMap<Box<[u8]>, Box<[u8]>> {
-        s.iter(col)
-            .filter(|(key, _)| {
-                let height_bytes = key[..size_of::<BlockHeight>()].try_into().unwrap();
-                let height = BlockHeight::from_be_bytes(height_bytes);
-                (start..=end).contains(&height)
-            })
-            .collect()
-    };
-    assert_eq!(collect(reader), collect(writer), "{col} parity mismatch");
-}
+) -> HashMap<DBCol, BTreeMap<Vec<u8>, Vec<u8>>> {
+    let writer_store = writer.chain_store();
+    let chain_head = writer_store.head().unwrap().height;
 
-fn assert_block_hash_keyed_parity(
-    reader: &Store,
-    writer: &Store,
-    col: DBCol,
-    in_range_hashes: &HashSet<CryptoHash>,
-) {
-    let collect = |s: &Store| -> BTreeMap<Box<[u8]>, Box<[u8]>> {
-        s.iter(col)
-            .filter(|(key, _)| {
-                if key.len() < CryptoHash::LENGTH {
-                    return false;
-                }
-                let hash = CryptoHash(key[..CryptoHash::LENGTH].try_into().unwrap());
-                in_range_hashes.contains(&hash)
-            })
-            .collect()
-    };
-    assert_eq!(collect(reader), collect(writer), "{col} parity mismatch");
+    let mut in_range: HashMap<DBCol, BTreeMap<Vec<u8>, Vec<u8>>> =
+        cols.iter().map(|&c| (c, BTreeMap::new())).collect();
+    let mut out_of_range: HashMap<DBCol, BTreeMap<Vec<u8>, Vec<u8>>> =
+        cols.iter().map(|&c| (c, BTreeMap::new())).collect();
+
+    // Walk the chain, reading each column's row at height `h` into the in-range or
+    // out-of-range map.
+    for h in 0..=chain_head {
+        let Ok(block_hash) = writer_store.get_block_hash_by_height(h) else {
+            continue;
+        };
+        let kvs = if (start..=end).contains(&h) { &mut in_range } else { &mut out_of_range };
+        let height_key = index_to_bytes(h).to_vec();
+        if let Some(value) = writer.get(DBCol::BlockHeight, &height_key) {
+            kvs.get_mut(&DBCol::BlockHeight).unwrap().insert(height_key, value.to_vec());
+        }
+        for col in [DBCol::Block, DBCol::BlockHeader, DBCol::BlockMerkleTree] {
+            let key = block_hash.as_ref().to_vec();
+            if let Some(value) = writer.get(col, &key) {
+                kvs.get_mut(&col).unwrap().insert(key, value.to_vec());
+            }
+        }
+    }
+
+    // TODO(cloud_archival): add a negative test (follow-up PR) that tampers a
+    // reader row and confirms these checks catch it.
+    // The walk must reproduce each writer column exactly, keys and values.
+    for &col in cols {
+        let writer_all: BTreeMap<Vec<u8>, Vec<u8>> =
+            writer.iter(col).map(|(k, v)| (k.into_vec(), v.into_vec())).collect();
+        let mut seen = in_range[&col].clone();
+        seen.extend(out_of_range[&col].clone());
+        assert_eq!(seen, writer_all, "{col}: walk did not reproduce writer's column");
+        assert!(
+            in_range[&col].keys().all(|k| !out_of_range[&col].contains_key(k)),
+            "{col}: key in both in-range and out-of-range",
+        );
+    }
+
+    in_range
 }


### PR DESCRIPTION
Replaces `verify_block_range` with `assert_reader_writer_parity`, which byte-compares the reader's reconstructed store against the writer's over `[start, end]`, comparing keys and values where the old check only verified presence.

The compared set is derived from `is_cloud_archive_reader_bootstrapped` rather than a hand-kept list, so a newly retained column can't silently escape the check. Only the columns the reader reconstructs today are compared.