### PR TITLE
feat(runtime): skip duplicate transactions within a chunk

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -357,6 +357,12 @@ pub enum ProtocolFeature {
     /// subtracted, overstating storage usage for accounts with global
     /// contracts and making them marginally harder to delete.
     FixDeleteAccountGlobalContractStorageUsage,
+    /// Skip transactions whose hash already appeared earlier in the same chunk.
+    /// A transaction hash is also its outcome id, and outcomes are committed
+    /// (via the chunk outcome root) keyed by that id. Including a transaction
+    /// twice would otherwise commit two conflicting outcomes (a success and an
+    /// InvalidNonce failure) under one id.
+    UniqueChunkTransactions,
     /// Apply PromiseYield receipts immediately after emitting them. Allows to perform the resume
     /// sooner, without waiting for the PromiseYield receipt to pass through outgoing receipts.
     InstantPromiseYield,
@@ -522,6 +528,7 @@ impl ProtocolFeature {
             | ProtocolFeature::DynamicResharding
             | ProtocolFeature::StickyReshardingValidatorAssignment
             | ProtocolFeature::StrictNonce
+            | ProtocolFeature::UniqueChunkTransactions
             | ProtocolFeature::YieldWithId => 85,
 
             // Nightly features:

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1809,7 +1809,18 @@ impl Runtime {
 
         let (maybe_expired_txs, _) =
             signed_txs.get_potentially_expired_transactions_and_expiration_flags();
+        let skip_duplicate_txs = ProtocolFeature::UniqueChunkTransactions.enabled(protocol_version);
+        let mut seen_tx_hashes = HashSet::with_capacity(num_transactions);
+        let mut num_skipped_duplicate_txs = 0;
         for (tx, maybe_validation_error) in maybe_expired_txs.iter().zip(validations) {
+            // A transaction hash is its outcome id, and outcomes are committed
+            // keyed by that id. Processing the same hash twice would commit two
+            // conflicting outcomes under one id, so skip any repeat occurrence.
+            if skip_duplicate_txs && !seen_tx_hashes.insert(*tx.hash()) {
+                tracing::debug!(tx_hash = ?tx.hash(), "skipping duplicate transaction in chunk");
+                num_skipped_duplicate_txs += 1;
+                continue;
+            }
             metrics::TRANSACTION_PROCESSED_TOTAL.inc();
             if let Some(err) = maybe_validation_error {
                 metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
@@ -2086,7 +2097,9 @@ impl Runtime {
         }
 
         if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(protocol_version) {
-            debug_assert!(processing_state.outcomes.len() == num_transactions);
+            debug_assert!(
+                processing_state.outcomes.len() == num_transactions - num_skipped_duplicate_txs
+            );
         }
 
         processing_state

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -3547,6 +3547,105 @@ fn test_expired_transaction() {
 }
 
 #[test]
+fn test_duplicate_transaction_in_chunk_skipped() {
+    let alice_signer = InMemorySigner::test_signer(&alice_account());
+    let send_money = |nonce| {
+        SignedTransaction::send_money(
+            nonce,
+            alice_account(),
+            bob_account(),
+            &alice_signer,
+            Balance::from_near(1),
+            CryptoHash::default(),
+        )
+    };
+    let tx = send_money(1);
+    // A distinct transaction (different nonce, different hash) that must not be skipped.
+    let other = send_money(2);
+    let (tx_hash, other_hash) = (tx.get_hash(), other.get_hash());
+    let (runtime, tries, root, apply_state, _signers, epoch_info_provider) = setup_runtime(
+        vec![alice_account(), bob_account()],
+        Balance::from_near(1_000_000),
+        Balance::from_near(500_000),
+        Gas::from_teragas(1000),
+    );
+    assert!(ProtocolFeature::UniqueChunkTransactions.enabled(PROTOCOL_VERSION));
+
+    // [T, U, T]: the repeat of T is non-adjacent to the original.
+    let signed_valid_period_txs =
+        SignedValidPeriodTransactions::new(vec![tx.clone(), other, tx], vec![true; 3]);
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            &None,
+            &apply_state,
+            &[],
+            signed_valid_period_txs,
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .expect("apply should succeed");
+
+    // The repeat of T is skipped, leaving a single success outcome under its
+    // hash rather than a success and a conflicting InvalidNonce failure, while
+    // the distinct transaction U is processed normally.
+    let tx_outcomes = |id| apply_result.outcomes.iter().filter(|o| o.id == id).collect::<Vec<_>>();
+    let (tx_outcomes, other_outcomes) = (tx_outcomes(tx_hash), tx_outcomes(other_hash));
+    assert_eq!(tx_outcomes.len(), 1, "duplicate transaction must be skipped");
+    assert_matches!(tx_outcomes[0].outcome.status, ExecutionStatus::SuccessReceiptId(_));
+    assert_eq!(other_outcomes.len(), 1, "distinct transaction must not be skipped");
+    assert_matches!(other_outcomes[0].outcome.status, ExecutionStatus::SuccessReceiptId(_));
+}
+
+#[test]
+fn test_duplicate_transaction_in_chunk_prior_behavior() {
+    let alice_signer = InMemorySigner::test_signer(&alice_account());
+    let tx = SignedTransaction::send_money(
+        1,
+        alice_account(),
+        bob_account(),
+        &alice_signer,
+        Balance::from_near(1),
+        CryptoHash::default(),
+    );
+    let tx_hash = tx.get_hash();
+    let (runtime, tries, root, mut apply_state, _signers, epoch_info_provider) = setup_runtime(
+        vec![alice_account(), bob_account()],
+        Balance::from_near(1_000_000),
+        Balance::from_near(500_000),
+        Gas::from_teragas(1000),
+    );
+    apply_state.current_protocol_version =
+        ProtocolFeature::UniqueChunkTransactions.protocol_version() - 1;
+
+    let signed_valid_period_txs =
+        SignedValidPeriodTransactions::new(vec![tx.clone(), tx], vec![true, true]);
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            &None,
+            &apply_state,
+            &[],
+            signed_valid_period_txs,
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .expect("apply should succeed");
+
+    // Without the feature both copies are processed: the second records a
+    // conflicting InvalidNonce failure under the same id as the success.
+    let tx_outcomes: Vec<_> = apply_result.outcomes.iter().filter(|o| o.id == tx_hash).collect();
+    assert_eq!(tx_outcomes.len(), 2);
+    assert_matches!(tx_outcomes[0].outcome.status, ExecutionStatus::SuccessReceiptId(_));
+    assert_matches!(
+        tx_outcomes[1].outcome.status,
+        ExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+            InvalidTxError::InvalidNonce { .. }
+        ))
+    );
+}
+
+#[test]
 fn test_gas_key_burn_not_reported_on_failed_receipt() {
     let (runtime, tries, root, mut apply_state, signers, epoch_info_provider) = setup_runtime(
         vec![alice_account()],


### PR DESCRIPTION
Adds the `UniqueChunkTransactions` protocol feature (v85). A transaction's hash doubles as its execution outcome id, so a chunk that contains the same transaction more than once would record multiple outcomes under one id. This change processes only the first occurrence and skips any repeat before it produces an outcome. The skipped copy is state-equivalent (a repeat would only ever fail `InvalidNonce`), so there's no behavioral change in practice. Tests cover both the new behavior and the prior behavior one version below the feature.