### PR TITLE
fix(mirror): handle ActionV2 receipts in extra key extraction

### DIFF
--- a/pytest/tools/mirror/offline_test.py
+++ b/pytest/tools/mirror/offline_test.py
@@ -181,14 +181,18 @@ class ContractTest(MirrorTestCase):
         assert nonce is not None, \
             f'contract extra key {mapped_pk} not found on target'
 
-        # Sub-account created via contract
+        # Sub-account created via contract. The mirror pre-creates it with the
+        # mapped key via an extra CreateAccount tx, and the contract call's own
+        # CreateAccount receipt then fails on target, so the unmapped key the
+        # contract passed never lands there.
         res = node.get_account('test0.test0', do_assert=False)
         assert 'error' not in res, 'account test0.test0 not found on target'
+        mapped_sub_pk = mirror_utils.map_key_no_secret(self.sub_key.key.pk)
         nonce = node.get_nonce_for_pk('test0.test0',
-                                      self.sub_key.key.pk,
+                                      mapped_sub_pk,
                                       finality='final')
         assert nonce is not None, \
-            f'sub key {self.sub_key.key.pk} not found on test0.test0'
+            f'mapped sub key {mapped_sub_pk} not found on test0.test0'
 
         assert mirror_utils.contract_deployed(node, 'test0'), \
             'contract not deployed on target test0'

--- a/pytest/tools/mirror/offline_test.py
+++ b/pytest/tools/mirror/offline_test.py
@@ -174,6 +174,16 @@ class ContractTest(MirrorTestCase):
         assert nonce is not None, \
             f'contract key {self.contract_key.key.pk} not found on target'
 
+        # the mirror must also synthesize the mapped version of contract_key
+        # from the promise-created AddKey receipt; both coexist on test0
+        mapped_contract_pk = mirror_utils.map_key_no_secret(
+            self.contract_key.key.pk)
+        nonce = node.get_nonce_for_pk('test0',
+                                      mapped_contract_pk,
+                                      finality='final')
+        assert nonce is not None, \
+            f'mapped contract key {mapped_contract_pk} not found on target'
+
         # contract_extra_key is a direct AddKey action (mapped)
         mapped_pk = mirror_utils.map_key_no_secret(
             self.contract_extra_key.key.pk)

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -13,7 +13,7 @@ use near_crypto::{PublicKey, SecretKey};
 use near_indexer::{Indexer, StreamerMessage};
 use near_primitives::action::{TransferToGasKeyAction, WithdrawFromGasKeyAction};
 use near_primitives::hash::CryptoHash;
-use near_primitives::receipt::{Receipt, ReceiptEnum};
+use near_primitives::receipt::{Receipt, VersionedReceiptEnum};
 use near_primitives::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction, NonceMode,
     SignedTransaction, StakeAction, Transaction, TransactionNonce, TransactionV1,
@@ -1355,7 +1355,9 @@ impl<T: ChainAccess> TxMirror<T> {
                 Err(ChainError::Other(e)) => return Err(e),
             };
 
-            if let ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) = receipt.receipt() {
+            if let VersionedReceiptEnum::Action(r) | VersionedReceiptEnum::PromiseYield(r) =
+                receipt.versioned_receipt()
+            {
                 if (provenance.is_create_account()
                     && receipt.predecessor_id() == receipt.receiver_id())
                     || (!provenance.is_create_account()
@@ -1367,7 +1369,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 // implicit accounts, etc...
                 let mut key_added = false;
                 let mut account_created = false;
-                for a in &r.actions {
+                for a in r.actions() {
                     match a {
                         Action::AddKey(_) => key_added = true,
                         Action::CreateAccount(_) => account_created = true,
@@ -1386,7 +1388,7 @@ impl<T: ChainAccess> TxMirror<T> {
                         tracing::warn!(
                             target: "mirror",
                             receipt_id = %receipt.receipt_id(),
-                            actions = ?r.actions,
+                            actions = ?r.actions(),
                             "predecessor and receiver are the same but there's a create account in the actions",
                         );
                     }
@@ -1417,7 +1419,7 @@ impl<T: ChainAccess> TxMirror<T> {
                     txs,
                     receipt.predecessor_id().clone(),
                     receipt.receiver_id().clone(),
-                    &r.actions,
+                    r.actions(),
                     ref_hash,
                     provenance,
                     Some(source_height),
@@ -1484,8 +1486,10 @@ impl<T: ChainAccess> TxMirror<T> {
         target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         txs: &mut Vec<TargetChainTx>,
     ) -> anyhow::Result<()> {
-        if let ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) = receipt.receipt() {
-            if r.actions.iter().any(|a| matches!(a, Action::FunctionCall(_))) {
+        if let VersionedReceiptEnum::Action(r) | VersionedReceiptEnum::PromiseYield(r) =
+            receipt.versioned_receipt()
+        {
+            if r.actions().iter().any(|a| matches!(a, Action::FunctionCall(_))) {
                 self.add_function_call_keys(
                     tracker,
                     tx_block_queue,


### PR DESCRIPTION
`ReceiptEnum` grew `ActionV2`/`PromiseYieldV2` variants (#14709), but the mirror's extra-key machinery (`add_function_call_keys` and the function-call receipt scan) still matched only the V1 variants. Promise-created receipts silently fell through the `if let`, so any access key added by a contract call (factory pattern, `add_key` promises) was never synthesized on the target chain, leaving such accounts permanently unreplayable. `genesis.rs` had already been fixed for V2; these two sites were missed, and `ReceiptEnumView` normalizes versions so the chain tracker side was unaffected — which is why this never produced an error anywhere.

The fix matches on `receipt.versioned_receipt()` (`VersionedReceiptEnum::Action | PromiseYield`) and uses `r.actions()`.

The offline test now asserts the synthesized mapped keys exist on the target: the mapped contract_key on test0, and the mapped sub key on the contract-created sub-account (the mirror pre-creates it with the mapped key, and the contract call's own `CreateAccount` receipt then fails on the target since the account already exists, so the unmapped key never lands; the old unmapped-key expectation was written against the silently-broken mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)