### PR TITLE
feat(debug-ui): add total stake column to recent epochs view

### DIFF
--- a/tools/debug-ui/src/RecentEpochsView.tsx
+++ b/tools/debug-ui/src/RecentEpochsView.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { parse } from 'date-fns';
-import { fetchEpochInfoLight, fetchFullStatus } from './api';
+import { fetchEpochInfo, fetchEpochInfoLight, fetchFullStatus } from './api';
 import './RecentEpochsView.scss';
 import { formatDurationInMillis } from './utils';
 
@@ -9,6 +9,8 @@ type RecentEpochsViewProps = {
 };
 
 export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
+    // The lightweight variant omits the heavy per-validator `validator_info`, so the
+    // page renders fast. This drives the initial load.
     const {
         data: epochData,
         error: epochError,
@@ -19,6 +21,14 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
         error: statusError,
         isLoading: statusIsLoading,
     } = useQuery(['fullStatus', addr], () => fetchFullStatus(addr));
+    // The full variant carries per-validator stake. We fetch it separately and let it
+    // populate the Total Stake column once it arrives, so it never blocks the page.
+    // `stakeIsLoading` is true only while the full data is loading for the first time;
+    // after it has loaded once, the data stays available and this flag stays false, so
+    // the "Loading…" placeholder can never replace a value that was already shown.
+    const { data: fullEpochData, isLoading: stakeIsLoading } = useQuery(['epochInfo', addr], () =>
+        fetchEpochInfo(addr, null)
+    );
 
     if (epochIsLoading || statusIsLoading) {
         return <div>Loading...</div>;
@@ -28,6 +38,33 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
     }
     const epochInfos = epochData!.status_response.EpochInfo;
     const status = statusData!;
+
+    // Map each epoch id to its total stake, derived from the full epoch info. The next
+    // epoch's row has no `validator_info` of its own, but its already-finalized stake is
+    // exposed as `next_validators` on the current epoch (the entry right after it).
+    // Proposals are deliberately excluded: they only affect the next-next epoch and can
+    // still change.
+    const fullEpochInfos = fullEpochData?.status_response.EpochInfo;
+    const totalStakeByEpochId = new Map<string, number>();
+    if (fullEpochInfos !== undefined) {
+        const sumStake = (validators: { stake: string }[]) =>
+            validators.reduce((sum, validator) => sum + parseFloat(validator.stake), 0);
+        for (const epochInfo of fullEpochInfos) {
+            if (epochInfo.validator_info) {
+                totalStakeByEpochId.set(
+                    epochInfo.epoch_id,
+                    sumStake(epochInfo.validator_info.current_validators)
+                );
+            }
+        }
+        const [nextEpoch, currentEpoch] = fullEpochInfos;
+        if (nextEpoch && currentEpoch?.validator_info) {
+            totalStakeByEpochId.set(
+                nextEpoch.epoch_id,
+                sumStake(currentEpoch.validator_info.next_validators)
+            );
+        }
+    }
 
     return (
         <table className="recent-epochs-table">
@@ -43,6 +80,7 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
                     <th>Block Producers</th>
                     <th>Chunk Producers</th>
                     <th>Chunk Validators</th>
+                    <th>Total Stake</th>
                 </tr>
             </thead>
             <tbody>
@@ -105,6 +143,15 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
                             <td>{epochInfo.block_producers.length}</td>
                             <td>{epochInfo.chunk_producers.length}</td>
                             <td>{epochInfo.chunk_validators.length}</td>
+                            <td>
+                                {totalStakeByEpochId.has(epochInfo.epoch_id)
+                                    ? Math.floor(
+                                          totalStakeByEpochId.get(epochInfo.epoch_id)! / 1e24
+                                      ).toLocaleString('en-US')
+                                    : stakeIsLoading
+                                    ? 'Loading…'
+                                    : ''}
+                            </td>
                         </tr>
                     );
                 })}

--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -193,7 +193,7 @@ export interface EpochInfoView {
     block_producers: ValidatorInfo[];
     chunk_producers: string[];
     chunk_validators: string[];
-    validator_info: EpochValidatorInfo;
+    validator_info: EpochValidatorInfo | null;
     protocol_version: number;
     shards_size_and_parts: [number, number, boolean][];
 }


### PR DESCRIPTION
Show each epoch's total validator stake in the epoch_info/recent table.

The lightweight epoch_info endpoint omits the heavy per-validator `validator_info`, so the table keeps loading from it for a fast initial render. The full epoch_info is fetched separately and lazily populates the new Total Stake column once it arrives, so it never blocks the page.

Stake is summed from each epoch's `current_validators`. The next epoch's row carries no `validator_info` of its own, so its already-finalized stake is taken from the current epoch's `next_validators`; proposals are excluded since they only affect the next-next epoch and can still change.