### PR TITLE
feat(congestion): clamp admission gas so allowed shard can forward

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -433,6 +433,7 @@ pub enum ProtocolFeature {
     /// `ContractCodeResponseV2` (with a signed inner payload); receivers
     /// require a verifiable signature before processing the response.
     SignedContractCodeResponse,
+    ClampOutgoingGasAdmission,
 }
 
 impl ProtocolFeature {
@@ -556,6 +557,7 @@ impl ProtocolFeature {
             | ProtocolFeature::YieldWithId
             | ProtocolFeature::ExecutionMetadataV4
             | ProtocolFeature::SignedContractCodeResponse
+            | ProtocolFeature::ClampOutgoingGasAdmission
             | ProtocolFeature::DelegateV2 => 85,
 
             // Nightly features:

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -16,6 +16,7 @@ use near_primitives::receipt::{
 };
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{EpochId, EpochInfoProvider, Gas, ShardId};
+use near_primitives::version::ProtocolFeature;
 use near_store::trie::outgoing_metadata::{OutgoingMetadatas, ReceiptGroupsConfig};
 use near_store::trie::receipts_column_helper::{
     DelayedReceiptQueue, ShardsOutgoingReceiptBuffer, TrieQueue,
@@ -439,11 +440,18 @@ impl ReceiptSinkV2 {
             OutgoingLimit { gas: default_gas_limit, size: default_size_limit };
         let forward_limit = outgoing_limit.entry(shard).or_insert(default_outgoing_limit);
 
-        if forward_limit.gas >= gas && forward_limit.size >= size {
+        let admission_gas = if ProtocolFeature::ClampOutgoingGasAdmission
+            .enabled(apply_state.current_protocol_version)
+        {
+            gas.min(apply_state.config.congestion_control_config.allowed_shard_outgoing_gas)
+        } else {
+            gas
+        };
+
+        if forward_limit.gas >= admission_gas && forward_limit.size >= size {
             tracing::trace!(target: "runtime", ?shard, receipt_id=?receipt.receipt_id(), "forwarding buffered receipt");
             outgoing_receipts.push(receipt);
-            // underflow impossible: checked forward_limit > gas/size_to_forward above
-            forward_limit.gas = forward_limit.gas.checked_sub(gas).unwrap();
+            forward_limit.gas = forward_limit.gas.saturating_sub(gas);
             forward_limit.size -= size;
             stats.forwarded_receipts.entry(shard).or_default().add_receipt(size, gas);
 


### PR DESCRIPTION
Refines the gas admission check used when forwarding buffered receipts under congestion control, so receipt forwarding behaves correctly at the per-shard gas budget boundary. Gated behind `ProtocolFeature::ClampOutgoingGasAdmission` (protocol version 85).