### PR TITLE
fix(spice): deflake test_spice_chain_with_missing_chunks

### DIFF
--- a/test-loop-tests/src/tests/spice/basic.rs
+++ b/test-loop-tests/src/tests/spice/basic.rs
@@ -849,28 +849,27 @@ fn test_spice_chain_with_missing_chunks() {
     let (sent_txs, balance_changes) =
         schedule_send_money_txs(&[node_data], &accounts, &env.test_loop);
 
-    let mut observed_txs = HashSet::new();
+    // A final result requires the whole receipt tree to resolve, including the gas-refund
+    // receipt, so balances have fully settled once every transaction reaches one.
+    let mut finalized_txs = HashSet::new();
     env.rpc_runner().run_until(
         |node| {
-            let head = node.head();
+            let sent_txs = sent_txs.lock();
+            if sent_txs.len() < accounts.len() {
+                return false;
+            }
             let client = node.client();
-            let block = client.chain.get_block(&head.last_block_hash).unwrap();
-            for chunk in block.chunks().iter() {
-                let Ok(chunk) = client.chain.get_chunk(&chunk.chunk_hash()) else {
-                    continue;
-                };
-                for tx in chunk.to_transactions() {
-                    observed_txs.insert(tx.get_hash());
+            for tx_hash in sent_txs.iter() {
+                if !finalized_txs.contains(tx_hash)
+                    && client.chain.get_final_transaction_result(tx_hash).is_ok()
+                {
+                    finalized_txs.insert(*tx_hash);
                 }
             }
-            observed_txs.len() == sent_txs.lock().len()
+            finalized_txs.len() == sent_txs.len()
         },
         Duration::seconds(200),
     );
-
-    // A few more blocks to make sure everything is executed.
-    let head_height = env.rpc_node().head().height;
-    env.rpc_runner().run_until_head_height(head_height + 3);
 
     {
         let node = env.rpc_node();


### PR DESCRIPTION
`test_spice_chain_with_missing_chunks` intermittently failed its post-transfer balance assertion (~10% standalone, more under parallel load). It is a pre-existing flake, independent of recent work.

The test waited only for transactions to be *included* (`observed_txs == sent_txs`) and then ran a fixed 3 extra blocks before checking balances. With genesis gas price 0, each cross-shard `send_money` still prepays gas at the `min_gas_purchase_price` floor, which is transiently debited from the sender and fully refunded once the receipt executes. The 3-block window was not always enough for the last-sent transactions' gas-refund receipts to settle, and which transactions were still pending depended on HashMap-iteration-order timing in the SPICE actors, making the failure nondeterministic per process.

The fix waits until every transaction reaches a final result via `get_final_transaction_result`, which requires the entire receipt tree (including the gas-refund receipt) to resolve, so balances are guaranteed to have settled before they are checked. This removes the fixed extra-block heuristic and makes the test deterministic regardless of message ordering.

Verified with 25 heavy parallel runs (previously ~25% failure rate) and repeated standalone runs, all passing.