### PR TITLE
chore(ci): upload spice coverage to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,11 @@ jobs:
           flags: unittests-nightly
       - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
         with:
+          files: unit-linux-spice.json
+          fail_ci_if_error: false
+          flags: unittests-spice
+      - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
+        with:
           files: py-nightly.json
           fail_ci_if_error: false
           flags: pytests-nightly

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 3 # Keep in sync with .github/workflows/ci.yml
+    after_n_builds: 4 # Keep in sync with .github/workflows/ci.yml
   # Dear h4xx0rz reading this,
   # Feel free to use this token to upload arbitrary coverage information to codecov.
   # We do not care. The best you can do is make us facepalm.


### PR DESCRIPTION
The `Linux Spice` coverage matrix entry runs the spice-gated tests under `--features protocol_feature_spice` and collects coverage into `unit-linux-spice.json`, but the `upload_coverage` job never sent that file to codecov.

This adds the missing `codecov/codecov-action` upload step for `unit-linux-spice.json` under a new `unittests-spice` flag, and bumps `after_n_builds` in `codecov.yml` from 3 to 4 to match.

The existing `unit-tests` component uses `flag_regexes: ["unittests"]`, which already matches `unittests-spice` (as it does `unittests-nightly`), so spice coverage rolls into the component status and spice diffs get real patch-coverage credit automatically.