### PR TITLE
feat(spice): tracked-shard validators contribute fallback endorsements (5/6)

### DIFF
--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -2,6 +2,7 @@ use crate::spice::core::{SpiceCoreReader, all_stake_fallback_assignment};
 use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
 use near_cache::SyncLruCache;
+use near_chain_configs::MutableValidatorSigner;
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::client::SpiceChunkEndorsementMessage;
@@ -46,6 +47,7 @@ pub struct SpiceCoreWriterActor {
 
     chain_store: ChainStoreAdapter,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
+    validator_signer: MutableValidatorSigner,
     chunk_executor_sender: Sender<ExecutionResultEndorsed>,
     spice_chunk_validator_sender: Sender<ExecutionResultEndorsed>,
     // Endorsements that arrived before the relevant block, so cannot be fully validated yet.
@@ -74,6 +76,7 @@ impl SpiceCoreWriterActor {
     pub fn new(
         chain_store: ChainStoreAdapter,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
+        validator_signer: MutableValidatorSigner,
         core_reader: SpiceCoreReader,
         chunk_executor_sender: Sender<ExecutionResultEndorsed>,
         spice_chunk_validator_sender: Sender<ExecutionResultEndorsed>,
@@ -83,6 +86,7 @@ impl SpiceCoreWriterActor {
             core_reader,
             chain_store,
             epoch_manager,
+            validator_signer,
             chunk_executor_sender,
             spice_chunk_validator_sender,
             pending_endorsements: SyncLruCache::new(PENDING_ENDORSEMENT_CACHE_SIZE.into()),
@@ -275,6 +279,16 @@ impl SpiceCoreWriterActor {
         )?;
 
         if chunk_validator_assignments.contains(endorsement.account_id()) {
+            return Ok(());
+        }
+
+        // Our own endorsement is trustworthy by construction (we executed the chunk). Keep it even
+        // before eligibility so the fallback can broadcast it once overdue; inert in the tally until.
+        if self
+            .validator_signer
+            .get()
+            .is_some_and(|signer| signer.validator_id() == endorsement.account_id())
+        {
             return Ok(());
         }
 

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -12,6 +12,7 @@ use assert_matches::assert_matches;
 use itertools::Itertools as _;
 use near_async::messaging::{Handler as _, IntoSender as _, noop};
 use near_async::time::Clock;
+use near_chain_configs::MutableConfigValue;
 use near_chain_configs::test_genesis::{TestGenesisBuilder, ValidatorsSpec};
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::recv_permit::RecvMessagePermit;
@@ -1942,6 +1943,7 @@ fn core_writer_actor(chain: &Chain) -> SpiceCoreWriterActor {
     SpiceCoreWriterActor::new(
         chain.chain_store().chain_store(),
         chain.epoch_manager.clone(),
+        MutableConfigValue::new(None, "validator_signer"),
         core_reader(&chain),
         noop().into_sender(),
         noop().into_sender(),

--- a/chain/chain/src/spice/tests/core_writer_actor.rs
+++ b/chain/chain/src/spice/tests/core_writer_actor.rs
@@ -10,8 +10,8 @@ use assert_matches::assert_matches;
 use itertools::Itertools as _;
 use near_async::messaging::{IntoSender as _, Sender, noop};
 use near_async::time::Clock;
-use near_chain_configs::Genesis;
 use near_chain_configs::test_genesis::{TestGenesisBuilder, ValidatorsSpec};
+use near_chain_configs::{Genesis, MutableConfigValue};
 use near_crypto::Signature;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Block;
@@ -765,6 +765,7 @@ fn setup_with_senders(
     let core_writer_actor = SpiceCoreWriterActor::new(
         chain.chain_store().chain_store(),
         chain.epoch_manager.clone(),
+        MutableConfigValue::new(None, "validator_signer"),
         core_reader(&chain),
         chunk_executor_sender,
         spice_chunk_validator_sender,
@@ -777,6 +778,7 @@ fn setup_with_genesis(genesis: Genesis) -> (Chain, SpiceCoreWriterActor) {
     let core_writer_actor = SpiceCoreWriterActor::new(
         chain.chain_store().chain_store(),
         chain.epoch_manager.clone(),
+        MutableConfigValue::new(None, "validator_signer"),
         core_reader(&chain),
         noop().into_sender(),
         noop().into_sender(),

--- a/chain/client/src/spice/chunk_executor_actor/per_shard.rs
+++ b/chain/client/src/spice/chunk_executor_actor/per_shard.rs
@@ -462,6 +462,18 @@ impl PerShardChunkExecutor {
                     &new_chunk_result,
                     outgoing_receipts_root,
                 );
+            } else if self
+                .epoch_manager
+                .get_validator_by_account_id(&epoch_id, my_signer.validator_id())
+                .is_ok()
+            {
+                // Non-designated epoch validator: record for the all-stake fallback.
+                self.record_own_fallback_endorsement(
+                    &block,
+                    &my_signer,
+                    &new_chunk_result,
+                    outgoing_receipts_root,
+                );
             }
 
             // Distribute witness and receipts if we are the chunk producer for the shard.
@@ -485,6 +497,23 @@ impl PerShardChunkExecutor {
         Ok(receipt_proofs)
     }
 
+    fn build_chunk_endorsement(
+        &self,
+        block: &Block,
+        my_signer: &ValidatorSigner,
+        new_chunk_result: &NewChunkResult,
+        outgoing_receipts_root: CryptoHash,
+    ) -> SpiceChunkEndorsement {
+        let NewChunkResult { shard_uid, gas_limit, apply_result } = new_chunk_result;
+        let execution_result =
+            new_execution_result(*gas_limit, apply_result, outgoing_receipts_root);
+        SpiceChunkEndorsement::new(
+            SpiceChunkId { block_hash: *block.hash(), shard_id: shard_uid.shard_id() },
+            execution_result,
+            my_signer,
+        )
+    }
+
     fn send_chunk_endorsement(
         &self,
         block: &Block,
@@ -492,20 +521,36 @@ impl PerShardChunkExecutor {
         new_chunk_result: &NewChunkResult,
         outgoing_receipts_root: CryptoHash,
     ) {
-        let NewChunkResult { shard_uid, gas_limit, apply_result } = new_chunk_result;
-        let shard_id = shard_uid.shard_id();
-        let execution_result =
-            new_execution_result(*gas_limit, apply_result, outgoing_receipts_root);
-        let endorsement = SpiceChunkEndorsement::new(
-            SpiceChunkId { block_hash: *block.hash(), shard_id },
-            execution_result,
+        let endorsement = self.build_chunk_endorsement(
+            block,
             my_signer,
+            new_chunk_result,
+            outgoing_receipts_root,
         );
         send_spice_chunk_endorsement(
             endorsement.clone(),
             self.epoch_manager.as_ref(),
             &self.network_adapter.clone().into_sender(),
             my_signer,
+        );
+        self.core_writer_sender
+            .send(SpiceChunkEndorsementMessage(endorsement, RecvMessagePermit::none()));
+    }
+
+    // Record our endorsement locally without broadcasting: the chunk isn't fallback-eligible yet so
+    // peers would reject it; the distributor broadcasts it from the stored result once overdue.
+    fn record_own_fallback_endorsement(
+        &self,
+        block: &Block,
+        my_signer: &ValidatorSigner,
+        new_chunk_result: &NewChunkResult,
+        outgoing_receipts_root: CryptoHash,
+    ) {
+        let endorsement = self.build_chunk_endorsement(
+            block,
+            my_signer,
+            new_chunk_result,
+            outgoing_receipts_root,
         );
         self.core_writer_sender
             .send(SpiceChunkEndorsementMessage(endorsement, RecvMessagePermit::none()));

--- a/chain/client/src/spice/chunk_executor_actor/testonly.rs
+++ b/chain/client/src/spice/chunk_executor_actor/testonly.rs
@@ -76,6 +76,7 @@ impl TestonlySyncChunkExecutorActor {
         let core_writer_actor = SpiceCoreWriterActor::new(
             runtime_adapter.store().chain_store(),
             epoch_manager.clone(),
+            validator_signer.clone(),
             core_reader,
             noop().into_sender(),
             noop().into_sender(),

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -3,7 +3,9 @@ use crate::spice::chunk_executor_actor::get_contract_accesses;
 use crate::spice::chunk_executor_actor::get_receipt_proof;
 use crate::spice::chunk_executor_actor::get_witness;
 use crate::spice::chunk_executor_actor::receipt_proof_exists;
-use crate::spice::chunk_validator_actor::SpiceChunkStateWitnessMessage;
+use crate::spice::chunk_validator_actor::{
+    SpiceChunkStateWitnessMessage, send_spice_chunk_endorsement,
+};
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use itertools::Itertools as _;
@@ -14,6 +16,7 @@ use near_async::futures::DelayedActionRunner;
 use near_async::futures::DelayedActionRunnerExt as _;
 use near_async::messaging::CanSend;
 use near_async::messaging::Handler;
+use near_async::messaging::IntoSender;
 use near_async::messaging::Sender;
 use near_async::time::Duration;
 use near_chain::Block;
@@ -44,6 +47,7 @@ use near_primitives::reed_solomon::ReedSolomonEncoderDeserialize;
 use near_primitives::reed_solomon::ReedSolomonPartsTracker;
 use near_primitives::reed_solomon::{ReedSolomonEncoderCache, ReedSolomonEncoderSerialize};
 use near_primitives::sharding::ReceiptProof;
+use near_primitives::spice::chunk_endorsement::SpiceChunkEndorsement;
 use near_primitives::spice::partial_data::SpiceDataCommitment;
 use near_primitives::spice::partial_data::SpiceDataIdentifier;
 use near_primitives::spice::partial_data::SpiceDataPart;
@@ -59,6 +63,7 @@ use near_primitives::types::EpochId;
 use near_primitives::types::ShardId;
 use near_primitives::types::SpiceChunkId;
 use near_primitives::types::validator_stake::ValidatorStake;
+use near_primitives::validator_signer::ValidatorSigner;
 use near_store::StorageError::MissingTrieValue;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
@@ -177,6 +182,11 @@ pub struct SpiceDataDistributorActor {
     /// Deduplication cache for contract code requests. Keyed by (chunk, requester)
     /// to avoid redundant storage lookups and network responses for repeated requests.
     processed_contract_code_requests: LruCache<(SpiceChunkId, AccountId), ()>,
+
+    /// Fallback endorsements we already broadcast from a locally recorded result, so we send each
+    /// at most once.
+    /// TODO(spice): re-broadcast until the endorsement appears on chain rather than once.
+    broadcast_own_fallback_endorsements: LruCache<SpiceChunkId, ()>,
 }
 
 struct DistributionData {
@@ -364,6 +374,8 @@ impl SpiceDataDistributorActor {
         const PENDING_PARTIAL_DATA_CAP: NonZeroUsize = NonZeroUsize::new(10).unwrap();
         const PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE: NonZeroUsize =
             NonZeroUsize::new(30).unwrap();
+        const BROADCAST_FALLBACK_ENDORSEMENTS_CACHE_SIZE: NonZeroUsize =
+            NonZeroUsize::new(100).unwrap();
         Self {
             // TODO(spice): Evaluate whether the same data parts ratio makes sense for all data
             // distributed.
@@ -383,6 +395,9 @@ impl SpiceDataDistributorActor {
             recently_decoded_data: LruCache::new(RECENTLY_DECODED_DATA_CACHE_SIZE),
             processed_contract_code_requests: LruCache::new(
                 PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE,
+            ),
+            broadcast_own_fallback_endorsements: LruCache::new(
+                BROADCAST_FALLBACK_ENDORSEMENTS_CACHE_SIZE,
             ),
         }
     }
@@ -846,9 +861,8 @@ impl SpiceDataDistributorActor {
 
     // TODO(spice): Implement a state machine to track all the data we produce or may need. This
     // would help make sure that we cannot have and request data at the same time.
-    /// As a non-designated, non-tracking epoch validator, certify overdue chunks via the all-stake
-    /// fallback by pulling each chunk's witness so we can validate and endorse it. Re-evaluated per
-    /// block; once we've endorsed a chunk there's nothing more to do.
+    /// As a non-designated epoch validator, certify overdue chunks via the all-stake fallback:
+    /// broadcast our recorded endorsement, or pull the witness to produce one. Re-evaluated per block.
     fn contribute_fallback_endorsements(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
         let Some(signer) = self.validator_signer.get() else {
             return Ok(());
@@ -875,21 +889,64 @@ impl SpiceDataDistributorActor {
             if assignments.contains(me) {
                 continue;
             }
-            // We already endorsed (the witness-validation flow broadcasts once eligible).
-            if self.core_reader.endorsement_exists(&chunk_id.block_hash, chunk_id.shard_id, me) {
-                continue;
-            }
-            // A non-tracker has no result to endorse; pull the witness so it can produce one.
             let tracks_shard = self.shard_tracker.should_apply_chunk(
                 ApplyChunksMode::IsCaughtUp,
                 chunk_block.header().prev_hash(),
                 chunk_id.shard_id,
             );
+
+            if self.core_reader.endorsement_exists(&chunk_id.block_hash, chunk_id.shard_id, me) {
+                // Trackers recorded their endorsement at apply time without broadcasting (not yet
+                // eligible); broadcast now. Non-trackers already broadcast via the witness path.
+                if tracks_shard {
+                    self.broadcast_own_fallback_endorsement(chunk_id, &signer);
+                }
+                continue;
+            }
+            // A tracker that hasn't applied the chunk yet has no result to endorse; it records and
+            // broadcasts once applied. A non-tracker pulls the witness so it can produce one.
             if !tracks_shard {
                 self.start_waiting_on_fallback_witness(chunk_id, &chunk_block, me)?;
             }
         }
         Ok(())
+    }
+
+    /// Rebuild the wire endorsement from our recorded result and broadcast it once, so producers
+    /// can include it in the all-stake fallback tally. The result was persisted when we recorded
+    /// the endorsement at apply time.
+    fn broadcast_own_fallback_endorsement(
+        &mut self,
+        chunk_id: &SpiceChunkId,
+        signer: &ValidatorSigner,
+    ) {
+        if self.broadcast_own_fallback_endorsements.contains(chunk_id) {
+            return;
+        }
+        let Some(stored) = self.core_reader.get_endorsement(
+            &chunk_id.block_hash,
+            chunk_id.shard_id,
+            signer.validator_id(),
+        ) else {
+            return;
+        };
+        let Some(execution_result) =
+            self.core_reader.get_uncertified_execution_result(&stored.execution_result_hash)
+        else {
+            return;
+        };
+        let endorsement = SpiceChunkEndorsement::new(
+            chunk_id.clone(),
+            Arc::unwrap_or_clone(execution_result),
+            signer,
+        );
+        send_spice_chunk_endorsement(
+            endorsement,
+            self.epoch_manager.as_ref(),
+            &self.network_adapter.clone().into_sender(),
+            signer,
+        );
+        self.broadcast_own_fallback_endorsements.put(chunk_id.clone(), ());
     }
 
     /// Pull a chunk's witness (not received by non-designated validators in the initial

--- a/chain/client/src/spice/tests/chunk_executor_actor.rs
+++ b/chain/client/src/spice/tests/chunk_executor_actor.rs
@@ -187,6 +187,7 @@ impl TestActor {
         let core_writer_actor = Arc::new(RwLock::new(SpiceCoreWriterActor::new(
             runtime.store().chain_store(),
             epoch_manager.clone(),
+            validator_signer.clone(),
             core_reader(&chain),
             noop().into_sender(),
             noop().into_sender(),

--- a/chain/client/src/spice/tests/chunk_validator_actor.rs
+++ b/chain/client/src/spice/tests/chunk_validator_actor.rs
@@ -367,17 +367,17 @@ fn setup_with_genesis(genesis: Genesis, signer: Arc<ValidatorSigner>) -> TestAct
 
     let (spawner, tasks_rc) = FakeSpawner::new();
 
+    let validator_signer = MutableConfigValue::new(Some(signer), "validator_signer");
     let core_writer_actor = Arc::new(RwLock::new(SpiceCoreWriterActor::new(
         runtime.store().chain_store(),
         epoch_manager.clone(),
+        validator_signer.clone(),
         core_reader.clone(),
         noop().into_sender(),
         noop().into_sender(),
     )));
     let core_writer_sender =
         Sender::from_fn(move |message| core_writer_actor.write().handle(message));
-
-    let validator_signer = MutableConfigValue::new(Some(signer), "validator_signer");
     let mut actor = TestActor {
         actor: SpiceChunkValidatorActor::new(
             runtime.store().clone(),

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -1019,6 +1019,7 @@ fn record_endorsement(chain: &Chain, chunk_id: SpiceChunkId, validator: &Account
     let mut core_writer_actor = SpiceCoreWriterActor::new(
         chain.runtime_adapter.store().chain_store(),
         chain.epoch_manager.clone(),
+        MutableConfigValue::new(None, "validator_signer"),
         core_reader(chain),
         noop().into_sender(),
         noop().into_sender(),

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -205,6 +205,7 @@ pub fn create_test_setup_with_accounts_and_validity(
         let spice_core_writer_actor = SpiceCoreWriterActor::new(
             runtime.store().chain_store(),
             epoch_manager.clone(),
+            signer.clone(),
             spice_core_reader.clone(),
             chunk_executor_adapter.as_sender(),
             spice_chunk_validator_adapter.as_sender(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -280,6 +280,7 @@ fn spawn_spice_actors(
     let spice_core_writer_actor = SpiceCoreWriterActor::new(
         runtime.store().chain_store(),
         epoch_manager.clone(),
+        validator_signer.clone(),
         spice_core_reader.clone(),
         chunk_executor_adapter.as_sender(),
         spice_chunk_validator_adapter.as_sender(),

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -444,6 +444,7 @@ pub fn setup_client(
     let spice_core_writer_actor = SpiceCoreWriterActor::new(
         runtime_adapter.store().chain_store(),
         epoch_manager.clone(),
+        validator_signer.clone(),
         spice_core_reader.clone(),
         chunk_executor_adapter.as_sender(),
         spice_chunk_validator_adapter.as_sender(),

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -186,3 +186,30 @@ fn slow_test_spice_all_stake_fallback_certifies_across_epoch_boundary() {
     let frontier = env.node(0).last_certified_block_header();
     assert_certified_via_fallback(&env.node(0), frontier.as_ref());
 }
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_all_stake_fallback_certifies_when_validators_track_all_shards() {
+    init_test_logger();
+
+    let (accounts, genesis, epoch_config_store) = FallbackSetup::new().build();
+
+    // Every validator tracks every shard, so non-designated validators self-execute instead of
+    // pulling witnesses; their stake must still certify the chunks via the fallback.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .track_all_shards()
+        .build()
+        .drop(DropCondition::DesignatedSpiceEndorsements);
+    assert_fallback_has_enough_stake(&env.node(0));
+
+    let target = env.node(0).last_certified_block_header().height() + 4;
+    env.node_runner(0).run_until(
+        |node| node.last_certified_block_header().height() >= target,
+        Duration::seconds(300),
+    );
+    let frontier = env.node(0).last_certified_block_header();
+    assert_certified_via_fallback(&env.node(0), frontier.as_ref());
+}


### PR DESCRIPTION
Lets a non-designated epoch validator that tracks a chunk's shard contribute to the all-stake fallback. The chunk executor records the validator's own endorsement at apply time without broadcasting (`record_own_fallback_endorsement`), since the chunk isn't fallback-eligible yet and peers would reject it. Once the chunk is overdue, the data distributor rebuilds the endorsement from the stored result and broadcasts it (`broadcast_own_fallback_endorsement`), so producers can include it in the fallback tally.

Threads a `validator_signer` into `SpiceCoreWriterActor` so endorsement ingest keeps our own endorsement even before eligibility (it is trustworthy by construction and inert in the tally until the chunk is overdue).

e2e: certifies-when-validators-track-all-shards, where every validator self-executes rather than pulling witnesses, so certification rides entirely on the tracked-shard contribution path.