### PR TITLE
feat(gas-keys): rosetta, mirror, prefetch support for DelegateV2 (3/3)

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -234,6 +234,73 @@ pub struct NearActions {
     pub actions: Vec<near_primitives::transaction::Action>,
 }
 
+/// Pushes the rosetta operations for a delegate action (`Delegate` or
+/// `DelegateV2`) onto `operations`. A `DelegateV2`'s `extension` is carried in
+/// the delegate action operation's metadata so the action round-trips.
+fn push_delegate_action_operations(
+    operations: &mut Vec<crate::models::Operation>,
+    sender_account_identifier: &crate::models::AccountIdentifier,
+    receiver_account_identifier: &crate::models::AccountIdentifier,
+    signature: near_crypto::Signature,
+    delegate_action: near_primitives::action::delegate::DelegateAction,
+    extension: Option<near_primitives::action::delegate::DelegateActionExtension>,
+) {
+    let initiate_signed_delegate_action_operation_id =
+        crate::models::OperationIdentifier::new(operations);
+    operations.push(
+        validated_operations::InitiateSignedDelegateActionOperation {
+            sender_account: sender_account_identifier.clone(),
+        }
+        .into_operation(initiate_signed_delegate_action_operation_id.clone()),
+    );
+
+    let signed_delegate_action_operation_id = crate::models::OperationIdentifier::new(operations);
+    operations.push(
+        validated_operations::signed_delegate_action::SignedDelegateActionOperation {
+            receiver_id: receiver_account_identifier.clone(),
+            signature,
+        }
+        .into_related_operation(
+            signed_delegate_action_operation_id.clone(),
+            vec![initiate_signed_delegate_action_operation_id],
+        ),
+    );
+
+    let initiate_delegate_action_operation_id = crate::models::OperationIdentifier::new(operations);
+    operations.push(
+        validated_operations::initiate_delegate_action::InitiateDelegateActionOperation {
+            sender_account: delegate_action.sender_id.clone().into(),
+        }
+        .into_related_operation(
+            initiate_delegate_action_operation_id.clone(),
+            vec![signed_delegate_action_operation_id],
+        ),
+    );
+
+    let delegate_action_operation_id = crate::models::OperationIdentifier::new(operations);
+    let mut delegate_action_operation: validated_operations::DelegateActionOperation =
+        delegate_action.clone().into();
+    delegate_action_operation.extension = extension;
+    operations.push(delegate_action_operation.into_related_operation(
+        delegate_action_operation_id,
+        vec![initiate_delegate_action_operation_id],
+    ));
+
+    // We know that there are no delegate actions inside so this is guaranteed to
+    // be a single-level recursion.
+    let delegated_operations: Vec<crate::models::Operation> = NearActions {
+        sender_account_id: delegate_action.sender_id.clone(),
+        receiver_account_id: delegate_action.receiver_id.clone(),
+        actions: delegate_action
+            .actions
+            .into_iter()
+            .map(|a| a.into())
+            .collect::<Vec<near_primitives::transaction::Action>>(),
+    }
+    .into();
+    operations.extend(delegated_operations);
+}
+
 impl From<NearActions> for Vec<crate::models::Operation> {
     /// Convert NEAR Actions to Rosetta Operations. It never fails.
     fn from(near_actions: NearActions) -> Self {
@@ -445,65 +512,24 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                     operations.push(deploy_contract_operation);
                 }
                 near_primitives::transaction::Action::Delegate(action) => {
-                    let initiate_signed_delegate_action_operation_id =
-                        crate::models::OperationIdentifier::new(&operations);
-                    operations.push(
-                        validated_operations::InitiateSignedDelegateActionOperation {
-                            sender_account: sender_account_identifier.clone(),
-                        }
-                        .into_operation(initiate_signed_delegate_action_operation_id.clone()),
+                    push_delegate_action_operations(
+                        &mut operations,
+                        &sender_account_identifier,
+                        &receiver_account_identifier,
+                        action.signature,
+                        action.delegate_action,
+                        None,
                     );
-
-                    let signed_delegate_action_operation_id =
-                        crate::models::OperationIdentifier::new(&operations);
-
-                    operations.push(
-                        validated_operations::signed_delegate_action::SignedDelegateActionOperation {
-                            receiver_id: receiver_account_identifier.clone(),
-                            signature: action.signature,
-                        }
-                        .into_related_operation(
-                            signed_delegate_action_operation_id.clone(),
-                            vec![initiate_signed_delegate_action_operation_id],
-                        )
+                }
+                near_primitives::transaction::Action::DelegateV2(action) => {
+                    push_delegate_action_operations(
+                        &mut operations,
+                        &sender_account_identifier,
+                        &receiver_account_identifier,
+                        action.signature,
+                        action.delegate_action,
+                        Some(action.extension),
                     );
-
-                    let initiate_delegate_action_operation_id =
-                        crate::models::OperationIdentifier::new(&operations);
-
-                    operations.push(validated_operations::initiate_delegate_action::InitiateDelegateActionOperation{
-                        sender_account: action.delegate_action.sender_id.clone().into()
-                    }.into_related_operation(initiate_delegate_action_operation_id.clone(), vec![signed_delegate_action_operation_id]));
-
-                    let delegate_action_operation_id =
-                        crate::models::OperationIdentifier::new(&operations);
-                    let delegate_action_operation: validated_operations::DelegateActionOperation =
-                        action.delegate_action.clone().into();
-
-                    operations.push(delegate_action_operation.into_related_operation(
-                        delegate_action_operation_id,
-                        vec![initiate_delegate_action_operation_id],
-                    ));
-
-                    // We know that there are no delegate actions inside so this is guaranteed to
-                    // be a single-level recursion.
-                    let delegated_operations: Vec<crate::models::Operation> = NearActions {
-                        sender_account_id: action.delegate_action.sender_id.clone(),
-                        receiver_account_id: action.delegate_action.receiver_id.clone(),
-                        actions: action
-                            .delegate_action
-                            .actions
-                            .into_iter()
-                            .map(|a| a.into())
-                            .collect::<Vec<near_primitives::transaction::Action>>(),
-                    }
-                    .into();
-
-                    operations.extend(delegated_operations);
-                } // TODO(#8469): Implement delegate action support, for now they are ignored.
-                near_primitives::transaction::Action::DelegateV2(_) => {
-                    // TODO(gas-keys): model DelegateV2 (and its extension) in
-                    // Rosetta; ignored for now.
                 }
                 near_primitives::transaction::Action::DeployGlobalContract(_)
                 | near_primitives::transaction::Action::UseGlobalContract(_) => {
@@ -816,46 +842,52 @@ impl TryFrom<Vec<crate::models::Operation>> for NearActions {
                     delegate_proxy_account_id
                         .try_set(&initiate_signed_delegate_action_operation.sender_account)?;
 
-                    let delegate_action: near_primitives::transaction::Action =
-                        near_primitives::action::delegate::SignedDelegateAction {
-                            delegate_action: near_primitives::action::delegate::DelegateAction {
-                                sender_id: initiate_delegate_action_operation
-                                    .sender_account
-                                    .address
-                                    .into(),
-                                receiver_id: delegate_action_operation.receiver_id.address.into(),
-                                actions: {
-                                    let mut non_delegate_actions = vec![];
-                                    for action in actions {
-                                        non_delegate_actions.push(match action.try_into() {
-                                            Ok(a) => a,
-                                            Err(_) => {
-                                                return Err(
-                                                    crate::errors::ErrorKind::InvalidInput(
-                                                        "Nested delegate actions not allowed"
-                                                            .to_string(),
-                                                    ),
-                                                );
-                                            }
-                                        });
-                                    }
-                                    non_delegate_actions
-                                },
-                                nonce: delegate_action_operation.nonce,
-                                max_block_height: delegate_action_operation.max_block_height,
-                                public_key: match (&delegate_action_operation.public_key).try_into()
-                                {
-                                    Ok(o) => o,
+                    let delegate_action = near_primitives::action::delegate::DelegateAction {
+                        sender_id: initiate_delegate_action_operation.sender_account.address.into(),
+                        receiver_id: delegate_action_operation.receiver_id.address.into(),
+                        actions: {
+                            let mut non_delegate_actions = vec![];
+                            for action in actions {
+                                non_delegate_actions.push(match action.try_into() {
+                                    Ok(a) => a,
                                     Err(_) => {
                                         return Err(crate::errors::ErrorKind::InvalidInput(
-                                            "Invalid public key on delegate action".to_string(),
+                                            "Nested delegate actions not allowed".to_string(),
                                         ));
                                     }
-                                },
+                                });
+                            }
+                            non_delegate_actions
+                        },
+                        nonce: delegate_action_operation.nonce,
+                        max_block_height: delegate_action_operation.max_block_height,
+                        public_key: match (&delegate_action_operation.public_key).try_into() {
+                            Ok(o) => o,
+                            Err(_) => {
+                                return Err(crate::errors::ErrorKind::InvalidInput(
+                                    "Invalid public key on delegate action".to_string(),
+                                ));
+                            }
+                        },
+                    };
+                    let signature = signed_delegate_action_operation.signature;
+                    // `Some` extension reconstructs the `DelegateV2` it came from;
+                    // `None` is the plain `Delegate`.
+                    let delegate_action = match delegate_action_operation.extension {
+                        None => near_primitives::transaction::Action::Delegate(Box::new(
+                            near_primitives::action::delegate::SignedDelegateAction {
+                                delegate_action,
+                                signature,
                             },
-                            signature: signed_delegate_action_operation.signature,
-                        }
-                        .into();
+                        )),
+                        Some(extension) => near_primitives::transaction::Action::DelegateV2(
+                            Box::new(near_primitives::action::delegate::SignedDelegateActionV2 {
+                                delegate_action,
+                                extension,
+                                signature,
+                            }),
+                        ),
+                    };
 
                     actions = vec![delegate_action];
                 }
@@ -968,7 +1000,9 @@ impl TryFrom<Vec<crate::models::Operation>> for NearActions {
 mod tests {
     use super::*;
     use near_crypto::{KeyType, SecretKey};
-    use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+    use near_primitives::action::delegate::{
+        DelegateAction, DelegateActionExtension, SignedDelegateAction, SignedDelegateActionV2,
+    };
     use near_primitives::transaction::{Action, TransferAction};
     use near_primitives::types::Gas;
 
@@ -1146,6 +1180,39 @@ mod tests {
                     max_block_height: 0,
                     public_key: sk.public_key(),
                 },
+                signature: sk.sign(&[0]),
+            }))],
+        };
+
+        let operations: Vec<crate::models::Operation> =
+            original_near_actions.clone().try_into().unwrap();
+
+        let converted_near_actions = NearActions::try_from(operations).unwrap();
+
+        assert_eq!(converted_near_actions, original_near_actions);
+    }
+
+    #[test]
+    fn test_delegate_v2_actions_bijection() {
+        let sk = SecretKey::from_seed(KeyType::ED25519, "");
+
+        let original_near_actions = NearActions {
+            sender_account_id: "proxy.near".parse().unwrap(),
+            receiver_account_id: "account.near".parse().unwrap(),
+            actions: vec![Action::DelegateV2(Box::new(SignedDelegateActionV2 {
+                delegate_action: DelegateAction {
+                    sender_id: "account.near".parse().unwrap(),
+                    receiver_id: "receiver.near".parse().unwrap(),
+                    actions: vec![
+                        Action::Transfer(TransferAction { deposit: Balance::from_yoctonear(1) })
+                            .try_into()
+                            .unwrap(),
+                    ],
+                    nonce: 0,
+                    max_block_height: 0,
+                    public_key: sk.public_key(),
+                },
+                extension: DelegateActionExtension::GasKey { nonce_index: 5 },
                 signature: sk.sign(&[0]),
             }))],
         };

--- a/chain/rosetta-rpc/src/adapters/validated_operations/delegate_action.rs
+++ b/chain/rosetta-rpc/src/adapters/validated_operations/delegate_action.rs
@@ -5,6 +5,8 @@ pub(crate) struct DelegateActionOperation {
     pub(crate) max_block_height: near_primitives::types::BlockHeight,
     pub(crate) public_key: crate::models::PublicKey,
     pub(crate) nonce: near_primitives::types::Nonce,
+    /// `None` for a plain `Delegate` action, `Some` for a `DelegateV2`.
+    pub(crate) extension: Option<near_primitives::action::delegate::DelegateActionExtension>,
 }
 
 impl ValidatedOperation for DelegateActionOperation {
@@ -24,6 +26,7 @@ impl ValidatedOperation for DelegateActionOperation {
                 public_key: Some(self.public_key),
                 max_block_height: Some(self.max_block_height),
                 nonce: Some(self.nonce),
+                delegate_action_extension: self.extension,
                 ..Default::default()
             }),
 
@@ -49,8 +52,9 @@ impl TryFrom<crate::models::Operation> for DelegateActionOperation {
         let public_key = metadata.public_key.ok_or_else(required_fields_error)?;
         let max_block_height = metadata.max_block_height.ok_or_else(required_fields_error)?;
         let nonce = metadata.nonce.ok_or_else(required_fields_error)?;
+        let extension = metadata.delegate_action_extension;
 
-        Ok(Self { receiver_id: operation.account, public_key, max_block_height, nonce })
+        Ok(Self { receiver_id: operation.account, public_key, max_block_height, nonce, extension })
     }
 }
 
@@ -61,6 +65,7 @@ impl From<near_primitives::action::delegate::DelegateAction> for DelegateActionO
             max_block_height: delegate_action.max_block_height,
             public_key: (&delegate_action.public_key).into(),
             nonce: delegate_action.nonce,
+            extension: None,
         }
     }
 }

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -833,6 +833,12 @@ pub(crate) struct OperationMetadata {
     /// Has to be specified for SIGNED_DELEGATE_ACTION operation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
+    /// Specified for DELEGATE_ACTION operations of a `DelegateV2` action so the
+    /// extension (e.g. a gas key's nonce index) round-trips through operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<Object>)]
+    pub delegate_action_extension:
+        Option<near_primitives::action::delegate::DelegateActionExtension>,
 }
 
 impl OperationMetadata {

--- a/runtime/runtime/src/prefetch.rs
+++ b/runtime/runtime/src/prefetch.rs
@@ -45,6 +45,7 @@ use crate::{SignedValidPeriodTransactions, metrics};
 use borsh::BorshSerialize as _;
 use near_o11y::metrics::prometheus;
 use near_o11y::metrics::prometheus::core::GenericCounter;
+use near_primitives::action::delegate::DelegateActionExtension;
 use near_primitives::receipt::{Receipt, VersionedActionReceipt, VersionedReceiptEnum};
 use near_primitives::transaction::Action;
 use near_primitives::trie_key::TrieKey;
@@ -116,6 +117,24 @@ impl TriePrefetcher {
                                 &delegate_action.delegate_action.public_key,
                             );
                             self.prefetch_trie_key(trie_key)?;
+                        }
+                        Action::DelegateV2(delegate_action) => {
+                            let inner = &delegate_action.delegate_action;
+                            let trie_key =
+                                TrieKey::access_key(inner.sender_id.clone(), &inner.public_key);
+                            self.prefetch_trie_key(trie_key)?;
+                            // A gas key delegate action also reads the per-index
+                            // nonce row during validation; prefetch it too.
+                            match delegate_action.extension {
+                                DelegateActionExtension::GasKey { nonce_index } => {
+                                    let trie_key = TrieKey::gas_key_nonce(
+                                        inner.sender_id.clone(),
+                                        &inner.public_key,
+                                        nonce_index,
+                                    );
+                                    self.prefetch_trie_key(trie_key)?;
+                                }
+                            }
                         }
                         Action::AddKey(add_key_action) => {
                             let trie_key =

--- a/tools/mirror/src/genesis.rs
+++ b/tools/mirror/src/genesis.rs
@@ -1,5 +1,7 @@
-use near_crypto::PublicKey;
-use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+use near_crypto::{InMemorySigner, PublicKey, SecretKey};
+use near_primitives::action::delegate::{
+    DelegateAction, SignedDelegateAction, SignedDelegateActionV2,
+};
 use near_primitives::receipt::{DataReceiver, Receipt, ReceiptEnum};
 use near_primitives::state_record::StateRecord;
 use near_primitives::transaction::{Action, AddKeyAction, DeleteAccountAction, DeleteKeyAction};
@@ -39,13 +41,32 @@ fn map_action(
             Some(Action::DeleteAccount(DeleteAccountAction { beneficiary_id }))
         }
         Action::Delegate(delegate) => {
-            if delegate_allowed {
-                map_delegate_action(delegate, secret, default_key)
-            } else {
-                // This should not happen, but we handle the case here defensively
+            if !delegate_allowed {
                 tracing::warn!(target: "mirror", ?delegate, "a delegate action was contained inside another delegate action");
-                None
+                return None;
             }
+            let resign = |action: DelegateAction, key: SecretKey| {
+                let tx_hash = action.get_nep461_hash();
+                let signature = key.sign(tx_hash.as_ref());
+                Action::Delegate(Box::new(SignedDelegateAction {
+                    delegate_action: action,
+                    signature,
+                }))
+            };
+            map_delegate_action(&delegate.delegate_action, secret, default_key, resign)
+        }
+        Action::DelegateV2(delegate) => {
+            if !delegate_allowed {
+                tracing::warn!(target: "mirror", ?delegate, "a delegate action was contained inside another delegate action");
+                return None;
+            }
+            let resign = |action: DelegateAction, key: SecretKey| {
+                let signer = InMemorySigner::from_secret_key(action.sender_id.clone(), key);
+                let signed =
+                    SignedDelegateActionV2::sign(&signer, action, delegate.extension.clone());
+                Action::DelegateV2(Box::new(signed))
+            };
+            map_delegate_action(&delegate.delegate_action, secret, default_key, resign)
         }
         // We don't want to mess with the set of validators in the target chain
         Action::Stake(_) => None,
@@ -53,12 +74,15 @@ fn map_action(
     }
 }
 
+/// Shared key/account remapping for delegate-style actions. `resign` rebuilds
+/// the signed action from the mapped inner action and the mapped signing key.
 fn map_delegate_action(
-    delegate: &SignedDelegateAction,
+    delegate_action: &DelegateAction,
     secret: Option<&[u8; crate::secret::SECRET_LEN]>,
     default_key: &PublicKey,
+    resign: impl FnOnce(DelegateAction, SecretKey) -> Action,
 ) -> Option<Action> {
-    let source_actions = delegate.delegate_action.get_actions();
+    let source_actions = delegate_action.get_actions();
     let mut actions = Vec::with_capacity(source_actions.len());
 
     let mut account_created = false;
@@ -92,21 +116,16 @@ fn map_delegate_action(
             .unwrap(),
         );
     }
-    let mapped_key = crate::key_mapping::map_key(&delegate.delegate_action.public_key, secret);
+    let mapped_key = crate::key_mapping::map_key(&delegate_action.public_key, secret);
     let mapped_action = DelegateAction {
-        sender_id: crate::key_mapping::map_account(&delegate.delegate_action.sender_id, secret),
-        receiver_id: crate::key_mapping::map_account(&delegate.delegate_action.receiver_id, secret),
+        sender_id: crate::key_mapping::map_account(&delegate_action.sender_id, secret),
+        receiver_id: crate::key_mapping::map_account(&delegate_action.receiver_id, secret),
         actions,
-        nonce: delegate.delegate_action.nonce,
-        max_block_height: delegate.delegate_action.max_block_height,
+        nonce: delegate_action.nonce,
+        max_block_height: delegate_action.max_block_height,
         public_key: mapped_key.public_key(),
     };
-    let tx_hash = mapped_action.get_nep461_hash();
-    let d = SignedDelegateAction {
-        delegate_action: mapped_action,
-        signature: mapped_key.sign(tx_hash.as_ref()),
-    };
-    Some(Action::Delegate(Box::new(d)))
+    Some(resign(mapped_action, mapped_key))
 }
 
 // map all the account IDs and keys in this receipt and its actions, and skip any stake actions


### PR DESCRIPTION
Last of the 3-PR stack (builds on #15884, original non-splitted: #15877). Non-consensus subsystem support for `DelegateV2`.

- Rosetta: round-trips the `DelegateActionExtension` through a new `OperationMetadata::delegate_action_extension` field, so `Action -> Operations -> Action` stays a bijection for `DelegateV2`. Adds `test_delegate_v2_actions_bijection`.
- Mirror: remaps and re-signs `DelegateV2` in `genesis.rs` instead of cloning it through.
- Prefetch: prefetches the per-index gas key nonce row that `DelegateV2` validation reads.