### PR TITLE
feat(gas-keys): version delegate actions to support gas key nonces

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -472,7 +472,7 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                         crate::models::OperationIdentifier::new(&operations);
 
                     operations.push(validated_operations::initiate_delegate_action::InitiateDelegateActionOperation{
-                        sender_account: action.delegate_action.sender_id.clone().into()
+                        sender_account: action.delegate_action.sender_id().clone().into()
                     }.into_related_operation(initiate_delegate_action_operation_id.clone(), vec![signed_delegate_action_operation_id]));
 
                     let delegate_action_operation_id =
@@ -488,14 +488,9 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                     // We know that there are no delegate actions inside so this is guaranteed to
                     // be a single-level recursion.
                     let delegated_operations: Vec<crate::models::Operation> = NearActions {
-                        sender_account_id: action.delegate_action.sender_id.clone(),
-                        receiver_account_id: action.delegate_action.receiver_id.clone(),
-                        actions: action
-                            .delegate_action
-                            .actions
-                            .into_iter()
-                            .map(|a| a.into())
-                            .collect::<Vec<near_primitives::transaction::Action>>(),
+                        sender_account_id: action.delegate_action.sender_id().clone(),
+                        receiver_account_id: action.delegate_action.receiver_id().clone(),
+                        actions: action.delegate_action.get_actions(),
                     }
                     .into();
 
@@ -814,41 +809,47 @@ impl TryFrom<Vec<crate::models::Operation>> for NearActions {
 
                     let delegate_action: near_primitives::transaction::Action =
                         near_primitives::action::delegate::SignedDelegateAction {
-                            delegate_action: near_primitives::action::delegate::DelegateAction {
-                                sender_id: initiate_delegate_action_operation
-                                    .sender_account
-                                    .address
-                                    .into(),
-                                receiver_id: delegate_action_operation.receiver_id.address.into(),
-                                actions: {
-                                    let mut non_delegate_actions = vec![];
-                                    for action in actions {
-                                        non_delegate_actions.push(match action.try_into() {
-                                            Ok(a) => a,
-                                            Err(_) => {
-                                                return Err(
-                                                    crate::errors::ErrorKind::InvalidInput(
-                                                        "Nested delegate actions not allowed"
-                                                            .to_string(),
-                                                    ),
-                                                );
-                                            }
-                                        });
-                                    }
-                                    non_delegate_actions
+                            delegate_action: near_primitives::action::delegate::DelegateAction::V0(
+                                near_primitives::action::delegate::DelegateActionV0 {
+                                    sender_id: initiate_delegate_action_operation
+                                        .sender_account
+                                        .address
+                                        .into(),
+                                    receiver_id: delegate_action_operation
+                                        .receiver_id
+                                        .address
+                                        .into(),
+                                    actions: {
+                                        let mut non_delegate_actions = vec![];
+                                        for action in actions {
+                                            non_delegate_actions.push(match action.try_into() {
+                                                Ok(a) => a,
+                                                Err(_) => {
+                                                    return Err(
+                                                        crate::errors::ErrorKind::InvalidInput(
+                                                            "Nested delegate actions not allowed"
+                                                                .to_string(),
+                                                        ),
+                                                    );
+                                                }
+                                            });
+                                        }
+                                        non_delegate_actions
+                                    },
+                                    nonce: delegate_action_operation.nonce,
+                                    max_block_height: delegate_action_operation.max_block_height,
+                                    public_key: match (&delegate_action_operation.public_key)
+                                        .try_into()
+                                    {
+                                        Ok(o) => o,
+                                        Err(_) => {
+                                            return Err(crate::errors::ErrorKind::InvalidInput(
+                                                "Invalid public key on delegate action".to_string(),
+                                            ));
+                                        }
+                                    },
                                 },
-                                nonce: delegate_action_operation.nonce,
-                                max_block_height: delegate_action_operation.max_block_height,
-                                public_key: match (&delegate_action_operation.public_key).try_into()
-                                {
-                                    Ok(o) => o,
-                                    Err(_) => {
-                                        return Err(crate::errors::ErrorKind::InvalidInput(
-                                            "Invalid public key on delegate action".to_string(),
-                                        ));
-                                    }
-                                },
-                            },
+                            ),
                             signature: signed_delegate_action_operation.signature,
                         }
                         .into();
@@ -964,7 +965,9 @@ impl TryFrom<Vec<crate::models::Operation>> for NearActions {
 mod tests {
     use super::*;
     use near_crypto::{KeyType, SecretKey};
-    use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+    use near_primitives::action::delegate::{
+        DelegateAction, DelegateActionV0, SignedDelegateAction,
+    };
     use near_primitives::transaction::{Action, TransferAction};
     use near_primitives::types::Gas;
 
@@ -1130,7 +1133,7 @@ mod tests {
             sender_account_id: "proxy.near".parse().unwrap(),
             receiver_account_id: "account.near".parse().unwrap(),
             actions: vec![Action::Delegate(Box::new(SignedDelegateAction {
-                delegate_action: DelegateAction {
+                delegate_action: DelegateAction::V0(DelegateActionV0 {
                     sender_id: "account.near".parse().unwrap(),
                     receiver_id: "receiver.near".parse().unwrap(),
                     actions: vec![
@@ -1141,7 +1144,7 @@ mod tests {
                     nonce: 0,
                     max_block_height: 0,
                     public_key: sk.public_key(),
-                },
+                }),
                 signature: sk.sign(&[0]),
             }))],
         };

--- a/chain/rosetta-rpc/src/adapters/validated_operations/delegate_action.rs
+++ b/chain/rosetta-rpc/src/adapters/validated_operations/delegate_action.rs
@@ -57,10 +57,10 @@ impl TryFrom<crate::models::Operation> for DelegateActionOperation {
 impl From<near_primitives::action::delegate::DelegateAction> for DelegateActionOperation {
     fn from(delegate_action: near_primitives::action::delegate::DelegateAction) -> Self {
         DelegateActionOperation {
-            receiver_id: delegate_action.receiver_id.into(),
-            max_block_height: delegate_action.max_block_height,
-            public_key: (&delegate_action.public_key).into(),
-            nonce: delegate_action.nonce,
+            receiver_id: delegate_action.receiver_id().clone().into(),
+            max_block_height: delegate_action.max_block_height(),
+            public_key: delegate_action.public_key().into(),
+            nonce: delegate_action.nonce(),
         }
     }
 }

--- a/core/primitives/src/action/delegate.rs
+++ b/core/primitives/src/action/delegate.rs
@@ -9,14 +9,17 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::{PublicKey, Signature, Signer};
 use near_primitives_core::hash::{CryptoHash, hash};
 use near_primitives_core::types::BlockHeight;
-use near_primitives_core::types::{AccountId, Nonce};
+use near_primitives_core::types::{AccountId, Nonce, NonceIndex};
 use near_schema_checker_lib::ProtocolSchema;
 use serde::{Deserialize, Serialize};
-use std::io::{Error, ErrorKind, Read};
+use std::io::{Error, ErrorKind, Read, Write};
 
 /// This is an index number of Action::Delegate in Action enumeration
 const ACTION_DELEGATE_NUMBER: u8 = 8;
-/// This action allows to execute the inner actions behalf of the defined sender.
+/// Version tag prefixed to the borsh encoding of a `DelegateActionV1`.
+const DELEGATE_ACTION_V1_TAG: u8 = 1;
+
+/// Fields shared by all delegate action versions.
 #[derive(
     BorshSerialize,
     BorshDeserialize,
@@ -29,7 +32,7 @@ const ACTION_DELEGATE_NUMBER: u8 = 8;
     ProtocolSchema,
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct DelegateAction {
+pub struct DelegateActionV0 {
     /// Signer of the delegated actions
     pub sender_id: AccountId,
     /// Receiver of the delegated actions.
@@ -47,6 +50,179 @@ pub struct DelegateAction {
     pub max_block_height: BlockHeight,
     /// Public key used to sign this delegated action.
     pub public_key: PublicKey,
+}
+
+/// Delegate action signed by a gas key, /// nonces, selected by `nonce_index`.
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    ProtocolSchema,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct DelegateActionV1 {
+    /// Signer of the delegated actions
+    pub sender_id: AccountId,
+    /// Receiver of the delegated actions.
+    pub receiver_id: AccountId,
+    /// List of actions to be executed.
+    pub actions: Vec<NonDelegateAction>,
+    /// Nonce for the gas key nonce at `nonce_index`. After this action is
+    /// processed the nonce for `nonce_index` increments.
+    pub nonce: Nonce,
+    /// The maximal height of the block in the blockchain below which the given DelegateAction is valid.
+    pub max_block_height: BlockHeight,
+    /// Public key used to sign this delegated action.
+    pub public_key: PublicKey,
+    /// Index of the gas key nonce this action advances.
+    pub nonce_index: NonceIndex,
+}
+
+/// This action allows to execute the inner actions behalf of the defined sender.
+///
+/// `V0` is the original NEP-366 form. `V1` additionally carries a `nonce_index`
+/// so a gas key can use one of its parallel nonces.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum DelegateAction {
+    V0(DelegateActionV0),
+    V1(DelegateActionV1),
+}
+
+impl BorshSerialize for DelegateAction {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        match self {
+            DelegateAction::V0(action) => BorshSerialize::serialize(action, writer),
+            DelegateAction::V1(action) => {
+                BorshSerialize::serialize(&DELEGATE_ACTION_V1_TAG, writer)?;
+                BorshSerialize::serialize(action, writer)
+            }
+        }
+    }
+}
+
+impl BorshDeserialize for DelegateAction {
+    /// Disambiguate V0 from V1 by the first two bytes, mirroring `Transaction`.
+    ///
+    /// V0 begins with `sender_id`, a borsh `String` whose 4-byte little-endian
+    /// length is at least 2 (the minimum AccountId length), so its second byte
+    /// is always 0. V1 is prefixed with the tag byte 1 followed by a struct that
+    /// also starts with that length, whose second byte is nonzero. Therefore
+    /// `u2 == 0` implies V0, and `u1 == 1` with `u2 != 0` implies V1.
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self, Error> {
+        let u1 = u8::deserialize_reader(reader)?;
+        let u2 = u8::deserialize_reader(reader)?;
+
+        // Erase the chained reader to `&mut dyn Read` before recursing. A
+        // delegate action can transitively contain another one (actions ->
+        // Action -> Delegate), so monomorphizing the inner deserialize on the
+        // chained reader type would recurse without bound.
+        if u2 == 0 {
+            let prefix = [u1, u2];
+            let mut chained = prefix.chain(reader);
+            let mut reader: &mut dyn Read = &mut chained;
+            return Ok(DelegateAction::V0(DelegateActionV0::deserialize_reader(&mut reader)?));
+        }
+        if u1 == DELEGATE_ACTION_V1_TAG {
+            let prefix = [u2];
+            let mut chained = prefix.chain(reader);
+            let mut reader: &mut dyn Read = &mut chained;
+            return Ok(DelegateAction::V1(DelegateActionV1::deserialize_reader(&mut reader)?));
+        }
+        Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("invalid delegate action version tag: {u1}"),
+        ))
+    }
+}
+
+/// Flat serde representation shared by both versions, keeping V0's JSON shape
+/// unchanged. `nonce_index` is present iff the value is a V1.
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+struct DelegateActionRepr {
+    sender_id: AccountId,
+    receiver_id: AccountId,
+    actions: Vec<NonDelegateAction>,
+    nonce: Nonce,
+    max_block_height: BlockHeight,
+    public_key: PublicKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    nonce_index: Option<NonceIndex>,
+}
+
+impl From<&DelegateAction> for DelegateActionRepr {
+    fn from(action: &DelegateAction) -> Self {
+        DelegateActionRepr {
+            sender_id: action.sender_id().clone(),
+            receiver_id: action.receiver_id().clone(),
+            actions: action.actions().to_vec(),
+            nonce: action.nonce(),
+            max_block_height: action.max_block_height(),
+            public_key: action.public_key().clone(),
+            nonce_index: action.nonce_index(),
+        }
+    }
+}
+
+impl From<DelegateActionRepr> for DelegateAction {
+    fn from(repr: DelegateActionRepr) -> Self {
+        let DelegateActionRepr {
+            sender_id,
+            receiver_id,
+            actions,
+            nonce,
+            max_block_height,
+            public_key,
+            nonce_index,
+        } = repr;
+        match nonce_index {
+            None => DelegateAction::V0(DelegateActionV0 {
+                sender_id,
+                receiver_id,
+                actions,
+                nonce,
+                max_block_height,
+                public_key,
+            }),
+            Some(nonce_index) => DelegateAction::V1(DelegateActionV1 {
+                sender_id,
+                receiver_id,
+                actions,
+                nonce,
+                max_block_height,
+                public_key,
+                nonce_index,
+            }),
+        }
+    }
+}
+
+impl Serialize for DelegateAction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        DelegateActionRepr::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DelegateAction {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        DelegateActionRepr::deserialize(deserializer).map(DelegateAction::from)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for DelegateAction {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "DelegateAction".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        DelegateActionRepr::json_schema(generator)
+    }
 }
 
 #[derive(
@@ -70,7 +246,7 @@ impl SignedDelegateAction {
     pub fn verify(&self) -> bool {
         let delegate_action = &self.delegate_action;
         let hash = delegate_action.get_nep461_hash();
-        let public_key = &delegate_action.public_key;
+        let public_key = delegate_action.public_key();
 
         self.signature.verify(hash.as_ref(), public_key)
     }
@@ -88,8 +264,72 @@ impl From<SignedDelegateAction> for Action {
 }
 
 impl DelegateAction {
+    pub fn sender_id(&self) -> &AccountId {
+        match self {
+            DelegateAction::V0(action) => &action.sender_id,
+            DelegateAction::V1(action) => &action.sender_id,
+        }
+    }
+
+    pub fn receiver_id(&self) -> &AccountId {
+        match self {
+            DelegateAction::V0(action) => &action.receiver_id,
+            DelegateAction::V1(action) => &action.receiver_id,
+        }
+    }
+
+    pub fn public_key(&self) -> &PublicKey {
+        match self {
+            DelegateAction::V0(action) => &action.public_key,
+            DelegateAction::V1(action) => &action.public_key,
+        }
+    }
+
+    pub fn nonce(&self) -> Nonce {
+        match self {
+            DelegateAction::V0(action) => action.nonce,
+            DelegateAction::V1(action) => action.nonce,
+        }
+    }
+
+    pub fn max_block_height(&self) -> BlockHeight {
+        match self {
+            DelegateAction::V0(action) => action.max_block_height,
+            DelegateAction::V1(action) => action.max_block_height,
+        }
+    }
+
+    /// Gas key nonce index for V1, `None` for V0.
+    pub fn nonce_index(&self) -> Option<NonceIndex> {
+        match self {
+            DelegateAction::V0(_) => None,
+            DelegateAction::V1(action) => Some(action.nonce_index),
+        }
+    }
+
+    pub fn actions(&self) -> &[NonDelegateAction] {
+        match self {
+            DelegateAction::V0(action) => &action.actions,
+            DelegateAction::V1(action) => &action.actions,
+        }
+    }
+
+    pub fn actions_mut(&mut self) -> &mut Vec<NonDelegateAction> {
+        match self {
+            DelegateAction::V0(action) => &mut action.actions,
+            DelegateAction::V1(action) => &mut action.actions,
+        }
+    }
+
+    pub fn nonce_mut(&mut self) -> &mut Nonce {
+        match self {
+            DelegateAction::V0(action) => &mut action.nonce,
+            DelegateAction::V1(action) => &mut action.nonce,
+        }
+    }
+
     pub fn get_actions(&self) -> Vec<Action> {
-        self.actions.iter().map(|a| a.clone().into()).collect()
+        self.actions().iter().map(|a| a.clone().into()).collect()
     }
 
     /// Delegate action hash used for NEP-461 signature scheme which tags
@@ -197,6 +437,17 @@ mod tests {
     use crate::action::CreateAccountAction;
     use near_crypto::KeyType;
 
+    fn delegate_action_v0(actions: Vec<NonDelegateAction>) -> DelegateAction {
+        DelegateAction::V0(DelegateActionV0 {
+            sender_id: "aaa".parse().unwrap(),
+            receiver_id: "bbb".parse().unwrap(),
+            actions,
+            nonce: 1,
+            max_block_height: 2,
+            public_key: PublicKey::empty(KeyType::ED25519),
+        })
+    }
+
     /// A serialized `Action::Delegate(SignedDelegateAction)` for testing.
     ///
     /// We want this to be parsable and accepted by protocol versions with meta
@@ -211,18 +462,10 @@ mod tests {
     );
 
     fn create_delegate_action(actions: Vec<Action>) -> Action {
+        let actions =
+            actions.iter().map(|a| NonDelegateAction::try_from(a.clone()).unwrap()).collect();
         Action::Delegate(Box::new(SignedDelegateAction {
-            delegate_action: DelegateAction {
-                sender_id: "aaa".parse().unwrap(),
-                receiver_id: "bbb".parse().unwrap(),
-                actions: actions
-                    .iter()
-                    .map(|a| NonDelegateAction::try_from(a.clone()).unwrap())
-                    .collect(),
-                nonce: 1,
-                max_block_height: 2,
-                public_key: PublicKey::empty(KeyType::ED25519),
-            },
+            delegate_action: delegate_action_v0(actions),
             signature: Signature::empty(KeyType::ED25519),
         }))
     }
@@ -272,6 +515,56 @@ mod tests {
             Action::try_from_slice(&serialized_delegate_action).expect("Expect ok"),
             delegate_action
         );
+    }
+
+    fn delegate_action_v1(nonce_index: NonceIndex) -> DelegateAction {
+        DelegateAction::V1(DelegateActionV1 {
+            sender_id: "aaa".parse().unwrap(),
+            receiver_id: "bbb".parse().unwrap(),
+            actions: vec![],
+            nonce: 1,
+            max_block_height: 2,
+            public_key: PublicKey::empty(KeyType::ED25519),
+            nonce_index,
+        })
+    }
+
+    #[test]
+    fn test_delegate_action_version_borsh_roundtrip() {
+        for action in [delegate_action_v0(vec![]), delegate_action_v1(7)] {
+            let bytes = borsh::to_vec(&action).unwrap();
+            assert_eq!(DelegateAction::try_from_slice(&bytes).unwrap(), action);
+        }
+    }
+
+    #[test]
+    fn test_delegate_action_v0_borsh_unchanged_by_versioning() {
+        // V0 must serialize identically to the bare inner struct so existing
+        // signatures and stored receipts stay valid.
+        let DelegateAction::V0(inner) = delegate_action_v0(vec![]) else { unreachable!() };
+        assert_eq!(
+            borsh::to_vec(&DelegateAction::V0(inner.clone())).unwrap(),
+            borsh::to_vec(&inner).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_delegate_action_v1_borsh_is_tagged() {
+        let bytes = borsh::to_vec(&delegate_action_v1(0)).unwrap();
+        assert_eq!(bytes[0], DELEGATE_ACTION_V1_TAG);
+    }
+
+    #[test]
+    fn test_delegate_action_serde_roundtrip_and_shape() {
+        let v0 = delegate_action_v0(vec![]);
+        let v0_json = serde_json::to_value(&v0).unwrap();
+        assert!(v0_json.get("nonce_index").is_none(), "V0 JSON must stay flat without nonce_index");
+        assert_eq!(serde_json::from_value::<DelegateAction>(v0_json).unwrap(), v0);
+
+        let v1 = delegate_action_v1(7);
+        let v1_json = serde_json::to_value(&v1).unwrap();
+        assert_eq!(v1_json.get("nonce_index").and_then(|v| v.as_u64()), Some(7));
+        assert_eq!(serde_json::from_value::<DelegateAction>(v1_json).unwrap(), v1);
     }
 
     #[cfg(feature = "schemars")]

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -421,7 +421,7 @@ impl Action {
             // its signature, and a nested set of actions; any of them can
             // transport post-quantum key material.
             Action::Delegate(sda) => {
-                sda.delegate_action.public_key.key_type().is_post_quantum()
+                sda.delegate_action.public_key().key_type().is_post_quantum()
                     || sda.signature.key_type().is_post_quantum()
                     || sda
                         .delegate_action

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -359,6 +359,8 @@ pub enum InvalidAccessKeyError {
     /// Gas keys track nonces per index in dedicated storage, which the delegate
     /// action path does not support, so a gas key can't sign a delegate action.
     RequiresNonGasKey = 6,
+    /// A versioned delegate action carrying a nonce index requires a gas key.
+    RequiresGasKey = 7,
 }
 
 /// Describes the error for validating a list of actions.
@@ -836,6 +838,11 @@ pub enum ActionErrorKind {
         public_key: Option<Box<PublicKey>>,
         balance: Balance,
     } = 25,
+    /// DelegateAction nonce index is outside the gas key's nonce range
+    DelegateActionInvalidNonceIndex {
+        nonce_index: NonceIndex,
+        num_nonces: NonceIndex,
+    } = 26,
 }
 
 impl From<ActionErrorKind> for ActionError {
@@ -994,6 +1001,9 @@ impl Display for InvalidAccessKeyError {
             InvalidAccessKeyError::RequiresNonGasKey => {
                 write!(f, "gas keys can't be used to sign a delegate action")
             }
+            InvalidAccessKeyError::RequiresGasKey => {
+                write!(f, "a delegate action with a nonce index requires a gas key")
+            }
         }
     }
 }
@@ -1135,6 +1145,11 @@ impl Display for ActionErrorKind {
                 f,
                 "DelegateAction nonce {} must be smaller than the access key nonce upper bound {}",
                 delegate_nonce, upper_bound
+            ),
+            ActionErrorKind::DelegateActionInvalidNonceIndex { nonce_index, num_nonces } => write!(
+                f,
+                "DelegateAction nonce index {} must be smaller than the gas key nonce count {}",
+                nonce_index, num_nonces
             ),
             ActionErrorKind::GlobalContractDoesNotExist { identifier } => {
                 write!(f, "Global contract identifier {:?} not found", identifier)

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -356,6 +356,9 @@ pub enum InvalidAccessKeyError {
     } = 4,
     /// Having a deposit with a function call action is not allowed with a function call access key.
     DepositWithFunctionCall = 5,
+    /// Gas keys track nonces per index in dedicated storage, which the delegate
+    /// action path does not support, so a gas key can't sign a delegate action.
+    RequiresNonGasKey = 6,
 }
 
 /// Describes the error for validating a list of actions.
@@ -987,6 +990,9 @@ impl Display for InvalidAccessKeyError {
                     f,
                     "Having a deposit with a function call action is not allowed with a function call access key."
                 )
+            }
+            InvalidAccessKeyError::RequiresNonGasKey => {
+                write!(f, "gas keys can't be used to sign a delegate action")
             }
         }
     }

--- a/core/primitives/src/signable_message.rs
+++ b/core/primitives/src/signable_message.rs
@@ -223,7 +223,7 @@ impl From<SignableMessageType> for MessageDiscriminant {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::action::delegate::{DelegateAction, SignedDelegateAction};
+    use crate::action::delegate::{DelegateAction, DelegateActionV0, SignedDelegateAction};
     use near_crypto::{InMemorySigner, PublicKey};
 
     // happy path for NEP-366 signature
@@ -280,14 +280,13 @@ mod tests {
         receiver_id: AccountId,
         public_key: PublicKey,
     ) -> DelegateAction {
-        let delegate_action = DelegateAction {
+        DelegateAction::V0(DelegateActionV0 {
             sender_id,
             receiver_id,
             actions: vec![],
             nonce: 0,
             max_block_height: 1000,
             public_key,
-        };
-        delegate_action
+        })
     }
 }

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -1067,7 +1067,9 @@ mod tests {
     /// `validate_delegate_action` and `validate_add_key_action`.
     #[test]
     fn test_check_valid_for_config_ml_dsa_in_delegate_gated() {
-        use crate::action::delegate::{DelegateAction, NonDelegateAction, SignedDelegateAction};
+        use crate::action::delegate::{
+            DelegateAction, DelegateActionV0, NonDelegateAction, SignedDelegateAction,
+        };
 
         let config = RuntimeConfig::test();
 
@@ -1082,14 +1084,14 @@ mod tests {
             access_key: AccessKey::full_access(),
         }));
 
-        let delegate_action = DelegateAction {
+        let delegate_action = DelegateAction::V0(DelegateActionV0 {
             sender_id: "carol.near".parse().unwrap(),
             receiver_id: "bob.near".parse().unwrap(),
             actions: vec![NonDelegateAction::try_from(inner_add_key).unwrap()],
             nonce: 1,
             max_block_height: 1,
             public_key: inner_signer.public_key(),
-        };
+        });
         let signed_delegate = SignedDelegateAction::sign(&inner_signer, delegate_action);
 
         // Outer transaction is signed with a classical ed25519 key, so the

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -32,7 +32,9 @@ use near_network::types::NetworkRequests;
 use near_network::types::PeerManagerMessageRequest;
 use near_network::types::{PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg};
 use near_parameters::RuntimeConfig;
-use near_primitives::action::delegate::{DelegateAction, NonDelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{
+    DelegateAction, DelegateActionV0, NonDelegateAction, SignedDelegateAction,
+};
 use near_primitives::block::Block;
 use near_primitives::epoch_info::RngSeed;
 use near_primitives::errors::InvalidTxError;
@@ -771,7 +773,7 @@ impl TestEnv {
         let tip = self.clients[0].chain.head().unwrap();
         let user_nonce = tip.height + 1;
         let relayer_nonce = tip.height + 1;
-        let delegate_action = DelegateAction {
+        let delegate_action = DelegateAction::V0(DelegateActionV0 {
             sender_id: inner_signer.get_account_id(),
             receiver_id,
             actions: actions
@@ -781,7 +783,7 @@ impl TestEnv {
             nonce: user_nonce,
             max_block_height: tip.height + 100,
             public_key: inner_signer.public_key(),
-        };
+        });
         let signature = inner_signer.sign(delegate_action.get_nep461_hash().as_bytes());
         let signed_delegate_action = SignedDelegateAction { delegate_action, signature };
         SignedTransaction::from_actions(

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -2,7 +2,9 @@ pub use crate::user::runtime_user::RuntimeUser;
 use near_crypto::{PublicKey, Signer};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_primitives::account::AccessKey;
-use near_primitives::action::delegate::{DelegateAction, NonDelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{
+    DelegateAction, DelegateActionV0, NonDelegateAction, SignedDelegateAction,
+};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::test_utils::create_user_test_signer;
@@ -296,7 +298,7 @@ pub trait User {
             .get_access_key(&signer_id, &inner_signer.public_key())
             .expect("failed reading user's nonce for access key")
             .nonce;
-        let delegate_action = DelegateAction {
+        let delegate_action = DelegateAction::V0(DelegateActionV0 {
             sender_id: signer_id.clone(),
             receiver_id,
             actions: actions
@@ -306,7 +308,7 @@ pub trait User {
             nonce: user_nonce + 1,
             max_block_height: 100,
             public_key: inner_signer.public_key(),
-        };
+        });
         let signature = inner_signer.sign(delegate_action.get_nep461_hash().as_bytes());
         let signed_delegate_action = SignedDelegateAction { delegate_action, signature };
 

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -852,19 +852,19 @@ pub(crate) fn empty_delegate_action(
     receiver_id: AccountId,
     sender_id: AccountId,
 ) -> Action {
-    use near_primitives::action::delegate::DelegateAction;
+    use near_primitives::action::delegate::{DelegateAction, DelegateActionV0};
     use near_primitives::signable_message::{SignableMessage, SignableMessageType};
     use near_primitives::test_utils::create_user_test_signer;
 
     let signer = create_user_test_signer(&sender_id);
-    let delegate_action = DelegateAction {
+    let delegate_action = DelegateAction::V0(DelegateActionV0 {
         sender_id,
         receiver_id,
         actions: vec![],
         nonce,
         max_block_height: 1000,
         public_key: signer.public_key(),
-    };
+    });
     let signature =
         SignableMessage::new(&delegate_action, SignableMessageType::DelegateAction).sign(&signer);
     Action::Delegate(Box::new(near_primitives::action::delegate::SignedDelegateAction {

--- a/runtime/runtime/src/action_validation.rs
+++ b/runtime/runtime/src/action_validation.rs
@@ -175,11 +175,16 @@ fn validate_delegate_action(
     current_protocol_version: ProtocolVersion,
     mode: ValidateReceiptMode,
 ) -> Result<(), ActionsValidationError> {
+    // A V1 delegate action selects a gas key nonce by index, which only exists
+    // once gas keys are enabled.
+    if signed_delegate_action.delegate_action.nonce_index().is_some() {
+        require_protocol_feature(ProtocolFeature::GasKeys, "GasKeys", current_protocol_version)?;
+    }
     let actions = signed_delegate_action.delegate_action.get_actions();
     let inner_receiver =
         if ProtocolFeature::FixDelegatedDeterministicStateInit.enabled(current_protocol_version) {
             // This is the correct receiver id to use for the check.
-            &signed_delegate_action.delegate_action.receiver_id
+            &signed_delegate_action.delegate_action.receiver_id()
         } else {
             // This is a bug fixed with `FixDelegatedDeterministicStateInit` that
             // validated against the wrong id. This makes it impossible to
@@ -472,7 +477,7 @@ mod tests {
     use near_crypto::{KeyType, PublicKey, Signature};
     use near_primitives::account::{AccessKey, FunctionCallPermission};
     use near_primitives::action::GlobalContractDeployMode;
-    use near_primitives::action::delegate::{DelegateAction, NonDelegateAction};
+    use near_primitives::action::delegate::{DelegateAction, DelegateActionV0, NonDelegateAction};
     use near_primitives::deterministic_account_id::{
         DeterministicAccountStateInit, DeterministicAccountStateInitV1,
     };
@@ -729,14 +734,14 @@ mod tests {
             let actions =
                 inner.into_iter().map(|a| NonDelegateAction::try_from(a).unwrap()).collect();
             Action::Delegate(Box::new(SignedDelegateAction {
-                delegate_action: DelegateAction {
+                delegate_action: DelegateAction::V0(DelegateActionV0 {
                     sender_id: "bob.test.near".parse().unwrap(),
                     receiver_id: "token.test.near".parse().unwrap(),
                     actions,
                     nonce: 19000001,
                     max_block_height: 57,
                     public_key: PublicKey::empty(KeyType::ED25519),
-                },
+                }),
                 signature: Signature::default(),
             }))
         };
@@ -1001,7 +1006,7 @@ mod tests {
     fn test_delegate_action_must_be_only_one() {
         let receiver = "alice.near".parse().unwrap();
         let signed_delegate_action = SignedDelegateAction {
-            delegate_action: DelegateAction {
+            delegate_action: DelegateAction::V0(DelegateActionV0 {
                 sender_id: "bob.test.near".parse().unwrap(),
                 receiver_id: "token.test.near".parse().unwrap(),
                 actions: vec![
@@ -1011,7 +1016,7 @@ mod tests {
                 nonce: 19000001,
                 max_block_height: 57,
                 public_key: PublicKey::empty(KeyType::ED25519),
-            },
+            }),
             signature: Signature::default(),
         };
         assert_eq!(

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -24,7 +24,9 @@ use near_primitives::transaction::{
     Action, DeleteAccountAction, DeployContractAction, StakeAction,
 };
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{AccountId, Balance, BlockHeight, EpochInfoProvider, StorageUsage};
+use near_primitives::types::{
+    AccountId, Balance, BlockHeight, EpochInfoProvider, NonceIndex, StorageUsage,
+};
 use near_primitives::utils::account_is_implicit;
 use near_primitives::version::ProtocolVersion;
 use near_primitives_core::account::id::AccountType;
@@ -32,7 +34,7 @@ use near_primitives_core::version::ProtocolFeature;
 use near_store::trie::AccessOptions;
 use near_store::{
     StorageError, TrieAccess, TrieUpdate, compute_gas_key_balance_sum, get_access_key,
-    remove_account, set_access_key,
+    get_gas_key_nonce, remove_account, set_access_key, set_gas_key_nonce,
 };
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use near_wallet_contract::{
@@ -494,13 +496,13 @@ pub(crate) fn apply_delegate_action(
         result.result = Err(ActionErrorKind::DelegateActionInvalidSignature.into());
         return Ok(());
     }
-    if apply_state.block_height > delegate_action.max_block_height {
+    if apply_state.block_height > delegate_action.max_block_height() {
         result.result = Err(ActionErrorKind::DelegateActionExpired.into());
         return Ok(());
     }
-    if delegate_action.sender_id.as_str() != sender_id.as_str() {
+    if delegate_action.sender_id().as_str() != sender_id.as_str() {
         result.result = Err(ActionErrorKind::DelegateActionSenderDoesNotMatchTxReceiver {
-            sender_id: delegate_action.sender_id.clone(),
+            sender_id: delegate_action.sender_id().clone(),
             receiver_id: sender_id.clone(),
         }
         .into());
@@ -517,7 +519,7 @@ pub(crate) fn apply_delegate_action(
     // Generate a new receipt from DelegateAction.
     let new_receipt = Receipt::V0(ReceiptV0 {
         predecessor_id: sender_id.clone(),
-        receiver_id: delegate_action.receiver_id.clone(),
+        receiver_id: delegate_action.receiver_id().clone(),
         receipt_id: CryptoHash::default(),
 
         receipt: ReceiptEnum::Action(ActionReceipt {
@@ -600,18 +602,18 @@ fn validate_delegate_action_key(
     delegate_action: &DelegateAction,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
-    // 'delegate_action.sender_id' account existence must be checked by a caller
+    // 'delegate_action.sender_id()' account existence must be checked by a caller
     let mut access_key = match get_access_key(
         state_update,
-        &delegate_action.sender_id,
-        &delegate_action.public_key,
+        &delegate_action.sender_id(),
+        &delegate_action.public_key(),
     )? {
         Some(access_key) => access_key,
         None => {
             result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
                 InvalidAccessKeyError::AccessKeyNotFound {
-                    account_id: delegate_action.sender_id.clone(),
-                    public_key: delegate_action.public_key.clone().into(),
+                    account_id: delegate_action.sender_id().clone(),
+                    public_key: delegate_action.public_key().clone().into(),
                 },
             )
             .into());
@@ -619,21 +621,51 @@ fn validate_delegate_action_key(
         }
     };
 
-    // Gas keys keep their nonces per index in dedicated storage, while the
-    // delegate path only tracks the single access_key.nonce. Reject them rather
-    // than silently advancing an unrelated counter and bypassing the gas key balance.
-    if access_key.gas_key_info().is_some() {
-        result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
-            InvalidAccessKeyError::RequiresNonGasKey,
-        )
-        .into());
-        return Ok(());
-    }
+    // Nonce handling depends on the delegate action version. V0 advances the
+    // single access_key.nonce and forbids gas keys; V1 advances one of a gas
+    // gas key's nonces, selected by nonce_index.
+    let (current_nonce, nonce_update) = match delegate_action.nonce_index() {
+        None => {
+            if access_key.gas_key_info().is_some() {
+                result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+                    InvalidAccessKeyError::RequiresNonGasKey,
+                )
+                .into());
+                return Ok(());
+            }
+            (access_key.nonce, DelegateNonceUpdate::AccessKey)
+        }
+        Some(nonce_index) => {
+            let Some(gas_key_info) = access_key.gas_key_info() else {
+                result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+                    InvalidAccessKeyError::RequiresGasKey,
+                )
+                .into());
+                return Ok(());
+            };
+            if nonce_index >= gas_key_info.num_nonces {
+                result.result = Err(ActionErrorKind::DelegateActionInvalidNonceIndex {
+                    nonce_index,
+                    num_nonces: gas_key_info.num_nonces,
+                }
+                .into());
+                return Ok(());
+            }
+            let current_nonce = get_gas_key_nonce(
+                state_update,
+                delegate_action.sender_id(),
+                delegate_action.public_key(),
+                nonce_index,
+            )?
+            .unwrap_or(0);
+            (current_nonce, DelegateNonceUpdate::GasKey { nonce_index })
+        }
+    };
 
-    if delegate_action.nonce <= access_key.nonce {
+    if delegate_action.nonce() <= current_nonce {
         result.result = Err(ActionErrorKind::DelegateActionInvalidNonce {
-            delegate_nonce: delegate_action.nonce,
-            ak_nonce: access_key.nonce,
+            delegate_nonce: delegate_action.nonce(),
+            ak_nonce: current_nonce,
         }
         .into());
         return Ok(());
@@ -641,16 +673,14 @@ fn validate_delegate_action_key(
 
     let upper_bound = apply_state.block_height
         * near_primitives::account::AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER;
-    if delegate_action.nonce >= upper_bound {
+    if delegate_action.nonce() >= upper_bound {
         result.result = Err(ActionErrorKind::DelegateActionNonceTooLarge {
-            delegate_nonce: delegate_action.nonce,
+            delegate_nonce: delegate_action.nonce(),
             upper_bound,
         }
         .into());
         return Ok(());
     }
-
-    access_key.nonce = delegate_action.nonce;
 
     let actions = delegate_action.get_actions();
 
@@ -679,10 +709,10 @@ fn validate_delegate_action_key(
                     return Ok(());
                 }
             }
-            if delegate_action.receiver_id != function_call_permission.receiver_id {
+            if *delegate_action.receiver_id() != function_call_permission.receiver_id {
                 result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
                     InvalidAccessKeyError::ReceiverMismatch {
-                        tx_receiver: delegate_action.receiver_id.clone(),
+                        tx_receiver: delegate_action.receiver_id().clone(),
                         ak_receiver: function_call_permission.receiver_id.clone(),
                     },
                 )
@@ -713,14 +743,35 @@ fn validate_delegate_action_key(
         }
     };
 
-    set_access_key(
-        state_update,
-        delegate_action.sender_id.clone(),
-        delegate_action.public_key.clone(),
-        &access_key,
-    );
+    match nonce_update {
+        DelegateNonceUpdate::AccessKey => {
+            access_key.nonce = delegate_action.nonce();
+            set_access_key(
+                state_update,
+                delegate_action.sender_id().clone(),
+                delegate_action.public_key().clone(),
+                &access_key,
+            );
+        }
+        DelegateNonceUpdate::GasKey { nonce_index } => {
+            set_gas_key_nonce(
+                state_update,
+                delegate_action.sender_id().clone(),
+                delegate_action.public_key().clone(),
+                nonce_index,
+                delegate_action.nonce(),
+            );
+        }
+    }
 
     Ok(())
+}
+
+/// How a validated delegate action's nonce is persisted: V0 bumps the access
+/// key nonce, V1 bumps the selected gas key nonce.
+enum DelegateNonceUpdate {
+    AccessKey,
+    GasKey { nonce_index: NonceIndex },
 }
 
 pub(crate) fn check_actor_permissions(
@@ -870,7 +921,9 @@ mod tests {
     use crate::near_primitives::shard_layout::ShardUId;
     use near_primitives::account::FunctionCallPermission;
     use near_primitives::action::FunctionCallAction;
-    use near_primitives::action::delegate::NonDelegateAction;
+    use near_primitives::action::delegate::{
+        DelegateActionV0, DelegateActionV1, NonDelegateAction,
+    };
     use near_primitives::apply::ApplyChunkReason;
     use near_primitives::bandwidth_scheduler::BlockBandwidthRequests;
     use near_primitives::congestion_info::BlockCongestionInfo;
@@ -1227,7 +1280,7 @@ mod tests {
 
     fn create_delegate_action_receipt() -> (ActionReceipt, SignedDelegateAction) {
         let signed_delegate_action = SignedDelegateAction {
-            delegate_action: DelegateAction {
+            delegate_action: DelegateAction::V0(DelegateActionV0 {
                 sender_id: "bob.test.near".parse().unwrap(),
                 receiver_id: "token.test.near".parse().unwrap(),
                 actions: vec![
@@ -1245,7 +1298,7 @@ mod tests {
                 nonce: 19000001,
                 max_block_height: 57,
                 public_key: "ed25519:32LnPNBZQJ3uhY8yV6JqnNxtRW8E27Ps9YD1XeUNuA1m".parse::<PublicKey>().unwrap(),
-            },
+            }),
             signature: "ed25519:5oswo6yH6u7xduXHEC4aWc8EGmWdbFz49DaHvAVioS9tbdrxpUtoNQUa8ST9Fxpk7zS2ogWvuKaL29JjMFDi3DLe".parse().unwrap()
         };
 
@@ -1295,12 +1348,12 @@ mod tests {
     fn test_delegate_action() {
         let mut result = ActionResult::default();
         let (action_receipt, signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = signed_delegate_action.delegate_action.sender_id.clone();
-        let sender_pub_key = signed_delegate_action.delegate_action.public_key.clone();
+        let sender_id = signed_delegate_action.delegate_action.sender_id().clone();
+        let sender_pub_key = signed_delegate_action.delegate_action.public_key().clone();
         let access_key = AccessKey { nonce: 19000000, permission: AccessKeyPermission::FullAccess };
 
         let apply_state =
-            create_apply_state(signed_delegate_action.delegate_action.max_block_height);
+            create_apply_state(signed_delegate_action.delegate_action.max_block_height());
         let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
 
         apply_delegate_action(
@@ -1318,7 +1371,7 @@ mod tests {
             result.new_receipts,
             vec![Receipt::V0(ReceiptV0 {
                 predecessor_id: sender_id.clone(),
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.clone(),
+                receiver_id: signed_delegate_action.delegate_action.receiver_id().clone(),
                 receipt_id: CryptoHash::default(),
                 receipt: ReceiptEnum::Action(ActionReceipt {
                     signer_id: action_receipt.signer_id.clone(),
@@ -1336,16 +1389,20 @@ mod tests {
     fn test_delegate_action_signature_verification() {
         let mut result = ActionResult::default();
         let (action_receipt, mut signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = signed_delegate_action.delegate_action.sender_id.clone();
-        let sender_pub_key = signed_delegate_action.delegate_action.public_key.clone();
+        let sender_id = signed_delegate_action.delegate_action.sender_id().clone();
+        let sender_pub_key = signed_delegate_action.delegate_action.public_key().clone();
         let access_key = AccessKey { nonce: 19000000, permission: AccessKeyPermission::FullAccess };
 
         let apply_state =
-            create_apply_state(signed_delegate_action.delegate_action.max_block_height);
+            create_apply_state(signed_delegate_action.delegate_action.max_block_height());
         let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
 
         // Corrupt receiver_id. Signature verification must fail.
-        signed_delegate_action.delegate_action.receiver_id = "www.test.near".parse().unwrap();
+        let DelegateAction::V0(mut inner) = signed_delegate_action.delegate_action.clone() else {
+            unreachable!()
+        };
+        inner.receiver_id = "www.test.near".parse().unwrap();
+        signed_delegate_action.delegate_action = DelegateAction::V0(inner);
 
         apply_delegate_action(
             &mut state_update,
@@ -1364,13 +1421,13 @@ mod tests {
     fn test_delegate_action_max_height() {
         let mut result = ActionResult::default();
         let (action_receipt, signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = signed_delegate_action.delegate_action.sender_id.clone();
-        let sender_pub_key = signed_delegate_action.delegate_action.public_key.clone();
+        let sender_id = signed_delegate_action.delegate_action.sender_id().clone();
+        let sender_pub_key = signed_delegate_action.delegate_action.public_key().clone();
         let access_key = AccessKey { nonce: 19000000, permission: AccessKeyPermission::FullAccess };
 
         // Setup current block as higher than max_block_height. Must fail.
         let apply_state =
-            create_apply_state(signed_delegate_action.delegate_action.max_block_height + 1);
+            create_apply_state(signed_delegate_action.delegate_action.max_block_height() + 1);
         let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
 
         apply_delegate_action(
@@ -1390,12 +1447,12 @@ mod tests {
     fn test_delegate_action_validate_sender_account() {
         let mut result = ActionResult::default();
         let (action_receipt, signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = signed_delegate_action.delegate_action.sender_id.clone();
-        let sender_pub_key = signed_delegate_action.delegate_action.public_key.clone();
+        let sender_id = signed_delegate_action.delegate_action.sender_id().clone();
+        let sender_pub_key = signed_delegate_action.delegate_action.public_key().clone();
         let access_key = AccessKey { nonce: 19000000, permission: AccessKeyPermission::FullAccess };
 
         let apply_state =
-            create_apply_state(signed_delegate_action.delegate_action.max_block_height);
+            create_apply_state(signed_delegate_action.delegate_action.max_block_height());
         let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
 
         // Use a different sender_id. Must fail.
@@ -1434,12 +1491,12 @@ mod tests {
     #[test]
     fn test_validate_delegate_action_key_update_nonce() {
         let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = &signed_delegate_action.delegate_action.sender_id;
-        let sender_pub_key = &signed_delegate_action.delegate_action.public_key;
+        let sender_id = &signed_delegate_action.delegate_action.sender_id();
+        let sender_pub_key = &signed_delegate_action.delegate_action.public_key();
         let access_key = AccessKey { nonce: 19000000, permission: AccessKeyPermission::FullAccess };
 
         let apply_state =
-            create_apply_state(signed_delegate_action.delegate_action.max_block_height);
+            create_apply_state(signed_delegate_action.delegate_action.max_block_height());
         let mut state_update = setup_account(sender_id, sender_pub_key, &access_key);
 
         // Everything is ok
@@ -1465,8 +1522,8 @@ mod tests {
         assert_eq!(
             result.result,
             Err(ActionErrorKind::DelegateActionInvalidNonce {
-                delegate_nonce: signed_delegate_action.delegate_action.nonce,
-                ak_nonce: signed_delegate_action.delegate_action.nonce,
+                delegate_nonce: signed_delegate_action.delegate_action.nonce(),
+                ak_nonce: signed_delegate_action.delegate_action.nonce(),
             }
             .into())
         );
@@ -1474,7 +1531,7 @@ mod tests {
         // Increment nonce. Must pass.
         result = ActionResult::default();
         let mut delegate_action = signed_delegate_action.delegate_action.clone();
-        delegate_action.nonce += 1;
+        *delegate_action.nonce_mut() += 1;
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
@@ -1489,12 +1546,12 @@ mod tests {
     fn test_delegate_action_key_does_not_exist() {
         let mut result = ActionResult::default();
         let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = signed_delegate_action.delegate_action.sender_id.clone();
-        let sender_pub_key = signed_delegate_action.delegate_action.public_key.clone();
+        let sender_id = signed_delegate_action.delegate_action.sender_id().clone();
+        let sender_pub_key = signed_delegate_action.delegate_action.public_key().clone();
         let access_key = AccessKey { nonce: 19000000, permission: AccessKeyPermission::FullAccess };
 
         let apply_state =
-            create_apply_state(signed_delegate_action.delegate_action.max_block_height);
+            create_apply_state(signed_delegate_action.delegate_action.max_block_height());
         let mut state_update = setup_account(
             &sender_id,
             &PublicKey::empty(near_crypto::KeyType::ED25519),
@@ -1524,15 +1581,15 @@ mod tests {
     fn test_delegate_action_key_incorrect_nonce() {
         let mut result = ActionResult::default();
         let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = signed_delegate_action.delegate_action.sender_id.clone();
-        let sender_pub_key = signed_delegate_action.delegate_action.public_key.clone();
+        let sender_id = signed_delegate_action.delegate_action.sender_id().clone();
+        let sender_pub_key = signed_delegate_action.delegate_action.public_key().clone();
         let access_key = AccessKey {
-            nonce: signed_delegate_action.delegate_action.nonce,
+            nonce: signed_delegate_action.delegate_action.nonce(),
             permission: AccessKeyPermission::FullAccess,
         };
 
         let apply_state =
-            create_apply_state(signed_delegate_action.delegate_action.max_block_height);
+            create_apply_state(signed_delegate_action.delegate_action.max_block_height());
         let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
 
         validate_delegate_action_key(
@@ -1545,8 +1602,8 @@ mod tests {
         assert_eq!(
             result.result,
             Err(ActionErrorKind::DelegateActionInvalidNonce {
-                delegate_nonce: signed_delegate_action.delegate_action.nonce,
-                ak_nonce: signed_delegate_action.delegate_action.nonce,
+                delegate_nonce: signed_delegate_action.delegate_action.nonce(),
+                ak_nonce: signed_delegate_action.delegate_action.nonce(),
             }
             .into())
         );
@@ -1556,8 +1613,8 @@ mod tests {
     fn test_delegate_action_key_nonce_too_large() {
         let mut result = ActionResult::default();
         let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = signed_delegate_action.delegate_action.sender_id.clone();
-        let sender_pub_key = signed_delegate_action.delegate_action.public_key.clone();
+        let sender_id = signed_delegate_action.delegate_action.sender_id().clone();
+        let sender_pub_key = signed_delegate_action.delegate_action.public_key().clone();
         let access_key = AccessKey { nonce: 19000000, permission: AccessKeyPermission::FullAccess };
 
         let apply_state = create_apply_state(1);
@@ -1573,7 +1630,7 @@ mod tests {
         assert_eq!(
             result.result,
             Err(ActionErrorKind::DelegateActionNonceTooLarge {
-                delegate_nonce: signed_delegate_action.delegate_action.nonce,
+                delegate_nonce: signed_delegate_action.delegate_action.nonce(),
                 upper_bound: 1000000,
             }
             .into())
@@ -1585,10 +1642,10 @@ mod tests {
         delegate_action: &DelegateAction,
     ) -> ActionResult {
         let mut result = ActionResult::default();
-        let sender_id = delegate_action.sender_id.clone();
-        let sender_pub_key = delegate_action.public_key.clone();
+        let sender_id = delegate_action.sender_id().clone();
+        let sender_pub_key = delegate_action.public_key().clone();
 
-        let apply_state = create_apply_state(delegate_action.max_block_height);
+        let apply_state = create_apply_state(delegate_action.max_block_height());
         let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
 
         validate_delegate_action_key(
@@ -1609,13 +1666,13 @@ mod tests {
             nonce: 19000000,
             permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
                 allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
+                receiver_id: signed_delegate_action.delegate_action.receiver_id().to_string(),
                 method_names: vec!["test_method".parse().unwrap()],
             }),
         };
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
+        *delegate_action.actions_mut() =
             vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: Balance::ZERO,
@@ -1633,13 +1690,13 @@ mod tests {
             nonce: 19000000,
             permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
                 allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
+                receiver_id: signed_delegate_action.delegate_action.receiver_id().to_string(),
                 method_names: vec!["test_method".parse().unwrap()],
             }),
         };
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
+        *delegate_action.actions_mut() =
             vec![non_delegate_action(Action::CreateAccount(CreateAccountAction {}))];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
@@ -1660,13 +1717,13 @@ mod tests {
             nonce: 19000000,
             permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
                 allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
+                receiver_id: signed_delegate_action.delegate_action.receiver_id().to_string(),
                 method_names: vec!["test_method".parse().unwrap()],
             }),
         };
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions = vec![
+        *delegate_action.actions_mut() = vec![
             non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: Balance::ZERO,
@@ -1699,13 +1756,13 @@ mod tests {
             nonce: 19000000,
             permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
                 allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
+                receiver_id: signed_delegate_action.delegate_action.receiver_id().to_string(),
                 method_names: Vec::new(),
             }),
         };
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
+        *delegate_action.actions_mut() =
             vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: Balance::from_yoctonear(1),
@@ -1731,8 +1788,8 @@ mod tests {
         protocol_version: ProtocolVersion,
     ) -> ActionResult {
         let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let sender_id = signed_delegate_action.delegate_action.sender_id.clone();
-        let sender_pub_key = signed_delegate_action.delegate_action.public_key.clone();
+        let sender_id = signed_delegate_action.delegate_action.sender_id().clone();
+        let sender_pub_key = signed_delegate_action.delegate_action.public_key().clone();
 
         let initial_nonce: u64 = 19_000_000;
         let access_key = AccessKey {
@@ -1747,13 +1804,13 @@ mod tests {
         };
 
         let mut apply_state =
-            create_apply_state(signed_delegate_action.delegate_action.max_block_height);
+            create_apply_state(signed_delegate_action.delegate_action.max_block_height());
         apply_state.current_protocol_version = protocol_version;
         let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.nonce = initial_nonce + 1;
-        delegate_action.actions =
+        *delegate_action.nonce_mut() = initial_nonce + 1;
+        *delegate_action.actions_mut() =
             vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: Balance::from_yoctonear(1),
@@ -1821,7 +1878,7 @@ mod tests {
         };
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
+        *delegate_action.actions_mut() =
             vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: Balance::ZERO,
@@ -1835,7 +1892,7 @@ mod tests {
             result.result,
             Err(ActionErrorKind::DelegateActionAccessKeyError(
                 InvalidAccessKeyError::ReceiverMismatch {
-                    tx_receiver: delegate_action.receiver_id,
+                    tx_receiver: delegate_action.receiver_id().clone(),
                     ak_receiver: "another.near".parse().unwrap(),
                 },
             )
@@ -1850,13 +1907,13 @@ mod tests {
             nonce: 19000000,
             permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
                 allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
+                receiver_id: signed_delegate_action.delegate_action.receiver_id().to_string(),
                 method_names: vec!["another_method".parse().unwrap()],
             }),
         };
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
+        *delegate_action.actions_mut() =
             vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: Balance::ZERO,
@@ -1884,13 +1941,13 @@ mod tests {
             TEST_GAS_KEY_NUM_NONCES,
             FunctionCallPermission {
                 allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
+                receiver_id: signed_delegate_action.delegate_action.receiver_id().to_string(),
                 method_names: vec!["test_method".parse().unwrap()],
             },
         );
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
+        *delegate_action.actions_mut() =
             vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: Balance::ZERO,
@@ -1913,13 +1970,216 @@ mod tests {
         let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
 
         let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
+        *delegate_action.actions_mut() =
             vec![non_delegate_action(Action::CreateAccount(CreateAccountAction {}))];
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
         assert_eq!(
             result.result,
             Err(ActionErrorKind::DelegateActionAccessKeyError(
                 InvalidAccessKeyError::RequiresNonGasKey,
+            )
+            .into())
+        );
+    }
+
+    fn v1_delegate_action(base: &DelegateAction, nonce_index: NonceIndex) -> DelegateAction {
+        DelegateAction::V1(DelegateActionV1 {
+            sender_id: base.sender_id().clone(),
+            receiver_id: base.receiver_id().clone(),
+            actions: base.actions().to_vec(),
+            nonce: base.nonce(),
+            max_block_height: base.max_block_height(),
+            public_key: base.public_key().clone(),
+            nonce_index,
+        })
+    }
+
+    #[test]
+    fn test_delegate_action_v1_gas_key_full_access_ok() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
+        let delegate_action = v1_delegate_action(&signed_delegate_action.delegate_action, 0);
+        let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
+        assert!(result.result.is_ok(), "result error: {:?}", result.result);
+    }
+
+    #[test]
+    fn test_delegate_action_v1_requires_gas_key() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::full_access();
+        let delegate_action = v1_delegate_action(&signed_delegate_action.delegate_action, 0);
+        let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresGasKey,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_delegate_action_v1_nonce_index_out_of_range() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
+        let delegate_action =
+            v1_delegate_action(&signed_delegate_action.delegate_action, TEST_GAS_KEY_NUM_NONCES);
+        let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionInvalidNonceIndex {
+                nonce_index: TEST_GAS_KEY_NUM_NONCES,
+                num_nonces: TEST_GAS_KEY_NUM_NONCES,
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_delegate_action_v1_advances_gas_key_nonce() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
+        let delegate_action = v1_delegate_action(&signed_delegate_action.delegate_action, 0);
+
+        let sender_id = delegate_action.sender_id().clone();
+        let sender_pub_key = delegate_action.public_key().clone();
+        let apply_state = create_apply_state(delegate_action.max_block_height());
+        let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
+
+        let mut result = ActionResult::default();
+        validate_delegate_action_key(
+            &mut state_update,
+            &apply_state,
+            &delegate_action,
+            &mut result,
+        )
+        .unwrap();
+        assert!(result.result.is_ok(), "result error: {:?}", result.result);
+
+        let stored = get_gas_key_nonce(&state_update, &sender_id, &sender_pub_key, 0).unwrap();
+        assert_eq!(stored, Some(delegate_action.nonce()));
+    }
+
+    // A V1 gas key with `GasKeyFunctionCall` permission runs the same function
+    // call restrictions as a regular function call access key.
+    fn v1_gas_key_function_call_result(
+        permission: FunctionCallPermission,
+        actions: Vec<NonDelegateAction>,
+    ) -> ActionResult {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_function_call(TEST_GAS_KEY_NUM_NONCES, permission);
+        let mut delegate_action = v1_delegate_action(&signed_delegate_action.delegate_action, 0);
+        *delegate_action.actions_mut() = actions;
+        test_delegate_action_key_permissions(&access_key, &delegate_action)
+    }
+
+    fn function_call_action(method_name: &str, deposit: Balance) -> NonDelegateAction {
+        non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
+            args: Vec::new(),
+            deposit,
+            gas: Gas::from_gas(300),
+            method_name: method_name.parse().unwrap(),
+        })))
+    }
+
+    fn function_call_permission(
+        receiver_id: &str,
+        method_names: Vec<String>,
+    ) -> FunctionCallPermission {
+        FunctionCallPermission {
+            allowance: None,
+            receiver_id: receiver_id.to_string(),
+            method_names,
+        }
+    }
+
+    #[test]
+    fn test_delegate_action_v1_gas_key_function_call_ok() {
+        let result = v1_gas_key_function_call_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert!(result.result.is_ok(), "result error: {:?}", result.result);
+    }
+
+    #[test]
+    fn test_delegate_action_v1_gas_key_function_call_incorrect_action() {
+        let result = v1_gas_key_function_call_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![non_delegate_action(Action::CreateAccount(CreateAccountAction {}))],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresFullAccess,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_delegate_action_v1_gas_key_function_call_actions_number() {
+        let result = v1_gas_key_function_call_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![
+                function_call_action("test_method", Balance::ZERO),
+                function_call_action("test_method", Balance::ZERO),
+            ],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresFullAccess,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_delegate_action_v1_gas_key_function_call_deposit() {
+        let result = v1_gas_key_function_call_result(
+            function_call_permission("token.test.near", Vec::new()),
+            vec![function_call_action("test_method", Balance::from_yoctonear(1))],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::DepositWithFunctionCall,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_delegate_action_v1_gas_key_function_call_receiver_id() {
+        let result = v1_gas_key_function_call_result(
+            function_call_permission("another.near", Vec::new()),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::ReceiverMismatch {
+                    tx_receiver: "token.test.near".parse().unwrap(),
+                    ak_receiver: "another.near".parse().unwrap(),
+                },
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_delegate_action_v1_gas_key_function_call_method() {
+        let result = v1_gas_key_function_call_result(
+            function_call_permission("token.test.near", vec!["another_method".to_string()]),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::MethodNameMismatch {
+                    method_name: "test_method".parse().unwrap(),
+                },
             )
             .into())
         );

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -619,6 +619,17 @@ fn validate_delegate_action_key(
         }
     };
 
+    // Gas keys keep their nonces per index in dedicated storage, while the
+    // delegate path only tracks the single access_key.nonce. Reject them rather
+    // than silently advancing an unrelated counter and bypassing the gas key balance.
+    if access_key.gas_key_info().is_some() {
+        result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+            InvalidAccessKeyError::RequiresNonGasKey,
+        )
+        .into());
+        return Ok(());
+    }
+
     if delegate_action.nonce <= access_key.nonce {
         result.result = Err(ActionErrorKind::DelegateActionInvalidNonce {
             delegate_nonce: delegate_action.nonce,
@@ -1867,7 +1878,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delegate_action_gas_key_function_call() {
+    fn test_delegate_action_gas_key_function_call_rejected() {
         let (_, signed_delegate_action) = create_delegate_action_receipt();
         let access_key = AccessKey::gas_key_function_call(
             TEST_GAS_KEY_NUM_NONCES,
@@ -1887,166 +1898,28 @@ mod tests {
                 method_name: "test_method".parse().unwrap(),
             })))];
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
-        assert!(result.result.is_ok(), "result error: {:?}", result.result);
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresNonGasKey,
+            )
+            .into())
+        );
     }
 
     #[test]
-    fn test_delegate_action_gas_key_function_call_incorrect_action() {
+    fn test_delegate_action_gas_key_full_access_rejected() {
         let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let access_key = AccessKey::gas_key_function_call(
-            TEST_GAS_KEY_NUM_NONCES,
-            FunctionCallPermission {
-                allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
-                method_names: vec!["test_method".parse().unwrap()],
-            },
-        );
+        let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
             vec![non_delegate_action(Action::CreateAccount(CreateAccountAction {}))];
-
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
         assert_eq!(
             result.result,
             Err(ActionErrorKind::DelegateActionAccessKeyError(
-                InvalidAccessKeyError::RequiresFullAccess,
-            )
-            .into())
-        );
-    }
-
-    #[test]
-    fn test_delegate_action_gas_key_function_call_actions_number() {
-        let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let access_key = AccessKey::gas_key_function_call(
-            TEST_GAS_KEY_NUM_NONCES,
-            FunctionCallPermission {
-                allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
-                method_names: vec!["test_method".parse().unwrap()],
-            },
-        );
-
-        let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions = vec![
-            non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
-                args: Vec::new(),
-                deposit: Balance::ZERO,
-                gas: Gas::from_gas(300),
-                method_name: "test_method".parse().unwrap(),
-            }))),
-            non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
-                args: Vec::new(),
-                deposit: Balance::ZERO,
-                gas: Gas::from_gas(300),
-                method_name: "test_method".parse().unwrap(),
-            }))),
-        ];
-
-        let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
-        assert_eq!(
-            result.result,
-            Err(ActionErrorKind::DelegateActionAccessKeyError(
-                InvalidAccessKeyError::RequiresFullAccess,
-            )
-            .into())
-        );
-    }
-
-    #[test]
-    fn test_delegate_action_gas_key_function_call_deposit() {
-        let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let access_key = AccessKey::gas_key_function_call(
-            TEST_GAS_KEY_NUM_NONCES,
-            FunctionCallPermission {
-                allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
-                method_names: Vec::new(),
-            },
-        );
-
-        let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
-                args: Vec::new(),
-                deposit: Balance::from_yoctonear(1),
-                gas: Gas::from_gas(300),
-                method_name: "test_method".parse().unwrap(),
-            })))];
-
-        let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
-        assert_eq!(
-            result.result,
-            Err(ActionErrorKind::DelegateActionAccessKeyError(
-                InvalidAccessKeyError::DepositWithFunctionCall,
-            )
-            .into())
-        );
-    }
-
-    #[test]
-    fn test_delegate_action_gas_key_function_call_receiver_id() {
-        let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let access_key = AccessKey::gas_key_function_call(
-            TEST_GAS_KEY_NUM_NONCES,
-            FunctionCallPermission {
-                allowance: None,
-                receiver_id: "another.near".parse().unwrap(),
-                method_names: Vec::new(),
-            },
-        );
-
-        let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
-                args: Vec::new(),
-                deposit: Balance::ZERO,
-                gas: Gas::from_gas(300),
-                method_name: "test_method".parse().unwrap(),
-            })))];
-
-        let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
-        assert_eq!(
-            result.result,
-            Err(ActionErrorKind::DelegateActionAccessKeyError(
-                InvalidAccessKeyError::ReceiverMismatch {
-                    tx_receiver: delegate_action.receiver_id,
-                    ak_receiver: "another.near".parse().unwrap(),
-                },
-            )
-            .into())
-        );
-    }
-
-    #[test]
-    fn test_delegate_action_gas_key_function_call_method() {
-        let (_, signed_delegate_action) = create_delegate_action_receipt();
-        let access_key = AccessKey::gas_key_function_call(
-            TEST_GAS_KEY_NUM_NONCES,
-            FunctionCallPermission {
-                allowance: None,
-                receiver_id: signed_delegate_action.delegate_action.receiver_id.to_string(),
-                method_names: vec!["another_method".parse().unwrap()],
-            },
-        );
-
-        let mut delegate_action = signed_delegate_action.delegate_action;
-        delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
-                args: Vec::new(),
-                deposit: Balance::ZERO,
-                gas: Gas::from_gas(300),
-                method_name: "test_method".parse().unwrap(),
-            })))];
-
-        let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
-        assert_eq!(
-            result.result,
-            Err(ActionErrorKind::DelegateActionAccessKeyError(
-                InvalidAccessKeyError::MethodNameMismatch {
-                    method_name: "test_method".parse().unwrap(),
-                },
+                InvalidAccessKeyError::RequiresNonGasKey,
             )
             .into())
         );

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -131,7 +131,7 @@ pub fn total_send_fees(
                         config,
                         sender_is_receiver,
                         &delegate_action.get_actions(),
-                        &delegate_action.receiver_id,
+                        &delegate_action.receiver_id(),
                     )?)
                     .unwrap()
             }
@@ -232,13 +232,14 @@ pub fn total_prepaid_send_fees(
         let delta = match action {
             Delegate(signed_delegate_action) => {
                 let delegate_action = &signed_delegate_action.delegate_action;
-                let sender_is_receiver = delegate_action.sender_id == delegate_action.receiver_id;
+                let sender_is_receiver =
+                    delegate_action.sender_id() == delegate_action.receiver_id();
 
                 total_send_fees(
                     config,
                     sender_is_receiver,
                     &delegate_action.get_actions(),
-                    &delegate_action.receiver_id,
+                    &delegate_action.receiver_id(),
                 )?
             }
             _ => ParameterCost::ZERO,
@@ -472,7 +473,8 @@ fn signature_verification_cost(
     let mut total = costs[signature_kind(signer_public_key.key_type())];
     for action in actions {
         if let Action::Delegate(signed_delegate_action) = action {
-            let kind = signature_kind(signed_delegate_action.delegate_action.public_key.key_type());
+            let kind =
+                signature_kind(signed_delegate_action.delegate_action.public_key().key_type());
             total = total.checked_add_result(costs[kind])?;
         }
     }
@@ -495,12 +497,12 @@ pub fn total_prepaid_exec_fees(
             delta = total_prepaid_exec_fees(
                 config,
                 &actions,
-                &signed_delegate_action.delegate_action.receiver_id,
+                &signed_delegate_action.delegate_action.receiver_id(),
             )?;
             delta = delta.checked_add_result(exec_fee(
                 config,
                 action,
-                &signed_delegate_action.delegate_action.receiver_id,
+                &signed_delegate_action.delegate_action.receiver_id(),
             ))?;
             delta =
                 delta.checked_add_result(fees.fee(ActionCosts::new_action_receipt).exec_fee())?;
@@ -564,7 +566,9 @@ mod tests {
     use super::*;
     use near_crypto::SecretKey;
     use near_primitives::action::TransferAction;
-    use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+    use near_primitives::action::delegate::{
+        DelegateAction, DelegateActionV0, SignedDelegateAction,
+    };
     use near_primitives::transaction::TransactionV0;
     use std::sync::Arc;
 
@@ -591,14 +595,14 @@ mod tests {
         let public_key = SecretKey::from_seed(inner_key_type, "inner").public_key();
         let signature = SecretKey::from_seed(KeyType::ED25519, "dummy").sign(b"x");
         Action::Delegate(Box::new(SignedDelegateAction {
-            delegate_action: DelegateAction {
+            delegate_action: DelegateAction::V0(DelegateActionV0 {
                 sender_id: "alice.near".parse().unwrap(),
                 receiver_id: "bob.near".parse().unwrap(),
                 actions: vec![transfer().try_into().unwrap()],
                 nonce: 1,
                 max_block_height: 100,
                 public_key,
-            },
+            }),
             signature,
         }))
     }

--- a/runtime/runtime/src/prefetch.rs
+++ b/runtime/runtime/src/prefetch.rs
@@ -112,8 +112,8 @@ impl TriePrefetcher {
                     match action {
                         Action::Delegate(delegate_action) => {
                             let trie_key = TrieKey::access_key(
-                                delegate_action.delegate_action.sender_id.clone(),
-                                &delegate_action.delegate_action.public_key,
+                                delegate_action.delegate_action.sender_id().clone(),
+                                delegate_action.delegate_action.public_key(),
                             );
                             self.prefetch_trie_key(trie_key)?;
                         }

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -16,7 +16,9 @@ use near_o11y::testonly::init_test_logger;
 use near_parameters::parameter_table::FeeComponent;
 use near_parameters::{ActionCosts, RuntimeConfig};
 use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
-use near_primitives::action::delegate::{DelegateAction, NonDelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{
+    DelegateAction, DelegateActionV0, NonDelegateAction, SignedDelegateAction,
+};
 use near_primitives::action::{Action, DeleteAccountAction, TransferToGasKeyAction};
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::bandwidth_scheduler::BlockBandwidthRequests;
@@ -529,7 +531,7 @@ fn generate_delegate_actions(deposit: Balance, n: u64) -> Vec<Receipt> {
                 deposit: deposit,
             }))];
 
-            let delegate_action = DelegateAction {
+            let delegate_action = DelegateAction::V0(DelegateActionV0 {
                 sender_id: sender_id.clone(),
                 receiver_id: receiver_id.clone(),
                 actions: inner_actions
@@ -539,7 +541,7 @@ fn generate_delegate_actions(deposit: Balance, n: u64) -> Vec<Receipt> {
                 nonce: 2 + i as u64,
                 max_block_height: 10000,
                 public_key: signer.public_key(),
-            };
+            });
             let signed_delegate_action = Action::Delegate(Box::new(SignedDelegateAction {
                 signature: signer.sign(delegate_action.get_nep461_hash().as_bytes()),
                 delegate_action,

--- a/test-loop-tests/src/tests/deterministic_account_id.rs
+++ b/test-loop-tests/src/tests/deterministic_account_id.rs
@@ -34,7 +34,9 @@ use near_crypto::{KeyType, PublicKey};
 use near_o11y::testonly::init_test_logger;
 use near_parameters::RuntimeConfigStore;
 use near_primitives::account::AccessKey;
-use near_primitives::action::delegate::{DelegateAction, NonDelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{
+    DelegateAction, DelegateActionV0, NonDelegateAction, SignedDelegateAction,
+};
 use near_primitives::action::{
     Action, AddKeyAction, DeployContractAction, DeterministicStateInitAction,
     GlobalContractDeployMode, GlobalContractIdentifier, TransferAction,
@@ -129,7 +131,7 @@ fn test_deterministic_state_init_via_meta_tx() {
 /// meta transactions.
 ///
 /// With the old (buggy) code, `validate_delegate_action` used
-/// `outer_tx.receiver_id` instead of `delegate_action.receiver_id` when
+/// `outer_tx.receiver_id` instead of `delegate_action.receiver_id()` when
 /// checking inner actions. The exploit tx therefore passes initial tx
 /// validation. The exploit is prevented by a following `validate_receipt` check
 /// when the meta transaction is unpacked.
@@ -240,14 +242,14 @@ fn try_meta_tx_deterministic_receiver_exploit(
         deposit: Balance::ZERO,
     }));
     let delegate_nonce = env.next_nonce_for(&det_account_b);
-    let delegate_action = DelegateAction {
+    let delegate_action = DelegateAction::V0(DelegateActionV0 {
         sender_id: det_account_b.clone(),
         receiver_id: det_account_a,
         actions: vec![NonDelegateAction::try_from(inner_action).unwrap()],
         nonce: delegate_nonce,
         max_block_height: 1_000_000,
         public_key: meta_tx_sender_signer.public_key(),
-    };
+    });
     let signed_delegate_action =
         SignedDelegateAction::sign(&meta_tx_sender_signer, delegate_action);
     let tx = SignedTransaction::from_actions(
@@ -1077,14 +1079,14 @@ impl TestEnv {
             deposit: balance,
         }));
 
-        let delegate_action = DelegateAction {
+        let delegate_action = DelegateAction::V0(DelegateActionV0 {
             sender_id: user_account.clone(),
             receiver_id: det_account,
             actions: vec![NonDelegateAction::try_from(inner_action).unwrap()],
             nonce: self.next_nonce(),
             max_block_height: 1_000_000,
             public_key: user_signer.public_key(),
-        };
+        });
         let signed_delegate_action = SignedDelegateAction::sign(&user_signer, delegate_action);
         let tx = SignedTransaction::from_actions(
             self.next_nonce(),

--- a/test-loop-tests/src/tests/global_contracts.rs
+++ b/test-loop-tests/src/tests/global_contracts.rs
@@ -6,7 +6,7 @@ use assert_matches::assert_matches;
 use near_async::time::Duration;
 use near_o11y::testonly::init_test_logger;
 use near_parameters::{ActionCosts, RuntimeConfigStore, RuntimeFeesConfig};
-use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{DelegateAction, DelegateActionV0, SignedDelegateAction};
 use near_primitives::action::{
     Action, GlobalContractDeployMode, GlobalContractIdentifier, UseGlobalContractAction,
 };
@@ -308,14 +308,14 @@ impl GlobalContractsTestEnv {
         let use_action =
             Action::UseGlobalContract(UseGlobalContractAction { contract_identifier }.into());
         let user_signer = create_user_test_signer(&user);
-        let delegate_action = DelegateAction {
+        let delegate_action = DelegateAction::V0(DelegateActionV0 {
             sender_id: user.clone(),
             receiver_id: user.clone(),
             actions: vec![use_action.try_into().unwrap()],
             nonce: self.next_nonce(),
             max_block_height: BlockHeight::MAX,
             public_key: user_signer.public_key(),
-        };
+        });
         let signed_delegate_action = SignedDelegateAction::sign(&user_signer, delegate_action);
         let tx = SignedTransaction::from_actions(
             self.next_nonce(),

--- a/test-loop-tests/src/tests/ml_dsa_verification_cost.rs
+++ b/test-loop-tests/src/tests/ml_dsa_verification_cost.rs
@@ -17,7 +17,7 @@ use near_crypto::{InMemorySigner, KeyType, PublicKey, Signer};
 use near_o11y::testonly::init_test_logger;
 use near_parameters::{RuntimeConfigStore, SignatureKind};
 use near_primitives::account::AccessKey;
-use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{DelegateAction, DelegateActionV0, SignedDelegateAction};
 use near_primitives::action::{AddKeyAction, TransferAction};
 use near_primitives::hash::CryptoHash;
 use near_primitives::test_utils::create_user_test_signer;
@@ -175,14 +175,14 @@ fn run_meta_tx(
         .view_access_key_query(inner_sender, &inner_signer.public_key())
         .unwrap()
         .nonce;
-    let delegate_action = DelegateAction {
+    let delegate_action = DelegateAction::V0(DelegateActionV0 {
         sender_id: inner_sender.clone(),
         receiver_id: receiver.clone(),
         actions: vec![Action::Transfer(TransferAction { deposit: amount }).try_into().unwrap()],
         nonce: inner_nonce + 1,
         max_block_height: BlockHeight::MAX,
         public_key: inner_signer.public_key(),
-    };
+    });
     let signed_delegate_action = SignedDelegateAction::sign(inner_signer, delegate_action);
     let tx = env.rpc_node().tx_from_actions(
         relayer,

--- a/tools/mirror/src/genesis.rs
+++ b/tools/mirror/src/genesis.rs
@@ -1,5 +1,5 @@
 use near_crypto::PublicKey;
-use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{DelegateAction, DelegateActionV0, SignedDelegateAction};
 use near_primitives::receipt::{DataReceiver, Receipt, ReceiptEnum};
 use near_primitives::state_record::StateRecord;
 use near_primitives::transaction::{Action, AddKeyAction, DeleteAccountAction, DeleteKeyAction};
@@ -92,15 +92,18 @@ fn map_delegate_action(
             .unwrap(),
         );
     }
-    let mapped_key = crate::key_mapping::map_key(&delegate.delegate_action.public_key, secret);
-    let mapped_action = DelegateAction {
-        sender_id: crate::key_mapping::map_account(&delegate.delegate_action.sender_id, secret),
-        receiver_id: crate::key_mapping::map_account(&delegate.delegate_action.receiver_id, secret),
+    let mapped_key = crate::key_mapping::map_key(&delegate.delegate_action.public_key(), secret);
+    let mapped_action = DelegateAction::V0(DelegateActionV0 {
+        sender_id: crate::key_mapping::map_account(&delegate.delegate_action.sender_id(), secret),
+        receiver_id: crate::key_mapping::map_account(
+            &delegate.delegate_action.receiver_id(),
+            secret,
+        ),
         actions,
-        nonce: delegate.delegate_action.nonce,
-        max_block_height: delegate.delegate_action.max_block_height,
+        nonce: delegate.delegate_action.nonce(),
+        max_block_height: delegate.delegate_action.max_block_height(),
         public_key: mapped_key.public_key(),
-    };
+    });
     let tx_hash = mapped_action.get_nep461_hash();
     let d = SignedDelegateAction {
         delegate_action: mapped_action,
@@ -312,7 +315,9 @@ pub(crate) fn map_records<P: AsRef<Path>>(
 mod test {
     use near_crypto::{KeyType, SecretKey};
     use near_primitives::account::{AccessKeyPermission, FunctionCallPermission, GasKeyInfo};
-    use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+    use near_primitives::action::delegate::{
+        DelegateAction, DelegateActionV0, SignedDelegateAction,
+    };
     use near_primitives::hash::CryptoHash;
     use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV0};
     use near_primitives::state_record::StateRecord;
@@ -390,7 +395,7 @@ mod test {
         });
 
         let secret_key = SecretKey::from_random(KeyType::ED25519);
-        let delegate_action = DelegateAction {
+        let delegate_action = DelegateAction::V0(DelegateActionV0 {
             sender_id: "d4156e03cb09f47117ddfde4fdcd5f3b8b087dccb364e228b8b3ed91d69054f4"
                 .parse()
                 .unwrap(),
@@ -408,7 +413,7 @@ mod test {
                 .try_into()
                 .unwrap(),
             ],
-        };
+        });
         let tx_hash = delegate_action.get_nep461_hash();
         let signature = secret_key.sign(tx_hash.as_ref());
 
@@ -438,7 +443,7 @@ mod test {
         });
 
         let mapped_secret_key = crate::key_mapping::map_key(&secret_key.public_key(), None);
-        let delegate_action = DelegateAction {
+        let delegate_action = DelegateAction::V0(DelegateActionV0 {
             sender_id: "799185fe8173d8adf46b0c088d57887b2550642c08aafdc20ccce67b5ad51976"
                 .parse()
                 .unwrap(),
@@ -456,7 +461,7 @@ mod test {
                 .try_into()
                 .unwrap(),
             ],
-        };
+        });
         let tx_hash = delegate_action.get_nep461_hash();
         let signature = mapped_secret_key.sign(tx_hash.as_ref());
         let want_receipt1 = Receipt::V0(ReceiptV0 {


### PR DESCRIPTION
Builds on the gas-key delegate rejection by adding a versioned delegate action so gas keys can be used in meta transactions.

`DelegateAction` becomes an enum `{ V0, V1 }`. V0 is the original NEP-366 form and stays byte-identical in Borsh and shape-identical in JSON, so existing signatures, stored receipts, and RPC clients are unaffected. V1 adds a `nonce_index` selecting one of a gas key's parallel nonces. Borsh disambiguates the versions by the first bytes (mirroring `Transaction`); the deserializer erases the reader to `&mut dyn Read` to break the self-recursion through nested actions.

The delegate verifier routes a V1 action's nonce through the gas key nonce storage (gas key required, `nonce_index` range-checked, relayer still pays gas). V0 keeps rejecting gas keys. V1 is gated under `ProtocolFeature::GasKeys`.

Still needs `protocol_schema.toml` and `openapi.json` regeneration.