### PR TITLE
fix(tx): count the signature in transaction size limits

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -965,7 +965,9 @@ impl RuntimeAdapter for NightshadeRuntime {
             // Take a single transaction from this transaction group
             while let Some(tx_peek) = transaction_group_iter.peek_next() {
                 // Stop adding transactions if the size limit would be exceeded
-                if total_size.saturating_add(tx_peek.get_size()) > size_limit as u64 {
+                if total_size.saturating_add(tx_peek.size_for_limits(protocol_version))
+                    > size_limit as u64
+                {
                     prepared_transactions.limited_by = PrepareTransactionsLimit::Size;
                     break 'add_txs_loop;
                 }
@@ -1108,7 +1110,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         }
                         tracing::trace!(target: "runtime", tx=?validated_tx.get_hash(), "including transaction that passed validation and verification");
                         total_gas_burnt = total_gas_burnt.checked_add(result.gas_burnt).unwrap();
-                        total_size += validated_tx.get_size();
+                        total_size += validated_tx.size_for_limits(protocol_version);
                         prepared_transactions.transactions.push(validated_tx);
                         // Take one transaction from this group, no more.
                         break;

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -98,7 +98,7 @@ impl TransactionPool {
         // to catch a logic error in estimation of transaction size.
         let new_total_transaction_size = self
             .total_transaction_size
-            .checked_add(validated_tx.get_size())
+            .checked_add(validated_tx.wire_size())
             .expect("Total transaction size is too large");
         if let Some(limit) = self.total_transaction_size_limit {
             if new_total_transaction_size > limit {
@@ -166,7 +166,7 @@ impl TransactionPool {
                     // here catches a logic error.
                     self.total_transaction_size = self
                         .total_transaction_size
-                        .checked_sub(tx.get_size())
+                        .checked_sub(tx.wire_size())
                         .expect("Total transaction size dropped below zero");
                     false
                 });
@@ -626,13 +626,13 @@ mod tests {
         let mut total_transaction_size = 0;
         // Adding transactions increases the size.
         for tx in transactions.clone() {
-            total_transaction_size += tx.get_size();
+            total_transaction_size += tx.wire_size();
             assert_eq!(pool.insert_transaction(tx), InsertTransactionResult::Success);
             assert_eq!(pool.transaction_size(), total_transaction_size);
         }
         // Removing transactions decreases the size.
         for tx in transactions {
-            total_transaction_size -= tx.get_size();
+            total_transaction_size -= tx.wire_size();
             pool.remove_transactions(&[tx.into_signed_tx()]);
             assert_eq!(pool.transaction_size(), total_transaction_size);
         }
@@ -644,7 +644,7 @@ mod tests {
         let transactions = generate_transactions("alice.near", "alice.near", 1, 100);
         // Each transaction is at least 1 byte in size, so the last transaction will not fit.
         let pool_size_limit =
-            transactions.iter().map(|tx| tx.get_size()).sum::<u64>().strict_sub(1);
+            transactions.iter().map(|tx| tx.wire_size()).sum::<u64>().strict_sub(1);
         let mut pool = TransactionPool::new(TEST_SEED, Some(pool_size_limit), "");
         for (i, tx) in transactions.iter().cloned().enumerate() {
             if i + 1 < transactions.len() {

--- a/chain/pool/src/types.rs
+++ b/chain/pool/src/types.rs
@@ -33,7 +33,7 @@ impl TransactionGroup {
     pub fn next(&mut self) -> Option<ValidatedTransaction> {
         if let Some(validated_tx) = self.transactions.pop() {
             self.removed_transaction_hashes.push(validated_tx.get_hash());
-            self.removed_transaction_size += validated_tx.get_size();
+            self.removed_transaction_size += validated_tx.wire_size();
             self.removed_any_since_yield = true;
             Some(validated_tx)
         } else {

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -324,7 +324,7 @@ impl ValidatedTransaction {
         {
             return Err(InvalidTxError::InvalidTransactionVersion);
         }
-        let tx_size = signed_tx.get_size();
+        let tx_size = signed_tx.size_for_limits(protocol_version);
         let max_tx_size = config.wasm_config.limit_config.max_transaction_size;
         if tx_size > max_tx_size {
             return Err(InvalidTxError::TransactionSizeExceeded {
@@ -361,6 +361,16 @@ impl ValidatedTransaction {
 
     pub fn get_size(&self) -> u64 {
         self.0.get_size()
+    }
+
+    /// See [`SignedTransaction::wire_size`].
+    pub fn wire_size(&self) -> u64 {
+        self.0.wire_size()
+    }
+
+    /// See [`SignedTransaction::size_for_limits`].
+    pub fn size_for_limits(&self, protocol_version: ProtocolVersion) -> u64 {
+        self.0.size_for_limits(protocol_version)
     }
 
     pub fn signer_id(&self) -> &AccountId {
@@ -423,6 +433,30 @@ impl SignedTransaction {
 
     pub fn get_size(&self) -> u64 {
         self.size
+    }
+
+    /// Full borsh-serialized size of the signed transaction, including the
+    /// signature.
+    ///
+    /// [`Self::get_size`] counts only the inner `Transaction` body, omitting
+    /// the signature - ~65 B for ed25519 but up to ~3.3 KiB for ML-DSA-65.
+    /// Use this where the true on-wire / in-witness size matters.
+    pub fn wire_size(&self) -> u64 {
+        let signature_size =
+            borsh::object_length(&self.signature).expect("borsh signature length") as u64;
+        self.size + signature_size
+    }
+
+    /// Transaction size charged against the `max_transaction_size` and
+    /// `combined_transactions_size_limit` gates: [`Self::wire_size`] from
+    /// [`ProtocolFeature::PostQuantumSignatures`] onward, else the legacy
+    /// [`Self::get_size`]. Version-gated to keep chunk production deterministic.
+    pub fn size_for_limits(&self, protocol_version: ProtocolVersion) -> u64 {
+        if ProtocolFeature::PostQuantumSignatures.enabled(protocol_version) {
+            self.wire_size()
+        } else {
+            self.get_size()
+        }
     }
 
     /// Returns `true` if this transaction carries any post-quantum key
@@ -1109,5 +1143,52 @@ mod tests {
         );
         ValidatedTransaction::check_valid_for_config(&config, &signed_tx, post)
             .expect("same transaction must be accepted post-feature");
+    }
+
+    /// `wire_size` equals the full borsh length of the signed transaction
+    /// (body + signature) and exceeds the body-only `get_size` by exactly the
+    /// serialized signature length. For ed25519 that delta is tiny.
+    #[test]
+    fn test_wire_size_counts_signature() {
+        let signed_tx = signed_tx_with_action(
+            KeyType::ED25519,
+            Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(1) }),
+        );
+        let full_len = borsh::to_vec(&signed_tx).unwrap().len() as u64;
+        assert_eq!(signed_tx.wire_size(), full_len, "wire_size must equal full borsh length");
+        let signature_len = borsh::object_length(&signed_tx.signature).unwrap() as u64;
+        assert_eq!(signed_tx.wire_size(), signed_tx.get_size() + signature_len);
+        assert!(signature_len < 100, "ed25519 signature unexpectedly large: {signature_len}");
+    }
+
+    /// The motivation for the change: an ML-DSA-65 signature is invisible to
+    /// `get_size` but adds ~3.3 KiB that `wire_size` accounts for.
+    #[test]
+    fn test_wire_size_ml_dsa_signature_is_large() {
+        let signed_tx = signed_tx_with_action(
+            KeyType::MLDSA65,
+            Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(1) }),
+        );
+        assert_eq!(signed_tx.wire_size(), borsh::to_vec(&signed_tx).unwrap().len() as u64);
+        let hidden_by_get_size = signed_tx.wire_size() - signed_tx.get_size();
+        assert!(
+            hidden_by_get_size > 3000,
+            "ML-DSA-65 signature should add >3 KiB beyond get_size, got {hidden_by_get_size}"
+        );
+    }
+
+    /// `size_for_limits` is the body-only size before `PostQuantumSignatures`
+    /// and the full wire size from that version onward.
+    #[test]
+    fn test_size_for_limits_version_gated() {
+        let signed_tx = signed_tx_with_action(
+            KeyType::MLDSA65,
+            Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(1) }),
+        );
+        let pre = ProtocolFeature::PostQuantumSignatures.protocol_version() - 1;
+        let post = ProtocolFeature::PostQuantumSignatures.protocol_version();
+        assert_eq!(signed_tx.size_for_limits(pre), signed_tx.get_size());
+        assert_eq!(signed_tx.size_for_limits(post), signed_tx.wire_size());
+        assert!(signed_tx.size_for_limits(post) > signed_tx.size_for_limits(pre));
     }
 }

--- a/docs/architecture/how/post_quantum_signatures.md
+++ b/docs/architecture/how/post_quantum_signatures.md
@@ -305,6 +305,22 @@ items the team should resolve before stabilizing in 2.13.
      bandwidth/witness gas-vs-bytes gap (large ML-DSA txs vs the per-chunk
      size limit) - both out of scope for the verification charge.
 
+   The **size axis** splits into accounting and pricing, and the
+   *accounting* half is now done. `SignedTransaction::get_size()` counts only
+   the inner `Transaction` body, so it under-counted every ML-DSA-65 tx by its
+   ~3.3 KiB signature - including inside `combined_transactions_size_limit`,
+   the bound on transaction bytes carried by the `ChunkStateWitness`.
+   `SignedTransaction::wire_size()` now returns the full borsh length
+   (signature included), and `size_for_limits(protocol_version)` selects it
+   for the `max_transaction_size` and `combined_transactions_size_limit` gates
+   from `PostQuantumSignatures` onward (version-gated to keep chunk production
+   deterministic across the boundary). The mempool counts `wire_size()`
+   unconditionally, since it physically buffers the signature. *Pricing* the
+   extra size - e.g. a per-wire-byte gas surcharge at conversion time,
+   mirroring the verify cost - is **out of scope for now**: the accounting fix
+   closes the witness-honesty gap on its own, independent of any later pricing
+   decision.
+
 3. **Wallet/SDK story for the view-RPC change.** Add the
    `near-api-js`/`near-cli-rs` side of the change, document the hash format,
    and decide whether to expose a separate `view_access_key_hash` endpoint

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2889,15 +2889,26 @@ fn test_reorg_reintroduces_old_branch_tx_when_pool_is_full() {
     // the chain allows zero; that check is orthogonal to what this exercises.
     genesis.config.min_gas_price = Balance::ZERO;
 
-    // A send_money tx in these tests is 112 bytes, so a 120-byte limit holds
-    // exactly one such tx; a second insert fails with `NoSpaceLeft`.
+    // Size the pool to hold exactly one `send_money` transaction; a second
+    // insert then fails with `NoSpaceLeft`. The pool accounts for the full
+    // `wire_size` (body + signature), so measure that rather than hard-coding
+    // a byte count.
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
+    let one_tx_size = SignedTransaction::send_money(
+        1,
+        "test0".parse().unwrap(),
+        "test1".parse().unwrap(),
+        &signer,
+        Balance::from_yoctonear(1),
+        CryptoHash::default(),
+    )
+    .wire_size();
     let mut env = TestEnv::builder(&genesis.config)
         .nightshade_runtimes(&genesis)
-        .transaction_pool_size_limit(Some(120))
+        .transaction_pool_size_limit(Some(one_tx_size))
         .build();
 
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let validator_signer = Arc::new(create_test_signer("test0"));
     let validator_id = env.clients[0].validator_signer.get().unwrap().validator_id().clone();
     let shard_uid = ShardUId::single_shard();

--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -29,7 +29,10 @@ fn test_deploy_max_size_contract() {
         vec![Action::DeployContract(DeployContractAction { code: vec![0u8] })],
         block_hash,
     );
-    let tx_overhead = signed_transaction.get_size();
+    // Size the contract against the same measure the `max_transaction_size`
+    // gate enforces: from `PostQuantumSignatures` onward that is the full wire
+    // size (signature included), so the overhead must account for it too.
+    let tx_overhead = signed_transaction.size_for_limits(PROTOCOL_VERSION);
 
     // Testable max contract size is limited by both `max_contract_size` and by `max_transaction_size`
     let max_contract_size = config.wasm_config.limit_config.max_contract_size;

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -1845,7 +1845,10 @@ mod tests {
             vec![Action::DeployContract(DeployContractAction { code: vec![1; 5] })],
             CryptoHash::default(),
         );
-        let transaction_size = signed_tx.get_size();
+        // The size gate uses the full wire size (signature included) once
+        // `PostQuantumSignatures` is enabled, and the body-only size before
+        // that. Mirror that here so the test holds on both stable and nightly.
+        let transaction_size = signed_tx.size_for_limits(PROTOCOL_VERSION);
 
         let mut config = RuntimeConfig::test();
         let max_transaction_size = transaction_size - 1;

--- a/test-loop-tests/src/tests/combined_transactions_size_limit.rs
+++ b/test-loop-tests/src/tests/combined_transactions_size_limit.rs
@@ -49,6 +49,10 @@ fn config_with_tx_size_limit(limit: usize) -> RuntimeConfigStore {
 /// Chunk packing stops at `combined_transactions_size_limit`, and the limit
 /// counts the ML-DSA-65 signature (i.e. uses `wire_size`, not `get_size`).
 #[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+// Spice prepares/includes transactions differently, so the per-chunk packing
+// this test inspects does not hold there (no transfers land in the chunks).
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_combined_tx_size_limit_counts_ml_dsa_signature() {
     init_test_logger();
     if !ProtocolFeature::PostQuantumSignatures.enabled(PROTOCOL_VERSION) {

--- a/test-loop-tests/src/tests/combined_transactions_size_limit.rs
+++ b/test-loop-tests/src/tests/combined_transactions_size_limit.rs
@@ -1,0 +1,147 @@
+//! The per-chunk `combined_transactions_size_limit` bounds how many bytes of
+//! transactions a chunk carries into the `ChunkStateWitness`. From
+//! `PostQuantumSignatures` onward that budget counts the full wire size of each
+//! transaction - signature included - so an ML-DSA-65 transaction, whose
+//! ~3.3 KiB signature is invisible to the legacy body-only `get_size`, consumes
+//! its true share of the budget.
+//!
+//! This checks that chunk packing actually stops at that limit: with the budget
+//! sized to hold a single ML-DSA-65 transfer by wire size, no chunk packs more
+//! than one - even though the body-only size would fit at least two.
+
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::env::TestLoopEnv;
+use crate::utils::account::create_account_id;
+use near_async::time::Duration;
+use near_crypto::{InMemorySigner, KeyType, PublicKey, Signer};
+use near_o11y::testonly::init_test_logger;
+use near_parameters::RuntimeConfigStore;
+use near_primitives::account::AccessKey;
+use near_primitives::action::{AddKeyAction, TransferAction};
+use near_primitives::hash::CryptoHash;
+use near_primitives::transaction::{Action, SignedTransaction};
+use near_primitives::types::{AccountId, Balance};
+use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+use std::collections::HashSet;
+
+/// Add `public_key` as a full-access key on `account`, signed by the account's
+/// default ed25519 key, and run it to completion.
+fn add_full_access_key(env: &mut TestLoopEnv, account: &AccountId, public_key: PublicKey) {
+    let tx = env.rpc_node().tx_from_actions(
+        account,
+        account,
+        vec![Action::AddKey(Box::new(AddKeyAction {
+            public_key,
+            access_key: AccessKey::full_access(),
+        }))],
+    );
+    env.rpc_runner().run_tx(tx, Duration::seconds(5));
+}
+
+/// A runtime config identical to the shipped one except for a low
+/// `combined_transactions_size_limit`.
+fn config_with_tx_size_limit(limit: usize) -> RuntimeConfigStore {
+    let mut config = RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION).as_ref().clone();
+    config.witness_config.combined_transactions_size_limit = limit;
+    RuntimeConfigStore::with_one_config(config)
+}
+
+/// Chunk packing stops at `combined_transactions_size_limit`, and the limit
+/// counts the ML-DSA-65 signature (i.e. uses `wire_size`, not `get_size`).
+#[test]
+fn slow_test_combined_tx_size_limit_counts_ml_dsa_signature() {
+    init_test_logger();
+    if !ProtocolFeature::PostQuantumSignatures.enabled(PROTOCOL_VERSION) {
+        tracing::info!("skipping: PostQuantumSignatures not enabled at this protocol version");
+        return;
+    }
+
+    let sender = create_account_id("sender-pq");
+    let receiver = create_account_id("receiver");
+    let pq_signer: Signer =
+        InMemorySigner::from_seed(sender.clone(), KeyType::MLDSA65, "pq").into();
+
+    // Measure the real sizes of an ML-DSA-65 transfer. `wire_size` includes the
+    // ~3.3 KiB signature; `get_size` (the legacy body-only measure) does not.
+    let transfer = || vec![Action::Transfer(TransferAction { deposit: Balance::from_near(1) })];
+    let sample = SignedTransaction::from_actions(
+        1,
+        sender.clone(),
+        receiver.clone(),
+        &pq_signer,
+        transfer(),
+        CryptoHash::default(),
+    );
+    let wire_size = sample.wire_size() as usize;
+    let body_size = sample.get_size() as usize;
+
+    // Size the chunk budget to hold exactly one such transfer by wire size. The
+    // body-only size would admit at least two - so a chunk capping at one is
+    // precisely the behaviour the signature-counting change introduces.
+    let limit = wire_size;
+    assert!(
+        2 * body_size <= limit && 2 * wire_size > limit,
+        "the limit must admit two transfers by body size but only one by wire size \
+         (body={body_size}, wire={wire_size}, limit={limit})",
+    );
+
+    let mut env = TestLoopBuilder::new()
+        .enable_rpc()
+        .add_user_accounts([&sender, &receiver], Balance::from_near(1_000))
+        .runtime_config_store(config_with_tx_size_limit(limit))
+        .build();
+
+    add_full_access_key(&mut env, &sender, pq_signer.public_key());
+
+    // Submit several ML-DSA-65 transfers at once so the pool holds more than one
+    // chunk's worth, then let the chain run.
+    let num_txs = 4u64;
+    let base_nonce =
+        env.rpc_node().view_access_key_query(&sender, &pq_signer.public_key()).unwrap().nonce;
+    let block_hash = env.rpc_node().head().last_block_hash;
+    let mut submitted = HashSet::new();
+    for i in 1..=num_txs {
+        let tx = SignedTransaction::from_actions(
+            base_nonce + i,
+            sender.clone(),
+            receiver.clone(),
+            &pq_signer,
+            transfer(),
+            block_hash,
+        );
+        submitted.insert(env.rpc_node().submit_tx(tx));
+    }
+
+    let start_height = env.rpc_node().head().height;
+    env.rpc_runner().run_for_number_of_blocks(2 * num_txs as usize + 3);
+
+    // Walk the produced blocks and count how many of our transfers each chunk
+    // packed. The size cap must keep every chunk at no more than one, and all
+    // transfers must eventually be included.
+    let rpc = env.rpc_node();
+    let end_height = rpc.head().height;
+    let mut included = HashSet::new();
+    let mut max_per_chunk = 0;
+    for height in start_height..=end_height {
+        let Ok(block) = rpc.client().chain.get_block_by_height(height) else { continue };
+        for chunk in rpc.block_chunks(&block) {
+            let count = chunk
+                .to_transactions()
+                .iter()
+                .filter(|tx| submitted.contains(&tx.get_hash()))
+                .map(|tx| included.insert(tx.get_hash()))
+                .count();
+            max_per_chunk = max_per_chunk.max(count);
+        }
+    }
+
+    assert_eq!(
+        max_per_chunk, 1,
+        "chunk packing must stop at combined_transactions_size_limit after a single ML-DSA-65 \
+         transfer (wire size {wire_size} incl. signature), but a chunk packed {max_per_chunk}",
+    );
+    assert_eq!(
+        included, submitted,
+        "every ML-DSA-65 transfer must eventually be included across chunks",
+    );
+}

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod chunk_validator_failover;
 mod chunk_validator_kickout;
 mod chunks_management;
 mod cloud_archival;
+mod combined_transactions_size_limit;
 mod congestion_control;
 mod congestion_control_genesis_bootstrap;
 mod consensus;


### PR DESCRIPTION
`SignedTransaction::get_size()` serializes only the inner `Transaction` body. The signature is a sibling field of `SignedTransaction`, so it is excluded from every transaction size gate. The undercount is ~65 B for ed25519 but ~3.3 KiB for an ML-DSA-65 signature, which leaves the per-chunk witness transaction-byte budget (`combined_transactions_size_limit`) running well over its intended bound once post-quantum transactions are in play.

This adds:
- `SignedTransaction::wire_size()` — full borsh size including the signature.
- `SignedTransaction::size_for_limits(protocol_version)` — `wire_size()` from `PostQuantumSignatures` (v154) onward, the legacy `get_size()` before that.

The `max_transaction_size` and `combined_transactions_size_limit` gates now use `size_for_limits`. The version gate keeps chunk production deterministic across the upgrade boundary; since the feature is not yet live on any network there is no change to existing traffic.

The mempool counts `wire_size()` unconditionally: it physically buffers the signature, its size total is node-local (metrics and a memory bound, never consensus), and a per-transaction version gate there would desync the running total across epoch boundaries.

Pricing the extra size (e.g. a per-wire-byte gas surcharge) is out of scope.