### PR TITLE
chore(protocol): deprecate tx-outcomes + allowance-charging features (v83)

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -771,7 +771,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         let shard_uid = shard_layout
             .account_id_to_shard_uid(validated_tx.to_signed_tx().transaction.signer_id());
         let trie = self.tries.get_trie_for_shard(shard_uid, state_root);
-        let (signer, mut access_key) = get_signer_and_access_key(&trie, &validated_tx)?;
+        let (signer, access_key) = get_signer_and_access_key(&trie, &validated_tx)?;
         // Here we do not know which block the transaction will be included and
         // therefore use `None` as `block_height` to skip the check on the nonce
         // upper bound.
@@ -805,11 +805,10 @@ impl RuntimeAdapter for NightshadeRuntime {
             match verify_and_charge_tx_ephemeral(
                 runtime_config,
                 &signer,
-                &mut access_key,
+                &access_key,
                 &tx,
                 &cost,
                 block_height,
-                current_protocol_version,
                 pending_constraints,
             ) {
                 TxVerdict::Success(_) => Ok(()),
@@ -1112,11 +1111,10 @@ impl RuntimeAdapter for NightshadeRuntime {
                     verify_and_charge_tx_ephemeral(
                         runtime_config,
                         account,
-                        &mut key_entry.access_key,
+                        &key_entry.access_key,
                         validated_tx.to_tx(),
                         &cost,
                         Some(next_block_height),
-                        protocol_version,
                         &pending_constraints,
                     )
                 };

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1100,7 +1100,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                     verify_and_charge_gas_key_tx_ephemeral(
                         runtime_config,
                         account,
-                        &mut key_entry.access_key,
+                        &key_entry.access_key,
                         current_nonce,
                         validated_tx.to_tx(),
                         &cost,

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -90,9 +90,7 @@ pub async fn build_streamer_message(
             .into_iter()
             .filter_map(|transaction| {
                 let outcome = outcomes.remove(&transaction.hash);
-                if outcome.is_none()
-                    && ProtocolFeature::InvalidTxGenerateOutcomes.enabled(protocol_version)
-                {
+                if outcome.is_none() {
                     tracing::error!(
                         target: INDEXER,
                         tx_hash = %transaction.hash,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -338,7 +338,8 @@ pub enum ProtocolFeature {
     /// NEP: https://github.com/near/NEPs/pull/616
     #[deprecated]
     _DeprecatedDeterministicAccountIds,
-    InvalidTxGenerateOutcomes,
+    #[deprecated]
+    _DeprecatedInvalidTxGenerateOutcomes,
     DynamicResharding,
     GasKeys,
     /// Meta transactions with gas key support via `Action::DelegateV2`.
@@ -347,7 +348,8 @@ pub enum ProtocolFeature {
     /// Previously, the allowance was decremented in-place before later checks
     /// (storage stake, function call permission) that could return an error,
     /// violating the documented contract of no mutation on error.
-    FixAccessKeyAllowanceCharging,
+    #[deprecated]
+    _DeprecatedFixAccessKeyAllowanceCharging,
     /// Fix missing early return on DepositWithFunctionCall error path in
     /// validate_delegate_action_key. Previously the error could be
     /// overwritten by a subsequent receiver_id or method_name check.
@@ -535,9 +537,9 @@ impl ProtocolFeature {
             ProtocolFeature::_DeprecatedIncreaseMaxCongestionMissedChunks => 79,
             ProtocolFeature::_DeprecatedStatePartsCompression
             | ProtocolFeature::_DeprecatedDeterministicAccountIds => 82,
-            ProtocolFeature::InvalidTxGenerateOutcomes
+            ProtocolFeature::_DeprecatedInvalidTxGenerateOutcomes
             | ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen
-            | ProtocolFeature::FixAccessKeyAllowanceCharging
+            | ProtocolFeature::_DeprecatedFixAccessKeyAllowanceCharging
             | ProtocolFeature::IncludeDeployGlobalContractOutcomeBurntStorage
             | ProtocolFeature::GlobalContractDistributionNonce
             | ProtocolFeature::_DeprecatedInstantPromiseYield

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -344,10 +344,6 @@ pub enum ProtocolFeature {
     GasKeys,
     /// Meta transactions with gas key support via `Action::DelegateV2`.
     DelegateV2,
-    /// Fix access key allowance mutation in verify_and_charge_tx_ephemeral.
-    /// Previously, the allowance was decremented in-place before later checks
-    /// (storage stake, function call permission) that could return an error,
-    /// violating the documented contract of no mutation on error.
     #[deprecated]
     _DeprecatedFixAccessKeyAllowanceCharging,
     /// Fix missing early return on DepositWithFunctionCall error path in

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -306,15 +306,11 @@ pub fn test_nonce_updated_when_tx_failed(node: impl Node) {
         bob_account(),
         TESTING_INIT_BALANCE.checked_add(Balance::from_yoctonear(1)).unwrap(),
     );
-    if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        assert_matches!(
-            result,
-            Err(CommitError::Server(ServerError::TxExecutionError(_)))
-                | Ok(FinalExecutionOutcomeView { status: FinalExecutionStatus::Failure(_), .. })
-        );
-    } else {
-        result.unwrap_err();
-    }
+    assert_matches!(
+        result,
+        Err(CommitError::Server(ServerError::TxExecutionError(_)))
+            | Ok(FinalExecutionOutcomeView { status: FinalExecutionStatus::Failure(_), .. })
+    );
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 0);
 }
 
@@ -684,26 +680,17 @@ pub fn test_transaction_invalid_signature(node: impl Node) {
     tx.signature = Signature::from_parts(KeyType::ED25519, &[0u8; 64]).unwrap();
     let result = node_user.commit_transaction(tx);
 
-    if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        assert_matches!(
-            result,
-            Err(CommitError::Server(ServerError::TxExecutionError(
-                TxExecutionError::InvalidTxError(InvalidTxError::InvalidSignature)
-            ))) | Ok(FinalExecutionOutcomeView {
-                status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
-                    InvalidTxError::InvalidSignature
-                )),
-                ..
-            })
-        );
-    } else {
-        assert_matches!(
-            result,
-            Err(CommitError::Server(ServerError::TxExecutionError(
-                TxExecutionError::InvalidTxError(InvalidTxError::InvalidSignature)
-            ))) | Err(CommitError::OutcomeNotFound)
-        );
-    }
+    assert_matches!(
+        result,
+        Err(CommitError::Server(ServerError::TxExecutionError(
+            TxExecutionError::InvalidTxError(InvalidTxError::InvalidSignature)
+        ))) | Ok(FinalExecutionOutcomeView {
+            status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+                InvalidTxError::InvalidSignature
+            )),
+            ..
+        })
+    );
 }
 
 pub fn test_send_money_over_balance(node: impl Node) {
@@ -711,21 +698,17 @@ pub fn test_send_money_over_balance(node: impl Node) {
     let node_user = node.user();
     let money_used = TESTING_INIT_BALANCE.checked_add(Balance::from_yoctonear(1)).unwrap();
     let result0 = node_user.send_money(account_id.clone(), bob_account(), money_used);
-    if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        assert_matches!(
-            result0,
-            Err(CommitError::Server(ServerError::TxExecutionError(
-                TxExecutionError::InvalidTxError(InvalidTxError::NotEnoughBalance { .. })
-            ))) | Ok(FinalExecutionOutcomeView {
-                status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
-                    InvalidTxError::NotEnoughBalance { .. }
-                )),
-                ..
-            })
-        );
-    } else {
-        result0.unwrap_err();
-    }
+    assert_matches!(
+        result0,
+        Err(CommitError::Server(ServerError::TxExecutionError(
+            TxExecutionError::InvalidTxError(InvalidTxError::NotEnoughBalance { .. })
+        ))) | Ok(FinalExecutionOutcomeView {
+            status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+                InvalidTxError::NotEnoughBalance { .. }
+            )),
+            ..
+        })
+    );
     let result1 = node_user.view_account(account_id).unwrap();
     assert_eq!(
         (result1.amount, result1.locked),
@@ -1380,21 +1363,17 @@ pub fn test_access_key_smart_contract_reject_method_name(node: impl Node) {
         Balance::ZERO,
     );
 
-    if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        assert_matches!(
-            transaction_result,
-            Ok(FinalExecutionOutcomeView {
-                status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
-                    InvalidTxError::InvalidAccessKeyError(
-                        InvalidAccessKeyError::MethodNameMismatch { .. }
-                    )
-                )),
-                ..
-            })
-        );
-    } else {
-        assert_eq!(transaction_result.unwrap_err(), CommitError::OutcomeNotFound);
-    }
+    assert_matches!(
+        transaction_result,
+        Ok(FinalExecutionOutcomeView {
+            status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+                InvalidTxError::InvalidAccessKeyError(
+                    InvalidAccessKeyError::MethodNameMismatch { .. }
+                )
+            )),
+            ..
+        })
+    );
 }
 
 pub fn test_access_key_smart_contract_reject_contract_id(node: impl Node) {
@@ -1421,21 +1400,17 @@ pub fn test_access_key_smart_contract_reject_contract_id(node: impl Node) {
         Balance::ZERO,
     );
 
-    if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        assert_matches!(
-            transaction_result,
-            Ok(FinalExecutionOutcomeView {
-                status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
-                    InvalidTxError::InvalidAccessKeyError(
-                        InvalidAccessKeyError::ReceiverMismatch { .. }
-                    )
-                )),
-                ..
-            })
-        );
-    } else {
-        assert_eq!(transaction_result.unwrap_err(), CommitError::OutcomeNotFound);
-    }
+    assert_matches!(
+        transaction_result,
+        Ok(FinalExecutionOutcomeView {
+            status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+                InvalidTxError::InvalidAccessKeyError(
+                    InvalidAccessKeyError::ReceiverMismatch { .. }
+                )
+            )),
+            ..
+        })
+    );
 }
 
 pub fn test_access_key_reject_non_function_call(node: impl Node) {
@@ -1455,25 +1430,21 @@ pub fn test_access_key_reject_non_function_call(node: impl Node) {
 
     let transaction_result = node_user.delete_key(account_id.clone(), node.signer().public_key());
 
-    if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        assert_matches!(
-            transaction_result,
-            Err(CommitError::Server(ServerError::TxExecutionError(
-                TxExecutionError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
-                    InvalidAccessKeyError::MethodNameMismatch { .. }
-                ))
-            ))) | Ok(FinalExecutionOutcomeView {
-                status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
-                    InvalidTxError::InvalidAccessKeyError(
-                        InvalidAccessKeyError::RequiresFullAccess
-                    )
-                )),
-                ..
-            })
-        );
-    } else {
-        assert_eq!(transaction_result.unwrap_err(), CommitError::OutcomeNotFound);
-    }
+    assert_matches!(
+        transaction_result,
+        Err(CommitError::Server(ServerError::TxExecutionError(
+            TxExecutionError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
+                InvalidAccessKeyError::MethodNameMismatch { .. }
+            ))
+        ))) | Ok(FinalExecutionOutcomeView {
+            status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+                InvalidTxError::InvalidAccessKeyError(
+                    InvalidAccessKeyError::RequiresFullAccess
+                )
+            )),
+            ..
+        })
+    );
 }
 
 pub fn test_increase_stake(node: impl Node) {
@@ -1569,19 +1540,15 @@ pub fn test_fail_not_enough_balance_for_storage(node: impl Node) {
     node_user.set_signer(signer);
     let result = node_user.send_money(account_id, alice_account(), Balance::from_yoctonear(10));
 
-    if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        assert_matches!(
-            result,
-            Ok(FinalExecutionOutcomeView {
-                status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
-                    InvalidTxError::LackBalanceForState { .. }
-                )),
-                ..
-            })
-        );
-    } else {
-        assert_eq!(result.unwrap_err(), CommitError::OutcomeNotFound);
-    }
+    assert_matches!(
+        result,
+        Ok(FinalExecutionOutcomeView {
+            status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+                InvalidTxError::LackBalanceForState { .. }
+            )),
+            ..
+        })
+    );
 }
 
 pub fn test_delete_account_ok(node: impl Node) {

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -682,9 +682,9 @@ pub fn test_transaction_invalid_signature(node: impl Node) {
 
     assert_matches!(
         result,
-        Err(CommitError::Server(ServerError::TxExecutionError(
-            TxExecutionError::InvalidTxError(InvalidTxError::InvalidSignature)
-        ))) | Ok(FinalExecutionOutcomeView {
+        Err(CommitError::Server(ServerError::TxExecutionError(TxExecutionError::InvalidTxError(
+            InvalidTxError::InvalidSignature
+        )))) | Ok(FinalExecutionOutcomeView {
             status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
                 InvalidTxError::InvalidSignature
             )),
@@ -700,9 +700,9 @@ pub fn test_send_money_over_balance(node: impl Node) {
     let result0 = node_user.send_money(account_id.clone(), bob_account(), money_used);
     assert_matches!(
         result0,
-        Err(CommitError::Server(ServerError::TxExecutionError(
-            TxExecutionError::InvalidTxError(InvalidTxError::NotEnoughBalance { .. })
-        ))) | Ok(FinalExecutionOutcomeView {
+        Err(CommitError::Server(ServerError::TxExecutionError(TxExecutionError::InvalidTxError(
+            InvalidTxError::NotEnoughBalance { .. }
+        )))) | Ok(FinalExecutionOutcomeView {
             status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
                 InvalidTxError::NotEnoughBalance { .. }
             )),
@@ -1432,15 +1432,11 @@ pub fn test_access_key_reject_non_function_call(node: impl Node) {
 
     assert_matches!(
         transaction_result,
-        Err(CommitError::Server(ServerError::TxExecutionError(
-            TxExecutionError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
-                InvalidAccessKeyError::MethodNameMismatch { .. }
-            ))
-        ))) | Ok(FinalExecutionOutcomeView {
+        Err(CommitError::Server(ServerError::TxExecutionError(TxExecutionError::InvalidTxError(
+            InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::MethodNameMismatch { .. })
+        )))) | Ok(FinalExecutionOutcomeView {
             status: FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
-                InvalidTxError::InvalidAccessKeyError(
-                    InvalidAccessKeyError::RequiresFullAccess
-                )
+                InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::RequiresFullAccess)
             )),
             ..
         })

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -510,11 +510,10 @@ impl Testbed<'_> {
         let TxVerdict::Success(result) = verify_and_charge_tx_ephemeral(
             &self.apply_state.config,
             &signer,
-            &mut access_key,
+            &access_key,
             validated_tx.to_tx(),
             &cost,
             block_height,
-            PROTOCOL_VERSION,
             &PendingConstraints::default(),
         ) else {
             panic!("tx verification should not fail in estimator");

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1839,20 +1839,6 @@ impl Runtime {
         state_update.commit(StateChangeCause::Migration);
     }
 
-    /// insert the outcome into the processing state depending on whether the protocol feature
-    /// `InvalidTxOutcome` is enabled or not
-    fn register_outcome(
-        protocol_version: ProtocolVersion,
-        outcomes: &mut Vec<ExecutionOutcomeWithId>,
-        outcome: ExecutionOutcomeWithId,
-    ) {
-        if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(protocol_version) {
-            outcomes.push(outcome);
-        } else if let ExecutionStatus::SuccessReceiptId(_) = outcome.outcome.status {
-            outcomes.push(outcome);
-        }
-    }
-
     /// Processes a collection of transactions.
     ///
     /// Fills the `processing_state` with local receipts generated during processing of the
@@ -1982,11 +1968,7 @@ impl Runtime {
             if let Some(err) = maybe_validation_error {
                 metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
                 let outcome = ExecutionOutcomeWithId::failed(tx, err);
-                Self::register_outcome(
-                    processing_state.protocol_version,
-                    &mut processing_state.outcomes,
-                    outcome,
-                );
+                processing_state.outcomes.push(outcome);
                 continue;
             }
             let signer_id = tx.transaction.signer_id();
@@ -2006,11 +1988,7 @@ impl Runtime {
                         let outcome = ExecutionOutcomeWithId::failed(tx, tx_error);
                         let error = &error as &dyn std::error::Error;
                         tracing::debug!(%tx_hash, error, "transaction cost calculation failed");
-                        Self::register_outcome(
-                            processing_state.protocol_version,
-                            &mut processing_state.outcomes,
-                            outcome,
-                        );
+                        processing_state.outcomes.push(outcome);
                         continue;
                     }
                 };
@@ -2025,11 +2003,7 @@ impl Runtime {
                         tx,
                         InvalidTxError::InvalidSignerId { signer_id: signer_id.to_string() },
                     );
-                    Self::register_outcome(
-                        processing_state.protocol_version,
-                        &mut processing_state.outcomes,
-                        outcome,
-                    );
+                    processing_state.outcomes.push(outcome);
                     continue;
                 }
                 Some(Err(e)) => return Err(e.clone().into()),
@@ -2051,11 +2025,7 @@ impl Runtime {
                         ),
                     );
 
-                    Self::register_outcome(
-                        processing_state.protocol_version,
-                        &mut processing_state.outcomes,
-                        outcome,
-                    );
+                    processing_state.outcomes.push(outcome);
                     continue;
                 }
                 Some(Err(e)) => return Err(e.clone().into()),
@@ -2079,11 +2049,7 @@ impl Runtime {
                                 num_nonces,
                             },
                         );
-                        Self::register_outcome(
-                            processing_state.protocol_version,
-                            &mut processing_state.outcomes,
-                            outcome,
-                        );
+                        processing_state.outcomes.push(outcome);
                         continue;
                     }
                     Some(Err(e)) => return Err(e.clone().into()),
@@ -2108,7 +2074,6 @@ impl Runtime {
                     &tx.transaction,
                     &cost,
                     Some(block_height),
-                    processing_state.protocol_version,
                     &PendingConstraints::default(),
                 )
             };
@@ -2188,11 +2153,7 @@ impl Runtime {
                     metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
                     tracing::debug!(%tx_hash, error = &error as &dyn std::error::Error, "transaction failed verify/charge");
                     let outcome = ExecutionOutcomeWithId::failed(tx, error);
-                    Self::register_outcome(
-                        processing_state.protocol_version,
-                        &mut processing_state.outcomes,
-                        outcome,
-                    );
+                    processing_state.outcomes.push(outcome);
                     continue;
                 }
             };
@@ -2253,11 +2214,9 @@ impl Runtime {
                 .commit(StateChangeCause::TransactionProcessing { tx_hash: tx.get_hash() });
         }
 
-        if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(protocol_version) {
-            debug_assert!(
-                processing_state.outcomes.len() == num_transactions - num_skipped_duplicate_txs
-            );
-        }
+        debug_assert!(
+            processing_state.outcomes.len() == num_transactions - num_skipped_duplicate_txs
+        );
 
         processing_state
             .metrics

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -3517,7 +3517,7 @@ fn test_fix_access_key_allowance_no_mutation_on_failed_tx() {
         gas_limit: Some(Gas::from_teragas(1000)),
         random_seed: Default::default(),
         current_protocol_version: PROTOCOL_VERSION,
-        config: config.clone(),
+        config,
         next_wasm_config: None,
         cache: Some(Box::new(contract_cache)),
         is_new_chunk: true,

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -3446,7 +3446,7 @@ fn test_transaction_multiple_access_keys_with_apply() {
 /// targets the correct receiver. Since tx1 does not touch the allowance, tx2
 /// still sees the full allowance and succeeds.
 #[test]
-fn test_fix_access_key_allowance_no_mutation_on_failed_tx() {
+fn test_access_key_allowance_not_mutated_on_failed_tx() {
     let alice_signer = Arc::new(InMemorySigner::test_signer(&alice_account()));
 
     let config = Arc::new(RuntimeConfig::test());

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -3342,24 +3342,14 @@ fn test_transaction_ordering_with_apply() {
         )
         .expect("apply should succeed");
 
-    let expected_order = if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        vec![
-            bob_tx1.get_hash(),
-            alice_invalid_tx.get_hash(),
-            alice_tx1.get_hash(),
-            bob_tx2.get_hash(),
-            alice_tx2.get_hash(),
-            bob_tx3.get_hash(),
-        ]
-    } else {
-        vec![
-            bob_tx1.get_hash(),
-            alice_tx1.get_hash(),
-            bob_tx2.get_hash(),
-            alice_tx2.get_hash(),
-            bob_tx3.get_hash(),
-        ]
-    };
+    let expected_order = vec![
+        bob_tx1.get_hash(),
+        alice_invalid_tx.get_hash(),
+        alice_tx1.get_hash(),
+        bob_tx2.get_hash(),
+        alice_tx2.get_hash(),
+        bob_tx3.get_hash(),
+    ];
 
     let num_outcomes = expected_order.len();
     // Note: The 3 local receipts are generated for valid transactions
@@ -3449,28 +3439,100 @@ fn test_transaction_multiple_access_keys_with_apply() {
     assert!(account.amount() > Balance::from_near(993_000));
 }
 
-/// Tests that the FixAccessKeyAllowanceCharging protocol feature prevents
-/// access key allowance mutation when a transaction fails after the allowance
-/// check. Scenario: two function call transactions using the same access key.
-/// Tx1 targets the wrong receiver (fails at verify_function_call_permission,
-/// which runs after the allowance check). Tx2 targets the correct receiver.
+/// Tests that a transaction failing after the allowance check does not mutate
+/// the access key allowance. Scenario: two function call transactions using the
+/// same access key. Tx1 targets the wrong receiver (fails at
+/// verify_function_call_permission, which runs after the allowance check). Tx2
+/// targets the correct receiver.
 ///
-/// Before the fix: tx1 incorrectly decrements the allowance, causing tx2 to
-/// see a lower allowance and fail with NotEnoughAllowance.
-/// After the fix: tx1 does not touch the allowance, and tx2 succeeds.
+/// Tx1 does not touch the allowance, so tx2 still sees the full allowance and
+/// succeeds. (Before this was fixed, tx1 incorrectly decremented the allowance,
+/// causing tx2 to fail with NotEnoughAllowance.)
 #[test]
 fn test_fix_access_key_allowance_no_mutation_on_failed_tx() {
     let alice_signer = Arc::new(InMemorySigner::test_signer(&alice_account()));
 
-    // We'll run the test twice: once with the old version and once with the new version.
-    let fix_version = ProtocolFeature::FixAccessKeyAllowanceCharging.protocol_version();
-    for (protocol_version, expect_tx2_success) in [(fix_version - 1, false), (fix_version, true)] {
-        let config = Arc::new(RuntimeConfig::test());
-        // Compute cost of one function call transaction so we can set allowance tightly.
-        let sample_tx = SignedTransaction::from_actions(
-            1,
+    let config = Arc::new(RuntimeConfig::test());
+    // Compute cost of one function call transaction so we can set allowance tightly.
+    let sample_tx = SignedTransaction::from_actions(
+        1,
+        alice_account(),
+        bob_account(),
+        &*alice_signer,
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
+            method_name: "hello".to_string(),
+            args: vec![],
+            gas: DEFAULT_MINIMAL_GAS_ATTACHMENT,
+            deposit: Balance::ZERO,
+        }))],
+        CryptoHash::default(),
+    );
+    let sample_cost = crate::config::tx_cost(&config, &sample_tx.transaction, GAS_PRICE).unwrap();
+    // Set allowance so it covers exactly one transaction's total_cost.
+    let allowance = sample_cost.total_cost;
+
+    // Build state manually with a function call access key.
+    let tries = TestTriesBuilder::new().build();
+    let shard_uid = ShardUId::single_shard();
+    let root = MerkleHash::default();
+    let mut initial_state = tries.new_trie_update(shard_uid, root);
+
+    let access_key = AccessKey {
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: Some(allowance),
+            receiver_id: bob_account().into(),
+            method_names: vec![],
+        }),
+    };
+    let mut alice = account_new(Balance::from_near(1_000_000), CryptoHash::default());
+    alice.set_storage_usage(182);
+    set_account(&mut initial_state, alice_account(), &alice);
+    set_access_key(&mut initial_state, alice_account(), alice_signer.public_key(), &access_key);
+    let bob = account_new(Balance::from_near(1_000_000), CryptoHash::default());
+    set_account(&mut initial_state, bob_account(), &bob);
+
+    initial_state.commit(StateChangeCause::InitialState);
+    let trie_changes = initial_state.finalize().unwrap().trie_changes;
+    let mut store_update = tries.store_update();
+    let root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
+    store_update.commit();
+
+    let runtime = Runtime::new();
+    let contract_cache = FilesystemContractRuntimeCache::test().unwrap();
+    let epoch_info_provider = MockEpochInfoProvider::default();
+    let shard_layout = epoch_info_provider.shard_layout(&EpochId::default()).unwrap();
+    let shard_ids = shard_layout.shard_ids();
+    let shards_congestion_info =
+        shard_ids.map(|id| (id, ExtendedCongestionInfo::default())).collect();
+    let mut apply_state = ApplyState {
+        apply_reason: ApplyChunkReason::UpdateTrackedShard,
+        block_height: 1,
+        prev_block_hash: Default::default(),
+        shard_id: shard_uid.shard_id(),
+        epoch_id: Default::default(),
+        epoch_height: 0,
+        gas_price: GAS_PRICE,
+        block_timestamp: 100,
+        gas_limit: Some(Gas::from_teragas(1000)),
+        random_seed: Default::default(),
+        current_protocol_version: PROTOCOL_VERSION,
+        config: config.clone(),
+        next_wasm_config: None,
+        cache: Some(Box::new(contract_cache)),
+        is_new_chunk: true,
+        save_receipt_to_tx: false,
+        congestion_info: BlockCongestionInfo::new(shards_congestion_info),
+        bandwidth_requests: BlockBandwidthRequests::empty(),
+        trie_access_tracker_state: Default::default(),
+        on_post_state_ready: None,
+    };
+
+    let make_fc_tx = |nonce, receiver| {
+        SignedTransaction::from_actions(
+            nonce,
             alice_account(),
-            bob_account(),
+            receiver,
             &*alice_signer,
             vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "hello".to_string(),
@@ -3479,156 +3541,53 @@ fn test_fix_access_key_allowance_no_mutation_on_failed_tx() {
                 deposit: Balance::ZERO,
             }))],
             CryptoHash::default(),
-        );
-        let sample_cost =
-            crate::config::tx_cost(&config, &sample_tx.transaction, GAS_PRICE).unwrap();
-        // Set allowance so it covers exactly one transaction's total_cost.
-        let allowance = sample_cost.total_cost;
+        )
+    };
 
-        // Build state manually with a function call access key.
-        let tries = TestTriesBuilder::new().build();
-        let shard_uid = ShardUId::single_shard();
-        let root = MerkleHash::default();
-        let mut initial_state = tries.new_trie_update(shard_uid, root);
+    // tx1: wrong receiver → fails at verify_function_call_permission
+    // tx2: correct receiver → should succeed if allowance is intact
+    let tx1 = make_fc_tx(1, alice_account()); // wrong receiver
+    let tx2 = make_fc_tx(2, bob_account()); // correct receiver
+    let txs = vec![tx1.clone(), tx2.clone()];
+    let signed_valid_period_txs = SignedValidPeriodTransactions::new(txs, vec![true, true]);
 
-        let access_key = AccessKey {
-            nonce: 0,
-            permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
-                allowance: Some(allowance),
-                receiver_id: bob_account().into(),
-                method_names: vec![],
-            }),
-        };
-        let mut alice = account_new(Balance::from_near(1_000_000), CryptoHash::default());
-        alice.set_storage_usage(182);
-        set_account(&mut initial_state, alice_account(), &alice);
-        set_access_key(&mut initial_state, alice_account(), alice_signer.public_key(), &access_key);
-        let bob = account_new(Balance::from_near(1_000_000), CryptoHash::default());
-        set_account(&mut initial_state, bob_account(), &bob);
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(shard_uid, root),
+            &None,
+            &apply_state,
+            &[],
+            signed_valid_period_txs,
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
 
-        initial_state.commit(StateChangeCause::InitialState);
-        let trie_changes = initial_state.finalize().unwrap().trie_changes;
-        let mut store_update = tries.store_update();
-        let root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
-        store_update.commit();
-
-        let runtime = Runtime::new();
-        let contract_cache = FilesystemContractRuntimeCache::test().unwrap();
-        let epoch_info_provider = MockEpochInfoProvider::default();
-        let shard_layout = epoch_info_provider.shard_layout(&EpochId::default()).unwrap();
-        let shard_ids = shard_layout.shard_ids();
-        let shards_congestion_info =
-            shard_ids.map(|id| (id, ExtendedCongestionInfo::default())).collect();
-        let mut apply_state = ApplyState {
-            apply_reason: ApplyChunkReason::UpdateTrackedShard,
-            block_height: 1,
-            prev_block_hash: Default::default(),
-            shard_id: shard_uid.shard_id(),
-            epoch_id: Default::default(),
-            epoch_height: 0,
-            gas_price: GAS_PRICE,
-            block_timestamp: 100,
-            gas_limit: Some(Gas::from_teragas(1000)),
-            random_seed: Default::default(),
-            current_protocol_version: protocol_version,
-            config: config.clone(),
-            next_wasm_config: None,
-            cache: Some(Box::new(contract_cache)),
-            is_new_chunk: true,
-            save_receipt_to_tx: false,
-            congestion_info: BlockCongestionInfo::new(shards_congestion_info),
-            bandwidth_requests: BlockBandwidthRequests::empty(),
-            trie_access_tracker_state: Default::default(),
-            on_post_state_ready: None,
-        };
-
-        let make_fc_tx = |nonce, receiver| {
-            SignedTransaction::from_actions(
-                nonce,
-                alice_account(),
-                receiver,
-                &*alice_signer,
-                vec![Action::FunctionCall(Box::new(FunctionCallAction {
-                    method_name: "hello".to_string(),
-                    args: vec![],
-                    gas: DEFAULT_MINIMAL_GAS_ATTACHMENT,
-                    deposit: Balance::ZERO,
-                }))],
-                CryptoHash::default(),
+    // tx1 fails at verify_function_call_permission (after the allowance check) but
+    // does not mutate the allowance, so tx2 still sees the full allowance and succeeds.
+    // Both outcomes are recorded.
+    assert_eq!(apply_result.outcomes.len(), 2);
+    let tx1_outcome = &apply_result.outcomes[0];
+    assert_eq!(tx1_outcome.id, tx1.get_hash());
+    assert_matches!(
+        &tx1_outcome.outcome.status,
+        ExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+            InvalidTxError::InvalidAccessKeyError(
+                near_primitives::errors::InvalidAccessKeyError::ReceiverMismatch { .. }
             )
-        };
+        ))
+    );
+    let tx2_outcome = &apply_result.outcomes[1];
+    assert_eq!(tx2_outcome.id, tx2.get_hash());
+    assert_matches!(&tx2_outcome.outcome.status, ExecutionStatus::SuccessReceiptId(_));
 
-        // tx1: wrong receiver → fails at verify_function_call_permission
-        // tx2: correct receiver → should succeed if allowance is intact
-        let tx1 = make_fc_tx(1, alice_account()); // wrong receiver
-        let tx2 = make_fc_tx(2, bob_account()); // correct receiver
-        let txs = vec![tx1.clone(), tx2.clone()];
-        let signed_valid_period_txs = SignedValidPeriodTransactions::new(txs, vec![true, true]);
-
-        let apply_result = runtime
-            .apply(
-                tries.get_trie_for_shard(shard_uid, root),
-                &None,
-                &apply_state,
-                &[],
-                signed_valid_period_txs,
-                &epoch_info_provider,
-                Default::default(),
-            )
-            .unwrap();
-
-        if expect_tx2_success {
-            // After the fix (also after InvalidTxGenerateOutcomes): both outcomes are recorded.
-            assert_eq!(apply_result.outcomes.len(), 2, "protocol_version={protocol_version}");
-            let tx1_outcome = &apply_result.outcomes[0];
-            assert_eq!(tx1_outcome.id, tx1.get_hash());
-            assert_matches!(
-                &tx1_outcome.outcome.status,
-                ExecutionStatus::Failure(TxExecutionError::InvalidTxError(
-                    InvalidTxError::InvalidAccessKeyError(
-                        near_primitives::errors::InvalidAccessKeyError::ReceiverMismatch { .. }
-                    )
-                ))
-            );
-            let tx2_outcome = &apply_result.outcomes[1];
-            assert_eq!(tx2_outcome.id, tx2.get_hash());
-            assert_matches!(
-                &tx2_outcome.outcome.status,
-                ExecutionStatus::SuccessReceiptId(_),
-                "protocol_version={protocol_version}: tx2 should succeed after fix"
-            );
-        } else {
-            // Before the fix (also before InvalidTxGenerateOutcomes): failed tx outcomes
-            // are not recorded. Both txs fail (tx1 with ReceiverMismatch, tx2 with
-            // NotEnoughAllowance due to tx1's buggy allowance mutation), so no outcomes
-            // or outgoing receipts are produced.
-            assert_eq!(apply_result.outcomes.len(), 0);
-            assert_eq!(apply_result.outgoing_receipts.len(), 0);
-        }
-
-        // Verify the access key state after apply.
-        // State is only written to trie for successful transactions (via set_access_key
-        // on the success path). So the trie reflects whether tx2 succeeded or not.
-        let root = commit_apply_result(&apply_result, &mut apply_state, &tries, shard_uid);
-        let state = tries.new_trie_update(shard_uid, root);
-        let ak =
-            get_access_key(&state, &alice_account(), &alice_signer.public_key()).unwrap().unwrap();
-        let final_allowance = ak.permission.function_call_permission().unwrap().allowance.unwrap();
-        if expect_tx2_success {
-            // After the fix: tx2 succeeded → allowance was consumed and written to trie.
-            assert!(
-                final_allowance < allowance,
-                "protocol_version={protocol_version}: allowance should decrease after successful tx2"
-            );
-        } else {
-            // Before the fix: tx1's buggy allowance mutation prevented tx2 from succeeding.
-            // Neither tx wrote to trie, so trie allowance is unchanged.
-            assert_eq!(
-                final_allowance, allowance,
-                "protocol_version={protocol_version}: trie allowance unchanged (both txs failed)"
-            );
-        }
-    }
+    // Verify the access key state after apply: tx2 succeeded → allowance was consumed
+    // and written to trie.
+    let root = commit_apply_result(&apply_result, &mut apply_state, &tries, shard_uid);
+    let state = tries.new_trie_update(shard_uid, root);
+    let ak = get_access_key(&state, &alice_account(), &alice_signer.public_key()).unwrap().unwrap();
+    let final_allowance = ak.permission.function_call_permission().unwrap().allowance.unwrap();
+    assert!(final_allowance < allowance, "allowance should decrease after successful tx2");
 }
 
 #[test]
@@ -3662,25 +3621,17 @@ fn test_expired_transaction() {
         )
         .expect("apply should succeed");
 
-    if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        assert_eq!(
-            apply_result.outcomes.len(),
-            1,
-            "should have produced one outcome for the expired tx"
-        );
-        let outcome = &apply_result.outcomes[0];
-        assert_eq!(outcome.id, expired_tx[0].get_hash());
-        assert_matches!(
-            &outcome.outcome.status,
-            ExecutionStatus::Failure(TxExecutionError::InvalidTxError(InvalidTxError::Expired))
-        );
-    } else {
-        assert_eq!(
-            apply_result.outcomes.len(),
-            0,
-            "should have not produced any outcomes for the expired tx"
-        );
-    }
+    assert_eq!(
+        apply_result.outcomes.len(),
+        1,
+        "should have produced one outcome for the expired tx"
+    );
+    let outcome = &apply_result.outcomes[0];
+    assert_eq!(outcome.id, expired_tx[0].get_hash());
+    assert_matches!(
+        &outcome.outcome.status,
+        ExecutionStatus::Failure(TxExecutionError::InvalidTxError(InvalidTxError::Expired))
+    );
 }
 
 #[test]

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -3443,11 +3443,8 @@ fn test_transaction_multiple_access_keys_with_apply() {
 /// the access key allowance. Scenario: two function call transactions using the
 /// same access key. Tx1 targets the wrong receiver (fails at
 /// verify_function_call_permission, which runs after the allowance check). Tx2
-/// targets the correct receiver.
-///
-/// Tx1 does not touch the allowance, so tx2 still sees the full allowance and
-/// succeeds. (Before this was fixed, tx1 incorrectly decremented the allowance,
-/// causing tx2 to fail with NotEnoughAllowance.)
+/// targets the correct receiver. Since tx1 does not touch the allowance, tx2
+/// still sees the full allowance and succeeds.
 #[test]
 fn test_fix_access_key_allowance_no_mutation_on_failed_tx() {
     let alice_signer = Arc::new(InMemorySigner::test_signer(&alice_account()));

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -15,7 +15,6 @@ use near_primitives::transaction::{
     Action, NonceMode, SignedTransaction, Transaction, ValidatedTransaction,
 };
 use near_primitives::types::{AccountId, Balance, BlockHeight, Nonce, StorageUsage};
-use near_primitives::version::ProtocolFeature;
 use near_primitives::version::ProtocolVersion;
 use near_store::{
     StorageError, TrieUpdate, get_access_key, get_account, set_access_key, set_account,
@@ -265,18 +264,15 @@ fn check_and_compute_new_allowance(
 /// Returns `TxVerdict::Success` or `TxVerdict::Failed` (never `DepositFailed`).
 /// Callers should apply state changes via `VerificationResult::apply` on success.
 ///
-/// Legacy: for pre-`FixAccessKeyAllowanceCharging` protocol versions, the allowance is
-/// mutated on `access_key` before later checks, preserving the historical bug where
-/// failed txs still decrement the allowance. This is the only mutation this function
-/// performs; all other state changes are returned in the `VerificationResult`.
+/// This function performs no mutation; all state changes are returned in the
+/// `VerificationResult`.
 pub fn verify_and_charge_tx_ephemeral(
     config: &RuntimeConfig,
     account: &Account,
-    access_key: &mut AccessKey,
+    access_key: &AccessKey,
     tx: &Transaction,
     transaction_cost: &TransactionCost,
     block_height: Option<BlockHeight>,
-    protocol_version: ProtocolVersion,
     pending: &PendingConstraints,
 ) -> TxVerdict {
     // It's the caller's responsibility to NOT call this function for transactions with
@@ -332,15 +328,6 @@ pub fn verify_and_charge_tx_ephemeral(
         Ok(a) => a,
         Err(e) => return TxVerdict::Failed(e),
     };
-    // Legacy bug: pre-FixAccessKeyAllowanceCharging protocol versions mutate the allowance
-    // before subsequent checks, causing incorrect allowance decrement on failed txs.
-    // TODO: remove this mutation when the legacy behavior is no longer needed.
-    let fix_allowance = ProtocolFeature::FixAccessKeyAllowanceCharging.enabled(protocol_version);
-    if !fix_allowance {
-        if let Some(new) = new_allowance {
-            access_key.permission.function_call_permission_mut().unwrap().allowance = Some(new);
-        }
-    }
 
     match check_storage_stake(account, new_amount, config) {
         Ok(()) => {}
@@ -900,7 +887,7 @@ mod tests {
             }
         };
 
-        let (signer, mut access_key) = match get_signer_and_access_key(state_update, &validated_tx)
+        let (signer, access_key) = match get_signer_and_access_key(state_update, &validated_tx)
         {
             Ok((signer, access_key)) => (signer, access_key),
             Err(err) => {
@@ -912,11 +899,10 @@ mod tests {
         let TxVerdict::Failed(err) = verify_and_charge_tx_ephemeral(
             config,
             &signer,
-            &mut access_key,
+            &access_key,
             validated_tx.to_tx(),
             &cost,
             None,
-            current_protocol_version,
             &PendingConstraints::default(),
         ) else {
             panic!("expected Failed verdict");
@@ -959,11 +945,10 @@ mod tests {
             verify_and_charge_tx_ephemeral(
                 config,
                 &signer,
-                &mut access_key,
+                &access_key,
                 tx,
                 &transaction_cost,
                 block_height,
-                current_protocol_version,
                 &PendingConstraints::default(),
             )
         };

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -887,8 +887,7 @@ mod tests {
             }
         };
 
-        let (signer, access_key) = match get_signer_and_access_key(state_update, &validated_tx)
-        {
+        let (signer, access_key) = match get_signer_and_access_key(state_update, &validated_tx) {
             Ok((signer, access_key)) => (signer, access_key),
             Err(err) => {
                 assert_eq!(err, expected_err);

--- a/test-loop-tests/src/tests/indexer.rs
+++ b/test-loop-tests/src/tests/indexer.rs
@@ -248,9 +248,6 @@ fn test_indexer_delayed_local_receipt() {
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_indexer_failed_local_tx() {
     init_test_logger();
-    if !ProtocolFeature::InvalidTxGenerateOutcomes.enabled(PROTOCOL_VERSION) {
-        return;
-    }
 
     let mut env = setup();
     env.validator_runner().send_adversarial_message(NetworkAdversarialMessage::AdvProduceChunks(


### PR DESCRIPTION
Deprecate `InvalidTxGenerateOutcomes` + `FixAccessKeyAllowanceCharging` (v83 features)

Failed-tx outcomes are now always recorded.
- Collapse the `outcome.is_none()` guard in the indexer streamer.
- Delete the `register_outcome` helper in `node-runtime`; call sites push directly to `processing_state.outcomes`.
- Make the final outcome-count `debug_assert!` unconditional.
 
`verify_and_charge_tx_ephemeral` no longer mutates the access key allowance.
- `access_key` becomes `&AccessKey` (was `&mut`), and the `protocol_version` param is dropped.
- The legacy in-place mutation block (and its doc paragraph) is removed.
- Call sites in `chain`, `node-runtime`, and the params estimator updated.

Tests gated on these features are collapsed to the post-feature case (`standard_cases`, `apply.rs`, `test-loop-tests/indexer.rs`). The enum variants are renamed to `_Deprecated*` with `#[deprecated]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)