### PR TITLE
feat(gas-keys): gas-key nonce routing for DelegateV2 (2/3)

### DIFF
--- a/runtime/runtime/src/action_validation.rs
+++ b/runtime/runtime/src/action_validation.rs
@@ -2,7 +2,7 @@ use crate::config::total_prepaid_gas;
 use crate::verifier::ValidateReceiptMode;
 use near_crypto::key_conversion::is_valid_staking_key;
 use near_primitives::account::AccessKeyPermission;
-use near_primitives::action::delegate::SignedDelegateAction;
+use near_primitives::action::delegate::{DelegateAction, DelegateActionExtension};
 use near_primitives::action::{
     AddKeyAction, DeployGlobalContractAction, DeterministicStateInitAction,
     GlobalContractIdentifier, UseGlobalContractAction,
@@ -153,14 +153,31 @@ fn validate_action_with_mode(
         Action::AddKey(a) => validate_add_key_action(limit_config, a, current_protocol_version),
         Action::DeleteKey(_) => Ok(()),
         Action::DeleteAccount(a) => validate_delete_action(a),
-        Action::Delegate(a) => {
-            validate_delegate_action(limit_config, a, receiver, current_protocol_version, mode)
+        Action::Delegate(a) => validate_delegate_action(
+            limit_config,
+            &a.delegate_action,
+            receiver,
+            current_protocol_version,
+            mode,
+        ),
+        Action::DelegateV2(a) => {
+            match &a.extension {
+                // A gas key delegate action selects a gas key nonce by index,
+                // which only exists once gas keys are enabled.
+                DelegateActionExtension::GasKey { .. } => require_protocol_feature(
+                    ProtocolFeature::GasKeys,
+                    "GasKeys",
+                    current_protocol_version,
+                )?,
+            }
+            validate_delegate_action(
+                limit_config,
+                &a.delegate_action,
+                receiver,
+                current_protocol_version,
+                mode,
+            )
         }
-        // TODO(gas-keys): accept DelegateV2 once execution lands; rejected until then.
-        Action::DelegateV2(_) => Err(ActionsValidationError::UnsupportedProtocolFeature {
-            protocol_feature: "GasKeys".to_owned(),
-            version: current_protocol_version,
-        }),
         Action::DeterministicStateInit(a) => {
             validate_deterministic_state_init(limit_config, a, receiver)
         }
@@ -175,16 +192,16 @@ fn validate_action_with_mode(
 
 fn validate_delegate_action(
     limit_config: &LimitConfig,
-    signed_delegate_action: &SignedDelegateAction,
+    delegate_action: &DelegateAction,
     receiver: &AccountId,
     current_protocol_version: ProtocolVersion,
     mode: ValidateReceiptMode,
 ) -> Result<(), ActionsValidationError> {
-    let actions = signed_delegate_action.delegate_action.get_actions();
+    let actions = delegate_action.get_actions();
     let inner_receiver =
         if ProtocolFeature::FixDelegatedDeterministicStateInit.enabled(current_protocol_version) {
             // This is the correct receiver id to use for the check.
-            &signed_delegate_action.delegate_action.receiver_id
+            &delegate_action.receiver_id
         } else {
             // This is a bug fixed with `FixDelegatedDeterministicStateInit` that
             // validated against the wrong id. This makes it impossible to
@@ -477,7 +494,10 @@ mod tests {
     use near_crypto::{KeyType, PublicKey, Signature};
     use near_primitives::account::{AccessKey, FunctionCallPermission};
     use near_primitives::action::GlobalContractDeployMode;
-    use near_primitives::action::delegate::{DelegateAction, NonDelegateAction};
+    use near_primitives::action::delegate::{
+        DelegateAction, DelegateActionExtension, NonDelegateAction, SignedDelegateAction,
+        SignedDelegateActionV2,
+    };
     use near_primitives::deterministic_account_id::{
         DeterministicAccountStateInit, DeterministicAccountStateInitV1,
     };
@@ -971,6 +991,31 @@ mod tests {
                 &"alice.near".parse().unwrap(),
                 protocol_version,
             ),
+            Err(ActionsValidationError::UnsupportedProtocolFeature {
+                protocol_feature: "GasKeys".to_owned(),
+                version: protocol_version,
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_action_invalid_delegate_v2_before_protocol_feature() {
+        let delegate_action = DelegateAction {
+            sender_id: alice_account(),
+            receiver_id: "bob.near".parse().unwrap(),
+            actions: vec![],
+            nonce: 1,
+            max_block_height: 1000,
+            public_key: PublicKey::empty(KeyType::ED25519),
+        };
+        let action = Action::DelegateV2(Box::new(SignedDelegateActionV2 {
+            delegate_action,
+            extension: DelegateActionExtension::GasKey { nonce_index: 0 },
+            signature: Signature::empty(KeyType::ED25519),
+        }));
+        let protocol_version = ProtocolFeature::GasKeys.protocol_version() - 1;
+        assert_eq!(
+            validate_action(&test_limit_config(), &action, &alice_account(), protocol_version),
             Err(ActionsValidationError::UnsupportedProtocolFeature {
                 protocol_feature: "GasKeys".to_owned(),
                 version: protocol_version,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -705,7 +705,8 @@ fn validate_delegate_action_key(
             )?
             .ok_or_else(|| {
                 StorageError::StorageInconsistentState(format!(
-                    "gas key nonce row missing for in-range index {nonce_index}"
+                    "gas key nonce row missing for {} {} at in-range index {nonce_index} (num_nonces {})",
+                    delegate_action.sender_id, delegate_action.public_key, gas_key_info.num_nonces,
                 ))
             })?;
             (current_nonce, DelegateNonceUpdate::GasKey { nonce_index })

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -14,7 +14,9 @@ use near_parameters::{
 use near_primitives::account::{
     AccessKey, AccessKeyPermission, Account, AccountContract, GasKeyInfo,
 };
-use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{
+    DelegateAction, DelegateActionExtension, SignedDelegateAction, SignedDelegateActionV2,
+};
 use near_primitives::errors::{ActionError, ActionErrorKind, InvalidAccessKeyError, RuntimeError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
@@ -24,7 +26,9 @@ use near_primitives::transaction::{
     Action, DeleteAccountAction, DeployContractAction, StakeAction,
 };
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{AccountId, Balance, BlockHeight, EpochInfoProvider, StorageUsage};
+use near_primitives::types::{
+    AccountId, Balance, BlockHeight, EpochInfoProvider, NonceIndex, StorageUsage,
+};
 use near_primitives::utils::account_is_implicit;
 use near_primitives::version::ProtocolVersion;
 use near_primitives_core::account::id::AccountType;
@@ -32,7 +36,7 @@ use near_primitives_core::version::ProtocolFeature;
 use near_store::trie::AccessOptions;
 use near_store::{
     StorageError, TrieAccess, TrieUpdate, compute_gas_key_balance_sum, get_access_key,
-    remove_account, set_access_key,
+    get_gas_key_nonce, remove_account, set_access_key, set_gas_key_nonce,
 };
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use near_wallet_contract::{
@@ -488,9 +492,49 @@ pub(crate) fn apply_delegate_action(
     signed_delegate_action: &SignedDelegateAction,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
-    let delegate_action = &signed_delegate_action.delegate_action;
+    apply_delegate_action_inner(
+        state_update,
+        apply_state,
+        action_receipt,
+        sender_id,
+        &signed_delegate_action.delegate_action,
+        signed_delegate_action.verify(),
+        None,
+        result,
+    )
+}
 
-    if !signed_delegate_action.verify() {
+pub(crate) fn apply_delegate_action_v2(
+    state_update: &mut TrieUpdate,
+    apply_state: &ApplyState,
+    action_receipt: &VersionedActionReceipt,
+    sender_id: &AccountId,
+    signed_delegate_action: &SignedDelegateActionV2,
+    result: &mut ActionResult,
+) -> Result<(), RuntimeError> {
+    apply_delegate_action_inner(
+        state_update,
+        apply_state,
+        action_receipt,
+        sender_id,
+        &signed_delegate_action.delegate_action,
+        signed_delegate_action.verify(),
+        Some(&signed_delegate_action.extension),
+        result,
+    )
+}
+
+fn apply_delegate_action_inner(
+    state_update: &mut TrieUpdate,
+    apply_state: &ApplyState,
+    action_receipt: &VersionedActionReceipt,
+    sender_id: &AccountId,
+    delegate_action: &DelegateAction,
+    signature_valid: bool,
+    extension: Option<&DelegateActionExtension>,
+    result: &mut ActionResult,
+) -> Result<(), RuntimeError> {
+    if !signature_valid {
         result.result = Err(ActionErrorKind::DelegateActionInvalidSignature.into());
         return Ok(());
     }
@@ -507,7 +551,7 @@ pub(crate) fn apply_delegate_action(
         return Ok(());
     }
 
-    validate_delegate_action_key(state_update, apply_state, delegate_action, result)?;
+    validate_delegate_action_key(state_update, apply_state, delegate_action, extension, result)?;
     if result.result.is_err() {
         // Validation failed. Need to return Ok() because this is not a runtime error.
         // "result.result" will be return to the User as the action execution result.
@@ -598,6 +642,7 @@ fn validate_delegate_action_key(
     state_update: &mut TrieUpdate,
     apply_state: &ApplyState,
     delegate_action: &DelegateAction,
+    extension: Option<&DelegateActionExtension>,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
     // 'delegate_action.sender_id' account existence must be checked by a caller
@@ -619,21 +664,58 @@ fn validate_delegate_action_key(
         }
     };
 
-    // Gas keys keep their nonces per index in dedicated storage, while the
-    // delegate path only tracks the single access_key.nonce. Reject them rather
-    // than silently advancing an unrelated counter and bypassing the gas key balance.
-    if access_key.gas_key_info().is_some() {
-        result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
-            InvalidAccessKeyError::RequiresNonGasKey,
-        )
-        .into());
-        return Ok(());
-    }
+    // A plain delegate action (no extension) advances the single
+    // access_key.nonce and forbids gas keys; a gas key delegate action advances
+    // one of the gas key's nonces selected by nonce_index.
+    let (current_nonce, nonce_update) = match extension {
+        None => {
+            if access_key.gas_key_info().is_some() {
+                result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+                    InvalidAccessKeyError::RequiresNonGasKey,
+                )
+                .into());
+                return Ok(());
+            }
+            (access_key.nonce, DelegateNonceUpdate::AccessKey)
+        }
+        Some(DelegateActionExtension::GasKey { nonce_index }) => {
+            let nonce_index = *nonce_index;
+            let Some(gas_key_info) = access_key.gas_key_info() else {
+                result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+                    InvalidAccessKeyError::RequiresGasKey,
+                )
+                .into());
+                return Ok(());
+            };
+            if nonce_index >= gas_key_info.num_nonces {
+                result.result = Err(ActionErrorKind::DelegateActionInvalidNonceIndex {
+                    nonce_index,
+                    num_nonces: gas_key_info.num_nonces,
+                }
+                .into());
+                return Ok(());
+            }
+            // The index is range-checked above and gas keys initialize every
+            // nonce row at creation, so a missing row is inconsistent state.
+            let current_nonce = get_gas_key_nonce(
+                state_update,
+                &delegate_action.sender_id,
+                &delegate_action.public_key,
+                nonce_index,
+            )?
+            .ok_or_else(|| {
+                StorageError::StorageInconsistentState(format!(
+                    "gas key nonce row missing for in-range index {nonce_index}"
+                ))
+            })?;
+            (current_nonce, DelegateNonceUpdate::GasKey { nonce_index })
+        }
+    };
 
-    if delegate_action.nonce <= access_key.nonce {
+    if delegate_action.nonce <= current_nonce {
         result.result = Err(ActionErrorKind::DelegateActionInvalidNonce {
             delegate_nonce: delegate_action.nonce,
-            ak_nonce: access_key.nonce,
+            ak_nonce: current_nonce,
         }
         .into());
         return Ok(());
@@ -649,8 +731,6 @@ fn validate_delegate_action_key(
         .into());
         return Ok(());
     }
-
-    access_key.nonce = delegate_action.nonce;
 
     let actions = delegate_action.get_actions();
 
@@ -713,14 +793,35 @@ fn validate_delegate_action_key(
         }
     };
 
-    set_access_key(
-        state_update,
-        delegate_action.sender_id.clone(),
-        delegate_action.public_key.clone(),
-        &access_key,
-    );
+    match nonce_update {
+        DelegateNonceUpdate::AccessKey => {
+            access_key.nonce = delegate_action.nonce;
+            set_access_key(
+                state_update,
+                delegate_action.sender_id.clone(),
+                delegate_action.public_key.clone(),
+                &access_key,
+            );
+        }
+        DelegateNonceUpdate::GasKey { nonce_index } => {
+            set_gas_key_nonce(
+                state_update,
+                delegate_action.sender_id.clone(),
+                delegate_action.public_key.clone(),
+                nonce_index,
+                delegate_action.nonce,
+            );
+        }
+    }
 
     Ok(())
+}
+
+/// How a validated delegate action's nonce is persisted: a plain action bumps
+/// the access key nonce, a gas key action bumps the selected gas key nonce.
+enum DelegateNonceUpdate {
+    AccessKey,
+    GasKey { nonce_index: NonceIndex },
 }
 
 pub(crate) fn check_actor_permissions(
@@ -765,7 +866,8 @@ pub(crate) fn check_actor_permissions(
         | Action::FunctionCall(_)
         | Action::Transfer(_)
         | Action::TransferToGasKey(_) => (),
-        Action::Delegate(_) | Action::DelegateV2(_) => (),
+        Action::Delegate(_) => (),
+        Action::DelegateV2(_) => (),
         Action::DeterministicStateInit(_) => (),
     };
     Ok(())
@@ -1449,6 +1551,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &signed_delegate_action.delegate_action,
+            None,
             &mut result,
         )
         .expect("Expect ok");
@@ -1460,6 +1563,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &signed_delegate_action.delegate_action,
+            None,
             &mut result,
         )
         .expect("Expect ok");
@@ -1480,6 +1584,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &delegate_action,
+            None,
             &mut result,
         )
         .expect("Expect ok");
@@ -1506,6 +1611,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &signed_delegate_action.delegate_action,
+            None,
             &mut result,
         )
         .expect("Expect ok");
@@ -1540,6 +1646,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &signed_delegate_action.delegate_action,
+            None,
             &mut result,
         )
         .expect("Expect ok");
@@ -1568,6 +1675,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &signed_delegate_action.delegate_action,
+            None,
             &mut result,
         )
         .expect("Expect ok");
@@ -1596,6 +1704,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &delegate_action,
+            None,
             &mut result,
         )
         .expect("Expect ok");
@@ -1767,6 +1876,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &delegate_action,
+            None,
             &mut result,
         )
         .expect("validate_delegate_action_key must not return a RuntimeError");
@@ -1921,6 +2031,227 @@ mod tests {
             result.result,
             Err(ActionErrorKind::DelegateActionAccessKeyError(
                 InvalidAccessKeyError::RequiresNonGasKey,
+            )
+            .into())
+        );
+    }
+
+    // Validates a delegate action with a gas key nonce index, returning the
+    // result and the state so the test can inspect the gas key nonce.
+    fn validate_gas_key_delegate(
+        access_key: &AccessKey,
+        delegate_action: &DelegateAction,
+        nonce_index: NonceIndex,
+    ) -> (ActionResult, TrieUpdate) {
+        let sender_id = delegate_action.sender_id.clone();
+        let sender_pub_key = delegate_action.public_key.clone();
+        let apply_state = create_apply_state(delegate_action.max_block_height);
+        let mut state_update = setup_account(&sender_id, &sender_pub_key, access_key);
+
+        // Real gas keys seed every nonce row at creation; mirror that so
+        // validation reads an existing row rather than treating it as missing.
+        // Seed below the action's nonce so the action remains valid.
+        if let Some(gas_key_info) = access_key.gas_key_info() {
+            for index in 0..gas_key_info.num_nonces {
+                set_gas_key_nonce(
+                    &mut state_update,
+                    sender_id.clone(),
+                    sender_pub_key.clone(),
+                    index,
+                    delegate_action.nonce - 1,
+                );
+            }
+        }
+
+        let mut result = ActionResult::default();
+        validate_delegate_action_key(
+            &mut state_update,
+            &apply_state,
+            delegate_action,
+            Some(&DelegateActionExtension::GasKey { nonce_index }),
+            &mut result,
+        )
+        .expect("Expect ok");
+        (result, state_update)
+    }
+
+    #[test]
+    fn test_gas_key_delegate_action_full_access_advances_nonce() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
+        let delegate_action = signed_delegate_action.delegate_action;
+        let nonce_index = 0;
+
+        let (result, state_update) =
+            validate_gas_key_delegate(&access_key, &delegate_action, nonce_index);
+        assert!(result.result.is_ok(), "result error: {:?}", result.result);
+
+        let stored = get_gas_key_nonce(
+            &state_update,
+            &delegate_action.sender_id,
+            &delegate_action.public_key,
+            nonce_index,
+        )
+        .unwrap();
+        assert_eq!(stored, Some(delegate_action.nonce));
+    }
+
+    #[test]
+    fn test_gas_key_delegate_action_requires_gas_key() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::full_access();
+        let delegate_action = signed_delegate_action.delegate_action;
+        let nonce_index = 0;
+
+        let (result, _) = validate_gas_key_delegate(&access_key, &delegate_action, nonce_index);
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresGasKey,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_action_invalid_nonce_index() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
+        let delegate_action = signed_delegate_action.delegate_action;
+        let nonce_index = TEST_GAS_KEY_NUM_NONCES; // invalid
+
+        let (result, _) = validate_gas_key_delegate(&access_key, &delegate_action, nonce_index);
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionInvalidNonceIndex {
+                nonce_index,
+                num_nonces: TEST_GAS_KEY_NUM_NONCES,
+            }
+            .into())
+        );
+    }
+
+    // A gas key delegate action with `GasKeyFunctionCall` permission runs the
+    // same function call restrictions as a regular function call access key.
+    fn gas_key_function_call_delegate_result(
+        permission: FunctionCallPermission,
+        actions: Vec<NonDelegateAction>,
+    ) -> ActionResult {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_function_call(TEST_GAS_KEY_NUM_NONCES, permission);
+        let mut delegate_action = signed_delegate_action.delegate_action;
+        delegate_action.actions = actions;
+        let nonce_index = 0;
+        validate_gas_key_delegate(&access_key, &delegate_action, nonce_index).0
+    }
+
+    fn function_call_action(method_name: &str, deposit: Balance) -> NonDelegateAction {
+        non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
+            args: Vec::new(),
+            deposit,
+            gas: Gas::from_gas(300),
+            method_name: method_name.parse().unwrap(),
+        })))
+    }
+
+    fn function_call_permission(
+        receiver_id: &str,
+        method_names: Vec<String>,
+    ) -> FunctionCallPermission {
+        FunctionCallPermission {
+            allowance: None,
+            receiver_id: receiver_id.to_string(),
+            method_names,
+        }
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_ok() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert!(result.result.is_ok(), "result error: {:?}", result.result);
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_incorrect_action() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![non_delegate_action(Action::CreateAccount(CreateAccountAction {}))],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresFullAccess,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_actions_number() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![
+                function_call_action("test_method", Balance::ZERO),
+                function_call_action("test_method", Balance::ZERO),
+            ],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresFullAccess,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_deposit() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", Vec::new()),
+            vec![function_call_action("test_method", Balance::from_yoctonear(1))],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::DepositWithFunctionCall,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_receiver_id() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("another.near", Vec::new()),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::ReceiverMismatch {
+                    tx_receiver: "token.test.near".parse().unwrap(),
+                    ak_receiver: "another.near".parse().unwrap(),
+                },
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_method() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", vec!["another_method".to_string()]),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::MethodNameMismatch {
+                    method_name: "test_method".parse().unwrap(),
+                },
             )
             .into())
         );

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -39,8 +39,8 @@ use near_primitives::bandwidth_scheduler::{BandwidthRequests, BlockBandwidthRequ
 use near_primitives::chunk_apply_stats::ChunkApplyStatsV1;
 use near_primitives::congestion_info::{BlockCongestionInfo, CongestionInfo};
 use near_primitives::errors::{
-    ActionError, ActionErrorKind, ActionsValidationError, EpochError, IntegerOverflowError,
-    InvalidAccessKeyError, InvalidTxError, ReceiptValidationError, RuntimeError, TxExecutionError,
+    ActionError, ActionErrorKind, EpochError, IntegerOverflowError, InvalidAccessKeyError,
+    InvalidTxError, RuntimeError, TxExecutionError,
 };
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
@@ -676,17 +676,16 @@ impl Runtime {
                     &mut result,
                 )?;
             }
-            // TODO(gas-keys): execute DelegateV2; rejected at validation until then.
-            Action::DelegateV2(_) => {
-                result.result = Err(ActionErrorKind::NewReceiptValidationError(
-                    ReceiptValidationError::ActionsValidation(
-                        ActionsValidationError::UnsupportedProtocolFeature {
-                            protocol_feature: "GasKeys".to_owned(),
-                            version: apply_state.current_protocol_version,
-                        },
-                    ),
-                )
-                .into());
+            Action::DelegateV2(signed_delegate_action) => {
+                metrics::ACTION_CALLED_COUNT.delegate.inc();
+                apply_delegate_action_v2(
+                    state_update,
+                    apply_state,
+                    action_receipt,
+                    account_id,
+                    signed_delegate_action,
+                    &mut result,
+                )?;
             }
             Action::TransferToGasKey(transfer_to_gas_key) => {
                 metrics::ACTION_CALLED_COUNT.transfer_to_gas_key.inc();

--- a/test-loop-tests/src/tests/gas_keys.rs
+++ b/test-loop-tests/src/tests/gas_keys.rs
@@ -217,7 +217,6 @@ fn test_gas_key_delegate_v2_meta_transaction() {
         block_hash,
     );
     env.rpc_runner().run_tx(add_key_tx, Duration::seconds(5));
-    env.rpc_runner().run_for_number_of_blocks(1);
 
     // Sign a delegate action with the gas key at `nonce_index`, wrapping a
     // transfer to `receiver`.
@@ -261,7 +260,6 @@ fn test_gas_key_delegate_v2_meta_transaction() {
         "meta transaction failed: {:?}",
         outcome.status,
     );
-    env.rpc_runner().run_for_number_of_blocks(1);
 
     // Only the chosen nonce index advanced.
     let updated_nonce = get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), nonce_index);

--- a/test-loop-tests/src/tests/gas_keys.rs
+++ b/test-loop-tests/src/tests/gas_keys.rs
@@ -7,6 +7,9 @@ use near_async::time::Duration;
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signer};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::{AccessKey, FunctionCallPermission};
+use near_primitives::action::delegate::{
+    DelegateAction, DelegateActionExtension, SignedDelegateActionV2,
+};
 use near_primitives::action::{AddKeyAction, DeleteKeyAction, TransferToGasKeyAction};
 use near_primitives::errors::{
     ActionError, ActionErrorKind, ActionsValidationError, ReceiptValidationError, TxExecutionError,
@@ -172,6 +175,131 @@ fn test_gas_key_transaction() {
     // Verify receiver got the transfer
     let receiver_balance = env.rpc_node().view_account_query(receiver).unwrap().amount;
     assert_eq!(receiver_balance, initial_balance.checked_add(transfer_amount).unwrap());
+}
+
+#[test]
+fn test_gas_key_delegate_v2_meta_transaction() {
+    init_test_logger();
+
+    let user_accounts = create_account_ids(["account0", "account1", "account2"]);
+    let initial_balance = Balance::from_near(1_000_000);
+    let gas_price = Balance::from_yoctonear(1);
+    let mut env = TestLoopBuilder::new()
+        .enable_rpc()
+        .add_user_accounts(&user_accounts, initial_balance)
+        .gas_prices(gas_price, gas_price)
+        .build();
+
+    let sender = &user_accounts[0]; // owns the gas key and delegates the action
+    let relayer = &user_accounts[1]; // wraps and submits the meta transaction
+    let receiver = &user_accounts[2]; // target of the inner transfer
+    let relayer_signer = create_user_test_signer(relayer);
+    let mut relayer_nonce = 0;
+    let mut next_relayer_nonce = || {
+        relayer_nonce += 1;
+        relayer_nonce
+    };
+
+    // Add a gas key to the sender.
+    let gas_key_signer: Signer =
+        InMemorySigner::from_seed(sender.clone(), KeyType::ED25519, "gas_key").into();
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    let num_nonces = 3;
+    let add_key_tx = SignedTransaction::from_actions(
+        1,
+        sender.clone(),
+        sender.clone(),
+        &create_user_test_signer(sender),
+        vec![Action::AddKey(Box::new(AddKeyAction {
+            public_key: gas_key_signer.public_key(),
+            access_key: AccessKey::gas_key_full_access(num_nonces),
+        }))],
+        block_hash,
+    );
+    env.rpc_runner().run_tx(add_key_tx, Duration::seconds(5));
+    env.rpc_runner().run_for_number_of_blocks(1);
+
+    // Sign a delegate action with the gas key at `nonce_index`, wrapping a
+    // transfer to `receiver`.
+    let nonce_index: NonceIndex = 1;
+    let untouched_nonce_index: NonceIndex = 0;
+    let gas_key_nonce = get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), nonce_index);
+    let untouched_nonce_before =
+        get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), untouched_nonce_index);
+    let transfer_amount = Balance::from_near(10);
+    let delegate_action = DelegateAction {
+        sender_id: sender.clone(),
+        receiver_id: receiver.clone(),
+        actions: vec![
+            Action::Transfer(TransferAction { deposit: transfer_amount }).try_into().unwrap(),
+        ],
+        nonce: gas_key_nonce + 1,
+        max_block_height: 1000,
+        public_key: gas_key_signer.public_key(),
+    };
+    let signed_delegate = SignedDelegateActionV2::sign(
+        &gas_key_signer,
+        delegate_action,
+        DelegateActionExtension::GasKey { nonce_index },
+    );
+
+    // The relayer submits it: the outer transaction's receiver is the delegate
+    // sender, who forwards the inner actions.
+    let receiver_balance_before = env.rpc_node().view_account_query(receiver).unwrap().amount;
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    let meta_tx = SignedTransaction::from_actions(
+        next_relayer_nonce(),
+        relayer.clone(),
+        sender.clone(),
+        &relayer_signer,
+        vec![Action::DelegateV2(Box::new(signed_delegate.clone()))],
+        block_hash,
+    );
+    let outcome = env.rpc_runner().execute_tx(meta_tx, Duration::seconds(5)).unwrap();
+    assert!(
+        matches!(outcome.status, FinalExecutionStatus::SuccessValue(_)),
+        "meta transaction failed: {:?}",
+        outcome.status,
+    );
+    env.rpc_runner().run_for_number_of_blocks(1);
+
+    // Only the chosen nonce index advanced.
+    let updated_nonce = get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), nonce_index);
+    assert_eq!(updated_nonce, gas_key_nonce + 1);
+    assert_eq!(
+        get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), untouched_nonce_index),
+        untouched_nonce_before,
+    );
+
+    // The inner transfer executed.
+    let receiver_balance_after = env.rpc_node().view_account_query(receiver).unwrap().amount;
+    assert_eq!(
+        receiver_balance_after,
+        receiver_balance_before.checked_add(transfer_amount).unwrap(),
+    );
+
+    // Replaying the same delegate (same gas key nonce) is rejected.
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    let replay_tx = SignedTransaction::from_actions(
+        next_relayer_nonce(),
+        relayer.clone(),
+        sender.clone(),
+        &relayer_signer,
+        vec![Action::DelegateV2(Box::new(signed_delegate))],
+        block_hash,
+    );
+    let replay_outcome = env.rpc_runner().execute_tx(replay_tx, Duration::seconds(5)).unwrap();
+    assert!(
+        matches!(
+            replay_outcome.status,
+            FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+                kind: ActionErrorKind::DelegateActionInvalidNonce { .. },
+                ..
+            }))
+        ),
+        "expected DelegateActionInvalidNonce on replay, got {:?}",
+        replay_outcome.status,
+    );
 }
 
 #[test]

--- a/test-loop-tests/src/tests/gas_keys.rs
+++ b/test-loop-tests/src/tests/gas_keys.rs
@@ -234,7 +234,7 @@ fn test_gas_key_delegate_v2_meta_transaction() {
             Action::Transfer(TransferAction { deposit: transfer_amount }).try_into().unwrap(),
         ],
         nonce: gas_key_nonce + 1,
-        max_block_height: 1000,
+        max_block_height: 1_000_000,
         public_key: gas_key_signer.public_key(),
     };
     let signed_delegate = SignedDelegateActionV2::sign(


### PR DESCRIPTION
Second of the 3-PR stack (builds on #15883, original non-splitted: #15877)

Flips `DelegateV2` from "rejected at validation" to fully executed: `validate_delegate_action_key` now threads `Option<&DelegateActionExtension>` and routes a `GasKey { nonce_index }` through the per-index gas key nonce storage (gated on `ProtocolFeature::GasKeys`, range-checked, relayer prepays). A missing in-range nonce row is treated as `StorageInconsistentState` rather than defaulting to 0, matching the transaction path.

Tests: unit coverage for `validate_delegate_action_key` (full-access / function-call permissions, invalid nonce index, pre-feature rejection) and an end-to-end test-loop meta transaction (relayer wraps the gas-key-signed `DelegateV2`, inner action executes, only the chosen nonce index advances, replay fails).
