### PR TITLE
feat(mirror): deferral, drain, and resend of txs lost on the target chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,6 +4901,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/pytest/tools/mirror/offline_test.py
+++ b/pytest/tools/mirror/offline_test.py
@@ -181,14 +181,18 @@ class ContractTest(MirrorTestCase):
         assert nonce is not None, \
             f'contract extra key {mapped_pk} not found on target'
 
-        # Sub-account created via contract
+        # Sub-account created via contract. The mirror pre-creates it with the
+        # mapped key via an extra CreateAccount tx, and the contract call's own
+        # CreateAccount receipt then fails on target, so the unmapped key the
+        # contract passed never lands there.
         res = node.get_account('test0.test0', do_assert=False)
         assert 'error' not in res, 'account test0.test0 not found on target'
+        mapped_sub_pk = mirror_utils.map_key_no_secret(self.sub_key.key.pk)
         nonce = node.get_nonce_for_pk('test0.test0',
-                                      self.sub_key.key.pk,
+                                      mapped_sub_pk,
                                       finality='final')
         assert nonce is not None, \
-            f'sub key {self.sub_key.key.pk} not found on test0.test0'
+            f'mapped sub key {mapped_sub_pk} not found on test0.test0'
 
         assert mirror_utils.contract_deployed(node, 'test0'), \
             'contract not deployed on target test0'

--- a/pytest/tools/mirror/offline_test.py
+++ b/pytest/tools/mirror/offline_test.py
@@ -174,6 +174,16 @@ class ContractTest(MirrorTestCase):
         assert nonce is not None, \
             f'contract key {self.contract_key.key.pk} not found on target'
 
+        # the mirror must also synthesize the mapped version of contract_key
+        # from the promise-created AddKey receipt; both coexist on test0
+        mapped_contract_pk = mirror_utils.map_key_no_secret(
+            self.contract_key.key.pk)
+        nonce = node.get_nonce_for_pk('test0',
+                                      mapped_contract_pk,
+                                      finality='final')
+        assert nonce is not None, \
+            f'mapped contract key {mapped_contract_pk} not found on target'
+
         # contract_extra_key is a direct AddKey action (mapped)
         mapped_pk = mirror_utils.map_key_no_secret(
             self.contract_extra_key.key.pk)

--- a/tools/mirror/Cargo.toml
+++ b/tools/mirror/Cargo.toml
@@ -29,7 +29,8 @@ serde_json.workspace = true
 sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["signal"] }
+tokio-util.workspace = true
 tracing.workspace = true
 
 nearcore.workspace = true

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -224,6 +224,11 @@ impl TxTracker {
         }
     }
 
+    // Transactions sent to the target chain but not yet seen in a target block.
+    pub(crate) fn sent_txs_remaining(&self) -> usize {
+        self.sent_txs.len()
+    }
+
     // Makes sure that there's something written in the DB for this access key.
     // This function is called before calling initialize_target_nonce(), which sets
     // in-memory data associated with this nonce. It would make sense to do this part at the same time,

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -1,3 +1,4 @@
+use crate::deferred_tx::{DeferredTx, DeferredTxTracker};
 use crate::{
     ChainAccess, ChainError, LatestTargetNonce, MappedBlock, MappedTx, MappedTxProvenance,
     NonceKind, NonceLookupKey, NonceUpdater, TargetChainTx, TargetNonce, TxBatch, TxRef,
@@ -36,6 +37,8 @@ struct TxSendInfo {
     target_receiver_id: Option<AccountId>,
     actions: Vec<String>,
     sent_at_target_height: BlockHeight,
+    // payload for re-signing and resending if the sent copy can never land
+    resend: DeferredTx,
 }
 
 impl TxSendInfo {
@@ -72,6 +75,7 @@ impl TxSendInfo {
                 .iter()
                 .map(|a| a.as_ref().to_string())
                 .collect::<Vec<_>>(),
+            resend: DeferredTx::from_mapped(tx, target_height, source_height),
         }
     }
 }
@@ -107,7 +111,8 @@ struct NonceInfo {
 
 pub(crate) enum SentBatch {
     MappedBlock(TxBatch),
-    ExtraTxs(Vec<TargetChainTx>),
+    UnstakeTxs(Vec<TargetChainTx>),
+    DeferredResendTxs(Vec<TargetChainTx>),
 }
 
 // a nonce lookup key along with the id of the tx or receipt that might have updated it
@@ -152,6 +157,10 @@ pub(crate) struct TxTracker {
     recent_block_timestamps: VecDeque<u64>,
     // last source block we'll be sending transactions for
     stop_height: Option<BlockHeight>,
+    // txs withheld because their signing key isn't on the target chain yet, in
+    // memory only. Resolved by try_set_nonces() or the periodic poll, dropped
+    // after DEFERRED_TX_TTL target heights.
+    pub(crate) deferred_txs: DeferredTxTracker,
 }
 
 impl TxTracker {
@@ -182,6 +191,7 @@ impl TxTracker {
             height_popped: None,
             height_seen: None,
             recent_block_timestamps: VecDeque::new(),
+            deferred_txs: DeferredTxTracker::new(),
         }
     }
 
@@ -219,12 +229,12 @@ impl TxTracker {
             Some(_) => {
                 self.height_popped >= self.stop_height
                     && self.height_seen >= self.nonempty_height_queued
+                    && self.deferred_txs.is_empty()
             }
             None => false,
         }
     }
 
-    // Transactions sent to the target chain but not yet seen in a target block.
     pub(crate) fn sent_txs_remaining(&self) -> usize {
         self.sent_txs.len()
     }
@@ -508,7 +518,7 @@ impl TxTracker {
         Ok(())
     }
 
-    fn remove_tx(&mut self, tx: &IndexerTransactionWithOutcome) {
+    fn remove_tx(&mut self, tx: &IndexerTransactionWithOutcome, target_height: BlockHeight) {
         let nonce_key = NonceLookupKey::from_tx_view(&tx.transaction);
         match self.txs_by_signer.entry(nonce_key.clone()) {
             hash_map::Entry::Occupied(mut e) => {
@@ -532,13 +542,19 @@ impl TxTracker {
                         "skip txs by tx inclusion",
                     );
                     for t in txs.iter() {
-                        if self.sent_txs.remove(&t.hash).is_none() {
+                        // below an included nonce, can never land; requeue for resend
+                        let Some(info) = self.sent_txs.remove(&t.hash) else {
                             tracing::warn!(
                                 target: "mirror",
                                 tx_hash = %t.hash,
                                 "tx with hash that we thought was skipped is not in the set of sent txs",
                             );
-                        }
+                            continue;
+                        };
+                        crate::metrics::TRANSACTIONS_REQUEUED
+                            .with_label_values(&["nonce_skipped"])
+                            .inc();
+                        self.deferred_txs.push_resend(info.resend, target_height);
                     }
                 }
                 *txs = txs_left;
@@ -692,7 +708,7 @@ impl TxTracker {
         db: &DB,
         updated_key: UpdatedKey,
         mut nonce: Option<Nonce>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<DeferredTx>> {
         let mut n = crate::read_target_nonce(db, &updated_key.nonce_key)?.unwrap();
         n.pending_outcomes.remove(&updated_key.id);
         n.nonce = std::cmp::max(n.nonce, nonce);
@@ -701,6 +717,11 @@ impl TxTracker {
 
         let updater = NonceUpdater::ChainObjectId(updated_key.id);
         let nonce_key = updated_key.nonce_key;
+
+        // Resolve deferred txs BEFORE assigning nonces to queued txs. Deferred
+        // txs are sent immediately via the deferred_resend channel, so they
+        // must receive lower nonces than the still-queued txs sent later.
+        let deferred = self.resolve_deferred_txs(&nonce_key, &mut nonce);
 
         if let Some(info) = self.nonces.get_mut(&nonce_key) {
             info.target_nonce.pending_outcomes.remove(&updater);
@@ -745,7 +766,23 @@ impl TxTracker {
             }
             info.target_nonce.nonce = std::cmp::max(info.target_nonce.nonce, nonce);
         }
-        Ok(())
+
+        Ok(deferred)
+    }
+
+    // Once we learn the nonce for `nonce_key`, assign nonces to any txs we deferred
+    // on it and hand them back to be resent. `nonce` is the next-free nonce after
+    // accounting for any in-memory txs awaiting this key; we keep advancing it.
+    pub(crate) fn resolve_deferred_txs(
+        &mut self,
+        nonce_key: &NonceLookupKey,
+        nonce: &mut Option<Nonce>,
+    ) -> Vec<DeferredTx> {
+        let txs = self.deferred_txs.resolve(nonce_key, nonce);
+        if let (Some(info), Some(n)) = (self.nonces.get_mut(nonce_key), *nonce) {
+            info.target_nonce.nonce = std::cmp::max(info.target_nonce.nonce, Some(n));
+        }
+        txs
     }
 
     fn on_outcome_finished(
@@ -767,10 +804,11 @@ impl TxTracker {
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
         db: &DB,
         tx: IndexerTransactionWithOutcome,
+        target_height: BlockHeight,
     ) -> anyhow::Result<()> {
         if let Some(info) = self.sent_txs.remove(&tx.transaction.hash) {
             crate::metrics::TRANSACTIONS_INCLUDED.inc();
-            self.remove_tx(&tx);
+            self.remove_tx(&tx, target_height);
             if info.source_height > self.height_seen {
                 self.height_seen = info.source_height;
             }
@@ -859,12 +897,13 @@ impl TxTracker {
         self.record_block_timestamp(&msg);
         self.log_target_block(&msg);
 
+        let target_height = msg.block.header.height;
         let mut access_key_updates = Vec::new();
         let mut staked_accounts = HashMap::new();
         for s in msg.shards {
             if let Some(c) = s.chunk {
                 for tx in c.transactions {
-                    self.on_target_block_tx(tx_block_queue, db, tx)?;
+                    self.on_target_block_tx(tx_block_queue, db, tx, target_height)?;
                 }
                 for outcome in s.receipt_execution_outcomes {
                     self.on_target_block_applied_receipt(
@@ -908,7 +947,9 @@ impl TxTracker {
             );
         }
         let nonce_key = NonceLookupKey::from_tx(&tx.target_tx.transaction);
-        let source_height = tx_ref.as_ref().map(|t| t.source_height);
+        // resent deferred txs have no tx_ref but carry their original source height,
+        // which finished() needs to see via height_seen when they land
+        let source_height = tx_ref.as_ref().map(|t| t.source_height).or(tx.source_height);
         // TODO: don't keep adding txs if we're not ever finding them on chain, since we'll OOM eventually
         // if that happens.
         self.sent_txs.insert(hash, TxSendInfo::new(&tx, source_height, target_height, now));
@@ -966,9 +1007,32 @@ impl TxTracker {
                 }
             }
             None => {
-                // if tx_ref is None, it was an extra tx we sent to unstake an unwanted validator,
-                // and there should be no access key updates
-                assert!(tx.nonce_updates.is_empty());
+                // out-of-band txs (unstake reversals, resent deferred txs) have
+                // no prior TxRef updater to replace; just register the new
+                // outcome for any keys this tx updates
+                let new_updater = NonceUpdater::ChainObjectId(hash);
+                for nonce_key in &tx.nonce_updates {
+                    let mut t = crate::read_target_nonce(db, nonce_key)?.unwrap();
+                    t.pending_outcomes.insert(hash);
+                    crate::put_target_nonce(db, nonce_key, &t)?;
+
+                    let Some(info) = self.nonces.get_mut(nonce_key) else {
+                        continue;
+                    };
+                    info.target_nonce.pending_outcomes.insert(new_updater.clone());
+                    let txs_awaiting_nonce = info.txs_awaiting_nonce.clone();
+                    if !txs_awaiting_nonce.is_empty() {
+                        let mut tx_block_queue = tx_block_queue.lock();
+                        for r in &txs_awaiting_nonce {
+                            match Self::get_tx(&mut tx_block_queue, r) {
+                                TargetChainTx::AwaitingNonce(t) => {
+                                    t.target_nonce.pending_outcomes.insert(new_updater.clone());
+                                }
+                                TargetChainTx::Ready(_) => unreachable!(),
+                            };
+                        }
+                    }
+                }
             }
         }
 
@@ -977,12 +1041,18 @@ impl TxTracker {
         let mut t = crate::read_target_nonce(db, &nonce_key)?.unwrap();
         t.nonce = std::cmp::max(t.nonce, Some(tx.target_tx.transaction.nonce().nonce()));
         crate::put_target_nonce(db, &nonce_key, &t)?;
-        let info = self.nonces.get_mut(&nonce_key).unwrap();
-        if info.last_height <= source_height {
-            keys_to_remove.insert(nonce_key);
-        }
         if let Some(tx_ref) = tx_ref {
+            // queued-batch txs must have a nonce entry; only out-of-band txs
+            // (unstake reversals, deferred resends) may lack one
+            let info = self.nonces.get_mut(&nonce_key).unwrap();
+            if info.last_height <= source_height {
+                keys_to_remove.insert(nonce_key);
+            }
             assert!(info.queued_txs.remove(&tx_ref));
+        } else if let Some(info) = self.nonces.get_mut(&nonce_key) {
+            if info.last_height <= source_height {
+                keys_to_remove.insert(nonce_key);
+            }
         }
         Ok(())
     }
@@ -1138,9 +1208,13 @@ impl TxTracker {
                     b.txs.into_iter().map(|(tx_ref, tx)| (Some(tx_ref), tx)).collect::<Vec<_>>();
                 (txs, format!("source #{}", b.source_height))
             }
-            SentBatch::ExtraTxs(txs) => (
+            SentBatch::UnstakeTxs(txs) => (
                 txs.into_iter().map(|tx| (None, tx)).collect::<Vec<_>>(),
                 String::from("extra unstake transactions"),
+            ),
+            SentBatch::DeferredResendTxs(txs) => (
+                txs.into_iter().map(|tx| (None, tx)).collect::<Vec<_>>(),
+                String::from("deferred resend transactions"),
             ),
         };
         for (tx_ref, tx) in txs_sent {
@@ -1175,6 +1249,11 @@ impl TxTracker {
                         &t.nonce_updates,
                         &mut keys_to_remove,
                     )?;
+                    self.deferred_txs.push(
+                        t,
+                        target_height,
+                        tx_ref.as_ref().map(|r| r.source_height),
+                    );
                 }
             }
         }

--- a/tools/mirror/src/cli.rs
+++ b/tools/mirror/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::shutdown::SignalHandler;
 use anyhow::Context;
 use near_primitives::types::BlockHeight;
 use near_primitives::views::AccessKeyPermissionView;
@@ -71,6 +72,7 @@ impl RunCmd {
             None
         };
 
+        let signal_handler = SignalHandler::install();
         let result = run_async(crate::run(
             self.source_home,
             self.target_home,
@@ -79,10 +81,13 @@ impl RunCmd {
             self.stop_height,
             self.online_source,
             self.config_path,
+            signal_handler.shutdown_token(),
         ));
+        signal_handler.mark_run_finished();
         // run() aborts spawned tasks, awaits them, and calls actor_system.stop(). By the time we
         // get here the tokio runtime is dropped and all Arc<DB> refs should be gone. Wait for RocksDB
-        // background threads to finish flushing.
+        // background threads to finish flushing; signal_handler makes sure the
+        // process still responds to SIGTERM if this ever hangs.
         near_store::db::RocksDB::block_until_all_instances_are_dropped();
         result
     }

--- a/tools/mirror/src/deferred_tx.rs
+++ b/tools/mirror/src/deferred_tx.rs
@@ -1,0 +1,266 @@
+use crate::{MappedTx, MappedTxProvenance, NonceLookupKey, SignedTransaction, TxAwaitingNonce};
+use near_crypto::SecretKey;
+use near_primitives::transaction::Transaction;
+use near_primitives::types::{AccountId, BlockHeight};
+use near_primitives_core::types::Nonce;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+// a deferred tx gets DEFERRED_TX_TTL / DEFERRED_TX_POLL_INTERVAL_BLOCKS polls
+// to resolve before it is dropped
+pub(crate) const DEFERRED_TX_POLL_INTERVAL_BLOCKS: BlockHeight = 10;
+const DEFERRED_TX_TTL: BlockHeight = 50;
+
+#[derive(Clone, Debug)]
+pub(crate) struct DeferredTx {
+    source_signer_id: AccountId,
+    source_receiver_id: AccountId,
+    source_height: Option<BlockHeight>,
+    provenance: MappedTxProvenance,
+    target_secret_key: SecretKey,
+    pub(crate) target_tx: Transaction,
+    nonce_updates: HashSet<NonceLookupKey>,
+    deferred_at: BlockHeight,
+}
+
+impl DeferredTx {
+    pub(crate) fn new(
+        tx: TxAwaitingNonce,
+        deferred_at: BlockHeight,
+        source_height: Option<BlockHeight>,
+    ) -> Self {
+        Self {
+            source_signer_id: tx.source_signer_id,
+            source_receiver_id: tx.source_receiver_id,
+            source_height,
+            provenance: tx.provenance,
+            target_secret_key: tx.target_secret_key,
+            target_tx: tx.target_tx,
+            nonce_updates: tx.nonce_updates,
+            deferred_at,
+        }
+    }
+
+    // Rebuilds the deferrable payload of a tx that was already signed and sent, so
+    // it can be requeued with a fresh nonce once we know the sent one can never land.
+    pub(crate) fn from_mapped(
+        tx: &MappedTx,
+        deferred_at: BlockHeight,
+        source_height: Option<BlockHeight>,
+    ) -> Self {
+        Self {
+            source_signer_id: tx.source_signer_id.clone(),
+            source_receiver_id: tx.source_receiver_id.clone(),
+            source_height,
+            provenance: tx.provenance,
+            target_secret_key: tx.target_secret_key.clone(),
+            target_tx: tx.target_tx.transaction.clone(),
+            nonce_updates: tx.nonce_updates.clone(),
+            deferred_at,
+        }
+    }
+
+    pub(crate) fn nonce_key(&self) -> NonceLookupKey {
+        NonceLookupKey::from_tx(&self.target_tx)
+    }
+
+    pub(crate) fn nonce(&self) -> Nonce {
+        self.target_tx.nonce().nonce()
+    }
+
+    pub(crate) fn into_ready(self) -> MappedTx {
+        let target_tx = SignedTransaction::new(
+            self.target_secret_key.sign(&self.target_tx.get_hash_and_size().0.as_ref()),
+            self.target_tx,
+        );
+        MappedTx {
+            source_signer_id: self.source_signer_id,
+            source_receiver_id: self.source_receiver_id,
+            source_height: self.source_height,
+            provenance: self.provenance,
+            target_secret_key: self.target_secret_key,
+            target_tx,
+            nonce_updates: self.nonce_updates,
+            sent_successfully: false,
+        }
+    }
+}
+
+pub(crate) struct DeferredTxTracker {
+    txs: HashMap<NonceLookupKey, Vec<DeferredTx>>,
+}
+
+impl DeferredTxTracker {
+    pub(crate) fn new() -> Self {
+        Self { txs: HashMap::new() }
+    }
+
+    pub(crate) fn keys(&self) -> Vec<NonceLookupKey> {
+        self.txs.keys().cloned().collect()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.txs.values().map(|txs| txs.len()).sum()
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        tx: TxAwaitingNonce,
+        target_height: BlockHeight,
+        source_height: Option<BlockHeight>,
+    ) {
+        let deferred = DeferredTx::new(tx, target_height, source_height);
+        let nonce_key = deferred.nonce_key();
+        self.txs.entry(nonce_key.clone()).or_default().push(deferred);
+        tracing::debug!(target: "mirror", ?nonce_key, "deferred tx until its access key appears on the target chain");
+    }
+
+    // Requeues a tx whose sent copy can never land because a later nonce of the
+    // same key was included on chain. The next deferred poll re-signs it with a
+    // fresh nonce since its access key already exists on the target chain.
+    pub(crate) fn push_resend(&mut self, mut tx: DeferredTx, target_height: BlockHeight) {
+        tx.deferred_at = target_height;
+        let nonce_key = tx.nonce_key();
+        let lost_nonce = tx.nonce();
+        self.txs.entry(nonce_key.clone()).or_default().push(tx);
+        tracing::warn!(target: "mirror", ?nonce_key, lost_nonce, "requeueing tx lost on the target chain for resend");
+    }
+
+    pub(crate) fn resolve(
+        &mut self,
+        nonce_key: &NonceLookupKey,
+        nonce: &mut Option<Nonce>,
+    ) -> Vec<DeferredTx> {
+        let Some(next_nonce) = nonce.as_mut() else {
+            return Vec::new();
+        };
+        let Some(mut txs) = self.txs.remove(nonce_key) else {
+            return Vec::new();
+        };
+        for tx in &mut txs {
+            *next_nonce += 1;
+            *tx.target_tx.nonce_mut() = *next_nonce;
+        }
+        tracing::debug!(target: "mirror", ?nonce_key, count = txs.len(), "resending deferred txs");
+        txs
+    }
+
+    pub(crate) fn prune(&mut self, target_height: BlockHeight) {
+        self.txs.retain(|nonce_key, txs| {
+            let before = txs.len();
+            txs.retain(|tx| target_height.saturating_sub(tx.deferred_at) <= DEFERRED_TX_TTL);
+            let dropped = before - txs.len();
+            if dropped > 0 {
+                tracing::warn!(target: "mirror", ?nonce_key, dropped, "dropping deferred txs whose access key never appeared on the target chain");
+            }
+            !txs.is_empty()
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::TargetNonce;
+    use near_crypto::KeyType;
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::types::ShardId;
+
+    fn awaiting_nonce(signer: &str, nonce: Nonce) -> TxAwaitingNonce {
+        let target_secret_key = SecretKey::from_seed(KeyType::ED25519, signer);
+        let signer_id: AccountId = signer.parse().unwrap();
+        let receiver_id: AccountId = "receiver.near".parse().unwrap();
+        let target_tx = Transaction::new_v0(
+            signer_id.clone(),
+            target_secret_key.public_key(),
+            receiver_id.clone(),
+            nonce,
+            CryptoHash::default(),
+        );
+        TxAwaitingNonce {
+            source_signer_id: signer_id,
+            source_receiver_id: receiver_id,
+            provenance: MappedTxProvenance::MappedSourceTx(1, ShardId::new(0), 0),
+            target_secret_key,
+            target_tx,
+            nonce_updates: HashSet::new(),
+            target_nonce: TargetNonce::default(),
+        }
+    }
+
+    fn assigned_nonce(tx: &DeferredTx) -> Nonce {
+        tx.target_tx.nonce().nonce()
+    }
+
+    #[test]
+    fn resolve_assigns_increasing_nonces() {
+        let mut tracker = DeferredTxTracker::new();
+        let key = NonceLookupKey::from_tx(&awaiting_nonce("alice.near", 0).target_tx);
+        tracker.push(awaiting_nonce("alice.near", 0), 5, Some(7));
+        tracker.push(awaiting_nonce("alice.near", 0), 5, Some(7));
+
+        let mut nonce = Some(10);
+        let resolved = tracker.resolve(&key, &mut nonce);
+
+        assert_eq!(resolved.iter().map(assigned_nonce).collect::<Vec<_>>(), vec![11, 12]);
+        assert_eq!(nonce, Some(12));
+        assert!(tracker.keys().is_empty());
+    }
+
+    #[test]
+    fn resolve_without_known_nonce_keeps_txs() {
+        let mut tracker = DeferredTxTracker::new();
+        let key = NonceLookupKey::from_tx(&awaiting_nonce("alice.near", 0).target_tx);
+        tracker.push(awaiting_nonce("alice.near", 0), 5, Some(7));
+
+        let mut nonce = None;
+        assert!(tracker.resolve(&key, &mut nonce).is_empty());
+        assert_eq!(tracker.keys(), vec![key]);
+    }
+
+    #[test]
+    fn prune_drops_after_ttl() {
+        let mut tracker = DeferredTxTracker::new();
+        tracker.push(awaiting_nonce("alice.near", 0), 5, Some(7));
+
+        tracker.prune(5 + DEFERRED_TX_TTL);
+        assert_eq!(tracker.keys().len(), 1);
+
+        tracker.prune(5 + DEFERRED_TX_TTL + 1);
+        assert!(tracker.keys().is_empty());
+    }
+
+    #[test]
+    fn push_resend_reassigns_nonce_and_resigns() {
+        let mut sent = awaiting_nonce("alice.near", 10);
+        *sent.target_tx.nonce_mut() = 10;
+        let lost = DeferredTx::new(sent, 5, Some(7)).into_ready();
+        let lost_hash = lost.target_tx.get_hash();
+        let key = NonceLookupKey::from_tx(&lost.target_tx.transaction);
+
+        let mut tracker = DeferredTxTracker::new();
+        tracker.push_resend(DeferredTx::from_mapped(&lost, 5, lost.source_height), 20);
+        assert_eq!(tracker.keys(), vec![key.clone()]);
+
+        // the resend stays alive relative to the requeue height, not the send height
+        tracker.prune(20 + DEFERRED_TX_TTL);
+        assert_eq!(tracker.keys().len(), 1);
+
+        let mut nonce = Some(12);
+        let resolved = tracker.resolve(&key, &mut nonce);
+        assert_eq!(resolved.iter().map(assigned_nonce).collect::<Vec<_>>(), vec![13]);
+        let resent = resolved.into_iter().next().unwrap().into_ready();
+        assert_eq!(resent.target_tx.transaction.nonce().nonce(), 13);
+        assert_eq!(resent.source_height, Some(7));
+        assert_ne!(resent.target_tx.get_hash(), lost_hash);
+        assert_eq!(resent.target_tx.transaction.actions(), lost.target_tx.transaction.actions());
+        assert!(resent.target_tx.signature.verify(
+            resent.target_tx.get_hash().as_ref(),
+            &resent.target_tx.transaction.public_key(),
+        ));
+    }
+}

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -35,9 +35,10 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use strum::IntoEnumIterator;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 mod chain_tracker;
 pub mod cli;
@@ -48,6 +49,7 @@ mod metrics;
 mod offline;
 mod online;
 pub mod secret;
+mod shutdown;
 
 pub use cli::MirrorCommand;
 use near_async::messaging::CanSendAsync;
@@ -446,6 +448,11 @@ struct MirrorConfig {
 
 const CREATE_ACCOUNT_DELTA: usize = 5;
 
+// On SIGTERM/SIGINT we stop sending and wait for already sent transactions to
+// appear on the target chain before exiting, so that a restarted mirror's
+// resume point doesn't skip past transactions that died in the mempool.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
 // TODO: separate out the code that uses the target chain clients, and
 // make it an option to send the transactions to some RPC node.
 // that way it would be possible to run this code and send transactions with an
@@ -622,6 +629,7 @@ struct MappedTx {
     source_signer_id: AccountId,
     source_receiver_id: AccountId,
     provenance: MappedTxProvenance,
+    target_secret_key: SecretKey,
     target_tx: SignedTransaction,
     nonce_updates: HashSet<NonceLookupKey>,
     sent_successfully: bool,
@@ -638,6 +646,7 @@ impl MappedTx {
             source_signer_id: mapping.source_signer_id,
             source_receiver_id: mapping.source_receiver_id,
             provenance: mapping.provenance,
+            target_secret_key: mapping.target_secret_key,
             target_tx,
             nonce_updates: mapping.nonce_updates,
             sent_successfully: false,
@@ -671,6 +680,7 @@ impl TargetChainTx {
                     source_signer_id: t.source_signer_id.clone(),
                     source_receiver_id: t.source_receiver_id.clone(),
                     provenance: t.provenance,
+                    target_secret_key: t.target_secret_key.clone(),
                     target_tx,
                     nonce_updates: t.nonce_updates.clone(),
                     sent_successfully: false,
@@ -1884,11 +1894,18 @@ impl<T: ChainAccess> TxMirror<T> {
         mut send_time: Pin<Box<tokio::time::Sleep>>,
         send_delay: Arc<Mutex<Duration>>,
         target_client: MultithreadRuntimeHandle<RpcHandlerActor>,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         let mut sent_source_height = None;
 
         loop {
             (&mut send_time).await;
+
+            if shutdown.is_cancelled() {
+                // stop sending and drop our end of blocks_sent, which tells
+                // queue_txs_loop that every batch we sent is now in the channel
+                return Ok(());
+            }
 
             let tx_batch = {
                 let tx_block_queue = tx_block_queue.lock();
@@ -1989,8 +2006,9 @@ impl<T: ChainAccess> TxMirror<T> {
 
         loop {
             let msg = target_stream.recv().await.unwrap();
+            let msg_height = msg.block.header.height;
             *target_head.write() = msg.block.header.hash;
-            *target_height.write() = msg.block.header.height;
+            *target_height.write() = msg_height;
             let target_block_info = {
                 let mut tracker = tracker.lock();
                 tracker.on_target_block(&tx_block_queue, db.as_ref(), msg)?
@@ -2006,6 +2024,35 @@ impl<T: ChainAccess> TxMirror<T> {
         }
     }
 
+    fn record_sent_batch(
+        &self,
+        tx_batch: TxBatch,
+        tracker: &Mutex<crate::chain_tracker::TxTracker>,
+        tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
+        target_height: &RwLock<BlockHeight>,
+        send_delay: &Mutex<Duration>,
+    ) -> anyhow::Result<()> {
+        // lock the tracker before removing the block from the queue so that
+        // we don't call on_target_block() in the other thread between removing the block
+        // and calling on_txs_sent(), because that could lead to a bug looking up transactions
+        // in TxTracker::get_tx()
+        let mut tracker = tracker.lock();
+        {
+            let mut tx_block_queue = tx_block_queue.lock();
+            let b = tx_block_queue.pop_front().unwrap();
+            assert!(b.source_height == tx_batch.source_height);
+        };
+        let target_height = *target_height.read();
+        let new_delay = tracker.on_txs_sent(
+            tx_block_queue,
+            &self.db,
+            crate::chain_tracker::SentBatch::MappedBlock(tx_batch),
+            target_height,
+        )?;
+        *send_delay.lock() = new_delay;
+        Ok(())
+    }
+
     async fn queue_txs_loop(
         &self,
         tracker: Arc<Mutex<crate::chain_tracker::TxTracker>>,
@@ -2019,37 +2066,33 @@ impl<T: ChainAccess> TxMirror<T> {
         target_head: Arc<RwLock<CryptoHash>>,
         mut source_hash: CryptoHash,
         have_stop_height: bool,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         let mut queue_txs_time = tokio::time::interval(Duration::from_millis(100));
 
         loop {
             tokio::select! {
+                _ = shutdown.cancelled() => {
+                    // the send loop exits on cancellation and drops its end of the
+                    // channel. record every batch it managed to send before waiting
+                    // on them, since the watermark already advanced past them.
+                    while let Some(tx_batch) = blocks_sent.recv().await {
+                        self.record_sent_batch(tx_batch, &tracker, &tx_block_queue, &target_height, &send_delay)?;
+                    }
+                    return Self::drain_sent_txs(&tracker).await;
+                }
                 // time to send a batch of transactions
                 _ = queue_txs_time.tick() => {
                     let target_head = *target_head.read();
                     self.queue_txs(&tracker, &tx_block_queue, &target_view_client, target_head, have_stop_height).await?;
                 }
                 tx_batch = blocks_sent.recv() => {
-                    let tx_batch = tx_batch.unwrap();
-                    source_hash = tx_batch.source_hash;
-                    // lock the tracker before removing the block from the queue so that
-                    // we don't call on_target_block() in the other thread between removing the block
-                    // and calling on_txs_sent(), because that could lead to a bug looking up transactions
-                    // in TxTracker::get_tx()
-                    let mut tracker = tracker.lock();
-                    {
-                        let mut tx_block_queue = tx_block_queue.lock();
-                        let b = tx_block_queue.pop_front().unwrap();
-                        assert!(b.source_height == tx_batch.source_height);
+                    let Some(tx_batch) = tx_batch else {
+                        // the send loop exited on cancellation
+                        return Self::drain_sent_txs(&tracker).await;
                     };
-                    let target_height = *target_height.read();
-                    let new_delay = tracker.on_txs_sent(
-                        &tx_block_queue,
-                        &self.db,
-                        crate::chain_tracker::SentBatch::MappedBlock(tx_batch),
-                        target_height,
-                    )?;
-                    *send_delay.lock() = new_delay;
+                    source_hash = tx_batch.source_hash;
+                    self.record_sent_batch(tx_batch, &tracker, &tx_block_queue, &target_height, &send_delay)?;
                 }
                 msg = accounts_to_unstake.recv() => {
                     let staked_accounts = msg.unwrap();
@@ -2071,6 +2114,28 @@ impl<T: ChainAccess> TxMirror<T> {
                     return Ok(());
                 }
             }
+        }
+    }
+
+    // Waits until every sent transaction has been observed in a target block, so
+    // a restarted mirror's resume point doesn't skip past txs that died in the
+    // mempool. The target indexer keeps running and clears sent_txs meanwhile.
+    async fn drain_sent_txs(
+        tracker: &Mutex<crate::chain_tracker::TxTracker>,
+    ) -> anyhow::Result<()> {
+        tracing::info!(target: "mirror", "stopped sending, waiting for already sent transactions to appear on the target chain");
+        let deadline = Instant::now() + DRAIN_TIMEOUT;
+        loop {
+            let sent_txs_remaining = tracker.lock().sent_txs_remaining();
+            if sent_txs_remaining == 0 {
+                tracing::info!(target: "mirror", "all sent transactions observed on the target chain, exiting after drain");
+                return Ok(());
+            }
+            if Instant::now() > deadline {
+                tracing::warn!(target: "mirror", sent_txs_remaining, "drain timed out with sent transactions never observed on the target chain");
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
     }
 
@@ -2137,9 +2202,20 @@ impl<T: ChainAccess> TxMirror<T> {
         stop_height: Option<BlockHeight>,
         target_home: PathBuf,
         actor_system: near_async::ActorSystem,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         let last_stored_height = get_last_source_height(&self.db)?;
         let last_height = last_stored_height.unwrap_or(self.target_genesis_height - 1);
+
+        // When resuming after having already sent everything up to --stop-height (e.g. a
+        // restart of a finished mirror over a finite source), there are no more blocks to
+        // send and we're done. Without this we'd bail below as if the source were broken.
+        if let Some(stop_height) = stop_height {
+            if last_height >= stop_height {
+                tracing::info!(target: "mirror", stop_height, last_height, "already sent all transactions up to --stop-height");
+                return Ok(());
+            }
+        }
 
         let next_heights =
             self.source_chain_access.init(last_height, CREATE_ACCOUNT_DELTA + 1).await?;
@@ -2282,6 +2358,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let tx_block_queue2 = tx_block_queue.clone();
         let rpc_handler2 = rpc_handler.clone();
         let db = self.db.clone();
+        let shutdown2 = shutdown.clone();
         let (send_txs_done_tx, send_txs_done_rx) =
             tokio::sync::oneshot::channel::<anyhow::Result<()>>();
         let send_txs_task = tokio::task::spawn(async move {
@@ -2292,6 +2369,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 send_time,
                 send_delay2,
                 rpc_handler2,
+                shutdown2,
             )
             .await;
             if let Err(err) = send_txs_done_tx.send(res) {
@@ -2302,7 +2380,7 @@ impl<T: ChainAccess> TxMirror<T> {
             res = self.queue_txs_loop(
                 tracker, tx_block_queue, rpc_handler, target_view_client,
                 blocks_sent_rx, unstake_rx, send_delay, target_height, target_head,
-                source_hash, stop_height.is_some(),
+                source_hash, stop_height.is_some(), shutdown,
             ) => {
                 res
             }
@@ -2334,6 +2412,7 @@ async fn run<P: AsRef<Path>>(
     stop_height: Option<BlockHeight>,
     online_source: bool,
     config_path: Option<P>,
+    shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
     let config: MirrorConfig = match config_path {
         Some(p) => {
@@ -2357,7 +2436,7 @@ async fn run<P: AsRef<Path>>(
             secret,
             config,
         )?
-        .run(Some(stop_height), target_home.as_ref().to_path_buf(), actor_system)
+        .run(Some(stop_height), target_home.as_ref().to_path_buf(), actor_system, shutdown)
         .await
     } else {
         TxMirror::new(
@@ -2367,7 +2446,7 @@ async fn run<P: AsRef<Path>>(
             secret,
             config,
         )?
-        .run(stop_height, target_home.as_ref().to_path_buf(), actor_system)
+        .run(stop_height, target_home.as_ref().to_path_buf(), actor_system, shutdown)
         .await
     }
 }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -42,6 +42,7 @@ use tokio_util::sync::CancellationToken;
 
 mod chain_tracker;
 pub mod cli;
+mod deferred_tx;
 pub mod genesis;
 pub mod key_mapping;
 mod key_util;
@@ -52,6 +53,7 @@ pub mod secret;
 mod shutdown;
 
 pub use cli::MirrorCommand;
+use deferred_tx::DeferredTx;
 use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::tokio::TokioRuntimeHandle;
@@ -628,6 +630,9 @@ impl TxAwaitingNonce {
 struct MappedTx {
     source_signer_id: AccountId,
     source_receiver_id: AccountId,
+    // set only for resent deferred txs; regular txs carry their source height in
+    // the TxRef they are sent with
+    source_height: Option<BlockHeight>,
     provenance: MappedTxProvenance,
     target_secret_key: SecretKey,
     target_tx: SignedTransaction,
@@ -645,6 +650,7 @@ impl MappedTx {
         Self {
             source_signer_id: mapping.source_signer_id,
             source_receiver_id: mapping.source_receiver_id,
+            source_height: None,
             provenance: mapping.provenance,
             target_secret_key: mapping.target_secret_key,
             target_tx,
@@ -679,6 +685,7 @@ impl TargetChainTx {
                 *self = Self::Ready(MappedTx {
                     source_signer_id: t.source_signer_id.clone(),
                     source_receiver_id: t.source_receiver_id.clone(),
+                    source_height: None,
                     provenance: t.provenance,
                     target_secret_key: t.target_secret_key.clone(),
                     target_tx,
@@ -1880,11 +1887,42 @@ impl<T: ChainAccess> TxMirror<T> {
             tracker.on_txs_sent(
                 tx_block_queue,
                 &self.db,
-                crate::chain_tracker::SentBatch::ExtraTxs(txs),
+                crate::chain_tracker::SentBatch::UnstakeTxs(txs),
                 target_height,
             )?;
         }
         Ok(())
+    }
+
+    // Query the target chain for all deferred tx keys and resolve any whose
+    // access key has appeared. Returns the resolved txs ready to resend.
+    async fn poll_deferred_txs(
+        tracker: &Mutex<crate::chain_tracker::TxTracker>,
+        view_client: &MultithreadRuntimeHandle<ViewClientActor>,
+    ) -> anyhow::Result<Vec<DeferredTx>> {
+        let deferred_keys = tracker.lock().deferred_txs.keys();
+        if deferred_keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut resend = Vec::new();
+        let mut resolved = 0;
+        for nonce_key in &deferred_keys {
+            let mut nonce = crate::fetch_nonce(view_client, nonce_key).await?;
+            if nonce.is_none() {
+                continue;
+            }
+            let txs = tracker.lock().resolve_deferred_txs(nonce_key, &mut nonce);
+            if txs.is_empty() {
+                // raced with try_set_nonces() resolving this key first
+                continue;
+            }
+            tracing::info!(target: "mirror", ?nonce_key, count = txs.len(), "resolved deferred txs");
+            resend.extend(txs);
+            resolved += 1;
+        }
+        let unresolved = deferred_keys.len() - resolved;
+        tracing::info!(target: "mirror", resolved, unresolved, resend_count = resend.len(), "deferred tx poll complete");
+        Ok(resend)
     }
 
     async fn send_txs_loop(
@@ -1967,6 +2005,7 @@ impl<T: ChainAccess> TxMirror<T> {
             MultithreadRuntimeHandle<RpcHandlerActor>,
         )>,
         accounts_to_unstake: mpsc::Sender<HashMap<(AccountId, PublicKey), AccountId>>,
+        deferred_resend: mpsc::Sender<Vec<DeferredTx>>,
         target_height: Arc<RwLock<BlockHeight>>,
         target_head: Arc<RwLock<CryptoHash>>,
         actor_system: near_async::ActorSystem,
@@ -2016,11 +2055,28 @@ impl<T: ChainAccess> TxMirror<T> {
             if !target_block_info.staked_accounts.is_empty() {
                 accounts_to_unstake.send(target_block_info.staked_accounts).await?;
             }
+            let mut resend =
+                if msg_height % crate::deferred_tx::DEFERRED_TX_POLL_INTERVAL_BLOCKS == 0 {
+                    Self::poll_deferred_txs(&tracker, &view_client).await?
+                } else {
+                    Vec::new()
+                };
             for access_key_update in target_block_info.access_key_updates {
                 let nonce = crate::fetch_nonce(&view_client, &access_key_update.nonce_key).await?;
                 let mut tracker = tracker.lock();
-                tracker.try_set_nonces(&tx_block_queue, db.as_ref(), access_key_update, nonce)?;
+                resend.extend(tracker.try_set_nonces(
+                    &tx_block_queue,
+                    db.as_ref(),
+                    access_key_update,
+                    nonce,
+                )?);
             }
+            if !resend.is_empty() {
+                deferred_resend.send(resend).await?;
+            }
+            // Prune after this block's access-key updates have been resolved, so a key that
+            // appears in this block resolves its deferred txs before we'd drop them.
+            tracker.lock().deferred_txs.prune(msg_height);
         }
     }
 
@@ -2061,6 +2117,7 @@ impl<T: ChainAccess> TxMirror<T> {
         target_view_client: MultithreadRuntimeHandle<ViewClientActor>,
         mut blocks_sent: mpsc::Receiver<TxBatch>,
         mut accounts_to_unstake: mpsc::Receiver<HashMap<(AccountId, PublicKey), AccountId>>,
+        mut deferred_resend: mpsc::Receiver<Vec<DeferredTx>>,
         send_delay: Arc<Mutex<Duration>>,
         target_height: Arc<RwLock<BlockHeight>>,
         target_head: Arc<RwLock<CryptoHash>>,
@@ -2104,6 +2161,27 @@ impl<T: ChainAccess> TxMirror<T> {
                         &target_head, target_height
                     ).await?;
                 }
+                msg = deferred_resend.recv() => {
+                    // resends carry lower nonces than queued txs of the same key, and
+                    // this arm has to win the race with send_txs_loop's next batch (it
+                    // does in practice: the resend lands here within one 100ms select
+                    // iteration while batches go out every block interval). A resend
+                    // that loses the race is rejected at submission as a stale nonce.
+                    let deferred = msg.unwrap();
+                    let mut txs = deferred
+                        .into_iter()
+                        .map(|tx| TargetChainTx::Ready(tx.into_ready()))
+                        .collect::<Vec<_>>();
+                    Self::send_transactions(&target_client, txs.iter_mut()).await?;
+                    let target_height = *target_height.read();
+                    let mut tracker = tracker.lock();
+                    tracker.on_txs_sent(
+                        &tx_block_queue,
+                        &self.db,
+                        crate::chain_tracker::SentBatch::DeferredResendTxs(txs),
+                        target_height,
+                    )?;
+                }
             };
             // TODO: this locking of the mutex before continuing the loop is kind of unnecessary since we should be able to tell
             // exactly when we've done the thing that makes finished() return true, usually after a call to on_target_block()
@@ -2120,19 +2198,23 @@ impl<T: ChainAccess> TxMirror<T> {
     // Waits until every sent transaction has been observed in a target block, so
     // a restarted mirror's resume point doesn't skip past txs that died in the
     // mempool. The target indexer keeps running and clears sent_txs meanwhile.
+    // Deferred txs whose keys never appeared are dropped, with their count logged.
     async fn drain_sent_txs(
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
     ) -> anyhow::Result<()> {
         tracing::info!(target: "mirror", "stopped sending, waiting for already sent transactions to appear on the target chain");
         let deadline = Instant::now() + DRAIN_TIMEOUT;
         loop {
-            let sent_txs_remaining = tracker.lock().sent_txs_remaining();
+            let (sent_txs_remaining, deferred_txs_dropped) = {
+                let tracker = tracker.lock();
+                (tracker.sent_txs_remaining(), tracker.deferred_txs.len())
+            };
             if sent_txs_remaining == 0 {
-                tracing::info!(target: "mirror", "all sent transactions observed on the target chain, exiting after drain");
+                tracing::info!(target: "mirror", deferred_txs_dropped, "all sent transactions observed on the target chain, exiting after drain");
                 return Ok(());
             }
             if Instant::now() > deadline {
-                tracing::warn!(target: "mirror", sent_txs_remaining, "drain timed out with sent transactions never observed on the target chain");
+                tracing::warn!(target: "mirror", sent_txs_remaining, deferred_txs_dropped, "drain timed out with sent transactions never observed on the target chain");
                 return Ok(());
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -2252,6 +2334,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let (target_indexer_done_tx, target_indexer_done_rx) =
             tokio::sync::oneshot::channel::<anyhow::Result<()>>();
         let (unstake_tx, unstake_rx) = mpsc::channel(10);
+        let (deferred_resend_tx, deferred_resend_rx) = mpsc::channel(10);
 
         let db = self.db.clone();
         let target_height2 = target_height.clone();
@@ -2273,6 +2356,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 db,
                 clients_tx,
                 unstake_tx,
+                deferred_resend_tx,
                 target_height2,
                 target_head2,
                 actor_system2,
@@ -2379,7 +2463,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let result = tokio::select! {
             res = self.queue_txs_loop(
                 tracker, tx_block_queue, rpc_handler, target_view_client,
-                blocks_sent_rx, unstake_rx, send_delay, target_height, target_head,
+                blocks_sent_rx, unstake_rx, deferred_resend_rx, send_delay, target_height, target_head,
                 source_hash, stop_height.is_some(), shutdown,
             ) => {
                 res

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -13,7 +13,7 @@ use near_crypto::{PublicKey, SecretKey};
 use near_indexer::{Indexer, StreamerMessage};
 use near_primitives::action::{TransferToGasKeyAction, WithdrawFromGasKeyAction};
 use near_primitives::hash::CryptoHash;
-use near_primitives::receipt::{Receipt, ReceiptEnum};
+use near_primitives::receipt::{Receipt, VersionedReceiptEnum};
 use near_primitives::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction, NonceMode,
     SignedTransaction, StakeAction, Transaction, TransactionNonce, TransactionV1,
@@ -1355,7 +1355,9 @@ impl<T: ChainAccess> TxMirror<T> {
                 Err(ChainError::Other(e)) => return Err(e),
             };
 
-            if let ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) = receipt.receipt() {
+            if let VersionedReceiptEnum::Action(r) | VersionedReceiptEnum::PromiseYield(r) =
+                receipt.versioned_receipt()
+            {
                 if (provenance.is_create_account()
                     && receipt.predecessor_id() == receipt.receiver_id())
                     || (!provenance.is_create_account()
@@ -1367,7 +1369,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 // implicit accounts, etc...
                 let mut key_added = false;
                 let mut account_created = false;
-                for a in &r.actions {
+                for a in r.actions() {
                     match a {
                         Action::AddKey(_) => key_added = true,
                         Action::CreateAccount(_) => account_created = true,
@@ -1386,7 +1388,7 @@ impl<T: ChainAccess> TxMirror<T> {
                         tracing::warn!(
                             target: "mirror",
                             receipt_id = %receipt.receipt_id(),
-                            actions = ?r.actions,
+                            actions = ?r.actions(),
                             "predecessor and receiver are the same but there's a create account in the actions",
                         );
                     }
@@ -1417,7 +1419,7 @@ impl<T: ChainAccess> TxMirror<T> {
                     txs,
                     receipt.predecessor_id().clone(),
                     receipt.receiver_id().clone(),
-                    &r.actions,
+                    r.actions(),
                     ref_hash,
                     provenance,
                     Some(source_height),
@@ -1484,8 +1486,10 @@ impl<T: ChainAccess> TxMirror<T> {
         target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         txs: &mut Vec<TargetChainTx>,
     ) -> anyhow::Result<()> {
-        if let ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) = receipt.receipt() {
-            if r.actions.iter().any(|a| matches!(a, Action::FunctionCall(_))) {
+        if let VersionedReceiptEnum::Action(r) | VersionedReceiptEnum::PromiseYield(r) =
+            receipt.versioned_receipt()
+        {
+            if r.actions().iter().any(|a| matches!(a, Action::FunctionCall(_))) {
                 self.add_function_call_keys(
                     tracker,
                     tx_block_queue,

--- a/tools/mirror/src/metrics.rs
+++ b/tools/mirror/src/metrics.rs
@@ -19,3 +19,12 @@ pub static TRANSACTIONS_INCLUDED: LazyLock<IntCounter> = LazyLock::new(|| {
     )
     .unwrap()
 });
+
+pub static TRANSACTIONS_REQUEUED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_mirror_transactions_requeued",
+        "Total number of sent transactions that were lost on the target chain and requeued for resend",
+        &["reason"],
+    )
+    .unwrap()
+});

--- a/tools/mirror/src/shutdown.rs
+++ b/tools/mirror/src/shutdown.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio_util::sync::CancellationToken;
+
+// Owns signal handling for the whole `mirror run` lifetime, on its own runtime
+// so it works both while run() is alive and during the rocksdb close wait after
+// run()'s runtime is gone. The first SIGTERM/SIGINT requests a graceful drain
+// via shutdown_token(); a second signal, or any signal after mark_run_finished(),
+// exits immediately.
+pub(crate) struct SignalHandler {
+    _runtime: tokio::runtime::Runtime,
+    shutdown: CancellationToken,
+    run_finished: Arc<AtomicBool>,
+}
+
+impl SignalHandler {
+    pub(crate) fn install() -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let shutdown = CancellationToken::new();
+        let run_finished = Arc::new(AtomicBool::new(false));
+        #[cfg(unix)]
+        runtime.spawn(handle_signals(shutdown.clone(), run_finished.clone()));
+        Self { _runtime: runtime, shutdown, run_finished }
+    }
+
+    pub(crate) fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    pub(crate) fn mark_run_finished(&self) {
+        self.run_finished.store(true, Ordering::Relaxed);
+    }
+}
+
+#[cfg(unix)]
+async fn handle_signals(shutdown: CancellationToken, run_finished: Arc<AtomicBool>) {
+    use tokio::signal::unix::{SignalKind, signal};
+    let (Ok(mut sigterm), Ok(mut sigint)) =
+        (signal(SignalKind::terminate()), signal(SignalKind::interrupt()))
+    else {
+        tracing::warn!(target: "mirror", "could not install signal handlers, will exit without draining sent transactions");
+        return;
+    };
+    tokio::select! {
+        _ = sigterm.recv() => {}
+        _ = sigint.recv() => {}
+    }
+    if run_finished.load(Ordering::Relaxed) {
+        tracing::warn!(target: "mirror", "got termination signal during shutdown, exiting immediately");
+        std::process::exit(1);
+    }
+    tracing::info!(target: "mirror", "got termination signal, draining sent transactions before exiting");
+    shutdown.cancel();
+    tokio::select! {
+        _ = sigterm.recv() => {}
+        _ = sigint.recv() => {}
+    }
+    tracing::warn!(target: "mirror", "got second termination signal, exiting immediately");
+    std::process::exit(1);
+}


### PR DESCRIPTION
Mirror txs that cannot land on the target chain are deferred in memory and resent, instead of being silently dropped.

- Deferred tx tracking (`DeferredTxTracker`): txs whose signing key is not yet on the target chain are held in memory, resolved when the key appears (pushed access-key updates or a periodic poll), re-signed with fresh nonces in original order, and resent. Fixes traffic loss on mirror resume and for newly created accounts.
- Observation-based resend: a sent tx whose nonce was passed by a later included tx of the same key can never land; it is requeued through the same deferral path and resent (new metric `near_mirror_transactions_requeued`).
- Resent txs carry their source height so `finished()` still waits for them at the end of a `--stop-height` run.

Known limitations: in-memory deferred txs that cannot be resolved by the end of the shutdown drain are dropped with their count logged; a resend rejected at submission (rare nonce race, counted by `TRANSACTIONS_SENT{invalid}`) is not retried; a tx lost in the mempool whose key sees no follow-up traffic stays lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)