### PR TITLE
fix(ci): make codecov patch status informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -33,6 +33,9 @@ component_management:
       - type: patch
         target: auto
         only_pulls: true
+        # Report patch coverage on PRs but never fail the check (avoids a
+        # spurious red cross on PRs that add code without full line coverage).
+        informational: true
   individual_components:
     - component_id: unit-tests
       flag_regexes: ["unittests"]


### PR DESCRIPTION
The codecov/patch/unit-tests and codecov/patch/all-tests checks fail on most PRs that add new code without full line coverage, putting a red cross on otherwise-green PRs even though the checks are optional.

Mark the patch status as informational so coverage is still computed and reported in the PR comment, but the check always passes instead of appearing to break CI.

https://docs.codecov.com/docs/commit-status#informational 