### PR TITLE
fix(ci): pin udeps nightly toolchain

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -118,14 +118,17 @@ python-style-checks:
     python3 scripts/check_pytests.py
     ./scripts/formatting --check
 
+# Pinned to avoid floating-nightly breakage (e.g. builtin `splat` attr vs finite-wasm 0.5.0).
+udeps_nightly := "nightly-2026-06-09"
+
 install-rustc-nightly:
-    rustup toolchain install nightly
-    rustup target add wasm32-unknown-unknown --toolchain nightly
-    rustup component add rust-src --toolchain nightly
+    rustup toolchain install {{udeps_nightly}}
+    rustup target add wasm32-unknown-unknown --toolchain {{udeps_nightly}}
+    rustup component add rust-src --toolchain {{udeps_nightly}}
 
 # verify there is no unused dependency specified in a Cargo.toml
 check-cargo-udeps: install-rustc-nightly
-    env CARGO_TARGET_DIR={{justfile_directory()}}/target/udeps RUSTFLAGS='--cfg=udeps --cap-lints=allow' cargo +nightly udeps
+    env CARGO_TARGET_DIR={{justfile_directory()}}/target/udeps RUSTFLAGS='--cfg=udeps --cap-lints=allow' cargo +{{udeps_nightly}} udeps
 
 check-cargo-machete:
     cargo machete


### PR DESCRIPTION
The `check-cargo-udeps` job installs and runs a floating `nightly` toolchain. The `2026-06-10` nightly introduced a builtin `splat` attribute that collides with `macro_rules! splat` in `finite-wasm 0.5.0`, causing `error[E0659]: splat is ambiguous` and failing the "Unused Dependencies" job on every PR regardless of its contents.

Pin the udeps toolchain to `nightly-2026-06-09` (the last nightly before the `splat` attribute landed) via a `udeps_nightly` Justfile variable shared by `install-rustc-nightly` and `check-cargo-udeps`. This recipe is the only consumer of `install-rustc-nightly`, so the change is scoped to the udeps job.

Follow-up: the real fix is upstream in finite-wasm (disambiguate the `splat` macro, release 0.5.1, bump the dep), after which this pin can be dropped.