### PR TITLE
fix(estimator): account for signature in max-size deploy contract tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7336,6 +7336,7 @@ name = "runtime-params-estimator"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "borsh",
  "bs58 0.4.0",
  "bytesize 1.1.0",
  "chrono",

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -17,6 +17,7 @@ required-features = ["costs_counting"]
 
 [dependencies]
 anyhow.workspace = true
+borsh.workspace = true
 bs58.workspace = true
 bytesize.workspace = true
 chrono.workspace = true

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -10,7 +10,7 @@ use crate::estimator_context::{EstimatorContext, Testbed};
 use crate::gas_cost::{GasCost, NonNegativeTolerance};
 use crate::transaction_builder::AccountRequirement;
 use crate::utils::{average_cost, percentiles};
-use near_crypto::{KeyType, PublicKey};
+use near_crypto::{KeyType, PublicKey, Signature};
 use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
 use near_primitives::action::{DeterministicStateInitAction, GlobalContractIdentifier};
 use near_primitives::deterministic_account_id::{
@@ -929,12 +929,17 @@ impl ActionSize {
         match self {
             // small number that still allows to generate a valid contract
             ActionSize::Min => 120,
-            // max_number_bytes_method_names: 2000
-            // This size exactly touches tx limit with 1 deploy action. If this suddenly
-            // fails with `InvalidTxError(TransactionSizeExceeded`, it could be a
+            // This size exactly touches tx limit with 1 deploy action, where the
+            // limit counts the full wire size including the ed25519 signature
+            // (`SignedTransaction::size_for_limits`). If this suddenly fails
+            // with `InvalidTxError::TransactionSizeExceeded`, it could be a
             // protocol change due to the TX limit computation changing.
             // The test `test_deploy_contract_tx_max_size` checks this.
-            ActionSize::Max => 1_572_864 - 182,
+            ActionSize::Max => {
+                let signature_size = borsh::object_length(&Signature::empty(KeyType::ED25519))
+                    .expect("borsh signature length") as u64;
+                1_572_864 - 182 - signature_size
+            }
         }
     }
 }
@@ -943,6 +948,7 @@ impl ActionSize {
 mod tests {
     use super::{ActionSize, deploy_action};
     use genesis_populate::get_account_id;
+    use near_primitives::version::PROTOCOL_VERSION;
 
     #[test]
     fn test_deploy_contract_tx_max_size() {
@@ -961,10 +967,10 @@ mod tests {
         let mut tb = crate::TransactionBuilder::new(test_accounts);
 
         let tx_0 = tb.transaction_from_actions(sender_0, receiver_0, vec![deploy_action.clone()]);
-        assert_eq!(tx_0.get_size(), limit, "TX size changed");
+        assert_eq!(tx_0.size_for_limits(PROTOCOL_VERSION), limit, "TX size changed");
 
         let tx_1 = tb.transaction_from_actions(sender_1, receiver_1, vec![deploy_action]);
-        assert_eq!(tx_1.get_size(), limit, "TX size changed");
+        assert_eq!(tx_1.size_for_limits(PROTOCOL_VERSION), limit, "TX size changed");
     }
 }
 

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -24,6 +24,14 @@ use near_primitives::utils::derive_near_deterministic_account_id;
 use std::collections::BTreeMap;
 use std::iter;
 
+/// Protocol `max_transaction_size` limit (1.5 MiB).
+const MAX_TRANSACTION_SIZE: u64 = 1_572_864;
+
+/// Borsh wire-size of a max-size deploy-contract transaction excluding its
+/// contract code and signature: account ids, public key, nonce, block hash,
+/// and action/enum tags.
+const MAX_DEPLOY_CONTRACT_TX_OVERHEAD: u64 = 182;
+
 const GAS_1_MICROSECOND: Gas = Gas::from_gigagas(1);
 const GAS_1_NANOSECOND: Gas = Gas::from_gas(1_000_000);
 const GAS_100_PICOSECONDS: Gas = Gas::from_gas(100_000);
@@ -938,7 +946,7 @@ impl ActionSize {
             ActionSize::Max => {
                 let signature_size = borsh::object_length(&Signature::empty(KeyType::ED25519))
                     .expect("borsh signature length") as u64;
-                1_572_864 - 182 - signature_size
+                MAX_TRANSACTION_SIZE - MAX_DEPLOY_CONTRACT_TX_OVERHEAD - signature_size
             }
         }
     }
@@ -946,7 +954,7 @@ impl ActionSize {
 
 #[cfg(test)]
 mod tests {
-    use super::{ActionSize, deploy_action};
+    use super::{ActionSize, MAX_TRANSACTION_SIZE, deploy_action};
     use genesis_populate::get_account_id;
     use near_primitives::version::PROTOCOL_VERSION;
 
@@ -954,7 +962,6 @@ mod tests {
     fn test_deploy_contract_tx_max_size() {
         // The size of a transaction constructed from this must be exactly at the limit.
         let deploy_action = deploy_action(ActionSize::Max);
-        let limit = 1_572_864;
 
         // We also need some account IDs constructed the same way as in the estimator.
         // Let's try multiple index sizes to ensure this does not affect the length.
@@ -967,10 +974,10 @@ mod tests {
         let mut tb = crate::TransactionBuilder::new(test_accounts);
 
         let tx_0 = tb.transaction_from_actions(sender_0, receiver_0, vec![deploy_action.clone()]);
-        assert_eq!(tx_0.size_for_limits(PROTOCOL_VERSION), limit, "TX size changed");
+        assert_eq!(tx_0.size_for_limits(PROTOCOL_VERSION), MAX_TRANSACTION_SIZE, "TX size changed");
 
         let tx_1 = tb.transaction_from_actions(sender_1, receiver_1, vec![deploy_action]);
-        assert_eq!(tx_1.size_for_limits(PROTOCOL_VERSION), limit, "TX size changed");
+        assert_eq!(tx_1.size_for_limits(PROTOCOL_VERSION), MAX_TRANSACTION_SIZE, "TX size changed");
     }
 }
 


### PR DESCRIPTION
The nightly `ultra_slow_test_full_estimator` fails with `TransactionSizeExceeded { size: 1572929, limit: 1572864 }` during the `deploy_contract_byte` estimations (https://nayduck.nearone.org/#/test/1351217).

Since #15869 the `max_transaction_size` gate counts the signature in the transaction size (`SignedTransaction::size_for_limits`), and #15878 stabilized `PostQuantumSignatures` at protocol 85, which activated the new computation for the stable-built estimator binary. The `ActionSize::Max` deploy contract payload is calibrated to put the transaction exactly at the size limit using the old body-only size, so validation now rejects it by exactly the 65 bytes of the ed25519 signature.

Shrink the calibrated payload by the borsh wire size of an ed25519 signature, derived with `borsh::object_length` the same way `wire_size()` computes it rather than hardcoded. Also update `test_deploy_contract_tx_max_size` to assert `size_for_limits(PROTOCOL_VERSION) == limit`, so the guard test exercises the same size computation as the validation gate and catches this class of change in CI.