### PR TITLE
test(spice): bump consensus epoch-switches timeout to 12m

### DIFF
--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -35,7 +35,7 @@ expensive --timeout=12m near-chain near_chain tests::doomslug::ultra_slow_test_f
 expensive --timeout=12m near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety --features nightly,protocol_feature_spice
 expensive --timeout=10m test-loop-tests test_loop_tests tests::consensus::ultra_slow_test_consensus_with_epoch_switches
 expensive --timeout=10m test-loop-tests test_loop_tests tests::consensus::ultra_slow_test_consensus_with_epoch_switches --features nightly
-expensive --timeout=10m test-loop-tests test_loop_tests tests::consensus::ultra_slow_test_consensus_with_epoch_switches --features nightly,protocol_feature_spice
+expensive --timeout=12m test-loop-tests test_loop_tests tests::consensus::ultra_slow_test_consensus_with_epoch_switches --features nightly,protocol_feature_spice
 
 expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_access_key_smart_contract_testnet
 expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_access_key_smart_contract_testnet --features nightly


### PR DESCRIPTION
`ultra_slow_test_consensus_with_epoch_switches` under `nightly,protocol_feature_spice` runs close to the 10m limit, and occasionally trips it. The spice variant is ~1.6x the non-spice runtime, still investigating why, possibly due to extra work of signature verification of core statements. Raise its timeout to 12m to give headroom. The non-spice variants run ~6m and keep the 10m limit.