### PR TITLE
feat(gas-keys): execute DelegateV2 with gas-key nonce routing (2/3)

### DIFF
--- a/runtime/runtime/src/action_validation.rs
+++ b/runtime/runtime/src/action_validation.rs
@@ -2,7 +2,7 @@ use crate::config::total_prepaid_gas;
 use crate::verifier::ValidateReceiptMode;
 use near_crypto::key_conversion::is_valid_staking_key;
 use near_primitives::account::AccessKeyPermission;
-use near_primitives::action::delegate::SignedDelegateAction;
+use near_primitives::action::delegate::VersionedDelegateActionRef;
 use near_primitives::action::{
     AddKeyAction, DeployGlobalContractAction, DeterministicStateInitAction,
     GlobalContractIdentifier, UseGlobalContractAction,
@@ -144,14 +144,27 @@ fn validate_action_with_mode(
         Action::AddKey(a) => validate_add_key_action(limit_config, a, current_protocol_version),
         Action::DeleteKey(_) => Ok(()),
         Action::DeleteAccount(a) => validate_delete_action(a),
-        Action::Delegate(a) => {
-            validate_delegate_action(limit_config, a, receiver, current_protocol_version, mode)
+        Action::Delegate(a) => validate_delegate_action(
+            limit_config,
+            (&a.delegate_action).into(),
+            receiver,
+            current_protocol_version,
+            mode,
+        ),
+        Action::DelegateV2(a) => {
+            require_protocol_feature(
+                ProtocolFeature::DelegateV2,
+                "DelegateV2",
+                current_protocol_version,
+            )?;
+            validate_delegate_action(
+                limit_config,
+                (&a.delegate_action).into(),
+                receiver,
+                current_protocol_version,
+                mode,
+            )
         }
-        // TODO(gas-keys): accept DelegateV2 once execution lands; rejected until then.
-        Action::DelegateV2(_) => Err(ActionsValidationError::UnsupportedProtocolFeature {
-            protocol_feature: "DelegateV2".to_owned(),
-            version: current_protocol_version,
-        }),
         Action::DeterministicStateInit(a) => {
             validate_deterministic_state_init(limit_config, a, receiver)
         }
@@ -166,16 +179,16 @@ fn validate_action_with_mode(
 
 fn validate_delegate_action(
     limit_config: &LimitConfig,
-    signed_delegate_action: &SignedDelegateAction,
+    delegate_action: VersionedDelegateActionRef<'_>,
     receiver: &AccountId,
     current_protocol_version: ProtocolVersion,
     mode: ValidateReceiptMode,
 ) -> Result<(), ActionsValidationError> {
-    let actions = signed_delegate_action.delegate_action.get_actions();
+    let actions = delegate_action.get_actions();
     let inner_receiver =
         if ProtocolFeature::FixDelegatedDeterministicStateInit.enabled(current_protocol_version) {
             // This is the correct receiver id to use for the check.
-            &signed_delegate_action.delegate_action.receiver_id
+            delegate_action.receiver_id()
         } else {
             // This is a bug fixed with `FixDelegatedDeterministicStateInit` that
             // validated against the wrong id. This makes it impossible to
@@ -468,12 +481,15 @@ mod tests {
     use near_crypto::{KeyType, PublicKey, Signature};
     use near_primitives::account::{AccessKey, FunctionCallPermission};
     use near_primitives::action::GlobalContractDeployMode;
-    use near_primitives::action::delegate::{DelegateAction, NonDelegateAction};
+    use near_primitives::action::delegate::{
+        DelegateAction, DelegateActionV2, NonDelegateAction, SignedDelegateAction,
+        VersionedSignedDelegateAction,
+    };
     use near_primitives::deterministic_account_id::{
         DeterministicAccountStateInit, DeterministicAccountStateInitV1,
     };
     use near_primitives::transaction::{
-        AddKeyAction, CreateAccountAction, DeleteKeyAction, TransferAction,
+        AddKeyAction, CreateAccountAction, DeleteKeyAction, TransactionNonce, TransferAction,
     };
     use near_primitives::version::PROTOCOL_VERSION;
     use std::collections::BTreeMap;
@@ -964,6 +980,30 @@ mod tests {
             ),
             Err(ActionsValidationError::UnsupportedProtocolFeature {
                 protocol_feature: "GasKeys".to_owned(),
+                version: protocol_version,
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_action_invalid_delegate_v2_before_protocol_feature() {
+        let delegate_action = DelegateActionV2 {
+            sender_id: alice_account(),
+            receiver_id: "bob.near".parse().unwrap(),
+            actions: vec![],
+            nonce: TransactionNonce::from_nonce_and_index(1, 0),
+            max_block_height: 1000,
+            public_key: PublicKey::empty(KeyType::ED25519),
+        };
+        let action = Action::DelegateV2(Box::new(VersionedSignedDelegateAction {
+            delegate_action: delegate_action.into(),
+            signature: Signature::empty(KeyType::ED25519),
+        }));
+        let protocol_version = ProtocolFeature::DelegateV2.protocol_version() - 1;
+        assert_eq!(
+            validate_action(&test_limit_config(), &action, &alice_account(), protocol_version),
+            Err(ActionsValidationError::UnsupportedProtocolFeature {
+                protocol_feature: "DelegateV2".to_owned(),
                 version: protocol_version,
             })
         );

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -14,17 +14,21 @@ use near_parameters::{
 use near_primitives::account::{
     AccessKey, AccessKeyPermission, Account, AccountContract, GasKeyInfo,
 };
-use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
+use near_primitives::action::delegate::{
+    VersionedDelegateActionRef, VersionedSignedDelegateActionRef,
+};
 use near_primitives::errors::{ActionError, ActionErrorKind, InvalidAccessKeyError, RuntimeError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
     ActionReceipt, Receipt, ReceiptEnum, ReceiptV0, VersionedActionReceipt, VersionedReceiptEnum,
 };
 use near_primitives::transaction::{
-    Action, DeleteAccountAction, DeployContractAction, StakeAction,
+    Action, DeleteAccountAction, DeployContractAction, StakeAction, TransactionNonce,
 };
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{AccountId, Balance, BlockHeight, EpochInfoProvider, StorageUsage};
+use near_primitives::types::{
+    AccountId, Balance, BlockHeight, EpochInfoProvider, NonceIndex, StorageUsage,
+};
 use near_primitives::utils::account_is_implicit;
 use near_primitives::version::ProtocolVersion;
 use near_primitives_core::account::id::AccountType;
@@ -32,7 +36,7 @@ use near_primitives_core::version::ProtocolFeature;
 use near_store::trie::AccessOptions;
 use near_store::{
     StorageError, TrieAccess, TrieUpdate, compute_gas_key_balance_sum, get_access_key,
-    remove_account, set_access_key,
+    get_gas_key_nonce, remove_account, set_access_key, set_gas_key_nonce,
 };
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use near_wallet_contract::{
@@ -485,22 +489,21 @@ pub(crate) fn apply_delegate_action(
     apply_state: &ApplyState,
     action_receipt: &VersionedActionReceipt,
     sender_id: &AccountId,
-    signed_delegate_action: &SignedDelegateAction,
+    signed_delegate_action: VersionedSignedDelegateActionRef<'_>,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
-    let delegate_action = &signed_delegate_action.delegate_action;
-
     if !signed_delegate_action.verify() {
         result.result = Err(ActionErrorKind::DelegateActionInvalidSignature.into());
         return Ok(());
     }
-    if apply_state.block_height > delegate_action.max_block_height {
+    let delegate_action = signed_delegate_action.delegate_action();
+    if apply_state.block_height > delegate_action.max_block_height() {
         result.result = Err(ActionErrorKind::DelegateActionExpired.into());
         return Ok(());
     }
-    if delegate_action.sender_id.as_str() != sender_id.as_str() {
+    if delegate_action.sender_id().as_str() != sender_id.as_str() {
         result.result = Err(ActionErrorKind::DelegateActionSenderDoesNotMatchTxReceiver {
-            sender_id: delegate_action.sender_id.clone(),
+            sender_id: delegate_action.sender_id().clone(),
             receiver_id: sender_id.clone(),
         }
         .into());
@@ -517,7 +520,7 @@ pub(crate) fn apply_delegate_action(
     // Generate a new receipt from DelegateAction.
     let new_receipt = Receipt::V0(ReceiptV0 {
         predecessor_id: sender_id.clone(),
-        receiver_id: delegate_action.receiver_id.clone(),
+        receiver_id: delegate_action.receiver_id().clone(),
         receipt_id: CryptoHash::default(),
 
         receipt: ReceiptEnum::Action(ActionReceipt {
@@ -597,21 +600,19 @@ fn action_receipt_required_cost(
 fn validate_delegate_action_key(
     state_update: &mut TrieUpdate,
     apply_state: &ApplyState,
-    delegate_action: &DelegateAction,
+    delegate_action: VersionedDelegateActionRef<'_>,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
-    // 'delegate_action.sender_id' account existence must be checked by a caller
-    let mut access_key = match get_access_key(
-        state_update,
-        &delegate_action.sender_id,
-        &delegate_action.public_key,
-    )? {
+    let sender_id = delegate_action.sender_id();
+    let public_key = delegate_action.public_key();
+    // 'sender_id' account existence must be checked by a caller
+    let mut access_key = match get_access_key(state_update, sender_id, public_key)? {
         Some(access_key) => access_key,
         None => {
             result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
                 InvalidAccessKeyError::AccessKeyNotFound {
-                    account_id: delegate_action.sender_id.clone(),
-                    public_key: delegate_action.public_key.clone().into(),
+                    account_id: sender_id.clone(),
+                    public_key: public_key.clone().into(),
                 },
             )
             .into());
@@ -619,21 +620,56 @@ fn validate_delegate_action_key(
         }
     };
 
-    // Gas keys keep their nonces per index in dedicated storage, while the
-    // delegate path only tracks the single access_key.nonce. Reject them rather
-    // than silently advancing an unrelated counter and bypassing the gas key balance.
-    if access_key.gas_key_info().is_some() {
-        result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
-            InvalidAccessKeyError::DelegateActionRequiresNonGasKey,
-        )
-        .into());
-        return Ok(());
-    }
+    // A plain nonce advances the single access_key.nonce and forbids gas keys;
+    // a gas key nonce advances one of the gas key's nonces selected by
+    // nonce_index.
+    let delegate_nonce = delegate_action.nonce();
+    let (current_nonce, nonce_update) = match delegate_nonce {
+        TransactionNonce::Nonce { .. } => {
+            if access_key.gas_key_info().is_some() {
+                result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+                    InvalidAccessKeyError::DelegateActionRequiresNonGasKey,
+                )
+                .into());
+                return Ok(());
+            }
+            (access_key.nonce, DelegateNonceUpdate::AccessKey)
+        }
+        TransactionNonce::GasKeyNonce { nonce_index, .. } => {
+            let Some(gas_key_info) = access_key.gas_key_info() else {
+                result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
+                    InvalidAccessKeyError::DelegateActionRequiresGasKey,
+                )
+                .into());
+                return Ok(());
+            };
+            if nonce_index >= gas_key_info.num_nonces {
+                result.result = Err(ActionErrorKind::DelegateActionInvalidNonceIndex {
+                    nonce_index,
+                    num_nonces: gas_key_info.num_nonces,
+                }
+                .into());
+                return Ok(());
+            }
+            // The index is range-checked above and gas keys initialize every
+            // nonce row at creation, so a missing row is inconsistent state.
+            let current_nonce =
+                get_gas_key_nonce(state_update, sender_id, public_key, nonce_index)?.ok_or_else(
+                    || {
+                        StorageError::StorageInconsistentState(format!(
+                            "gas key nonce row missing for {} {} at in-range index {nonce_index} (num_nonces {})",
+                            sender_id, public_key, gas_key_info.num_nonces,
+                        ))
+                    },
+                )?;
+            (current_nonce, DelegateNonceUpdate::GasKey { nonce_index })
+        }
+    };
 
-    if delegate_action.nonce <= access_key.nonce {
+    if delegate_nonce.nonce() <= current_nonce {
         result.result = Err(ActionErrorKind::DelegateActionInvalidNonce {
-            delegate_nonce: delegate_action.nonce,
-            ak_nonce: access_key.nonce,
+            delegate_nonce: delegate_nonce.nonce(),
+            ak_nonce: current_nonce,
         }
         .into());
         return Ok(());
@@ -641,16 +677,14 @@ fn validate_delegate_action_key(
 
     let upper_bound = apply_state.block_height
         * near_primitives::account::AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER;
-    if delegate_action.nonce >= upper_bound {
+    if delegate_nonce.nonce() >= upper_bound {
         result.result = Err(ActionErrorKind::DelegateActionNonceTooLarge {
-            delegate_nonce: delegate_action.nonce,
+            delegate_nonce: delegate_nonce.nonce(),
             upper_bound,
         }
         .into());
         return Ok(());
     }
-
-    access_key.nonce = delegate_action.nonce;
 
     let actions = delegate_action.get_actions();
 
@@ -679,10 +713,10 @@ fn validate_delegate_action_key(
                     return Ok(());
                 }
             }
-            if delegate_action.receiver_id != function_call_permission.receiver_id {
+            if delegate_action.receiver_id() != &function_call_permission.receiver_id {
                 result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
                     InvalidAccessKeyError::ReceiverMismatch {
-                        tx_receiver: delegate_action.receiver_id.clone(),
+                        tx_receiver: delegate_action.receiver_id().clone(),
                         ak_receiver: function_call_permission.receiver_id.clone(),
                     },
                 )
@@ -713,14 +747,30 @@ fn validate_delegate_action_key(
         }
     };
 
-    set_access_key(
-        state_update,
-        delegate_action.sender_id.clone(),
-        delegate_action.public_key.clone(),
-        &access_key,
-    );
+    match nonce_update {
+        DelegateNonceUpdate::AccessKey => {
+            access_key.nonce = delegate_nonce.nonce();
+            set_access_key(state_update, sender_id.clone(), public_key.clone(), &access_key);
+        }
+        DelegateNonceUpdate::GasKey { nonce_index } => {
+            set_gas_key_nonce(
+                state_update,
+                sender_id.clone(),
+                public_key.clone(),
+                nonce_index,
+                delegate_nonce.nonce(),
+            );
+        }
+    }
 
     Ok(())
+}
+
+/// How a validated delegate action's nonce is persisted: a plain action bumps
+/// the access key nonce, a gas key action bumps the selected gas key nonce.
+enum DelegateNonceUpdate {
+    AccessKey,
+    GasKey { nonce_index: NonceIndex },
 }
 
 pub(crate) fn check_actor_permissions(
@@ -871,7 +921,9 @@ mod tests {
     use crate::near_primitives::shard_layout::ShardUId;
     use near_primitives::account::FunctionCallPermission;
     use near_primitives::action::FunctionCallAction;
-    use near_primitives::action::delegate::NonDelegateAction;
+    use near_primitives::action::delegate::{
+        DelegateAction, DelegateActionV2, NonDelegateAction, SignedDelegateAction,
+    };
     use near_primitives::apply::ApplyChunkReason;
     use near_primitives::bandwidth_scheduler::BlockBandwidthRequests;
     use near_primitives::congestion_info::BlockCongestionInfo;
@@ -1309,7 +1361,7 @@ mod tests {
             &apply_state,
             &VersionedActionReceipt::from(&action_receipt),
             &sender_id,
-            &signed_delegate_action,
+            (&signed_delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1353,7 +1405,7 @@ mod tests {
             &apply_state,
             &VersionedActionReceipt::from(action_receipt),
             &sender_id,
-            &signed_delegate_action,
+            (&signed_delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1379,7 +1431,7 @@ mod tests {
             &apply_state,
             &VersionedActionReceipt::from(action_receipt),
             &sender_id,
-            &signed_delegate_action,
+            (&signed_delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1405,7 +1457,7 @@ mod tests {
             &apply_state,
             &VersionedActionReceipt::from(action_receipt),
             &"www.test.near".parse().unwrap(),
-            &signed_delegate_action,
+            (&signed_delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1448,7 +1500,7 @@ mod tests {
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
-            &signed_delegate_action.delegate_action,
+            (&signed_delegate_action.delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1459,7 +1511,7 @@ mod tests {
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
-            &signed_delegate_action.delegate_action,
+            (&signed_delegate_action.delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1479,7 +1531,7 @@ mod tests {
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
-            &delegate_action,
+            (&delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1505,7 +1557,7 @@ mod tests {
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
-            &signed_delegate_action.delegate_action,
+            (&signed_delegate_action.delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1539,7 +1591,7 @@ mod tests {
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
-            &signed_delegate_action.delegate_action,
+            (&signed_delegate_action.delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1567,7 +1619,7 @@ mod tests {
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
-            &signed_delegate_action.delegate_action,
+            (&signed_delegate_action.delegate_action).into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1595,7 +1647,7 @@ mod tests {
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
-            &delegate_action,
+            delegate_action.into(),
             &mut result,
         )
         .expect("Expect ok");
@@ -1766,7 +1818,7 @@ mod tests {
         validate_delegate_action_key(
             &mut state_update,
             &apply_state,
-            &delegate_action,
+            (&delegate_action).into(),
             &mut result,
         )
         .expect("validate_delegate_action_key must not return a RuntimeError");
@@ -1921,6 +1973,234 @@ mod tests {
             result.result,
             Err(ActionErrorKind::DelegateActionAccessKeyError(
                 InvalidAccessKeyError::DelegateActionRequiresNonGasKey,
+            )
+            .into())
+        );
+    }
+
+    // Validates a delegate action with a gas key nonce index, returning the
+    // result and the state so the test can inspect the gas key nonce.
+    fn validate_gas_key_delegate(
+        access_key: &AccessKey,
+        delegate_action: &DelegateAction,
+        nonce_index: NonceIndex,
+    ) -> (ActionResult, TrieUpdate) {
+        let sender_id = delegate_action.sender_id.clone();
+        let sender_pub_key = delegate_action.public_key.clone();
+        let apply_state = create_apply_state(delegate_action.max_block_height);
+        let mut state_update = setup_account(&sender_id, &sender_pub_key, access_key);
+
+        // Real gas keys seed every nonce row at creation; mirror that so
+        // validation reads an existing row rather than treating it as missing.
+        // Seed below the action's nonce so the action remains valid.
+        if let Some(gas_key_info) = access_key.gas_key_info() {
+            for index in 0..gas_key_info.num_nonces {
+                set_gas_key_nonce(
+                    &mut state_update,
+                    sender_id.clone(),
+                    sender_pub_key.clone(),
+                    index,
+                    delegate_action.nonce - 1,
+                );
+            }
+        }
+
+        let delegate_action_v2 = DelegateActionV2 {
+            sender_id,
+            receiver_id: delegate_action.receiver_id.clone(),
+            actions: delegate_action.actions.clone(),
+            nonce: TransactionNonce::from_nonce_and_index(delegate_action.nonce, nonce_index),
+            max_block_height: delegate_action.max_block_height,
+            public_key: sender_pub_key,
+        };
+        let mut result = ActionResult::default();
+        validate_delegate_action_key(
+            &mut state_update,
+            &apply_state,
+            (&delegate_action_v2).into(),
+            &mut result,
+        )
+        .expect("Expect ok");
+        (result, state_update)
+    }
+
+    #[test]
+    fn test_gas_key_delegate_action_full_access_advances_nonce() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
+        let delegate_action = signed_delegate_action.delegate_action;
+        let nonce_index = 0;
+
+        let (result, state_update) =
+            validate_gas_key_delegate(&access_key, &delegate_action, nonce_index);
+        assert!(result.result.is_ok(), "result error: {:?}", result.result);
+
+        let stored = get_gas_key_nonce(
+            &state_update,
+            &delegate_action.sender_id,
+            &delegate_action.public_key,
+            nonce_index,
+        )
+        .unwrap();
+        assert_eq!(stored, Some(delegate_action.nonce));
+    }
+
+    #[test]
+    fn test_gas_key_delegate_action_requires_gas_key() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::full_access();
+        let delegate_action = signed_delegate_action.delegate_action;
+        let nonce_index = 0;
+
+        let (result, _) = validate_gas_key_delegate(&access_key, &delegate_action, nonce_index);
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::DelegateActionRequiresGasKey,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_action_invalid_nonce_index() {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_full_access(TEST_GAS_KEY_NUM_NONCES);
+        let delegate_action = signed_delegate_action.delegate_action;
+        let nonce_index = TEST_GAS_KEY_NUM_NONCES; // invalid
+
+        let (result, _) = validate_gas_key_delegate(&access_key, &delegate_action, nonce_index);
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionInvalidNonceIndex {
+                nonce_index,
+                num_nonces: TEST_GAS_KEY_NUM_NONCES,
+            }
+            .into())
+        );
+    }
+
+    // A gas key delegate action with `GasKeyFunctionCall` permission runs the
+    // same function call restrictions as a regular function call access key.
+    fn gas_key_function_call_delegate_result(
+        permission: FunctionCallPermission,
+        actions: Vec<NonDelegateAction>,
+    ) -> ActionResult {
+        let (_, signed_delegate_action) = create_delegate_action_receipt();
+        let access_key = AccessKey::gas_key_function_call(TEST_GAS_KEY_NUM_NONCES, permission);
+        let mut delegate_action = signed_delegate_action.delegate_action;
+        delegate_action.actions = actions;
+        let nonce_index = 0;
+        validate_gas_key_delegate(&access_key, &delegate_action, nonce_index).0
+    }
+
+    fn function_call_action(method_name: &str, deposit: Balance) -> NonDelegateAction {
+        non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
+            args: Vec::new(),
+            deposit,
+            gas: Gas::from_gas(300),
+            method_name: method_name.parse().unwrap(),
+        })))
+    }
+
+    fn function_call_permission(
+        receiver_id: &str,
+        method_names: Vec<String>,
+    ) -> FunctionCallPermission {
+        FunctionCallPermission {
+            allowance: None,
+            receiver_id: receiver_id.to_string(),
+            method_names,
+        }
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_ok() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert!(result.result.is_ok(), "result error: {:?}", result.result);
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_incorrect_action() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![non_delegate_action(Action::CreateAccount(CreateAccountAction {}))],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresFullAccess,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_actions_number() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", vec!["test_method".to_string()]),
+            vec![
+                function_call_action("test_method", Balance::ZERO),
+                function_call_action("test_method", Balance::ZERO),
+            ],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::RequiresFullAccess,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_deposit() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", Vec::new()),
+            vec![function_call_action("test_method", Balance::from_yoctonear(1))],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::DepositWithFunctionCall,
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_receiver_id() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("another.near", Vec::new()),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::ReceiverMismatch {
+                    tx_receiver: "token.test.near".parse().unwrap(),
+                    ak_receiver: "another.near".parse().unwrap(),
+                },
+            )
+            .into())
+        );
+    }
+
+    #[test]
+    fn test_gas_key_delegate_function_call_method() {
+        let result = gas_key_function_call_delegate_result(
+            function_call_permission("token.test.near", vec!["another_method".to_string()]),
+            vec![function_call_action("test_method", Balance::ZERO)],
+        );
+        assert_eq!(
+            result.result,
+            Err(ActionErrorKind::DelegateActionAccessKeyError(
+                InvalidAccessKeyError::MethodNameMismatch {
+                    method_name: "test_method".parse().unwrap(),
+                },
             )
             .into())
         );

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -39,8 +39,8 @@ use near_primitives::bandwidth_scheduler::{BandwidthRequests, BlockBandwidthRequ
 use near_primitives::chunk_apply_stats::ChunkApplyStatsV1;
 use near_primitives::congestion_info::{BlockCongestionInfo, CongestionInfo};
 use near_primitives::errors::{
-    ActionError, ActionErrorKind, ActionsValidationError, EpochError, IntegerOverflowError,
-    InvalidAccessKeyError, InvalidTxError, ReceiptValidationError, RuntimeError, TxExecutionError,
+    ActionError, ActionErrorKind, EpochError, IntegerOverflowError, InvalidAccessKeyError,
+    InvalidTxError, RuntimeError, TxExecutionError,
 };
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
@@ -730,21 +730,20 @@ impl Runtime {
                     apply_state,
                     action_receipt,
                     account_id,
-                    signed_delegate_action,
+                    signed_delegate_action.as_ref().into(),
                     &mut result,
                 )?;
             }
-            // TODO(gas-keys): execute DelegateV2; rejected at validation until then.
-            Action::DelegateV2(_) => {
-                result.result = Err(ActionErrorKind::NewReceiptValidationError(
-                    ReceiptValidationError::ActionsValidation(
-                        ActionsValidationError::UnsupportedProtocolFeature {
-                            protocol_feature: "DelegateV2".to_owned(),
-                            version: apply_state.current_protocol_version,
-                        },
-                    ),
-                )
-                .into());
+            Action::DelegateV2(signed_delegate_action) => {
+                metrics::ACTION_CALLED_COUNT.delegate.inc();
+                apply_delegate_action(
+                    state_update,
+                    apply_state,
+                    action_receipt,
+                    account_id,
+                    signed_delegate_action.as_ref().into(),
+                    &mut result,
+                )?;
             }
             Action::TransferToGasKey(transfer_to_gas_key) => {
                 metrics::ACTION_CALLED_COUNT.transfer_to_gas_key.inc();

--- a/test-loop-tests/src/tests/gas_keys.rs
+++ b/test-loop-tests/src/tests/gas_keys.rs
@@ -7,6 +7,7 @@ use near_async::time::Duration;
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signer};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::{AccessKey, FunctionCallPermission};
+use near_primitives::action::delegate::{DelegateActionV2, VersionedSignedDelegateAction};
 use near_primitives::action::{AddKeyAction, DeleteKeyAction, TransferToGasKeyAction};
 use near_primitives::errors::{
     ActionError, ActionErrorKind, ActionsValidationError, ReceiptValidationError, TxExecutionError,
@@ -172,6 +173,126 @@ fn test_gas_key_transaction() {
     // Verify receiver got the transfer
     let receiver_balance = env.rpc_node().view_account_query(receiver).unwrap().amount;
     assert_eq!(receiver_balance, initial_balance.checked_add(transfer_amount).unwrap());
+}
+
+#[test]
+fn test_gas_key_delegate_v2_meta_transaction() {
+    init_test_logger();
+
+    let user_accounts = create_account_ids(["account0", "account1", "account2"]);
+    let initial_balance = Balance::from_near(1_000_000);
+    let gas_price = Balance::from_yoctonear(1);
+    let mut env = TestLoopBuilder::new()
+        .enable_rpc()
+        .add_user_accounts(&user_accounts, initial_balance)
+        .gas_prices(gas_price, gas_price)
+        .build();
+
+    let sender = &user_accounts[0]; // owns the gas key and delegates the action
+    let relayer = &user_accounts[1]; // wraps and submits the meta transaction
+    let receiver = &user_accounts[2]; // target of the inner transfer
+    let relayer_signer = create_user_test_signer(relayer);
+    let mut relayer_nonce = 0;
+    let mut next_relayer_nonce = || {
+        relayer_nonce += 1;
+        relayer_nonce
+    };
+
+    // Add a gas key to the sender.
+    let gas_key_signer: Signer =
+        InMemorySigner::from_seed(sender.clone(), KeyType::ED25519, "gas_key").into();
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    let num_nonces = 3;
+    let add_key_tx = SignedTransaction::from_actions(
+        1,
+        sender.clone(),
+        sender.clone(),
+        &create_user_test_signer(sender),
+        vec![Action::AddKey(Box::new(AddKeyAction {
+            public_key: gas_key_signer.public_key(),
+            access_key: AccessKey::gas_key_full_access(num_nonces),
+        }))],
+        block_hash,
+    );
+    env.rpc_runner().run_tx(add_key_tx, Duration::seconds(5));
+
+    // Sign a delegate action with the gas key at `nonce_index`, wrapping a
+    // transfer to `receiver`.
+    let nonce_index: NonceIndex = 1;
+    let untouched_nonce_index: NonceIndex = 0;
+    let gas_key_nonce = get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), nonce_index);
+    let untouched_nonce_before =
+        get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), untouched_nonce_index);
+    let transfer_amount = Balance::from_near(10);
+    let delegate_action = DelegateActionV2 {
+        sender_id: sender.clone(),
+        receiver_id: receiver.clone(),
+        actions: vec![
+            Action::Transfer(TransferAction { deposit: transfer_amount }).try_into().unwrap(),
+        ],
+        nonce: TransactionNonce::from_nonce_and_index(gas_key_nonce + 1, nonce_index),
+        max_block_height: 1_000_000,
+        public_key: gas_key_signer.public_key(),
+    };
+    let signed_delegate =
+        VersionedSignedDelegateAction::sign(&gas_key_signer, delegate_action.into());
+
+    // The relayer submits it: the outer transaction's receiver is the delegate
+    // sender, who forwards the inner actions.
+    let receiver_balance_before = env.rpc_node().view_account_query(receiver).unwrap().amount;
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    let meta_tx = SignedTransaction::from_actions(
+        next_relayer_nonce(),
+        relayer.clone(),
+        sender.clone(),
+        &relayer_signer,
+        vec![Action::DelegateV2(Box::new(signed_delegate.clone()))],
+        block_hash,
+    );
+    let outcome = env.rpc_runner().execute_tx(meta_tx, Duration::seconds(5)).unwrap();
+    assert!(
+        matches!(outcome.status, FinalExecutionStatus::SuccessValue(_)),
+        "meta transaction failed: {:?}",
+        outcome.status,
+    );
+
+    // Only the chosen nonce index advanced.
+    let updated_nonce = get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), nonce_index);
+    assert_eq!(updated_nonce, gas_key_nonce + 1);
+    assert_eq!(
+        get_gas_key_nonce(&env, sender, &gas_key_signer.public_key(), untouched_nonce_index),
+        untouched_nonce_before,
+    );
+
+    // The inner transfer executed.
+    let receiver_balance_after = env.rpc_node().view_account_query(receiver).unwrap().amount;
+    assert_eq!(
+        receiver_balance_after,
+        receiver_balance_before.checked_add(transfer_amount).unwrap(),
+    );
+
+    // Replaying the same delegate (same gas key nonce) is rejected.
+    let block_hash = get_shared_block_hash(&env.node_datas, &env.test_loop.data);
+    let replay_tx = SignedTransaction::from_actions(
+        next_relayer_nonce(),
+        relayer.clone(),
+        sender.clone(),
+        &relayer_signer,
+        vec![Action::DelegateV2(Box::new(signed_delegate))],
+        block_hash,
+    );
+    let replay_outcome = env.rpc_runner().execute_tx(replay_tx, Duration::seconds(5)).unwrap();
+    assert!(
+        matches!(
+            replay_outcome.status,
+            FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+                kind: ActionErrorKind::DelegateActionInvalidNonce { .. },
+                ..
+            }))
+        ),
+        "expected DelegateActionInvalidNonce on replay, got {:?}",
+        replay_outcome.status,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Second PR of the stack (on top of #15904). Wires up execution of `DelegateV2`:
- `validate_delegate_action_key` dispatches on `TransactionNonce`: a plain nonce advances `access_key.nonce` (and still rejects gas keys), a gas key nonce range-checks `nonce_index` against `num_nonces` and advances the selected gas key nonce row.
- The separate V1/V2 apply paths collapse into one `apply_delegate_action` over `VersionedSignedDelegateActionRef`.
- Validation now accepts `DelegateV2` behind the dedicated `ProtocolFeature::DelegateV2`, replacing the inert rejection arm from the previous PR.

Adds an end-to-end test-loop test of a gas-key meta transaction plus unit tests for the nonce routing.