### PR TITLE
feat(spice): per-shard chassis + ChainStoreAdapter substrate (3/n)

### DIFF
--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -12,7 +12,7 @@ pub use near_chain_primitives::{self, Error};
 pub use near_primitives::receipt::ReceiptResult;
 pub use pending_shard_jobs::{FromPanic, PendingShardJobs};
 pub use store::utils::{
-    check_transaction_validity_period, get_chunk_clone_from_header,
+    check_transaction_validity_period, compute_transaction_validity, get_chunk_clone_from_header,
     get_incoming_receipts_for_shard, retrieve_headers,
 };
 pub use store::{

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -54,7 +54,10 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io;
 use std::ops::Deref;
 use std::sync::Arc;
-use utils::{check_transaction_validity_period, early_prepare_txs_check_validity_period};
+use utils::{
+    check_transaction_validity_period, compute_transaction_validity,
+    early_prepare_txs_check_validity_period,
+};
 
 pub mod latest_witnesses;
 pub mod utils;
@@ -517,17 +520,12 @@ impl ChainStore {
         prev_block_header: &BlockHeader,
         chunk: &ShardChunk,
     ) -> Vec<bool> {
-        chunk
-            .to_transactions()
-            .into_iter()
-            .map(|signed_tx| {
-                self.check_transaction_validity_period(
-                    prev_block_header,
-                    signed_tx.transaction.block_hash(),
-                )
-                .is_ok()
-            })
-            .collect()
+        compute_transaction_validity(
+            &self.store,
+            self.transaction_validity_period,
+            prev_block_header,
+            chunk,
+        )
     }
 
     /// Builds a closure that checks whether a gapped strict-nonce transaction's

--- a/chain/chain/src/store/utils.rs
+++ b/chain/chain/src/store/utils.rs
@@ -74,6 +74,29 @@ pub fn check_transaction_validity_period(
     validity_period_validate_is_ancestor(&base_header, prev_block_header, chain_store)
 }
 
+/// Computes, for each transaction in `chunk`, whether it is still within its
+/// validity period relative to `prev_block_header`.
+pub fn compute_transaction_validity(
+    chain_store: &ChainStoreAdapter,
+    transaction_validity_period: BlockHeightDelta,
+    prev_block_header: &BlockHeader,
+    chunk: &ShardChunk,
+) -> Vec<bool> {
+    chunk
+        .to_transactions()
+        .into_iter()
+        .map(|signed_tx| {
+            check_transaction_validity_period(
+                chain_store,
+                prev_block_header,
+                signed_tx.transaction.block_hash(),
+                transaction_validity_period,
+            )
+            .is_ok()
+        })
+        .collect()
+}
+
 /// Transaction validity period check used in early prepare transactions. It's different from the
 /// standard `check_transaction_validity_period` because early transaction preparation doesn't know
 /// what the previous block hash is, it only knows the one before that. Normal validity check uses

--- a/chain/client/src/spice/chunk_executor_actor.rs
+++ b/chain/client/src/spice/chunk_executor_actor.rs
@@ -79,6 +79,7 @@ struct ChunkExecutionData {
 /// Construction-only dependencies shared with every per-shard executor. Bundled
 /// so `PerShardChunkExecutor::new` takes one argument instead of eight; the
 /// coordinator keeps its own clones (the apply path stays coordinator-side for now).
+#[derive(Clone)]
 pub(crate) struct PerShardDeps {
     pub(crate) runtime_adapter: Arc<dyn RuntimeAdapter>,
     pub(crate) epoch_manager: Arc<dyn EpochManagerAdapter>,
@@ -109,7 +110,7 @@ pub(crate) struct PerShardChunkExecutor {
     apply_chunks_spawner: Arc<dyn AsyncComputationSpawner>,
     apply_done_sender: Sender<ExecutorApplyChunksDone>,
     blocks_in_execution: HashSet<CryptoHash>,
-    pending: BTreeSet<(BlockHeight, CryptoHash)>,
+    parked_blocks: BTreeSet<(BlockHeight, CryptoHash)>,
     unverified_receipts: HashMap<CryptoHash, Vec<ReceiptProof>>,
 }
 
@@ -147,7 +148,7 @@ impl PerShardChunkExecutor {
             apply_chunks_spawner,
             apply_done_sender,
             blocks_in_execution: HashSet::new(),
-            pending: BTreeSet::new(),
+            parked_blocks: BTreeSet::new(),
             unverified_receipts: HashMap::new(),
         }
     }
@@ -166,8 +167,9 @@ pub struct ChunkExecutorActor {
     data_distributor_adapter: SpiceDataDistributorAdapter,
     config: ChunkPersistenceConfig,
 
-    /// One executor per tracked shard, reconciled on every block.
-    per_shard_executors: HashMap<ShardId, PerShardChunkExecutor>,
+    /// One executor per tracked shard, reconciled on every block. Keyed by
+    /// `ShardUId` so per-shard state can't be conflated across shard layouts.
+    per_shard_executors: HashMap<ShardUId, PerShardChunkExecutor>,
 
     blocks_in_execution: HashSet<CryptoHash>,
     pending_unverified_receipts: HashMap<CryptoHash, Vec<ExecutorIncomingUnverifiedReceipts>>,
@@ -482,26 +484,24 @@ impl ChunkExecutorActor {
     }
 
     /// Lazily construct the executor for `shard_uid`, cloning a `ChainStoreAdapter`
-    /// and the shared deps from the coordinator.
+    /// and the shared deps from the coordinator only when the executor is absent
+    /// (the hot reconcile path hits the already-present branch and clones nothing).
     fn get_or_create_per_shard_executor(
         &mut self,
         shard_uid: ShardUId,
     ) -> &mut PerShardChunkExecutor {
-        let deps = self.per_shard_deps();
-        let chain_store = self.chain_store.clone();
-        let transaction_validity_period = self.transaction_validity_period;
-        let spawner = self.apply_chunks_spawner.clone();
-        let apply_done_sender = self.myself_sender.clone();
-        self.per_shard_executors.entry(shard_uid.shard_id()).or_insert_with(|| {
-            PerShardChunkExecutor::new(
+        if !self.per_shard_executors.contains_key(&shard_uid) {
+            let executor = PerShardChunkExecutor::new(
                 shard_uid,
-                chain_store,
-                deps,
-                transaction_validity_period,
-                spawner,
-                apply_done_sender,
-            )
-        })
+                self.chain_store.clone(),
+                self.per_shard_deps(),
+                self.transaction_validity_period,
+                self.apply_chunks_spawner.clone(),
+                self.myself_sender.clone(),
+            );
+            self.per_shard_executors.insert(shard_uid, executor);
+        }
+        self.per_shard_executors.get_mut(&shard_uid).expect("inserted above when absent")
     }
 
     /// Spawn executors for newly-tracked shards and evict ones no longer tracked.
@@ -513,9 +513,8 @@ impl ChunkExecutorActor {
         for shard_uid in &tracked {
             self.get_or_create_per_shard_executor(*shard_uid);
         }
-        let tracked_ids: HashSet<ShardId> =
-            tracked.iter().map(|shard_uid| shard_uid.shard_id()).collect();
-        self.per_shard_executors.retain(|shard_id, _| tracked_ids.contains(shard_id));
+        let tracked_set: HashSet<ShardUId> = tracked.iter().copied().collect();
+        self.per_shard_executors.retain(|shard_uid, _| tracked_set.contains(shard_uid));
         Ok(())
     }
 
@@ -542,8 +541,8 @@ impl ChunkExecutorActor {
         let header = block.header();
         let prev_block_hash = header.prev_hash();
         // Keep the per-shard executor set in sync with tracked shards. Dispatch is
-        // still coordinator-side in this PR, so spawn/evict here is inert beyond
-        // maintaining the registry; PR 4 routes applies through these executors.
+        // still coordinator-side, so spawn/evict here only maintains the registry.
+        // TODO(spice): route chunk applies through these per-shard executors.
         self.reconcile_tracked_shards(prev_block_hash)?;
         let prev_block = self.chain_store.get_block(&prev_block_hash)?;
         let store = self.chain_store.store();

--- a/chain/client/src/spice/chunk_executor_actor.rs
+++ b/chain/client/src/spice/chunk_executor_actor.rs
@@ -8,7 +8,6 @@ use near_async::messaging::Handler;
 use near_async::messaging::IntoSender;
 use near_async::messaging::Sender;
 use near_chain::BlockHeader;
-use near_chain::ChainStoreAccess;
 use near_chain::PendingShardJobs;
 use near_chain::chain::{NewChunkData, NewChunkResult, ShardContext, StorageContext};
 use near_chain::sharding::get_receipts_shuffle_salt;
@@ -24,7 +23,8 @@ use near_chain::types::ApplyChunkResult;
 use near_chain::types::{ApplyChunkBlockContext, RuntimeAdapter, StorageDataSource};
 use near_chain::update_shard::{ShardUpdateReason, ShardUpdateResult, process_shard_update};
 use near_chain::{
-    Block, Chain, ChainGenesis, ChainStore, Error, collect_receipts, get_chunk_clone_from_header,
+    Block, Chain, ChainGenesis, Error, collect_receipts, compute_transaction_validity,
+    get_chunk_clone_from_header,
 };
 use near_chain_configs::MutableValidatorSigner;
 use near_chain_primitives::ApplyChunksMode;
@@ -47,6 +47,7 @@ use near_primitives::types::BlockExecutionResults;
 use near_primitives::types::BlockHeight;
 use near_primitives::types::ChunkExecutionResult;
 use near_primitives::types::ChunkExecutionResultHash;
+use near_primitives::types::NumBlocks;
 use near_primitives::types::SpiceChunkId;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{Gas, ShardId};
@@ -62,6 +63,7 @@ use near_store::StoreUpdate;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use node_runtime::SignedValidPeriodTransactions;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -74,8 +76,86 @@ struct ChunkExecutionData {
     pub code_accesses: HashSet<CodeHash>,
 }
 
+/// Construction-only dependencies shared with every per-shard executor. Bundled
+/// so `PerShardChunkExecutor::new` takes one argument instead of eight; the
+/// coordinator keeps its own clones (the apply path stays coordinator-side for now).
+pub(crate) struct PerShardDeps {
+    pub(crate) runtime_adapter: Arc<dyn RuntimeAdapter>,
+    pub(crate) epoch_manager: Arc<dyn EpochManagerAdapter>,
+    pub(crate) network_adapter: PeerManagerAdapter,
+    pub(crate) core_writer_sender: Sender<SpiceChunkEndorsementMessage>,
+    pub(crate) data_distributor_adapter: SpiceDataDistributorAdapter,
+    pub(crate) config: ChunkPersistenceConfig,
+    pub(crate) validator_signer: MutableValidatorSigner,
+    pub(crate) core_reader: SpiceCoreReader,
+}
+
+/// Per-tracked-shard executor. This change lands the chassis and lifecycle; the
+/// apply path, sinks, and receipt tracker migrate here in follow-up changes, which
+/// wire in these fields and drop the suppression.
+#[allow(dead_code)]
+pub(crate) struct PerShardChunkExecutor {
+    shard_uid: ShardUId,
+    chain_store: ChainStoreAdapter,
+    transaction_validity_period: NumBlocks,
+    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    network_adapter: PeerManagerAdapter,
+    core_writer_sender: Sender<SpiceChunkEndorsementMessage>,
+    data_distributor_adapter: SpiceDataDistributorAdapter,
+    config: ChunkPersistenceConfig,
+    validator_signer: MutableValidatorSigner,
+    core_reader: SpiceCoreReader,
+    apply_chunks_spawner: Arc<dyn AsyncComputationSpawner>,
+    apply_done_sender: Sender<ExecutorApplyChunksDone>,
+    blocks_in_execution: HashSet<CryptoHash>,
+    pending: BTreeSet<(BlockHeight, CryptoHash)>,
+    unverified_receipts: HashMap<CryptoHash, Vec<ReceiptProof>>,
+}
+
+impl PerShardChunkExecutor {
+    fn new(
+        shard_uid: ShardUId,
+        chain_store: ChainStoreAdapter,
+        deps: PerShardDeps,
+        transaction_validity_period: NumBlocks,
+        apply_chunks_spawner: Arc<dyn AsyncComputationSpawner>,
+        apply_done_sender: Sender<ExecutorApplyChunksDone>,
+    ) -> Self {
+        let PerShardDeps {
+            runtime_adapter,
+            epoch_manager,
+            network_adapter,
+            core_writer_sender,
+            data_distributor_adapter,
+            config,
+            validator_signer,
+            core_reader,
+        } = deps;
+        Self {
+            shard_uid,
+            chain_store,
+            transaction_validity_period,
+            runtime_adapter,
+            epoch_manager,
+            network_adapter,
+            core_writer_sender,
+            data_distributor_adapter,
+            config,
+            validator_signer,
+            core_reader,
+            apply_chunks_spawner,
+            apply_done_sender,
+            blocks_in_execution: HashSet::new(),
+            pending: BTreeSet::new(),
+            unverified_receipts: HashMap::new(),
+        }
+    }
+}
+
 pub struct ChunkExecutorActor {
-    pub(crate) chain_store: ChainStore,
+    pub(crate) chain_store: ChainStoreAdapter,
+    transaction_validity_period: NumBlocks,
     pub(crate) runtime_adapter: Arc<dyn RuntimeAdapter>,
     pub(crate) epoch_manager: Arc<dyn EpochManagerAdapter>,
     pub(crate) shard_tracker: ShardTracker,
@@ -85,6 +165,9 @@ pub struct ChunkExecutorActor {
     pub(crate) core_writer_sender: Sender<SpiceChunkEndorsementMessage>,
     data_distributor_adapter: SpiceDataDistributorAdapter,
     config: ChunkPersistenceConfig,
+
+    /// One executor per tracked shard, reconciled on every block.
+    per_shard_executors: HashMap<ShardId, PerShardChunkExecutor>,
 
     blocks_in_execution: HashSet<CryptoHash>,
     pending_unverified_receipts: HashMap<CryptoHash, Vec<ExecutorIncomingUnverifiedReceipts>>,
@@ -110,19 +193,20 @@ impl ChunkExecutorActor {
     ) -> Self {
         let core_reader =
             SpiceCoreReader::new(store.chain_store(), epoch_manager.clone(), genesis.gas_limit);
-        let chain_store =
-            ChainStore::new(store, config.save_trie_changes, genesis.transaction_validity_period)
-                .with_save_tx_outcomes(config.save_tx_outcomes)
-                .with_save_receipt_to_tx(config.save_receipt_to_tx)
-                .with_save_state_changes(config.save_state_changes);
+        // Spice reads/writes only through adapters; the `with_save_*` flags on
+        // `ChainStore` gate its own write methods, which spice never calls
+        // (writes go through `apply_chunk_postprocessing` with `ChunkPersistenceConfig`).
+        let chain_store = store.chain_store();
         Self {
             chain_store,
+            transaction_validity_period: genesis.transaction_validity_period,
             runtime_adapter,
             epoch_manager,
             shard_tracker,
             network_adapter,
             apply_chunks_spawner,
             myself_sender,
+            per_shard_executors: HashMap::new(),
             blocks_in_execution: HashSet::new(),
             validator_signer,
             core_reader,
@@ -383,6 +467,58 @@ struct ChunkApplicationContext<'a> {
 }
 
 impl ChunkExecutorActor {
+    /// Snapshot of the construction-only deps shared with each per-shard executor.
+    fn per_shard_deps(&self) -> PerShardDeps {
+        PerShardDeps {
+            runtime_adapter: self.runtime_adapter.clone(),
+            epoch_manager: self.epoch_manager.clone(),
+            network_adapter: self.network_adapter.clone(),
+            core_writer_sender: self.core_writer_sender.clone(),
+            data_distributor_adapter: self.data_distributor_adapter.clone(),
+            config: self.config.clone(),
+            validator_signer: self.validator_signer.clone(),
+            core_reader: self.core_reader.clone(),
+        }
+    }
+
+    /// Lazily construct the executor for `shard_uid`, cloning a `ChainStoreAdapter`
+    /// and the shared deps from the coordinator.
+    fn get_or_create_per_shard_executor(
+        &mut self,
+        shard_uid: ShardUId,
+    ) -> &mut PerShardChunkExecutor {
+        let deps = self.per_shard_deps();
+        let chain_store = self.chain_store.clone();
+        let transaction_validity_period = self.transaction_validity_period;
+        let spawner = self.apply_chunks_spawner.clone();
+        let apply_done_sender = self.myself_sender.clone();
+        self.per_shard_executors.entry(shard_uid.shard_id()).or_insert_with(|| {
+            PerShardChunkExecutor::new(
+                shard_uid,
+                chain_store,
+                deps,
+                transaction_validity_period,
+                spawner,
+                apply_done_sender,
+            )
+        })
+    }
+
+    /// Spawn executors for newly-tracked shards and evict ones no longer tracked.
+    /// Eviction is immediate; the apply-done handler's graceful-drop guard (added
+    /// when the apply path migrates) covers any in-flight apply that lands after
+    /// eviction.
+    fn reconcile_tracked_shards(&mut self, prev_hash: &CryptoHash) -> Result<(), Error> {
+        let tracked = self.shard_tracker.tracked_shard_uids(prev_hash)?;
+        for shard_uid in &tracked {
+            self.get_or_create_per_shard_executor(*shard_uid);
+        }
+        let tracked_ids: HashSet<ShardId> =
+            tracked.iter().map(|shard_uid| shard_uid.shard_id()).collect();
+        self.per_shard_executors.retain(|shard_id, _| tracked_ids.contains(shard_id));
+        Ok(())
+    }
+
     #[instrument(target = "chunk_executor", level = "debug", skip_all, fields(%block_hash))]
     fn try_apply_chunks(
         &mut self,
@@ -405,6 +541,10 @@ impl ChunkExecutorActor {
         let block_chunk_headers = block.chunks();
         let header = block.header();
         let prev_block_hash = header.prev_hash();
+        // Keep the per-shard executor set in sync with tracked shards. Dispatch is
+        // still coordinator-side in this PR, so spawn/evict here is inert beyond
+        // maintaining the registry; PR 4 routes applies through these executors.
+        self.reconcile_tracked_shards(prev_block_hash)?;
         let prev_block = self.chain_store.get_block(&prev_block_hash)?;
         let store = self.chain_store.store();
 
@@ -824,6 +964,7 @@ impl ChunkExecutorActor {
                     let proof = if chunk_header.is_new_chunk(block.header().height()) {
                         // Chunk is new but invalid (malicious producer): include proof.
                         self.chain_store
+                            .chunk_store()
                             .is_invalid_chunk(chunk_header.chunk_hash())
                             .map(|enc| Box::new(enc.content().clone()))
                     } else {
@@ -888,10 +1029,11 @@ impl ChunkExecutorActor {
         if !chunk_header.is_new_chunk(height) {
             return Ok(None);
         }
-        match get_chunk_clone_from_header(&self.chain_store.chunk_store(), chunk_header) {
+        let chunk_store = self.chain_store.chunk_store();
+        match get_chunk_clone_from_header(&chunk_store, chunk_header) {
             Ok(chunk) => Ok(Some(chunk)),
             Err(Error::ChunkMissing(_))
-                if self.chain_store.is_invalid_chunk(chunk_header.chunk_hash()).is_some() =>
+                if chunk_store.is_invalid_chunk(chunk_header.chunk_hash()).is_some() =>
             {
                 Ok(None)
             }
@@ -922,8 +1064,12 @@ impl ChunkExecutorActor {
         {
             Some(chunk) => {
                 let chunk_hash = chunk.chunk_hash().clone();
-                let tx_valid_list =
-                    self.chain_store.compute_transaction_validity(prev_block_header, &chunk);
+                let tx_valid_list = compute_transaction_validity(
+                    &self.chain_store,
+                    self.transaction_validity_period,
+                    prev_block_header,
+                    &chunk,
+                );
                 (
                     SignedValidPeriodTransactions::new(chunk.into_transactions(), tx_valid_list),
                     Some(chunk_hash),
@@ -975,7 +1121,7 @@ impl ChunkExecutorActor {
         block_hash: &CryptoHash,
         shard_uid: &ShardUId,
     ) -> Result<Option<Arc<ChunkExtra>>, Error> {
-        match self.chain_store.get_chunk_extra(block_hash, shard_uid) {
+        match self.chain_store.chunk_store().get_chunk_extra(block_hash, shard_uid) {
             Ok(chunk_extra) => Ok(Some(chunk_extra)),
             Err(Error::DBNotFoundErr(_)) => Ok(None),
             Err(err) => Err(err),

--- a/chain/client/src/spice/tests/chunk_executor_actor.rs
+++ b/chain/client/src/spice/tests/chunk_executor_actor.rs
@@ -368,7 +368,7 @@ fn produce_block(actors: &mut [TestActor], prev_block: &Block) -> Arc<Block> {
     let chunks =
         get_fake_next_block_chunk_headers(&prev_block, actors[0].actor.epoch_manager.as_ref());
     for actor in actors.iter_mut() {
-        let mut store_update = actor.actor.chain_store.store_update();
+        let mut store_update = actor.chain.chain_store.store_update();
         for chunk_header in &chunks {
             store_update.save_chunk(ShardChunk::new(chunk_header.clone(), vec![], vec![]));
         }
@@ -1048,7 +1048,7 @@ fn test_witness_is_valid() {
             &prev_block,
             &prev_block_execution_results,
             actor.actor.epoch_manager.as_ref(),
-            &actor.actor.chain_store,
+            &actor.chain.chain_store,
             prev_validator_proposals,
         )
         .unwrap();


### PR DESCRIPTION
Part of the SPICE chunk-executor per-shard redesign; continues the stack after #15818 and #15819. This PR lays the two foundations the per-shard apply path needs, with no execution-semantics change — the apply dispatch and receipt tracker move per-shard in the following PRs (#15888, #15890).

## Background

The redesign makes each tracked shard execute independently, owned by its own per-shard unit. Two things have to exist before any execution logic can move off the coordinator:

1. **Adapter-only storage.** The executor currently holds a `ChainStore` — a `Chain`-level handle carrying builder flags and write methods that SPICE never uses (SPICE writes go through `apply_chunk_postprocessing` with a `ChunkPersistenceConfig`). The design mandates the subsystem touch storage only through the lightweight adapters, and a per-shard unit must be cheap to clone a handle into.
2. **A per-shard container.** There is no per-shard structure yet — all execution state is coordinator-global.

This PR provides both as inert substrate.

## Before

```
   ┌──────────────────────────────────────────┐
   │  ChunkExecutorActor (coordinator)          │
   │    chain_store: ChainStore  ◄── heavy,      │
   │      Chain-level, with_save_* write flags   │
   │    all execution state lives here           │
   │    (no per-shard structure)                 │
   └──────────────────────────────────────────┘

   compute_transaction_validity → a method on
   ChainStore, unreachable from an adapter-only caller
```

## After

```
   ┌──────────────────────────────────────────┐
   │  ChunkExecutorActor (coordinator)          │
   │    chain_store: ChainStoreAdapter           │
   │    transaction_validity_period              │
   │    per_shard_executors: { shard → … }  ◄── new chassis,
   │      reconciled each block, but INERT       │   one per tracked shard
   └───────────────┬──────────────────────────┘
                   │ get_or_create / reconcile (spawn + immediate evict)
                   ▼
        ┌──────────────────────────┐
        │  PerShardChunkExecutor    │  fields present, not yet read
        │  (chassis only this PR)   │  (#[allow(dead_code)])
        └──────────────────────────┘

   compute_transaction_validity → a free fn in store::utils,
   callable from anything holding a ChainStoreAdapter
```

The chassis is reconciled against the tracked-shard set on each block but does no work yet — dispatch stays coordinator-side until the next PR. So this PR is a pure substrate change: the executor compiles and behaves exactly as before, now sitting on the adapter with the per-shard scaffold in place.

## Why this is safe / what's deliberately unchanged

- **No execution-semantics change.** The apply path, finalize, and receipt handling are untouched; the per-shard chassis is inert.
- **The adapter swap loses no behavior.** The `with_save_*` builder flags dropped from `ChainStore::new` only gate `ChainStore`'s own write methods, which SPICE never calls — its writes already go through `apply_chunk_postprocessing`.
- **No caller churn for the validity helper.** `ChainStore::compute_transaction_validity` is kept as a thin delegation to the new free fn, so every existing `ChainStore` holder is unaffected; only the adapter-side SPICE caller uses the free fn directly.
- **The `#[allow(dead_code)]` is temporary scaffolding.** The per-shard fields are populated as the apply path and receipt tracker migrate in the follow-up PRs, which remove the suppression.

## Key changes

For reviewers:

- `ChunkExecutorActor.chain_store`: `ChainStore` → `ChainStoreAdapter`, plus a `transaction_validity_period` field; the vestigial `with_save_*` builder chain is dropped from construction.
- New `PerShardChunkExecutor` struct + `PerShardDeps` construction bundle, with `reconcile_tracked_shards` / `get_or_create_per_shard_executor` (spawn missing shards, evict untracked ones immediately). Reconcile is invoked from the existing apply entry point; the per-shard unit is otherwise unused.
- `compute_transaction_validity` promoted to a free fn in `store::utils` beside `check_transaction_validity_period`; the `ChainStore` method delegates to it.

The structural cleanup (collapsing the executor file's impl blocks, extracting `PerShardChunkExecutor` into its own file) is deferred to a later mechanical PR.
