### PR TITLE
chore(protocol): deprecate remaining v83 features

### DIFF
--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -21114,10 +21114,6 @@
             "description": "See [VMConfig::eth_implicit_accounts](crate::vm::Config::eth_implicit_accounts).",
             "type": "boolean"
           },
-          "eth_implicit_global_contract": {
-            "description": "See [VMConfig::eth_implicit_global_contract](crate::vm::Config::eth_implicit_global_contract).",
-            "type": "boolean"
-          },
           "ext_costs": {
             "allOf": [
               {

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -12375,10 +12375,6 @@
             "description": "See [VMConfig::eth_implicit_accounts](crate::vm::Config::eth_implicit_accounts).",
             "type": "boolean"
           },
-          "eth_implicit_global_contract": {
-            "description": "See [VMConfig::eth_implicit_global_contract](crate::vm::Config::eth_implicit_global_contract).",
-            "type": "boolean"
-          },
           "ext_costs": {
             "allOf": [
               {

--- a/core/parameters/res/runtime_configs/83.yaml
+++ b/core/parameters/res/runtime_configs/83.yaml
@@ -1,7 +1,6 @@
 # Enable strict AccountID validation
 # Use AccountIdValidityRulesVersion::V2 instead of a separate forbid_unvalidated_account_id flag.
 account_id_validity_rules_version: { old: 1, new: 2 }
-eth_implicit_global_contract: { old: false, new: true }
 
 # Increase gas limit to 1 PetaGas
 max_gas_burnt:         { old: 300_000_000_000_000, new: 1_000_000_000_000_000 }

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -244,7 +244,6 @@ fix_contract_loading_cost               false
 fix_contract_loading_error              true
 vm_kind                                 Wasmtime
 eth_implicit_accounts                   true
-eth_implicit_global_contract            true
 discard_custom_sections                 true
 reftypes_bulk_memory                    true
 max_congestion_incoming_gas             400_000_000_000_000_000

--- a/core/parameters/res/runtime_configs/parameters.yaml
+++ b/core/parameters/res/runtime_configs/parameters.yaml
@@ -281,7 +281,6 @@ fix_contract_loading_cost: false
 fix_contract_loading_error: false
 vm_kind: Wasmer0
 eth_implicit_accounts: false
-eth_implicit_global_contract: false
 discard_custom_sections: false
 global_contract_host_fns: false
 reftypes_bulk_memory: false

--- a/core/parameters/res/runtime_configs/parameters_testnet.yaml
+++ b/core/parameters/res/runtime_configs/parameters_testnet.yaml
@@ -276,7 +276,6 @@ fix_contract_loading_cost: false
 fix_contract_loading_error: false
 vm_kind: Wasmer0
 eth_implicit_accounts: false
-eth_implicit_global_contract: false
 discard_custom_sections: false
 global_contract_host_fns: false
 reftypes_bulk_memory: false

--- a/core/parameters/src/parameter.rs
+++ b/core/parameters/src/parameter.rs
@@ -229,7 +229,6 @@ pub enum Parameter {
     FixContractLoadingError,
     VmKind,
     EthImplicitAccounts,
-    EthImplicitGlobalContract,
     DiscardCustomSections,
     ReftypesBulkMemory,
 

--- a/core/parameters/src/parameter_table.rs
+++ b/core/parameters/src/parameter_table.rs
@@ -463,7 +463,6 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                     false => StorageGetMode::Trie,
                 },
                 eth_implicit_accounts: params.get(Parameter::EthImplicitAccounts)?,
-                eth_implicit_global_contract: params.get(Parameter::EthImplicitGlobalContract)?,
                 global_contract_host_fns: params.get(Parameter::GlobalContractHostFns)?,
                 gas_key_host_fns: params.get(Parameter::GasKeyHostFns)?,
                 one_yocto_on_promise: params.get(Parameter::OneYoctoOnPromise)?,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -1,6 +1,7 @@
 ---
 source: core/parameters/src/config_store.rs
 expression: config_view
+snapshot_kind: text
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",
@@ -216,7 +217,6 @@ expression: config_view
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__155.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__155.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__49.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__69.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__69.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__70.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__70.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__72.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__72.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__74.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__74.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__77.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__77.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__78.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__78.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__79.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__79.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__82.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__82.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__83.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__83.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__84.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__84.json.snap
@@ -1,6 +1,7 @@
 ---
 source: core/parameters/src/config_store.rs
 expression: config_view
+snapshot_kind: text
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",
@@ -216,7 +217,6 @@ expression: config_view
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__85.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__85.json.snap
@@ -1,6 +1,7 @@
 ---
 source: core/parameters/src/config_store.rs
 expression: config_view
+snapshot_kind: text
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",
@@ -216,7 +217,6 @@ expression: config_view
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__86.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__86.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -1,6 +1,7 @@
 ---
 source: core/parameters/src/config_store.rs
 expression: config_view
+snapshot_kind: text
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",
@@ -216,7 +217,6 @@ expression: config_view
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_155.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_155.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_69.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_69.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": false,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_70.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_70.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_72.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_72.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_74.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_74.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_77.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_77.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_78.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_78.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_79.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_79.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_82.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_82.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_83.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_83.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_84.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_84.json.snap
@@ -1,6 +1,7 @@
 ---
 source: core/parameters/src/config_store.rs
 expression: config_view
+snapshot_kind: text
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",
@@ -216,7 +217,6 @@ expression: config_view
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_85.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_85.json.snap
@@ -1,6 +1,7 @@
 ---
 source: core/parameters/src/config_store.rs
 expression: config_view
+snapshot_kind: text
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",
@@ -216,7 +217,6 @@ expression: config_view
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_86.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_86.json.snap
@@ -217,7 +217,6 @@ snapshot_kind: text
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -1,6 +1,7 @@
 ---
 source: core/parameters/src/view.rs
 expression: "&view"
+snapshot_kind: text
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",
@@ -216,7 +217,6 @@ expression: "&view"
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/view.rs
+++ b/core/parameters/src/view.rs
@@ -268,8 +268,6 @@ pub struct VMConfigView {
     pub implicit_account_creation: bool,
     /// See [VMConfig::eth_implicit_accounts](crate::vm::Config::eth_implicit_accounts).
     pub eth_implicit_accounts: bool,
-    /// See [VMConfig::eth_implicit_global_contract](crate::vm::Config::eth_implicit_global_contract).
-    pub eth_implicit_global_contract: bool,
 
     /// Describes limits for VM and Runtime.
     ///
@@ -293,7 +291,6 @@ impl From<crate::vm::Config> for VMConfigView {
             implicit_account_creation: true,
             vm_kind: config.vm_kind,
             eth_implicit_accounts: config.eth_implicit_accounts,
-            eth_implicit_global_contract: config.eth_implicit_global_contract,
             global_contract_host_fns: config.global_contract_host_fns,
             reftypes_bulk_memory: config.reftypes_bulk_memory,
             gas_key_host_fns: config.gas_key_host_fns,

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -213,9 +213,6 @@ pub struct Config {
     /// Enable the `EthImplicitAccounts` protocol feature.
     pub eth_implicit_accounts: bool,
 
-    /// Enable using global contract for ETH implicit accounts.
-    pub eth_implicit_global_contract: bool,
-
     /// Whether to discard custom sections.
     pub discard_custom_sections: bool,
 
@@ -279,7 +276,6 @@ impl Config {
     /// Enable all protocol features. Only used for gas cost estimations.
     pub fn enable_all_features(&mut self) {
         self.eth_implicit_accounts = true;
-        self.eth_implicit_global_contract = true;
         self.global_contract_host_fns = true;
         self.gas_key_host_fns = true;
         self.p256_verify_host_fn = true;

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -295,9 +295,8 @@ pub enum ProtocolFeature {
         note = "Was used for protocol versions where we checked balances which is not supported anymore."
     )]
     _DeprecatedRemoveCheckBalance,
-    /// Exclude existing contract code in deploy-contract and delete-account actions from the chunk state witness.
-    /// Instead of sending code in the witness, the code checks the code-size using the internal trie nodes.
-    ExcludeExistingCodeFromWitnessForCodeLen,
+    #[deprecated]
+    _DeprecatedExcludeExistingCodeFromWitnessForCodeLen,
     /// Use the block height instead of the block hash to calculate the receipt ID.
     #[deprecated]
     _DeprecatedBlockHeightForReceiptId,
@@ -372,17 +371,12 @@ pub enum ProtocolFeature {
     /// Keeping the status in the state could allow to query it from contracts.
     #[deprecated]
     _DeprecatedYieldResumeImprovements,
-    /// Includes tokens burnt as part of global contract deploys into corresponding
-    /// execution outcome's `tokens_burnt`.
-    IncludeDeployGlobalContractOutcomeBurntStorage,
-    /// Nonce-based idempotency for global contract distribution receipts. Each
-    /// distribution carries an auto-incremented nonce. Any distribution receipt
-    /// with a nonce less than the one already stored will be dropped. This
-    /// prevents race conditions in the case of multiple distribution attempts
-    /// for the same contract.
-    GlobalContractDistributionNonce,
-    /// Use global contract for ETH implicit accounts instead of embedded WASM.
-    EthImplicitGlobalContract,
+    #[deprecated]
+    _DeprecatedIncludeDeployGlobalContractOutcomeBurntStorage,
+    #[deprecated]
+    _DeprecatedGlobalContractDistributionNonce,
+    #[deprecated]
+    _DeprecatedEthImplicitGlobalContract,
     /// Process action receipts containing a single DeleteAccount action as
     /// instant receipts, executing them immediately after the receipt that
     /// produced them rather than sending them as outgoing receipts.
@@ -548,13 +542,13 @@ impl ProtocolFeature {
             ProtocolFeature::_DeprecatedStatePartsCompression
             | ProtocolFeature::_DeprecatedDeterministicAccountIds => 82,
             ProtocolFeature::_DeprecatedInvalidTxGenerateOutcomes
-            | ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen
+            | ProtocolFeature::_DeprecatedExcludeExistingCodeFromWitnessForCodeLen
             | ProtocolFeature::_DeprecatedFixAccessKeyAllowanceCharging
-            | ProtocolFeature::IncludeDeployGlobalContractOutcomeBurntStorage
-            | ProtocolFeature::GlobalContractDistributionNonce
+            | ProtocolFeature::_DeprecatedIncludeDeployGlobalContractOutcomeBurntStorage
+            | ProtocolFeature::_DeprecatedGlobalContractDistributionNonce
             | ProtocolFeature::_DeprecatedInstantPromiseYield
             | ProtocolFeature::_DeprecatedYieldResumeImprovements
-            | ProtocolFeature::EthImplicitGlobalContract
+            | ProtocolFeature::_DeprecatedEthImplicitGlobalContract
             | ProtocolFeature::_DeprecatedInstantDeleteAccount => 83,
             ProtocolFeature::Wasmtime => 84,
             ProtocolFeature::FixDelegateActionDepositWithFunctionCallError

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -8,8 +8,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
 use near_crypto::{KeyType, PublicKey};
 use near_fmt::AbbrBytes;
-use near_primitives_core::types::{Gas, ProtocolVersion};
-use near_primitives_core::version::ProtocolFeature;
+use near_primitives_core::types::Gas;
 use near_schema_checker_lib::ProtocolSchema;
 use serde_with::base64::Base64;
 use serde_with::serde_as;
@@ -885,13 +884,8 @@ impl GlobalContractDistributionReceipt {
         already_delivered_shards: Vec<ShardId>,
         code: Arc<[u8]>,
         nonce: u64,
-        protocol_version: ProtocolVersion,
     ) -> Self {
-        if ProtocolFeature::GlobalContractDistributionNonce.enabled(protocol_version) {
-            Self::new_v2(id, target_shard, already_delivered_shards, code, nonce)
-        } else {
-            Self::new_v1(id, target_shard, already_delivered_shards, code)
-        }
+        Self::new_v2(id, target_shard, already_delivered_shards, code, nonce)
     }
 
     pub fn new_v1(

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -1,6 +1,7 @@
 ---
 source: core/primitives/src/views.rs
 expression: "&view"
+snapshot_kind: text
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",
@@ -216,7 +217,6 @@ expression: "&view"
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
-    "eth_implicit_global_contract": true,
     "limit_config": {
       "max_gas_burnt": 1000000000000000,
       "max_stack_height": 262144,

--- a/integration-tests/src/tests/features/stateless_validation.rs
+++ b/integration-tests/src/tests/features/stateless_validation.rs
@@ -394,29 +394,22 @@ fn test_eth_implicit_accounts() {
     let chain_id = &genesis.config.chain_id;
     let signer = create_user_test_signer(AccountIdRef::new("test2").unwrap());
 
-    // Deploy global contract if the feature is enabled.
-    let uses_global_contract =
-        ProtocolFeature::EthImplicitGlobalContract.enabled(genesis.config.protocol_version);
+    // Deploy the wallet contract as a global contract for ETH implicit accounts.
     let mut next_nonce = 1;
-    if uses_global_contract {
-        let magic_bytes = wallet_contract_magic_bytes(chain_id);
-        let wallet_code = wallet_contract(*magic_bytes.hash()).unwrap();
-        let deploy_tx = SignedTransaction::deploy_global_contract(
-            next_nonce,
-            signer.get_account_id(),
-            wallet_code.code().to_vec(),
-            &signer.clone().into(),
-            *genesis_block.hash(),
-            GlobalContractDeployMode::CodeHash,
-        );
-        next_nonce += 1;
-        assert_eq!(
-            env.rpc_handlers[0].process_tx(deploy_tx, false, false),
-            ProcessTxResponse::ValidTx
-        );
-        for _ in 0..5 {
-            produce_block(&mut env);
-        }
+    let magic_bytes = wallet_contract_magic_bytes(chain_id);
+    let wallet_code = wallet_contract(*magic_bytes.hash()).unwrap();
+    let deploy_tx = SignedTransaction::deploy_global_contract(
+        next_nonce,
+        signer.get_account_id(),
+        wallet_code.code().to_vec(),
+        &signer.clone().into(),
+        *genesis_block.hash(),
+        GlobalContractDeployMode::CodeHash,
+    );
+    next_nonce += 1;
+    assert_eq!(env.rpc_handlers[0].process_tx(deploy_tx, false, false), ProcessTxResponse::ValidTx);
+    for _ in 0..5 {
+        produce_block(&mut env);
     }
 
     // 1. Create two eth-implicit accounts

--- a/integration-tests/src/tests/features/wallet_contract.rs
+++ b/integration-tests/src/tests/features/wallet_contract.rs
@@ -117,7 +117,7 @@ fn test_eth_implicit_account_creation() {
 
     // Verify the ETH-implicit account has zero balance and appropriate code hash.
     // Check that the account storage fits within zero balance account limit.
-    let request = QueryRequest::ViewAccount { account_id: eth_implicit_account_id.clone() };
+    let request = QueryRequest::ViewAccount { account_id: eth_implicit_account_id };
     match view_request(&env, request).kind {
         QueryResponseKind::ViewAccount(view) => {
             assert!(view.amount.is_zero());

--- a/integration-tests/src/tests/features/wallet_contract.rs
+++ b/integration-tests/src/tests/features/wallet_contract.rs
@@ -20,13 +20,11 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::{Balance, Gas};
 use near_primitives::utils::derive_eth_implicit_account_id;
-use near_primitives::version::ProtocolFeature;
 use near_primitives::views::{
     FinalExecutionStatus, QueryRequest, QueryResponse, QueryResponseKind,
 };
 use near_primitives_core::{account::AccessKey, types::BlockHeight};
 use near_store::ShardUId;
-use near_vm_runner::ContractCode;
 use near_wallet_contract::{
     eth_wallet_global_contract_hash, wallet_contract, wallet_contract_magic_bytes,
 };
@@ -100,9 +98,6 @@ fn test_eth_implicit_account_creation() {
     let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let eth_implicit_account_id = eth_implicit_test_account();
 
-    let uses_global_contract =
-        ProtocolFeature::EthImplicitGlobalContract.enabled(genesis.config.protocol_version);
-
     // Make zero-transfer to ETH-implicit account, invoking its creation.
     let transfer_tx = SignedTransaction::send_money(
         1,
@@ -120,38 +115,16 @@ fn test_eth_implicit_account_creation() {
         env.produce_block(0, i);
     }
 
-    let magic_bytes = wallet_contract_magic_bytes(chain_id);
-
     // Verify the ETH-implicit account has zero balance and appropriate code hash.
     // Check that the account storage fits within zero balance account limit.
     let request = QueryRequest::ViewAccount { account_id: eth_implicit_account_id.clone() };
     match view_request(&env, request).kind {
         QueryResponseKind::ViewAccount(view) => {
             assert!(view.amount.is_zero());
-            if uses_global_contract {
-                assert_eq!(
-                    view.global_contract_hash,
-                    Some(eth_wallet_global_contract_hash(chain_id))
-                );
-            } else {
-                assert_eq!(view.code_hash, *magic_bytes.hash());
-            }
+            assert_eq!(view.global_contract_hash, Some(eth_wallet_global_contract_hash(chain_id)));
             assert!(view.storage_usage <= ZERO_BALANCE_ACCOUNT_STORAGE_LIMIT)
         }
         _ => panic!("wrong query response"),
-    }
-
-    // Verify contract code for non-global contract path.
-    if !uses_global_contract {
-        let request = QueryRequest::ViewCode { account_id: eth_implicit_account_id };
-        match view_request(&env, request).kind {
-            QueryResponseKind::ViewCode(view) => {
-                let contract_code = ContractCode::new(view.code, None);
-                assert_eq!(contract_code.hash(), magic_bytes.hash());
-                assert_eq!(contract_code.code(), magic_bytes.code());
-            }
-            _ => panic!("wrong query response"),
-        }
     }
 }
 
@@ -269,22 +242,18 @@ fn test_wallet_contract_interaction() {
     // Bob will receive a $NEAR transfer from the eth implicit account
     let receiver = bob_account();
 
-    // Deploy global contract if the feature is enabled.
-    let uses_global_contract =
-        ProtocolFeature::EthImplicitGlobalContract.enabled(genesis.config.protocol_version);
-    if uses_global_contract {
-        let magic_bytes = wallet_contract_magic_bytes(chain_id);
-        let wallet_code = wallet_contract(*magic_bytes.hash()).unwrap();
-        let deploy_tx = SignedTransaction::deploy_global_contract(
-            1,
-            relayer.clone(),
-            wallet_code.code().to_vec(),
-            &relayer_signer.signer,
-            *genesis_block.hash(),
-            GlobalContractDeployMode::CodeHash,
-        );
-        height = check_tx_processing(&mut env, deploy_tx, height, blocks_number);
-    }
+    // Deploy the wallet contract as a global contract for ETH implicit accounts.
+    let magic_bytes = wallet_contract_magic_bytes(chain_id);
+    let wallet_code = wallet_contract(*magic_bytes.hash()).unwrap();
+    let deploy_tx = SignedTransaction::deploy_global_contract(
+        1,
+        relayer.clone(),
+        wallet_code.code().to_vec(),
+        &relayer_signer.signer,
+        *genesis_block.hash(),
+        GlobalContractDeployMode::CodeHash,
+    );
+    height = check_tx_processing(&mut env, deploy_tx, height, blocks_number);
 
     // Generate an eth implicit account for the user
     let secret_key = SecretKey::from_seed(KeyType::SECP256K1, "test");
@@ -297,7 +266,7 @@ fn test_wallet_contract_interaction() {
     let deposit_for_account_creation = Balance::from_near(1);
     let actions = vec![Action::Transfer(TransferAction { deposit: deposit_for_account_creation })];
     let block_hash = *genesis_block.hash();
-    let nonce = if uses_global_contract { 2 } else { 1 };
+    let nonce = 2;
     let signed_transaction = SignedTransaction::from_actions(
         nonce,
         relayer.clone(),

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -33,15 +33,12 @@ use near_primitives::utils::account_is_implicit;
 use near_primitives::version::ProtocolVersion;
 use near_primitives_core::account::id::AccountType;
 use near_primitives_core::version::ProtocolFeature;
-use near_store::trie::AccessOptions;
 use near_store::{
-    StorageError, TrieAccess, TrieUpdate, compute_gas_key_balance_sum, get_access_key,
-    get_gas_key_nonce, remove_account, set_access_key, set_gas_key_nonce,
+    StorageError, TrieUpdate, compute_gas_key_balance_sum, get_access_key, get_gas_key_nonce,
+    remove_account, set_access_key, set_gas_key_nonce,
 };
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
-use near_wallet_contract::{
-    eth_wallet_global_contract_hash, wallet_contract, wallet_contract_magic_bytes,
-};
+use near_wallet_contract::eth_wallet_global_contract_hash;
 use std::sync::Arc;
 
 pub(crate) fn action_stake(
@@ -235,52 +232,17 @@ pub(crate) fn action_implicit_account_creation_transfer(
         AccountType::EthImplicitAccount => {
             let chain_id = epoch_info_provider.chain_id();
 
-            if ProtocolFeature::EthImplicitGlobalContract
-                .enabled(apply_state.current_protocol_version)
-            {
-                // Use a deployed global contract for ETH implicit accounts.
-                let global_contract_hash = eth_wallet_global_contract_hash(&chain_id);
-                let storage_usage = fee_config.storage_usage_config.num_bytes_account
-                    + global_contract_hash.as_bytes().len() as u64;
+            // Use a deployed global contract for ETH implicit accounts.
+            let global_contract_hash = eth_wallet_global_contract_hash(&chain_id);
+            let storage_usage = fee_config.storage_usage_config.num_bytes_account
+                + global_contract_hash.as_bytes().len() as u64;
 
-                *account = Some(Account::new(
-                    deposit,
-                    Balance::ZERO,
-                    AccountContract::Global(global_contract_hash),
-                    storage_usage,
-                ));
-            } else {
-                // We deploy "near[wallet contract hash]" magic bytes as the contract code,
-                // to mark that this is a neard-defined contract. It will not be used on a function call.
-                // Instead, neard-defined Wallet Contract implementation will be used.
-                let magic_bytes = wallet_contract_magic_bytes(&chain_id);
-
-                let storage_usage = fee_config.storage_usage_config.num_bytes_account
-                    + magic_bytes.code().len() as u64
-                    + fee_config.storage_usage_config.num_extra_bytes_record;
-
-                let contract_hash = *magic_bytes.hash();
-                *account = Some(Account::new(
-                    deposit,
-                    Balance::ZERO,
-                    AccountContract::from_local_code_hash(contract_hash),
-                    storage_usage,
-                ));
-                state_update.set_code(account_id.clone(), &magic_bytes);
-
-                // Precompile Wallet Contract and store result (compiled code or error) in the database.
-                // Note this contract is shared among ETH-implicit accounts and `precompile_contract`
-                // is a no-op if the contract was already compiled. If a protocol upgrade with a
-                // different `wasm_config` is scheduled for the next epoch, also warm the new
-                // cache key in the background.
-                precompile_contract_with_warming(
-                    &wallet_contract(contract_hash).expect("should definitely exist"),
-                    Arc::clone(&apply_state.config.wasm_config),
-                    apply_state.next_wasm_config.clone(),
-                    apply_state.cache.as_deref(),
-                );
-                near_vm_runner::report_metrics(apply_state.shard_id, "deploy");
-            }
+            *account = Some(Account::new(
+                deposit,
+                Balance::ZERO,
+                AccountContract::Global(global_contract_hash),
+                storage_usage,
+            ));
         }
         AccountType::NearDeterministicAccount => {
             *account = Some(create_deterministic_account(
@@ -302,15 +264,9 @@ pub(crate) fn action_deploy_contract(
     config: Arc<VmConfig>,
     next_config: Option<Arc<VmConfig>>,
     cache: Option<&dyn ContractRuntimeCache>,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<(), StorageError> {
     let _span = tracing::debug_span!(target: "runtime", "action_deploy_contract").entered();
-    clear_account_contract_storage_usage(
-        state_update,
-        account_id,
-        account,
-        current_protocol_version,
-    )?;
+    clear_account_contract_storage_usage(state_update, account_id, account)?;
 
     let code = ContractCode::new(deploy_contract.code.clone(), None);
     account.set_storage_usage(
@@ -355,12 +311,7 @@ pub(crate) fn action_delete_account(
     let account_storage_usage = if ProtocolFeature::FixDeleteAccountGlobalContractStorageUsage
         .enabled(current_protocol_version)
     {
-        let contract_storage = get_contract_storage_usage(
-            state_update,
-            account_id,
-            account_ref,
-            current_protocol_version,
-        )?;
+        let contract_storage = get_contract_storage_usage(state_update, account_id, account_ref)?;
         account_ref.storage_usage().saturating_sub(contract_storage)
     } else {
         // Legacy behavior: only subtracts local contract code, misses the
@@ -370,7 +321,6 @@ pub(crate) fn action_delete_account(
             state_update,
             account_id.clone(),
             account_ref.local_contract_hash().unwrap_or_default(),
-            current_protocol_version,
         )?;
         debug_assert!(
             code_len == 0 || account_storage_usage > code_len,
@@ -427,22 +377,13 @@ pub(crate) fn action_delete_account(
 /// Returns the storage usage for the contract code with the given `code_hash` and deployed to the
 /// given `account_id`. If no contract was deployed to the account, returns `0`.
 ///
-/// This implements different behaviors based on the protocol version:
-/// If `ExcludeExistingCodeFromWitnessForCodeLen` is enabled then the code-length is obtained without reading
-/// the code but from the value-ref in the trie leaf node, otherwise it reads the code and returns its size.
+/// The code-length is obtained without reading the code but from the value-ref in the trie leaf node.
 fn get_code_len_or_default(
     state_update: &TrieUpdate,
     account_id: AccountId,
     code_hash: CryptoHash,
-    protocol_version: ProtocolVersion,
 ) -> Result<StorageUsage, StorageError> {
-    let code_len =
-        if ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen.enabled(protocol_version) {
-            state_update.get_code_len(account_id, code_hash)?
-        } else {
-            let key = near_primitives::trie_key::TrieKey::ContractCode { account_id };
-            state_update.get(&key, AccessOptions::DEFAULT)?.map(|code| code.len())
-        };
+    let code_len = state_update.get_code_len(account_id, code_hash)?;
     debug_assert!(
         code_len.is_some() || code_hash == CryptoHash::default(),
         "Non-default code hash for account with no contract deployed: {:?}",
@@ -455,16 +396,12 @@ fn get_contract_storage_usage(
     state_update: &TrieUpdate,
     account_id: &AccountId,
     account: &Account,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<StorageUsage, StorageError> {
     Ok(match account.contract().as_ref() {
         AccountContract::None => 0,
-        AccountContract::Local(code_hash) => get_code_len_or_default(
-            state_update,
-            account_id.clone(),
-            *code_hash,
-            current_protocol_version,
-        )?,
+        AccountContract::Local(code_hash) => {
+            get_code_len_or_default(state_update, account_id.clone(), *code_hash)?
+        }
         AccountContract::Global(_) | AccountContract::GlobalByAccount(_) => {
             account.contract().identifier_storage_usage()
         }
@@ -476,10 +413,8 @@ pub(crate) fn clear_account_contract_storage_usage(
     state_update: &TrieUpdate,
     account_id: &AccountId,
     account: &mut Account,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<(), StorageError> {
-    let contract_storage =
-        get_contract_storage_usage(state_update, account_id, account, current_protocol_version)?;
+    let contract_storage = get_contract_storage_usage(state_update, account_id, account)?;
     account.set_storage_usage(account.storage_usage().saturating_sub(contract_storage));
     Ok(())
 }
@@ -1082,7 +1017,6 @@ mod tests {
             Arc::clone(&apply_state.config.wasm_config),
             None,
             None,
-            apply_state.current_protocol_version,
         );
         assert!(res.is_ok());
         test_delete_account(

--- a/runtime/runtime/src/contract_code.rs
+++ b/runtime/runtime/src/contract_code.rs
@@ -27,9 +27,6 @@ pub(crate) enum RuntimeContractIdentifier {
     /// time. The original `GlobalContractIdentifier` is preserved so that
     /// `record_contract_call` can construct the correct trie key.
     Global { code_hash: CryptoHash, identifier: GlobalContractIdentifier },
-    /// Non-global legacy ETH wallet contract.
-    /// Code comes from the built-in wallet contract, not from storage.
-    LegacyEthWallet(LegacyEthWallet),
 }
 
 impl RuntimeContractIdentifier {
@@ -40,7 +37,6 @@ impl RuntimeContractIdentifier {
         account_id: &AccountId,
         account_contract: AccountContract,
         state_update: &TrieUpdate,
-        config: &near_parameters::vm::Config,
         chain_id: &str,
         access: AccessOptions,
     ) -> Result<Self, StorageError> {
@@ -59,20 +55,14 @@ impl RuntimeContractIdentifier {
             // description of #11606) may have something else deployed to them. Only return
             // something here if the accounts have a wallet contract hash. Otherwise use the
             // regular path to grab the deployed contract.
-            if let Some(legacy) = LegacyEthWallet::resolve(local_hash) {
-                // With EthImplicitGlobalContract, ETH implicit wallet accounts
-                // switched to global contracts, including those created in old
-                // protocol versions.
-                let identifier = if config.eth_implicit_global_contract {
-                    let global_hash = eth_wallet_global_contract_hash(chain_id);
-                    RuntimeContractIdentifier::Global {
-                        code_hash: global_hash,
-                        identifier: GlobalContractIdentifier::CodeHash(global_hash),
-                    }
-                } else {
-                    RuntimeContractIdentifier::LegacyEthWallet(legacy)
-                };
-                return Ok(identifier);
+            if LegacyEthWallet::resolve(local_hash).is_some() {
+                // ETH implicit wallet accounts use global contracts, including
+                // those created in old protocol versions.
+                let global_hash = eth_wallet_global_contract_hash(chain_id);
+                return Ok(RuntimeContractIdentifier::Global {
+                    code_hash: global_hash,
+                    identifier: GlobalContractIdentifier::CodeHash(global_hash),
+                });
             }
         }
 
@@ -89,7 +79,6 @@ impl RuntimeContractIdentifier {
             // `code_hash` to indicate contract code absence in `AccountV1`.
             Self::None => CryptoHash::default(),
             Self::AccountLocal { code_hash, .. } | Self::Global { code_hash, .. } => *code_hash,
-            Self::LegacyEthWallet(legacy) => *legacy.contract().hash(),
         }
     }
 }

--- a/runtime/runtime/src/deterministic_account_id.rs
+++ b/runtime/runtime/src/deterministic_account_id.rs
@@ -11,7 +11,6 @@ use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{AccountId, Balance};
 use near_primitives_core::deterministic_account_id::DeterministicAccountStateInit;
 use near_store::{StorageError, TrieUpdate};
-use near_vm_runner::logic::ProtocolVersion;
 
 pub(crate) fn action_deterministic_state_init(
     state_update: &mut TrieUpdate,
@@ -45,7 +44,6 @@ pub(crate) fn action_deterministic_state_init(
             &action.state_init,
             result,
             storage_usage_config,
-            apply_state.current_protocol_version,
         )?;
     }
     if result.result.is_err() {
@@ -123,17 +121,9 @@ fn deploy_deterministic_account(
     state_init: &DeterministicAccountStateInit,
     result: &mut ActionResult,
     storage_usage_config: &StorageUsageConfig,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<(), RuntimeError> {
     // Step 1: set contract code (includes storage usage accounting)
-    use_global_contract(
-        state_update,
-        account_id,
-        account,
-        state_init.code(),
-        current_protocol_version,
-        result,
-    )?;
+    use_global_contract(state_update, account_id, account, state_init.code(), result)?;
     if result.result.is_err() {
         return Ok(());
     }

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -628,7 +628,6 @@ impl Contract for RuntimeContractExt {
             | RuntimeContractIdentifier::Global { code_hash, .. } => {
                 self.storage.get(*code_hash).map(Arc::new)
             }
-            RuntimeContractIdentifier::LegacyEthWallet(legacy) => Some(legacy.contract()),
         }
     }
 }

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -348,7 +348,7 @@ fn record_contract_call(
     }
 
     let (code_hash, trie_key) = match contract_id {
-        RuntimeContractIdentifier::None | RuntimeContractIdentifier::LegacyEthWallet(_) => {
+        RuntimeContractIdentifier::None => {
             return Ok(());
         }
         RuntimeContractIdentifier::AccountLocal { code_hash, account_id } => {

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -14,11 +14,9 @@ use near_primitives::receipt::{
 };
 use near_primitives::trie_key::{GlobalContractCodeIdentifier, TrieKey};
 use near_primitives::types::{AccountId, Compute, EpochInfoProvider, ShardId, StateChangeCause};
-use near_primitives::version::ProtocolFeature;
 use near_store::trie::AccessOptions;
 use near_store::{StorageError, TrieAccess as _, TrieUpdate};
 use near_vm_runner::ContractCode;
-use near_vm_runner::logic::ProtocolVersion;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -46,12 +44,8 @@ pub(crate) fn action_deploy_global_contract(
         .into());
         return Ok(());
     };
-    if ProtocolFeature::IncludeDeployGlobalContractOutcomeBurntStorage
-        .enabled(apply_state.current_protocol_version)
-    {
-        result.tokens_burnt =
-            result.tokens_burnt.checked_add(storage_cost).ok_or(IntegerOverflowError)?;
-    }
+    result.tokens_burnt =
+        result.tokens_burnt.checked_add(storage_cost).ok_or(IntegerOverflowError)?;
     account.set_amount(updated_balance);
 
     initiate_distribution(
@@ -60,7 +54,6 @@ pub(crate) fn action_deploy_global_contract(
         deploy_contract.code.clone(),
         &deploy_contract.deploy_mode,
         apply_state.shard_id,
-        apply_state.current_protocol_version,
         result,
     )?;
 
@@ -72,18 +65,10 @@ pub(crate) fn action_use_global_contract(
     account_id: &AccountId,
     account: &mut Account,
     action: &UseGlobalContractAction,
-    current_protocol_version: ProtocolVersion,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
     let _span = tracing::debug_span!(target: "runtime", "action_use_global_contract").entered();
-    use_global_contract(
-        state_update,
-        account_id,
-        account,
-        &action.contract_identifier,
-        current_protocol_version,
-        result,
-    )
+    use_global_contract(state_update, account_id, account, &action.contract_identifier, result)
 }
 
 pub(crate) fn use_global_contract(
@@ -91,7 +76,6 @@ pub(crate) fn use_global_contract(
     account_id: &AccountId,
     account: &mut Account,
     contract_identifier: &GlobalContractIdentifier,
-    current_protocol_version: ProtocolVersion,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
     let key = TrieKey::GlobalContractCode { identifier: contract_identifier.clone().into() };
@@ -102,12 +86,7 @@ pub(crate) fn use_global_contract(
         .into());
         return Ok(());
     }
-    clear_account_contract_storage_usage(
-        state_update,
-        account_id,
-        account,
-        current_protocol_version,
-    )?;
+    clear_account_contract_storage_usage(state_update, account_id, account)?;
     if account.contract().is_local() {
         state_update.remove(TrieKey::ContractCode { account_id: account_id.clone() });
     }
@@ -165,7 +144,6 @@ fn initiate_distribution(
     contract_code: Arc<[u8]>,
     deploy_mode: &GlobalContractDeployMode,
     current_shard_id: ShardId,
-    protocol_version: ProtocolVersion,
     result: &mut ActionResult,
 ) -> Result<(), RuntimeError> {
     let id = match deploy_mode {
@@ -180,15 +158,9 @@ fn initiate_distribution(
     // distributions with the same nonce from being initiated. This requires
     // allowing the same nonce in the freshness check when applying the
     // distribution receipt.
-    let nonce = increment_nonce(protocol_version, state_update, &id)?;
-    let distribution_receipt = GlobalContractDistributionReceipt::new(
-        id,
-        current_shard_id,
-        vec![],
-        contract_code,
-        nonce,
-        protocol_version,
-    );
+    let nonce = increment_nonce(state_update, &id)?;
+    let distribution_receipt =
+        GlobalContractDistributionReceipt::new(id, current_shard_id, vec![], contract_code, nonce);
     let distribution_receipts =
         Receipt::new_global_contract_distribution(account_id, distribution_receipt);
     // No need to set receipt_id here, it will be generated as part of apply_action_receipt
@@ -199,15 +171,9 @@ fn initiate_distribution(
 /// Increments the nonce for the given global contract identifier and writes
 /// it to state immediately.
 fn increment_nonce(
-    protocol_version: u32,
     state_update: &mut TrieUpdate,
     id: &GlobalContractIdentifier,
 ) -> Result<u64, RuntimeError> {
-    if !ProtocolFeature::GlobalContractDistributionNonce.enabled(protocol_version) {
-        // If the feature is not enabled yet the nonce will be ignored anyway.
-        return Ok(0);
-    }
-
     let identifier: GlobalContractCodeIdentifier = id.clone().into();
 
     let nonce_key = TrieKey::GlobalContractNonce { identifier };
@@ -233,8 +199,7 @@ fn apply_distribution_current_shard(
         }
     };
 
-    let is_nonce_fresh =
-        check_and_update_nonce(global_contract_data, &identifier, apply_state, state_update)?;
+    let is_nonce_fresh = check_and_update_nonce(global_contract_data, &identifier, state_update)?;
     if !is_nonce_fresh {
         return Ok(0);
     }
@@ -273,15 +238,8 @@ fn apply_distribution_current_shard(
 fn check_and_update_nonce(
     global_contract_data: &GlobalContractDistributionReceipt,
     identifier: &GlobalContractCodeIdentifier,
-    apply_state: &ApplyState,
     state_update: &mut TrieUpdate,
 ) -> Result<bool, RuntimeError> {
-    if !ProtocolFeature::GlobalContractDistributionNonce
-        .enabled(apply_state.current_protocol_version)
-    {
-        return Ok(true);
-    }
-
     let nonce_key = TrieKey::GlobalContractNonce { identifier: identifier.clone() };
     let stored_nonce = get_nonce(state_update, &nonce_key)?;
     let incoming_nonce = global_contract_data.nonce();

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -180,7 +180,7 @@ fn increment_nonce(
     let stored_nonce = get_nonce(state_update, &nonce_key)?;
 
     let new_nonce = stored_nonce.checked_add(1).ok_or_else(|| {
-        RuntimeError::UnexpectedIntegerOverflow("GlobalContractDistributionNonce".into())
+        RuntimeError::UnexpectedIntegerOverflow("increment_global_contract_nonce".into())
     })?;
     set_nonce(state_update, nonce_key, new_nonce);
     Ok(new_nonce)

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -587,7 +587,6 @@ impl Runtime {
                     Arc::clone(&apply_state.config.wasm_config),
                     apply_state.next_wasm_config.clone(),
                     apply_state.cache.as_deref(),
-                    apply_state.current_protocol_version,
                 )?;
                 near_vm_runner::report_metrics(apply_state.shard_id, "deploy");
             }
@@ -611,7 +610,6 @@ impl Runtime {
                     account_id,
                     account,
                     use_global_contract,
-                    apply_state.current_protocol_version,
                     &mut result,
                 )?;
             }
@@ -635,7 +633,6 @@ impl Runtime {
                     account_id,
                     account_contract,
                     &state_update,
-                    &apply_state.config.wasm_config,
                     &epoch_info_provider.chain_id(),
                     AccessOptions::DEFAULT,
                 )?;

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -229,7 +229,6 @@ impl ReceiptPreparationPipeline {
                         &account_id,
                         account.contract().into_owned(),
                         state_update,
-                        &self.config.wasm_config,
                         &self.chain_id,
                         AccessOptions::NO_SIDE_EFFECTS,
                     ) else {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -102,13 +102,10 @@ impl TrieViewer {
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         assert_supported_protocol_version(current_protocol_version);
         let account = self.view_account(state_update, account_id)?;
-        let wasm_config =
-            &self.runtime_config_store.get_config(current_protocol_version).wasm_config;
         let contract_id = RuntimeContractIdentifier::resolve(
             account_id,
             account.contract().into_owned(),
             state_update,
-            wasm_config,
             chain_id,
             AccessOptions::DEFAULT,
         )?;
@@ -121,9 +118,6 @@ impl TrieViewer {
             }
             RuntimeContractIdentifier::Global { identifier, .. } => {
                 identifier.code(state_update)?
-            }
-            RuntimeContractIdentifier::LegacyEthWallet(legacy) => {
-                Some((*legacy.contract()).clone())
             }
         };
         maybe_code.ok_or_else(|| errors::ViewContractCodeError::NoContractCode {
@@ -406,7 +400,6 @@ impl TrieViewer {
             contract_id,
             account.contract().into_owned(),
             &state_update,
-            &config.wasm_config,
             &epoch_info_provider.chain_id(),
             AccessOptions::DEFAULT,
         )?;

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -2558,19 +2558,11 @@ fn test_exclude_existing_contract_code_for_deploy_action() {
     let PartialState::TrieValues(storage_proof) = partial_storage.nodes;
     let total_size: usize = storage_proof.iter().map(|v| v.len()).sum();
     // Contract size is much larger than the rest of the storage proof, so we compare them to check if the contract is excluded.
-    if ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen.enabled(PROTOCOL_VERSION) {
-        assert!(
-            total_size < PREV_CONTRACT_SIZE,
-            "Contract code should not be in storage proof. Storage proof size: {}",
-            total_size
-        );
-    } else {
-        assert!(
-            total_size > PREV_CONTRACT_SIZE,
-            "Contract code should be in storage proof. Storage proof size: {}",
-            total_size
-        );
-    }
+    assert!(
+        total_size < PREV_CONTRACT_SIZE,
+        "Contract code should not be in storage proof. Storage proof size: {}",
+        total_size
+    );
 }
 
 /// Tests that the existing contract is not recorded in the state witness for a delete-account action.
@@ -2660,19 +2652,11 @@ fn test_exclude_existing_contract_code_for_delete_account_action() {
     let PartialState::TrieValues(storage_proof) = partial_storage.nodes;
     let total_size: usize = storage_proof.iter().map(|v| v.len()).sum();
     // Contract size is much larger than the rest of the storage proof, so we compare them to check if the contract is excluded.
-    if ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen.enabled(PROTOCOL_VERSION) {
-        assert!(
-            total_size < CONTRACT_SIZE,
-            "Contract code should not be in storage proof. Storage proof size: {}",
-            total_size
-        );
-    } else {
-        assert!(
-            total_size > CONTRACT_SIZE,
-            "Contract code should be in storage proof. Storage proof size: {}",
-            total_size
-        );
-    }
+    assert!(
+        total_size < CONTRACT_SIZE,
+        "Contract code should not be in storage proof. Storage proof size: {}",
+        total_size
+    );
 }
 
 /// Check that applying nothing does not change the state trie.


### PR DESCRIPTION
Deprecate the remaining protocol-version-83 features, all unconditionally active since v83 is `MIN_SUPPORTED_PROTOCOL_VERSION`. Each enum variant is renamed to `_Deprecated*` with `#[deprecated]`, and call sites collapse to the post-feature behavior.

- `ExcludeExistingCodeFromWitnessForCodeLen`: `get_code_len_or_default` always reads the code length from the trie leaf value-ref. Drops the now-dead `current_protocol_version` threading through `get_contract_storage_usage` / `clear_account_contract_storage_usage` / `action_deploy_contract` / `use_global_contract` / `deploy_deterministic_account`.
- `IncludeDeployGlobalContractOutcomeBurntStorage`: global-contract deploy storage cost is always added to `tokens_burnt`.
- `GlobalContractDistributionNonce`: `GlobalContractDistributionReceipt::new` always builds V2; nonce increment and freshness checks always run. The V1 variant is kept for deserialization.
- `EthImplicitGlobalContract`: ETH implicit accounts always use the global wallet contract. Removes the parallel runtime `Parameter::EthImplicitGlobalContract`, the `Config`/`VMConfigView` fields, and the `83.yaml`/`parameters.yaml`/`parameters_testnet.yaml` entries (mirrors the DeterministicAccountIds deprecation, #15757). Drops the now-unreachable `RuntimeContractIdentifier::LegacyEthWallet` variant.