### PR TITLE
feat(spice): fallback validators fetch missing contract code (6/6)

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -1264,14 +1264,25 @@ impl SpiceDataDistributorActor {
             chunk_id.shard_id,
             block_header.height(),
         )?;
+        // Designated validators may always request; a non-designated epoch validator may once the
+        // chunk is past the fallback window, since it then needs the code to endorse via the
+        // all-stake fallback.
         if !assignments.contains(&requester) {
-            tracing::warn!(
-                target: "spice_data_distribution",
-                ?chunk_id,
-                ?requester,
-                "contract code request from non-chunk-validator"
-            );
-            return Ok(());
+            let head = self.chain_store.head()?;
+            let eligible = self.core_reader.fallback_eligible_in_carrying_block(
+                head.height + 1,
+                &head.last_block_hash,
+                &chunk_id,
+            )?;
+            if !eligible {
+                tracing::warn!(
+                    target: "spice_data_distribution",
+                    ?chunk_id,
+                    ?requester,
+                    "contract code request from non-chunk-validator"
+                );
+                return Ok(());
+            }
         }
 
         // Deduplicate repeated requests from the same requester for the same chunk.

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -57,6 +57,9 @@ pub(crate) struct TestLoopBuilder {
     track_all_shards: bool,
     /// Whether to load mem tries for the tracked shards.
     load_memtries_for_tracked_shards: bool,
+    /// Whether to give every node a no-op compiled contract cache, forcing
+    /// validators to request contract code rather than reuse a precompiled copy.
+    disable_compiled_contract_cache: bool,
     /// Whether to add a non-validator RPC node (tracks all shards). Honored by both the auto and
     /// manual setup APIs.
     enable_rpc: bool,
@@ -95,6 +98,7 @@ impl TestLoopBuilder {
             warmup_mode: WarmupMode::Auto,
             track_all_shards: false,
             load_memtries_for_tracked_shards: true,
+            disable_compiled_contract_cache: false,
             enable_rpc: false,
             upgrade_schedule: None,
             rpc_pool: None,
@@ -405,6 +409,11 @@ impl TestLoopBuilder {
         self
     }
 
+    pub fn disable_compiled_contract_cache(mut self) -> Self {
+        self.disable_compiled_contract_cache = true;
+        self
+    }
+
     pub fn protocol_upgrade_schedule(mut self, schedule: ProtocolUpgradeVotingSchedule) -> Self {
         self.upgrade_schedule = Some(schedule);
         self
@@ -540,6 +549,7 @@ impl TestLoopBuilder {
             chunks_storage: Default::default(),
             drop_conditions: Default::default(),
             load_memtries_for_tracked_shards: self.load_memtries_for_tracked_shards,
+            disable_compiled_contract_cache: self.disable_compiled_contract_cache,
             warmup_pending,
             bucket_config: self.bucket_config.clone(),
             task_delay_fn: self.task_delay_fn.clone(),

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -44,7 +44,9 @@ use near_primitives::test_utils::create_test_signer;
 use near_store::adapter::StoreAdapter;
 use near_store::config::SplitStorageConfig;
 use near_store::{StoreConfig, TrieConfig};
-use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
+use near_vm_runner::{
+    ContractRuntimeCache, FilesystemContractRuntimeCache, NoContractRuntimeCache,
+};
 use nearcore::state_sync::StateSyncDumper;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -71,6 +73,7 @@ pub fn setup_client(
         chunks_storage,
         drop_conditions,
         load_memtries_for_tracked_shards,
+        disable_compiled_contract_cache,
         task_delay_fn,
         ..
     } = shared_state;
@@ -107,7 +110,11 @@ pub fn setup_client(
         epoch_config_store.clone(),
     );
 
-    let contract_cache = FilesystemContractRuntimeCache::test().expect("filesystem contract cache");
+    let contract_cache: Box<dyn ContractRuntimeCache> = if *disable_compiled_contract_cache {
+        Box::new(NoContractRuntimeCache)
+    } else {
+        Box::new(FilesystemContractRuntimeCache::test().expect("filesystem contract cache"))
+    };
     let snapshot_every_n_epochs = client_config
         .cloud_archival_writer
         .as_ref()

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -65,6 +65,9 @@ pub struct SharedState {
     /// List of drop conditions that apply to all nodes in the network.
     pub drop_conditions: Vec<DropCondition>,
     pub load_memtries_for_tracked_shards: bool,
+    /// When set, every node uses a no-op compiled contract cache so validators
+    /// must request contract code instead of reusing a precompiled copy.
+    pub disable_compiled_contract_cache: bool,
     /// Flag to indicate if warmup is pending. This is used to ensure that warmup is only done once.
     pub warmup_pending: Arc<AtomicBool>,
     /// Archive-wide config for cloud archival nodes. Defaults to

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -1,5 +1,6 @@
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::drop_condition::DropCondition;
+use crate::utils::account::create_account_id;
 use crate::utils::node::TestLoopNode;
 use itertools::Itertools;
 use near_async::time::Duration;
@@ -9,6 +10,7 @@ use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::BlockHeader;
 use near_primitives::epoch_manager::EpochConfigStore;
+use near_primitives::gas::Gas;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{AccountId, AccountInfo, Balance, BlockHeightDelta};
@@ -19,6 +21,7 @@ use std::collections::HashSet;
 #[derive(Default)]
 struct FallbackSetup {
     epoch_length: Option<BlockHeightDelta>,
+    user_accounts: Vec<(AccountId, Balance)>,
 }
 
 impl FallbackSetup {
@@ -28,6 +31,11 @@ impl FallbackSetup {
 
     fn epoch_length(mut self, epoch_length: BlockHeightDelta) -> Self {
         self.epoch_length = Some(epoch_length);
+        self
+    }
+
+    fn user_account(mut self, account_id: AccountId, balance: Balance) -> Self {
+        self.user_accounts.push((account_id, balance));
         self
     }
 
@@ -52,6 +60,9 @@ impl FallbackSetup {
             .validators_spec(validators_spec);
         if let Some(epoch_length) = self.epoch_length {
             genesis_builder = genesis_builder.epoch_length(epoch_length);
+        }
+        for (account_id, balance) in self.user_accounts {
+            genesis_builder = genesis_builder.add_user_account_simple(account_id, balance);
         }
         let genesis = genesis_builder.build();
         let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
@@ -212,4 +223,59 @@ fn slow_test_spice_all_stake_fallback_certifies_when_validators_track_all_shards
     );
     let frontier = env.node(0).last_certified_block_header();
     assert_certified_via_fallback(&env.node(0), frontier.as_ref());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_all_stake_fallback_certifies_chunk_accessing_contract_code() {
+    init_test_logger();
+
+    let contract_user = create_account_id("contract-user");
+    // epoch_length 100 keeps the call chunk (~height 9) within the genesis epoch the precondition checks.
+    let (accounts, genesis, epoch_config_store) = FallbackSetup::new()
+        .epoch_length(100)
+        .user_account(contract_user.clone(), Balance::from_near(100))
+        .build();
+
+    // The no-op compiled contract cache forces validators to fetch contract code via a
+    // SpiceContractCodeRequest; otherwise the fallback code-request gate is never exercised.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .enable_rpc()
+        .disable_compiled_contract_cache()
+        .build()
+        .drop(DropCondition::DesignatedSpiceEndorsements);
+    assert_fallback_has_enough_stake(&env.rpc_node());
+
+    // Wait for the deploy to be included before submitting the call, so the call runs against an
+    // already-settled contract (`record_contract_call` skips newly-deployed code).
+    let deploy_tx = env.rpc_node().tx_deploy_test_contract(&contract_user);
+    let deploy_hash = deploy_tx.get_hash();
+    env.rpc_node().submit_tx(deploy_tx);
+    env.rpc_runner().run_until_included(&[deploy_hash]);
+
+    // The call's chunk witness omits the code, so a cold non-designated fallback validator must
+    // fetch it via a contract-code request.
+    let call_tx = env.rpc_node().tx_call(
+        &contract_user,
+        &contract_user,
+        "log_something",
+        vec![],
+        Balance::ZERO,
+        Gas::from_teragas(300),
+    );
+    let call_hash = call_tx.get_hash();
+    env.rpc_node().submit_tx(call_tx);
+    let call_height = env.rpc_runner().run_until_included(&[call_hash]);
+
+    // Execution advances only as the fallback certifies; wait for the certified frontier to reach
+    // the call chunk. Pre-fix its code requests are rejected, so the frontier stalls below it.
+    env.rpc_runner().run_until(
+        |node| node.last_certified_block_header().height() >= call_height,
+        Duration::seconds(120),
+    );
+    let frontier = env.rpc_node().last_certified_block_header();
+    assert_certified_via_fallback(&env.rpc_node(), frontier.as_ref());
 }


### PR DESCRIPTION
A non-designated validator that pulls a chunk's witness to endorse it for the all-stake fallback may need contract code the witness omits (the SPICE witness ships only the contract-accesses hash, not the bytecode). `handle_spice_contract_code_request` now admits a non-designated epoch validator's `SpiceContractCodeRequest` once the chunk is past the fallback window; designated validators may always request as before.

Adds a `disable_compiled_contract_cache` test-loop builder flag that gives every node a `NoContractRuntimeCache`, so validators must actually request contract code rather than reuse a precompiled copy. Without it the code-request gate is never exercised.

e2e: certifies-chunk-accessing-contract-code deploys a contract, calls it under a total designated-endorsement outage, and asserts the certified frontier reaches the call chunk via the fallback (which requires a cold non-designated validator to fetch the code).