### PR TITLE
feat(spice): all-stake fallback chunk certification

### DIFF
--- a/chain/chain/src/spice/ancestry_endorsements.rs
+++ b/chain/chain/src/spice/ancestry_endorsements.rs
@@ -1,0 +1,56 @@
+use near_primitives::spice::chunk_endorsement::SpiceStoredVerifiedEndorsement;
+use near_primitives::types::{AccountId, SpiceChunkId, SpiceUncertifiedChunkInfo};
+use std::collections::{HashMap, HashSet};
+
+/// Endorsement state derived from the uncertified chunks as of the previous block: the context
+/// against which a block's core statements are validated. Borrows `prev_uncertified_chunks`.
+pub(crate) struct AncestryEndorsements<'a> {
+    pending_designated: HashSet<(&'a SpiceChunkId, &'a AccountId)>,
+    on_chain: HashMap<&'a SpiceChunkId, HashMap<&'a AccountId, &'a SpiceStoredVerifiedEndorsement>>,
+}
+
+impl<'a> AncestryEndorsements<'a> {
+    pub(crate) fn collect(prev_uncertified_chunks: &'a [SpiceUncertifiedChunkInfo]) -> Self {
+        let mut on_chain: HashMap<_, HashMap<_, _>> = HashMap::new();
+        for info in prev_uncertified_chunks {
+            for (account_id, endorsement) in info.all_present_endorsements() {
+                on_chain.entry(&info.chunk_id).or_default().insert(account_id, endorsement);
+            }
+        }
+        Self {
+            pending_designated: prev_uncertified_chunks
+                .iter()
+                .flat_map(|info| {
+                    info.missing_endorsements.iter().map(|account_id| (&info.chunk_id, account_id))
+                })
+                .collect(),
+            on_chain,
+        }
+    }
+
+    /// Whether `(chunk_id, account_id)` is a designated endorsement still awaited on chain.
+    pub(crate) fn is_pending_designated(
+        &self,
+        chunk_id: &'a SpiceChunkId,
+        account_id: &'a AccountId,
+    ) -> bool {
+        self.pending_designated.contains(&(chunk_id, account_id))
+    }
+
+    /// Chunks awaiting a designated endorsement on chain (with repeats per missing validator).
+    pub(crate) fn pending_designated_chunks(&self) -> impl Iterator<Item = &'a SpiceChunkId> + '_ {
+        self.pending_designated.iter().map(|(chunk_id, _)| *chunk_id)
+    }
+
+    /// Endorsements (designated and non-designated) already on chain for `chunk_id`.
+    pub(crate) fn on_chain_for(
+        &self,
+        chunk_id: &SpiceChunkId,
+    ) -> impl Iterator<Item = (&'a AccountId, &'a SpiceStoredVerifiedEndorsement)> + '_ {
+        self.on_chain
+            .get(chunk_id)
+            .into_iter()
+            .flatten()
+            .map(|(account_id, endorsement)| (*account_id, *endorsement))
+    }
+}

--- a/chain/chain/src/spice/ancestry_endorsements.rs
+++ b/chain/chain/src/spice/ancestry_endorsements.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 /// against which a block's core statements are validated. Borrows `prev_uncertified_chunks`.
 pub(crate) struct AncestryEndorsements<'a> {
     pending_designated: HashSet<(&'a SpiceChunkId, &'a AccountId)>,
+    uncertified_chunks: HashSet<&'a SpiceChunkId>,
     on_chain: HashMap<&'a SpiceChunkId, HashMap<&'a AccountId, &'a SpiceStoredVerifiedEndorsement>>,
 }
 
@@ -24,6 +25,7 @@ impl<'a> AncestryEndorsements<'a> {
                     info.missing_endorsements.iter().map(|account_id| (&info.chunk_id, account_id))
                 })
                 .collect(),
+            uncertified_chunks: prev_uncertified_chunks.iter().map(|info| &info.chunk_id).collect(),
             on_chain,
         }
     }
@@ -35,6 +37,16 @@ impl<'a> AncestryEndorsements<'a> {
         account_id: &'a AccountId,
     ) -> bool {
         self.pending_designated.contains(&(chunk_id, account_id))
+    }
+
+    /// Whether `chunk_id` is still uncertified as of the previous block.
+    pub(crate) fn is_uncertified(&self, chunk_id: &SpiceChunkId) -> bool {
+        self.uncertified_chunks.contains(chunk_id)
+    }
+
+    /// Whether `(chunk_id, account_id)`'s endorsement is already on chain in the ancestry.
+    pub(crate) fn is_on_chain(&self, chunk_id: &SpiceChunkId, account_id: &AccountId) -> bool {
+        self.on_chain.get(chunk_id).is_some_and(|endorsers| endorsers.contains_key(account_id))
     }
 
     /// Chunks awaiting a designated endorsement on chain (with repeats per missing validator).

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -13,6 +13,7 @@ use near_primitives::shard_layout::ShardUId;
 use near_primitives::spice::chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
 };
+use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
@@ -73,6 +74,33 @@ impl SpiceCoreReader {
         self.chain_store
             .store()
             .get_ser(DBCol::endorsements(), &get_endorsements_key(block_hash, shard_id, account_id))
+    }
+
+    /// Whether the union of `endorsers` and the validators whose stored endorsement attests
+    /// `result_hash` certifies the chunk under `assignment`. `endorsers` seeds the set with the
+    /// endorsers already in hand (e.g. from the block); the rest are read from the store.
+    pub(crate) fn reaches_endorsement_threshold(
+        &self,
+        chunk_id: &SpiceChunkId,
+        result_hash: &ChunkExecutionResultHash,
+        assignment: &ChunkValidatorAssignments,
+        mut endorsers: HashSet<AccountId>,
+    ) -> bool {
+        for (account_id, _) in assignment.assignments() {
+            if endorsers.contains(account_id) {
+                continue;
+            }
+            let Some(stored) =
+                self.get_endorsement(&chunk_id.block_hash, chunk_id.shard_id, account_id)
+            else {
+                continue;
+            };
+            if stored.execution_result_hash != *result_hash {
+                continue;
+            }
+            endorsers.insert(account_id.clone());
+        }
+        assignment.is_endorsed(&endorsers)
     }
 
     fn get_execution_result(

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -6,7 +6,7 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::block_body::{SpiceCoreStatement, SpiceCoreStatements};
 use near_primitives::epoch_info::EpochInfo;
-use near_primitives::errors::InvalidSpiceCoreStatementsError;
+use near_primitives::errors::{EpochError, InvalidSpiceCoreStatementsError};
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::merklize;
@@ -22,12 +22,19 @@ use near_primitives::types::{
     EpochId, ShardId, SpiceChunkEndorsementStats, SpiceChunkId, SpiceUncertifiedChunkInfo,
     ValidatorId,
 };
-use near_primitives::utils::{get_endorsements_key, get_execution_results_key};
+use near_primitives::utils::{
+    get_endorsements_key, get_execution_results_key, get_uncertified_execution_results_key,
+};
 use near_store::adapter::StoreAdapter as _;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::{DBCol, Store};
 use std::collections::{HashMap, HashSet};
+use std::io;
 use std::sync::Arc;
+
+/// Blocks a chunk must stay certifiable-but-uncertified before the all-stake fallback opens for it.
+/// Well below epoch length (to rescue liveness before the one-epoch lag guard stalls consensus).
+pub const SPICE_FALLBACK_CERTIFICATION_DELAY: BlockHeight = 5;
 
 #[derive(Clone)]
 pub struct SpiceCoreReader {
@@ -66,7 +73,7 @@ impl SpiceCoreReader {
             .exists(DBCol::endorsements(), &get_endorsements_key(block_hash, shard_id, account_id))
     }
 
-    fn get_endorsement(
+    pub fn get_endorsement(
         &self,
         block_hash: &CryptoHash,
         shard_id: ShardId,
@@ -75,6 +82,14 @@ impl SpiceCoreReader {
         self.chain_store
             .store()
             .get_ser(DBCol::endorsements(), &get_endorsements_key(block_hash, shard_id, account_id))
+    }
+
+    pub fn get_uncertified_execution_result(
+        &self,
+        execution_result_hash: &ChunkExecutionResultHash,
+    ) -> Option<Arc<ChunkExecutionResult>> {
+        let key = get_uncertified_execution_results_key(execution_result_hash);
+        self.chain_store.store().caching_get_ser(DBCol::uncertified_execution_results(), &key)
     }
 
     /// Whether the union of `endorsers` and the validators whose stored endorsement attests
@@ -341,6 +356,35 @@ impl SpiceCoreReader {
         }
     }
 
+    /// Includes not-yet-on-chain non-designated (fallback-set) endorsements over successive blocks,
+    /// so they accumulate toward the 2/3-total-stake threshold rather than one fat certifying block.
+    fn push_fallback_endorsements(
+        &self,
+        chunk_info: &SpiceUncertifiedChunkInfo,
+        core_statements: &mut Vec<SpiceCoreStatement>,
+    ) -> Result<(), Error> {
+        let chunk_id = &chunk_info.chunk_id;
+        let chunk_block_header = self.chain_store.get_block_header(&chunk_id.block_hash)?;
+        let epoch_id = chunk_block_header.epoch_id();
+        let designated = self.epoch_manager.get_chunk_validator_assignments(
+            epoch_id,
+            chunk_id.shard_id,
+            chunk_block_header.height(),
+        )?;
+        let all_validators = all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?;
+        let on_chain: HashSet<&AccountId> = chunk_info
+            .present_fallback_endorsements
+            .iter()
+            .map(|(account_id, _)| account_id)
+            .collect();
+        let fallback_accounts =
+            all_validators.assignments().iter().map(|(account_id, _)| account_id).filter(
+                |account_id| !designated.contains(account_id) && !on_chain.contains(*account_id),
+            );
+        self.push_stored_endorsements(chunk_id, fallback_accounts, core_statements);
+        Ok(())
+    }
+
     pub fn core_statements_for_next_block(
         &self,
         block_header: &BlockHeader,
@@ -354,16 +398,30 @@ impl SpiceCoreReader {
 
         let mut core_statements = Vec::new();
         for chunk_info in uncertified_chunks {
+            let chunk_id = &chunk_info.chunk_id;
+            // Designated endorsements the producer holds that aren't on chain yet.
             self.push_stored_endorsements(
-                &chunk_info.chunk_id,
+                chunk_id,
                 &chunk_info.missing_endorsements,
                 &mut core_statements,
             );
 
+            // Once uncertified past the fallback window, also include the non-designated endorsements.
+            // height() + 1 underestimates the next block's height, but eligibility is monotone in it
+            // so anything eligible here stays eligible at the height validation checks against.
+            if fallback_eligible(
+                &self.chain_store,
+                block_header.height() + 1,
+                block_hash,
+                chunk_id,
+            )? {
+                self.push_fallback_endorsements(&chunk_info, &mut core_statements)?;
+            }
+
             let Some(execution_result) = get_execution_result_from_store(
                 &self.chain_store,
-                &chunk_info.chunk_id.block_hash,
-                chunk_info.chunk_id.shard_id,
+                &chunk_id.block_hash,
+                chunk_id.shard_id,
             ) else {
                 continue;
             };
@@ -458,6 +516,28 @@ impl SpiceCoreReader {
         Ok(())
     }
 
+    /// `fallback_eligible` for `chunk_id` as of `block`, mapping the `near_chain` error into the
+    /// validation error type (the block's ancestry is present, so an error is internal).
+    // TODO(spice-perf): called per non-designated endorsement in the admission loop and again per
+    // chunk in the certification loop, but the verdict only depends on (block, chunk_id). Memoize
+    // it per chunk_id for the duration of validate_core_statements_in_block, and hoist the
+    // chunk-independent ancestor walk + certified-frontier lookup out of the per-chunk path.
+    fn fallback_eligible_in_block(
+        &self,
+        block: &Block,
+        chunk_id: &SpiceChunkId,
+    ) -> Result<bool, InvalidSpiceCoreStatementsError> {
+        fallback_eligible(
+            &self.chain_store,
+            block.header().height(),
+            block.header().prev_hash(),
+            chunk_id,
+        )
+        .map_err(|error| InvalidSpiceCoreStatementsError::IoError {
+            error: io::Error::other(error.to_string()),
+        })
+    }
+
     /// Verifies `endorsement`'s signature against its signer's key in `epoch_id`, returning the
     /// signed data and signature. The error is a reason string for `InvalidCoreStatement`.
     fn verify_endorsement_signature<'e>(
@@ -511,13 +591,24 @@ impl SpiceCoreReader {
                     // regardless of result hash. The dup check below is per result hash and
                     // `pending_designated` is not updated mid-loop, so a validator can
                     // equivocate (endorse two results for one chunk) and count toward both.
-                    if !ancestry_endorsements.is_pending_designated(chunk_id, account_id) {
+                    // Re-inclusion of an endorsement already carried in the ancestry is invalid.
+                    if ancestry_endorsements.is_on_chain(chunk_id, account_id) {
                         return Err(InvalidCoreStatement {
                             index,
-                            // It can either be already included in the ancestry or be for a block
-                            // outside of ancestry.
                             reason: "endorsement is irrelevant",
                         });
+                    }
+                    // Non-designated endorsements are admissible only once the chunk is
+                    // fallback-eligible and still uncertified.
+                    if !ancestry_endorsements.is_pending_designated(chunk_id, account_id) {
+                        let eligible_fallback = ancestry_endorsements.is_uncertified(chunk_id)
+                            && self.fallback_eligible_in_block(block, chunk_id)?;
+                        if !eligible_fallback {
+                            return Err(InvalidCoreStatement {
+                                index,
+                                reason: "endorsement is irrelevant",
+                            });
+                        }
                     }
 
                     let endorsement_block =
@@ -584,28 +675,42 @@ impl SpiceCoreReader {
         }
 
         for (chunk_id, mut on_chain_endorsements) in in_block_endorsements {
-            let block = get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
+            let chunk_block = get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
             let chunk_validator_assignments = self
                 .epoch_manager
                 .get_chunk_validator_assignments(
-                    &block.header().epoch_id(),
+                    &chunk_block.header().epoch_id(),
                     chunk_id.shard_id,
-                    block.header().height(),
+                    chunk_block.header().height(),
                 )
                 .expect(
                     "since we are waiting for endorsement we should know it's validator assignments",
                 );
-            // Add the on-chain ancestry endorsements to the in-block ones, grouped by attested result.
+            // Add the on-chain ancestry endorsements (designated and non-designated) to the in-block
+            // ones, grouped by attested result; the designated tally ignores non-designated accounts.
             for (account_id, endorsement) in ancestry_endorsements.on_chain_for(chunk_id) {
                 on_chain_endorsements
                     .entry(endorsement.execution_result_hash.clone())
                     .or_default()
                     .insert(account_id, endorsement.signature.clone());
             }
+            // Once fallback-eligible, the chunk may also certify via 2/3 of total epoch stake.
+            let fallback_assignment =
+                self.fallback_eligible_in_block(block, chunk_id)?.then(|| {
+                    all_stake_fallback_assignment(
+                        self.epoch_manager.as_ref(),
+                        chunk_block.header().epoch_id(),
+                    )
+                    .expect("epoch of an uncertified chunk's block is known")
+                });
             for (execution_result_hash, validator_signatures) in on_chain_endorsements {
-                let endorsement_state =
-                    chunk_validator_assignments.compute_endorsement_state(validator_signatures);
-                if !endorsement_state.is_endorsed {
+                let endorsed = chunk_validator_assignments
+                    .compute_endorsement_state(validator_signatures.clone())
+                    .is_endorsed
+                    || fallback_assignment.as_ref().is_some_and(|all| {
+                        all.compute_endorsement_state(validator_signatures).is_endorsed
+                    });
+                if !endorsed {
                     continue;
                 }
 
@@ -777,14 +882,18 @@ pub fn record_uncertified_chunks_for_block(
     epoch_manager: &dyn EpochManagerAdapter,
     block: &Block,
 ) -> Result<(), Error> {
-    let block_endorsements: HashMap<(&SpiceChunkId, &AccountId), &SpiceEndorsementCoreStatement> =
-        block
-            .spice_core_statements()
-            .iter_endorsements()
-            .map(|e| ((e.chunk_id(), e.account_id()), e))
-            .collect();
     let block_execution_results: HashMap<&SpiceChunkId, &ChunkExecutionResult> =
         block.spice_core_statements().iter_execution_results().collect();
+    let mut block_endorsements: HashMap<
+        &SpiceChunkId,
+        HashMap<&AccountId, &SpiceEndorsementCoreStatement>,
+    > = HashMap::new();
+    for endorsement in block.spice_core_statements().iter_endorsements() {
+        block_endorsements
+            .entry(endorsement.chunk_id())
+            .or_default()
+            .insert(endorsement.account_id(), endorsement);
+    }
 
     let prev_hash = block.header().prev_hash();
     let mut uncertified_chunks =
@@ -792,24 +901,41 @@ pub fn record_uncertified_chunks_for_block(
     uncertified_chunks
         .retain(|chunk_info| !block_execution_results.contains_key(&chunk_info.chunk_id));
     for chunk_info in &mut uncertified_chunks {
+        let chunk_endorsements = block_endorsements.get(&chunk_info.chunk_id);
         for account_id in &chunk_info.missing_endorsements {
-            let Some(endorsement_core_statement) =
-                block_endorsements.get(&(&chunk_info.chunk_id, account_id))
-            else {
+            let Some(endorsement) = chunk_endorsements.and_then(|e| e.get(account_id)) else {
                 continue;
             };
             // By the time of recording block is already validated.
-            let endorsement = endorsement_core_statement.unchecked_to_stored();
-            chunk_info.present_endorsements.push((account_id.clone(), endorsement));
+            chunk_info
+                .present_endorsements
+                .push((account_id.clone(), endorsement.unchecked_to_stored()));
         }
-
-        chunk_info.missing_endorsements.retain(|account_id| {
-            !block_endorsements.contains_key(&(&chunk_info.chunk_id, account_id))
-        });
+        chunk_info
+            .missing_endorsements
+            .retain(|account_id| !chunk_endorsements.is_some_and(|e| e.contains_key(account_id)));
         assert!(
             !chunk_info.missing_endorsements.is_empty(),
             "when there are no missing endorsements execution result should be present"
         );
+
+        // Record non-designated endorsements (not in the designated assignment, so not tracked
+        // above) for the all-stake fallback.
+        let Some(chunk_endorsements) = chunk_endorsements else {
+            continue;
+        };
+        let on_chain: HashSet<AccountId> = chunk_info
+            .all_present_endorsements()
+            .map(|(account_id, _)| account_id.clone())
+            .collect();
+        for (account_id, endorsement) in chunk_endorsements {
+            if on_chain.contains(*account_id) {
+                continue;
+            }
+            chunk_info
+                .present_fallback_endorsements
+                .push(((*account_id).clone(), endorsement.unchecked_to_stored()));
+        }
     }
 
     let shard_layout = epoch_manager.get_shard_layout(block.header().epoch_id())?;
@@ -1092,4 +1218,47 @@ pub fn get_last_certified_block_header(
         );
         Ok(header)
     }
+}
+
+/// Whether `chunk_id` may certify via the all-stake fallback as of a carrying block at
+/// `carrying_height`/`carrying_prev_hash`: true once its parent certified at least
+/// `SPICE_FALLBACK_CERTIFICATION_DELAY` blocks ago.
+pub fn fallback_eligible(
+    chain_store: &ChainStoreAdapter,
+    carrying_height: BlockHeight,
+    carrying_prev_hash: &CryptoHash,
+    chunk_id: &SpiceChunkId,
+) -> Result<bool, Error> {
+    if carrying_height < SPICE_FALLBACK_CERTIFICATION_DELAY {
+        return Ok(false);
+    }
+    let target_height = carrying_height - SPICE_FALLBACK_CERTIFICATION_DELAY;
+
+    // Youngest ancestor of the carrying block with height <= target_height, reached by walking
+    // back over any skipped heights.
+    let mut ancestor = chain_store.get_block_header(carrying_prev_hash)?;
+    while ancestor.height() > target_height && !ancestor.is_genesis() {
+        ancestor = chain_store.get_block_header(ancestor.prev_hash())?;
+    }
+
+    // prev(chunk block) is certified as of the ancestor iff the ancestor's certified frontier reaches
+    // its height. `>=` also rejects prev(chunk block) in the ancestor's future, so no extra guard.
+    let chunk_block = chain_store.get_block_header(&chunk_id.block_hash)?;
+    let prev_chunk_block = chain_store.get_block_header(chunk_block.prev_hash())?;
+    let frontier = get_last_certified_block_header(chain_store, ancestor.hash())?;
+    Ok(frontier.height() >= prev_chunk_block.height())
+}
+
+/// The epoch's full validator set as a shard-independent assignment weighted by real stake. The
+/// all-stake fallback certifies via 2/3 of this total when the designated assignment didn't in time.
+// TODO(spice-perf): the result is epoch-invariant but rebuilt (with per-validator AccountId clones)
+// on every call, and this is called per fallback-eligible chunk from validation, the producer, and
+// the writer. Cache it per EpochId, like get_chunk_validator_assignments.
+pub fn all_stake_fallback_assignment(
+    epoch_manager: &dyn EpochManagerAdapter,
+    epoch_id: &EpochId,
+) -> Result<ChunkValidatorAssignments, EpochError> {
+    let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
+    let assignments = epoch_info.validators_iter().map(|validator| validator.account_and_stake());
+    Ok(ChunkValidatorAssignments::new(assignments.collect()))
 }

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,3 +1,4 @@
+use crate::spice::ancestry_endorsements::AncestryEndorsements;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
 use near_chain_primitives::Error;
 use near_crypto::Signature;
@@ -11,7 +12,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::merklize;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::spice::chunk_endorsement::{
-    SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
+    SpiceEndorsementCoreStatement, SpiceEndorsementSignedData, SpiceStoredVerifiedEndorsement,
 };
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::types::chunk_extra::ChunkExtra;
@@ -322,6 +323,24 @@ impl SpiceCoreReader {
         Ok(())
     }
 
+    /// Pushes, as endorsement core statements, the stored endorsements the producer holds for
+    /// `accounts`. Accounts whose endorsement isn't in the store are simply skipped.
+    fn push_stored_endorsements<'b>(
+        &self,
+        chunk_id: &SpiceChunkId,
+        accounts: impl IntoIterator<Item = &'b AccountId>,
+        core_statements: &mut Vec<SpiceCoreStatement>,
+    ) {
+        for account_id in accounts {
+            if let Some(endorsement) =
+                self.get_endorsement(&chunk_id.block_hash, chunk_id.shard_id, account_id)
+            {
+                core_statements
+                    .push(endorsement.into_core_statement(chunk_id.clone(), account_id.clone()));
+            }
+        }
+    }
+
     pub fn core_statements_for_next_block(
         &self,
         block_header: &BlockHeader,
@@ -335,17 +354,11 @@ impl SpiceCoreReader {
 
         let mut core_statements = Vec::new();
         for chunk_info in uncertified_chunks {
-            for account_id in chunk_info.missing_endorsements {
-                if let Some(endorsement) = self.get_endorsement(
-                    &chunk_info.chunk_id.block_hash,
-                    chunk_info.chunk_id.shard_id,
-                    &account_id,
-                ) {
-                    core_statements.push(
-                        endorsement.into_core_statement(chunk_info.chunk_id.clone(), account_id),
-                    );
-                }
-            }
+            self.push_stored_endorsements(
+                &chunk_info.chunk_id,
+                &chunk_info.missing_endorsements,
+                &mut core_statements,
+            );
 
             let Some(execution_result) = get_execution_result_from_store(
                 &self.chain_store,
@@ -445,6 +458,20 @@ impl SpiceCoreReader {
         Ok(())
     }
 
+    /// Verifies `endorsement`'s signature against its signer's key in `epoch_id`, returning the
+    /// signed data and signature. The error is a reason string for `InvalidCoreStatement`.
+    fn verify_endorsement_signature<'e>(
+        &self,
+        epoch_id: &EpochId,
+        endorsement: &'e SpiceEndorsementCoreStatement,
+    ) -> Result<(&'e SpiceEndorsementSignedData, &'e Signature), &'static str> {
+        let validator_info = self
+            .epoch_manager
+            .get_validator_by_account_id(epoch_id, endorsement.account_id())
+            .map_err(|_| "endorsement from non-validator")?;
+        endorsement.verified_signed_data(validator_info.public_key()).ok_or("invalid signature")
+    }
+
     pub fn validate_core_statements_in_block(
         &self,
         block: &Block,
@@ -466,23 +493,7 @@ impl SpiceCoreReader {
                 tracing::debug!(target: "spice_core", prev_hash=?block.header().prev_hash(), ?err, "failed getting uncertified_chunks");
                 NoPrevUncertifiedChunks
             })?;
-        let waiting_on_endorsements: HashSet<_> = prev_uncertified_chunks
-            .iter()
-            .flat_map(|info| {
-                info.missing_endorsements.iter().map(|account_id| (&info.chunk_id, account_id))
-            })
-            .collect();
-        let known_endorsements: HashMap<
-            (&SpiceChunkId, &AccountId),
-            &SpiceStoredVerifiedEndorsement,
-        > = prev_uncertified_chunks
-            .iter()
-            .flat_map(|info| {
-                info.present_endorsements
-                    .iter()
-                    .map(|(account_id, endorsement)| ((&info.chunk_id, account_id), endorsement))
-            })
-            .collect();
+        let ancestry_endorsements = AncestryEndorsements::collect(&prev_uncertified_chunks);
 
         let mut in_block_endorsements: HashMap<
             &SpiceChunkId,
@@ -498,11 +509,9 @@ impl SpiceCoreReader {
                     let account_id = endorsement.account_id();
                     // TODO(spice): reject more than one endorsement per (chunk, account),
                     // regardless of result hash. The dup check below is per result hash and
-                    // `waiting_on_endorsements` is not updated mid-loop, so a validator can
+                    // `pending_designated` is not updated mid-loop, so a validator can
                     // equivocate (endorse two results for one chunk) and count toward both.
-                    // Checking contents of waiting_on_endorsements makes sure that
-                    // chunk_id and account_id are valid.
-                    if !waiting_on_endorsements.contains(&(chunk_id, account_id)) {
+                    if !ancestry_endorsements.is_pending_designated(chunk_id, account_id) {
                         return Err(InvalidCoreStatement {
                             index,
                             // It can either be already included in the ancestry or be for a block
@@ -511,18 +520,14 @@ impl SpiceCoreReader {
                         });
                     }
 
-                    let block = get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
-
-                    let validator_info = self
-                        .epoch_manager
-                        .get_validator_by_account_id(block.header().epoch_id(), account_id)
-                        .expect("we are waiting on endorsement for this account so relevant validator has to exist");
-
-                    let Some((signed_data, signature)) =
-                        endorsement.verified_signed_data(validator_info.public_key())
-                    else {
-                        return Err(InvalidCoreStatement { index, reason: "invalid signature" });
-                    };
+                    let endorsement_block =
+                        get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
+                    let (signed_data, signature) = self
+                        .verify_endorsement_signature(
+                            endorsement_block.header().epoch_id(),
+                            endorsement,
+                        )
+                        .map_err(|reason| InvalidCoreStatement { index, reason })?;
 
                     if in_block_endorsements
                         .entry(chunk_id)
@@ -559,7 +564,7 @@ impl SpiceCoreReader {
 
         // TODO(spice): Add validation that endorsements for blocks are included only when previous
         // block is fully endorsed (as part of block we are validating or it's ancestry).
-        for (chunk_id, _) in &waiting_on_endorsements {
+        for chunk_id in ancestry_endorsements.pending_designated_chunks() {
             if block_execution_results.contains_key(chunk_id) {
                 continue;
             }
@@ -574,7 +579,7 @@ impl SpiceCoreReader {
                 // We cannot be waiting on an endorsement for chunk created at height that is less
                 // than maximum endorsed height for the chunk as that would mean that child is
                 // endorsed before parent.
-                return Err(SkippedExecutionResult { chunk_id: (*chunk_id).clone() });
+                return Err(SkippedExecutionResult { chunk_id: chunk_id.clone() });
             }
         }
 
@@ -590,19 +595,12 @@ impl SpiceCoreReader {
                 .expect(
                     "since we are waiting for endorsement we should know it's validator assignments",
                 );
-            for (account_id, _) in chunk_validator_assignments.assignments() {
-                // We cannot look for endorsements in store since there they are written by a
-                // separate actor which isn't synchronized with block processing.
-                if !waiting_on_endorsements.contains(&(chunk_id, account_id)) {
-                    let endorsement = known_endorsements.get(&(chunk_id, account_id))
-                        .expect(
-                        "if we aren't waiting for endorsement in this block it should be in ancestry and known"
-                    );
-                    on_chain_endorsements
-                        .entry(endorsement.execution_result_hash.clone())
-                        .or_default()
-                        .insert(account_id, endorsement.signature.clone());
-                }
+            // Add the on-chain ancestry endorsements to the in-block ones, grouped by attested result.
+            for (account_id, endorsement) in ancestry_endorsements.on_chain_for(chunk_id) {
+                on_chain_endorsements
+                    .entry(endorsement.execution_result_hash.clone())
+                    .or_default()
+                    .insert(account_id, endorsement.signature.clone());
             }
             for (execution_result_hash, validator_signatures) in on_chain_endorsements {
                 let endorsement_state =
@@ -833,6 +831,7 @@ pub fn record_uncertified_chunks_for_block(
             chunk_id: SpiceChunkId { block_hash: *block.hash(), shard_id },
             missing_endorsements,
             present_endorsements: Vec::new(),
+            present_fallback_endorsements: Vec::new(),
         });
     }
 

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -2,6 +2,7 @@ use crate::spice::core::{SpiceCoreReader, all_stake_fallback_assignment, fallbac
 use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
 use near_cache::SyncLruCache;
+use near_chain_configs::MutableValidatorSigner;
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::client::SpiceChunkEndorsementMessage;
@@ -46,6 +47,7 @@ pub struct SpiceCoreWriterActor {
 
     chain_store: ChainStoreAdapter,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
+    validator_signer: MutableValidatorSigner,
     chunk_executor_sender: Sender<ExecutionResultEndorsed>,
     spice_chunk_validator_sender: Sender<ExecutionResultEndorsed>,
     // Endorsements that arrived before the relevant block, so cannot be fully validated yet.
@@ -74,6 +76,7 @@ impl SpiceCoreWriterActor {
     pub fn new(
         chain_store: ChainStoreAdapter,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
+        validator_signer: MutableValidatorSigner,
         core_reader: SpiceCoreReader,
         chunk_executor_sender: Sender<ExecutionResultEndorsed>,
         spice_chunk_validator_sender: Sender<ExecutionResultEndorsed>,
@@ -83,6 +86,7 @@ impl SpiceCoreWriterActor {
             core_reader,
             chain_store,
             epoch_manager,
+            validator_signer,
             chunk_executor_sender,
             spice_chunk_validator_sender,
             pending_endorsements: SyncLruCache::new(PENDING_ENDORSEMENT_CACHE_SIZE.into()),
@@ -271,6 +275,16 @@ impl SpiceCoreWriterActor {
         )?;
 
         if chunk_validator_assignments.contains(endorsement.account_id()) {
+            return Ok(());
+        }
+
+        // Our own endorsement is trustworthy by construction (we executed the chunk). Keep it even
+        // before eligibility so the fallback can broadcast it once overdue; inert in the tally until.
+        if self
+            .validator_signer
+            .get()
+            .is_some_and(|signer| signer.validator_id() == endorsement.account_id())
+        {
             return Ok(());
         }
 

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -1,4 +1,4 @@
-use crate::spice::core::SpiceCoreReader;
+use crate::spice::core::{SpiceCoreReader, all_stake_fallback_assignment, fallback_eligible};
 use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
 use near_cache::SyncLruCache;
@@ -14,7 +14,8 @@ use near_primitives::spice::chunk_endorsement::{
 };
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, ChunkExecutionResult, ChunkExecutionResultHash, EpochId, ShardId, SpiceChunkId,
+    AccountId, BlockHeight, ChunkExecutionResult, ChunkExecutionResultHash, EpochId, ShardId,
+    SpiceChunkId,
 };
 use near_primitives::utils::{
     get_endorsements_key, get_execution_results_key, get_uncertified_execution_results_key,
@@ -139,6 +140,43 @@ impl SpiceCoreWriterActor {
         Ok(())
     }
 
+    /// Whether `chunk_id`'s stored endorsements certify `result_hash`: by 2/3 of its designated
+    /// assignment, or, once fallback-eligible, by 2/3 of total epoch stake. `endorsers` seeds it.
+    fn endorsed_by_designated_or_fallback(
+        &self,
+        chunk_id: &SpiceChunkId,
+        result_hash: &ChunkExecutionResultHash,
+        carrying_height: BlockHeight,
+        carrying_prev_hash: &CryptoHash,
+        endorsers: HashSet<AccountId>,
+    ) -> Result<bool, Error> {
+        let chunk_block = self.chain_store.get_block_header(&chunk_id.block_hash)?;
+        let epoch_id = chunk_block.epoch_id();
+        let designated = self.epoch_manager.get_chunk_validator_assignments(
+            epoch_id,
+            chunk_id.shard_id,
+            chunk_block.height(),
+        )?;
+        if self.core_reader.reaches_endorsement_threshold(
+            chunk_id,
+            result_hash,
+            &designated,
+            endorsers.clone(),
+        ) {
+            return Ok(true);
+        }
+        if !fallback_eligible(&self.chain_store, carrying_height, carrying_prev_hash, chunk_id)? {
+            return Ok(false);
+        }
+        let all_validators = all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?;
+        Ok(self.core_reader.reaches_endorsement_threshold(
+            chunk_id,
+            result_hash,
+            &all_validators,
+            endorsers,
+        ))
+    }
+
     fn record_chunk_endorsements_with_block(
         &self,
         block: &Block,
@@ -170,18 +208,15 @@ impl SpiceCoreWriterActor {
             execution_results.insert(execution_result_hash, endorsement.execution_result());
         }
 
+        let head = self.chain_store.head()?;
         for ((chunk_id, chunk_execution_result_hash), endorsers) in endorsers_by_unique_result {
-            let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
-                &block.header().epoch_id(),
-                chunk_id.shard_id,
-                block.header().height(),
-            )?;
-            if !self.core_reader.reaches_endorsement_threshold(
+            if !self.endorsed_by_designated_or_fallback(
                 chunk_id,
                 &chunk_execution_result_hash,
-                &chunk_validator_assignments,
+                head.height + 1,
+                &head.last_block_hash,
                 endorsers,
-            ) {
+            )? {
                 continue;
             }
 
@@ -235,10 +270,23 @@ impl SpiceCoreWriterActor {
             block.header().height(),
         )?;
 
-        if !chunk_validator_assignments.contains(endorsement.account_id()) {
-            return Err(InvalidSpiceEndorsementError::EndorsementIsNotRelevant);
+        if chunk_validator_assignments.contains(endorsement.account_id()) {
+            return Ok(());
         }
 
+        // All-stake fallback: past the fallback window any epoch validator's endorsement is relevant.
+        // Gate ingest on eligibility as of head so only overdue chunks accept the wider set.
+        let head = self.chain_store.head().map_err(InvalidSpiceEndorsementError::NearChainError)?;
+        let eligible = fallback_eligible(
+            &self.chain_store,
+            head.height + 1,
+            &head.last_block_hash,
+            endorsement.chunk_id(),
+        )
+        .map_err(InvalidSpiceEndorsementError::NearChainError)?;
+        if !eligible {
+            return Err(InvalidSpiceEndorsementError::EndorsementIsNotRelevant);
+        }
         Ok(())
     }
 
@@ -465,18 +513,13 @@ impl SpiceCoreWriterActor {
                 continue;
             }
 
-            let endorsement_block = self.chain_store.get_block(&chunk_id.block_hash)?;
-            let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
-                &endorsement_block.header().epoch_id(),
-                chunk_id.shard_id,
-                endorsement_block.header().height(),
-            )?;
-            if self.core_reader.reaches_endorsement_threshold(
+            if self.endorsed_by_designated_or_fallback(
                 chunk_id,
                 &chunk_execution_result_hash,
-                &chunk_validator_assignments,
+                block.header().height(),
+                block.header().prev_hash(),
                 endorsers,
-            ) {
+            )? {
                 let execution_result = self.get_uncertified_execution_result(&chunk_execution_result_hash)
                     .expect("for each endorsement we should save corresponding uncertified execution result");
                 store_update.merge(self.save_execution_result(

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -3,7 +3,6 @@ use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
 use near_cache::SyncLruCache;
 use near_chain_primitives::Error;
-use near_crypto::Signature;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_primitives::block::Block;
@@ -146,9 +145,9 @@ impl SpiceCoreWriterActor {
         endorsements: Vec<SpiceVerifiedEndorsement>,
     ) -> Result<StoreUpdate, Error> {
         let mut store_update = self.chain_store.store().store_update();
-        let mut endorsements_by_unique_result: HashMap<
+        let mut endorsers_by_unique_result: HashMap<
             (&SpiceChunkId, ChunkExecutionResultHash),
-            HashMap<&AccountId, Signature>,
+            HashSet<AccountId>,
         > = HashMap::new();
         let mut execution_results: HashMap<ChunkExecutionResultHash, &ChunkExecutionResult> =
             HashMap::new();
@@ -164,41 +163,25 @@ impl SpiceCoreWriterActor {
                 &endorsement.to_stored(),
             ));
             let execution_result_hash = endorsement.execution_result().compute_hash();
-            endorsements_by_unique_result
+            endorsers_by_unique_result
                 .entry((chunk_id, execution_result_hash.clone()))
                 .or_default()
-                .insert(endorsement.account_id(), endorsement.signature().clone());
+                .insert(endorsement.account_id().clone());
             execution_results.insert(execution_result_hash, endorsement.execution_result());
         }
 
-        for ((chunk_id, chunk_execution_result_hash), mut signatures) in
-            endorsements_by_unique_result
-        {
+        for ((chunk_id, chunk_execution_result_hash), endorsers) in endorsers_by_unique_result {
             let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
                 &block.header().epoch_id(),
                 chunk_id.shard_id,
                 block.header().height(),
             )?;
-
-            for (account_id, _) in chunk_validator_assignments.assignments() {
-                if signatures.contains_key(account_id) {
-                    continue;
-                }
-                let Some(stored_endorsement) =
-                    self.get_endorsement(&chunk_id.block_hash, chunk_id.shard_id, &account_id)
-                else {
-                    continue;
-                };
-                if stored_endorsement.execution_result_hash != chunk_execution_result_hash {
-                    continue;
-                }
-                signatures.insert(account_id, stored_endorsement.signature);
-            }
-
-            let endorsement_state =
-                chunk_validator_assignments.compute_endorsement_state(signatures);
-
-            if !endorsement_state.is_endorsed {
+            if !self.core_reader.reaches_endorsement_threshold(
+                chunk_id,
+                &chunk_execution_result_hash,
+                &chunk_validator_assignments,
+                endorsers,
+            ) {
                 continue;
             }
 
@@ -216,17 +199,6 @@ impl SpiceCoreWriterActor {
         }
 
         return Ok(store_update);
-    }
-
-    fn get_endorsement(
-        &self,
-        block_hash: &CryptoHash,
-        shard_id: ShardId,
-        account_id: &AccountId,
-    ) -> Option<SpiceStoredVerifiedEndorsement> {
-        self.chain_store
-            .store()
-            .get_ser(DBCol::endorsements(), &get_endorsements_key(block_hash, shard_id, account_id))
     }
 
     fn get_execution_result_from_store(
@@ -446,9 +418,9 @@ impl SpiceCoreWriterActor {
     fn record_block_core_statements(&self, block: &Block) -> Result<StoreUpdate, Error> {
         let mut store_update = self.chain_store.store().store_update();
 
-        let mut endorsements_by_unique_result: HashMap<
+        let mut endorsers_by_unique_result: HashMap<
             (&SpiceChunkId, ChunkExecutionResultHash),
-            HashMap<&AccountId, Signature>,
+            HashSet<AccountId>,
         > = HashMap::new();
         let mut in_block_execution_results: HashSet<&SpiceChunkId> = HashSet::new();
         for core_statement in block.spice_core_statements() {
@@ -464,10 +436,10 @@ impl SpiceCoreWriterActor {
                         account_id,
                         &stored_endorsement,
                     ));
-                    endorsements_by_unique_result
+                    endorsers_by_unique_result
                         .entry((chunk_id, stored_endorsement.execution_result_hash))
                         .or_default()
-                        .insert(endorsement.account_id(), stored_endorsement.signature);
+                        .insert(endorsement.account_id().clone());
                 }
                 SpiceCoreStatement::ChunkExecutionResult { execution_result, chunk_id } => {
                     store_update.merge(self.save_execution_result(
@@ -479,9 +451,7 @@ impl SpiceCoreWriterActor {
                 }
             };
         }
-        for ((chunk_id, chunk_execution_result_hash), mut signatures) in
-            endorsements_by_unique_result
-        {
+        for ((chunk_id, chunk_execution_result_hash), endorsers) in endorsers_by_unique_result {
             if in_block_execution_results.contains(chunk_id) {
                 continue;
             }
@@ -501,23 +471,12 @@ impl SpiceCoreWriterActor {
                 chunk_id.shard_id,
                 endorsement_block.header().height(),
             )?;
-            for (account_id, _) in chunk_validator_assignments.assignments() {
-                if signatures.contains_key(account_id) {
-                    continue;
-                }
-                let Some(stored_endorsement) =
-                    self.get_endorsement(&chunk_id.block_hash, chunk_id.shard_id, &account_id)
-                else {
-                    continue;
-                };
-                if stored_endorsement.execution_result_hash != chunk_execution_result_hash {
-                    continue;
-                }
-                signatures.insert(account_id, stored_endorsement.signature);
-            }
-            let endorsement_state =
-                chunk_validator_assignments.compute_endorsement_state(signatures);
-            if endorsement_state.is_endorsed {
+            if self.core_reader.reaches_endorsement_threshold(
+                chunk_id,
+                &chunk_execution_result_hash,
+                &chunk_validator_assignments,
+                endorsers,
+            ) {
                 let execution_result = self.get_uncertified_execution_result(&chunk_execution_result_hash)
                     .expect("for each endorsement we should save corresponding uncertified execution result");
                 store_update.merge(self.save_execution_result(

--- a/chain/chain/src/spice/mod.rs
+++ b/chain/chain/src/spice/mod.rs
@@ -1,3 +1,4 @@
+mod ancestry_endorsements;
 pub mod block_application;
 pub mod chain;
 pub mod chunk_application;

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -1,0 +1,394 @@
+use crate::spice::core::{SPICE_FALLBACK_CERTIFICATION_DELAY, fallback_eligible};
+use crate::spice::tests::core::{
+    block_certification_core_statements, build_block, endorsement_into_core_statement,
+    process_block, setup, setup_with_validators, test_chunk_endorsement,
+    test_execution_result_for_chunk,
+};
+use crate::{Block, Chain};
+use assert_matches::assert_matches;
+use near_primitives::block_body::SpiceCoreStatement;
+use near_primitives::errors::InvalidSpiceCoreStatementsError;
+use near_primitives::sharding::ShardChunkHeader;
+use near_primitives::types::{AccountId, BlockHeight, SpiceChunkId};
+use near_store::adapter::StoreAdapter as _;
+use near_store::adapter::chain_store::ChainStoreAdapter;
+use std::sync::Arc;
+
+fn store_adapter(chain: &Chain) -> ChainStoreAdapter {
+    chain.chain_store().chain_store()
+}
+
+fn first_shard_chunk_id(block: &Block) -> SpiceChunkId {
+    let shard_id = block.chunks().iter_raw().next().unwrap().shard_id();
+    SpiceChunkId { block_hash: *block.hash(), shard_id }
+}
+
+// Builds a block on `prev`, processes it, and returns it.
+fn append_block(
+    chain: &mut Chain,
+    prev: &Block,
+    statements: Vec<SpiceCoreStatement>,
+) -> Arc<Block> {
+    let block = build_block(chain, prev, statements);
+    process_block(chain, block.clone());
+    block
+}
+
+// Appends empty blocks onto `from` until the tip reaches `target_height`, returning that tip.
+fn advance_to_height(
+    chain: &mut Chain,
+    from: &Arc<Block>,
+    target_height: BlockHeight,
+) -> Arc<Block> {
+    let mut tip = from.clone();
+    while tip.header().height() < target_height {
+        tip = append_block(chain, &tip, vec![]);
+    }
+    tip
+}
+
+// Endorsement core statements from `accounts` for `chunk` in `block`.
+fn endorsement_statements(
+    accounts: &[AccountId],
+    block: &Block,
+    chunk: &ShardChunkHeader,
+) -> Vec<SpiceCoreStatement> {
+    accounts
+        .iter()
+        .map(|account| {
+            endorsement_into_core_statement(test_chunk_endorsement(account.as_str(), block, chunk))
+        })
+        .collect()
+}
+
+// The execution-result core statement for `chunk` in `block`.
+fn execution_result_statement(block: &Block, chunk: &ShardChunkHeader) -> SpiceCoreStatement {
+    SpiceCoreStatement::ChunkExecutionResult {
+        chunk_id: SpiceChunkId { block_hash: *block.hash(), shard_id: chunk.shard_id() },
+        execution_result: test_execution_result_for_chunk(chunk),
+    }
+}
+
+// `accounts`' endorsements for `chunk` plus its execution result (the shape of a certifying block).
+fn endorsements_and_execution_result(
+    accounts: &[AccountId],
+    block: &Block,
+    chunk: &ShardChunkHeader,
+) -> Vec<SpiceCoreStatement> {
+    let mut statements = endorsement_statements(accounts, block, chunk);
+    statements.push(execution_result_statement(block, chunk));
+    statements
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_fallback_eligible_false_when_parent_not_certified() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let block1 = append_block(&mut chain, &genesis, vec![]);
+    let block2 = append_block(&mut chain, &block1, vec![]); // prev(block2) = block1 is uncertified
+
+    // Even arbitrarily far in the future, block2 is not eligible while its parent block1 is
+    // uncertified.
+    let eligible = fallback_eligible(
+        &store_adapter(&chain),
+        100,
+        block2.hash(),
+        &first_shard_chunk_id(&block2),
+    )
+    .unwrap();
+    assert!(!eligible);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_fallback_eligible_respects_delay_after_parent_certified() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let block1 = append_block(&mut chain, &genesis, vec![]);
+    let block2 = append_block(&mut chain, &block1, vec![]);
+    // block3 includes block1's endorsements + results, certifying it. cert_height(block1) =
+    // block3.height().
+    let block3 = append_block(&mut chain, &block2, block_certification_core_statements(&block1));
+
+    let store = store_adapter(&chain);
+    let chunk = first_shard_chunk_id(&block2);
+    let delay = SPICE_FALLBACK_CERTIFICATION_DELAY;
+    let cert_height = block3.header().height();
+
+    // Below the window: not eligible.
+    assert!(!fallback_eligible(&store, cert_height + delay - 1, block3.hash(), &chunk).unwrap());
+    // At the window: eligible.
+    assert!(fallback_eligible(&store, cert_height + delay, block3.hash(), &chunk).unwrap());
+    // Monotone: stays eligible far past the window (also exercises a large height gap in the
+    // look-back walk).
+    assert!(fallback_eligible(&store, cert_height + delay + 50, block3.hash(), &chunk).unwrap());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_fallback_eligible_false_when_height_below_delay() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let block1 = append_block(&mut chain, &genesis, vec![]);
+    let block2 = append_block(&mut chain, &block1, vec![]);
+
+    // carrying_height < delay short-circuits to false (covers genesis / spice activation).
+    let below_delay = SPICE_FALLBACK_CERTIFICATION_DELAY - 1;
+    assert!(
+        !fallback_eligible(
+            &store_adapter(&chain),
+            below_delay,
+            block2.hash(),
+            &first_shard_chunk_id(&block2)
+        )
+        .unwrap()
+    );
+}
+
+// More validators than the default chunk-validator mandate count per shard (68), so each chunk's
+// designated assignment is a strict subset and there are non-designated validators to exercise
+// the all-stake fallback path.
+fn many_validators() -> Vec<String> {
+    (0..100).map(|i| format!("test{i}")).collect()
+}
+
+// Certifies `block` using only each chunk's designated validators.
+fn certify_block_designated(chain: &Chain, block: &Block) -> Vec<SpiceCoreStatement> {
+    let epoch_id = block.header().epoch_id();
+    let mut statements = Vec::new();
+    for chunk in block.chunks().iter_raw() {
+        let assignments = chain
+            .epoch_manager
+            .get_chunk_validator_assignments(epoch_id, chunk.shard_id(), block.header().height())
+            .unwrap();
+        statements.extend(endorsements_and_execution_result(
+            &assignments.ordered_chunk_validators(),
+            block,
+            chunk,
+        ));
+    }
+    statements
+}
+
+// Finds a (chunk header, validator) where the validator is NOT in the chunk's designated
+// assignment, so its endorsement is only admissible via the all-stake fallback.
+fn find_non_designated(
+    chain: &Chain,
+    block: &Block,
+    validators: &[String],
+) -> (ShardChunkHeader, AccountId) {
+    let epoch_id = block.header().epoch_id();
+    for chunk in block.chunks().iter_raw() {
+        let assignments = chain
+            .epoch_manager
+            .get_chunk_validator_assignments(epoch_id, chunk.shard_id(), block.header().height())
+            .unwrap();
+        for validator in validators {
+            let account: AccountId = validator.parse().unwrap();
+            if !assignments.contains(&account) {
+                return (chunk.clone(), account);
+            }
+        }
+    }
+    panic!("no non-designated validator found; increase validator count");
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_admits_non_designated_endorsement_only_when_eligible() {
+    let validators = many_validators();
+    let (mut chain, core_reader) = setup_with_validators(&validators);
+    let genesis = chain.genesis_block();
+    let block1 = append_block(&mut chain, &genesis, vec![]);
+    let certify_block1 = certify_block_designated(&chain, &block1);
+    let block2 = append_block(&mut chain, &block1, vec![]); // target chunk's block
+    let block3 = append_block(&mut chain, &block2, certify_block1); // certifies block1
+
+    // block3 certifies block1, so cert_height(block1) = block3.height(). block2's chunks become
+    // fallback-eligible once the block including their endorsement is at height
+    // cert_height + SPICE_FALLBACK_CERTIFICATION_DELAY or above. Advance empty blocks so `tip` sits
+    // at cert_height + SPICE_FALLBACK_CERTIFICATION_DELAY - 1 and `prev` one block below it: then a
+    // block built on `tip` lands exactly at the window (eligible) and one built on `prev` lands
+    // just below it (ineligible).
+    let delay = SPICE_FALLBACK_CERTIFICATION_DELAY;
+    let cert_height = block3.header().height();
+    let prev = advance_to_height(&mut chain, &block3, cert_height + delay - 2);
+    let tip = append_block(&mut chain, &prev, vec![]);
+
+    let (chunk_header, non_designated) = find_non_designated(&chain, &block2, &validators);
+    let endorsement = test_chunk_endorsement(non_designated.as_str(), &block2, &chunk_header);
+    let core_endorsement = endorsement_into_core_statement(endorsement);
+
+    // Built on `tip`, this block lands at the window: the non-designated endorsement is admitted.
+    let eligible_block = build_block(&chain, &tip, vec![core_endorsement.clone()]);
+    assert_eq!(eligible_block.header().height(), cert_height + delay);
+    core_reader.validate_core_statements_in_block(&eligible_block).unwrap();
+
+    // Built on `prev`, this block lands just below the window: the same endorsement is rejected as
+    // irrelevant.
+    let ineligible_block = build_block(&chain, &prev, vec![core_endorsement]);
+    assert_eq!(ineligible_block.header().height(), cert_height + delay - 1);
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&ineligible_block),
+        Err(InvalidSpiceCoreStatementsError::InvalidCoreStatement {
+            reason: "endorsement is irrelevant",
+            ..
+        })
+    );
+}
+
+// Splits `validators` into (designated, non_designated) for `chunk` as of `block`.
+fn split_designated(
+    chain: &Chain,
+    block: &Block,
+    chunk: &ShardChunkHeader,
+    validators: &[String],
+) -> (Vec<AccountId>, Vec<AccountId>) {
+    let assignments = chain
+        .epoch_manager
+        .get_chunk_validator_assignments(
+            block.header().epoch_id(),
+            chunk.shard_id(),
+            block.header().height(),
+        )
+        .unwrap();
+    let mut designated = Vec::new();
+    let mut non_designated = Vec::new();
+    for validator in validators {
+        let account: AccountId = validator.parse().unwrap();
+        if assignments.contains(&account) {
+            designated.push(account);
+        } else {
+            non_designated.push(account);
+        }
+    }
+    (designated, non_designated)
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_all_stake_certification_when_designated_insufficient() {
+    let validators = many_validators();
+    let (mut chain, core_reader) = setup_with_validators(&validators);
+    let genesis = chain.genesis_block();
+    let block1 = append_block(&mut chain, &genesis, vec![]);
+    let certify_block1 = certify_block_designated(&chain, &block1);
+    let block2 = append_block(&mut chain, &block1, vec![]);
+    let block3 = append_block(&mut chain, &block2, certify_block1);
+
+    let delay = SPICE_FALLBACK_CERTIFICATION_DELAY;
+    let cert_height = block3.header().height();
+    let tip = advance_to_height(&mut chain, &block3, cert_height + delay - 1);
+
+    let (chunk_header, _) = find_non_designated(&chain, &block2, &validators);
+    let (designated, non_designated) =
+        split_designated(&chain, &block2, &chunk_header, &validators);
+    // Include all non-designated plus at most 2/3 of the designated set by count (validators have
+    // equal stake, so count ratios match stake ratios): below the strict >2/3 designated-stake
+    // threshold, but enough total stake to certify on the all-stake path.
+    let designated_subset = &designated[..2 * designated.len() / 3];
+
+    // Block at the window (eligible): non-designated + partial designated certifies via all-stake.
+    let mut all_stake_endorsers = non_designated;
+    all_stake_endorsers.extend_from_slice(designated_subset);
+    let certifying_block = build_block(
+        &chain,
+        &tip,
+        endorsements_and_execution_result(&all_stake_endorsers, &block2, &chunk_header),
+    );
+    core_reader.validate_core_statements_in_block(&certifying_block).unwrap();
+
+    // Same window block but only the partial designated set: neither path reaches the threshold, so
+    // the included result is rejected.
+    let insufficient_block = build_block(
+        &chain,
+        &tip,
+        endorsements_and_execution_result(designated_subset, &block2, &chunk_header),
+    );
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&insufficient_block),
+        Err(InvalidSpiceCoreStatementsError::InvalidCoreStatement {
+            reason: "execution results included without enough corresponding endorsement",
+            ..
+        })
+    );
+}
+
+// Like the designated path, once on-chain endorsements reach the all-stake threshold (2/3 of total
+// epoch stake) the block must include the execution result; the certifying endorser set is rejected
+// when the result is omitted.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_all_stake_certification_requires_execution_result() {
+    let validators = many_validators();
+    let (mut chain, core_reader) = setup_with_validators(&validators);
+    let genesis = chain.genesis_block();
+    let block1 = append_block(&mut chain, &genesis, vec![]);
+    let certify_block1 = certify_block_designated(&chain, &block1);
+    let block2 = append_block(&mut chain, &block1, vec![]);
+    let block3 = append_block(&mut chain, &block2, certify_block1);
+
+    let delay = SPICE_FALLBACK_CERTIFICATION_DELAY;
+    let cert_height = block3.header().height();
+    let tip = advance_to_height(&mut chain, &block3, cert_height + delay - 1);
+
+    let (chunk_header, _) = find_non_designated(&chain, &block2, &validators);
+    let (designated, non_designated) =
+        split_designated(&chain, &block2, &chunk_header, &validators);
+    let designated_subset = &designated[..2 * designated.len() / 3];
+
+    // Non-designated + sub-quorum designated reach 2/3 of total stake but the block omits the
+    // execution result.
+    let mut all_stake_endorsers = non_designated;
+    all_stake_endorsers.extend_from_slice(designated_subset);
+    let endorsements = endorsement_statements(&all_stake_endorsers, &block2, &chunk_header);
+    let block_without_result = build_block(&chain, &tip, endorsements);
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&block_without_result),
+        Err(InvalidSpiceCoreStatementsError::NoExecutionResultForEndorsedChunk { .. })
+    );
+}
+
+// A designated endorsement already carried in the ancestry cannot be re-included, even once the
+// chunk is fallback-eligible (when the wider non-designated admissibility opens up).
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_rejects_reincluded_designated_endorsement_when_eligible() {
+    let validators = many_validators();
+    let (mut chain, core_reader) = setup_with_validators(&validators);
+    let genesis = chain.genesis_block();
+    let block1 = append_block(&mut chain, &genesis, vec![]);
+    let certify_block1 = certify_block_designated(&chain, &block1);
+    let block2 = append_block(&mut chain, &block1, vec![]);
+    let block3 = append_block(&mut chain, &block2, certify_block1);
+
+    let (chunk_header, _) = find_non_designated(&chain, &block2, &validators);
+    let (designated, _) = split_designated(&chain, &block2, &chunk_header, &validators);
+    let endorser = designated[0].clone();
+    let endorsement = || {
+        endorsement_into_core_statement(test_chunk_endorsement(
+            endorser.as_str(),
+            &block2,
+            &chunk_header,
+        ))
+    };
+
+    // The designated endorsement lands on chain, moving into the chunk's present endorsements.
+    let block4 = append_block(&mut chain, &block3, vec![endorsement()]);
+
+    let delay = SPICE_FALLBACK_CERTIFICATION_DELAY;
+    let cert_height = block3.header().height();
+    let tip = advance_to_height(&mut chain, &block4, cert_height + delay - 1);
+
+    // Re-including the already-on-chain designated endorsement in an eligible block is rejected.
+    let reinclude = build_block(&chain, &tip, vec![endorsement()]);
+    assert!(reinclude.header().height() >= cert_height + delay);
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&reinclude),
+        Err(InvalidSpiceCoreStatementsError::InvalidCoreStatement {
+            reason: "endorsement is irrelevant",
+            ..
+        })
+    );
+}

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -11,6 +11,7 @@ use assert_matches::assert_matches;
 use itertools::Itertools as _;
 use near_async::messaging::{Handler as _, IntoSender as _, noop};
 use near_async::time::Clock;
+use near_chain_configs::MutableConfigValue;
 use near_chain_configs::test_genesis::{TestGenesisBuilder, ValidatorsSpec};
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_o11y::testonly::init_test_logger;
@@ -1627,6 +1628,7 @@ fn core_writer_actor(chain: &Chain) -> SpiceCoreWriterActor {
     SpiceCoreWriterActor::new(
         chain.chain_store().chain_store(),
         chain.epoch_manager.clone(),
+        MutableConfigValue::new(None, "validator_signer"),
         core_reader(&chain),
         noop().into_sender(),
         noop().into_sender(),

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -1724,6 +1724,7 @@ fn uncertified_chunk_info(block_hash: CryptoHash, shard_id: ShardId) -> SpiceUnc
         chunk_id: SpiceChunkId { block_hash, shard_id },
         missing_endorsements: vec![],
         present_endorsements: vec![],
+        present_fallback_endorsements: vec![],
     }
 }
 

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -1511,7 +1511,7 @@ fn block_execution_results(block: &Block) -> BlockExecutionResults {
     BlockExecutionResults(results)
 }
 
-fn block_certification_core_statements(block: &Block) -> Vec<SpiceCoreStatement> {
+pub(super) fn block_certification_core_statements(block: &Block) -> Vec<SpiceCoreStatement> {
     let validators = test_validators();
     let mut core_statements = Vec::new();
 
@@ -1568,7 +1568,7 @@ fn block_builder(chain: &Chain, prev_block: &Block) -> TestBlockBuilder {
         .chunks(get_fake_next_block_chunk_headers(&prev_block, chain.epoch_manager.as_ref()))
 }
 
-fn build_block(
+pub(super) fn build_block(
     chain: &Chain,
     prev_block: &Block,
     spice_core_statements: Vec<SpiceCoreStatement>,
@@ -1576,7 +1576,7 @@ fn build_block(
     block_builder(chain, prev_block).spice_core_statements(spice_core_statements).build()
 }
 
-fn process_block(chain: &mut Chain, block: Arc<Block>) {
+pub(super) fn process_block(chain: &mut Chain, block: Arc<Block>) {
     process_block_sync(
         chain,
         block.into(),
@@ -1586,15 +1586,15 @@ fn process_block(chain: &mut Chain, block: Arc<Block>) {
     .unwrap();
 }
 
-fn test_validators() -> Vec<String> {
+pub(super) fn test_validators() -> Vec<String> {
     (0..4).map(|i| format!("test{i}")).collect()
 }
 
-fn setup() -> (Chain, SpiceCoreReader) {
+pub(super) fn setup() -> (Chain, SpiceCoreReader) {
     setup_with_validators(&test_validators())
 }
 
-fn setup_with_validators(validators: &[String]) -> (Chain, SpiceCoreReader) {
+pub(super) fn setup_with_validators(validators: &[String]) -> (Chain, SpiceCoreReader) {
     init_test_logger();
 
     let num_shards = 3;
@@ -1633,7 +1633,9 @@ fn core_writer_actor(chain: &Chain) -> SpiceCoreWriterActor {
     )
 }
 
-fn test_execution_result_for_chunk(chunk_header: &ShardChunkHeader) -> ChunkExecutionResult {
+pub(super) fn test_execution_result_for_chunk(
+    chunk_header: &ShardChunkHeader,
+) -> ChunkExecutionResult {
     ChunkExecutionResult {
         // Using chunk_hash makes sure that each chunk has a different execution result.
         chunk_extra: ChunkExtra::new_with_only_state_root(&chunk_header.chunk_hash().0),
@@ -1648,7 +1650,7 @@ fn invalid_execution_result_for_chunk(chunk_header: &ShardChunkHeader) -> ChunkE
     execution_result
 }
 
-fn test_chunk_endorsement(
+pub(super) fn test_chunk_endorsement(
     validator: &str,
     block: &Block,
     chunk_header: &ShardChunkHeader,
@@ -1667,7 +1669,9 @@ fn endorsement_into_verified(endorsement: SpiceChunkEndorsement) -> SpiceVerifie
     endorsement.into_verified(&signer.public_key()).unwrap()
 }
 
-fn endorsement_into_core_statement(endorsement: SpiceChunkEndorsement) -> SpiceCoreStatement {
+pub(super) fn endorsement_into_core_statement(
+    endorsement: SpiceChunkEndorsement,
+) -> SpiceCoreStatement {
     let verified = endorsement_into_verified(endorsement);
     verified
         .to_stored()

--- a/chain/chain/src/spice/tests/core_writer_actor.rs
+++ b/chain/chain/src/spice/tests/core_writer_actor.rs
@@ -10,8 +10,8 @@ use assert_matches::assert_matches;
 use itertools::Itertools as _;
 use near_async::messaging::{IntoSender as _, Sender, noop};
 use near_async::time::Clock;
-use near_chain_configs::Genesis;
 use near_chain_configs::test_genesis::{TestGenesisBuilder, ValidatorsSpec};
+use near_chain_configs::{Genesis, MutableConfigValue};
 use near_crypto::Signature;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Block;
@@ -765,6 +765,7 @@ fn setup_with_senders(
     let core_writer_actor = SpiceCoreWriterActor::new(
         chain.chain_store().chain_store(),
         chain.epoch_manager.clone(),
+        MutableConfigValue::new(None, "validator_signer"),
         core_reader(&chain),
         chunk_executor_sender,
         spice_chunk_validator_sender,
@@ -777,6 +778,7 @@ fn setup_with_genesis(genesis: Genesis) -> (Chain, SpiceCoreWriterActor) {
     let core_writer_actor = SpiceCoreWriterActor::new(
         chain.chain_store().chain_store(),
         chain.epoch_manager.clone(),
+        MutableConfigValue::new(None, "validator_signer"),
         core_reader(&chain),
         noop().into_sender(),
         noop().into_sender(),

--- a/chain/chain/src/spice/tests/mod.rs
+++ b/chain/chain/src/spice/tests/mod.rs
@@ -1,2 +1,3 @@
+mod all_stake_fallback;
 mod core;
 mod core_writer_actor;

--- a/chain/client/src/spice/chunk_executor_actor/per_shard.rs
+++ b/chain/client/src/spice/chunk_executor_actor/per_shard.rs
@@ -461,6 +461,18 @@ impl PerShardChunkExecutor {
                     &new_chunk_result,
                     outgoing_receipts_root,
                 );
+            } else if self
+                .epoch_manager
+                .get_validator_by_account_id(&epoch_id, my_signer.validator_id())
+                .is_ok()
+            {
+                // Non-designated epoch validator: record for the all-stake fallback.
+                self.record_own_fallback_endorsement(
+                    &block,
+                    &my_signer,
+                    &new_chunk_result,
+                    outgoing_receipts_root,
+                );
             }
 
             // Distribute witness and receipts if we are the chunk producer for the shard.
@@ -484,6 +496,23 @@ impl PerShardChunkExecutor {
         Ok(receipt_proofs)
     }
 
+    fn build_chunk_endorsement(
+        &self,
+        block: &Block,
+        my_signer: &ValidatorSigner,
+        new_chunk_result: &NewChunkResult,
+        outgoing_receipts_root: CryptoHash,
+    ) -> SpiceChunkEndorsement {
+        let NewChunkResult { shard_uid, gas_limit, apply_result } = new_chunk_result;
+        let execution_result =
+            new_execution_result(*gas_limit, apply_result, outgoing_receipts_root);
+        SpiceChunkEndorsement::new(
+            SpiceChunkId { block_hash: *block.hash(), shard_id: shard_uid.shard_id() },
+            execution_result,
+            my_signer,
+        )
+    }
+
     fn send_chunk_endorsement(
         &self,
         block: &Block,
@@ -491,20 +520,35 @@ impl PerShardChunkExecutor {
         new_chunk_result: &NewChunkResult,
         outgoing_receipts_root: CryptoHash,
     ) {
-        let NewChunkResult { shard_uid, gas_limit, apply_result } = new_chunk_result;
-        let shard_id = shard_uid.shard_id();
-        let execution_result =
-            new_execution_result(*gas_limit, apply_result, outgoing_receipts_root);
-        let endorsement = SpiceChunkEndorsement::new(
-            SpiceChunkId { block_hash: *block.hash(), shard_id },
-            execution_result,
+        let endorsement = self.build_chunk_endorsement(
+            block,
             my_signer,
+            new_chunk_result,
+            outgoing_receipts_root,
         );
         send_spice_chunk_endorsement(
             endorsement.clone(),
             self.epoch_manager.as_ref(),
             &self.network_adapter.clone().into_sender(),
             my_signer,
+        );
+        self.core_writer_sender.send(SpiceChunkEndorsementMessage(endorsement));
+    }
+
+    // Record our endorsement locally without broadcasting: the chunk isn't fallback-eligible yet so
+    // peers would reject it; the distributor broadcasts it from the stored result once overdue.
+    fn record_own_fallback_endorsement(
+        &self,
+        block: &Block,
+        my_signer: &ValidatorSigner,
+        new_chunk_result: &NewChunkResult,
+        outgoing_receipts_root: CryptoHash,
+    ) {
+        let endorsement = self.build_chunk_endorsement(
+            block,
+            my_signer,
+            new_chunk_result,
+            outgoing_receipts_root,
         );
         self.core_writer_sender.send(SpiceChunkEndorsementMessage(endorsement));
     }

--- a/chain/client/src/spice/chunk_executor_actor/testonly.rs
+++ b/chain/client/src/spice/chunk_executor_actor/testonly.rs
@@ -76,6 +76,7 @@ impl TestonlySyncChunkExecutorActor {
         let core_writer_actor = SpiceCoreWriterActor::new(
             runtime_adapter.store().chain_store(),
             epoch_manager.clone(),
+            validator_signer.clone(),
             core_reader,
             noop().into_sender(),
             noop().into_sender(),

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -17,7 +17,7 @@ use near_async::messaging::Handler;
 use near_async::messaging::Sender;
 use near_async::time::Duration;
 use near_chain::Block;
-use near_chain::spice::core::SpiceCoreReader;
+use near_chain::spice::core::{SpiceCoreReader, fallback_eligible};
 use near_chain::spice::core_writer_actor::ProcessedBlock;
 use near_chain::stateless_validation::metrics::PROCESS_CONTRACT_CODE_REQUEST_TIME;
 use near_chain_configs::MutableValidatorSigner;
@@ -329,6 +329,9 @@ impl Handler<SpiceContractCodeResponseMessage> for SpiceDataDistributorActor {
 
 impl Handler<ProcessedBlock> for SpiceDataDistributorActor {
     fn handle(&mut self, ProcessedBlock { block_hash }: ProcessedBlock) {
+        if let Err(err) = self.contribute_fallback_endorsements(&block_hash) {
+            tracing::error!(target: "spice_data_distribution", ?err, "failed contributing fallback endorsements");
+        }
         if let Err(err) = self.start_waiting_on_data(&block_hash) {
             tracing::error!(target: "spice_data_distribution", ?err, ?block_hash, "failure when starting waiting on data");
         }
@@ -838,6 +841,76 @@ impl SpiceDataDistributorActor {
 
     // TODO(spice): Implement a state machine to track all the data we produce or may need. This
     // would help make sure that we cannot have and request data at the same time.
+    /// As a non-designated, non-tracking epoch validator, certify overdue chunks via the all-stake
+    /// fallback by pulling each chunk's witness so we can validate and endorse it. Re-evaluated per
+    /// block; once we've endorsed a chunk there's nothing more to do.
+    fn contribute_fallback_endorsements(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
+        let Some(signer) = self.validator_signer.get() else {
+            return Ok(());
+        };
+        let me = signer.validator_id();
+        let block = self.chain_store.get_block(block_hash)?;
+        let carrying_height = block.header().height() + 1;
+
+        for chunk_info in self.core_reader.get_uncertified_chunks(block_hash)? {
+            let chunk_id = &chunk_info.chunk_id;
+            if !fallback_eligible(&self.chain_store, carrying_height, block_hash, chunk_id)? {
+                continue;
+            }
+            let chunk_block = self.chain_store.get_block(&chunk_id.block_hash)?;
+            let epoch_id = chunk_block.header().epoch_id();
+            if self.epoch_manager.get_validator_by_account_id(epoch_id, me).is_err() {
+                continue;
+            }
+            let assignments = self.epoch_manager.get_chunk_validator_assignments(
+                epoch_id,
+                chunk_id.shard_id,
+                chunk_block.header().height(),
+            )?;
+            if assignments.contains(me) {
+                continue;
+            }
+            // We already endorsed (the witness-validation flow broadcasts once eligible).
+            if self.core_reader.endorsement_exists(&chunk_id.block_hash, chunk_id.shard_id, me) {
+                continue;
+            }
+            // A non-tracker has no result to endorse; pull the witness so it can produce one.
+            let tracks_shard = self.shard_tracker.should_apply_chunk(
+                ApplyChunksMode::IsCaughtUp,
+                chunk_block.header().prev_hash(),
+                chunk_id.shard_id,
+            );
+            if !tracks_shard {
+                self.start_waiting_on_fallback_witness(chunk_id, &chunk_block, me)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Pull a chunk's witness (not received by non-designated validators in the initial
+    /// distribution) so we can apply the chunk and endorse it for the fallback.
+    fn start_waiting_on_fallback_witness(
+        &mut self,
+        chunk_id: &SpiceChunkId,
+        chunk_block: &Block,
+        me: &AccountId,
+    ) -> Result<(), Error> {
+        let id = SpiceDataIdentifier::Witness {
+            block_hash: chunk_id.block_hash,
+            shard_id: chunk_id.shard_id,
+        };
+        let (_recipients, producers) = self.recipients_and_producers(&id, chunk_block)?;
+        if producers.contains(me)
+            || self.waiting_on_data.contains_key(&id)
+            || self.recently_decoded_data.contains(&id)
+            || self.is_data_known(me, chunk_block, &id)
+        {
+            return Ok(());
+        }
+        self.waiting_on_data.insert(id, HashMap::new());
+        Ok(())
+    }
+
     fn start_waiting_on_data(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
         let signer = self.validator_signer.get();
         let me = signer.as_ref().map(|signer| signer.validator_id());

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -1259,14 +1259,26 @@ impl SpiceDataDistributorActor {
             chunk_id.shard_id,
             block_header.height(),
         )?;
+        // Designated validators may always request; a non-designated epoch validator may once the
+        // chunk is past the fallback window, since it then needs the code to endorse via the
+        // all-stake fallback.
         if !assignments.contains(&requester) {
-            tracing::warn!(
-                target: "spice_data_distribution",
-                ?chunk_id,
-                ?requester,
-                "contract code request from non-chunk-validator"
-            );
-            return Ok(());
+            let head = self.chain_store.head()?;
+            let eligible = fallback_eligible(
+                &self.chain_store,
+                head.height + 1,
+                &head.last_block_hash,
+                &chunk_id,
+            )?;
+            if !eligible {
+                tracing::warn!(
+                    target: "spice_data_distribution",
+                    ?chunk_id,
+                    ?requester,
+                    "contract code request from non-chunk-validator"
+                );
+                return Ok(());
+            }
         }
 
         // Deduplicate repeated requests from the same requester for the same chunk.

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -3,7 +3,9 @@ use crate::spice::chunk_executor_actor::get_contract_accesses;
 use crate::spice::chunk_executor_actor::get_receipt_proof;
 use crate::spice::chunk_executor_actor::get_witness;
 use crate::spice::chunk_executor_actor::receipt_proof_exists;
-use crate::spice::chunk_validator_actor::SpiceChunkStateWitnessMessage;
+use crate::spice::chunk_validator_actor::{
+    SpiceChunkStateWitnessMessage, send_spice_chunk_endorsement,
+};
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use itertools::Itertools as _;
@@ -14,6 +16,7 @@ use near_async::futures::DelayedActionRunner;
 use near_async::futures::DelayedActionRunnerExt as _;
 use near_async::messaging::CanSend;
 use near_async::messaging::Handler;
+use near_async::messaging::IntoSender;
 use near_async::messaging::Sender;
 use near_async::time::Duration;
 use near_chain::Block;
@@ -42,6 +45,7 @@ use near_primitives::reed_solomon::ReedSolomonEncoderDeserialize;
 use near_primitives::reed_solomon::ReedSolomonPartsTracker;
 use near_primitives::reed_solomon::{ReedSolomonEncoderCache, ReedSolomonEncoderSerialize};
 use near_primitives::sharding::ReceiptProof;
+use near_primitives::spice::chunk_endorsement::SpiceChunkEndorsement;
 use near_primitives::spice::partial_data::SpiceDataCommitment;
 use near_primitives::spice::partial_data::SpiceDataIdentifier;
 use near_primitives::spice::partial_data::SpiceDataPart;
@@ -57,6 +61,7 @@ use near_primitives::types::EpochId;
 use near_primitives::types::ShardId;
 use near_primitives::types::SpiceChunkId;
 use near_primitives::types::validator_stake::ValidatorStake;
+use near_primitives::validator_signer::ValidatorSigner;
 use near_store::StorageError::MissingTrieValue;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
@@ -175,6 +180,11 @@ pub struct SpiceDataDistributorActor {
     /// Deduplication cache for contract code requests. Keyed by (chunk, requester)
     /// to avoid redundant storage lookups and network responses for repeated requests.
     processed_contract_code_requests: LruCache<(SpiceChunkId, AccountId), ()>,
+
+    /// Fallback endorsements we already broadcast from a locally recorded result, so we send each
+    /// at most once.
+    /// TODO(spice): re-broadcast until the endorsement appears on chain rather than once.
+    broadcast_own_fallback_endorsements: LruCache<SpiceChunkId, ()>,
 }
 
 struct DistributionData {
@@ -359,6 +369,8 @@ impl SpiceDataDistributorActor {
         const PENDING_PARTIAL_DATA_CAP: NonZeroUsize = NonZeroUsize::new(10).unwrap();
         const PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE: NonZeroUsize =
             NonZeroUsize::new(30).unwrap();
+        const BROADCAST_FALLBACK_ENDORSEMENTS_CACHE_SIZE: NonZeroUsize =
+            NonZeroUsize::new(100).unwrap();
         Self {
             // TODO(spice): Evaluate whether the same data parts ratio makes sense for all data
             // distributed.
@@ -378,6 +390,9 @@ impl SpiceDataDistributorActor {
             recently_decoded_data: LruCache::new(RECENTLY_DECODED_DATA_CACHE_SIZE),
             processed_contract_code_requests: LruCache::new(
                 PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE,
+            ),
+            broadcast_own_fallback_endorsements: LruCache::new(
+                BROADCAST_FALLBACK_ENDORSEMENTS_CACHE_SIZE,
             ),
         }
     }
@@ -841,9 +856,8 @@ impl SpiceDataDistributorActor {
 
     // TODO(spice): Implement a state machine to track all the data we produce or may need. This
     // would help make sure that we cannot have and request data at the same time.
-    /// As a non-designated, non-tracking epoch validator, certify overdue chunks via the all-stake
-    /// fallback by pulling each chunk's witness so we can validate and endorse it. Re-evaluated per
-    /// block; once we've endorsed a chunk there's nothing more to do.
+    /// As a non-designated epoch validator, certify overdue chunks via the all-stake fallback:
+    /// broadcast our recorded endorsement, or pull the witness to produce one. Re-evaluated per block.
     fn contribute_fallback_endorsements(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
         let Some(signer) = self.validator_signer.get() else {
             return Ok(());
@@ -870,21 +884,64 @@ impl SpiceDataDistributorActor {
             if assignments.contains(me) {
                 continue;
             }
-            // We already endorsed (the witness-validation flow broadcasts once eligible).
-            if self.core_reader.endorsement_exists(&chunk_id.block_hash, chunk_id.shard_id, me) {
-                continue;
-            }
-            // A non-tracker has no result to endorse; pull the witness so it can produce one.
             let tracks_shard = self.shard_tracker.should_apply_chunk(
                 ApplyChunksMode::IsCaughtUp,
                 chunk_block.header().prev_hash(),
                 chunk_id.shard_id,
             );
+
+            if self.core_reader.endorsement_exists(&chunk_id.block_hash, chunk_id.shard_id, me) {
+                // Trackers recorded their endorsement at apply time without broadcasting (not yet
+                // eligible); broadcast now. Non-trackers already broadcast via the witness path.
+                if tracks_shard {
+                    self.broadcast_own_fallback_endorsement(chunk_id, &signer);
+                }
+                continue;
+            }
+            // A tracker that hasn't applied the chunk yet has no result to endorse; it records and
+            // broadcasts once applied. A non-tracker pulls the witness so it can produce one.
             if !tracks_shard {
                 self.start_waiting_on_fallback_witness(chunk_id, &chunk_block, me)?;
             }
         }
         Ok(())
+    }
+
+    /// Rebuild the wire endorsement from our recorded result and broadcast it once, so producers
+    /// can include it in the all-stake fallback tally. The result was persisted when we recorded
+    /// the endorsement at apply time.
+    fn broadcast_own_fallback_endorsement(
+        &mut self,
+        chunk_id: &SpiceChunkId,
+        signer: &ValidatorSigner,
+    ) {
+        if self.broadcast_own_fallback_endorsements.contains(chunk_id) {
+            return;
+        }
+        let Some(stored) = self.core_reader.get_endorsement(
+            &chunk_id.block_hash,
+            chunk_id.shard_id,
+            signer.validator_id(),
+        ) else {
+            return;
+        };
+        let Some(execution_result) =
+            self.core_reader.get_uncertified_execution_result(&stored.execution_result_hash)
+        else {
+            return;
+        };
+        let endorsement = SpiceChunkEndorsement::new(
+            chunk_id.clone(),
+            Arc::unwrap_or_clone(execution_result),
+            signer,
+        );
+        send_spice_chunk_endorsement(
+            endorsement,
+            self.epoch_manager.as_ref(),
+            &self.network_adapter.clone().into_sender(),
+            signer,
+        );
+        self.broadcast_own_fallback_endorsements.put(chunk_id.clone(), ());
     }
 
     /// Pull a chunk's witness (not received by non-designated validators in the initial

--- a/chain/client/src/spice/tests/chunk_executor_actor.rs
+++ b/chain/client/src/spice/tests/chunk_executor_actor.rs
@@ -177,6 +177,7 @@ impl TestActor {
         let core_writer_actor = Arc::new(RwLock::new(SpiceCoreWriterActor::new(
             runtime.store().chain_store(),
             epoch_manager.clone(),
+            validator_signer.clone(),
             core_reader(&chain),
             noop().into_sender(),
             noop().into_sender(),

--- a/chain/client/src/spice/tests/chunk_validator_actor.rs
+++ b/chain/client/src/spice/tests/chunk_validator_actor.rs
@@ -357,17 +357,17 @@ fn setup_with_genesis(genesis: Genesis, signer: Arc<ValidatorSigner>) -> TestAct
 
     let (spawner, tasks_rc) = FakeSpawner::new();
 
+    let validator_signer = MutableConfigValue::new(Some(signer), "validator_signer");
     let core_writer_actor = Arc::new(RwLock::new(SpiceCoreWriterActor::new(
         runtime.store().chain_store(),
         epoch_manager.clone(),
+        validator_signer.clone(),
         core_reader.clone(),
         noop().into_sender(),
         noop().into_sender(),
     )));
     let core_writer_sender =
         Sender::from_fn(move |message| core_writer_actor.write().handle(message));
-
-    let validator_signer = MutableConfigValue::new(Some(signer), "validator_signer");
     let mut actor = TestActor {
         actor: SpiceChunkValidatorActor::new(
             runtime.store().clone(),

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -997,6 +997,7 @@ fn record_endorsement(chain: &Chain, chunk_id: SpiceChunkId, validator: &Account
     let mut core_writer_actor = SpiceCoreWriterActor::new(
         chain.runtime_adapter.store().chain_store(),
         chain.epoch_manager.clone(),
+        MutableConfigValue::new(None, "validator_signer"),
         core_reader(chain),
         noop().into_sender(),
         noop().into_sender(),

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -205,6 +205,7 @@ pub fn create_test_setup_with_accounts_and_validity(
         let spice_core_writer_actor = SpiceCoreWriterActor::new(
             runtime.store().chain_store(),
             epoch_manager.clone(),
+            signer.clone(),
             spice_core_reader.clone(),
             chunk_executor_adapter.as_sender(),
             spice_chunk_validator_adapter.as_sender(),

--- a/core/primitives/src/spice/chunk_endorsement.rs
+++ b/core/primitives/src/spice/chunk_endorsement.rs
@@ -6,7 +6,7 @@ use crate::validator_signer::ValidatorSigner;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::{PublicKey, Signature};
 use near_primitives_core::hash::CryptoHash;
-use near_primitives_core::types::AccountId;
+use near_primitives_core::types::{AccountId, ShardId};
 use near_schema_checker_lib::ProtocolSchema;
 use std::fmt::Debug;
 
@@ -50,6 +50,12 @@ impl SpiceChunkEndorsement {
     pub fn block_hash(&self) -> &CryptoHash {
         match self {
             Self::V1(v1) => &v1.chunk_id.block_hash,
+        }
+    }
+
+    pub fn shard_id(&self) -> ShardId {
+        match self {
+            Self::V1(v1) => v1.chunk_id.shard_id,
         }
     }
 

--- a/core/primitives/src/stateless_validation/validator_assignment.rs
+++ b/core/primitives/src/stateless_validation/validator_assignment.rs
@@ -90,4 +90,19 @@ impl ChunkValidatorAssignments {
             signatures,
         }
     }
+
+    /// Whether `endorsers` hold at least 2/3 of the assignment's total stake. Like
+    /// `compute_endorsement_state(..).is_endorsed`, but without materializing the full state when
+    /// only the verdict is needed.
+    pub fn is_endorsed(&self, endorsers: &HashSet<AccountId>) -> bool {
+        let mut total_stake = Balance::ZERO;
+        let mut endorsed_stake = Balance::ZERO;
+        for (account_id, stake) in &self.assignments {
+            total_stake = total_stake.checked_add(*stake).unwrap();
+            if endorsers.contains(account_id) {
+                endorsed_stake = endorsed_stake.checked_add(*stake).unwrap();
+            }
+        }
+        has_enough_stake(total_stake, endorsed_stake)
+    }
 }

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1381,6 +1381,18 @@ pub struct SpiceUncertifiedChunkInfo {
     pub chunk_id: SpiceChunkId,
     pub missing_endorsements: Vec<AccountId>,
     pub present_endorsements: Vec<(AccountId, SpiceStoredVerifiedEndorsement)>,
+    /// Non-designated endorsements already on chain, accumulated for the all-stake fallback.
+    pub present_fallback_endorsements: Vec<(AccountId, SpiceStoredVerifiedEndorsement)>,
+}
+
+impl SpiceUncertifiedChunkInfo {
+    /// All endorsements already on chain for this chunk: designated (`present_endorsements`) and
+    /// non-designated (`present_fallback_endorsements`).
+    pub fn all_present_endorsements(
+        &self,
+    ) -> impl Iterator<Item = &(AccountId, SpiceStoredVerifiedEndorsement)> {
+        self.present_endorsements.iter().chain(&self.present_fallback_endorsements)
+    }
 }
 
 /// Keeps the current status of a single yield/resume operation. Before yielding and after executing

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -280,6 +280,7 @@ fn spawn_spice_actors(
     let spice_core_writer_actor = SpiceCoreWriterActor::new(
         runtime.store().chain_store(),
         epoch_manager.clone(),
+        validator_signer.clone(),
         spice_core_reader.clone(),
         chunk_executor_adapter.as_sender(),
         spice_chunk_validator_adapter.as_sender(),

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -4,8 +4,7 @@ use super::rpc::{FaultyRpcTransport, RpcFaultHandle};
 use super::setup::setup_client;
 use super::state::{NodeExecutionData, NodeSetupState, SharedState};
 use crate::utils::account::{
-    archival_account_id, create_validators_spec, validators_spec_clients,
-    validators_spec_clients_with_rpc,
+    archival_account_id, create_validators_spec, rpc_account_id, validators_spec_clients,
 };
 use itertools::Itertools;
 use near_async::test_loop::TestLoopV2;
@@ -61,6 +60,9 @@ pub(crate) struct TestLoopBuilder {
     track_all_shards: bool,
     /// Whether to load mem tries for the tracked shards.
     load_memtries_for_tracked_shards: bool,
+    /// Whether to add a non-validator RPC node (tracks all shards). Honored by both the auto and
+    /// manual setup APIs.
+    enable_rpc: bool,
     /// Upgrade schedule which determines when the clients start voting for new protocol versions.
     /// If not explicitly set, the chain_id from genesis determines the schedule.
     upgrade_schedule: Option<ProtocolUpgradeVotingSchedule>,
@@ -96,6 +98,7 @@ impl TestLoopBuilder {
             warmup_mode: WarmupMode::Auto,
             track_all_shards: false,
             load_memtries_for_tracked_shards: true,
+            enable_rpc: false,
             upgrade_schedule: None,
             rpc_pool: None,
             bucket_config: BucketConfig::canonical(),
@@ -175,9 +178,8 @@ impl TestLoopBuilder {
     }
 
     pub(crate) fn enable_rpc(mut self) -> Self {
-        let auto = self.setup_config.ensure_auto();
-        assert!(!auto.enable_rpc, "enable_rpc is already set");
-        auto.enable_rpc = true;
+        assert!(!self.enable_rpc, "enable_rpc is already set");
+        self.enable_rpc = true;
         self
     }
 
@@ -427,7 +429,16 @@ impl TestLoopBuilder {
 
     fn resolve_setup_config(&mut self) -> (Genesis, Vec<ClientSpec>) {
         let setup_config = std::mem::replace(&mut self.setup_config, SetupConfig::Undecided);
-        setup_config.resolve()
+        let (genesis, mut clients) = setup_config.resolve();
+        if self.enable_rpc {
+            let account_id = rpc_account_id();
+            assert!(
+                !clients.iter().any(|client| client.account_id == account_id),
+                "enable_rpc but rpc client already present",
+            );
+            clients.push(ClientSpec { account_id, client_type: ClientType::Regular });
+        }
+        (genesis, clients)
     }
 
     fn ensure_epoch_config_store(&mut self, genesis: &Genesis) {
@@ -705,7 +716,6 @@ enum SetupConfig {
 /// Data for auto-derived setup (new API).
 struct AutoSetupConfig {
     validators_spec: Option<ValidatorsSpec>,
-    enable_rpc: bool,
     archival_node: Option<ArchivalKind>,
     shard_layout: Option<ShardLayout>,
     user_accounts: Vec<(AccountId, Balance)>,
@@ -768,7 +778,6 @@ impl AutoSetupConfig {
     fn new() -> Self {
         Self {
             validators_spec: None,
-            enable_rpc: false,
             archival_node: None,
             shard_layout: None,
             user_accounts: vec![],
@@ -820,12 +829,7 @@ impl AutoSetupConfig {
             genesis_builder = genesis_builder.add_user_account_simple(account_id, balance);
         }
         let genesis = genesis_builder.build();
-        let account_ids = if self.enable_rpc {
-            validators_spec_clients_with_rpc(&validators_spec)
-        } else {
-            validators_spec_clients(&validators_spec)
-        };
-        let mut clients: Vec<ClientSpec> = account_ids
+        let mut clients: Vec<ClientSpec> = validators_spec_clients(&validators_spec)
             .into_iter()
             .map(|account_id| ClientSpec { account_id, client_type: ClientType::Regular })
             .collect();

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -60,6 +60,9 @@ pub(crate) struct TestLoopBuilder {
     track_all_shards: bool,
     /// Whether to load mem tries for the tracked shards.
     load_memtries_for_tracked_shards: bool,
+    /// Whether to give every node a no-op compiled contract cache, forcing
+    /// validators to request contract code rather than reuse a precompiled copy.
+    disable_compiled_contract_cache: bool,
     /// Whether to add a non-validator RPC node (tracks all shards). Honored by both the auto and
     /// manual setup APIs.
     enable_rpc: bool,
@@ -98,6 +101,7 @@ impl TestLoopBuilder {
             warmup_mode: WarmupMode::Auto,
             track_all_shards: false,
             load_memtries_for_tracked_shards: true,
+            disable_compiled_contract_cache: false,
             enable_rpc: false,
             upgrade_schedule: None,
             rpc_pool: None,
@@ -408,6 +412,11 @@ impl TestLoopBuilder {
         self
     }
 
+    pub fn disable_compiled_contract_cache(mut self) -> Self {
+        self.disable_compiled_contract_cache = true;
+        self
+    }
+
     pub fn protocol_upgrade_schedule(mut self, schedule: ProtocolUpgradeVotingSchedule) -> Self {
         self.upgrade_schedule = Some(schedule);
         self
@@ -543,6 +552,7 @@ impl TestLoopBuilder {
             chunks_storage: Default::default(),
             drop_conditions: Default::default(),
             load_memtries_for_tracked_shards: self.load_memtries_for_tracked_shards,
+            disable_compiled_contract_cache: self.disable_compiled_contract_cache,
             warmup_pending,
             bucket_config: self.bucket_config.clone(),
             task_delay_fn: self.task_delay_fn.clone(),

--- a/test-loop-tests/src/setup/drop_condition.rs
+++ b/test-loop-tests/src/setup/drop_condition.rs
@@ -2,6 +2,7 @@ use super::peer_manager_actor::NetworkRequestHandler;
 use super::state::NodeExecutionData;
 use crate::utils::network::{
     block_dropper_by_height, chunk_endorsement_dropper, chunk_endorsement_dropper_by_hash,
+    spice_designated_endorsement_dropper,
 };
 use near_async::messaging::{CanSend, LateBoundSender};
 use near_async::test_loop::data::TestLoopData;
@@ -34,6 +35,10 @@ pub enum DropCondition {
     ChunksProducedByHeight(HashMap<ShardId, Vec<bool>>),
     // Drops Block broadcast messages with height in `self.0`
     BlocksByHeight(HashSet<BlockHeight>),
+    /// Drops every SPICE chunk endorsement whose sender is designated for the endorsed chunk,
+    /// disabling the designated certification path so chunks can certify only via the all-stake
+    /// fallback.
+    DesignatedSpiceEndorsements,
 }
 
 /// Stores all chunks ever observed on chain. Determines if a chunk can be
@@ -126,7 +131,19 @@ impl NodeExecutionData {
             DropCondition::BlocksByHeight(heights) => {
                 self.register_drop_blocks_by_height(test_loop_data, heights);
             }
+            DropCondition::DesignatedSpiceEndorsements => {
+                self.register_drop_designated_spice_endorsements(test_loop_data);
+            }
         }
+    }
+
+    fn register_drop_designated_spice_endorsements(&self, test_loop_data: &mut TestLoopData) {
+        let client_actor = test_loop_data.get(&self.client_sender.actor_handle());
+        let epoch_manager = client_actor.client.chain.epoch_manager.clone();
+        self.register_override_handler(
+            test_loop_data,
+            spice_designated_endorsement_dropper(epoch_manager),
+        );
     }
 
     fn register_drop_chunks_validated_by(

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -44,7 +44,9 @@ use near_primitives::test_utils::create_test_signer;
 use near_store::adapter::StoreAdapter;
 use near_store::config::SplitStorageConfig;
 use near_store::{StoreConfig, TrieConfig};
-use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
+use near_vm_runner::{
+    ContractRuntimeCache, FilesystemContractRuntimeCache, NoContractRuntimeCache,
+};
 use nearcore::state_sync::StateSyncDumper;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -71,6 +73,7 @@ pub fn setup_client(
         chunks_storage,
         drop_conditions,
         load_memtries_for_tracked_shards,
+        disable_compiled_contract_cache,
         task_delay_fn,
         ..
     } = shared_state;
@@ -107,7 +110,11 @@ pub fn setup_client(
         epoch_config_store.clone(),
     );
 
-    let contract_cache = FilesystemContractRuntimeCache::test().expect("filesystem contract cache");
+    let contract_cache: Box<dyn ContractRuntimeCache> = if *disable_compiled_contract_cache {
+        Box::new(NoContractRuntimeCache)
+    } else {
+        Box::new(FilesystemContractRuntimeCache::test().expect("filesystem contract cache"))
+    };
     let snapshot_every_n_epochs = client_config
         .cloud_archival_writer
         .as_ref()

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -442,6 +442,7 @@ pub fn setup_client(
     let spice_core_writer_actor = SpiceCoreWriterActor::new(
         runtime_adapter.store().chain_store(),
         epoch_manager.clone(),
+        validator_signer.clone(),
         spice_core_reader.clone(),
         chunk_executor_adapter.as_sender(),
         spice_chunk_validator_adapter.as_sender(),

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -65,6 +65,9 @@ pub struct SharedState {
     /// List of drop conditions that apply to all nodes in the network.
     pub drop_conditions: Vec<DropCondition>,
     pub load_memtries_for_tracked_shards: bool,
+    /// When set, every node uses a no-op compiled contract cache so validators
+    /// must request contract code instead of reusing a precompiled copy.
+    pub disable_compiled_contract_cache: bool,
     /// Flag to indicate if warmup is pending. This is used to ensure that warmup is only done once.
     pub warmup_pending: Arc<AtomicBool>,
     /// Archive-wide config for cloud archival nodes. Defaults to

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -1,0 +1,188 @@
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::drop_condition::DropCondition;
+use crate::utils::node::TestLoopNode;
+use itertools::Itertools;
+use near_async::time::Duration;
+use near_chain::spice::core::all_stake_fallback_assignment;
+use near_chain_configs::Genesis;
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::block::BlockHeader;
+use near_primitives::epoch_manager::EpochConfigStore;
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::test_utils::create_test_signer;
+use near_primitives::types::{AccountId, AccountInfo, Balance, BlockHeightDelta};
+use std::collections::HashSet;
+
+/// Genesis, epoch config, and client accounts for the fallback tests: 14 equal-stake validators
+/// over 6 shards with 2 mandates each, keeping each chunk's designated subset under 1/3 of stake.
+#[derive(Default)]
+struct FallbackSetup {
+    epoch_length: Option<BlockHeightDelta>,
+}
+
+impl FallbackSetup {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn epoch_length(mut self, epoch_length: BlockHeightDelta) -> Self {
+        self.epoch_length = Some(epoch_length);
+        self
+    }
+
+    fn build(self) -> (Vec<AccountId>, Genesis, EpochConfigStore) {
+        let num_producers = 4;
+        let num_validators = 14;
+        let accounts: Vec<AccountId> =
+            (0..num_validators).map(|i| format!("validator{i}").parse().unwrap()).collect_vec();
+        let all_validators: Vec<AccountInfo> = accounts
+            .iter()
+            .map(|account_id| AccountInfo {
+                public_key: create_test_signer(account_id.as_str()).public_key(),
+                account_id: account_id.clone(),
+                amount: Balance::from_near(100),
+            })
+            .collect();
+        let validators_spec =
+            ValidatorsSpec::raw(all_validators, num_producers, num_producers, num_validators);
+
+        let mut genesis_builder = TestLoopBuilder::new_genesis_builder()
+            .shard_layout(ShardLayout::multi_shard(6, 0))
+            .validators_spec(validators_spec);
+        if let Some(epoch_length) = self.epoch_length {
+            genesis_builder = genesis_builder.epoch_length(epoch_length);
+        }
+        let genesis = genesis_builder.build();
+        let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+            .target_validator_mandates_per_shard(2)
+            .build_store_for_genesis_protocol_version();
+        (accounts, genesis, epoch_config_store)
+    }
+}
+
+/// Asserts every (height, shard) of the genesis epoch has designated validators under 1/3 of total
+/// stake, so the fallback's non-designated remainder can reach 2/3. Genesis epoch is representative.
+fn assert_fallback_has_enough_stake(node: &TestLoopNode) {
+    let epoch_manager = node.client().epoch_manager.clone();
+    let epoch_id = node.head().epoch_id;
+    let epoch_length = epoch_manager.get_epoch_config(&epoch_id).unwrap().epoch_length;
+    let shard_ids: Vec<_> =
+        epoch_manager.get_shard_layout(&epoch_id).unwrap().shard_ids().collect();
+    let total_stake: u128 = all_stake_fallback_assignment(epoch_manager.as_ref(), &epoch_id)
+        .unwrap()
+        .assignments()
+        .iter()
+        .map(|(_, stake)| stake.as_yoctonear())
+        .sum();
+    for height in 1..=epoch_length {
+        for &shard_id in &shard_ids {
+            let designated: u128 = epoch_manager
+                .get_chunk_validator_assignments(&epoch_id, shard_id, height)
+                .unwrap()
+                .assignments()
+                .iter()
+                .map(|(_, stake)| stake.as_yoctonear())
+                .sum();
+            assert!(
+                designated * 3 < total_stake,
+                "designated stake reaches 1/3 at height {height} shard {shard_id}: {designated} of {total_stake}",
+            );
+        }
+    }
+}
+
+/// Asserts `header`'s block is certified and at least one of its chunks certified via the all-stake
+/// fallback: the present designated endorsements alone don't meet the designated 2/3 threshold, so
+/// the non-designated remainder must have carried it.
+fn assert_certified_via_fallback(node: &TestLoopNode, header: &BlockHeader) {
+    let client = node.client();
+    let core_reader = &client.chain.spice_core_reader;
+    let epoch_manager = client.epoch_manager.as_ref();
+    assert!(core_reader.all_execution_results_exist(header).unwrap(), "block is not certified");
+
+    let epoch_id = header.epoch_id();
+    let mut fallback_certified_chunks = 0;
+    for shard_id in epoch_manager.get_shard_layout(epoch_id).unwrap().shard_ids() {
+        let designated = epoch_manager
+            .get_chunk_validator_assignments(epoch_id, shard_id, header.height())
+            .unwrap();
+        let designated_present: HashSet<AccountId> = designated
+            .assignments()
+            .iter()
+            .map(|(account_id, _)| account_id)
+            .filter(|account_id| {
+                core_reader.get_endorsement(header.hash(), shard_id, account_id).is_some()
+            })
+            .cloned()
+            .collect();
+        if !designated.is_endorsed(&designated_present) {
+            fallback_certified_chunks += 1;
+        }
+    }
+    assert!(
+        fallback_certified_chunks > 0,
+        "every chunk met the designated threshold; none certified via the fallback",
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_all_stake_fallback_certifies_without_designated_endorsements() {
+    init_test_logger();
+
+    let (accounts, genesis, epoch_config_store) = FallbackSetup::new().build();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .build()
+        .drop(DropCondition::DesignatedSpiceEndorsements);
+    assert_fallback_has_enough_stake(&env.node(0));
+
+    // The certified frontier must keep advancing via the all-stake fallback though every designated
+    // endorsement is dropped (slowly: ~1 block per fallback window under a total outage).
+    let target = env.node(0).last_certified_block_header().height() + 4;
+    env.node_runner(0).run_until(
+        |node| node.last_certified_block_header().height() >= target,
+        Duration::seconds(60),
+    );
+    let frontier = env.node(0).last_certified_block_header();
+    assert_certified_via_fallback(&env.node(0), frontier.as_ref());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_all_stake_fallback_certifies_across_epoch_boundary() {
+    init_test_logger();
+
+    let epoch_length = 25;
+    let (accounts, genesis, epoch_config_store) =
+        FallbackSetup::new().epoch_length(epoch_length).build();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .build();
+    assert_fallback_has_enough_stake(&env.node(0));
+
+    // Run normally up to just before the epoch boundary, then drop designated endorsements: the
+    // all-stake fallback alone must carry certification across into the next epoch.
+    env.node_runner(0)
+        .run_until(|node| node.head().height >= epoch_length - 5, Duration::seconds(60));
+    let initial_epoch = env.node(0).head().epoch_id;
+    let mut env = env.drop(DropCondition::DesignatedSpiceEndorsements);
+
+    // The certified frontier must reach the second epoch (height past the boundary, with a different
+    // epoch id), proving the fallback certified the boundary chunks under the new assignments.
+    env.node_runner(0).run_until(
+        |node| {
+            let header = node.last_certified_block_header();
+            let epoch_id = node.client().epoch_manager.get_epoch_id(header.hash()).unwrap();
+            header.height() > epoch_length && epoch_id != initial_epoch
+        },
+        Duration::seconds(120),
+    );
+    let frontier = env.node(0).last_certified_block_header();
+    assert_certified_via_fallback(&env.node(0), frontier.as_ref());
+}

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -186,3 +186,30 @@ fn slow_test_spice_all_stake_fallback_certifies_across_epoch_boundary() {
     let frontier = env.node(0).last_certified_block_header();
     assert_certified_via_fallback(&env.node(0), frontier.as_ref());
 }
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_all_stake_fallback_certifies_when_validators_track_all_shards() {
+    init_test_logger();
+
+    let (accounts, genesis, epoch_config_store) = FallbackSetup::new().build();
+
+    // Every validator tracks every shard, so non-designated validators self-execute instead of
+    // pulling witnesses; their stake must still certify the chunks via the fallback.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .track_all_shards()
+        .build()
+        .drop(DropCondition::DesignatedSpiceEndorsements);
+    assert_fallback_has_enough_stake(&env.node(0));
+
+    let target = env.node(0).last_certified_block_header().height() + 4;
+    env.node_runner(0).run_until(
+        |node| node.last_certified_block_header().height() >= target,
+        Duration::seconds(60),
+    );
+    let frontier = env.node(0).last_certified_block_header();
+    assert_certified_via_fallback(&env.node(0), frontier.as_ref());
+}

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -1,5 +1,6 @@
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::drop_condition::DropCondition;
+use crate::utils::account::create_account_id;
 use crate::utils::node::TestLoopNode;
 use itertools::Itertools;
 use near_async::time::Duration;
@@ -9,6 +10,7 @@ use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::BlockHeader;
 use near_primitives::epoch_manager::EpochConfigStore;
+use near_primitives::gas::Gas;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{AccountId, AccountInfo, Balance, BlockHeightDelta};
@@ -19,6 +21,7 @@ use std::collections::HashSet;
 #[derive(Default)]
 struct FallbackSetup {
     epoch_length: Option<BlockHeightDelta>,
+    user_accounts: Vec<(AccountId, Balance)>,
 }
 
 impl FallbackSetup {
@@ -28,6 +31,11 @@ impl FallbackSetup {
 
     fn epoch_length(mut self, epoch_length: BlockHeightDelta) -> Self {
         self.epoch_length = Some(epoch_length);
+        self
+    }
+
+    fn user_account(mut self, account_id: AccountId, balance: Balance) -> Self {
+        self.user_accounts.push((account_id, balance));
         self
     }
 
@@ -52,6 +60,9 @@ impl FallbackSetup {
             .validators_spec(validators_spec);
         if let Some(epoch_length) = self.epoch_length {
             genesis_builder = genesis_builder.epoch_length(epoch_length);
+        }
+        for (account_id, balance) in self.user_accounts {
+            genesis_builder = genesis_builder.add_user_account_simple(account_id, balance);
         }
         let genesis = genesis_builder.build();
         let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
@@ -212,4 +223,59 @@ fn slow_test_spice_all_stake_fallback_certifies_when_validators_track_all_shards
     );
     let frontier = env.node(0).last_certified_block_header();
     assert_certified_via_fallback(&env.node(0), frontier.as_ref());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_all_stake_fallback_certifies_chunk_accessing_contract_code() {
+    init_test_logger();
+
+    let contract_user = create_account_id("contract-user");
+    // epoch_length 100 keeps the call chunk (~height 9) within the genesis epoch the precondition checks.
+    let (accounts, genesis, epoch_config_store) = FallbackSetup::new()
+        .epoch_length(100)
+        .user_account(contract_user.clone(), Balance::from_near(100))
+        .build();
+
+    // The no-op compiled contract cache forces validators to fetch contract code via a
+    // SpiceContractCodeRequest; otherwise the fallback code-request gate is never exercised.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .enable_rpc()
+        .disable_compiled_contract_cache()
+        .build()
+        .drop(DropCondition::DesignatedSpiceEndorsements);
+    assert_fallback_has_enough_stake(&env.rpc_node());
+
+    // Wait for the deploy to be included before submitting the call, so the call runs against an
+    // already-settled contract (`record_contract_call` skips newly-deployed code).
+    let deploy_tx = env.rpc_node().tx_deploy_test_contract(&contract_user);
+    let deploy_hash = deploy_tx.get_hash();
+    env.rpc_node().submit_tx(deploy_tx);
+    env.rpc_runner().run_until_included(&[deploy_hash]);
+
+    // The call's chunk witness omits the code, so a cold non-designated fallback validator must
+    // fetch it via a contract-code request.
+    let call_tx = env.rpc_node().tx_call(
+        &contract_user,
+        &contract_user,
+        "log_something",
+        vec![],
+        Balance::ZERO,
+        Gas::from_teragas(300),
+    );
+    let call_hash = call_tx.get_hash();
+    env.rpc_node().submit_tx(call_tx);
+    let call_height = env.rpc_runner().run_until_included(&[call_hash]);
+
+    // Execution advances only as the fallback certifies; wait for the certified frontier to reach
+    // the call chunk. Pre-fix its code requests are rejected, so the frontier stalls below it.
+    env.rpc_runner().run_until(
+        |node| node.last_certified_block_header().height() >= call_height,
+        Duration::seconds(120),
+    );
+    let frontier = env.rpc_node().last_certified_block_header();
+    assert_certified_via_fallback(&env.rpc_node(), frontier.as_ref());
 }

--- a/test-loop-tests/src/tests/spice/mod.rs
+++ b/test-loop-tests/src/tests/spice/mod.rs
@@ -1,3 +1,4 @@
+mod all_stake_fallback;
 mod basic;
 mod congestion;
 mod malicious_chunk_producer;

--- a/test-loop-tests/src/utils/network.rs
+++ b/test-loop-tests/src/utils/network.rs
@@ -58,6 +58,32 @@ pub fn chunk_endorsement_dropper_by_hash(
     })
 }
 
+/// Drops every SPICE chunk endorsement whose sender is designated for the endorsed chunk, so chunks
+/// can only certify via the all-stake fallback. Non-designated endorsements pass through.
+pub fn spice_designated_endorsement_dropper(
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+) -> Box<dyn Fn(NetworkRequests) -> HandlerResult> {
+    Box::new(move |request| {
+        let NetworkRequests::SpiceChunkEndorsement(_target, endorsement) = &request else {
+            return HandlerResult::Unhandled(request);
+        };
+        let Ok(block_info) = epoch_manager.get_block_info(endorsement.block_hash()) else {
+            return HandlerResult::Unhandled(request);
+        };
+        let Ok(assignments) = epoch_manager.get_chunk_validator_assignments(
+            block_info.epoch_id(),
+            endorsement.shard_id(),
+            block_info.height(),
+        ) else {
+            return HandlerResult::Unhandled(request);
+        };
+        if assignments.contains(endorsement.account_id()) {
+            return HandlerResult::Handled(NetworkResponses::NoResponse);
+        }
+        HandlerResult::Unhandled(request)
+    })
+}
+
 /// Handler to drop all network messages containing chunk endorsements sent
 /// from a given chunk-validator account.
 pub fn chunk_endorsement_dropper(

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -6,6 +6,7 @@ use near_async::messaging::CanSend;
 use near_async::test_loop::TestLoopV2;
 use near_async::test_loop::data::TestLoopData;
 use near_async::time::Duration;
+use near_chain::spice::core::get_last_certified_block_header;
 use near_chain::types::Tip;
 use near_chain::{Block, BlockHeader};
 use near_client::client_actor::ClientActor;
@@ -85,6 +86,12 @@ impl<'a> TestLoopNode<'a> {
     pub fn last_executed_block(&self) -> Arc<Block> {
         let block_hash = self.last_executed().last_block_hash;
         self.block(block_hash)
+    }
+
+    pub fn last_certified_block_header(&self) -> Arc<BlockHeader> {
+        let chain_store = &self.client().chain.chain_store;
+        let head_hash = self.head().last_block_hash;
+        get_last_certified_block_header(chain_store, &head_hash).unwrap()
     }
 
     pub fn block(&self, block_hash: CryptoHash) -> Arc<Block> {


### PR DESCRIPTION
This PR is the full feature, kept for reference. It is split into a stack of smaller, independently-reviewable PRs (review and merge these instead):

1. #15936 refactor(spice): tidy chunk-certification endorsement bookkeeping
2. #15937 refactor(test-loop): make enable_rpc work for both setup APIs
3. #15938 feat(spice): certify chunks via all-stake fallback
4. #15940 feat(spice): non-tracking validators pull witness for fallback
5. #15941 feat(spice): tracked-shard validators contribute fallback endorsements
6. #15942 feat(spice): fallback validators fetch missing contract code

---

Adds an additive all-stake fallback to SPICE chunk certification. A chunk still certifies on the fast path at ≥2/3 of its designated chunk-validator assignment stake; additionally, once it has been certifiable-but-uncertified for `SPICE_FALLBACK_CERTIFICATION_DELAY` (5) blocks, endorsements from any validator of the chunk's epoch become admissible and it can certify at ≥2/3 of total epoch stake. This rescues liveness before the one-epoch certification-lag guard can stall consensus when too many of a chunk's designated validators are offline or adversarial.

- Eligibility is anchored at the parent's certification height (`fallback_eligible`), so only the frontier-successor chunk is eligible at a time, each with its own delay window.
- Non-designated epoch validators contribute endorsements: shard-trackers record theirs at apply time, non-trackers pull the chunk witness on demand (and may fetch missing contract code, now permitted for fallback-eligible requesters).
- Block validation is reworked around an `AncestryEndorsements` view; the either-threshold check is applied consistently at the live tally, the on-chain tally, and block validation.
- Covered by unit tests for the eligibility predicate and the validation admit/reject matrix, plus test-loop e2e tests for liveness under a total designated-endorsement outage, certification across an epoch boundary, and the contract-code-fetch path.