### PR TITLE
fix(post-quantum): remove undesired non_exhaustive

### DIFF
--- a/core/crypto/src/hash_domain.rs
+++ b/core/crypto/src/hash_domain.rs
@@ -3,7 +3,6 @@
 /// collide with a digest from another. Each variant is one domain; uses that
 /// are meant to produce the same digest must use the same variant.
 #[derive(Debug, Clone, Copy)]
-#[non_exhaustive]
 pub enum HashDomainTag {
     /// `MlDsa65PublicKey`-to-digest derivation. The digest serves as the
     /// on-trie access-key identifier (`MlDsa65PublicKeyHandle`).


### PR DESCRIPTION
As discussed offline, it's better to have the compilation fail to force users to handle the new variants. 

Blessed be the DevEx team. 

Please add to merge queue if approved without comments. 