### PR TITLE
fix(estimator): fix yield/resume block latencies for instant yield

### DIFF
--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -266,6 +266,39 @@ pub(crate) struct Testbed<'c> {
     transaction_builder: TransactionBuilder,
 }
 
+/// Expected block latency (extra blocks needed to drain all receipts) for the
+/// blocks passed to [`Testbed::measure_blocks`].
+pub(crate) enum BlockLatency {
+    /// Every block drains in the same number of extra blocks.
+    Uniform(usize),
+    /// Setup and measured blocks alternate, as produced by `fn_cost_with_setup`:
+    /// even-indexed blocks run the setup, odd-indexed blocks the measurement.
+    SetupAndMeasured { setup: usize, measured: usize },
+}
+
+impl BlockLatency {
+    fn expected_at(&self, block_index: usize) -> usize {
+        match self {
+            BlockLatency::Uniform(latency) => *latency,
+            BlockLatency::SetupAndMeasured { setup, measured } => {
+                if block_index.is_multiple_of(2) {
+                    *setup
+                } else {
+                    *measured
+                }
+            }
+        }
+    }
+
+    /// Latency of the measured blocks, used to size the per-measurement overhead.
+    pub(crate) fn measured(&self) -> usize {
+        match self {
+            BlockLatency::Uniform(latency) => *latency,
+            BlockLatency::SetupAndMeasured { measured, .. } => *measured,
+        }
+    }
+}
+
 impl Testbed<'_> {
     pub(crate) fn transaction_builder(&mut self) -> &mut TransactionBuilder {
         &mut self.transaction_builder
@@ -282,13 +315,13 @@ impl Testbed<'_> {
     pub(crate) fn measure_blocks(
         &mut self,
         blocks: Vec<Vec<SignedTransaction>>,
-        block_latency: usize,
+        block_latency: BlockLatency,
     ) -> Vec<(GasCost, HashMap<ExtCosts, u64>)> {
         let allow_failures = false;
 
         let mut res = Vec::with_capacity(blocks.len());
 
-        for block in blocks {
+        for (block_index, block) in blocks.into_iter().enumerate() {
             node_runtime::with_ext_cost_counter(|cc| cc.clear());
             let extra_blocks;
             let gas_cost = {
@@ -298,9 +331,10 @@ impl Testbed<'_> {
                 extra_blocks = self.process_blocks_until_no_receipts(allow_failures);
                 start.elapsed()
             };
+            let expected_latency = block_latency.expected_at(block_index);
             assert_eq!(
-                block_latency, extra_blocks,
-                "block latency {block_latency} does not match expected {extra_blocks}"
+                expected_latency, extra_blocks,
+                "block {block_index}: expected block latency {expected_latency} but drained in {extra_blocks}"
             );
 
             let mut ext_costs: HashMap<ExtCosts, u64> = HashMap::new();

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -89,7 +89,7 @@ pub use crate::cost::Cost;
 pub use crate::cost_table::CostTable;
 use crate::cost_table::format_gas;
 pub use crate::costs_to_runtime_config::costs_to_runtime_config;
-use crate::estimator_context::EstimatorContext;
+use crate::estimator_context::{BlockLatency, EstimatorContext};
 use crate::gas_cost::GasCost;
 pub use crate::qemu::QemuCommandBuilder;
 pub use crate::rocksdb::RocksDBTestConfig;
@@ -1343,7 +1343,7 @@ fn storage_has_key_base(ctx: &mut EstimatorContext) -> GasCost {
         "storage_has_key_10b_key_1k",
         ExtCosts::storage_has_key_base,
         1000,
-        0,
+        BlockLatency::Uniform(0),
     )
 }
 fn storage_has_key_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1353,7 +1353,7 @@ fn storage_has_key_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_has_key_10kib_key_1k",
         ExtCosts::storage_has_key_byte,
         10 * 1024 * 1000,
-        0,
+        BlockLatency::Uniform(0),
     )
 }
 
@@ -1367,7 +1367,7 @@ fn storage_read_base(ctx: &mut EstimatorContext) -> GasCost {
         "storage_read_10b_key_1k",
         ExtCosts::storage_read_base,
         1000,
-        0,
+        BlockLatency::Uniform(0),
     );
     ctx.cached.storage_read_base.insert(cost).clone()
 }
@@ -1378,7 +1378,7 @@ fn storage_read_key_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_read_10kib_key_1k",
         ExtCosts::storage_read_key_byte,
         10 * 1024 * 1000,
-        0,
+        BlockLatency::Uniform(0),
     )
 }
 fn storage_read_value_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1388,7 +1388,7 @@ fn storage_read_value_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_read_10b_key_1k",
         ExtCosts::storage_read_value_byte,
         100 * 1024 * 1000,
-        0,
+        BlockLatency::Uniform(0),
     )
 }
 
@@ -1418,7 +1418,7 @@ fn storage_write_evicted_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_write_10b_key_10kib_value_1k",
         ExtCosts::storage_write_evicted_byte,
         10 * 1024 * 1000,
-        0,
+        BlockLatency::Uniform(0),
     )
 }
 
@@ -1429,7 +1429,7 @@ fn storage_remove_base(ctx: &mut EstimatorContext) -> GasCost {
         "storage_remove_10b_key_1k",
         ExtCosts::storage_remove_base,
         1000,
-        0,
+        BlockLatency::Uniform(0),
     )
 }
 fn storage_remove_key_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1439,7 +1439,7 @@ fn storage_remove_key_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_remove_10kib_key_1k",
         ExtCosts::storage_remove_key_byte,
         10 * 1024 * 1000,
-        0,
+        BlockLatency::Uniform(0),
     )
 }
 fn storage_remove_ret_value_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1449,7 +1449,7 @@ fn storage_remove_ret_value_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_remove_10b_key_1k",
         ExtCosts::storage_remove_ret_value_byte,
         10 * 1024 * 1000,
-        0,
+        BlockLatency::Uniform(0),
     )
 }
 
@@ -1517,7 +1517,7 @@ fn apply_block_cost(ctx: &mut EstimatorContext) -> GasCost {
     let blocks = vec![vec![]; n_blocks + n_warmup];
     let measurements = iter::repeat_with(|| {
         testbed
-            .measure_blocks(blocks.clone(), 0)
+            .measure_blocks(blocks.clone(), BlockLatency::Uniform(0))
             .into_iter()
             .skip(n_warmup)
             .map(|(gas, _ext)| gas)
@@ -1561,7 +1561,7 @@ fn yield_create_base(ctx: &mut EstimatorContext) -> GasCost {
         cost.clone()
     } else {
         let (result, count) =
-            fn_cost_count(ctx, "yield_create_base", ExtCosts::yield_create_base, 1);
+            fn_cost_count(ctx, "yield_create_base", ExtCosts::yield_create_base, 0);
         assert_eq!(count, 1000);
         let result = result / count;
         ctx.cached.yield_create_base.insert(result).clone()
@@ -1573,12 +1573,12 @@ fn yield_create_byte(ctx: &mut EstimatorContext) -> GasCost {
     let noop_function_call = noop_function_call_cost(ctx);
     let base_cost = yield_create_base(ctx);
     let method_cost =
-        fn_cost_count(ctx, "yield_create_byte_100b_method_length", ExtCosts::yield_create_base, 1);
+        fn_cost_count(ctx, "yield_create_byte_100b_method_length", ExtCosts::yield_create_base, 0);
     let argument_cost = fn_cost_count(
         ctx,
         "yield_create_byte_1000b_argument_length",
         ExtCosts::yield_create_base,
-        1,
+        0,
     );
     let compute = |(cost, count): (GasCost, u64), bytes: u64| -> GasCost {
         let it = cost.saturating_sub(&noop_function_call, &NonNegativeTolerance::PER_MILLE) / count;
@@ -1608,7 +1608,7 @@ fn yield_resume_base(ctx: &mut EstimatorContext) -> GasCost {
         "yield_resume_base",
         ExtCosts::yield_resume_base,
         255,
-        1,
+        BlockLatency::SetupAndMeasured { setup: 0, measured: 1 },
     )
 }
 
@@ -1619,7 +1619,7 @@ fn yield_resume_byte(ctx: &mut EstimatorContext) -> GasCost {
         "yield_resume_base",
         ExtCosts::yield_resume_base,
         255,
-        1,
+        BlockLatency::SetupAndMeasured { setup: 0, measured: 1 },
     );
     let with_payload = fn_cost_with_setup(
         ctx,
@@ -1627,7 +1627,7 @@ fn yield_resume_byte(ctx: &mut EstimatorContext) -> GasCost {
         "yield_resume_payload",
         ExtCosts::yield_resume_base,
         255,
-        1,
+        BlockLatency::SetupAndMeasured { setup: 0, measured: 1 },
     );
     with_payload.saturating_sub(&baseline, &NonNegativeTolerance::PER_MILLE) / 1000
 }

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -1,4 +1,4 @@
-use crate::estimator_context::{EstimatorContext, Testbed};
+use crate::estimator_context::{BlockLatency, EstimatorContext, Testbed};
 use crate::gas_cost::{GasCost, NonNegativeTolerance};
 use crate::utils::{aggregate_per_block_measurements, overhead_per_measured_block, percentiles};
 use near_parameters::ExtCosts;
@@ -49,7 +49,7 @@ pub(crate) fn write_node(
             .map(|value| vec![tb.account_insert_key(signer.clone(), key.as_bytes(), *value)])
             .take(measured_iters + warmup_iters),
     );
-    let results = &testbed.measure_blocks(blocks, block_latency)[1..];
+    let results = &testbed.measure_blocks(blocks, BlockLatency::Uniform(block_latency))[1..];
     let (short_key_results, long_key_results) = results.split_at(measured_iters + warmup_iters);
     let (cost_short_key, ext_cost_short_key) = aggregate_per_block_measurements(
         1,

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::apply_block_cost;
-use crate::estimator_context::EstimatorContext;
+use crate::estimator_context::{BlockLatency, EstimatorContext};
 use crate::gas_cost::{GasCost, NonNegativeTolerance};
 use crate::transaction_builder::TransactionBuilder;
 use near_parameters::ExtCosts;
@@ -64,7 +64,7 @@ pub(crate) fn transaction_cost_ext(
         blocks
     };
 
-    let measurements = testbed.measure_blocks(blocks, block_latency);
+    let measurements = testbed.measure_blocks(blocks, BlockLatency::Uniform(block_latency));
     if verbose {
         // prints individual block measurements (without division by number of
         // inner items) which helps understanding issue with high variance
@@ -169,10 +169,10 @@ pub(crate) fn fn_cost_with_setup(
     method: &str,
     ext_cost: ExtCosts,
     count: u64,
-    block_latency: usize,
+    block_latency: BlockLatency,
 ) -> GasCost {
     let (total_cost, measured_count) = {
-        let overhead = overhead_per_measured_block(ctx, block_latency);
+        let overhead = overhead_per_measured_block(ctx, block_latency.measured());
         let block_size = 2usize;
         let n_blocks = ctx.config.warmup_iters_per_block + ctx.config.iter_per_block;
 
@@ -292,7 +292,7 @@ pub(crate) fn fn_cost_in_contract(
     );
     blocks.insert(n_warmup_blocks, vec![base_tx]);
 
-    let mut measurements = testbed.measure_blocks(blocks, 0);
+    let mut measurements = testbed.measure_blocks(blocks, BlockLatency::Uniform(0));
     measurements.drain(0..n_warmup_blocks);
 
     let (base_gas_cost, _base_ext_costs) = measurements.remove(0);


### PR DESCRIPTION
The yield estimators assumed yield receipts are dispatched cross-block, but since `InstantPromiseYield` (v83) `PromiseYield` receipts are instant (applied in the same block). This was dormant because these estimators were `#[cfg(feature = "nightly")]` and `ultra_slow_test_full_estimator` runs on a non-nightly build; #15839 ungated them, so they now run and panic in `measure_blocks`.

- `yield_create_base` / `yield_create_byte`: now drain in 0 extra blocks (was 1).
- `yield_resume_base` / `yield_resume_byte`: the setup block creates yields (instant, 0 extra blocks) while the measured block calls `promise_yield_resume`, producing a non-instant `PromiseResume` receipt that drains in 1 extra block. A single shared latency in `fn_cost_with_setup` can't express both.

To handle that, `measure_blocks` / `fn_cost_with_setup` now take a `BlockLatency` enum: `Uniform(n)` for the common single-kind case, and `SetupAndMeasured { setup, measured }` for the interleaved setup/measured blocks `fn_cost_with_setup` produces.