### PR TITLE
feat(mirror): drain sent txs on shutdown, stay killable while exiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,6 +4901,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/tools/mirror/Cargo.toml
+++ b/tools/mirror/Cargo.toml
@@ -29,7 +29,8 @@ serde_json.workspace = true
 sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["signal"] }
+tokio-util.workspace = true
 tracing.workspace = true
 
 nearcore.workspace = true

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -224,6 +224,11 @@ impl TxTracker {
         }
     }
 
+    // Transactions sent to the target chain but not yet seen in a target block.
+    pub(crate) fn sent_txs_remaining(&self) -> usize {
+        self.sent_txs.len()
+    }
+
     // Makes sure that there's something written in the DB for this access key.
     // This function is called before calling initialize_target_nonce(), which sets
     // in-memory data associated with this nonce. It would make sense to do this part at the same time,

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -5,7 +5,7 @@ use crate::{
 use anyhow::Context;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_client::ViewClientActor;
-use near_crypto::{PublicKey, SecretKey};
+use near_crypto::PublicKey;
 use near_indexer::StreamerMessage;
 use near_indexer_primitives::{IndexerExecutionOutcomeWithReceipt, IndexerTransactionWithOutcome};
 use near_primitives::hash::CryptoHash;
@@ -356,7 +356,6 @@ impl TxTracker {
         target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         db: &DB,
         nonce_key: &NonceLookupKey,
-        secret_key: &SecretKey,
     ) -> anyhow::Result<TargetNonce> {
         Self::store_target_nonce(target_view_client, db, nonce_key).await?;
         let mut me = lock.lock();
@@ -377,7 +376,7 @@ impl TxTracker {
                 if first_nonce.is_none() {
                     first_nonce = Some(tx.target_nonce());
                 }
-                tx.inc_target_nonce(secret_key)
+                tx.inc_target_nonce()
             }
         }
         match first_nonce {

--- a/tools/mirror/src/cli.rs
+++ b/tools/mirror/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::shutdown::SignalHandler;
 use anyhow::Context;
 use near_primitives::types::BlockHeight;
 use near_primitives::views::AccessKeyPermissionView;
@@ -71,6 +72,7 @@ impl RunCmd {
             None
         };
 
+        let signal_handler = SignalHandler::install();
         let result = run_async(crate::run(
             self.source_home,
             self.target_home,
@@ -79,10 +81,13 @@ impl RunCmd {
             self.stop_height,
             self.online_source,
             self.config_path,
+            signal_handler.shutdown_token(),
         ));
+        signal_handler.mark_run_finished();
         // run() aborts spawned tasks, awaits them, and calls actor_system.stop(). By the time we
         // get here the tokio runtime is dropped and all Arc<DB> refs should be gone. Wait for RocksDB
-        // background threads to finish flushing.
+        // background threads to finish flushing; signal_handler makes sure the
+        // process still responds to SIGTERM if this ever hangs.
         near_store::db::RocksDB::block_until_all_instances_are_dropped();
         result
     }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1898,12 +1898,12 @@ impl<T: ChainAccess> TxMirror<T> {
         let mut sent_source_height = None;
 
         loop {
-            (&mut send_time).await;
-
-            if shutdown.is_cancelled() {
+            tokio::select! {
+                biased;
                 // stop sending and drop our end of blocks_sent, which tells
                 // queue_txs_loop that every batch we sent is now in the channel
-                return Ok(());
+                _ = shutdown.cancelled() => return Ok(()),
+                _ = &mut send_time => {}
             }
 
             let tx_batch = {
@@ -2005,9 +2005,8 @@ impl<T: ChainAccess> TxMirror<T> {
 
         loop {
             let msg = target_stream.recv().await.unwrap();
-            let msg_height = msg.block.header.height;
             *target_head.write() = msg.block.header.hash;
-            *target_height.write() = msg_height;
+            *target_height.write() = msg.block.header.height;
             let target_block_info = {
                 let mut tracker = tracker.lock();
                 tracker.on_target_block(&tx_block_queue, db.as_ref(), msg)?
@@ -2078,7 +2077,7 @@ impl<T: ChainAccess> TxMirror<T> {
                     while let Some(tx_batch) = blocks_sent.recv().await {
                         self.record_sent_batch(tx_batch, &tracker, &tx_block_queue, &target_height, &send_delay)?;
                     }
-                    return Self::drain_sent_txs(&tracker).await;
+                    break;
                 }
                 // time to send a batch of transactions
                 _ = queue_txs_time.tick() => {
@@ -2087,8 +2086,10 @@ impl<T: ChainAccess> TxMirror<T> {
                 }
                 tx_batch = blocks_sent.recv() => {
                     let Some(tx_batch) = tx_batch else {
-                        // the send loop exited on cancellation
-                        return Self::drain_sent_txs(&tracker).await;
+                        if !shutdown.is_cancelled() {
+                            anyhow::bail!("send tx loop exited unexpectedly");
+                        }
+                        break;
                     };
                     source_hash = tx_batch.source_hash;
                     self.record_sent_batch(tx_batch, &tracker, &tx_block_queue, &target_height, &send_delay)?;
@@ -2114,16 +2115,21 @@ impl<T: ChainAccess> TxMirror<T> {
                 }
             }
         }
+        Self::drain_sent_txs(&tracker, &mut accounts_to_unstake).await
     }
 
     // waits until the still-running target indexer observes every sent tx in a
     // target block, since a restart would resume past any tx not yet included
     async fn drain_sent_txs(
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
+        accounts_to_unstake: &mut mpsc::Receiver<HashMap<(AccountId, PublicKey), AccountId>>,
     ) -> anyhow::Result<()> {
         tracing::info!(target: "mirror", "stopped sending, waiting for already sent transactions to appear on the target chain");
         let deadline = Instant::now() + DRAIN_TIMEOUT;
         loop {
+            // discard unstake events so the indexer never blocks on a full
+            // channel, which would stop it from observing the sent txs
+            while accounts_to_unstake.try_recv().is_ok() {}
             let sent_txs_remaining = tracker.lock().sent_txs_remaining();
             if sent_txs_remaining == 0 {
                 tracing::info!(target: "mirror", "all sent transactions observed on the target chain, exiting after drain");
@@ -2211,6 +2217,9 @@ impl<T: ChainAccess> TxMirror<T> {
         if let Some(stop_height) = stop_height {
             if last_height >= stop_height {
                 tracing::info!(target: "mirror", stop_height, last_height, "already sent all transactions up to --stop-height");
+                // in online mode the source node is already running, and its
+                // db handles keep the process alive unless the actors stop
+                actor_system.stop();
                 return Ok(());
             }
         }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -2117,7 +2117,7 @@ impl<T: ChainAccess> TxMirror<T> {
     }
 
     // waits until the still-running target indexer observes every sent tx in a
-    // target block, so txs that died in the mempool aren't lost across a restart
+    // target block, since a restart would resume past any tx not yet included
     async fn drain_sent_txs(
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
     ) -> anyhow::Result<()> {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use strum::IntoEnumIterator;
 use tokio::sync::mpsc;
+use tokio::task::JoinError;
 use tokio_util::sync::CancellationToken;
 
 mod chain_tracker;
@@ -2384,13 +2385,25 @@ impl<T: ChainAccess> TxMirror<T> {
         let _ = index_target_task.await;
         let send_txs_result = send_txs_task.await;
         actor_system.stop();
-        // queue_txs_loop only sees the send loop exit as a closed channel; the
-        // underlying error is in the join result
-        if let Ok(Err(err)) = send_txs_result {
+        if let Some(err) = Self::send_txs_loop_error(send_txs_result) {
             tracing::error!(target: "mirror", ?err, "transaction sending thread exited");
             return Err(err.context("transaction sending thread failure"));
         }
         result
+    }
+
+    // queue_txs_loop only sees the send loop exit as a closed channel; the
+    // underlying error or panic is in the join result
+    fn send_txs_loop_error(
+        join_result: Result<anyhow::Result<()>, JoinError>,
+    ) -> Option<anyhow::Error> {
+        match join_result {
+            Ok(Ok(())) => None,
+            Ok(Err(err)) => Some(err),
+            // cancelled means our own abort() above, not a failure
+            Err(join_error) if join_error.is_cancelled() => None,
+            Err(join_error) => Some(anyhow::anyhow!(join_error)),
+        }
     }
 }
 

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -2209,19 +2209,6 @@ impl<T: ChainAccess> TxMirror<T> {
         let last_stored_height = get_last_source_height(&self.db)?;
         let last_height = last_stored_height.unwrap_or(self.target_genesis_height - 1);
 
-        // When resuming after having already sent everything up to --stop-height (e.g. a
-        // restart of a finished mirror over a finite source), there are no more blocks to
-        // send and we're done. Without this we'd bail below as if the source were broken.
-        if let Some(stop_height) = stop_height {
-            if last_height >= stop_height {
-                tracing::info!(target: "mirror", stop_height, last_height, "already sent all transactions up to --stop-height");
-                // in online mode the source node is already running, and its
-                // db handles keep the process alive unless the actors stop
-                actor_system.stop();
-                return Ok(());
-            }
-        }
-
         let next_heights =
             self.source_chain_access.init(last_height, CREATE_ACCOUNT_DELTA + 1).await?;
 

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -35,9 +35,10 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use strum::IntoEnumIterator;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 mod chain_tracker;
 pub mod cli;
@@ -48,6 +49,7 @@ mod metrics;
 mod offline;
 mod online;
 pub mod secret;
+mod shutdown;
 
 pub use cli::MirrorCommand;
 use near_async::messaging::CanSendAsync;
@@ -446,6 +448,11 @@ struct MirrorConfig {
 
 const CREATE_ACCOUNT_DELTA: usize = 5;
 
+// On SIGTERM/SIGINT we stop sending and wait for already sent transactions to
+// appear on the target chain before exiting, so that a restarted mirror's
+// resume point doesn't skip past transactions that died in the mempool.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
 // TODO: separate out the code that uses the target chain clients, and
 // make it an option to send the transactions to some RPC node.
 // that way it would be possible to run this code and send transactions with an
@@ -622,6 +629,7 @@ struct MappedTx {
     source_signer_id: AccountId,
     source_receiver_id: AccountId,
     provenance: MappedTxProvenance,
+    target_secret_key: SecretKey,
     target_tx: SignedTransaction,
     nonce_updates: HashSet<NonceLookupKey>,
     sent_successfully: bool,
@@ -638,6 +646,7 @@ impl MappedTx {
             source_signer_id: mapping.source_signer_id,
             source_receiver_id: mapping.source_receiver_id,
             provenance: mapping.provenance,
+            target_secret_key: mapping.target_secret_key,
             target_tx,
             nonce_updates: mapping.nonce_updates,
             sent_successfully: false,
@@ -671,6 +680,7 @@ impl TargetChainTx {
                     source_signer_id: t.source_signer_id.clone(),
                     source_receiver_id: t.source_receiver_id.clone(),
                     provenance: t.provenance,
+                    target_secret_key: t.target_secret_key.clone(),
                     target_tx,
                     nonce_updates: t.nonce_updates.clone(),
                     sent_successfully: false,
@@ -1884,11 +1894,18 @@ impl<T: ChainAccess> TxMirror<T> {
         mut send_time: Pin<Box<tokio::time::Sleep>>,
         send_delay: Arc<Mutex<Duration>>,
         target_client: MultithreadRuntimeHandle<RpcHandlerActor>,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         let mut sent_source_height = None;
 
         loop {
             (&mut send_time).await;
+
+            if shutdown.is_cancelled() {
+                // stop sending and drop our end of blocks_sent, which tells
+                // queue_txs_loop that every batch we sent is now in the channel
+                return Ok(());
+            }
 
             let tx_batch = {
                 let tx_block_queue = tx_block_queue.lock();
@@ -1989,8 +2006,9 @@ impl<T: ChainAccess> TxMirror<T> {
 
         loop {
             let msg = target_stream.recv().await.unwrap();
+            let msg_height = msg.block.header.height;
             *target_head.write() = msg.block.header.hash;
-            *target_height.write() = msg.block.header.height;
+            *target_height.write() = msg_height;
             let target_block_info = {
                 let mut tracker = tracker.lock();
                 tracker.on_target_block(&tx_block_queue, db.as_ref(), msg)?
@@ -2006,6 +2024,35 @@ impl<T: ChainAccess> TxMirror<T> {
         }
     }
 
+    fn record_sent_batch(
+        &self,
+        tx_batch: TxBatch,
+        tracker: &Mutex<crate::chain_tracker::TxTracker>,
+        tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
+        target_height: &RwLock<BlockHeight>,
+        send_delay: &Mutex<Duration>,
+    ) -> anyhow::Result<()> {
+        // lock the tracker before removing the block from the queue so that
+        // we don't call on_target_block() in the other thread between removing the block
+        // and calling on_txs_sent(), because that could lead to a bug looking up transactions
+        // in TxTracker::get_tx()
+        let mut tracker = tracker.lock();
+        {
+            let mut tx_block_queue = tx_block_queue.lock();
+            let b = tx_block_queue.pop_front().unwrap();
+            assert!(b.source_height == tx_batch.source_height);
+        };
+        let target_height = *target_height.read();
+        let new_delay = tracker.on_txs_sent(
+            tx_block_queue,
+            &self.db,
+            crate::chain_tracker::SentBatch::MappedBlock(tx_batch),
+            target_height,
+        )?;
+        *send_delay.lock() = new_delay;
+        Ok(())
+    }
+
     async fn queue_txs_loop(
         &self,
         tracker: Arc<Mutex<crate::chain_tracker::TxTracker>>,
@@ -2019,37 +2066,33 @@ impl<T: ChainAccess> TxMirror<T> {
         target_head: Arc<RwLock<CryptoHash>>,
         mut source_hash: CryptoHash,
         have_stop_height: bool,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         let mut queue_txs_time = tokio::time::interval(Duration::from_millis(100));
 
         loop {
             tokio::select! {
+                _ = shutdown.cancelled() => {
+                    // the send loop exits on cancellation and drops its end of the
+                    // channel. record every batch it managed to send before waiting
+                    // on them, since the watermark already advanced past them.
+                    while let Some(tx_batch) = blocks_sent.recv().await {
+                        self.record_sent_batch(tx_batch, &tracker, &tx_block_queue, &target_height, &send_delay)?;
+                    }
+                    return Self::drain_sent_txs(&tracker).await;
+                }
                 // time to send a batch of transactions
                 _ = queue_txs_time.tick() => {
                     let target_head = *target_head.read();
                     self.queue_txs(&tracker, &tx_block_queue, &target_view_client, target_head, have_stop_height).await?;
                 }
                 tx_batch = blocks_sent.recv() => {
-                    let tx_batch = tx_batch.unwrap();
-                    source_hash = tx_batch.source_hash;
-                    // lock the tracker before removing the block from the queue so that
-                    // we don't call on_target_block() in the other thread between removing the block
-                    // and calling on_txs_sent(), because that could lead to a bug looking up transactions
-                    // in TxTracker::get_tx()
-                    let mut tracker = tracker.lock();
-                    {
-                        let mut tx_block_queue = tx_block_queue.lock();
-                        let b = tx_block_queue.pop_front().unwrap();
-                        assert!(b.source_height == tx_batch.source_height);
+                    let Some(tx_batch) = tx_batch else {
+                        // the send loop exited on cancellation
+                        return Self::drain_sent_txs(&tracker).await;
                     };
-                    let target_height = *target_height.read();
-                    let new_delay = tracker.on_txs_sent(
-                        &tx_block_queue,
-                        &self.db,
-                        crate::chain_tracker::SentBatch::MappedBlock(tx_batch),
-                        target_height,
-                    )?;
-                    *send_delay.lock() = new_delay;
+                    source_hash = tx_batch.source_hash;
+                    self.record_sent_batch(tx_batch, &tracker, &tx_block_queue, &target_height, &send_delay)?;
                 }
                 msg = accounts_to_unstake.recv() => {
                     let staked_accounts = msg.unwrap();
@@ -2071,6 +2114,28 @@ impl<T: ChainAccess> TxMirror<T> {
                     return Ok(());
                 }
             }
+        }
+    }
+
+    // Waits until every sent transaction has been observed in a target block, so
+    // a restarted mirror's resume point doesn't skip past txs that died in the
+    // mempool. The target indexer keeps running and clears sent_txs meanwhile.
+    async fn drain_sent_txs(
+        tracker: &Mutex<crate::chain_tracker::TxTracker>,
+    ) -> anyhow::Result<()> {
+        tracing::info!(target: "mirror", "stopped sending, waiting for already sent transactions to appear on the target chain");
+        let deadline = Instant::now() + DRAIN_TIMEOUT;
+        loop {
+            let sent_txs_remaining = tracker.lock().sent_txs_remaining();
+            if sent_txs_remaining == 0 {
+                tracing::info!(target: "mirror", "all sent transactions observed on the target chain, exiting after drain");
+                return Ok(());
+            }
+            if Instant::now() > deadline {
+                tracing::warn!(target: "mirror", sent_txs_remaining, "drain timed out with sent transactions never observed on the target chain");
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
     }
 
@@ -2137,9 +2202,20 @@ impl<T: ChainAccess> TxMirror<T> {
         stop_height: Option<BlockHeight>,
         target_home: PathBuf,
         actor_system: near_async::ActorSystem,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         let last_stored_height = get_last_source_height(&self.db)?;
         let last_height = last_stored_height.unwrap_or(self.target_genesis_height - 1);
+
+        // When resuming after having already sent everything up to --stop-height (e.g. a
+        // restart of a finished mirror over a finite source), there are no more blocks to
+        // send and we're done. Without this we'd bail below as if the source were broken.
+        if let Some(stop_height) = stop_height {
+            if last_height >= stop_height {
+                tracing::info!(target: "mirror", stop_height, last_height, "already sent all transactions up to --stop-height");
+                return Ok(());
+            }
+        }
 
         let next_heights =
             self.source_chain_access.init(last_height, CREATE_ACCOUNT_DELTA + 1).await?;
@@ -2282,6 +2358,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let tx_block_queue2 = tx_block_queue.clone();
         let rpc_handler2 = rpc_handler.clone();
         let db = self.db.clone();
+        let shutdown2 = shutdown.clone();
         let (send_txs_done_tx, send_txs_done_rx) =
             tokio::sync::oneshot::channel::<anyhow::Result<()>>();
         let send_txs_task = tokio::task::spawn(async move {
@@ -2292,6 +2369,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 send_time,
                 send_delay2,
                 rpc_handler2,
+                shutdown2,
             )
             .await;
             if let Err(err) = send_txs_done_tx.send(res) {
@@ -2302,7 +2380,7 @@ impl<T: ChainAccess> TxMirror<T> {
             res = self.queue_txs_loop(
                 tracker, tx_block_queue, rpc_handler, target_view_client,
                 blocks_sent_rx, unstake_rx, send_delay, target_height, target_head,
-                source_hash, stop_height.is_some(),
+                source_hash, stop_height.is_some(), shutdown,
             ) => {
                 res
             }
@@ -2334,6 +2412,7 @@ async fn run<P: AsRef<Path>>(
     stop_height: Option<BlockHeight>,
     online_source: bool,
     config_path: Option<P>,
+    shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
     let config: MirrorConfig = match config_path {
         Some(p) => {
@@ -2357,7 +2436,7 @@ async fn run<P: AsRef<Path>>(
             secret,
             config,
         )?
-        .run(Some(stop_height), target_home.as_ref().to_path_buf(), actor_system)
+        .run(Some(stop_height), target_home.as_ref().to_path_buf(), actor_system, shutdown)
         .await
     } else {
         TxMirror::new(
@@ -2367,7 +2446,7 @@ async fn run<P: AsRef<Path>>(
             secret,
             config,
         )?
-        .run(stop_height, target_home.as_ref().to_path_buf(), actor_system)
+        .run(stop_height, target_home.as_ref().to_path_buf(), actor_system, shutdown)
         .await
     }
 }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -32,7 +32,6 @@ use nearcore::NearNode;
 use parking_lot::{Mutex, RwLock};
 use rocksdb::DB;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::future::pending;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -2364,36 +2363,21 @@ impl<T: ChainAccess> TxMirror<T> {
         let tx_block_queue2 = tx_block_queue.clone();
         let rpc_handler2 = rpc_handler.clone();
         let db = self.db.clone();
-        let (send_txs_done_tx, send_txs_done_rx) =
-            tokio::sync::oneshot::channel::<anyhow::Result<()>>();
         let send_txs_task = tokio::task::spawn({
             let shutdown = shutdown.clone();
             async move {
-                let res = Self::send_txs_loop(
+                Self::send_txs_loop(
                     db,
                     blocks_sent_tx,
                     tx_block_queue2,
                     send_time,
                     send_delay2,
                     rpc_handler2,
-                    shutdown.clone(),
+                    shutdown,
                 )
-                .await;
-                // on graceful shutdown, exit without reporting a result so that the
-                // select below keeps waiting for the queue loop to drain sent txs
-                if res.is_err() || !shutdown.is_cancelled() {
-                    if let Err(err) = send_txs_done_tx.send(res) {
-                        tracing::error!(target: "mirror", ?err, "failed send txs loop res");
-                    }
-                }
+                .await
             }
         });
-        let send_txs_failed = async move {
-            match send_txs_done_rx.await {
-                Ok(res) => res,
-                Err(_) => pending().await,
-            }
-        };
         let result = tokio::select! {
             res = self.queue_txs_loop(
                 tracker, tx_block_queue, rpc_handler, target_view_client,
@@ -2407,16 +2391,18 @@ impl<T: ChainAccess> TxMirror<T> {
                 tracing::error!(target: "mirror", ?res, "target indexer thread exited");
                 res.context("target indexer thread failure")
             }
-            res = send_txs_failed => {
-                tracing::error!(target: "mirror", ?res, "transaction sending thread exited");
-                res.context("transaction sending thread failure")
-            }
         };
         index_target_task.abort();
         send_txs_task.abort();
         let _ = index_target_task.await;
-        let _ = send_txs_task.await;
+        let send_txs_result = send_txs_task.await;
         actor_system.stop();
+        // queue_txs_loop only sees the send loop exit as a closed channel; the
+        // underlying error is in the join result
+        if let Ok(Err(err)) = send_txs_result {
+            tracing::error!(target: "mirror", ?err, "transaction sending thread exited");
+            return Err(err.context("transaction sending thread failure"));
+        }
         result
     }
 }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -449,8 +449,6 @@ struct MirrorConfig {
 
 const CREATE_ACCOUNT_DELTA: usize = 5;
 
-const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
-
 // TODO: separate out the code that uses the target chain clients, and
 // make it an option to send the transactions to some RPC node.
 // that way it would be possible to run this code and send transactions with an
@@ -2124,6 +2122,7 @@ impl<T: ChainAccess> TxMirror<T> {
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         accounts_to_unstake: &mut mpsc::Receiver<HashMap<(AccountId, PublicKey), AccountId>>,
     ) -> anyhow::Result<()> {
+        const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
         tracing::info!(target: "mirror", "stopped sending, waiting for already sent transactions to appear on the target chain");
         let deadline = Instant::now() + DRAIN_TIMEOUT;
         loop {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -654,11 +654,13 @@ impl MappedTx {
         }
     }
 
-    fn inc_nonce(&mut self, target_secret_key: &SecretKey) {
+    fn inc_nonce(&mut self) {
         let mut tx = self.target_tx.transaction.clone();
         *tx.nonce_mut() += 1;
-        self.target_tx =
-            SignedTransaction::new(target_secret_key.sign(&tx.get_hash_and_size().0.as_ref()), tx);
+        self.target_tx = SignedTransaction::new(
+            self.target_secret_key.sign(&tx.get_hash_and_size().0.as_ref()),
+            tx,
+        );
     }
 }
 
@@ -722,9 +724,9 @@ impl TargetChainTx {
         }
     }
 
-    fn inc_target_nonce(&mut self, target_secret_key: &SecretKey) {
+    fn inc_target_nonce(&mut self) {
         match self {
-            Self::Ready(t) => t.inc_nonce(target_secret_key),
+            Self::Ready(t) => t.inc_nonce(),
             Self::AwaitingNonce(t) => {
                 if let Some(n) = &mut t.target_nonce.nonce {
                     *n += 1;
@@ -1146,7 +1148,6 @@ impl<T: ChainAccess> TxMirror<T> {
                 target_view_client,
                 &self.db,
                 &nonce_key,
-                &mapping.target_secret_key,
             )
             .await?
         };

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -32,6 +32,7 @@ use nearcore::NearNode;
 use parking_lot::{Mutex, RwLock};
 use rocksdb::DB;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::pending;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -2359,6 +2360,7 @@ impl<T: ChainAccess> TxMirror<T> {
         let rpc_handler2 = rpc_handler.clone();
         let db = self.db.clone();
         let shutdown2 = shutdown.clone();
+        let shutdown3 = shutdown.clone();
         let (send_txs_done_tx, send_txs_done_rx) =
             tokio::sync::oneshot::channel::<anyhow::Result<()>>();
         let send_txs_task = tokio::task::spawn(async move {
@@ -2372,10 +2374,20 @@ impl<T: ChainAccess> TxMirror<T> {
                 shutdown2,
             )
             .await;
-            if let Err(err) = send_txs_done_tx.send(res) {
-                tracing::error!(target: "mirror", ?err, "failed send txs loop res");
+            // on graceful shutdown, exit without reporting a result so that the
+            // select below keeps waiting for the queue loop to drain sent txs
+            if res.is_err() || !shutdown3.is_cancelled() {
+                if let Err(err) = send_txs_done_tx.send(res) {
+                    tracing::error!(target: "mirror", ?err, "failed send txs loop res");
+                }
             }
         });
+        let send_txs_failed = async move {
+            match send_txs_done_rx.await {
+                Ok(res) => res,
+                Err(_) => pending().await,
+            }
+        };
         let result = tokio::select! {
             res = self.queue_txs_loop(
                 tracker, tx_block_queue, rpc_handler, target_view_client,
@@ -2389,10 +2401,9 @@ impl<T: ChainAccess> TxMirror<T> {
                 tracing::error!(target: "mirror", ?res, "target indexer thread exited");
                 res.context("target indexer thread failure")
             }
-            res = send_txs_done_rx => {
-                let res = res.unwrap();
+            res = send_txs_failed => {
                 tracing::error!(target: "mirror", ?res, "transaction sending thread exited");
-                res.context("target indexer thread failure")
+                res.context("transaction sending thread failure")
             }
         };
         index_target_task.abort();

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -449,9 +449,6 @@ struct MirrorConfig {
 
 const CREATE_ACCOUNT_DELTA: usize = 5;
 
-// On SIGTERM/SIGINT we stop sending and wait for already sent transactions to
-// appear on the target chain before exiting, so that a restarted mirror's
-// resume point doesn't skip past transactions that died in the mempool.
 const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
 // TODO: separate out the code that uses the target chain clients, and
@@ -2075,9 +2072,9 @@ impl<T: ChainAccess> TxMirror<T> {
         loop {
             tokio::select! {
                 _ = shutdown.cancelled() => {
-                    // the send loop exits on cancellation and drops its end of the
-                    // channel. record every batch it managed to send before waiting
-                    // on them, since the watermark already advanced past them.
+                    // record every batch the cancelled send loop already handed to the
+                    // network: last_source_height has advanced past them, so a restart
+                    // won't resend them and they must be drained here instead.
                     while let Some(tx_batch) = blocks_sent.recv().await {
                         self.record_sent_batch(tx_batch, &tracker, &tx_block_queue, &target_height, &send_delay)?;
                     }
@@ -2119,9 +2116,8 @@ impl<T: ChainAccess> TxMirror<T> {
         }
     }
 
-    // Waits until every sent transaction has been observed in a target block, so
-    // a restarted mirror's resume point doesn't skip past txs that died in the
-    // mempool. The target indexer keeps running and clears sent_txs meanwhile.
+    // waits until the still-running target indexer observes every sent tx in a
+    // target block, so txs that died in the mempool aren't lost across a restart
     async fn drain_sent_txs(
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
     ) -> anyhow::Result<()> {
@@ -2360,26 +2356,27 @@ impl<T: ChainAccess> TxMirror<T> {
         let tx_block_queue2 = tx_block_queue.clone();
         let rpc_handler2 = rpc_handler.clone();
         let db = self.db.clone();
-        let shutdown2 = shutdown.clone();
-        let shutdown3 = shutdown.clone();
         let (send_txs_done_tx, send_txs_done_rx) =
             tokio::sync::oneshot::channel::<anyhow::Result<()>>();
-        let send_txs_task = tokio::task::spawn(async move {
-            let res = Self::send_txs_loop(
-                db,
-                blocks_sent_tx,
-                tx_block_queue2,
-                send_time,
-                send_delay2,
-                rpc_handler2,
-                shutdown2,
-            )
-            .await;
-            // on graceful shutdown, exit without reporting a result so that the
-            // select below keeps waiting for the queue loop to drain sent txs
-            if res.is_err() || !shutdown3.is_cancelled() {
-                if let Err(err) = send_txs_done_tx.send(res) {
-                    tracing::error!(target: "mirror", ?err, "failed send txs loop res");
+        let send_txs_task = tokio::task::spawn({
+            let shutdown = shutdown.clone();
+            async move {
+                let res = Self::send_txs_loop(
+                    db,
+                    blocks_sent_tx,
+                    tx_block_queue2,
+                    send_time,
+                    send_delay2,
+                    rpc_handler2,
+                    shutdown.clone(),
+                )
+                .await;
+                // on graceful shutdown, exit without reporting a result so that the
+                // select below keeps waiting for the queue loop to drain sent txs
+                if res.is_err() || !shutdown.is_cancelled() {
+                    if let Err(err) = send_txs_done_tx.send(res) {
+                        tracing::error!(target: "mirror", ?err, "failed send txs loop res");
+                    }
                 }
             }
         });

--- a/tools/mirror/src/shutdown.rs
+++ b/tools/mirror/src/shutdown.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio_util::sync::CancellationToken;
+
+// Owns signal handling for the whole `mirror run` lifetime, on its own runtime
+// so it works both while run() is alive and during the rocksdb close wait after
+// run()'s runtime is gone. The first SIGTERM/SIGINT requests a graceful drain
+// via shutdown_token(); a second signal, or any signal after mark_run_finished(),
+// exits immediately.
+pub(crate) struct SignalHandler {
+    _runtime: tokio::runtime::Runtime,
+    shutdown: CancellationToken,
+    run_finished: Arc<AtomicBool>,
+}
+
+impl SignalHandler {
+    pub(crate) fn install() -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let shutdown = CancellationToken::new();
+        let run_finished = Arc::new(AtomicBool::new(false));
+        #[cfg(unix)]
+        runtime.spawn(handle_signals(shutdown.clone(), run_finished.clone()));
+        Self { _runtime: runtime, shutdown, run_finished }
+    }
+
+    pub(crate) fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    pub(crate) fn mark_run_finished(&self) {
+        self.run_finished.store(true, Ordering::Relaxed);
+    }
+}
+
+#[cfg(unix)]
+async fn handle_signals(shutdown: CancellationToken, run_finished: Arc<AtomicBool>) {
+    use tokio::signal::unix::{SignalKind, signal};
+    let (Ok(mut sigterm), Ok(mut sigint)) =
+        (signal(SignalKind::terminate()), signal(SignalKind::interrupt()))
+    else {
+        tracing::warn!(target: "mirror", "could not install signal handlers, will exit without draining sent transactions");
+        return;
+    };
+    tokio::select! {
+        _ = sigterm.recv() => {}
+        _ = sigint.recv() => {}
+    }
+    if run_finished.load(Ordering::Relaxed) {
+        tracing::warn!(target: "mirror", "got termination signal during shutdown, exiting immediately");
+        std::process::exit(1);
+    }
+    tracing::info!(target: "mirror", "got termination signal, draining sent transactions before exiting");
+    shutdown.cancel();
+    tokio::select! {
+        _ = sigterm.recv() => {}
+        _ = sigint.recv() => {}
+    }
+    tracing::warn!(target: "mirror", "got second termination signal, exiting immediately");
+    std::process::exit(1);
+}


### PR DESCRIPTION
On SIGTERM the mirror used to exit immediately: txs already accepted into the target pool could die with the embedded node, and since the persisted `last_source_height` had already advanced past them, a restarted mirror skipped them permanently.

- One `SignalHandler` (new `shutdown.rs` module) on its own runtime owns signal handling for the whole process lifetime: the first SIGTERM/SIGINT requests a graceful drain via a `CancellationToken` threaded into `run()`, a second signal (or any signal during the final rocksdb close wait) exits immediately. The process stays killable even if the close wait hangs.
- On cancellation the send loop stops (even mid-sleep) and drops its end of the batch channel; the queue loop records every batch that was already routed (`last_source_height` has advanced past them, so a restart would not resend them) and then waits up to 30s for all sent txs to be observed in target blocks before exiting, discarding unstake events meanwhile so the indexer never blocks on a full channel.
- The queue loop sees any send loop exit as the channel closing: with shutdown requested it proceeds to the drain, otherwise it errors out; the send loop's own error is taken from its join handle at teardown so it isn't masked by the drain.
- `MappedTx` now keeps its signing key and `inc_nonce` signs with it instead of threading the key through as a parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)