### PR TITLE
fix(network): run add_edges demux on a runtime that outlives its callers

### DIFF
--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -93,7 +93,6 @@ impl PeerHandle {
         });
         let network_state = Arc::new(NetworkState::new(
             &clock,
-            &*actor_system.new_future_spawner("network demux"),
             store,
             peer_store::PeerStore::new(&clock, network_cfg.peer_store.clone()).unwrap(),
             network_cfg.verify().unwrap(),

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -263,7 +263,6 @@ impl From<&connection::Connection> for PeerDisconnectInfo {
 impl NetworkState {
     pub fn new(
         clock: &time::Clock,
-        future_spawner: &dyn FutureSpawner,
         store: store::Store,
         peer_store: peer_store::PeerStore,
         config: config::VerifiedConfig,
@@ -277,8 +276,17 @@ impl NetworkState {
         spice_data_distributor_adapter: SpiceDataDistributorSenderForNetwork,
         spice_core_writer_adapter: Sender<SpiceChunkEndorsementMessage>,
     ) -> Self {
+        // The demux loop must run on a runtime that outlives every caller of
+        // add_edges(): a call into a demux whose loop task died with its runtime
+        // pends forever on the response, and a caller like on_peer_disconnected
+        // then pins NetworkState (and the store) past shutdown. ops_spawner has
+        // exactly the right lifetime: it is stopped when NetworkState drops.
+        let ops_spawner = new_owned_future_spawner("NetworkState ops");
+        let add_edges_demux =
+            demux::Demux::new(config.routing_table_update_rate_limit, &*ops_spawner);
         Self {
-            ops_spawner: new_owned_future_spawner("NetworkState ops"),
+            ops_spawner,
+            add_edges_demux,
             graph: crate::routing::Graph::new(
                 clock.clone(),
                 crate::routing::GraphConfig {
@@ -315,10 +323,6 @@ impl NetworkState {
             txns_since_last_block: AtomicUsize::new(0),
             pending_tier3_requests: DashMap::new(),
             whitelist_nodes,
-            add_edges_demux: demux::Demux::new(
-                config.routing_table_update_rate_limit,
-                future_spawner,
-            ),
             set_chain_info_mutex: Mutex::new(()),
             config,
             created_at: clock.now(),

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -368,7 +368,6 @@ impl PeerManagerActor {
         let clock = clock;
         let state = Arc::new(NetworkState::new(
             &clock,
-            &*handle.future_spawner(),
             store,
             peer_store,
             config,


### PR DESCRIPTION
`add_edges_demux` was constructed on the `PeerManagerActor` runtime's future spawner. That runtime is torn down with `shutdown_background()` at actor system stop, which can leak the demux loop task and queued `Call`s without running destructors, so a pending call's oneshot never resolves. Meanwhile `on_peer_disconnected` runs on the `ops_spawner` runtime (whose lifetime is tied to `NetworkState` itself) and awaits `add_edges` → `add_edges_demux.call()`. If the demux loop dies first, that await pends forever, the spawned task keeps its `Arc<NetworkState>` alive, the store is never released, and shutdown blocks indefinitely waiting for the last rocksdb instance to close. This is the lifetime mismatch documented in the TODO in `demux.rs`.

Fix: construct `add_edges_demux` on `ops_spawner`, which stops only when `NetworkState` drops, so the demux loop outlives every caller and each call either completes or fails with `ServiceStoppedError`. The other demuxes (`accounts_data_demuxes`, `snapshot_hosts_demuxes`) already use `ops_spawner`. The now-unused `future_spawner` parameter is removed from `NetworkState::new`.