### PR TITLE
feat(strict-nonce): stabilize strict nonce at protocol version 85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [unreleased]
 
 ### Protocol Changes
-* Stabilized opt-in strict nonce mode for transactions. When enabled, each transaction must use a nonce exactly equal to the previous nonce for that access key plus one; nonces that repeat or skip values are rejected. ([#15361](https://github.com/near/nearcore/pull/15361), [#15402](https://github.com/near/nearcore/pull/15402))
+* Opt-in strict nonce mode for transactions. A transaction may opt in to require its nonce be exactly the previous nonce for that access key plus one; such transactions are rejected when the nonce repeats or skips a value. Transactions that do not opt in keep the existing monotonic nonce behavior. ([#15361](https://github.com/near/nearcore/pull/15361), [#15402](https://github.com/near/nearcore/pull/15402))
 * Added FIPS 204 ML-DSA-65 post-quantum signature scheme for access keys in nightly. Public keys are stored on-trie as a 32-byte SHA3-256 hash rather than the full 1952 bytes. ([#15731](https://github.com/near/nearcore/pull/15731))
 * Ensure delegate action returns the correct error consistently. ([#15458](https://github.com/near/nearcore/pull/15458))
 * Fix `action_delete_account` not accounting for the global contract identifier when checking the account deletion storage limit. For accounts using a global contract, the check overcounted storage usage by the identifier size (32 bytes, or the account id length for `GlobalByAccount`), so they were slightly harder to delete. ([#15752](https://github.com/near/nearcore/pull/15752))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [unreleased]
 
 ### Protocol Changes
-* New opt-in strict nonce mode for transactions added in nightly. When enabled, each transaction must use a nonce exactly equal to the previous nonce for that access key plus one; nonces that repeat or skip values are rejected. ([#15361](https://github.com/near/nearcore/pull/15361), [#15402](https://github.com/near/nearcore/pull/15402))
+* Stabilized opt-in strict nonce mode for transactions. When enabled, each transaction must use a nonce exactly equal to the previous nonce for that access key plus one; nonces that repeat or skip values are rejected. ([#15361](https://github.com/near/nearcore/pull/15361), [#15402](https://github.com/near/nearcore/pull/15402))
 * Added FIPS 204 ML-DSA-65 post-quantum signature scheme for access keys in nightly. Public keys are stored on-trie as a 32-byte SHA3-256 hash rather than the full 1952 bytes. ([#15731](https://github.com/near/nearcore/pull/15731))
 * Ensure delegate action returns the correct error consistently. ([#15458](https://github.com/near/nearcore/pull/15458))
 * Fix `action_delete_account` not accounting for the global contract identifier when checking the account deletion storage limit. For accounts using a global contract, the check overcounted storage usage by the identifier size (32 bytes, or the account id length for `GlobalByAccount`), so they were slightly harder to delete. ([#15752](https://github.com/near/nearcore/pull/15752))

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -521,6 +521,7 @@ impl ProtocolFeature {
             | ProtocolFeature::ContinuousEpochSync
             | ProtocolFeature::DynamicResharding
             | ProtocolFeature::StickyReshardingValidatorAssignment
+            | ProtocolFeature::StrictNonce
             | ProtocolFeature::YieldWithId => 85,
 
             // Nightly features:
@@ -528,7 +529,6 @@ impl ProtocolFeature {
             // TODO(#11201): When stabilizing this feature in mainnet, also remove the temporary code
             // that always enables this for mocknet (see config_mocknet function).
             ProtocolFeature::ShuffleShardAssignments => 143,
-            ProtocolFeature::StrictNonce => 151,
             ProtocolFeature::EarlyKickout => 152,
             ProtocolFeature::PostQuantumSignatures => 154,
             // Spice is setup to include nightly, but not be part of it for now so that features

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -2486,7 +2486,7 @@ mod tests {
     mod strict_nonce_tests {
         use super::*;
 
-        /// The nightly protocol version where StrictNonce is enabled.
+        /// The protocol version where StrictNonce is enabled.
         const STRICT_NONCE_PROTOCOL_VERSION: ProtocolVersion =
             ProtocolFeature::StrictNonce.protocol_version();
 
@@ -2634,7 +2634,7 @@ mod tests {
         }
 
         #[test]
-        fn test_strict_nonce_rejected_when_feature_disabled() {
+        fn test_strict_nonce_v1_rejected_before_feature() {
             let config = RuntimeConfig::test();
             let (signer, _state_update, _gas_price) =
                 setup_common(TESTING_INIT_BALANCE, Balance::ZERO, Some(AccessKey::full_access()));
@@ -2648,16 +2648,9 @@ mod tests {
                 CryptoHash::default(),
             );
 
-            // Use a protocol version where StrictNonce is NOT enabled.
-            // GasKeys must be enabled for V1 to be accepted at all.
-            let protocol_version = ProtocolFeature::GasKeys.protocol_version();
-            assert!(
-                !ProtocolFeature::StrictNonce.enabled(protocol_version),
-                "StrictNonce should not be enabled at GasKeys protocol version"
-            );
-
+            let protocol_version = STRICT_NONCE_PROTOCOL_VERSION - 1;
             let err = validate_transaction(&config, signed_tx, protocol_version)
-                .expect_err("strict nonce should be rejected when feature disabled");
+                .expect_err("strict nonce V1 tx should be rejected before the feature");
             assert_eq!(err.0, InvalidTxError::InvalidTransactionVersion);
         }
 


### PR DESCRIPTION
Stabilize the `StrictNonce` protocol feature by moving it from nightly into the stable protocol version 85 group, alongside GasKeys.

Test changes in `verifier.rs`: deleted `test_strict_nonce_rejected_when_feature_disabled`. Its precondition — a protocol version where a V1 transaction is valid but `StrictNonce` is disabled — no longer exists, since all V1 transactions require GasKeys (85) and `StrictNonce` is now also 85. Replaced it with `test_strict_nonce_v1_rejected_before_feature`, which asserts a strict V1 tx is rejected with `InvalidTransactionVersion` one version below the feature.

CHANGELOG entry reworded from "added in nightly" to "Stabilized".