### PR TITLE
feat(chain): recompute block_ordinal/epoch_sync_data_hash on headers

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -232,6 +232,12 @@ pub enum Error {
     /// Invalid block merkle root.
     #[error("Invalid Block Merkle Root")]
     InvalidBlockMerkleRoot,
+    /// Invalid block ordinal.
+    #[error("Invalid Block Ordinal")]
+    InvalidBlockOrdinal,
+    /// Invalid epoch sync data hash.
+    #[error("Invalid Epoch Sync Data Hash")]
+    InvalidEpochSyncDataHash,
     /// Invalid split shard ids.
     #[error("Invalid Split Shard Ids when resharding. shard_id: {0}, parent_shard_id: {1}")]
     InvalidSplitShardsIds(ShardId, ShardId),
@@ -368,6 +374,8 @@ impl Error {
             | Error::InvalidStateRequest(_)
             | Error::InvalidRandomnessBeaconOutput
             | Error::InvalidBlockMerkleRoot
+            | Error::InvalidBlockOrdinal
+            | Error::InvalidEpochSyncDataHash
             | Error::InvalidProtocolVersion
             | Error::NotAValidator(_)
             | Error::NotAChunkValidator
@@ -455,6 +463,8 @@ impl Error {
             Error::InvalidStateRequest(_) => "invalid_state_request",
             Error::InvalidRandomnessBeaconOutput => "invalid_randomness_beacon_output",
             Error::InvalidBlockMerkleRoot => "invalid_block_merkle_root",
+            Error::InvalidBlockOrdinal => "invalid_block_ordinal",
+            Error::InvalidEpochSyncDataHash => "invalid_epoch_sync_data_hash",
             Error::InvalidProtocolVersion => "invalid_protocol_version",
             Error::NotAValidator(_) => "not_a_validator",
             Error::NotAChunkValidator => "not_a_chunk_validator",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1001,6 +1001,21 @@ impl Chain {
                 return Err(Error::InvalidBlockMerkleRoot);
             }
 
+            if ProtocolFeature::ValidateBlockOrdinalAndEpochSyncDataHash
+                .enabled(epoch_protocol_version)
+            {
+                // block_ordinal is the number of blocks up to and including this one.
+                if block_merkle_tree.size() + 1 != header.block_ordinal() {
+                    return Err(Error::InvalidBlockOrdinal);
+                }
+
+                let expected_epoch_sync_data_hash =
+                    self.epoch_manager.compute_epoch_sync_data_hash(header.prev_hash())?;
+                if expected_epoch_sync_data_hash != header.epoch_sync_data_hash() {
+                    return Err(Error::InvalidEpochSyncDataHash);
+                }
+            }
+
             if !ProtocolFeature::Spice.enabled(epoch_protocol_version) {
                 validate_chunk_endorsements_in_header(self.epoch_manager.as_ref(), header)?;
             }

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -127,9 +127,15 @@ mod tests {
         let mut block_merkle_tree = PartialMerkleTree::default();
         for i in 0..3 {
             clock.advance(Duration::milliseconds(1));
+            let epoch_sync_data_hash = if blocks[i].header().is_genesis() {
+                epoch_manager.compute_epoch_sync_data_hash(blocks[i].hash()).unwrap()
+            } else {
+                None
+            };
             blocks.push(
                 TestBlockBuilder::from_prev_block(clock.clock(), &blocks[i], signer.clone())
                     .block_merkle_tree(&mut block_merkle_tree)
+                    .epoch_sync_data_hash(epoch_sync_data_hash)
                     .build(),
             );
         }

--- a/chain/chain/src/tests/mod.rs
+++ b/chain/chain/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod doomslug;
 mod garbage_collection;
 mod simple_chain;
 mod sync_chain;
+mod validate_header_recompute;
 
 use crate::block_processing_utils::BlockProcessingArtifact;
 use crate::test_utils::process_block_sync;

--- a/chain/chain/src/tests/sync_chain.rs
+++ b/chain/chain/src/tests/sync_chain.rs
@@ -10,14 +10,22 @@ use near_primitives::test_utils::TestBlockBuilder;
 #[test]
 fn chain_sync_headers() {
     init_test_logger();
-    let (mut chain, _, _, bls_signer) = setup(Clock::real());
+    let (mut chain, epoch_manager, _, bls_signer) = setup(Clock::real());
     assert_eq!(chain.header_head().unwrap().height, 0);
     let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap()];
     let mut block_merkle_tree = PartialMerkleTree::default();
     for i in 0..4 {
+        // Only the first block after genesis is epoch-start; later prev blocks are
+        // not yet in the epoch manager, so compute the hash only where it applies.
+        let epoch_sync_data_hash = if blocks[i].header().is_genesis() {
+            epoch_manager.compute_epoch_sync_data_hash(blocks[i].hash()).unwrap()
+        } else {
+            None
+        };
         blocks.push(
             TestBlockBuilder::from_prev_block(Clock::real(), &blocks[i], bls_signer.clone())
                 .block_merkle_tree(&mut block_merkle_tree)
+                .epoch_sync_data_hash(epoch_sync_data_hash)
                 .build(),
         )
     }
@@ -36,9 +44,15 @@ fn chain_sync_headers_records_spice_block_info() {
     let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap()];
     let mut block_merkle_tree = PartialMerkleTree::default();
     for i in 0..3 {
+        let epoch_sync_data_hash = if blocks[i].header().is_genesis() {
+            epoch_manager.compute_epoch_sync_data_hash(blocks[i].hash()).unwrap()
+        } else {
+            None
+        };
         blocks.push(
             TestBlockBuilder::from_prev_block(Clock::real(), &blocks[i], bls_signer.clone())
                 .block_merkle_tree(&mut block_merkle_tree)
+                .epoch_sync_data_hash(epoch_sync_data_hash)
                 .build(),
         )
     }

--- a/chain/chain/src/tests/validate_header_recompute.rs
+++ b/chain/chain/src/tests/validate_header_recompute.rs
@@ -1,0 +1,53 @@
+use crate::test_utils::setup;
+use crate::{ChainStoreAccess, Error};
+use near_async::time::Clock;
+use near_epoch_manager::EpochManagerAdapter;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::test_utils::TestBlockBuilder;
+use std::sync::Arc;
+
+// `validate_header` recomputes `block_ordinal` and `epoch_sync_data_hash`. The first
+// block after genesis is epoch-start, so it carries a real (`Some`) epoch_sync_data_hash;
+// forging either field is rejected while the honest header is accepted.
+#[test]
+fn validate_header_recomputes_block_ordinal_and_epoch_sync_data_hash() {
+    init_test_logger();
+    let clock = Clock::real();
+    let (chain, epoch_manager, _, signer) = setup(clock.clone());
+
+    let genesis = chain.get_block(&chain.genesis().hash().clone()).unwrap();
+    let epoch_sync_data_hash = epoch_manager.compute_epoch_sync_data_hash(genesis.hash()).unwrap();
+    assert!(epoch_sync_data_hash.is_some(), "first block after genesis is epoch-start");
+
+    let stored_tree = chain.chain_store().get_block_merkle_tree(genesis.hash()).unwrap();
+    let mut tree = PartialMerkleTree::clone(&stored_tree);
+    let block = TestBlockBuilder::from_prev_block(clock, &genesis, signer.clone())
+        .block_merkle_tree(&mut tree)
+        .epoch_sync_data_hash(epoch_sync_data_hash)
+        .build();
+
+    // Honest epoch-start header is accepted.
+    chain.process_block_header(block.header()).unwrap();
+
+    // Forged block_ordinal is rejected.
+    let mut forged = block.clone();
+    {
+        let header = Arc::make_mut(&mut forged).mut_header();
+        header.set_block_ordinal(header.block_ordinal() + 1000);
+        header.resign(&signer);
+    }
+    let result = chain.process_block_header(forged.header());
+    assert!(matches!(result, Err(Error::InvalidBlockOrdinal)), "got {:?}", result);
+
+    // Forged epoch_sync_data_hash (the real Some replaced with a different Some) is rejected.
+    let mut forged = block;
+    {
+        let header = Arc::make_mut(&mut forged).mut_header();
+        header.set_epoch_sync_data_hash(Some(CryptoHash::hash_bytes(b"forged")));
+        header.resign(&signer);
+    }
+    let result = chain.process_block_header(forged.header());
+    assert!(matches!(result, Err(Error::InvalidEpochSyncDataHash)), "got {:?}", result);
+}

--- a/chain/chain/src/tests/validate_header_recompute.rs
+++ b/chain/chain/src/tests/validate_header_recompute.rs
@@ -8,9 +8,6 @@ use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::test_utils::TestBlockBuilder;
 use std::sync::Arc;
 
-// `validate_header` recomputes `block_ordinal` and `epoch_sync_data_hash`. The first
-// block after genesis is epoch-start, so it carries a real (`Some`) epoch_sync_data_hash;
-// forging either field is rejected while the honest header is accepted.
 #[test]
 fn validate_header_recomputes_block_ordinal_and_epoch_sync_data_hash() {
     init_test_logger();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1116,27 +1116,7 @@ impl Client {
             None
         };
 
-        let epoch_sync_data_hash = if self.epoch_manager.is_next_block_epoch_start(&prev_hash)? {
-            let last_block_info = self.epoch_manager.get_block_info(prev_block.hash())?;
-            let prev_epoch_id = *last_block_info.epoch_id();
-            let prev_epoch_first_block_info =
-                self.epoch_manager.get_block_info(last_block_info.epoch_first_block())?;
-            let prev_epoch_prev_last_block_info =
-                self.epoch_manager.get_block_info(last_block_info.prev_hash())?;
-            let prev_epoch_info = self.epoch_manager.get_epoch_info(&prev_epoch_id)?;
-            let cur_epoch_info = self.epoch_manager.get_epoch_info(&epoch_id)?;
-            let next_epoch_info = self.epoch_manager.get_epoch_info(&next_epoch_id)?;
-            Some(CryptoHash::hash_borsh(&(
-                prev_epoch_first_block_info,
-                prev_epoch_prev_last_block_info,
-                last_block_info,
-                prev_epoch_info,
-                cur_epoch_info,
-                next_epoch_info,
-            )))
-        } else {
-            None
-        };
+        let epoch_sync_data_hash = self.epoch_manager.compute_epoch_sync_data_hash(&prev_hash)?;
 
         // Last final block **after this block is produced**
         let last_final_block = prev.last_final_block_for_height(height);

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -463,14 +463,7 @@ impl EpochSync {
         last_epoch: &EpochSyncProofLastEpochData,
         current_epoch_first_block_header: &BlockHeader,
     ) -> Result<(), Error> {
-        let epoch_sync_data_hash = CryptoHash::hash_borsh(&(
-            &last_epoch.first_block_in_epoch,
-            &last_epoch.second_last_block_in_epoch,
-            &last_epoch.last_block_in_epoch,
-            &last_epoch.epoch_info,
-            &last_epoch.next_epoch_info,
-            &last_epoch.next_next_epoch_info,
-        ));
+        let epoch_sync_data_hash = last_epoch.compute_epoch_sync_data_hash();
         let expected_epoch_sync_data_hash =
             current_epoch_first_block_header.epoch_sync_data_hash().ok_or_else(|| {
                 Error::InvalidEpochSyncProof("missing epoch_sync_data_hash".to_string())

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -252,12 +252,15 @@ pub fn create_chunk(
     let signer = client.validator_signer.get().unwrap();
     let endorsement =
         ChunkEndorsement::new(EpochId::default(), &encoded_chunk.cloned_header(), signer.as_ref());
+    let epoch_sync_data_hash =
+        client.epoch_manager.compute_epoch_sync_data_hash(last_block.hash()).unwrap();
     let block = TestBlockBuilder::from_prev_block(client.clock.clone(), &last_block, signer)
         .height(next_height)
         .chunks(vec![encoded_chunk.cloned_header()])
         .chunk_endorsements(vec![vec![Some(Box::new(endorsement.signature()))]])
         .max_gas_price(Balance::from_yoctonear(100))
         .block_merkle_tree(&mut block_merkle_tree)
+        .epoch_sync_data_hash(epoch_sync_data_hash)
         .build();
     let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)
         .map_err(|(err, _)| err)

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -102,8 +102,7 @@ pub trait EpochManagerAdapter: Send + Sync {
     fn is_next_block_epoch_start(&self, block_hash: &CryptoHash) -> Result<bool, EpochError>;
 
     /// Computes the `epoch_sync_data_hash` for the block built on top of `prev_hash`.
-    /// It is `Some` only for the first block of an epoch. Used by the block producer,
-    /// header validation, and tests, which must agree on the value.
+    /// It is `Some` only for the first block of an epoch.
     fn compute_epoch_sync_data_hash(
         &self,
         prev_hash: &CryptoHash,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -103,8 +103,7 @@ pub trait EpochManagerAdapter: Send + Sync {
 
     /// Computes the `epoch_sync_data_hash` for the block built on top of `prev_hash`.
     /// It is `Some` only for the first block of an epoch. Used by the block producer,
-    /// header validation, and tests, which must agree, so this is the single source
-    /// of truth.
+    /// header validation, and tests, which must agree on the value.
     fn compute_epoch_sync_data_hash(
         &self,
         prev_hash: &CryptoHash,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -102,7 +102,8 @@ pub trait EpochManagerAdapter: Send + Sync {
     fn is_next_block_epoch_start(&self, block_hash: &CryptoHash) -> Result<bool, EpochError>;
 
     /// Computes the `epoch_sync_data_hash` for the block built on top of `prev_hash`.
-    /// It is `Some` only for the first block of an epoch.
+    /// It is `Some` only for the first block of an epoch. Used by the block producer,
+    /// header validation, and tests.
     fn compute_epoch_sync_data_hash(
         &self,
         prev_hash: &CryptoHash,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -5,6 +5,7 @@ use near_primitives::block::{Block, Tip};
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::EpochConfig;
+use near_primitives::epoch_sync::EpochSyncProofLastEpochData;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{ShardInfo, ShardLayout};
@@ -99,6 +100,35 @@ pub trait EpochManagerAdapter: Send + Sync {
 
     /// Returns true, if the block with the given `block_hash` is the last block in its epoch.
     fn is_next_block_epoch_start(&self, block_hash: &CryptoHash) -> Result<bool, EpochError>;
+
+    /// Computes the `epoch_sync_data_hash` for the block built on top of `prev_hash`.
+    /// It is `Some` only for the first block of an epoch. Used by the block producer,
+    /// header validation, and tests, which must agree, so this is the single source
+    /// of truth.
+    fn compute_epoch_sync_data_hash(
+        &self,
+        prev_hash: &CryptoHash,
+    ) -> Result<Option<CryptoHash>, EpochError> {
+        if !self.is_next_block_epoch_start(prev_hash)? {
+            return Ok(None);
+        }
+        let epoch_id = self.get_epoch_id_from_prev_block(prev_hash)?;
+        let next_epoch_id = self.get_next_epoch_id_from_prev_block(prev_hash)?;
+        let last_block_info = self.get_block_info(prev_hash)?;
+        let prev_epoch_id = *last_block_info.epoch_id();
+        let prev_epoch_first_block_info =
+            self.get_block_info(last_block_info.epoch_first_block())?;
+        let prev_epoch_prev_last_block_info = self.get_block_info(last_block_info.prev_hash())?;
+        let last_epoch = EpochSyncProofLastEpochData {
+            epoch_info: self.get_epoch_info(&prev_epoch_id)?.as_ref().clone(),
+            next_epoch_info: self.get_epoch_info(&epoch_id)?.as_ref().clone(),
+            next_next_epoch_info: self.get_epoch_info(&next_epoch_id)?.as_ref().clone(),
+            first_block_in_epoch: prev_epoch_first_block_info.as_ref().clone(),
+            last_block_in_epoch: last_block_info.as_ref().clone(),
+            second_last_block_in_epoch: prev_epoch_prev_last_block_info.as_ref().clone(),
+        };
+        Ok(Some(last_epoch.compute_epoch_sync_data_hash()))
+    }
 
     /// Returns true if the block after the one being produced will belong to a new epoch.
     ///

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -411,6 +411,10 @@ pub enum ProtocolFeature {
     /// New host functions `promise_yield_create_with_id` and `promise_yield_resume_with_yield_id`
     /// that allow contracts to provide a custom yield ID for yield/resume.
     YieldWithId,
+    /// Recompute `block_ordinal` and `epoch_sync_data_hash` against local chain
+    /// state when validating received block headers, rather than trusting the
+    /// producer-supplied values.
+    ValidateBlockOrdinalAndEpochSyncDataHash,
 }
 
 impl ProtocolFeature {
@@ -529,6 +533,7 @@ impl ProtocolFeature {
             | ProtocolFeature::StickyReshardingValidatorAssignment
             | ProtocolFeature::StrictNonce
             | ProtocolFeature::UniqueChunkTransactions
+            | ProtocolFeature::ValidateBlockOrdinalAndEpochSyncDataHash
             | ProtocolFeature::YieldWithId => 85,
 
             // Nightly features:

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -412,8 +412,7 @@ pub enum ProtocolFeature {
     /// that allow contracts to provide a custom yield ID for yield/resume.
     YieldWithId,
     /// Recompute `block_ordinal` and `epoch_sync_data_hash` against local chain
-    /// state when validating received block headers, rather than trusting the
-    /// producer-supplied values.
+    /// state when validating received block headers.
     ValidateBlockOrdinalAndEpochSyncDataHash,
 }
 

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -166,8 +166,7 @@ pub struct EpochSyncProofLastEpochData {
 
 impl EpochSyncProofLastEpochData {
     /// Canonical computation of the `epoch_sync_data_hash` carried by the first
-    /// block of the next epoch. Shared by the block producer, header validation,
-    /// and epoch sync proof verification, which must all agree on the value.
+    /// block of the next epoch.
     pub fn compute_epoch_sync_data_hash(&self) -> CryptoHash {
         CryptoHash::hash_borsh(&(
             &self.first_block_in_epoch,

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -166,7 +166,8 @@ pub struct EpochSyncProofLastEpochData {
 
 impl EpochSyncProofLastEpochData {
     /// Canonical computation of the `epoch_sync_data_hash` carried by the first
-    /// block of the next epoch.
+    /// block of the next epoch. Shared by the block producer, header validation,
+    /// and epoch sync proof verification.
     pub fn compute_epoch_sync_data_hash(&self) -> CryptoHash {
         CryptoHash::hash_borsh(&(
             &self.first_block_in_epoch,

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -166,9 +166,8 @@ pub struct EpochSyncProofLastEpochData {
 
 impl EpochSyncProofLastEpochData {
     /// Canonical computation of the `epoch_sync_data_hash` carried by the first
-    /// block of the next epoch. The single source of truth shared by the block
-    /// producer, header validation, and epoch sync proof verification, which
-    /// must all agree on the value.
+    /// block of the next epoch. Shared by the block producer, header validation,
+    /// and epoch sync proof verification, which must all agree on the value.
     pub fn compute_epoch_sync_data_hash(&self) -> CryptoHash {
         CryptoHash::hash_borsh(&(
             &self.first_block_in_epoch,

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -1,5 +1,6 @@
 use crate::epoch_block_info::BlockInfo;
 use crate::epoch_info::EpochInfo;
+use crate::hash::CryptoHash;
 use crate::merkle::PartialMerkleTree;
 use crate::types::validator_stake::ValidatorStake;
 use crate::utils::compression::CompressedData;
@@ -161,6 +162,23 @@ pub struct EpochSyncProofLastEpochData {
     pub first_block_in_epoch: BlockInfo,
     pub last_block_in_epoch: BlockInfo,
     pub second_last_block_in_epoch: BlockInfo,
+}
+
+impl EpochSyncProofLastEpochData {
+    /// Canonical computation of the `epoch_sync_data_hash` carried by the first
+    /// block of the next epoch. The single source of truth shared by the block
+    /// producer, header validation, and epoch sync proof verification, which
+    /// must all agree on the value.
+    pub fn compute_epoch_sync_data_hash(&self) -> CryptoHash {
+        CryptoHash::hash_borsh(&(
+            &self.first_block_in_epoch,
+            &self.second_last_block_in_epoch,
+            &self.last_block_in_epoch,
+            &self.epoch_info,
+            &self.next_epoch_info,
+            &self.next_next_epoch_info,
+        ))
+    }
 }
 
 /// Data needed to initialize the current epoch we're syncing to.

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -19,7 +19,9 @@ use crate::transaction::{
     Transaction, TransactionNonce, TransactionV0, TransactionV1, TransferAction,
 };
 use crate::types::validator_stake::ValidatorStake;
-use crate::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas, Nonce, ShardId};
+use crate::types::{
+    AccountId, Balance, EpochId, EpochInfoProvider, Gas, Nonce, NumBlocks, ShardId,
+};
 use crate::validator_signer::ValidatorSigner;
 use crate::views::{ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionStatus};
 use itertools::Itertools;
@@ -681,6 +683,34 @@ impl BlockHeader {
         }
     }
 
+    pub fn set_block_ordinal(&mut self, value: NumBlocks) {
+        match self {
+            BlockHeader::BlockHeaderV1(_)
+            | BlockHeader::BlockHeaderV2(_)
+            | BlockHeader::BlockHeaderV3(_) => {
+                unreachable!("old header should not appear in tests")
+            }
+            BlockHeader::BlockHeaderV4(header) => header.inner_rest.block_ordinal = value,
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.block_ordinal = value,
+            BlockHeader::BlockHeaderV6(header) => header.inner_rest.block_ordinal = value,
+            BlockHeader::BlockHeaderV7(header) => header.inner_rest.block_ordinal = value,
+        }
+    }
+
+    pub fn set_epoch_sync_data_hash(&mut self, value: Option<CryptoHash>) {
+        match self {
+            BlockHeader::BlockHeaderV1(_)
+            | BlockHeader::BlockHeaderV2(_)
+            | BlockHeader::BlockHeaderV3(_) => {
+                unreachable!("old header should not appear in tests")
+            }
+            BlockHeader::BlockHeaderV4(header) => header.inner_rest.epoch_sync_data_hash = value,
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.epoch_sync_data_hash = value,
+            BlockHeader::BlockHeaderV6(header) => header.inner_rest.epoch_sync_data_hash = value,
+            BlockHeader::BlockHeaderV7(header) => header.inner_rest.epoch_sync_data_hash = value,
+        }
+    }
+
     pub fn set_chunk_endorsements(&mut self, value: ChunkEndorsementsBitmap) {
         match self {
             BlockHeader::BlockHeaderV1(_)
@@ -899,6 +929,7 @@ pub struct TestBlockBuilder {
     block_merkle_root: CryptoHash,
     chunks: Vec<ShardChunkHeader>,
     chunk_endorsements: Vec<ChunkEndorsementSignatures>,
+    epoch_sync_data_hash: Option<CryptoHash>,
     timestamp_nanos: Option<u64>,
     // TODO(spice): Once spice is released remove Option.
     /// Iff `Some` spice block will be created.
@@ -935,6 +966,7 @@ impl TestBlockBuilder {
             block_merkle_root: tree.root(),
             chunks: prev_chunks,
             chunk_endorsements: vec![vec![]; chunks_len],
+            epoch_sync_data_hash: None,
             timestamp_nanos: None,
             spice_core_statements: if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
                 Some(crate::block_body::SpiceCoreStatements::new(vec![]))
@@ -1019,6 +1051,13 @@ impl TestBlockBuilder {
         self
     }
 
+    /// Sets the `epoch_sync_data_hash`, which must be `Some` for epoch-start blocks.
+    /// Compute it with `EpochManagerAdapter::compute_epoch_sync_data_hash(prev_hash)`.
+    pub fn epoch_sync_data_hash(mut self, epoch_sync_data_hash: Option<CryptoHash>) -> Self {
+        self.epoch_sync_data_hash = epoch_sync_data_hash;
+        self
+    }
+
     pub fn chunks(mut self, chunks: impl IntoIterator<Item = ShardChunkHeader>) -> Self {
         self.chunks = chunks.into_iter().collect();
         self
@@ -1076,7 +1115,7 @@ impl TestBlockBuilder {
             self.chunk_endorsements,
             self.epoch_id,
             self.next_epoch_id,
-            None,
+            self.epoch_sync_data_hash,
             self.approvals,
             num_rational::Ratio::new(0, 1),
             Balance::ZERO,

--- a/integration-tests/src/env/setup.rs
+++ b/integration-tests/src/env/setup.rs
@@ -36,7 +36,7 @@ use near_client::{
 use near_client::{ChunkEndorsementHandlerActor, spawn_rpc_handler_actor};
 use near_crypto::{KeyType, PublicKey};
 use near_epoch_manager::shard_tracker::ShardTracker;
-use near_epoch_manager::{EpochManager, EpochManagerAdapter};
+use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
 use near_network::client::ChunkEndorsementMessage;
 use near_network::shards_manager::ShardsManagerRequestFromNetwork;
 use near_network::state_witness::PartialWitnessSenderForNetwork;
@@ -86,6 +86,7 @@ fn setup(
     ShardsManagerAdapterForTest,
     PartialWitnessSenderForNetwork,
     tempfile::TempDir,
+    Arc<EpochManagerHandle>,
 ) {
     let store = create_test_store();
 
@@ -263,7 +264,7 @@ fn setup(
     let shards_manager_adapter = start_shards_manager(
         actor_system,
         epoch_manager.clone(),
-        epoch_manager,
+        epoch_manager.clone(),
         shard_tracker,
         network_adapter.into_sender(),
         client_actor.clone().into_sender(),
@@ -286,6 +287,7 @@ fn setup(
         shards_manager_adapter.into_multi_sender(),
         partial_witness_adapter.into_multi_sender(),
         tempdir,
+        epoch_manager,
     )
 }
 
@@ -342,6 +344,7 @@ fn setup_mock_with_validity_period(
         shards_manager_adapter,
         partial_witness_sender,
         runtime_tempdir,
+        epoch_manager,
     ) = setup(
         clock.clone(),
         actor_system.clone(),
@@ -370,6 +373,7 @@ fn setup_mock_with_validity_period(
         shards_manager_adapter,
         partial_witness_sender,
         runtime_tempdir: Some(runtime_tempdir.into()),
+        epoch_manager,
     }
 }
 
@@ -384,6 +388,7 @@ pub struct ActorHandlesForTesting {
     // this TempDir isn't dropped before test finishes, but is dropped after to avoid leaking temp
     // dirs.
     pub runtime_tempdir: Option<Arc<tempfile::TempDir>>,
+    pub epoch_manager: Arc<EpochManagerHandle>,
 }
 
 /// Sets up ClientActor and ViewClientActor without network.

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -18,6 +18,7 @@ use near_client::test_utils::{create_chunk, create_chunk_on_height};
 use near_client::{GetBlockWithMerkleTree, ProcessTxResponse, ProduceChunkResult};
 use near_client_primitives::types::{EpochSyncStatus, SyncStatus};
 use near_crypto::{InMemorySigner, KeyType, Signature};
+use near_epoch_manager::EpochManagerAdapter;
 use near_network::client::{BlockApproval, BlockResponse, SetNetworkInfo};
 use near_network::test_utils::MockPeerManagerAdapter;
 use near_network::types::{
@@ -198,9 +199,12 @@ async fn produce_block_with_approvals() {
     let (last_block, block_merkle_tree) = res.unwrap().unwrap();
     let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
     let signer1 = create_test_signer(&block_producer);
+    let epoch_sync_data_hash =
+        actor_handles.epoch_manager.compute_epoch_sync_data_hash(&last_block.header.hash).unwrap();
     let block =
         TestBlockBuilder::from_prev_block_view(Clock::real(), &last_block, Arc::new(signer1))
             .block_merkle_tree(&mut block_merkle_tree)
+            .epoch_sync_data_hash(epoch_sync_data_hash)
             .build();
     actor_handles.client_actor.send(
         BlockResponse {
@@ -279,9 +283,12 @@ async fn invalid_blocks_common(is_requested: bool) {
     let (last_block, block_merkle_tree) = res.unwrap().unwrap();
     let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
     let signer = create_test_signer("test");
+    let epoch_sync_data_hash =
+        actor_handles.epoch_manager.compute_epoch_sync_data_hash(&last_block.header.hash).unwrap();
     let valid_block = Arc::unwrap_or_clone(
         TestBlockBuilder::from_prev_block_view(Clock::real(), &last_block, Arc::new(signer))
             .block_merkle_tree(&mut block_merkle_tree)
+            .epoch_sync_data_hash(epoch_sync_data_hash)
             .build(),
     );
 
@@ -538,7 +545,11 @@ fn test_time_attack() {
     let client = &mut env.clients[0];
     let signer = client.validator_signer.get().unwrap();
     let genesis = client.chain.get_block_by_height(0).unwrap();
-    let mut b1 = TestBlockBuilder::from_prev_block(Clock::real(), &genesis, signer.clone()).build();
+    let epoch_sync_data_hash =
+        client.epoch_manager.compute_epoch_sync_data_hash(genesis.hash()).unwrap();
+    let mut b1 = TestBlockBuilder::from_prev_block(Clock::real(), &genesis, signer.clone())
+        .epoch_sync_data_hash(epoch_sync_data_hash)
+        .build();
     let timestamp = b1.header().timestamp();
     Arc::make_mut(&mut b1)
         .mut_header()
@@ -569,7 +580,11 @@ fn test_invalid_gas_price() {
     let signer = client.validator_signer.get().unwrap();
 
     let genesis = client.chain.get_block_by_height(0).unwrap();
-    let mut b1 = TestBlockBuilder::from_prev_block(Clock::real(), &genesis, signer.clone()).build();
+    let epoch_sync_data_hash =
+        client.epoch_manager.compute_epoch_sync_data_hash(genesis.hash()).unwrap();
+    let mut b1 = TestBlockBuilder::from_prev_block(Clock::real(), &genesis, signer.clone())
+        .epoch_sync_data_hash(epoch_sync_data_hash)
+        .build();
     Arc::make_mut(&mut b1).mut_header().set_next_gas_price(Balance::ZERO);
     Arc::make_mut(&mut b1).mut_header().resign(signer.as_ref());
 
@@ -2963,12 +2978,15 @@ fn test_reorg_reintroduces_old_branch_tx_when_pool_is_full() {
     let block_merkle_tree_raw =
         env.clients[0].chain.chain_store().get_block_merkle_tree(genesis_block.hash()).unwrap();
     let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree_raw);
+    let epoch_sync_data_hash =
+        env.clients[0].epoch_manager.compute_epoch_sync_data_hash(genesis_block.hash()).unwrap();
     let block_b = TestBlockBuilder::from_prev_block(clock, &genesis_block, validator_signer)
         .height(2)
         .chunks(vec![chunk_header_b])
         .chunk_endorsements(vec![vec![Some(Box::new(endorsement_b.signature()))]])
         .max_gas_price(Balance::from_yoctonear(100))
         .block_merkle_tree(&mut block_merkle_tree)
+        .epoch_sync_data_hash(epoch_sync_data_hash)
         .build();
     env.clients[0]
         .distribute_and_persist_encoded_chunk(
@@ -3090,12 +3108,15 @@ fn test_reorg_skips_overlap_txs_during_reintroduction() {
     let merkle_raw =
         env.clients[0].chain.chain_store().get_block_merkle_tree(genesis_block.hash()).unwrap();
     let mut merkle = PartialMerkleTree::clone(&merkle_raw);
+    let epoch_sync_data_hash =
+        env.clients[0].epoch_manager.compute_epoch_sync_data_hash(genesis_block.hash()).unwrap();
     let block_b = TestBlockBuilder::from_prev_block(clock, &genesis_block, validator_signer)
         .height(2)
         .chunks(vec![chunk_header_b])
         .chunk_endorsements(vec![vec![Some(Box::new(endorsement_b.signature()))]])
         .max_gas_price(Balance::from_yoctonear(100))
         .block_merkle_tree(&mut merkle)
+        .epoch_sync_data_hash(epoch_sync_data_hash)
         .build();
     env.clients[0]
         .distribute_and_persist_encoded_chunk(chunk_b, encoded_paths_b, receipts_b, validator_id)


### PR DESCRIPTION
`Chain::validate_header` already recomputes most `BlockHeaderInnerRest` fields against local chain state for received headers, but `block_ordinal` and `epoch_sync_data_hash` were not among them. This adds those two checks (gated behind a protocol feature) so header validation is consistent with the rest of the fields. While here, the `epoch_sync_data_hash` computation — previously duplicated between the block producer and epoch sync proof verification — is consolidated into a single `EpochSyncProofLastEpochData::compute_epoch_sync_data_hash` primitive used by all three sites, with test helpers updated to supply the value for invalid epoch-start blocks.