### PR TITLE
perf(test-loop): render event descriptions lazily

### DIFF
--- a/core/async/src/test_loop/mod.rs
+++ b/core/async/src/test_loop/mod.rs
@@ -375,17 +375,19 @@ impl TestLoopV2 {
             }
         }
         let event_ignored = self.denylisted_identifiers.contains(&event.event.identifier);
-        let start_json = serde_json::to_string(&EventStartLogOutput {
-            current_index: event.id,
-            total_events: self.next_event_index,
-            identifier: event.event.identifier.clone(),
-            current_event: event.event.description,
-            current_time_ms: event.due.whole_milliseconds() as u64,
-            event_ignored,
-        })
-        .unwrap();
-        // TODO(logging): testloop visualizer may have a dependency on seeing the trace in this specific format
-        tracing::info!(target: "test_loop", "TEST_LOOP_EVENT_START {}", start_json);
+        if tracing::enabled!(target: "test_loop", tracing::Level::INFO) {
+            let start_json = serde_json::to_string(&EventStartLogOutput {
+                current_index: event.id,
+                total_events: self.next_event_index,
+                identifier: event.event.identifier.clone(),
+                current_event: event.event.description.clone(),
+                current_time_ms: event.due.whole_milliseconds() as u64,
+                event_ignored,
+            })
+            .unwrap();
+            // TODO(logging): testloop visualizer may have a dependency on seeing the trace in this specific format
+            tracing::info!(target: "test_loop", "TEST_LOOP_EVENT_START {}", start_json);
+        }
         assert_eq!(self.current_time, event.due);
 
         if !event_ignored {
@@ -400,11 +402,13 @@ impl TestLoopV2 {
         // Push any new events into the queue. Do this before emitting the end log line,
         // so that it contains the correct new total number of events.
         self.queue_received_events();
-        let end_json =
-            serde_json::to_string(&EventEndLogOutput { total_events: self.next_event_index })
-                .unwrap();
-        // TODO(logging): testloop visualizer may have a dependency on seeing the trace in this specific format
-        tracing::info!(target: "test_loop", "TEST_LOOP_EVENT_END {}", end_json);
+        if tracing::enabled!(target: "test_loop", tracing::Level::INFO) {
+            let end_json =
+                serde_json::to_string(&EventEndLogOutput { total_events: self.next_event_index })
+                    .unwrap();
+            // TODO(logging): testloop visualizer may have a dependency on seeing the trace in this specific format
+            tracing::info!(target: "test_loop", "TEST_LOOP_EVENT_END {}", end_json);
+        }
     }
 
     /// Runs the test loop for the given duration. This function may be called

--- a/core/async/src/test_loop/sender.rs
+++ b/core/async/src/test_loop/sender.rs
@@ -83,7 +83,7 @@ where
 {
     fn send(&self, msg: M) {
         let mut this = self.clone();
-        let description = format!("{}({:?})", pretty_type_name::<A>(), &msg);
+        let description = event_description::<A, M>(&msg);
         let callback = move |data: &mut TestLoopData| {
             let actor = data.get_mut(&this.actor_handle);
             actor.handle(msg, &mut this);
@@ -104,7 +104,7 @@ where
 {
     fn send_async(&self, msg: M) -> BoxFuture<'static, Result<R, AsyncSendError>> {
         let mut this = self.clone();
-        let description = format!("{}({:?})", pretty_type_name::<A>(), &msg);
+        let description = event_description::<A, M>(&msg);
         let (sender, receiver) = oneshot::channel::<R>();
         let callback = move |data: &mut TestLoopData| {
             let actor = data.get_mut(&this.actor_handle);
@@ -147,4 +147,16 @@ where
 // example near_chunks::shards_manager_actor::ShardsManagerActor -> ShardsManagerActor
 fn pretty_type_name<T>() -> &'static str {
     type_name::<T>().split("::").last().unwrap()
+}
+
+// Full `{:?}` payload only when the `test_loop` target is enabled: for large messages it
+// base58-encodes every hash, dominating test runtime. The type name is always kept so the
+// diagnostic panics that print the description stay legible.
+fn event_description<A, M: Debug>(msg: &M) -> String {
+    let type_name = pretty_type_name::<A>();
+    if tracing::enabled!(target: "test_loop", tracing::Level::INFO) {
+        format!("{type_name}({msg:?})")
+    } else {
+        type_name.to_string()
+    }
 }

--- a/core/o11y/src/testonly.rs
+++ b/core/o11y/src/testonly.rs
@@ -28,10 +28,19 @@ fn setup_subscriber_from_filter(mut env_filter: EnvFilter) {
         .try_init();
 }
 
+const TEST_LOG_ENV_FILTER: &str = "cranelift=warn,wasmtime=warn,h2=warn,tower=warn,trust_dns=warn,tokio_reactor=info,tokio_core=info,hyper=info,debug";
+
 pub fn init_test_logger() {
-    let env_filter = EnvFilter::new(
-        "cranelift=warn,wasmtime=warn,h2=warn,tower=warn,trust_dns=warn,tokio_reactor=info,tokio_core=info,hyper=info,debug",
-    );
+    setup_subscriber_from_filter(EnvFilter::new(TEST_LOG_ENV_FILTER));
+}
+
+/// Like [`init_test_logger`] but layers extra comma-separated directives on top of the default
+/// filter, e.g. `"test_loop=warn"` to mute the expensive per-event visualizer trace in long tests.
+pub fn init_test_logger_with_directives(directives: &str) {
+    let mut env_filter = EnvFilter::new(TEST_LOG_ENV_FILTER);
+    for directive in directives.split(',').filter(|s| !s.is_empty()) {
+        env_filter = env_filter.add_directive(directive.parse().unwrap());
+    }
     setup_subscriber_from_filter(env_filter);
 }
 

--- a/test-loop-tests/src/tests/consensus.rs
+++ b/test-loop-tests/src/tests/consensus.rs
@@ -13,7 +13,7 @@ use near_network::client::{BlockApproval, BlockResponse};
 use near_network::types::NetworkRequests;
 use near_network::types::NetworkResponses;
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
-use near_o11y::testonly::init_test_logger;
+use near_o11y::testonly::init_test_logger_with_directives;
 use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
@@ -31,7 +31,7 @@ use std::sync::Arc;
 /// This test is designed to reproduce finality bugs on the epoch boundaries.
 #[test]
 fn ultra_slow_test_consensus_with_epoch_switches() {
-    init_test_logger();
+    init_test_logger_with_directives("test_loop=warn");
 
     let seed: u64 = thread_rng().r#gen();
     println!("RNG seed: {seed}. If test fails use it to find the issue.");


### PR DESCRIPTION
The test-loop runtime eagerly Debug-formats every dispatched message into an event description (`format!("{}({:?})", ...)`) and serializes it to JSON for the `TEST_LOOP_EVENT_START/END` visualizer trace, on every event, unconditionally. For messages carrying many hashes (e.g. spice blocks full of `SpiceCoreStatement`s) this base58-encodes every hash and ends up dominating test runtime.

- `TestLoopSender` now renders the full `{:?}` payload only when the `test_loop` trace target is enabled, falling back to the actor type name otherwise (kept so the diagnostic panics that print the description stay legible).
- The per-event `serde_json` serialization and `TEST_LOOP_EVENT_*` logging are gated behind the same `test_loop` target check, so they cost nothing when the trace is muted.
- Adds `init_test_logger_with_directives`, a generic helper to layer extra filter directives onto the default test logger.
- `ultra_slow_test_consensus_with_epoch_switches` opts out of the trace via `test_loop=warn`; locally it drops from ~6m to ~1.5m, and ~9.5m to ~1.5m on the nightly+spice lane.

All other tests keep the full visualizer trace; the default logger is unchanged.