### PR TITLE
feat(spice): light client proofs over certified execution results

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2569,6 +2569,7 @@ impl Chain {
             self.spice_core_reader.validate_core_statements_in_block(&block).map_err(Box::new)?;
             self.spice_core_reader.validate_prev_last_certified_block_epoch_id(header)?;
             self.spice_core_reader.validate_spice_chunk_endorsement_stats(header)?;
+            self.spice_core_reader.validate_certified_block_header_info(header)?;
         } else {
             if block.is_spice_block() {
                 return Err(Error::Other(

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1888,6 +1888,7 @@ impl Chain {
             self.should_produce_state_witness_for_this_or_next_epoch(block.header())?;
         let epoch_to_check = self.protocol_version_check;
         let sandbox_patch_gen = block_preprocess_info.sandbox_patch_generation;
+        let spice_core_reader = self.spice_core_reader.clone();
         let mut chain_update = self.chain_update();
         let block_hash = *block.hash();
         let new_head = chain_update.postprocess_block(
@@ -1895,6 +1896,7 @@ impl Chain {
             block_preprocess_info,
             apply_results,
             should_save_state_transition_data,
+            &spice_core_reader,
         )?;
         if new_head.is_some() {
             chain_update.check_protocol_version(&block_hash, epoch_to_check)?;

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -90,7 +90,7 @@ use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::{
     BlockStatusView, DroppedReason, ExecutionOutcomeWithIdView, ExecutionStatusView,
     FinalExecutionOutcomeView, FinalExecutionOutcomeWithReceiptView, FinalExecutionStatus,
-    LightClientBlockView, SignedTransactionView,
+    LightClientBlockLiteView, LightClientBlockView, SignedTransactionView,
 };
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
@@ -711,7 +711,7 @@ impl Chain {
         &self,
         block_hash: &CryptoHash,
         head_block_hash: &CryptoHash,
-    ) -> Result<(near_primitives::views::LightClientBlockLiteView, MerklePath), Error> {
+    ) -> Result<(LightClientBlockLiteView, MerklePath), Error> {
         let block_header = self.get_block_header(block_hash)?;
         let (state_root, outcome_root) = self
             .spice_core_reader

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -18,7 +18,8 @@ use crate::signature_verification::{
     verify_block_header_signature_with_epoch_manager, verify_block_vrf,
     verify_chunk_header_signature_by_hash,
 };
-use crate::spice::core::{SpiceCoreReader, compute_certified_block_proof};
+use crate::spice::certified_accumulator::compute_certified_block_proof;
+use crate::spice::core::SpiceCoreReader;
 use crate::state_snapshot_actor::SnapshotCallbacks;
 use crate::state_sync::ChainStateSyncAdapter;
 use crate::stateless_validation::chunk_endorsement::{

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -705,9 +705,8 @@ impl Chain {
         create_light_client_block_view(&final_block_header, chain_store, Some(next_block_producers))
     }
 
-    /// Spice: the light-client `block_header_lite` (reconstructed with certified
-    /// roots) and the inclusion proof of `block_hash`'s certified leaf, anchored
-    /// to `head_block_hash`'s `certified_block_merkle_root`.
+    /// Spice: `block_header_lite` (reconstructed with certified roots) and the proof of
+    /// `block_hash`'s leaf, anchored to `head_block_hash`'s `certified_block_merkle_root`.
     pub fn spice_block_header_lite_and_proof(
         &self,
         block_hash: &CryptoHash,
@@ -721,9 +720,8 @@ impl Chain {
         let block_header_lite =
             reconstruct_certified_lite_view(&block_header, state_root, outcome_root);
         let leaf_ordinal = self.chain_store().get_certified_block_leaf_ordinal(block_hash)?;
-        // `head_block_hash`'s header commits the certified accumulator as of its
-        // predecessor (mirroring `prev_last_certified_block_epoch_id`), so the
-        // proof anchors to the tree as of `head`'s prev.
+        // The header commits the certified accumulator as of its prev, so the proof
+        // anchors to the tree as of `head`'s prev.
         let head_prev = *self.get_block_header(head_block_hash)?.prev_hash();
         let tree_size = self.chain_store().get_certified_block_merkle_tree(&head_prev)?.size();
         let proof = compute_certified_block_proof(self.chain_store(), leaf_ordinal, tree_size)?;

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -6,7 +6,7 @@ use crate::block_processing_utils::{
 use crate::blocks_delay_tracker::BlocksDelayTracker;
 use crate::chain_update::ChainUpdate;
 use crate::crypto_hash_timer::CryptoHashTimer;
-use crate::lightclient::get_epoch_block_producers_view;
+use crate::lightclient::{get_epoch_block_producers_view, reconstruct_certified_lite_view};
 use crate::missing_chunks::{MissingChunksPool, OptimisticBlockChunksPool};
 use crate::orphan::{Orphan, OrphanBlockPool};
 use crate::pending::PendingBlocksPool;
@@ -18,7 +18,7 @@ use crate::signature_verification::{
     verify_block_header_signature_with_epoch_manager, verify_block_vrf,
     verify_chunk_header_signature_by_hash,
 };
-use crate::spice::core::SpiceCoreReader;
+use crate::spice::core::{SpiceCoreReader, compute_certified_block_proof};
 use crate::state_snapshot_actor::SnapshotCallbacks;
 use crate::state_sync::ChainStateSyncAdapter;
 use crate::stateless_validation::chunk_endorsement::{
@@ -64,7 +64,7 @@ use near_primitives::challenge::ChunkProofs;
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::{CryptoHash, hash};
-use near_primitives::merkle::{PartialMerkleTree, merklize};
+use near_primitives::merkle::{MerklePath, PartialMerkleTree, merklize};
 use near_primitives::optimistic_block::{
     BlockToApply, CachedShardUpdateKey, OptimisticBlock, OptimisticBlockKeySource,
 };
@@ -702,6 +702,27 @@ impl Chain {
             get_epoch_block_producers_view(final_block_header.next_epoch_id(), epoch_manager)?;
 
         create_light_client_block_view(&final_block_header, chain_store, Some(next_block_producers))
+    }
+
+    /// Spice: the light-client `block_header_lite` (reconstructed with certified
+    /// roots) and the inclusion proof of `block_hash`'s certified leaf, anchored
+    /// to `head_block_hash`'s `certified_block_merkle_root`.
+    pub fn spice_block_header_lite_and_proof(
+        &self,
+        block_hash: &CryptoHash,
+        head_block_hash: &CryptoHash,
+    ) -> Result<(near_primitives::views::LightClientBlockLiteView, MerklePath), Error> {
+        let block_header = self.get_block_header(block_hash)?;
+        let (state_root, outcome_root) = self
+            .spice_core_reader
+            .certified_block_roots(head_block_hash, &block_header)?
+            .ok_or_else(|| Error::Other(format!("block {block_hash} is not certified")))?;
+        let block_header_lite =
+            reconstruct_certified_lite_view(&block_header, state_root, outcome_root);
+        let leaf_ordinal = self.chain_store().get_certified_block_leaf_ordinal(block_hash)?;
+        let tree_size = self.chain_store().get_certified_block_merkle_tree(head_block_hash)?.size();
+        let proof = compute_certified_block_proof(self.chain_store(), leaf_ordinal, tree_size)?;
+        Ok((block_header_lite, proof))
     }
 
     pub fn save_block(&mut self, block: MaybeValidated<Arc<Block>>) -> Result<(), Error> {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -720,7 +720,11 @@ impl Chain {
         let block_header_lite =
             reconstruct_certified_lite_view(&block_header, state_root, outcome_root);
         let leaf_ordinal = self.chain_store().get_certified_block_leaf_ordinal(block_hash)?;
-        let tree_size = self.chain_store().get_certified_block_merkle_tree(head_block_hash)?.size();
+        // `head_block_hash`'s header commits the certified accumulator as of its
+        // predecessor (mirroring `prev_last_certified_block_epoch_id`), so the
+        // proof anchors to the tree as of `head`'s prev.
+        let head_prev = *self.get_block_header(head_block_hash)?.prev_hash();
+        let tree_size = self.chain_store().get_certified_block_merkle_tree(&head_prev)?.size();
         let proof = compute_certified_block_proof(self.chain_store(), leaf_ordinal, tree_size)?;
         Ok((block_header_lite, proof))
     }

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -2,10 +2,10 @@ use crate::approval_verification::verify_approvals_and_threshold_orphan;
 use crate::block_processing_utils::BlockPreprocessInfo;
 use crate::chain::collect_receipts_from_response;
 use crate::metrics::{SHARD_LAYOUT_NUM_SHARDS, SHARD_LAYOUT_VERSION};
+use crate::spice::certified_accumulator::update_and_save_certified_block_merkle_tree;
 use crate::spice::chunk_application::apply_chunk_postprocessing;
 use crate::spice::core::{
     record_spice_endorsement_stats_for_block, record_uncertified_chunks_for_block,
-    update_and_save_certified_block_merkle_tree,
 };
 use crate::store::utils::get_block_header_on_chain_by_height;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -2,7 +2,7 @@ use crate::approval_verification::verify_approvals_and_threshold_orphan;
 use crate::block_processing_utils::BlockPreprocessInfo;
 use crate::chain::collect_receipts_from_response;
 use crate::metrics::{SHARD_LAYOUT_NUM_SHARDS, SHARD_LAYOUT_VERSION};
-use crate::spice::certified_accumulator::update_and_save_certified_block_merkle_tree;
+use crate::spice::certified_accumulator::save_certified_block_merkle_tree_for_block;
 use crate::spice::chunk_application::apply_chunk_postprocessing;
 use crate::spice::core::{
     SpiceCoreReader, record_spice_endorsement_stats_for_block, record_uncertified_chunks_for_block,
@@ -316,11 +316,21 @@ impl<'a> ChainUpdate<'a> {
                 self.epoch_manager.as_ref(),
                 &block,
             )?;
-            update_and_save_certified_block_merkle_tree(
+            // Fork-local per-block state. Its leaves are indexed into the canonical ordinal index
+            // only when the block is canonical: here at body processing (the header head can be
+            // ahead from header sync), and via `update_height` for reorg in-between blocks.
+            save_certified_block_merkle_tree_for_block(
                 &mut self.chain_store_update,
                 spice_core_reader,
                 &block,
             )?;
+            let is_canonical =
+                self.chain_store_update.get_block_hash_by_height(block.header().height())?
+                    == *block.hash();
+            if is_canonical {
+                self.chain_store_update
+                    .index_canonical_certified_leaves(block.hash(), block.header().prev_hash())?;
+            }
         }
 
         // Update the chain head if it's the new tip

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -324,9 +324,13 @@ impl<'a> ChainUpdate<'a> {
                 spice_core_reader,
                 &block,
             )?;
+            // No canonical block at this height yet means this block is not (currently) canonical.
             let is_canonical =
-                self.chain_store_update.get_block_hash_by_height(block.header().height())?
-                    == *block.hash();
+                match self.chain_store_update.get_block_hash_by_height(block.header().height()) {
+                    Ok(hash) => hash == *block.hash(),
+                    Err(Error::DBNotFoundErr(_)) => false,
+                    Err(err) => return Err(err),
+                };
             if is_canonical {
                 self.chain_store_update
                     .index_canonical_certified_leaves(block.hash(), block.header().prev_hash())?;

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -5,6 +5,7 @@ use crate::metrics::{SHARD_LAYOUT_NUM_SHARDS, SHARD_LAYOUT_VERSION};
 use crate::spice::chunk_application::apply_chunk_postprocessing;
 use crate::spice::core::{
     record_spice_endorsement_stats_for_block, record_uncertified_chunks_for_block,
+    update_and_save_certified_block_merkle_tree,
 };
 use crate::store::utils::get_block_header_on_chain_by_height;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
@@ -310,6 +311,11 @@ impl<'a> ChainUpdate<'a> {
                 &block,
             )?;
             record_spice_endorsement_stats_for_block(
+                &mut self.chain_store_update,
+                self.epoch_manager.as_ref(),
+                &block,
+            )?;
+            update_and_save_certified_block_merkle_tree(
                 &mut self.chain_store_update,
                 self.epoch_manager.as_ref(),
                 &block,

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -5,7 +5,7 @@ use crate::metrics::{SHARD_LAYOUT_NUM_SHARDS, SHARD_LAYOUT_VERSION};
 use crate::spice::certified_accumulator::update_and_save_certified_block_merkle_tree;
 use crate::spice::chunk_application::apply_chunk_postprocessing;
 use crate::spice::core::{
-    record_spice_endorsement_stats_for_block, record_uncertified_chunks_for_block,
+    SpiceCoreReader, record_spice_endorsement_stats_for_block, record_uncertified_chunks_for_block,
 };
 use crate::store::utils::get_block_header_on_chain_by_height;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
@@ -229,6 +229,7 @@ impl<'a> ChainUpdate<'a> {
         block_preprocess_info: BlockPreprocessInfo,
         apply_chunks_results: Vec<(ShardId, Result<ShardUpdateResult, Error>)>,
         should_save_state_transition_data: bool,
+        spice_core_reader: &SpiceCoreReader,
     ) -> Result<Option<Tip>, Error> {
         let prev_hash = block.header().prev_hash();
         let results = apply_chunks_results.into_iter().map(|(shard_id, x)| {
@@ -317,7 +318,7 @@ impl<'a> ChainUpdate<'a> {
             )?;
             update_and_save_certified_block_merkle_tree(
                 &mut self.chain_store_update,
-                self.epoch_manager.as_ref(),
+                spice_core_reader,
                 &block,
             )?;
         }

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -46,6 +46,8 @@ pub fn create_light_client_block_view(
         timestamp_nanosec: block_header.raw_timestamp(),
         next_bp_hash: *block_header.next_bp_hash(),
         block_merkle_root: *block_header.block_merkle_root(),
+        certified_block_merkle_root: block_header.certified_block_merkle_root().copied(),
+        last_certified_block: block_header.last_certified_block().copied(),
     };
     let inner_rest_hash = hash(&block_header.inner_rest_bytes());
 

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -2,10 +2,12 @@ use crate::ChainStoreAccess;
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::BlockHeader;
-use near_primitives::hash::hash;
+use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::types::EpochId;
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
-use near_primitives::views::{BlockHeaderInnerLiteView, LightClientBlockView};
+use near_primitives::views::{
+    BlockHeaderInnerLiteView, LightClientBlockLiteView, LightClientBlockView,
+};
 
 pub fn get_epoch_block_producers_view(
     epoch_id: &EpochId,
@@ -16,6 +18,35 @@ pub fn get_epoch_block_producers_view(
         .iter()
         .map(|x| x.clone().into())
         .collect::<Vec<_>>())
+}
+
+/// Reconstructs the light-client lite view of a certified spice block, placing the
+/// certified roots into the classic `prev_state_root` / `outcome_root` slots. Its
+/// `hash()` is both the leaf in the certified-block merkle tree and the
+/// `block_header_lite` returned for proofs anchored to `certified_block_merkle_root`.
+pub fn reconstruct_certified_lite_view(
+    block_header: &BlockHeader,
+    certified_state_root: CryptoHash,
+    certified_outcome_root: CryptoHash,
+) -> LightClientBlockLiteView {
+    let inner_lite = BlockHeaderInnerLiteView {
+        height: block_header.height(),
+        epoch_id: block_header.epoch_id().0,
+        next_epoch_id: block_header.next_epoch_id().0,
+        prev_state_root: certified_state_root,
+        outcome_root: certified_outcome_root,
+        timestamp: block_header.raw_timestamp(),
+        timestamp_nanosec: block_header.raw_timestamp(),
+        next_bp_hash: *block_header.next_bp_hash(),
+        block_merkle_root: *block_header.block_merkle_root(),
+        certified_block_merkle_root: block_header.certified_block_merkle_root().copied(),
+        last_certified_block: block_header.last_certified_block().copied(),
+    };
+    LightClientBlockLiteView {
+        prev_block_hash: *block_header.prev_hash(),
+        inner_rest_hash: hash(&block_header.inner_rest_bytes()),
+        inner_lite,
+    }
 }
 
 /// Creates the `LightClientBlock` from the information in the chain store for a given block.

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -20,10 +20,8 @@ pub fn get_epoch_block_producers_view(
         .collect::<Vec<_>>())
 }
 
-/// Reconstructs the light-client lite view of a certified spice block, placing the
-/// certified roots into the classic `prev_state_root` / `outcome_root` slots. Its
-/// `hash()` is both the leaf in the certified-block merkle tree and the
-/// `block_header_lite` returned for proofs anchored to `certified_block_merkle_root`.
+/// Light-client lite view of a certified spice block, with the certified roots in the
+/// classic `prev_state_root` / `outcome_root` slots. Its `hash()` is the accumulator leaf.
 pub fn reconstruct_certified_lite_view(
     block_header: &BlockHeader,
     certified_state_root: CryptoHash,

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -1,5 +1,5 @@
 //! A merkle tree, mirroring `block_merkle_tree`, over the reconstructed lite views
-//! of certified spice blocks. Its root is the V7 `certified_block_merkle_root`.
+//! of certified spice blocks. Its root is the header's `certified_block_merkle_root`.
 
 use crate::lightclient::reconstruct_certified_lite_view;
 use crate::spice::core::{SpiceCoreReader, find_newly_certified_block_hashes};

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -14,14 +14,13 @@ use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::{
-    Direction, MerklePath, MerklePathItem, PartialMerkleTree, combine_hash,
-};
+use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::types::{ChunkExecutionResult, ShardId, SpiceChunkId};
 use near_primitives::utils::get_execution_results_key;
 use near_store::DBCol;
 use near_store::adapter::StoreAdapter as _;
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use near_store::merkle_proof::compute_merkle_path_by_ordinal;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -142,9 +141,8 @@ fn build_certified_block_merkle_tree(
 }
 
 /// Inclusion proof of the certified leaf at `leaf_ordinal` within the certified
-/// accumulator of size `tree_size`. Mirrors
-/// `MerkleProofAccess::compute_past_block_proof_in_merkle_tree_of_later_block`,
-/// reading the per-ordinal frontier+leaf from `CertifiedAccumulatorByOrdinal`.
+/// accumulator of size `tree_size`, reading the per-ordinal frontier+leaf from
+/// `CertifiedAccumulatorByOrdinal`.
 pub fn compute_certified_block_proof(
     chain_store: &ChainStoreAdapter,
     leaf_ordinal: u64,
@@ -155,54 +153,10 @@ pub fn compute_certified_block_proof(
             "certified leaf ordinal {leaf_ordinal} is ahead of accumulator size {tree_size}"
         )));
     }
-
-    let mut path = vec![];
-    let mut level: u64 = 0;
-    let mut index = leaf_ordinal;
-    let mut remaining_size = tree_size;
-
-    while remaining_size > 1 {
-        // Walk left.
-        {
-            let cur_index = index;
-            let cur_level = level;
-            while remaining_size > 1 && index % 2 == 1 {
-                index /= 2;
-                remaining_size = (remaining_size + 1) / 2;
-                level += 1;
-            }
-            if level > cur_level {
-                let ordinal = ((cur_index + 1) * (1 << cur_level) - 1).min(tree_size - 1);
-                let (frontier, _) = chain_store.get_certified_accumulator_by_ordinal(ordinal)?;
-                frontier.iter_path_from_bottom(|hash, l| {
-                    if l >= cur_level && l < level {
-                        path.push(MerklePathItem { hash, direction: Direction::Left });
-                    }
-                });
-            }
-        }
-        // Walk right.
-        if remaining_size > 1 {
-            let right_sibling_index = index + 1;
-            let ordinal = ((right_sibling_index + 1) * (1 << level) - 1).min(tree_size - 1);
-            if ordinal >= right_sibling_index * (1 << level) {
-                let (frontier, leaf_hash) =
-                    chain_store.get_certified_accumulator_by_ordinal(ordinal)?;
-                let mut subtree_root_hash = leaf_hash;
-                if level > 0 {
-                    frontier.iter_path_from_bottom(|hash, l| {
-                        if l < level {
-                            subtree_root_hash = combine_hash(&hash, &subtree_root_hash);
-                        }
-                    });
-                }
-                path.push(MerklePathItem { hash: subtree_root_hash, direction: Direction::Right });
-            }
-
-            index = (index + 1) / 2;
-            remaining_size = (remaining_size + 1) / 2;
-            level += 1;
-        }
-    }
-    Ok(path)
+    compute_merkle_path_by_ordinal(
+        leaf_ordinal,
+        tree_size,
+        |ordinal| Ok(Arc::new(chain_store.get_certified_accumulator_by_ordinal(ordinal)?.0)),
+        |ordinal| Ok(chain_store.get_certified_accumulator_by_ordinal(ordinal)?.1),
+    )
 }

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -81,11 +81,8 @@ pub fn compute_certified_block_proof(
     leaf_ordinal: u64,
     tree_size: u64,
 ) -> Result<MerklePath, Error> {
-    if leaf_ordinal >= tree_size {
-        return Err(Error::Other(format!(
-            "certified leaf ordinal {leaf_ordinal} is ahead of accumulator size {tree_size}"
-        )));
-    }
+    // TODO(spice-perf): each ordinal row is read twice (frontier + leaf). Consider a
+    // per-call cache so it is fetched once.
     compute_merkle_path_by_ordinal(
         leaf_ordinal,
         tree_size,

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -41,7 +41,9 @@ fn build_certified_block_merkle_tree(
         return Ok((PartialMerkleTree::default(), vec![]));
     }
     let prev_hash = block.header().prev_hash();
-    let prev_tree = if chain_store.get_block_header(prev_hash)?.is_genesis() {
+    let prev_header = chain_store.get_block_header(prev_hash)?;
+    // Genesis and the pre-spice block at the activation boundary anchor an empty accumulator.
+    let prev_tree = if prev_header.is_genesis() || !prev_header.is_spice() {
         PartialMerkleTree::default()
     } else {
         chain_store.get_certified_block_merkle_tree(prev_hash)?

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -6,37 +6,36 @@ use crate::spice::core::{SpiceCoreReader, find_newly_certified_block_hashes};
 use crate::{ChainStoreAccess, ChainStoreUpdate};
 use near_chain_primitives::Error;
 use near_primitives::block::Block;
-use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
+use near_primitives::types::{CertifiedBlockAccumulatorState, CertifiedBlockLeaf};
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::merkle_proof::compute_merkle_path_by_ordinal;
 use std::sync::Arc;
 
-/// Builds and saves the certified-block merkle tree as of `block`: its prev's tree
-/// extended with a leaf per block `block` newly certifies, keyed by `block`'s hash.
-pub fn update_and_save_certified_block_merkle_tree(
+/// Builds and saves the fork-local certified accumulator state for `block` (prev's tree
+/// plus `block`'s newly-certified leaves), keyed by `block`'s hash. The per-ordinal index
+/// is written only for canonical blocks (see `index_canonical_certified_leaves`).
+pub fn save_certified_block_merkle_tree_for_block(
     chain_store_update: &mut ChainStoreUpdate,
     reader: &SpiceCoreReader,
     block: &Block,
 ) -> Result<(), Error> {
-    let (tree, leaves) =
+    let (tree, newly_certified_leaves) =
         build_certified_block_merkle_tree(chain_store_update.chain_store(), reader, block)?;
-    chain_store_update.save_certified_block_merkle_tree(*block.header().hash(), tree);
-    // Per-leaf-ordinal index for light-client inclusion proofs.
-    for (ordinal, frontier, leaf, block_hash) in leaves {
-        chain_store_update.save_certified_accumulator_entry(ordinal, frontier, leaf);
-        chain_store_update.save_certified_block_leaf_ordinal(block_hash, ordinal);
-    }
+    chain_store_update.save_certified_block_merkle_tree(
+        *block.header().hash(),
+        CertifiedBlockAccumulatorState { tree, newly_certified_leaves },
+    );
     Ok(())
 }
 
-/// Returns the accumulator frontier as of `block`, plus one entry per
-/// newly-certified leaf: `(ordinal, frontier-before-leaf, leaf, block_hash)`.
+/// Returns the certified accumulator tree as of `block`, plus one entry per
+/// newly-certified leaf.
 fn build_certified_block_merkle_tree(
     chain_store: &ChainStoreAdapter,
     reader: &SpiceCoreReader,
     block: &Block,
-) -> Result<(PartialMerkleTree, Vec<(u64, PartialMerkleTree, CryptoHash, CryptoHash)>), Error> {
+) -> Result<(PartialMerkleTree, Vec<CertifiedBlockLeaf>), Error> {
     if block.header().is_genesis() {
         return Ok((PartialMerkleTree::default(), vec![]));
     }
@@ -67,10 +66,9 @@ fn build_certified_block_merkle_tree(
             reader.certified_block_roots_for_certifying_block(block, header)?.ok_or_else(|| {
                 Error::Other(format!("certified block {} missing execution results", header.hash()))
             })?;
-        let leaf = reconstruct_certified_lite_view(header, state_root, outcome_root).hash();
-        let ordinal = tree.size();
-        leaves.push((ordinal, tree.clone(), leaf, *header.hash()));
-        tree.insert(leaf);
+        let leaf_hash = reconstruct_certified_lite_view(header, state_root, outcome_root).hash();
+        leaves.push(CertifiedBlockLeaf { certified_block_hash: *header.hash(), leaf_hash });
+        tree.insert(leaf_hash);
     }
     Ok((tree, leaves))
 }

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -1,0 +1,208 @@
+//! The certified-block merkle accumulator: a parallel merkle tree (mirroring
+//! `block_merkle_tree`) over the reconstructed light-client lite view of every
+//! block whose spice execution results are certified. Its root is committed in
+//! the V7 header (`certified_block_merkle_root`) and anchors light-client
+//! inclusion proofs. The per-leaf-ordinal index keeps proofs O(log n).
+
+use crate::lightclient::reconstruct_certified_lite_view;
+use crate::spice::core::{
+    certified_roots_from_results, collect_certified_execution_results_from_ancestry,
+    find_newly_certified_block_hashes, get_uncertified_chunks,
+};
+use crate::{ChainStoreAccess, ChainStoreUpdate};
+use near_chain_primitives::Error;
+use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::block::Block;
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::{
+    Direction, MerklePath, MerklePathItem, PartialMerkleTree, combine_hash,
+};
+use near_primitives::types::{ChunkExecutionResult, ShardId, SpiceChunkId};
+use near_primitives::utils::get_execution_results_key;
+use near_store::DBCol;
+use near_store::adapter::StoreAdapter as _;
+use near_store::adapter::chain_store::ChainStoreAdapter;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// Builds and saves the certified-block merkle tree as of `block`: the tree as
+/// of its prev, extended by the blocks `block` newly certifies (one leaf each,
+/// in ascending height order). Keyed by `block`'s hash so the next block's
+/// header commits its root. Mirrors `record_uncertified_chunks_for_block`:
+/// reads and writes through `chain_store_update`.
+pub fn update_and_save_certified_block_merkle_tree(
+    chain_store_update: &mut ChainStoreUpdate,
+    epoch_manager: &dyn EpochManagerAdapter,
+    block: &Block,
+) -> Result<(), Error> {
+    let (tree, leaves) =
+        build_certified_block_merkle_tree(chain_store_update.chain_store(), epoch_manager, block)?;
+    chain_store_update.save_certified_block_merkle_tree(*block.header().hash(), tree);
+    // Per-leaf-ordinal index for light-client inclusion proofs.
+    for (ordinal, frontier, leaf, block_hash) in leaves {
+        chain_store_update.save_certified_accumulator_entry(ordinal, frontier, leaf);
+        chain_store_update.save_certified_block_leaf_ordinal(block_hash, ordinal);
+    }
+    Ok(())
+}
+
+/// Returns the accumulator frontier as of `block`, plus one entry per
+/// newly-certified leaf: `(ordinal, frontier-before-leaf, leaf, block_hash)`.
+fn build_certified_block_merkle_tree(
+    chain_store: &ChainStoreAdapter,
+    epoch_manager: &dyn EpochManagerAdapter,
+    block: &Block,
+) -> Result<(PartialMerkleTree, Vec<(u64, PartialMerkleTree, CryptoHash, CryptoHash)>), Error> {
+    if block.header().is_genesis() {
+        return Ok((PartialMerkleTree::default(), vec![]));
+    }
+    let prev_hash = block.header().prev_hash();
+    let prev_tree = if chain_store.get_block_header(prev_hash)?.is_genesis() {
+        PartialMerkleTree::default()
+    } else {
+        chain_store.get_certified_block_merkle_tree(prev_hash)?
+    };
+    let prev_uncertified = get_uncertified_chunks(chain_store, prev_hash)?;
+    let newly_certified =
+        find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
+
+    // Chunks this block itself certifies are only in its (still uncommitted) core
+    // statements; overlay them on the committed results so the producer and every
+    // validator derive identical leaves.
+    let mut overlay: HashMap<SpiceChunkId, &ChunkExecutionResult> = HashMap::new();
+    for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
+        overlay.insert(chunk_id.clone(), result);
+    }
+
+    let mut headers = Vec::with_capacity(newly_certified.len());
+    for block_hash in &newly_certified {
+        headers.push(chain_store.get_block_header(block_hash)?);
+    }
+    headers.sort_by_key(|header| header.height());
+
+    // Gather each newly-certified block's per-shard results from the committed
+    // `execution_results` column plus this block's overlay (precedence:
+    // overlay > column > ancestry-fallback below).
+    let mut results_per_block: Vec<HashMap<ShardId, Arc<ChunkExecutionResult>>> =
+        Vec::with_capacity(headers.len());
+    let mut needs_ancestry = false;
+    for header in &headers {
+        let shard_layout = epoch_manager.get_shard_layout(header.epoch_id())?;
+        let mut results: HashMap<ShardId, Arc<ChunkExecutionResult>> = HashMap::new();
+        for shard_id in shard_layout.shard_ids() {
+            let key = get_execution_results_key(header.hash(), shard_id);
+            if let Some(result) = chain_store
+                .store()
+                .caching_get_ser::<ChunkExecutionResult>(DBCol::execution_results(), &key)
+            {
+                results.insert(shard_id, result);
+            }
+            let chunk_id = SpiceChunkId { block_hash: *header.hash(), shard_id };
+            if let Some(result) = overlay.get(&chunk_id) {
+                results.insert(shard_id, Arc::new((*result).clone()));
+            }
+        }
+        needs_ancestry |= shard_layout.shard_ids().any(|shard_id| !results.contains_key(&shard_id));
+        results_per_block.push(results);
+    }
+
+    // When the async writer is behind, recover the still-missing shards from the
+    // ancestry's block bodies. One walk (stopping at the oldest, height-sorted
+    // first) covers every newly-certified block at once.
+    if needs_ancestry {
+        let relevant_blocks: HashSet<CryptoHash> = headers.iter().map(|h| *h.hash()).collect();
+        let mut results_by_block = HashMap::new();
+        collect_certified_execution_results_from_ancestry(
+            chain_store,
+            prev_hash,
+            &headers[0],
+            &relevant_blocks,
+            &mut results_by_block,
+        )?;
+        for (header, results) in headers.iter().zip(results_per_block.iter_mut()) {
+            for (shard_id, result) in results_by_block.remove(header.hash()).unwrap_or_default() {
+                results.entry(shard_id).or_insert(result);
+            }
+        }
+    }
+
+    let mut tree = prev_tree;
+    let mut leaves = Vec::with_capacity(headers.len());
+    for (header, results) in headers.iter().zip(results_per_block.iter()) {
+        let (state_root, outcome_root) =
+            certified_roots_from_results(epoch_manager, header, results)?.ok_or_else(|| {
+                Error::Other(format!("certified block {} missing execution results", header.hash()))
+            })?;
+        let leaf = reconstruct_certified_lite_view(header, state_root, outcome_root).hash();
+        let ordinal = tree.size();
+        leaves.push((ordinal, tree.clone(), leaf, *header.hash()));
+        tree.insert(leaf);
+    }
+    Ok((tree, leaves))
+}
+
+/// Inclusion proof of the certified leaf at `leaf_ordinal` within the certified
+/// accumulator of size `tree_size`. Mirrors
+/// `MerkleProofAccess::compute_past_block_proof_in_merkle_tree_of_later_block`,
+/// reading the per-ordinal frontier+leaf from `CertifiedAccumulatorByOrdinal`.
+pub fn compute_certified_block_proof(
+    chain_store: &ChainStoreAdapter,
+    leaf_ordinal: u64,
+    tree_size: u64,
+) -> Result<MerklePath, Error> {
+    if leaf_ordinal >= tree_size {
+        return Err(Error::Other(format!(
+            "certified leaf ordinal {leaf_ordinal} is ahead of accumulator size {tree_size}"
+        )));
+    }
+
+    let mut path = vec![];
+    let mut level: u64 = 0;
+    let mut index = leaf_ordinal;
+    let mut remaining_size = tree_size;
+
+    while remaining_size > 1 {
+        // Walk left.
+        {
+            let cur_index = index;
+            let cur_level = level;
+            while remaining_size > 1 && index % 2 == 1 {
+                index /= 2;
+                remaining_size = (remaining_size + 1) / 2;
+                level += 1;
+            }
+            if level > cur_level {
+                let ordinal = ((cur_index + 1) * (1 << cur_level) - 1).min(tree_size - 1);
+                let (frontier, _) = chain_store.get_certified_accumulator_by_ordinal(ordinal)?;
+                frontier.iter_path_from_bottom(|hash, l| {
+                    if l >= cur_level && l < level {
+                        path.push(MerklePathItem { hash, direction: Direction::Left });
+                    }
+                });
+            }
+        }
+        // Walk right.
+        if remaining_size > 1 {
+            let right_sibling_index = index + 1;
+            let ordinal = ((right_sibling_index + 1) * (1 << level) - 1).min(tree_size - 1);
+            if ordinal >= right_sibling_index * (1 << level) {
+                let (frontier, leaf_hash) =
+                    chain_store.get_certified_accumulator_by_ordinal(ordinal)?;
+                let mut subtree_root_hash = leaf_hash;
+                if level > 0 {
+                    frontier.iter_path_from_bottom(|hash, l| {
+                        if l < level {
+                            subtree_root_hash = combine_hash(&hash, &subtree_root_hash);
+                        }
+                    });
+                }
+                path.push(MerklePathItem { hash: subtree_root_hash, direction: Direction::Right });
+            }
+
+            index = (index + 1) / 2;
+            remaining_size = (remaining_size + 1) / 2;
+            level += 1;
+        }
+    }
+    Ok(path)
+}

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -1,8 +1,5 @@
-//! The certified-block merkle accumulator: a parallel merkle tree (mirroring
-//! `block_merkle_tree`) over the reconstructed light-client lite view of every
-//! block whose spice execution results are certified. Its root is committed in
-//! the V7 header (`certified_block_merkle_root`) and anchors light-client
-//! inclusion proofs. The per-leaf-ordinal index keeps proofs O(log n).
+//! A merkle tree, mirroring `block_merkle_tree`, over the reconstructed lite views
+//! of certified spice blocks. Its root is the V7 `certified_block_merkle_root`.
 
 use crate::lightclient::reconstruct_certified_lite_view;
 use crate::spice::core::{SpiceCoreReader, find_newly_certified_block_hashes};
@@ -15,11 +12,8 @@ use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::merkle_proof::compute_merkle_path_by_ordinal;
 use std::sync::Arc;
 
-/// Builds and saves the certified-block merkle tree as of `block`: the tree as
-/// of its prev, extended by the blocks `block` newly certifies (one leaf each,
-/// in ascending height order). Keyed by `block`'s hash so the next block's
-/// header commits its root. Mirrors `record_uncertified_chunks_for_block`:
-/// reads and writes through `chain_store_update`.
+/// Builds and saves the certified-block merkle tree as of `block`: its prev's tree
+/// extended with a leaf per block `block` newly certifies, keyed by `block`'s hash.
 pub fn update_and_save_certified_block_merkle_tree(
     chain_store_update: &mut ChainStoreUpdate,
     reader: &SpiceCoreReader,

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -5,23 +5,14 @@
 //! inclusion proofs. The per-leaf-ordinal index keeps proofs O(log n).
 
 use crate::lightclient::reconstruct_certified_lite_view;
-use crate::spice::core::{
-    certified_roots_from_results, collect_certified_execution_results_from_ancestry,
-    find_newly_certified_block_hashes, get_uncertified_chunks,
-};
+use crate::spice::core::{SpiceCoreReader, find_newly_certified_block_hashes};
 use crate::{ChainStoreAccess, ChainStoreUpdate};
 use near_chain_primitives::Error;
-use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
-use near_primitives::types::{ChunkExecutionResult, ShardId, SpiceChunkId};
-use near_primitives::utils::get_execution_results_key;
-use near_store::DBCol;
-use near_store::adapter::StoreAdapter as _;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::merkle_proof::compute_merkle_path_by_ordinal;
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Builds and saves the certified-block merkle tree as of `block`: the tree as
@@ -31,11 +22,11 @@ use std::sync::Arc;
 /// reads and writes through `chain_store_update`.
 pub fn update_and_save_certified_block_merkle_tree(
     chain_store_update: &mut ChainStoreUpdate,
-    epoch_manager: &dyn EpochManagerAdapter,
+    reader: &SpiceCoreReader,
     block: &Block,
 ) -> Result<(), Error> {
     let (tree, leaves) =
-        build_certified_block_merkle_tree(chain_store_update.chain_store(), epoch_manager, block)?;
+        build_certified_block_merkle_tree(chain_store_update.chain_store(), reader, block)?;
     chain_store_update.save_certified_block_merkle_tree(*block.header().hash(), tree);
     // Per-leaf-ordinal index for light-client inclusion proofs.
     for (ordinal, frontier, leaf, block_hash) in leaves {
@@ -49,7 +40,7 @@ pub fn update_and_save_certified_block_merkle_tree(
 /// newly-certified leaf: `(ordinal, frontier-before-leaf, leaf, block_hash)`.
 fn build_certified_block_merkle_tree(
     chain_store: &ChainStoreAdapter,
-    epoch_manager: &dyn EpochManagerAdapter,
+    reader: &SpiceCoreReader,
     block: &Block,
 ) -> Result<(PartialMerkleTree, Vec<(u64, PartialMerkleTree, CryptoHash, CryptoHash)>), Error> {
     if block.header().is_genesis() {
@@ -61,17 +52,9 @@ fn build_certified_block_merkle_tree(
     } else {
         chain_store.get_certified_block_merkle_tree(prev_hash)?
     };
-    let prev_uncertified = get_uncertified_chunks(chain_store, prev_hash)?;
+    let prev_uncertified = reader.get_uncertified_chunks(prev_hash)?;
     let newly_certified =
         find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
-
-    // Chunks this block itself certifies are only in its (still uncommitted) core
-    // statements; overlay them on the committed results so the producer and every
-    // validator derive identical leaves.
-    let mut overlay: HashMap<SpiceChunkId, &ChunkExecutionResult> = HashMap::new();
-    for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
-        overlay.insert(chunk_id.clone(), result);
-    }
 
     let mut headers = Vec::with_capacity(newly_certified.len());
     for block_hash in &newly_certified {
@@ -79,57 +62,13 @@ fn build_certified_block_merkle_tree(
     }
     headers.sort_by_key(|header| header.height());
 
-    // Gather each newly-certified block's per-shard results from the committed
-    // `execution_results` column plus this block's overlay (precedence:
-    // overlay > column > ancestry-fallback below).
-    let mut results_per_block: Vec<HashMap<ShardId, Arc<ChunkExecutionResult>>> =
-        Vec::with_capacity(headers.len());
-    let mut needs_ancestry = false;
-    for header in &headers {
-        let shard_layout = epoch_manager.get_shard_layout(header.epoch_id())?;
-        let mut results: HashMap<ShardId, Arc<ChunkExecutionResult>> = HashMap::new();
-        for shard_id in shard_layout.shard_ids() {
-            let key = get_execution_results_key(header.hash(), shard_id);
-            if let Some(result) = chain_store
-                .store()
-                .caching_get_ser::<ChunkExecutionResult>(DBCol::execution_results(), &key)
-            {
-                results.insert(shard_id, result);
-            }
-            let chunk_id = SpiceChunkId { block_hash: *header.hash(), shard_id };
-            if let Some(result) = overlay.get(&chunk_id) {
-                results.insert(shard_id, Arc::new((*result).clone()));
-            }
-        }
-        needs_ancestry |= shard_layout.shard_ids().any(|shard_id| !results.contains_key(&shard_id));
-        results_per_block.push(results);
-    }
-
-    // When the async writer is behind, recover the still-missing shards from the
-    // ancestry's block bodies. One walk (stopping at the oldest, height-sorted
-    // first) covers every newly-certified block at once.
-    if needs_ancestry {
-        let relevant_blocks: HashSet<CryptoHash> = headers.iter().map(|h| *h.hash()).collect();
-        let mut results_by_block = HashMap::new();
-        collect_certified_execution_results_from_ancestry(
-            chain_store,
-            prev_hash,
-            &headers[0],
-            &relevant_blocks,
-            &mut results_by_block,
-        )?;
-        for (header, results) in headers.iter().zip(results_per_block.iter_mut()) {
-            for (shard_id, result) in results_by_block.remove(header.hash()).unwrap_or_default() {
-                results.entry(shard_id).or_insert(result);
-            }
-        }
-    }
-
     let mut tree = prev_tree;
     let mut leaves = Vec::with_capacity(headers.len());
-    for (header, results) in headers.iter().zip(results_per_block.iter()) {
+    for header in &headers {
+        // The chunks this block certifies are still in its uncommitted statements,
+        // so the certifying block must overlay them onto the committed results.
         let (state_root, outcome_root) =
-            certified_roots_from_results(epoch_manager, header, results)?.ok_or_else(|| {
+            reader.certified_block_roots_for_certifying_block(block, header)?.ok_or_else(|| {
                 Error::Other(format!("certified block {} missing execution results", header.hash()))
             })?;
         let leaf = reconstruct_certified_lite_view(header, state_root, outcome_root).hash();

--- a/chain/chain/src/spice/chunk_validation.rs
+++ b/chain/chain/src/spice/chunk_validation.rs
@@ -1158,8 +1158,6 @@ mod tests {
             let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
             let core_reader = &self.chain.spice_core_reader;
             let prev_hash = prev_block.header().hash();
-            // Default when the prev block is not recorded (tests that build on an
-            // unprocessed parent and never validate the certified header fields).
             let certified_block_merkle_root =
                 core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
             let last_certified_block =

--- a/chain/chain/src/spice/chunk_validation.rs
+++ b/chain/chain/src/spice/chunk_validation.rs
@@ -1156,9 +1156,19 @@ mod tests {
                 )
                 .unwrap();
             let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
+            let core_reader = &self.chain.spice_core_reader;
+            let prev_hash = prev_block.header().hash();
+            // Default when the prev block is not recorded (tests that build on an
+            // unprocessed parent and never validate the certified header fields).
+            let certified_block_merkle_root =
+                core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
+            let last_certified_block =
+                core_reader.last_certified_block(prev_hash).unwrap_or_default();
             TestBlockBuilder::from_prev_block(Clock::real(), prev_block, signer)
                 .chunks(chunks)
                 .spice_core_statements(vec![])
+                .certified_block_merkle_root(certified_block_merkle_root)
+                .last_certified_block(last_certified_block)
                 .build()
         }
 

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -223,15 +223,9 @@ impl SpiceCoreReader {
         Ok(Some(BlockExecutionResults(results)))
     }
 
-    /// Per-shard certified execution results for `block_header` from the
-    /// committed store: fast path `DBCol::execution_results` (written async by
-    /// `SpiceCoreWriterActor`), slow path the ancestry block bodies under
-    /// `context_hash` for shards the writer or this node lacks. Genesis carries
-    /// no certifying statements, so only the fast path applies there.
-    ///
-    /// `certifying_block`, when set, additionally overlays its own in-flight
-    /// statements, for shards it is certifying that are not yet committed; these
-    /// take precedence over the committed store.
+    /// Per-shard certified execution results for `block_header`: the committed
+    /// `execution_results` column, the ancestry under `context_hash` for shards it
+    /// lacks, and `certifying_block`'s own in-flight statements (when set, winning).
     fn gather_certified_results(
         &self,
         context_hash: &CryptoHash,
@@ -279,9 +273,7 @@ impl SpiceCoreReader {
         self.certified_roots_from_results(block_header, &results)
     }
 
-    /// Merklizes per-shard state/outcome roots like the non-spice
-    /// `Chunks::compute_state_root` / `compute_outcome_root`. `None` if any shard
-    /// is missing from `results`.
+    /// Merkle roots over the per-shard state and outcome roots. `None` if any shard is missing.
     fn certified_roots_from_results(
         &self,
         block_header: &BlockHeader,
@@ -310,10 +302,8 @@ impl SpiceCoreReader {
         self.certified_block_roots_impl(context_hash, block_header, None)
     }
 
-    /// Like `certified_block_roots`, but for a `block_header` that `certifying_block`
-    /// is in the act of certifying: overlays the certifying block's own in-flight
-    /// results, which are not yet committed. Used while building the certified-block
-    /// merkle tree during block application.
+    /// Like `certified_block_roots`, but overlays `certifying_block`'s own not-yet-
+    /// committed results. Used while building the certified-block tree during application.
     pub fn certified_block_roots_for_certifying_block(
         &self,
         certifying_block: &Block,
@@ -326,10 +316,8 @@ impl SpiceCoreReader {
         )
     }
 
-    /// Per-shard certified outcome roots for `block_header`, in shard order.
-    /// `merklize`d, these give the block's certified `outcome_root` and the
-    /// per-shard inclusion path used by light-client proofs. `None` when any
-    /// shard's result is unavailable.
+    /// Per-shard certified outcome roots for `block_header`, in shard order; `merklize`d
+    /// they give the block's certified `outcome_root`. `None` if any shard is missing.
     pub fn certified_block_shard_outcome_roots(
         &self,
         context_hash: &CryptoHash,
@@ -347,9 +335,8 @@ impl SpiceCoreReader {
         Ok(Some(outcome_roots))
     }
 
-    /// State root certified as of `block_hash`: the merkle root over per-shard
-    /// state roots of the last fully certified block. Returns `None` when the
-    /// certified block's execution results are not all available yet.
+    /// State root certified as of `block_hash`: the merkle root over the last fully
+    /// certified block's per-shard state roots. `None` if its results aren't all available.
     pub fn last_certified_state_root(
         &self,
         block_hash: &CryptoHash,
@@ -371,9 +358,8 @@ impl SpiceCoreReader {
         self.chain_store.get_certified_block_merkle_tree(prev_hash)
     }
 
-    /// Certified-block merkle root committed in the header of a block built on
-    /// `prev_hash` (the tree as of `prev_hash`). Produced and validated like
-    /// `prev_last_certified_block_epoch_id`.
+    /// Certified-block merkle root for a block built on `prev_hash` (the tree as of
+    /// `prev_hash`), committed in its header.
     pub fn certified_block_merkle_root(&self, prev_hash: &CryptoHash) -> Result<CryptoHash, Error> {
         Ok(self.prev_certified_block_merkle_tree(prev_hash)?.root())
     }

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,3 +1,4 @@
+use crate::lightclient::reconstruct_certified_lite_view;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
 use near_chain_primitives::Error;
 use near_crypto::Signature;
@@ -8,7 +9,7 @@ use near_primitives::epoch_info::EpochInfo;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::merklize;
+use near_primitives::merkle::{PartialMerkleTree, merklize};
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::spice::chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
@@ -285,6 +286,47 @@ impl SpiceCoreReader {
         Ok(self
             .certified_block_roots(block_hash, &last_certified)?
             .map(|(state_root, _)| state_root))
+    }
+
+    /// Leaf of the certified-block merkle tree for `block_header`: the hash of its
+    /// reconstructed certified lite view. `None` if its results are unavailable.
+    pub fn certified_block_lite_hash(
+        &self,
+        context_hash: &CryptoHash,
+        block_header: &BlockHeader,
+    ) -> Result<Option<CryptoHash>, Error> {
+        let Some((state_root, outcome_root)) =
+            self.certified_block_roots(context_hash, block_header)?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(reconstruct_certified_lite_view(block_header, state_root, outcome_root).hash()))
+    }
+
+    /// Extends `prev_certified_tree` (the tree as of the previous block) with one
+    /// leaf per newly-certified block, appended in ascending height order.
+    /// `context_hash` identifies the block whose ancestry carries the certifying
+    /// core statements.
+    pub fn extend_certified_block_merkle_tree(
+        &self,
+        context_hash: &CryptoHash,
+        prev_certified_tree: &PartialMerkleTree,
+        newly_certified: &[CryptoHash],
+    ) -> Result<PartialMerkleTree, Error> {
+        let mut headers = Vec::with_capacity(newly_certified.len());
+        for block_hash in newly_certified {
+            headers.push(self.chain_store.get_block_header(block_hash)?);
+        }
+        headers.sort_by_key(|header| header.height());
+
+        let mut tree = prev_certified_tree.clone();
+        for header in &headers {
+            let leaf = self.certified_block_lite_hash(context_hash, header)?.ok_or_else(|| {
+                Error::Other(format!("certified block {} missing execution results", header.hash()))
+            })?;
+            tree.insert(leaf);
+        }
+        Ok(tree)
     }
 
     /// Walks the canonical ancestry backwards from `from_hash` down to (but excluding)

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -224,33 +224,24 @@ impl SpiceCoreReader {
         Ok(Some(BlockExecutionResults(results)))
     }
 
-    /// Certified state and outcome roots for `block_header` (a fully certified
-    /// block): merkle roots over its per-shard state/outcome roots, like the
-    /// non-spice `Chunks::compute_state_root` / `compute_outcome_root`.
-    /// `context_hash` is a descendant whose ancestry carries the certifying core
-    /// statements (used to recover results the async writer has not stored yet).
-    /// Returns `None` when any shard's execution result is unavailable.
-    pub fn certified_block_roots(
+    /// Per-shard certified execution results for `block_header` from the
+    /// committed store: fast path `DBCol::execution_results` (written async by
+    /// `SpiceCoreWriterActor`), slow path the ancestry block bodies under
+    /// `context_hash` for shards the writer or this node lacks. Genesis carries
+    /// no certifying statements, so only the fast path applies there.
+    fn gather_certified_results(
         &self,
         context_hash: &CryptoHash,
         block_header: &BlockHeader,
-    ) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
+    ) -> Result<HashMap<ShardId, Arc<ChunkExecutionResult>>, Error> {
         let shard_layout = self.epoch_manager.get_shard_layout(block_header.epoch_id())?;
-
-        // Fast path: `DBCol::execution_results`, written asynchronously by
-        // `SpiceCoreWriterActor`. By the time a block is fully certified the writer has
-        // almost always recorded its results, so this usually returns everything.
         let mut results = self.get_execution_results_by_shard_id(block_header)?;
-
-        // Slow path: when the writer has not caught up yet some shards are missing. Recover
-        // them from the ancestry's block bodies, which is also the only source for shards
-        // this node does not track. Genesis carries no certifying statements, so its results
-        // only ever come from the fast path above.
         let all_present = shard_layout.shard_ids().all(|shard_id| results.contains_key(&shard_id));
         if !all_present && !block_header.is_genesis() {
             let relevant_blocks = HashSet::from([*block_header.hash()]);
             let mut results_by_block = HashMap::new();
-            self.collect_certified_execution_results_from_ancestry(
+            collect_certified_execution_results_from_ancestry(
+                &self.chain_store,
                 context_hash,
                 block_header,
                 &relevant_blocks,
@@ -262,17 +253,18 @@ impl SpiceCoreReader {
                 results.entry(shard_id).or_insert(result);
             }
         }
+        Ok(results)
+    }
 
-        let mut state_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
-        let mut outcome_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
-        for shard_id in shard_layout.shard_ids() {
-            let Some(result) = results.get(&shard_id) else {
-                return Ok(None);
-            };
-            state_roots.push(*result.chunk_extra.state_root());
-            outcome_roots.push(*result.chunk_extra.outcome_root());
-        }
-        Ok(Some((merklize(&state_roots).0, merklize(&outcome_roots).0)))
+    /// Certified state and outcome roots for a fully certified `block_header`,
+    /// from the committed store. `None` when any shard's result is unavailable.
+    pub fn certified_block_roots(
+        &self,
+        context_hash: &CryptoHash,
+        block_header: &BlockHeader,
+    ) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
+        let results = self.gather_certified_results(context_hash, block_header)?;
+        certified_roots_from_results(self.epoch_manager.as_ref(), block_header, &results)
     }
 
     /// State root certified as of `block_hash`: the merkle root over per-shard
@@ -303,32 +295,6 @@ impl SpiceCoreReader {
         Ok(Some(reconstruct_certified_lite_view(block_header, state_root, outcome_root).hash()))
     }
 
-    /// Extends `prev_certified_tree` (the tree as of the previous block) with one
-    /// leaf per newly-certified block, appended in ascending height order.
-    /// `context_hash` identifies the block whose ancestry carries the certifying
-    /// core statements.
-    pub fn extend_certified_block_merkle_tree(
-        &self,
-        context_hash: &CryptoHash,
-        prev_certified_tree: &PartialMerkleTree,
-        newly_certified: &[CryptoHash],
-    ) -> Result<PartialMerkleTree, Error> {
-        let mut headers = Vec::with_capacity(newly_certified.len());
-        for block_hash in newly_certified {
-            headers.push(self.chain_store.get_block_header(block_hash)?);
-        }
-        headers.sort_by_key(|header| header.height());
-
-        let mut tree = prev_certified_tree.clone();
-        for header in &headers {
-            let leaf = self.certified_block_lite_hash(context_hash, header)?.ok_or_else(|| {
-                Error::Other(format!("certified block {} missing execution results", header.hash()))
-            })?;
-            tree.insert(leaf);
-        }
-        Ok(tree)
-    }
-
     /// The certified-block tree as of `prev_hash` (empty for genesis).
     fn prev_certified_block_merkle_tree(
         &self,
@@ -352,24 +318,6 @@ impl SpiceCoreReader {
         Ok(*get_last_certified_block_header(&self.chain_store, prev_hash)?.hash())
     }
 
-    /// Certified-block tree as of `block`: the tree as of its prev extended by
-    /// the blocks `block` newly certifies. Saved during processing keyed by
-    /// `block`'s hash, so the next block's header commits its root.
-    pub fn build_certified_block_merkle_tree(
-        &self,
-        block: &Block,
-    ) -> Result<PartialMerkleTree, Error> {
-        if block.header().is_genesis() {
-            return Ok(PartialMerkleTree::default());
-        }
-        let prev_hash = block.header().prev_hash();
-        let prev_tree = self.prev_certified_block_merkle_tree(prev_hash)?;
-        let prev_uncertified = self.get_uncertified_chunks(prev_hash)?;
-        let newly_certified =
-            find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
-        self.extend_certified_block_merkle_tree(block.hash(), &prev_tree, &newly_certified)
-    }
-
     pub fn validate_certified_block_header_info(&self, header: &BlockHeader) -> Result<(), Error> {
         let prev_hash = header.prev_hash();
 
@@ -391,39 +339,6 @@ impl SpiceCoreReader {
             return Err(Error::Other(format!(
                 "invalid last_certified_block: expected {expected_last:?}, got {actual_last:?}"
             )));
-        }
-        Ok(())
-    }
-
-    /// Walks the canonical ancestry backwards from `from_hash` down to (but excluding)
-    /// `stop_header`, collecting `ChunkExecutionResult` core statements whose certified
-    /// chunk belongs to a block in `relevant_blocks`, grouped by block hash and shard.
-    /// Reads block bodies because `DBCol::execution_results` is written asynchronously by
-    /// `SpiceCoreWriterActor`. Pre-existing entries in `results_by_block` take precedence.
-    fn collect_certified_execution_results_from_ancestry(
-        &self,
-        from_hash: &CryptoHash,
-        stop_header: &BlockHeader,
-        relevant_blocks: &HashSet<CryptoHash>,
-        results_by_block: &mut HashMap<CryptoHash, HashMap<ShardId, Arc<ChunkExecutionResult>>>,
-    ) -> Result<(), Error> {
-        let mut current_hash = *from_hash;
-        while current_hash != *stop_header.hash() {
-            let block = self.chain_store.get_block(&current_hash)?;
-            if block.header().height() <= stop_header.height() {
-                break;
-            }
-            for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
-                if !relevant_blocks.contains(&chunk_id.block_hash) {
-                    continue;
-                }
-                results_by_block
-                    .entry(chunk_id.block_hash)
-                    .or_default()
-                    .entry(chunk_id.shard_id)
-                    .or_insert_with(|| Arc::new(result.clone()));
-            }
-            current_hash = *block.header().prev_hash();
         }
         Ok(())
     }
@@ -816,7 +731,8 @@ impl SpiceCoreReader {
 
         // Collect execution results from the ancestry's block bodies, keeping any
         // already seeded from `core_statements_for_next_block` above.
-        self.collect_certified_execution_results_from_ancestry(
+        collect_certified_execution_results_from_ancestry(
+            &self.chain_store,
             block_header.hash(),
             &old_last_certified,
             &newly_certified_set,
@@ -1146,6 +1062,150 @@ fn find_oldest_uncertified_block_header(
 /// Returns block hashes that became fully certified due to the execution results
 /// in `core_statements`. A block is newly certified when all of its previously
 /// uncertified chunks appear in the execution results.
+/// Merklizes per-shard state/outcome roots like the non-spice
+/// `Chunks::compute_state_root` / `compute_outcome_root`. `None` if any shard is
+/// missing from `results`.
+fn certified_roots_from_results(
+    epoch_manager: &dyn EpochManagerAdapter,
+    block_header: &BlockHeader,
+    results: &HashMap<ShardId, Arc<ChunkExecutionResult>>,
+) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
+    let shard_layout = epoch_manager.get_shard_layout(block_header.epoch_id())?;
+    let mut state_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
+    let mut outcome_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
+    for shard_id in shard_layout.shard_ids() {
+        let Some(result) = results.get(&shard_id) else {
+            return Ok(None);
+        };
+        state_roots.push(*result.chunk_extra.state_root());
+        outcome_roots.push(*result.chunk_extra.outcome_root());
+    }
+    Ok(Some((merklize(&state_roots).0, merklize(&outcome_roots).0)))
+}
+
+/// Walks the canonical ancestry backwards from `from_hash` down to (but
+/// excluding) `stop_header`, collecting `ChunkExecutionResult` core statements
+/// whose certified chunk belongs to a block in `relevant_blocks`, grouped by
+/// block hash and shard. Reads block bodies because `DBCol::execution_results`
+/// is written asynchronously. Pre-existing entries take precedence.
+fn collect_certified_execution_results_from_ancestry(
+    chain_store: &ChainStoreAdapter,
+    from_hash: &CryptoHash,
+    stop_header: &BlockHeader,
+    relevant_blocks: &HashSet<CryptoHash>,
+    results_by_block: &mut HashMap<CryptoHash, HashMap<ShardId, Arc<ChunkExecutionResult>>>,
+) -> Result<(), Error> {
+    let mut current_hash = *from_hash;
+    while current_hash != *stop_header.hash() {
+        let block = chain_store.get_block(&current_hash)?;
+        if block.header().height() <= stop_header.height() {
+            break;
+        }
+        for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
+            if !relevant_blocks.contains(&chunk_id.block_hash) {
+                continue;
+            }
+            results_by_block
+                .entry(chunk_id.block_hash)
+                .or_default()
+                .entry(chunk_id.shard_id)
+                .or_insert_with(|| Arc::new(result.clone()));
+        }
+        current_hash = *block.header().prev_hash();
+    }
+    Ok(())
+}
+
+/// Builds and saves the certified-block merkle tree as of `block`: the tree as
+/// of its prev, extended by the blocks `block` newly certifies (one leaf each,
+/// in ascending height order). Keyed by `block`'s hash so the next block's
+/// header commits its root. Mirrors `record_uncertified_chunks_for_block`:
+/// reads and writes through `chain_store_update`.
+pub fn update_and_save_certified_block_merkle_tree(
+    chain_store_update: &mut ChainStoreUpdate,
+    epoch_manager: &dyn EpochManagerAdapter,
+    block: &Block,
+) -> Result<(), Error> {
+    let tree =
+        build_certified_block_merkle_tree(chain_store_update.chain_store(), epoch_manager, block)?;
+    chain_store_update.save_certified_block_merkle_tree(*block.header().hash(), tree);
+    Ok(())
+}
+
+fn build_certified_block_merkle_tree(
+    chain_store: &ChainStoreAdapter,
+    epoch_manager: &dyn EpochManagerAdapter,
+    block: &Block,
+) -> Result<PartialMerkleTree, Error> {
+    if block.header().is_genesis() {
+        return Ok(PartialMerkleTree::default());
+    }
+    let prev_hash = block.header().prev_hash();
+    let prev_tree = if chain_store.get_block_header(prev_hash)?.is_genesis() {
+        PartialMerkleTree::default()
+    } else {
+        chain_store.get_certified_block_merkle_tree(prev_hash)?
+    };
+    let prev_uncertified = get_uncertified_chunks(chain_store, prev_hash)?;
+    let newly_certified =
+        find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
+
+    // Chunks this block itself certifies are only in its (still uncommitted) core
+    // statements; overlay them on the committed results so the producer and every
+    // validator derive identical leaves.
+    let mut overlay: HashMap<SpiceChunkId, &ChunkExecutionResult> = HashMap::new();
+    for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
+        overlay.insert(chunk_id.clone(), result);
+    }
+
+    let mut headers = Vec::with_capacity(newly_certified.len());
+    for block_hash in &newly_certified {
+        headers.push(chain_store.get_block_header(block_hash)?);
+    }
+    headers.sort_by_key(|header| header.height());
+
+    let mut tree = prev_tree;
+    for header in &headers {
+        let shard_layout = epoch_manager.get_shard_layout(header.epoch_id())?;
+        let mut results: HashMap<ShardId, Arc<ChunkExecutionResult>> = HashMap::new();
+        for shard_id in shard_layout.shard_ids() {
+            let key = get_execution_results_key(header.hash(), shard_id);
+            if let Some(result) = chain_store
+                .store()
+                .caching_get_ser::<ChunkExecutionResult>(DBCol::execution_results(), &key)
+            {
+                results.insert(shard_id, result);
+            }
+        }
+        if shard_layout.shard_ids().any(|shard_id| !results.contains_key(&shard_id)) {
+            let relevant_blocks = HashSet::from([*header.hash()]);
+            let mut results_by_block = HashMap::new();
+            collect_certified_execution_results_from_ancestry(
+                chain_store,
+                prev_hash,
+                header,
+                &relevant_blocks,
+                &mut results_by_block,
+            )?;
+            for (shard_id, result) in results_by_block.remove(header.hash()).unwrap_or_default() {
+                results.entry(shard_id).or_insert(result);
+            }
+        }
+        for shard_id in shard_layout.shard_ids() {
+            let chunk_id = SpiceChunkId { block_hash: *header.hash(), shard_id };
+            if let Some(result) = overlay.get(&chunk_id) {
+                results.insert(shard_id, Arc::new((*result).clone()));
+            }
+        }
+        let (state_root, outcome_root) =
+            certified_roots_from_results(epoch_manager, header, &results)?.ok_or_else(|| {
+                Error::Other(format!("certified block {} missing execution results", header.hash()))
+            })?;
+        tree.insert(reconstruct_certified_lite_view(header, state_root, outcome_root).hash());
+    }
+    Ok(tree)
+}
+
 pub fn find_newly_certified_block_hashes(
     prev_uncertified_chunks: &[SpiceUncertifiedChunkInfo],
     core_statements: &SpiceCoreStatements,

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -335,8 +335,9 @@ impl SpiceCoreReader {
         Ok(Some(outcome_roots))
     }
 
-    /// State root certified as of `block_hash`: the merkle root over the last fully
-    /// certified block's per-shard state roots. `None` if its results aren't all available.
+    /// State root certified as of `block_hash`: the merkle root over per-shard
+    /// state roots of the last fully certified block. Returns `None` when the
+    /// certified block's execution results are not all available yet.
     pub fn last_certified_state_root(
         &self,
         block_hash: &CryptoHash,

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -348,12 +348,14 @@ impl SpiceCoreReader {
             .map(|(state_root, _)| state_root))
     }
 
-    /// The certified-block tree as of `prev_hash` (empty for genesis).
+    /// The certified-block tree as of `prev_hash` (empty for genesis or a pre-spice block
+    /// at the spice activation boundary).
     fn prev_certified_block_merkle_tree(
         &self,
         prev_hash: &CryptoHash,
     ) -> Result<PartialMerkleTree, Error> {
-        if self.chain_store.get_block_header(prev_hash)?.is_genesis() {
+        let prev_header = self.chain_store.get_block_header(prev_hash)?;
+        if prev_header.is_genesis() || !prev_header.is_spice() {
             return Ok(PartialMerkleTree::default());
         }
         self.chain_store.get_certified_block_merkle_tree(prev_hash)

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -269,6 +269,27 @@ impl SpiceCoreReader {
         certified_roots_from_results(self.epoch_manager.as_ref(), block_header, &results)
     }
 
+    /// Per-shard certified outcome roots for `block_header`, in shard order.
+    /// `merklize`d, these give the block's certified `outcome_root` and the
+    /// per-shard inclusion path used by light-client proofs. `None` when any
+    /// shard's result is unavailable.
+    pub fn certified_block_shard_outcome_roots(
+        &self,
+        context_hash: &CryptoHash,
+        block_header: &BlockHeader,
+    ) -> Result<Option<Vec<CryptoHash>>, Error> {
+        let results = self.gather_certified_results(context_hash, block_header)?;
+        let shard_layout = self.epoch_manager.get_shard_layout(block_header.epoch_id())?;
+        let mut outcome_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
+        for shard_id in shard_layout.shard_ids() {
+            let Some(result) = results.get(&shard_id) else {
+                return Ok(None);
+            };
+            outcome_roots.push(*result.chunk_extra.outcome_root());
+        }
+        Ok(Some(outcome_roots))
+    }
+
     /// State root certified as of `block_hash`: the merkle root over per-shard
     /// state roots of the last fully certified block. Returns `None` when the
     /// certified block's execution results are not all available yet.

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -228,19 +228,32 @@ impl SpiceCoreReader {
     /// `SpiceCoreWriterActor`), slow path the ancestry block bodies under
     /// `context_hash` for shards the writer or this node lacks. Genesis carries
     /// no certifying statements, so only the fast path applies there.
+    ///
+    /// `certifying_block`, when set, additionally overlays its own in-flight
+    /// statements, for shards it is certifying that are not yet committed; these
+    /// take precedence over the committed store.
     fn gather_certified_results(
         &self,
         context_hash: &CryptoHash,
         block_header: &BlockHeader,
+        certifying_block: Option<&Block>,
     ) -> Result<HashMap<ShardId, Arc<ChunkExecutionResult>>, Error> {
         let shard_layout = self.epoch_manager.get_shard_layout(block_header.epoch_id())?;
         let mut results = self.get_execution_results_by_shard_id(block_header)?;
+        if let Some(certifying_block) = certifying_block {
+            for (chunk_id, result) in
+                certifying_block.spice_core_statements().iter_execution_results()
+            {
+                if chunk_id.block_hash == *block_header.hash() {
+                    results.insert(chunk_id.shard_id, Arc::new(result.clone()));
+                }
+            }
+        }
         let all_present = shard_layout.shard_ids().all(|shard_id| results.contains_key(&shard_id));
         if !all_present && !block_header.is_genesis() {
             let relevant_blocks = HashSet::from([*block_header.hash()]);
             let mut results_by_block = HashMap::new();
-            collect_certified_execution_results_from_ancestry(
-                &self.chain_store,
+            self.collect_certified_execution_results_from_ancestry(
                 context_hash,
                 block_header,
                 &relevant_blocks,
@@ -255,6 +268,38 @@ impl SpiceCoreReader {
         Ok(results)
     }
 
+    fn certified_block_roots_impl(
+        &self,
+        context_hash: &CryptoHash,
+        block_header: &BlockHeader,
+        certifying_block: Option<&Block>,
+    ) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
+        let results =
+            self.gather_certified_results(context_hash, block_header, certifying_block)?;
+        self.certified_roots_from_results(block_header, &results)
+    }
+
+    /// Merklizes per-shard state/outcome roots like the non-spice
+    /// `Chunks::compute_state_root` / `compute_outcome_root`. `None` if any shard
+    /// is missing from `results`.
+    fn certified_roots_from_results(
+        &self,
+        block_header: &BlockHeader,
+        results: &HashMap<ShardId, Arc<ChunkExecutionResult>>,
+    ) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
+        let shard_layout = self.epoch_manager.get_shard_layout(block_header.epoch_id())?;
+        let mut state_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
+        let mut outcome_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
+        for shard_id in shard_layout.shard_ids() {
+            let Some(result) = results.get(&shard_id) else {
+                return Ok(None);
+            };
+            state_roots.push(*result.chunk_extra.state_root());
+            outcome_roots.push(*result.chunk_extra.outcome_root());
+        }
+        Ok(Some((merklize(&state_roots).0, merklize(&outcome_roots).0)))
+    }
+
     /// Certified state and outcome roots for a fully certified `block_header`,
     /// from the committed store. `None` when any shard's result is unavailable.
     pub fn certified_block_roots(
@@ -262,8 +307,23 @@ impl SpiceCoreReader {
         context_hash: &CryptoHash,
         block_header: &BlockHeader,
     ) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
-        let results = self.gather_certified_results(context_hash, block_header)?;
-        certified_roots_from_results(self.epoch_manager.as_ref(), block_header, &results)
+        self.certified_block_roots_impl(context_hash, block_header, None)
+    }
+
+    /// Like `certified_block_roots`, but for a `block_header` that `certifying_block`
+    /// is in the act of certifying: overlays the certifying block's own in-flight
+    /// results, which are not yet committed. Used while building the certified-block
+    /// merkle tree during block application.
+    pub fn certified_block_roots_for_certifying_block(
+        &self,
+        certifying_block: &Block,
+        block_header: &BlockHeader,
+    ) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
+        self.certified_block_roots_impl(
+            certifying_block.header().prev_hash(),
+            block_header,
+            Some(certifying_block),
+        )
     }
 
     /// Per-shard certified outcome roots for `block_header`, in shard order.
@@ -275,7 +335,7 @@ impl SpiceCoreReader {
         context_hash: &CryptoHash,
         block_header: &BlockHeader,
     ) -> Result<Option<Vec<CryptoHash>>, Error> {
-        let results = self.gather_certified_results(context_hash, block_header)?;
+        let results = self.gather_certified_results(context_hash, block_header, None)?;
         let shard_layout = self.epoch_manager.get_shard_layout(block_header.epoch_id())?;
         let mut outcome_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
         for shard_id in shard_layout.shard_ids() {
@@ -344,6 +404,39 @@ impl SpiceCoreReader {
             return Err(Error::Other(format!(
                 "invalid last_certified_block: expected {expected_last:?}, got {actual_last:?}"
             )));
+        }
+        Ok(())
+    }
+
+    /// Walks the canonical ancestry backwards from `from_hash` down to (but excluding)
+    /// `stop_header`, collecting `ChunkExecutionResult` core statements whose certified
+    /// chunk belongs to a block in `relevant_blocks`, grouped by block hash and shard.
+    /// Reads block bodies because `DBCol::execution_results` is written asynchronously by
+    /// `SpiceCoreWriterActor`. Pre-existing entries in `results_by_block` take precedence.
+    fn collect_certified_execution_results_from_ancestry(
+        &self,
+        from_hash: &CryptoHash,
+        stop_header: &BlockHeader,
+        relevant_blocks: &HashSet<CryptoHash>,
+        results_by_block: &mut HashMap<CryptoHash, HashMap<ShardId, Arc<ChunkExecutionResult>>>,
+    ) -> Result<(), Error> {
+        let mut current_hash = *from_hash;
+        while current_hash != *stop_header.hash() {
+            let block = self.chain_store.get_block(&current_hash)?;
+            if block.header().height() <= stop_header.height() {
+                break;
+            }
+            for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
+                if !relevant_blocks.contains(&chunk_id.block_hash) {
+                    continue;
+                }
+                results_by_block
+                    .entry(chunk_id.block_hash)
+                    .or_default()
+                    .entry(chunk_id.shard_id)
+                    .or_insert_with(|| Arc::new(result.clone()));
+            }
+            current_hash = *block.header().prev_hash();
         }
         Ok(())
     }
@@ -736,8 +829,7 @@ impl SpiceCoreReader {
 
         // Collect execution results from the ancestry's block bodies, keeping any
         // already seeded from `core_statements_for_next_block` above.
-        collect_certified_execution_results_from_ancestry(
-            &self.chain_store,
+        self.collect_certified_execution_results_from_ancestry(
             block_header.hash(),
             &old_last_certified,
             &newly_certified_set,
@@ -762,7 +854,7 @@ impl SpiceCoreReader {
     }
 }
 
-pub(crate) fn get_uncertified_chunks(
+fn get_uncertified_chunks(
     chain_store: &ChainStoreAdapter,
     block_hash: &CryptoHash,
 ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {
@@ -1067,60 +1159,6 @@ fn find_oldest_uncertified_block_header(
 /// Returns block hashes that became fully certified due to the execution results
 /// in `core_statements`. A block is newly certified when all of its previously
 /// uncertified chunks appear in the execution results.
-/// Merklizes per-shard state/outcome roots like the non-spice
-/// `Chunks::compute_state_root` / `compute_outcome_root`. `None` if any shard is
-/// missing from `results`.
-pub(crate) fn certified_roots_from_results(
-    epoch_manager: &dyn EpochManagerAdapter,
-    block_header: &BlockHeader,
-    results: &HashMap<ShardId, Arc<ChunkExecutionResult>>,
-) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
-    let shard_layout = epoch_manager.get_shard_layout(block_header.epoch_id())?;
-    let mut state_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
-    let mut outcome_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
-    for shard_id in shard_layout.shard_ids() {
-        let Some(result) = results.get(&shard_id) else {
-            return Ok(None);
-        };
-        state_roots.push(*result.chunk_extra.state_root());
-        outcome_roots.push(*result.chunk_extra.outcome_root());
-    }
-    Ok(Some((merklize(&state_roots).0, merklize(&outcome_roots).0)))
-}
-
-/// Walks the canonical ancestry backwards from `from_hash` down to (but
-/// excluding) `stop_header`, collecting `ChunkExecutionResult` core statements
-/// whose certified chunk belongs to a block in `relevant_blocks`, grouped by
-/// block hash and shard. Reads block bodies because `DBCol::execution_results`
-/// is written asynchronously. Pre-existing entries take precedence.
-pub(crate) fn collect_certified_execution_results_from_ancestry(
-    chain_store: &ChainStoreAdapter,
-    from_hash: &CryptoHash,
-    stop_header: &BlockHeader,
-    relevant_blocks: &HashSet<CryptoHash>,
-    results_by_block: &mut HashMap<CryptoHash, HashMap<ShardId, Arc<ChunkExecutionResult>>>,
-) -> Result<(), Error> {
-    let mut current_hash = *from_hash;
-    while current_hash != *stop_header.hash() {
-        let block = chain_store.get_block(&current_hash)?;
-        if block.header().height() <= stop_header.height() {
-            break;
-        }
-        for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
-            if !relevant_blocks.contains(&chunk_id.block_hash) {
-                continue;
-            }
-            results_by_block
-                .entry(chunk_id.block_hash)
-                .or_default()
-                .entry(chunk_id.shard_id)
-                .or_insert_with(|| Arc::new(result.clone()));
-        }
-        current_hash = *block.header().prev_hash();
-    }
-    Ok(())
-}
-
 pub fn find_newly_certified_block_hashes(
     prev_uncertified_chunks: &[SpiceUncertifiedChunkInfo],
     core_statements: &SpiceCoreStatements,

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -223,51 +223,68 @@ impl SpiceCoreReader {
         Ok(Some(BlockExecutionResults(results)))
     }
 
-    /// State root certified as of `block_hash`: the merkle root over per-shard
-    /// state roots of the last fully certified block. Mirrors the non-spice
-    /// `Chunks::compute_state_root`. Returns `None` when the certified block's
-    /// execution results are not all available yet.
-    pub fn last_certified_state_root(
+    /// Certified state and outcome roots for `block_header` (a fully certified
+    /// block): merkle roots over its per-shard state/outcome roots, like the
+    /// non-spice `Chunks::compute_state_root` / `compute_outcome_root`.
+    /// `context_hash` is a descendant whose ancestry carries the certifying core
+    /// statements (used to recover results the async writer has not stored yet).
+    /// Returns `None` when any shard's execution result is unavailable.
+    pub fn certified_block_roots(
         &self,
-        block_hash: &CryptoHash,
-    ) -> Result<Option<CryptoHash>, Error> {
-        let last_certified = get_last_certified_block_header(&self.chain_store, block_hash)?;
-        let shard_layout = self.epoch_manager.get_shard_layout(last_certified.epoch_id())?;
+        context_hash: &CryptoHash,
+        block_header: &BlockHeader,
+    ) -> Result<Option<(CryptoHash, CryptoHash)>, Error> {
+        let shard_layout = self.epoch_manager.get_shard_layout(block_header.epoch_id())?;
 
         // Fast path: `DBCol::execution_results`, written asynchronously by
         // `SpiceCoreWriterActor`. By the time a block is fully certified the writer has
         // almost always recorded its results, so this usually returns everything.
-        let mut results = self.get_execution_results_by_shard_id(&last_certified)?;
+        let mut results = self.get_execution_results_by_shard_id(block_header)?;
 
         // Slow path: when the writer has not caught up yet some shards are missing. Recover
         // them from the ancestry's block bodies, which is also the only source for shards
         // this node does not track. Genesis carries no certifying statements, so its results
         // only ever come from the fast path above.
         let all_present = shard_layout.shard_ids().all(|shard_id| results.contains_key(&shard_id));
-        if !all_present && !last_certified.is_genesis() {
-            let relevant_blocks = HashSet::from([*last_certified.hash()]);
+        if !all_present && !block_header.is_genesis() {
+            let relevant_blocks = HashSet::from([*block_header.hash()]);
             let mut results_by_block = HashMap::new();
             self.collect_certified_execution_results_from_ancestry(
-                block_hash,
-                &last_certified,
+                context_hash,
+                block_header,
                 &relevant_blocks,
                 &mut results_by_block,
             )?;
             for (shard_id, result) in
-                results_by_block.remove(last_certified.hash()).unwrap_or_default()
+                results_by_block.remove(block_header.hash()).unwrap_or_default()
             {
                 results.entry(shard_id).or_insert(result);
             }
         }
 
         let mut state_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
+        let mut outcome_roots = Vec::with_capacity(shard_layout.num_shards() as usize);
         for shard_id in shard_layout.shard_ids() {
             let Some(result) = results.get(&shard_id) else {
                 return Ok(None);
             };
             state_roots.push(*result.chunk_extra.state_root());
+            outcome_roots.push(*result.chunk_extra.outcome_root());
         }
-        Ok(Some(merklize(&state_roots).0))
+        Ok(Some((merklize(&state_roots).0, merklize(&outcome_roots).0)))
+    }
+
+    /// State root certified as of `block_hash`: the merkle root over per-shard
+    /// state roots of the last fully certified block. Returns `None` when the
+    /// certified block's execution results are not all available yet.
+    pub fn last_certified_state_root(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<Option<CryptoHash>, Error> {
+        let last_certified = get_last_certified_block_header(&self.chain_store, block_hash)?;
+        Ok(self
+            .certified_block_roots(block_hash, &last_certified)?
+            .map(|(state_root, _)| state_root))
     }
 
     /// Walks the canonical ancestry backwards from `from_hash` down to (but excluding)

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -9,7 +9,9 @@ use near_primitives::epoch_info::EpochInfo;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::{PartialMerkleTree, merklize};
+use near_primitives::merkle::{
+    Direction, MerklePath, MerklePathItem, PartialMerkleTree, combine_hash, merklize,
+};
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::spice::chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
@@ -1126,19 +1128,26 @@ pub fn update_and_save_certified_block_merkle_tree(
     epoch_manager: &dyn EpochManagerAdapter,
     block: &Block,
 ) -> Result<(), Error> {
-    let tree =
+    let (tree, leaves) =
         build_certified_block_merkle_tree(chain_store_update.chain_store(), epoch_manager, block)?;
     chain_store_update.save_certified_block_merkle_tree(*block.header().hash(), tree);
+    // Per-leaf-ordinal index for light-client inclusion proofs.
+    for (ordinal, frontier, leaf, block_hash) in leaves {
+        chain_store_update.save_certified_accumulator_entry(ordinal, frontier, leaf);
+        chain_store_update.save_certified_block_leaf_ordinal(block_hash, ordinal);
+    }
     Ok(())
 }
 
+/// Returns the accumulator frontier as of `block`, plus one entry per
+/// newly-certified leaf: `(ordinal, frontier-before-leaf, leaf, block_hash)`.
 fn build_certified_block_merkle_tree(
     chain_store: &ChainStoreAdapter,
     epoch_manager: &dyn EpochManagerAdapter,
     block: &Block,
-) -> Result<PartialMerkleTree, Error> {
+) -> Result<(PartialMerkleTree, Vec<(u64, PartialMerkleTree, CryptoHash, CryptoHash)>), Error> {
     if block.header().is_genesis() {
-        return Ok(PartialMerkleTree::default());
+        return Ok((PartialMerkleTree::default(), vec![]));
     }
     let prev_hash = block.header().prev_hash();
     let prev_tree = if chain_store.get_block_header(prev_hash)?.is_genesis() {
@@ -1165,6 +1174,7 @@ fn build_certified_block_merkle_tree(
     headers.sort_by_key(|header| header.height());
 
     let mut tree = prev_tree;
+    let mut leaves = Vec::with_capacity(headers.len());
     for header in &headers {
         let shard_layout = epoch_manager.get_shard_layout(header.epoch_id())?;
         let mut results: HashMap<ShardId, Arc<ChunkExecutionResult>> = HashMap::new();
@@ -1201,9 +1211,78 @@ fn build_certified_block_merkle_tree(
             certified_roots_from_results(epoch_manager, header, &results)?.ok_or_else(|| {
                 Error::Other(format!("certified block {} missing execution results", header.hash()))
             })?;
-        tree.insert(reconstruct_certified_lite_view(header, state_root, outcome_root).hash());
+        let leaf = reconstruct_certified_lite_view(header, state_root, outcome_root).hash();
+        let ordinal = tree.size();
+        leaves.push((ordinal, tree.clone(), leaf, *header.hash()));
+        tree.insert(leaf);
     }
-    Ok(tree)
+    Ok((tree, leaves))
+}
+
+/// Inclusion proof of the certified leaf at `leaf_ordinal` within the certified
+/// accumulator of size `tree_size`. Mirrors
+/// `MerkleProofAccess::compute_past_block_proof_in_merkle_tree_of_later_block`,
+/// reading the per-ordinal frontier+leaf from `CertifiedAccumulatorByOrdinal`.
+pub fn compute_certified_block_proof(
+    chain_store: &ChainStoreAdapter,
+    leaf_ordinal: u64,
+    tree_size: u64,
+) -> Result<MerklePath, Error> {
+    if leaf_ordinal >= tree_size {
+        return Err(Error::Other(format!(
+            "certified leaf ordinal {leaf_ordinal} is ahead of accumulator size {tree_size}"
+        )));
+    }
+
+    let mut path = vec![];
+    let mut level: u64 = 0;
+    let mut index = leaf_ordinal;
+    let mut remaining_size = tree_size;
+
+    while remaining_size > 1 {
+        // Walk left.
+        {
+            let cur_index = index;
+            let cur_level = level;
+            while remaining_size > 1 && index % 2 == 1 {
+                index /= 2;
+                remaining_size = (remaining_size + 1) / 2;
+                level += 1;
+            }
+            if level > cur_level {
+                let ordinal = ((cur_index + 1) * (1 << cur_level) - 1).min(tree_size - 1);
+                let (frontier, _) = chain_store.get_certified_accumulator_by_ordinal(ordinal)?;
+                frontier.iter_path_from_bottom(|hash, l| {
+                    if l >= cur_level && l < level {
+                        path.push(MerklePathItem { hash, direction: Direction::Left });
+                    }
+                });
+            }
+        }
+        // Walk right.
+        if remaining_size > 1 {
+            let right_sibling_index = index + 1;
+            let ordinal = ((right_sibling_index + 1) * (1 << level) - 1).min(tree_size - 1);
+            if ordinal >= right_sibling_index * (1 << level) {
+                let (frontier, leaf_hash) =
+                    chain_store.get_certified_accumulator_by_ordinal(ordinal)?;
+                let mut subtree_root_hash = leaf_hash;
+                if level > 0 {
+                    frontier.iter_path_from_bottom(|hash, l| {
+                        if l < level {
+                            subtree_root_hash = combine_hash(&hash, &subtree_root_hash);
+                        }
+                    });
+                }
+                path.push(MerklePathItem { hash: subtree_root_hash, direction: Direction::Right });
+            }
+
+            index = (index + 1) / 2;
+            remaining_size = (remaining_size + 1) / 2;
+            level += 1;
+        }
+    }
+    Ok(path)
 }
 
 pub fn find_newly_certified_block_hashes(

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -329,6 +329,72 @@ impl SpiceCoreReader {
         Ok(tree)
     }
 
+    /// The certified-block tree as of `prev_hash` (empty for genesis).
+    fn prev_certified_block_merkle_tree(
+        &self,
+        prev_hash: &CryptoHash,
+    ) -> Result<PartialMerkleTree, Error> {
+        if self.chain_store.get_block_header(prev_hash)?.is_genesis() {
+            return Ok(PartialMerkleTree::default());
+        }
+        self.chain_store.get_certified_block_merkle_tree(prev_hash)
+    }
+
+    /// Certified-block merkle root committed in the header of a block built on
+    /// `prev_hash` (the tree as of `prev_hash`). Produced and validated like
+    /// `prev_last_certified_block_epoch_id`.
+    pub fn certified_block_merkle_root(&self, prev_hash: &CryptoHash) -> Result<CryptoHash, Error> {
+        Ok(self.prev_certified_block_merkle_tree(prev_hash)?.root())
+    }
+
+    /// Hash of the last fully certified block as of `prev_hash`.
+    pub fn last_certified_block(&self, prev_hash: &CryptoHash) -> Result<CryptoHash, Error> {
+        Ok(*get_last_certified_block_header(&self.chain_store, prev_hash)?.hash())
+    }
+
+    /// Certified-block tree as of `block`: the tree as of its prev extended by
+    /// the blocks `block` newly certifies. Saved during processing keyed by
+    /// `block`'s hash, so the next block's header commits its root.
+    pub fn build_certified_block_merkle_tree(
+        &self,
+        block: &Block,
+    ) -> Result<PartialMerkleTree, Error> {
+        if block.header().is_genesis() {
+            return Ok(PartialMerkleTree::default());
+        }
+        let prev_hash = block.header().prev_hash();
+        let prev_tree = self.prev_certified_block_merkle_tree(prev_hash)?;
+        let prev_uncertified = self.get_uncertified_chunks(prev_hash)?;
+        let newly_certified =
+            find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
+        self.extend_certified_block_merkle_tree(block.hash(), &prev_tree, &newly_certified)
+    }
+
+    pub fn validate_certified_block_header_info(&self, header: &BlockHeader) -> Result<(), Error> {
+        let prev_hash = header.prev_hash();
+
+        let actual_root = header.certified_block_merkle_root().ok_or_else(|| {
+            Error::Other("missing certified_block_merkle_root on spice block header".to_string())
+        })?;
+        let expected_root = self.certified_block_merkle_root(prev_hash)?;
+        if &expected_root != actual_root {
+            return Err(Error::Other(format!(
+                "invalid certified_block_merkle_root: expected {expected_root:?}, got {actual_root:?}"
+            )));
+        }
+
+        let actual_last = header.last_certified_block().ok_or_else(|| {
+            Error::Other("missing last_certified_block on spice block header".to_string())
+        })?;
+        let expected_last = self.last_certified_block(prev_hash)?;
+        if &expected_last != actual_last {
+            return Err(Error::Other(format!(
+                "invalid last_certified_block: expected {expected_last:?}, got {actual_last:?}"
+            )));
+        }
+        Ok(())
+    }
+
     /// Walks the canonical ancestry backwards from `from_hash` down to (but excluding)
     /// `stop_header`, collecting `ChunkExecutionResult` core statements whose certified
     /// chunk belongs to a block in `relevant_blocks`, grouped by block hash and shard.

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,4 +1,3 @@
-use crate::lightclient::reconstruct_certified_lite_view;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
 use near_chain_primitives::Error;
 use near_crypto::Signature;
@@ -9,9 +8,7 @@ use near_primitives::epoch_info::EpochInfo;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::{
-    Direction, MerklePath, MerklePathItem, PartialMerkleTree, combine_hash, merklize,
-};
+use near_primitives::merkle::{PartialMerkleTree, merklize};
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::spice::chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
@@ -765,7 +762,7 @@ impl SpiceCoreReader {
     }
 }
 
-fn get_uncertified_chunks(
+pub(crate) fn get_uncertified_chunks(
     chain_store: &ChainStoreAdapter,
     block_hash: &CryptoHash,
 ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {
@@ -1073,7 +1070,7 @@ fn find_oldest_uncertified_block_header(
 /// Merklizes per-shard state/outcome roots like the non-spice
 /// `Chunks::compute_state_root` / `compute_outcome_root`. `None` if any shard is
 /// missing from `results`.
-fn certified_roots_from_results(
+pub(crate) fn certified_roots_from_results(
     epoch_manager: &dyn EpochManagerAdapter,
     block_header: &BlockHeader,
     results: &HashMap<ShardId, Arc<ChunkExecutionResult>>,
@@ -1096,7 +1093,7 @@ fn certified_roots_from_results(
 /// whose certified chunk belongs to a block in `relevant_blocks`, grouped by
 /// block hash and shard. Reads block bodies because `DBCol::execution_results`
 /// is written asynchronously. Pre-existing entries take precedence.
-fn collect_certified_execution_results_from_ancestry(
+pub(crate) fn collect_certified_execution_results_from_ancestry(
     chain_store: &ChainStoreAdapter,
     from_hash: &CryptoHash,
     stop_header: &BlockHeader,
@@ -1122,188 +1119,6 @@ fn collect_certified_execution_results_from_ancestry(
         current_hash = *block.header().prev_hash();
     }
     Ok(())
-}
-
-/// Builds and saves the certified-block merkle tree as of `block`: the tree as
-/// of its prev, extended by the blocks `block` newly certifies (one leaf each,
-/// in ascending height order). Keyed by `block`'s hash so the next block's
-/// header commits its root. Mirrors `record_uncertified_chunks_for_block`:
-/// reads and writes through `chain_store_update`.
-pub fn update_and_save_certified_block_merkle_tree(
-    chain_store_update: &mut ChainStoreUpdate,
-    epoch_manager: &dyn EpochManagerAdapter,
-    block: &Block,
-) -> Result<(), Error> {
-    let (tree, leaves) =
-        build_certified_block_merkle_tree(chain_store_update.chain_store(), epoch_manager, block)?;
-    chain_store_update.save_certified_block_merkle_tree(*block.header().hash(), tree);
-    // Per-leaf-ordinal index for light-client inclusion proofs.
-    for (ordinal, frontier, leaf, block_hash) in leaves {
-        chain_store_update.save_certified_accumulator_entry(ordinal, frontier, leaf);
-        chain_store_update.save_certified_block_leaf_ordinal(block_hash, ordinal);
-    }
-    Ok(())
-}
-
-/// Returns the accumulator frontier as of `block`, plus one entry per
-/// newly-certified leaf: `(ordinal, frontier-before-leaf, leaf, block_hash)`.
-fn build_certified_block_merkle_tree(
-    chain_store: &ChainStoreAdapter,
-    epoch_manager: &dyn EpochManagerAdapter,
-    block: &Block,
-) -> Result<(PartialMerkleTree, Vec<(u64, PartialMerkleTree, CryptoHash, CryptoHash)>), Error> {
-    if block.header().is_genesis() {
-        return Ok((PartialMerkleTree::default(), vec![]));
-    }
-    let prev_hash = block.header().prev_hash();
-    let prev_tree = if chain_store.get_block_header(prev_hash)?.is_genesis() {
-        PartialMerkleTree::default()
-    } else {
-        chain_store.get_certified_block_merkle_tree(prev_hash)?
-    };
-    let prev_uncertified = get_uncertified_chunks(chain_store, prev_hash)?;
-    let newly_certified =
-        find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
-
-    // Chunks this block itself certifies are only in its (still uncommitted) core
-    // statements; overlay them on the committed results so the producer and every
-    // validator derive identical leaves.
-    let mut overlay: HashMap<SpiceChunkId, &ChunkExecutionResult> = HashMap::new();
-    for (chunk_id, result) in block.spice_core_statements().iter_execution_results() {
-        overlay.insert(chunk_id.clone(), result);
-    }
-
-    let mut headers = Vec::with_capacity(newly_certified.len());
-    for block_hash in &newly_certified {
-        headers.push(chain_store.get_block_header(block_hash)?);
-    }
-    headers.sort_by_key(|header| header.height());
-
-    // Gather each newly-certified block's per-shard results from the committed
-    // `execution_results` column plus this block's overlay (precedence:
-    // overlay > column > ancestry-fallback below).
-    let mut results_per_block: Vec<HashMap<ShardId, Arc<ChunkExecutionResult>>> =
-        Vec::with_capacity(headers.len());
-    let mut needs_ancestry = false;
-    for header in &headers {
-        let shard_layout = epoch_manager.get_shard_layout(header.epoch_id())?;
-        let mut results: HashMap<ShardId, Arc<ChunkExecutionResult>> = HashMap::new();
-        for shard_id in shard_layout.shard_ids() {
-            let key = get_execution_results_key(header.hash(), shard_id);
-            if let Some(result) = chain_store
-                .store()
-                .caching_get_ser::<ChunkExecutionResult>(DBCol::execution_results(), &key)
-            {
-                results.insert(shard_id, result);
-            }
-            let chunk_id = SpiceChunkId { block_hash: *header.hash(), shard_id };
-            if let Some(result) = overlay.get(&chunk_id) {
-                results.insert(shard_id, Arc::new((*result).clone()));
-            }
-        }
-        needs_ancestry |= shard_layout.shard_ids().any(|shard_id| !results.contains_key(&shard_id));
-        results_per_block.push(results);
-    }
-
-    // When the async writer is behind, recover the still-missing shards from the
-    // ancestry's block bodies. One walk (stopping at the oldest, height-sorted
-    // first) covers every newly-certified block at once.
-    if needs_ancestry {
-        let relevant_blocks: HashSet<CryptoHash> = headers.iter().map(|h| *h.hash()).collect();
-        let mut results_by_block = HashMap::new();
-        collect_certified_execution_results_from_ancestry(
-            chain_store,
-            prev_hash,
-            &headers[0],
-            &relevant_blocks,
-            &mut results_by_block,
-        )?;
-        for (header, results) in headers.iter().zip(results_per_block.iter_mut()) {
-            for (shard_id, result) in results_by_block.remove(header.hash()).unwrap_or_default() {
-                results.entry(shard_id).or_insert(result);
-            }
-        }
-    }
-
-    let mut tree = prev_tree;
-    let mut leaves = Vec::with_capacity(headers.len());
-    for (header, results) in headers.iter().zip(results_per_block.iter()) {
-        let (state_root, outcome_root) =
-            certified_roots_from_results(epoch_manager, header, results)?.ok_or_else(|| {
-                Error::Other(format!("certified block {} missing execution results", header.hash()))
-            })?;
-        let leaf = reconstruct_certified_lite_view(header, state_root, outcome_root).hash();
-        let ordinal = tree.size();
-        leaves.push((ordinal, tree.clone(), leaf, *header.hash()));
-        tree.insert(leaf);
-    }
-    Ok((tree, leaves))
-}
-
-/// Inclusion proof of the certified leaf at `leaf_ordinal` within the certified
-/// accumulator of size `tree_size`. Mirrors
-/// `MerkleProofAccess::compute_past_block_proof_in_merkle_tree_of_later_block`,
-/// reading the per-ordinal frontier+leaf from `CertifiedAccumulatorByOrdinal`.
-pub fn compute_certified_block_proof(
-    chain_store: &ChainStoreAdapter,
-    leaf_ordinal: u64,
-    tree_size: u64,
-) -> Result<MerklePath, Error> {
-    if leaf_ordinal >= tree_size {
-        return Err(Error::Other(format!(
-            "certified leaf ordinal {leaf_ordinal} is ahead of accumulator size {tree_size}"
-        )));
-    }
-
-    let mut path = vec![];
-    let mut level: u64 = 0;
-    let mut index = leaf_ordinal;
-    let mut remaining_size = tree_size;
-
-    while remaining_size > 1 {
-        // Walk left.
-        {
-            let cur_index = index;
-            let cur_level = level;
-            while remaining_size > 1 && index % 2 == 1 {
-                index /= 2;
-                remaining_size = (remaining_size + 1) / 2;
-                level += 1;
-            }
-            if level > cur_level {
-                let ordinal = ((cur_index + 1) * (1 << cur_level) - 1).min(tree_size - 1);
-                let (frontier, _) = chain_store.get_certified_accumulator_by_ordinal(ordinal)?;
-                frontier.iter_path_from_bottom(|hash, l| {
-                    if l >= cur_level && l < level {
-                        path.push(MerklePathItem { hash, direction: Direction::Left });
-                    }
-                });
-            }
-        }
-        // Walk right.
-        if remaining_size > 1 {
-            let right_sibling_index = index + 1;
-            let ordinal = ((right_sibling_index + 1) * (1 << level) - 1).min(tree_size - 1);
-            if ordinal >= right_sibling_index * (1 << level) {
-                let (frontier, leaf_hash) =
-                    chain_store.get_certified_accumulator_by_ordinal(ordinal)?;
-                let mut subtree_root_hash = leaf_hash;
-                if level > 0 {
-                    frontier.iter_path_from_bottom(|hash, l| {
-                        if l < level {
-                            subtree_root_hash = combine_hash(&hash, &subtree_root_hash);
-                        }
-                    });
-                }
-                path.push(MerklePathItem { hash: subtree_root_hash, direction: Direction::Right });
-            }
-
-            index = (index + 1) / 2;
-            remaining_size = (remaining_size + 1) / 2;
-            level += 1;
-        }
-    }
-    Ok(path)
 }
 
 pub fn find_newly_certified_block_hashes(

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -303,21 +303,6 @@ impl SpiceCoreReader {
             .map(|(state_root, _)| state_root))
     }
 
-    /// Leaf of the certified-block merkle tree for `block_header`: the hash of its
-    /// reconstructed certified lite view. `None` if its results are unavailable.
-    pub fn certified_block_lite_hash(
-        &self,
-        context_hash: &CryptoHash,
-        block_header: &BlockHeader,
-    ) -> Result<Option<CryptoHash>, Error> {
-        let Some((state_root, outcome_root)) =
-            self.certified_block_roots(context_hash, block_header)?
-        else {
-            return Ok(None);
-        };
-        Ok(Some(reconstruct_certified_lite_view(block_header, state_root, outcome_root).hash()))
-    }
-
     /// The certified-block tree as of `prev_hash` (empty for genesis).
     fn prev_certified_block_merkle_tree(
         &self,
@@ -1194,8 +1179,12 @@ fn build_certified_block_merkle_tree(
     }
     headers.sort_by_key(|header| header.height());
 
-    let mut tree = prev_tree;
-    let mut leaves = Vec::with_capacity(headers.len());
+    // Gather each newly-certified block's per-shard results from the committed
+    // `execution_results` column plus this block's overlay (precedence:
+    // overlay > column > ancestry-fallback below).
+    let mut results_per_block: Vec<HashMap<ShardId, Arc<ChunkExecutionResult>>> =
+        Vec::with_capacity(headers.len());
+    let mut needs_ancestry = false;
     for header in &headers {
         let shard_layout = epoch_manager.get_shard_layout(header.epoch_id())?;
         let mut results: HashMap<ShardId, Arc<ChunkExecutionResult>> = HashMap::new();
@@ -1207,29 +1196,40 @@ fn build_certified_block_merkle_tree(
             {
                 results.insert(shard_id, result);
             }
-        }
-        if shard_layout.shard_ids().any(|shard_id| !results.contains_key(&shard_id)) {
-            let relevant_blocks = HashSet::from([*header.hash()]);
-            let mut results_by_block = HashMap::new();
-            collect_certified_execution_results_from_ancestry(
-                chain_store,
-                prev_hash,
-                header,
-                &relevant_blocks,
-                &mut results_by_block,
-            )?;
-            for (shard_id, result) in results_by_block.remove(header.hash()).unwrap_or_default() {
-                results.entry(shard_id).or_insert(result);
-            }
-        }
-        for shard_id in shard_layout.shard_ids() {
             let chunk_id = SpiceChunkId { block_hash: *header.hash(), shard_id };
             if let Some(result) = overlay.get(&chunk_id) {
                 results.insert(shard_id, Arc::new((*result).clone()));
             }
         }
+        needs_ancestry |= shard_layout.shard_ids().any(|shard_id| !results.contains_key(&shard_id));
+        results_per_block.push(results);
+    }
+
+    // When the async writer is behind, recover the still-missing shards from the
+    // ancestry's block bodies. One walk (stopping at the oldest, height-sorted
+    // first) covers every newly-certified block at once.
+    if needs_ancestry {
+        let relevant_blocks: HashSet<CryptoHash> = headers.iter().map(|h| *h.hash()).collect();
+        let mut results_by_block = HashMap::new();
+        collect_certified_execution_results_from_ancestry(
+            chain_store,
+            prev_hash,
+            &headers[0],
+            &relevant_blocks,
+            &mut results_by_block,
+        )?;
+        for (header, results) in headers.iter().zip(results_per_block.iter_mut()) {
+            for (shard_id, result) in results_by_block.remove(header.hash()).unwrap_or_default() {
+                results.entry(shard_id).or_insert(result);
+            }
+        }
+    }
+
+    let mut tree = prev_tree;
+    let mut leaves = Vec::with_capacity(headers.len());
+    for (header, results) in headers.iter().zip(results_per_block.iter()) {
         let (state_root, outcome_root) =
-            certified_roots_from_results(epoch_manager, header, &results)?.ok_or_else(|| {
+            certified_roots_from_results(epoch_manager, header, results)?.ok_or_else(|| {
                 Error::Other(format!("certified block {} missing execution results", header.hash()))
             })?;
         let leaf = reconstruct_certified_lite_view(header, state_root, outcome_root).hash();

--- a/chain/chain/src/spice/mod.rs
+++ b/chain/chain/src/spice/mod.rs
@@ -1,4 +1,5 @@
 pub mod block_application;
+pub mod certified_accumulator;
 pub mod chain;
 pub mod chunk_application;
 pub mod chunk_validation;

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -272,6 +272,48 @@ fn test_certified_block_proof_unaffected_by_side_fork() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_certified_block_proof_follows_reorg() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    // Canonical b-chain: b2 certifies b1, b3 anchors root([leaf(b1)]).
+    let b1 = build_block(&chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let b2 = build_block(&chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, b2.clone());
+    let b3 = build_block(&chain, &b2, vec![]);
+    process_block(&mut chain, b3.clone());
+    assert_eq!(chain.head().unwrap().last_block_hash, *b3.hash());
+
+    let b_root = *b3.header().certified_block_merkle_root().unwrap();
+    let (b_lite, b_proof) = chain.spice_block_header_lite_and_proof(b1.hash(), b3.hash()).unwrap();
+    assert_eq!(compute_root_from_path(&b_proof, b_lite.hash()), b_root);
+
+    // Heavier fork off b1 re-certifies b1 with a different root, then overtakes.
+    let fork_state_root = *b2.hash();
+    let c2 = build_block(
+        &chain,
+        &b1,
+        block_certification_core_statements_with_state_root(&b1, fork_state_root),
+    );
+    process_block(&mut chain, c2.clone());
+    let c3 = build_block(&chain, &c2, vec![]);
+    process_block(&mut chain, c3.clone());
+    let c4 = build_block(&chain, &c3, vec![]);
+    process_block(&mut chain, c4.clone());
+    assert_eq!(chain.head().unwrap().last_block_hash, *c4.hash());
+
+    // The reorg re-points the canonical ordinal index to the fork's leaf for b1, so a
+    // proof anchored to the new head verifies against the fork's root and differing leaf.
+    let c_root = *c4.header().certified_block_merkle_root().unwrap();
+    let (c_lite, c_proof) = chain.spice_block_header_lite_and_proof(b1.hash(), c4.hash()).unwrap();
+    assert_eq!(compute_root_from_path(&c_proof, c_lite.hash()), c_root);
+    assert_ne!(c_lite.hash(), b_lite.hash());
+    assert_ne!(c_root, b_root);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_validate_certified_block_header_info_rejects_wrong_fields() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();
@@ -1660,8 +1702,6 @@ fn block_builder(chain: &Chain, prev_block: &Block) -> TestBlockBuilder {
     let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
     let core_reader = core_reader(chain);
     let prev_hash = prev_block.header().hash();
-    // Default when the prev block is not recorded (tests that build on an
-    // unprocessed parent and never validate the certified header fields).
     let certified_block_merkle_root =
         core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
     let last_certified_block = core_reader.last_certified_block(prev_hash).unwrap_or_default();

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -272,6 +272,38 @@ fn test_certified_block_proof_unaffected_by_side_fork() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_certified_block_header_info_rejects_wrong_fields() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    // b2 certifies b1, so the certified fields as of b2 are non-default.
+    let b2 = build_block(&chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, b2.clone());
+
+    // A correctly built block on b2 validates.
+    let good = block_builder(&chain, &b2).spice_core_statements(vec![]).build();
+    core_reader.validate_certified_block_header_info(good.header()).unwrap();
+
+    // A wrong certified_block_merkle_root is rejected.
+    let bad_root = block_builder(&chain, &b2)
+        .certified_block_merkle_root(*b2.hash())
+        .spice_core_statements(vec![])
+        .build();
+    let err = core_reader.validate_certified_block_header_info(bad_root.header()).unwrap_err();
+    assert!(format!("{err:?}").contains("invalid certified_block_merkle_root"), "{err:?}");
+
+    // A wrong last_certified_block is rejected (its root is still correct).
+    let bad_last = block_builder(&chain, &b2)
+        .last_certified_block(*b2.hash())
+        .spice_core_statements(vec![])
+        .build();
+    let err = core_reader.validate_certified_block_header_info(bad_last.header()).unwrap_err();
+    assert!(format!("{err:?}").contains("invalid last_certified_block"), "{err:?}");
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_all_execution_results_exist_when_all_exist() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -21,7 +21,7 @@ use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::merklize;
+use near_primitives::merkle::{compute_root_from_path, merklize};
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::ShardChunkHeader;
@@ -232,6 +232,42 @@ fn test_last_certified_state_root_when_execution_results_column_is_partially_wri
 
     let root = core_reader.last_certified_state_root(b2.hash()).unwrap();
     assert_eq!(root, Some(expected));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_certified_block_proof_unaffected_by_side_fork() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    // Canonical: b2 certifies b1 (ordinal 0), b3 certifies b2 (ordinal 1); b4 commits
+    // certified_block_merkle_root = root([leaf(b1), leaf(b2)]).
+    let b1 = build_block(&chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let b2 = build_block(&chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, b2.clone());
+    let b3 = build_block(&chain, &b2, block_certification_core_statements(&b2));
+    process_block(&mut chain, b3.clone());
+    let b4 = build_block(&chain, &b3, vec![]);
+    process_block(&mut chain, b4.clone());
+
+    let certified_root = *b4.header().certified_block_merkle_root().unwrap();
+    let (lite, proof) = chain.spice_block_header_lite_and_proof(b1.hash(), b4.hash()).unwrap();
+    assert_eq!(compute_root_from_path(&proof, lite.hash()), certified_root);
+
+    // A side fork re-certifies b2 with different roots: a sibling of b3 (same prev b2)
+    // whose leaf at ordinal 1 differs, processed after the canonical head.
+    let fork_state_root = *b1.hash();
+    let y = build_block(
+        &chain,
+        &b2,
+        block_certification_core_statements_with_state_root(&b2, fork_state_root),
+    );
+    process_block(&mut chain, y.clone());
+
+    // The side fork must not corrupt the canonical accumulator; the proof still verifies.
+    let (lite, proof) = chain.spice_block_header_lite_and_proof(b1.hash(), b4.hash()).unwrap();
+    assert_eq!(compute_root_from_path(&proof, lite.hash()), certified_root);
 }
 
 #[test]
@@ -1554,6 +1590,32 @@ fn block_certification_core_statements_with_wrong_endorser(
             chunk_id: SpiceChunkId { block_hash: *block.hash(), shard_id: chunk.shard_id() },
             execution_result: test_execution_result_for_chunk(chunk),
         });
+    }
+    core_statements
+}
+
+/// Like `block_certification_core_statements`, but certifies with a chosen state root so
+/// the produced leaf differs (used to forge a divergent side-fork certification).
+fn block_certification_core_statements_with_state_root(
+    block: &Block,
+    state_root: CryptoHash,
+) -> Vec<SpiceCoreStatement> {
+    let validators = test_validators();
+    let mut core_statements = Vec::new();
+    for chunk in block.chunks().iter_raw() {
+        let execution_result = ChunkExecutionResult {
+            chunk_extra: ChunkExtra::new_with_only_state_root(&state_root),
+            outgoing_receipts_root: CryptoHash::default(),
+        };
+        let chunk_id = SpiceChunkId { block_hash: *block.hash(), shard_id: chunk.shard_id() };
+        for validator in &validators {
+            let signer = create_test_signer(validator);
+            let endorsement =
+                SpiceChunkEndorsement::new(chunk_id.clone(), execution_result.clone(), &signer);
+            core_statements.push(endorsement_into_core_statement(endorsement));
+        }
+        core_statements
+            .push(SpiceCoreStatement::ChunkExecutionResult { chunk_id, execution_result });
     }
     core_statements
 }

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -263,7 +263,7 @@ fn test_certified_block_proof_unaffected_by_side_fork() {
         &b2,
         block_certification_core_statements_with_state_root(&b2, fork_state_root),
     );
-    process_block(&mut chain, y.clone());
+    process_block(&mut chain, y);
 
     // The side fork must not corrupt the canonical accumulator; the proof still verifies.
     let (lite, proof) = chain.spice_block_header_lite_and_proof(b1.hash(), b4.hash()).unwrap();

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -1564,8 +1564,17 @@ fn block_builder(chain: &Chain, prev_block: &Block) -> TestBlockBuilder {
         .get_block_producer_info(prev_block.header().epoch_id(), prev_block.header().height() + 1)
         .unwrap();
     let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
+    let core_reader = core_reader(chain);
+    let prev_hash = prev_block.header().hash();
+    // Default when the prev block is not recorded (tests that build on an
+    // unprocessed parent and never validate the certified header fields).
+    let certified_block_merkle_root =
+        core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
+    let last_certified_block = core_reader.last_certified_block(prev_hash).unwrap_or_default();
     TestBlockBuilder::from_prev_block(Clock::real(), prev_block, signer)
         .chunks(get_fake_next_block_chunk_headers(&prev_block, chain.epoch_manager.as_ref()))
+        .certified_block_merkle_root(certified_block_merkle_root)
+        .last_certified_block(last_certified_block)
 }
 
 fn build_block(

--- a/chain/chain/src/spice/tests/core_writer_actor.rs
+++ b/chain/chain/src/spice/tests/core_writer_actor.rs
@@ -698,8 +698,6 @@ fn block_builder(chain: &Chain, prev_block: &Block) -> TestBlockBuilder {
     let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
     let core_reader = core_reader(chain);
     let prev_hash = prev_block.header().hash();
-    // Default when the prev block is not recorded (tests that build on an
-    // unprocessed parent and never validate the certified header fields).
     let certified_block_merkle_root =
         core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
     let last_certified_block = core_reader.last_certified_block(prev_hash).unwrap_or_default();

--- a/chain/chain/src/spice/tests/core_writer_actor.rs
+++ b/chain/chain/src/spice/tests/core_writer_actor.rs
@@ -696,8 +696,17 @@ fn block_builder(chain: &Chain, prev_block: &Block) -> TestBlockBuilder {
         .get_block_producer_info(prev_block.header().epoch_id(), prev_block.header().height() + 1)
         .unwrap();
     let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
+    let core_reader = core_reader(chain);
+    let prev_hash = prev_block.header().hash();
+    // Default when the prev block is not recorded (tests that build on an
+    // unprocessed parent and never validate the certified header fields).
+    let certified_block_merkle_root =
+        core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
+    let last_certified_block = core_reader.last_certified_block(prev_hash).unwrap_or_default();
     TestBlockBuilder::from_prev_block(Clock::real(), prev_block, signer)
         .chunks(get_fake_next_block_chunk_headers(&prev_block, chain.epoch_manager.as_ref()))
+        .certified_block_merkle_root(certified_block_merkle_root)
+        .last_certified_block(last_certified_block)
 }
 
 fn build_block(

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -31,8 +31,8 @@ use near_primitives::trie_key::{TrieKey, trie_key_parsers};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    BlockHeight, BlockHeightDelta, EpochId, NumBlocks, ShardId, StateChanges, StateChangesExt,
-    StateChangesKinds, StateChangesKindsExt, StateChangesRequest,
+    BlockHeight, BlockHeightDelta, CertifiedBlockAccumulatorState, EpochId, NumBlocks, ShardId,
+    StateChanges, StateChangesExt, StateChangesKinds, StateChangesKindsExt, StateChangesRequest,
 };
 use near_primitives::utils::{
     get_block_shard_id, get_outcome_id_block_hash, get_outcome_id_block_hash_rev, index_to_bytes,
@@ -1050,7 +1050,7 @@ pub(crate) struct ChainStoreCacheUpdate {
     receipts: HashMap<CryptoHash, Arc<Receipt>>,
     block_refcounts: HashMap<CryptoHash, u64>,
     block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
-    certified_block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
+    certified_block_merkle_tree: HashMap<CryptoHash, Arc<CertifiedBlockAccumulatorState>>,
     certified_accumulator_by_ordinal: HashMap<u64, (PartialMerkleTree, CryptoHash)>,
     certified_block_leaf_ordinal: HashMap<CryptoHash, u64>,
     block_ordinal_to_hash: HashMap<NumBlocks, CryptoHash>,
@@ -1481,6 +1481,11 @@ impl<'a> ChainStoreUpdate<'a> {
             // At this point block_merkle_tree for header is already saved.
             let block_ordinal = self.get_block_merkle_tree(&header_hash)?.size();
             self.chain_store_cache_update.block_ordinal_to_hash.insert(block_ordinal, header_hash);
+            // Re-point the certified accumulator's ordinal index for canonical spice blocks.
+            // The per-block state is fork-local; the ordinal index follows the canonical chain.
+            if header.is_spice() {
+                self.index_canonical_certified_leaves(&header_hash, &header_prev_hash)?;
+            }
             match self.get_block_hash_by_height(header_height) {
                 Ok(cur_hash) if cur_hash == header_hash => {
                     // Found common ancestor.
@@ -1606,11 +1611,56 @@ impl<'a> ChainStoreUpdate<'a> {
     pub fn save_certified_block_merkle_tree(
         &mut self,
         block_hash: CryptoHash,
-        certified_block_merkle_tree: PartialMerkleTree,
+        state: CertifiedBlockAccumulatorState,
     ) {
         self.chain_store_cache_update
             .certified_block_merkle_tree
-            .insert(block_hash, Arc::new(certified_block_merkle_tree));
+            .insert(block_hash, Arc::new(state));
+    }
+
+    fn get_certified_block_merkle_state(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<CertifiedBlockAccumulatorState, Error> {
+        if let Some(state) =
+            self.chain_store_cache_update.certified_block_merkle_tree.get(block_hash)
+        {
+            Ok(state.as_ref().clone())
+        } else {
+            self.chain_store.get_certified_block_merkle_state(block_hash)
+        }
+    }
+
+    /// Points the per-ordinal certified index at `block_hash`'s leaves. Each frontier is
+    /// rebuilt onto the prev block's tree, so only leaf hashes are stored per block. Missing
+    /// state means nothing to index yet (genesis, or a header synced ahead of its body).
+    pub(crate) fn index_canonical_certified_leaves(
+        &mut self,
+        block_hash: &CryptoHash,
+        prev_hash: &CryptoHash,
+    ) -> Result<(), Error> {
+        let leaves = match self.get_certified_block_merkle_state(block_hash) {
+            Ok(state) => state.newly_certified_leaves,
+            Err(Error::DBNotFoundErr(_)) => return Ok(()),
+            Err(err) => return Err(err),
+        };
+        if leaves.is_empty() {
+            return Ok(());
+        }
+        let prev_header = self.get_block_header(prev_hash)?;
+        // Genesis and the pre-spice activation-boundary block anchor an empty accumulator.
+        let mut frontier = if prev_header.is_genesis() || !prev_header.is_spice() {
+            PartialMerkleTree::default()
+        } else {
+            self.get_certified_block_merkle_state(prev_hash)?.tree
+        };
+        for leaf in leaves {
+            let ordinal = frontier.size();
+            self.save_certified_accumulator_entry(ordinal, frontier.clone(), leaf.leaf_hash);
+            self.save_certified_block_leaf_ordinal(leaf.certified_block_hash, ordinal);
+            frontier.insert(leaf.leaf_hash);
+        }
+        Ok(())
     }
 
     pub fn save_certified_accumulator_entry(

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1050,6 +1050,7 @@ pub(crate) struct ChainStoreCacheUpdate {
     receipts: HashMap<CryptoHash, Arc<Receipt>>,
     block_refcounts: HashMap<CryptoHash, u64>,
     block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
+    certified_block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
     block_ordinal_to_hash: HashMap<NumBlocks, CryptoHash>,
     processed_block_heights: HashSet<BlockHeight>,
     receipt_to_tx: Vec<(CryptoHash, ReceiptToTxInfo)>,
@@ -1600,6 +1601,16 @@ impl<'a> ChainStoreUpdate<'a> {
             .insert(block_hash, Arc::new(block_merkle_tree));
     }
 
+    pub fn save_certified_block_merkle_tree(
+        &mut self,
+        block_hash: CryptoHash,
+        certified_block_merkle_tree: PartialMerkleTree,
+    ) {
+        self.chain_store_cache_update
+            .certified_block_merkle_tree
+            .insert(block_hash, Arc::new(certified_block_merkle_tree));
+    }
+
     fn update_and_save_block_merkle_tree(&mut self, header: &BlockHeader) -> Result<(), Error> {
         if header.is_genesis() {
             self.save_block_merkle_tree(*header.hash(), PartialMerkleTree::default());
@@ -2146,6 +2157,15 @@ impl<'a> ChainStoreUpdate<'a> {
         }
         for (block_hash, block_merkle_tree) in &self.chain_store_cache_update.block_merkle_tree {
             store_update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree);
+        }
+        for (block_hash, certified_block_merkle_tree) in
+            &self.chain_store_cache_update.certified_block_merkle_tree
+        {
+            store_update.set_ser(
+                DBCol::certified_block_merkle_tree(),
+                block_hash.as_ref(),
+                certified_block_merkle_tree,
+            );
         }
         for (block_ordinal, block_hash) in &self.chain_store_cache_update.block_ordinal_to_hash {
             store_update.set_ser(DBCol::BlockOrdinal, &index_to_bytes(*block_ordinal), block_hash);

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1051,6 +1051,8 @@ pub(crate) struct ChainStoreCacheUpdate {
     block_refcounts: HashMap<CryptoHash, u64>,
     block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
     certified_block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
+    certified_accumulator_by_ordinal: HashMap<u64, (PartialMerkleTree, CryptoHash)>,
+    certified_block_leaf_ordinal: HashMap<CryptoHash, u64>,
     block_ordinal_to_hash: HashMap<NumBlocks, CryptoHash>,
     processed_block_heights: HashSet<BlockHeight>,
     receipt_to_tx: Vec<(CryptoHash, ReceiptToTxInfo)>,
@@ -1611,6 +1613,21 @@ impl<'a> ChainStoreUpdate<'a> {
             .insert(block_hash, Arc::new(certified_block_merkle_tree));
     }
 
+    pub fn save_certified_accumulator_entry(
+        &mut self,
+        ordinal: u64,
+        frontier: PartialMerkleTree,
+        leaf: CryptoHash,
+    ) {
+        self.chain_store_cache_update
+            .certified_accumulator_by_ordinal
+            .insert(ordinal, (frontier, leaf));
+    }
+
+    pub fn save_certified_block_leaf_ordinal(&mut self, block_hash: CryptoHash, ordinal: u64) {
+        self.chain_store_cache_update.certified_block_leaf_ordinal.insert(block_hash, ordinal);
+    }
+
     fn update_and_save_block_merkle_tree(&mut self, header: &BlockHeader) -> Result<(), Error> {
         if header.is_genesis() {
             self.save_block_merkle_tree(*header.hash(), PartialMerkleTree::default());
@@ -2165,6 +2182,20 @@ impl<'a> ChainStoreUpdate<'a> {
                 DBCol::certified_block_merkle_tree(),
                 block_hash.as_ref(),
                 certified_block_merkle_tree,
+            );
+        }
+        for (ordinal, entry) in &self.chain_store_cache_update.certified_accumulator_by_ordinal {
+            store_update.set_ser(
+                DBCol::certified_accumulator_by_ordinal(),
+                &index_to_bytes(*ordinal),
+                entry,
+            );
+        }
+        for (block_hash, ordinal) in &self.chain_store_cache_update.certified_block_leaf_ordinal {
+            store_update.set_ser(
+                DBCol::certified_block_leaf_ordinal(),
+                block_hash.as_ref(),
+                ordinal,
             );
         }
         for (block_ordinal, block_hash) in &self.chain_store_cache_update.block_ordinal_to_hash {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1159,10 +1159,10 @@ impl Client {
                 .chain
                 .spice_core_reader
                 .spice_chunk_endorsement_stats_for_next_block(prev_header, height)?;
-            // TODO(spice): populate from the certified-block merkle tree once the
-            // save path (with the in-memory core-statement overlay) is wired.
-            let certified_block_merkle_root = CryptoHash::default();
-            let last_certified_block = CryptoHash::default();
+            let certified_block_merkle_root =
+                self.chain.spice_core_reader.certified_block_merkle_root(prev_header.hash())?;
+            let last_certified_block =
+                self.chain.spice_core_reader.last_certified_block(prev_header.hash())?;
             Some(SpiceNewBlockProductionInfo {
                 core_statements,
                 newly_certified_block_execution_results,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1159,11 +1159,17 @@ impl Client {
                 .chain
                 .spice_core_reader
                 .spice_chunk_endorsement_stats_for_next_block(prev_header, height)?;
+            // TODO(spice): populate from the certified-block merkle tree once the
+            // save path (with the in-memory core-statement overlay) is wired.
+            let certified_block_merkle_root = CryptoHash::default();
+            let last_certified_block = CryptoHash::default();
             Some(SpiceNewBlockProductionInfo {
                 core_statements,
                 newly_certified_block_execution_results,
                 prev_last_certified_block_epoch_id,
                 spice_chunk_endorsement_stats,
+                certified_block_merkle_root,
+                last_certified_block,
             })
         } else {
             None

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -264,6 +264,18 @@ pub fn create_chunk(
     };
     let epoch_sync_data_hash =
         client.epoch_manager.compute_epoch_sync_data_hash(last_block.hash()).unwrap();
+    // The chain may have certified blocks by now, so take the certified header fields
+    // from the actual chain state rather than the builder's no-certification default.
+    let (certified_block_merkle_root, last_certified_block) =
+        if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
+            let reader = &client.chain.spice_core_reader;
+            (
+                reader.certified_block_merkle_root(last_block.hash()).unwrap(),
+                reader.last_certified_block(last_block.hash()).unwrap(),
+            )
+        } else {
+            (CryptoHash::default(), CryptoHash::default())
+        };
     let block = TestBlockBuilder::from_prev_block(client.clock.clone(), &last_block, signer)
         .height(next_height)
         .chunks(vec![encoded_chunk.cloned_header()])
@@ -272,6 +284,8 @@ pub fn create_chunk(
         .block_merkle_tree(&mut block_merkle_tree)
         .spice_chunk_endorsement_stats(spice_chunk_endorsement_stats)
         .epoch_sync_data_hash(epoch_sync_data_hash)
+        .certified_block_merkle_root(certified_block_merkle_root)
+        .last_certified_block(last_certified_block)
         .build();
     let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)
         .map_err(|(err, _)| err)

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -50,9 +50,10 @@ use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptOrigin,
 use near_primitives::shard_layout::{ShardLayout, ShardLayoutError};
 use near_primitives::sharding::ShardChunk;
 use near_primitives::stateless_validation::ChunkProductionKey;
+use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockId, BlockReference, EpochHeight, EpochId, EpochReference,
-    Finality, MaybeBlockId, ShardId, SyncCheckpoint, TransactionOrReceiptId,
+    Finality, MaybeBlockId, ShardId, ShardIndex, SyncCheckpoint, TransactionOrReceiptId,
     ValidatorInfoIdentifier,
 };
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
@@ -1120,6 +1121,34 @@ impl
     }
 }
 
+/// `GetExecutionOutcome` for a spice block: the certified outcome root lives in the
+/// outcome's own block, not the next block (classic `prev_outcome_root`), so resolve
+/// against it without advancing.
+fn spice_execution_outcome_response(
+    chain: &Chain,
+    outcome_proof: ExecutionOutcomeWithIdAndProof,
+    outcome_block_header: &BlockHeader,
+    target_shard_id: ShardId,
+    target_shard_index: ShardIndex,
+    id: CryptoHash,
+) -> Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError> {
+    let context = chain.head()?.last_block_hash;
+    let outcome_roots = chain
+        .spice_core_reader
+        .certified_block_shard_outcome_roots(&context, outcome_block_header)?
+        .ok_or(GetExecutionOutcomeError::NotConfirmed { transaction_or_receipt_id: id })?;
+    if target_shard_index >= outcome_roots.len() {
+        return Err(GetExecutionOutcomeError::InconsistentState {
+            number_or_shards: outcome_roots.len(),
+            execution_outcome_shard_id: target_shard_id,
+        });
+    }
+    Ok(GetExecutionOutcomeResponse {
+        outcome_proof: outcome_proof.into(),
+        outcome_root_proof: merklize(&outcome_roots).1[target_shard_index].clone(),
+    })
+}
+
 impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>
     for ViewClientActor
 {
@@ -1153,29 +1182,17 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
                     .get_shard_index(target_shard_id)
                     .map_err(Into::into)
                     .into_chain_error()?;
-                // Spice: the certified outcome root lives in the outcome's own block, not the
-                // next block (classic `prev_outcome_root`), so resolve against it without advancing.
                 let outcome_block_header =
                     self.chain.get_block_header(&outcome_proof.block_hash)?;
-                if outcome_block_header.certified_block_merkle_root().is_some() {
-                    let context = self.chain.head()?.last_block_hash;
-                    let outcome_roots = self
-                        .chain
-                        .spice_core_reader
-                        .certified_block_shard_outcome_roots(&context, &outcome_block_header)?
-                        .ok_or(GetExecutionOutcomeError::NotConfirmed {
-                            transaction_or_receipt_id: id,
-                        })?;
-                    if target_shard_index >= outcome_roots.len() {
-                        return Err(GetExecutionOutcomeError::InconsistentState {
-                            number_or_shards: outcome_roots.len(),
-                            execution_outcome_shard_id: target_shard_id,
-                        });
-                    }
-                    return Ok(GetExecutionOutcomeResponse {
-                        outcome_proof: outcome_proof.into(),
-                        outcome_root_proof: merklize(&outcome_roots).1[target_shard_index].clone(),
-                    });
+                if outcome_block_header.is_spice() {
+                    return spice_execution_outcome_response(
+                        &self.chain,
+                        outcome_proof,
+                        &outcome_block_header,
+                        target_shard_id,
+                        target_shard_index,
+                        id,
+                    );
                 }
                 let res = self.chain.get_next_block_hash_with_new_chunk(
                     &outcome_proof.block_hash,
@@ -1641,7 +1658,7 @@ impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> f
         let head_block_header = self.chain.get_block_header(&msg.head_block_hash)?;
         let head_block_header = BlockHeader::clone(&head_block_header);
         self.chain.check_blocks_final_and_canonical(&[block_header.clone(), head_block_header])?;
-        let (block_header_lite, proof) = if block_header.certified_block_merkle_root().is_some() {
+        let (block_header_lite, proof) = if block_header.is_spice() {
             // Spice: reconstruct with certified roots and anchor to the certified accumulator.
             self.chain.spice_block_header_lite_and_proof(&msg.block_hash, &msg.head_block_hash)?
         } else {

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -1161,13 +1161,25 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
                     outcome_proof.block_hash = h;
                     // Here we assume the number of shards is small so this reconstruction
                     // should be fast
-                    let outcome_roots = self
-                        .chain
-                        .get_block(&h)?
-                        .chunks()
-                        .iter()
-                        .map(|header| *header.prev_outcome_root())
-                        .collect::<Vec<_>>();
+                    let h_header = self.chain.get_block_header(&h)?;
+                    let outcome_roots = if h_header.certified_block_merkle_root().is_some() {
+                        // Spice: outcomes are certified asynchronously, so the chunk
+                        // headers carry placeholders; use the certified per-shard roots.
+                        let context = self.chain.head()?.last_block_hash;
+                        self.chain
+                            .spice_core_reader
+                            .certified_block_shard_outcome_roots(&context, &h_header)?
+                            .ok_or(GetExecutionOutcomeError::NotConfirmed {
+                                transaction_or_receipt_id: id,
+                            })?
+                    } else {
+                        self.chain
+                            .get_block(&h)?
+                            .chunks()
+                            .iter()
+                            .map(|header| *header.prev_outcome_root())
+                            .collect::<Vec<_>>()
+                    };
                     if target_shard_index >= outcome_roots.len() {
                         return Err(GetExecutionOutcomeError::InconsistentState {
                             number_or_shards: outcome_roots.len(),
@@ -1617,11 +1629,17 @@ impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> f
         let head_block_header = self.chain.get_block_header(&msg.head_block_hash)?;
         let head_block_header = BlockHeader::clone(&head_block_header);
         self.chain.check_blocks_final_and_canonical(&[block_header.clone(), head_block_header])?;
-        let block_header_lite = block_header.into();
-        let proof = self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
-            &msg.block_hash,
-            &msg.head_block_hash,
-        )?;
+        let (block_header_lite, proof) = if block_header.certified_block_merkle_root().is_some() {
+            // Spice: reconstruct with certified roots and anchor to the certified accumulator.
+            self.chain.spice_block_header_lite_and_proof(&msg.block_hash, &msg.head_block_hash)?
+        } else {
+            let block_header_lite = block_header.into();
+            let proof = self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
+                &msg.block_hash,
+                &msg.head_block_hash,
+            )?;
+            (block_header_lite, proof)
+        };
         Ok(GetBlockProofResponse { block_header_lite, proof })
     }
 }

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -1153,6 +1153,32 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
                     .get_shard_index(target_shard_id)
                     .map_err(Into::into)
                     .into_chain_error()?;
+                // Spice: the certified outcome roots belong to the block where the
+                // chunk executed (the outcome's own block), not the next block that
+                // carries `prev_outcome_root` in the classic model. So resolve the
+                // proof against that block directly without advancing.
+                let outcome_block_header =
+                    self.chain.get_block_header(&outcome_proof.block_hash)?;
+                if outcome_block_header.certified_block_merkle_root().is_some() {
+                    let context = self.chain.head()?.last_block_hash;
+                    let outcome_roots = self
+                        .chain
+                        .spice_core_reader
+                        .certified_block_shard_outcome_roots(&context, &outcome_block_header)?
+                        .ok_or(GetExecutionOutcomeError::NotConfirmed {
+                            transaction_or_receipt_id: id,
+                        })?;
+                    if target_shard_index >= outcome_roots.len() {
+                        return Err(GetExecutionOutcomeError::InconsistentState {
+                            number_or_shards: outcome_roots.len(),
+                            execution_outcome_shard_id: target_shard_id,
+                        });
+                    }
+                    return Ok(GetExecutionOutcomeResponse {
+                        outcome_proof: outcome_proof.into(),
+                        outcome_root_proof: merklize(&outcome_roots).1[target_shard_index].clone(),
+                    });
+                }
                 let res = self.chain.get_next_block_hash_with_new_chunk(
                     &outcome_proof.block_hash,
                     target_shard_id,
@@ -1161,25 +1187,13 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
                     outcome_proof.block_hash = h;
                     // Here we assume the number of shards is small so this reconstruction
                     // should be fast
-                    let h_header = self.chain.get_block_header(&h)?;
-                    let outcome_roots = if h_header.certified_block_merkle_root().is_some() {
-                        // Spice: outcomes are certified asynchronously, so the chunk
-                        // headers carry placeholders; use the certified per-shard roots.
-                        let context = self.chain.head()?.last_block_hash;
-                        self.chain
-                            .spice_core_reader
-                            .certified_block_shard_outcome_roots(&context, &h_header)?
-                            .ok_or(GetExecutionOutcomeError::NotConfirmed {
-                                transaction_or_receipt_id: id,
-                            })?
-                    } else {
-                        self.chain
-                            .get_block(&h)?
-                            .chunks()
-                            .iter()
-                            .map(|header| *header.prev_outcome_root())
-                            .collect::<Vec<_>>()
-                    };
+                    let outcome_roots = self
+                        .chain
+                        .get_block(&h)?
+                        .chunks()
+                        .iter()
+                        .map(|header| *header.prev_outcome_root())
+                        .collect::<Vec<_>>();
                     if target_shard_index >= outcome_roots.len() {
                         return Err(GetExecutionOutcomeError::InconsistentState {
                             number_or_shards: outcome_roots.len(),

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -1153,10 +1153,8 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
                     .get_shard_index(target_shard_id)
                     .map_err(Into::into)
                     .into_chain_error()?;
-                // Spice: the certified outcome roots belong to the block where the
-                // chunk executed (the outcome's own block), not the next block that
-                // carries `prev_outcome_root` in the classic model. So resolve the
-                // proof against that block directly without advancing.
+                // Spice: the certified outcome root lives in the outcome's own block, not the
+                // next block (classic `prev_outcome_root`), so resolve against it without advancing.
                 let outcome_block_header =
                     self.chain.get_block_header(&outcome_proof.block_hash)?;
                 if outcome_block_header.certified_block_merkle_root().is_some() {

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -1108,7 +1108,30 @@ impl
             if ret.inner_lite.height <= last_height { Ok(None) } else { Ok(Some(Arc::new(ret))) }
         } else {
             match self.chain.chain_store().get_epoch_light_client_block(&last_next_epoch_id.0) {
-                Ok(light_block) => Ok(Some(light_block)),
+                Ok(light_block) => {
+                    let epoch_id = EpochId(light_block.inner_lite.epoch_id);
+                    let protocol_version = self
+                        .epoch_manager
+                        .get_epoch_protocol_version(&epoch_id)
+                        .into_chain_error()?;
+                    if !ProtocolFeature::Spice.enabled(protocol_version) {
+                        return Ok(Some(light_block));
+                    }
+                    // The persisted view borsh-skips the certified fields; read them from
+                    // the block's own header. It is retained as long as the light client's
+                    // last block is, so it is present whenever this branch can serve.
+                    let block_hash = self
+                        .chain
+                        .chain_store()
+                        .get_block_hash_by_height(light_block.inner_lite.height)?;
+                    let header = self.chain.get_block_header(&block_hash)?;
+                    let mut light_block = LightClientBlockView::clone(&light_block);
+                    light_block.inner_lite.certified_block_merkle_root =
+                        header.certified_block_merkle_root().copied();
+                    light_block.inner_lite.last_certified_block =
+                        header.last_certified_block().copied();
+                    Ok(Some(Arc::new(light_block)))
+                }
                 Err(e) => {
                     if let near_chain::Error::DBNotFoundErr(_) = e {
                         Ok(None)

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -265,6 +265,9 @@ impl Block {
             spice_info.as_ref().map(|info| info.prev_last_certified_block_epoch_id);
         let spice_chunk_endorsement_stats =
             spice_info.as_ref().map(|info| info.spice_chunk_endorsement_stats.clone());
+        let certified_block_merkle_root =
+            spice_info.as_ref().map(|info| info.certified_block_merkle_root);
+        let last_certified_block = spice_info.as_ref().map(|info| info.last_certified_block);
         let body = if let Some(spice_info) = spice_info {
             BlockBody::new_for_spice(chunks, vrf_value, vrf_proof, spice_info.core_statements)
         } else {
@@ -303,6 +306,8 @@ impl Block {
             shard_split,
             prev_last_certified_block_epoch_id,
             spice_chunk_endorsement_stats,
+            certified_block_merkle_root,
+            last_certified_block,
         );
 
         Self::new_block(header, body)
@@ -652,6 +657,10 @@ pub struct SpiceNewBlockProductionInfo {
     /// Accumulated per-validator endorsement stats for the epoch; non-empty
     /// only on the last block of an epoch.
     pub spice_chunk_endorsement_stats: Vec<SpiceChunkEndorsementStats>,
+    /// Certified-block merkle root committed in the header (as of prev block).
+    pub certified_block_merkle_root: CryptoHash,
+    /// Most recently certified block (as of prev block).
+    pub last_certified_block: CryptoHash,
 }
 
 /// Distinguishes between new and old chunks.

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -46,8 +46,8 @@ pub struct BlockHeaderInnerLite {
     pub block_merkle_root: CryptoHash,
 }
 
-/// V1 -> V2: spice commits certified execution roots so light clients can
-/// verify them from the headers alone.
+/// Spice commits certified execution roots so light clients can verify them
+/// from the headers alone.
 #[derive(
     BorshSerialize,
     BorshDeserialize,
@@ -71,7 +71,6 @@ pub struct BlockHeaderInnerLiteV2 {
     /// Merkle root over the reconstructed light-client lite views of every
     /// block whose spice execution results are certified.
     pub certified_block_merkle_root: CryptoHash,
-    /// Most recently certified block.
     pub last_certified_block: CryptoHash,
 }
 

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -46,6 +46,35 @@ pub struct BlockHeaderInnerLite {
     pub block_merkle_root: CryptoHash,
 }
 
+/// V1 -> V2: spice commits certified execution roots so light clients can
+/// verify them from the headers alone.
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Default,
+    ProtocolSchema,
+)]
+pub struct BlockHeaderInnerLiteV2 {
+    pub height: BlockHeight,
+    pub epoch_id: EpochId,
+    pub next_epoch_id: EpochId,
+    pub prev_state_root: MerkleHash,
+    pub prev_outcome_root: MerkleHash,
+    pub timestamp: u64,
+    pub next_bp_hash: CryptoHash,
+    pub block_merkle_root: CryptoHash,
+    /// Merkle root over the reconstructed light-client lite views of every
+    /// block whose spice execution results are certified.
+    pub certified_block_merkle_root: CryptoHash,
+    /// Most recently certified block.
+    pub last_certified_block: CryptoHash,
+}
+
 #[derive(
     BorshSerialize, BorshDeserialize, serde::Serialize, Debug, Clone, Eq, PartialEq, ProtocolSchema,
 )]
@@ -680,7 +709,7 @@ pub struct BlockHeaderV7 {
     /// Inner part of the block header that gets hashed.
     /// It's split into two parts: one that is sent to light clients,
     /// and the other which contains the rest of information.
-    pub inner_lite: BlockHeaderInnerLite,
+    pub inner_lite: BlockHeaderInnerLiteV2,
     pub inner_rest: BlockHeaderInnerRestV7,
 
     /// Signature of the block producer.
@@ -993,6 +1022,19 @@ impl BlockHeader {
             let spice_chunk_endorsement_stats = spice_chunk_endorsement_stats.expect(
                 "BlockHeaderV7 requires spice_chunk_endorsement_stats when Spice is enabled",
             );
+            let inner_lite = BlockHeaderInnerLiteV2 {
+                height,
+                epoch_id,
+                next_epoch_id,
+                prev_state_root,
+                prev_outcome_root: outcome_root,
+                timestamp,
+                next_bp_hash,
+                block_merkle_root,
+                // TODO(spice): populate from the certified-block merkle tree.
+                certified_block_merkle_root: CryptoHash::default(),
+                last_certified_block: CryptoHash::default(),
+            };
             let inner_rest = BlockHeaderInnerRestV7 {
                 block_body_hash,
                 prev_chunk_outgoing_receipts_root,
@@ -1093,13 +1135,14 @@ impl BlockHeader {
     /// Exactly one of the `signer` and `signature` must be provided.
     /// If `signer` is given signs the header with given `prev_hash`, `inner_lite`, and `inner_rest` and returns the hash and signature of the header.
     /// If `signature` is given, uses the signature as is and only computes the hash.
-    fn compute_hash_and_sign<T>(
+    fn compute_hash_and_sign<L, T>(
         signature_source: SignatureSource,
         prev_hash: CryptoHash,
-        inner_lite: &BlockHeaderInnerLite,
+        inner_lite: &L,
         inner_rest: &T,
     ) -> (CryptoHash, Signature)
     where
+        L: BorshSerialize + ?Sized,
         T: BorshSerialize + ?Sized,
     {
         let hash = BlockHeader::compute_hash(
@@ -1677,15 +1720,20 @@ impl BlockHeader {
     }
 
     #[inline]
-    pub fn inner_lite(&self) -> &BlockHeaderInnerLite {
+    pub fn certified_block_merkle_root(&self) -> Option<&CryptoHash> {
         match self {
-            BlockHeader::BlockHeaderV1(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV2(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV3(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV4(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV5(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV6(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV7(header) => &header.inner_lite,
+            BlockHeader::BlockHeaderV7(header) => {
+                Some(&header.inner_lite.certified_block_merkle_root)
+            }
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn last_certified_block(&self) -> Option<&CryptoHash> {
+        match self {
+            BlockHeader::BlockHeaderV7(header) => Some(&header.inner_lite.last_certified_block),
+            _ => None,
         }
     }
 

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -852,6 +852,8 @@ impl BlockHeader {
         shard_split: Option<(ShardId, AccountId)>,
         prev_last_certified_block_epoch_id: Option<EpochId>,
         spice_chunk_endorsement_stats: Option<Vec<SpiceChunkEndorsementStats>>,
+        certified_block_merkle_root: Option<CryptoHash>,
+        last_certified_block: Option<CryptoHash>,
     ) -> Self {
         Self::new_impl(
             current_protocol_version,
@@ -885,6 +887,8 @@ impl BlockHeader {
             shard_split,
             prev_last_certified_block_epoch_id,
             spice_chunk_endorsement_stats,
+            certified_block_merkle_root,
+            last_certified_block,
         )
     }
 
@@ -921,6 +925,8 @@ impl BlockHeader {
         shard_split: Option<(ShardId, AccountId)>,
         prev_last_certified_block_epoch_id: Option<EpochId>,
         spice_chunk_endorsement_stats: Option<Vec<SpiceChunkEndorsementStats>>,
+        certified_block_merkle_root: Option<CryptoHash>,
+        last_certified_block: Option<CryptoHash>,
     ) -> Self {
         let header = Self::new_impl(
             epoch_protocol_version,
@@ -954,6 +960,8 @@ impl BlockHeader {
             shard_split,
             prev_last_certified_block_epoch_id,
             spice_chunk_endorsement_stats,
+            certified_block_merkle_root,
+            last_certified_block,
         );
         // Note: We do not panic but only log if the hash of the created header does not match the expected hash (From the view)
         // because there are tests that check if we can downgrade a BlockHeader's view a previous version, in which case the hash
@@ -997,6 +1005,8 @@ impl BlockHeader {
         shard_split: Option<(ShardId, AccountId)>,
         prev_last_certified_block_epoch_id: Option<EpochId>,
         spice_chunk_endorsement_stats: Option<Vec<SpiceChunkEndorsementStats>>,
+        certified_block_merkle_root: Option<CryptoHash>,
+        last_certified_block: Option<CryptoHash>,
     ) -> Self {
         let inner_lite = BlockHeaderInnerLite {
             height,
@@ -1022,6 +1032,10 @@ impl BlockHeader {
             let spice_chunk_endorsement_stats = spice_chunk_endorsement_stats.expect(
                 "BlockHeaderV7 requires spice_chunk_endorsement_stats when Spice is enabled",
             );
+            let certified_block_merkle_root = certified_block_merkle_root
+                .expect("BlockHeaderV7 requires certified_block_merkle_root when Spice is enabled");
+            let last_certified_block = last_certified_block
+                .expect("BlockHeaderV7 requires last_certified_block when Spice is enabled");
             let inner_lite = BlockHeaderInnerLiteV2 {
                 height,
                 epoch_id,
@@ -1031,9 +1045,8 @@ impl BlockHeader {
                 timestamp,
                 next_bp_hash,
                 block_merkle_root,
-                // TODO(spice): populate from the certified-block merkle tree.
-                certified_block_merkle_root: CryptoHash::default(),
-                last_certified_block: CryptoHash::default(),
+                certified_block_merkle_root,
+                last_certified_block,
             };
             let inner_rest = BlockHeaderInnerRestV7 {
                 block_body_hash,
@@ -1183,6 +1196,10 @@ impl BlockHeader {
             } else {
                 None
             };
+        let genesis_certified_block_merkle_root =
+            ProtocolFeature::Spice.enabled(genesis_protocol_version).then(CryptoHash::default);
+        let genesis_last_certified_block =
+            ProtocolFeature::Spice.enabled(genesis_protocol_version).then(CryptoHash::default);
         Self::new_impl(
             genesis_protocol_version,
             genesis_protocol_version,
@@ -1215,6 +1232,8 @@ impl BlockHeader {
             None, // shard_split
             genesis_prev_last_certified_block_epoch_id,
             genesis_spice_chunk_endorsement_stats,
+            genesis_certified_block_merkle_root,
+            genesis_last_certified_block,
         )
     }
 

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -939,6 +939,8 @@ pub struct TestBlockBuilder {
     newly_certified_block_execution_results: Vec<crate::types::BlockExecutionResults>,
     prev_last_certified_block_epoch_id: Option<EpochId>,
     spice_chunk_endorsement_stats: Vec<SpiceChunkEndorsementStats>,
+    certified_block_merkle_root: CryptoHash,
+    last_certified_block: CryptoHash,
 }
 
 #[cfg(feature = "clock")]
@@ -984,6 +986,8 @@ impl TestBlockBuilder {
                 None
             },
             spice_chunk_endorsement_stats: Vec::new(),
+            certified_block_merkle_root: CryptoHash::default(),
+            last_certified_block: CryptoHash::default(),
             prev_header,
         }
     }
@@ -1089,6 +1093,16 @@ impl TestBlockBuilder {
         self
     }
 
+    pub fn certified_block_merkle_root(mut self, root: CryptoHash) -> Self {
+        self.certified_block_merkle_root = root;
+        self
+    }
+
+    pub fn last_certified_block(mut self, block_hash: CryptoHash) -> Self {
+        self.last_certified_block = block_hash;
+        self
+    }
+
     pub fn spice_chunk_endorsement_stats(mut self, stats: Vec<SpiceChunkEndorsementStats>) -> Self {
         self.spice_chunk_endorsement_stats = stats;
         self
@@ -1146,8 +1160,8 @@ impl TestBlockBuilder {
                         .prev_last_certified_block_epoch_id
                         .expect("prev_last_certified_block_epoch_id not set for spice block"),
                     spice_chunk_endorsement_stats: self.spice_chunk_endorsement_stats,
-                    certified_block_merkle_root: CryptoHash::default(),
-                    last_certified_block: CryptoHash::default(),
+                    certified_block_merkle_root: self.certified_block_merkle_root,
+                    last_certified_block: self.last_certified_block,
                 }
             }),
         );

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -959,6 +959,14 @@ impl TestBlockBuilder {
             *prev_header.next_epoch_id()
         };
         let chunks_len = prev_chunks.len();
+        // With no certification happening in most tests, the last certified block stays
+        // at genesis: a block on genesis points at it, later blocks carry it forward.
+        // Tests that certify set this explicitly.
+        let last_certified_block = if prev_header.is_genesis() {
+            *prev_header.hash()
+        } else {
+            prev_header.last_certified_block().copied().unwrap_or_else(|| *prev_header.hash())
+        };
         Self {
             clock,
             signer,
@@ -987,7 +995,7 @@ impl TestBlockBuilder {
             },
             spice_chunk_endorsement_stats: Vec::new(),
             certified_block_merkle_root: CryptoHash::default(),
-            last_certified_block: CryptoHash::default(),
+            last_certified_block,
             prev_header,
         }
     }

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -1146,6 +1146,8 @@ impl TestBlockBuilder {
                         .prev_last_certified_block_epoch_id
                         .expect("prev_last_certified_block_epoch_id not set for spice block"),
                     spice_chunk_endorsement_stats: self.spice_chunk_endorsement_stats,
+                    certified_block_merkle_root: CryptoHash::default(),
+                    last_certified_block: CryptoHash::default(),
                 }
             }),
         );

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -959,9 +959,8 @@ impl TestBlockBuilder {
             *prev_header.next_epoch_id()
         };
         let chunks_len = prev_chunks.len();
-        // With no certification happening in most tests, the last certified block stays
-        // at genesis: a block on genesis points at it, later blocks carry it forward.
-        // Tests that certify set this explicitly.
+        // Default the last certified block to genesis (no certification in most tests),
+        // carried forward from prev. Tests that certify set it explicitly.
         let last_certified_block = if prev_header.is_genesis() {
             *prev_header.hash()
         } else {

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -2,6 +2,7 @@ use self::chunk_extra::ChunkExtra;
 use crate::account::{AccessKey, Account};
 use crate::errors::EpochError;
 use crate::hash::CryptoHash;
+use crate::merkle::PartialMerkleTree;
 use crate::shard_layout::ShardLayout;
 use crate::spice::chunk_endorsement::SpiceStoredVerifiedEndorsement;
 use crate::trie_key::TrieKey;
@@ -1381,6 +1382,23 @@ pub struct SpiceUncertifiedChunkInfo {
     pub chunk_id: SpiceChunkId,
     pub missing_endorsements: Vec<AccountId>,
     pub present_endorsements: Vec<(AccountId, SpiceStoredVerifiedEndorsement)>,
+}
+
+/// Value of `DBCol::CertifiedBlockMerkleTree`: the certified accumulator as of a block
+/// (children build on `tree`) plus the leaves it newly certified. The leaves are indexed
+/// per-ordinal only when the block is canonical, so the ordinal index ignores forks.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, ProtocolSchema)]
+pub struct CertifiedBlockAccumulatorState {
+    pub tree: PartialMerkleTree,
+    pub newly_certified_leaves: Vec<CertifiedBlockLeaf>,
+}
+
+/// One certified-block leaf: the block it certifies and its reconstructed lite-view hash.
+/// The ordinal and frontier are derived on replay, so they are not stored.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, ProtocolSchema)]
+pub struct CertifiedBlockLeaf {
+    pub certified_block_hash: CryptoHash,
+    pub leaf_hash: CryptoHash,
 }
 
 /// Keeps the current status of a single yield/resume operation. Before yielding and after executing

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1061,8 +1061,7 @@ pub struct BlockHeaderInnerLiteView {
     /// The merkle root of all the block hashes
     pub block_merkle_root: CryptoHash,
     /// Spice (V7 headers only): merkle root anchoring certified execution roots.
-    /// Borsh-skipped to keep the persisted `EpochLightClientBlocks` layout intact;
-    /// carried over JSON and reconstructed on demand.
+    /// Borsh-skipped to keep the persisted `EpochLightClientBlocks` layout intact.
     #[borsh(skip)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub certified_block_merkle_root: Option<CryptoHash>,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1060,12 +1060,12 @@ pub struct BlockHeaderInnerLiteView {
     pub next_bp_hash: CryptoHash,
     /// The merkle root of all the block hashes
     pub block_merkle_root: CryptoHash,
-    /// Spice (V7 headers only): merkle root anchoring certified execution roots.
+    /// Spice: merkle root anchoring certified execution roots (`None` on older headers).
     /// Borsh-skipped to keep the persisted `EpochLightClientBlocks` layout intact.
     #[borsh(skip)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub certified_block_merkle_root: Option<CryptoHash>,
-    /// Spice (V7 headers only): most recently certified block.
+    /// Spice: most recently certified block (`None` on older headers).
     #[borsh(skip)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_certified_block: Option<CryptoHash>,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -15,7 +15,7 @@ use crate::action::{
 };
 use crate::bandwidth_scheduler::BandwidthRequests;
 use crate::block::{Block, BlockHeader, Tip};
-use crate::block_header::BlockHeaderInnerLite;
+use crate::block_header::{BlockHeaderInnerLite, BlockHeaderInnerLiteV2};
 use crate::challenge::SlashedValidator;
 use crate::congestion_info::{CongestionInfo, CongestionInfoV1};
 use crate::errors::TxExecutionError;
@@ -1052,21 +1052,32 @@ pub struct BlockHeaderInnerLiteView {
     pub next_bp_hash: CryptoHash,
     /// The merkle root of all the block hashes
     pub block_merkle_root: CryptoHash,
+    /// Spice (V7 headers only): merkle root anchoring certified execution roots.
+    /// Borsh-skipped to keep the persisted `EpochLightClientBlocks` layout intact;
+    /// carried over JSON and reconstructed on demand.
+    #[borsh(skip)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub certified_block_merkle_root: Option<CryptoHash>,
+    /// Spice (V7 headers only): most recently certified block.
+    #[borsh(skip)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_certified_block: Option<CryptoHash>,
 }
 
 impl From<BlockHeader> for BlockHeaderInnerLiteView {
     fn from(header: BlockHeader) -> Self {
-        let inner_lite = header.inner_lite();
         BlockHeaderInnerLiteView {
-            height: inner_lite.height,
-            epoch_id: inner_lite.epoch_id.0,
-            next_epoch_id: inner_lite.next_epoch_id.0,
-            prev_state_root: inner_lite.prev_state_root,
-            outcome_root: inner_lite.prev_outcome_root,
-            timestamp: inner_lite.timestamp,
-            timestamp_nanosec: inner_lite.timestamp,
-            next_bp_hash: inner_lite.next_bp_hash,
-            block_merkle_root: inner_lite.block_merkle_root,
+            height: header.height(),
+            epoch_id: header.epoch_id().0,
+            next_epoch_id: header.next_epoch_id().0,
+            prev_state_root: *header.prev_state_root(),
+            outcome_root: *header.outcome_root(),
+            timestamp: header.raw_timestamp(),
+            timestamp_nanosec: header.raw_timestamp(),
+            next_bp_hash: *header.next_bp_hash(),
+            block_merkle_root: *header.block_merkle_root(),
+            certified_block_merkle_root: header.certified_block_merkle_root().copied(),
+            last_certified_block: header.last_certified_block().copied(),
         }
     }
 }
@@ -2713,14 +2724,28 @@ impl From<BlockHeader> for LightClientBlockLiteView {
 }
 impl LightClientBlockLiteView {
     pub fn hash(&self) -> CryptoHash {
-        let block_header_inner_lite: BlockHeaderInnerLite = self.inner_lite.clone().into();
-        combine_hash(
-            &combine_hash(
-                &hash(&borsh::to_vec(&block_header_inner_lite).unwrap()),
-                &self.inner_rest_hash,
-            ),
-            &self.prev_block_hash,
-        )
+        let inner_lite_hash = match self.inner_lite.certified_block_merkle_root {
+            Some(certified_block_merkle_root) => {
+                let inner_lite = BlockHeaderInnerLiteV2 {
+                    height: self.inner_lite.height,
+                    epoch_id: EpochId(self.inner_lite.epoch_id),
+                    next_epoch_id: EpochId(self.inner_lite.next_epoch_id),
+                    prev_state_root: self.inner_lite.prev_state_root,
+                    prev_outcome_root: self.inner_lite.outcome_root,
+                    timestamp: self.inner_lite.timestamp_nanosec,
+                    next_bp_hash: self.inner_lite.next_bp_hash,
+                    block_merkle_root: self.inner_lite.block_merkle_root,
+                    certified_block_merkle_root,
+                    last_certified_block: self.inner_lite.last_certified_block.unwrap_or_default(),
+                };
+                hash(&borsh::to_vec(&inner_lite).unwrap())
+            }
+            None => {
+                let inner_lite: BlockHeaderInnerLite = self.inner_lite.clone().into();
+                hash(&borsh::to_vec(&inner_lite).unwrap())
+            }
+        };
+        combine_hash(&combine_hash(&inner_lite_hash, &self.inner_rest_hash), &self.prev_block_hash)
     }
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -931,6 +931,10 @@ pub struct BlockHeaderView {
     pub prev_last_certified_block_epoch_id: Option<EpochId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spice_chunk_endorsement_stats: Option<Vec<SpiceChunkEndorsementStats>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub certified_block_merkle_root: Option<CryptoHash>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_certified_block: Option<CryptoHash>,
 }
 
 impl From<&BlockHeader> for BlockHeaderView {
@@ -981,6 +985,8 @@ impl From<&BlockHeader> for BlockHeaderView {
             spice_chunk_endorsement_stats: header
                 .spice_chunk_endorsement_stats()
                 .map(<[SpiceChunkEndorsementStats]>::to_vec),
+            certified_block_merkle_root: header.certified_block_merkle_root().copied(),
+            last_certified_block: header.last_certified_block().copied(),
         }
     }
 }
@@ -1019,6 +1025,8 @@ impl From<BlockHeaderView> for BlockHeader {
             view.shard_split,
             view.prev_last_certified_block_epoch_id,
             view.spice_chunk_endorsement_stats,
+            view.certified_block_merkle_root,
+            view.last_certified_block,
         )
     }
 }

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -14,7 +14,9 @@ use near_primitives::state_sync::{ShardStateSyncResponseHeader, StateHeaderKey};
 use near_primitives::transaction::{
     ExecutionOutcomeWithId, ExecutionOutcomeWithProof, SignedTransaction,
 };
-use near_primitives::types::{BlockHeight, EpochId, NumBlocks, ShardId};
+use near_primitives::types::{
+    BlockHeight, CertifiedBlockAccumulatorState, EpochId, NumBlocks, ShardId,
+};
 use near_primitives::utils::{
     get_block_shard_id, get_outcome_id_block_hash, get_receipt_proof_key,
     get_receipt_proof_target_shard_prefix, index_to_bytes,
@@ -306,14 +308,21 @@ impl ChainStoreAdapter {
         )
     }
 
-    pub fn get_certified_block_merkle_tree(
+    pub fn get_certified_block_merkle_state(
         &self,
         block_hash: &CryptoHash,
-    ) -> Result<PartialMerkleTree, Error> {
+    ) -> Result<CertifiedBlockAccumulatorState, Error> {
         option_to_not_found(
             self.store.get_ser(DBCol::certified_block_merkle_tree(), block_hash.as_ref()),
             format_args!("CERTIFIED BLOCK MERKLE TREE: {}", block_hash),
         )
+    }
+
+    pub fn get_certified_block_merkle_tree(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<PartialMerkleTree, Error> {
+        Ok(self.get_certified_block_merkle_state(block_hash)?.tree)
     }
 
     /// (frontier before leaf `ordinal`, leaf hash at `ordinal`) in the certified accumulator.

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -306,6 +306,17 @@ impl ChainStoreAdapter {
         )
     }
 
+    #[cfg(feature = "protocol_feature_spice")]
+    pub fn get_certified_block_merkle_tree(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<PartialMerkleTree, Error> {
+        option_to_not_found(
+            self.store.get_ser(DBCol::CertifiedBlockMerkleTree, block_hash.as_ref()),
+            format_args!("CERTIFIED BLOCK MERKLE TREE: {}", block_hash),
+        )
+    }
+
     pub fn get_block_hash_from_ordinal(
         &self,
         block_ordinal: NumBlocks,
@@ -444,6 +455,19 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
         block_merkle_tree: &PartialMerkleTree,
     ) {
         self.store_update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree);
+    }
+
+    #[cfg(feature = "protocol_feature_spice")]
+    pub fn set_certified_block_merkle_tree(
+        &mut self,
+        block_hash: &CryptoHash,
+        certified_block_merkle_tree: &PartialMerkleTree,
+    ) {
+        self.store_update.set_ser(
+            DBCol::CertifiedBlockMerkleTree,
+            block_hash.as_ref(),
+            certified_block_merkle_tree,
+        );
     }
 
     pub fn set_block_ordinal(&mut self, block_ordinal: NumBlocks, block_hash: &CryptoHash) {

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -316,6 +316,24 @@ impl ChainStoreAdapter {
         )
     }
 
+    /// (frontier before leaf `ordinal`, leaf hash at `ordinal`) in the certified accumulator.
+    pub fn get_certified_accumulator_by_ordinal(
+        &self,
+        ordinal: u64,
+    ) -> Result<(PartialMerkleTree, CryptoHash), Error> {
+        option_to_not_found(
+            self.store.get_ser(DBCol::certified_accumulator_by_ordinal(), &index_to_bytes(ordinal)),
+            format_args!("CERTIFIED ACCUMULATOR BY ORDINAL: {}", ordinal),
+        )
+    }
+
+    pub fn get_certified_block_leaf_ordinal(&self, block_hash: &CryptoHash) -> Result<u64, Error> {
+        option_to_not_found(
+            self.store.get_ser(DBCol::certified_block_leaf_ordinal(), block_hash.as_ref()),
+            format_args!("CERTIFIED BLOCK LEAF ORDINAL: {}", block_hash),
+        )
+    }
+
     pub fn get_block_hash_from_ordinal(
         &self,
         block_ordinal: NumBlocks,

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -456,18 +456,6 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
         self.store_update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree);
     }
 
-    pub fn set_certified_block_merkle_tree(
-        &mut self,
-        block_hash: &CryptoHash,
-        certified_block_merkle_tree: &PartialMerkleTree,
-    ) {
-        self.store_update.set_ser(
-            DBCol::certified_block_merkle_tree(),
-            block_hash.as_ref(),
-            certified_block_merkle_tree,
-        );
-    }
-
     pub fn set_block_ordinal(&mut self, block_ordinal: NumBlocks, block_hash: &CryptoHash) {
         self.store_update.set_ser(DBCol::BlockOrdinal, &index_to_bytes(block_ordinal), block_hash);
     }

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -306,13 +306,12 @@ impl ChainStoreAdapter {
         )
     }
 
-    #[cfg(feature = "protocol_feature_spice")]
     pub fn get_certified_block_merkle_tree(
         &self,
         block_hash: &CryptoHash,
     ) -> Result<PartialMerkleTree, Error> {
         option_to_not_found(
-            self.store.get_ser(DBCol::CertifiedBlockMerkleTree, block_hash.as_ref()),
+            self.store.get_ser(DBCol::certified_block_merkle_tree(), block_hash.as_ref()),
             format_args!("CERTIFIED BLOCK MERKLE TREE: {}", block_hash),
         )
     }
@@ -457,14 +456,13 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
         self.store_update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree);
     }
 
-    #[cfg(feature = "protocol_feature_spice")]
     pub fn set_certified_block_merkle_tree(
         &mut self,
         block_hash: &CryptoHash,
         certified_block_merkle_tree: &PartialMerkleTree,
     ) {
         self.store_update.set_ser(
-            DBCol::CertifiedBlockMerkleTree,
+            DBCol::certified_block_merkle_tree(),
             block_hash.as_ref(),
             certified_block_merkle_tree,
         );

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -187,7 +187,13 @@ pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
 fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
     // TODO(spice): decide how the reader handles spice columns.
     #[cfg(feature = "protocol_feature_spice")]
-    if col == DBCol::ReceiptProofs {
+    if matches!(
+        col,
+        DBCol::ReceiptProofs
+            | DBCol::CertifiedBlockMerkleTree
+            | DBCol::CertifiedAccumulatorByOrdinal
+            | DBCol::CertifiedBlockLeafOrdinal
+    ) {
         return true;
     }
     matches!(

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -207,6 +207,12 @@ pub enum DBCol {
     /// - *Rows*: BlockHash
     /// - *Column type*: PartialMerkleTree - MerklePath to the leaf + number of leaves in the whole tree.
     BlockMerkleTree,
+    /// Spice: like BlockMerkleTree but over reconstructed certified light-client block
+    /// hashes; anchors light-client proofs of certified execution results.
+    /// - *Rows*: BlockHash
+    /// - *Column type*: PartialMerkleTree
+    #[cfg(feature = "protocol_feature_spice")]
+    CertifiedBlockMerkleTree,
     /// Mapping from height to the set of Chunk Hashes that were included in the block at that height.
     /// - *Rows*: height (u64)
     /// - *Column type*: Vec<ChunkHash (CryptoHash)>
@@ -667,6 +673,8 @@ impl DBCol {
             | DBCol::StateSyncNewChunks
             // TODO(early-kickout): Make ChunkProducers a cold column when GC is implemented.
             => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockMerkleTree => false,
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => false,
         }
@@ -729,6 +737,8 @@ impl DBCol {
             | DBCol::EpochStart
             | DBCol::EpochSyncProof
             | DBCol::EpochValidatorInfo => GcPolicy::Permanent,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockMerkleTree => GcPolicy::Permanent,
 
             DBCol::AccountAnnouncements
             | DBCol::_BlockExtra
@@ -864,6 +874,8 @@ impl DBCol {
             DBCol::UncertifiedChunks => &[DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::SpiceEndorsementStats => &[DBKeyType::BlockHash],
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockMerkleTree => &[DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::ContractAccesses => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             #[cfg(feature = "nightly")]

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -890,6 +890,13 @@ impl DBCol {
         panic!("Expected protocol_feature_spice to be enabled")
     }
 
+    pub fn certified_block_merkle_tree() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::CertifiedBlockMerkleTree;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
     pub fn receipt_proofs() -> DBCol {
         #[cfg(feature = "protocol_feature_spice")]
         return DBCol::ReceiptProofs;

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -208,9 +208,11 @@ pub enum DBCol {
     /// - *Column type*: PartialMerkleTree - MerklePath to the leaf + number of leaves in the whole tree.
     BlockMerkleTree,
     /// Spice: like BlockMerkleTree but over reconstructed certified light-client block
-    /// hashes; anchors light-client proofs of certified execution results.
+    /// hashes; anchors light-client proofs of certified execution results. Also carries
+    /// the leaves this block newly certified, replayed into the per-ordinal index on
+    /// canonicalization.
     /// - *Rows*: BlockHash
-    /// - *Column type*: PartialMerkleTree
+    /// - *Column type*: CertifiedBlockAccumulatorState
     #[cfg(feature = "protocol_feature_spice")]
     CertifiedBlockMerkleTree,
     /// Spice: per certified-leaf ordinal, the accumulator frontier before that

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -213,6 +213,18 @@ pub enum DBCol {
     /// - *Column type*: PartialMerkleTree
     #[cfg(feature = "protocol_feature_spice")]
     CertifiedBlockMerkleTree,
+    /// Spice: per certified-leaf ordinal, the accumulator frontier before that
+    /// leaf plus the leaf hash. Enables light-client inclusion proofs.
+    /// - *Rows*: certified ordinal (u64)
+    /// - *Column type*: (PartialMerkleTree, CryptoHash)
+    #[cfg(feature = "protocol_feature_spice")]
+    CertifiedAccumulatorByOrdinal,
+    /// Spice: a block's position (certified ordinal) in the certified
+    /// accumulator. Present once the block's execution is certified.
+    /// - *Rows*: BlockHash
+    /// - *Column type*: u64
+    #[cfg(feature = "protocol_feature_spice")]
+    CertifiedBlockLeafOrdinal,
     /// Mapping from height to the set of Chunk Hashes that were included in the block at that height.
     /// - *Rows*: height (u64)
     /// - *Column type*: Vec<ChunkHash (CryptoHash)>
@@ -675,6 +687,10 @@ impl DBCol {
             => false,
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::CertifiedBlockMerkleTree => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedAccumulatorByOrdinal => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockLeafOrdinal => false,
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => false,
         }
@@ -739,6 +755,10 @@ impl DBCol {
             | DBCol::EpochValidatorInfo => GcPolicy::Permanent,
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::CertifiedBlockMerkleTree => GcPolicy::Permanent,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedAccumulatorByOrdinal => GcPolicy::Permanent,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockLeafOrdinal => GcPolicy::Permanent,
 
             DBCol::AccountAnnouncements
             | DBCol::_BlockExtra
@@ -877,6 +897,10 @@ impl DBCol {
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::CertifiedBlockMerkleTree => &[DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedAccumulatorByOrdinal => &[DBKeyType::BlockOrdinal],
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockLeafOrdinal => &[DBKeyType::BlockHash],
+            #[cfg(feature = "protocol_feature_spice")]
             DBCol::ContractAccesses => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => &[DBKeyType::BlockHash, DBKeyType::ShardId],
@@ -893,6 +917,20 @@ impl DBCol {
     pub fn certified_block_merkle_tree() -> DBCol {
         #[cfg(feature = "protocol_feature_spice")]
         return DBCol::CertifiedBlockMerkleTree;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn certified_accumulator_by_ordinal() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::CertifiedAccumulatorByOrdinal;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn certified_block_leaf_ordinal() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::CertifiedBlockLeafOrdinal;
         #[cfg(not(feature = "protocol_feature_spice"))]
         panic!("Expected protocol_feature_spice to be enabled")
     }

--- a/core/store/src/merkle_proof.rs
+++ b/core/store/src/merkle_proof.rs
@@ -42,71 +42,12 @@ pub trait MerkleProofAccess {
                 block_hash, head_block_hash
             )));
         }
-
-        let mut path = vec![];
-        let mut level: u64 = 0;
-        let mut index = leaf_index;
-        let mut remaining_size = tree_size;
-
-        while remaining_size > 1 {
-            // Walk left.
-            {
-                let cur_index = index;
-                let cur_level = level;
-                // Go up as long as we're the right child. This finds us a largest subtree for
-                // which our current node is the rightmost descendant of at the current level.
-                while remaining_size > 1 && index % 2 == 1 {
-                    index /= 2;
-                    remaining_size = (remaining_size + 1) / 2;
-                    level += 1;
-                }
-                if level > cur_level {
-                    // To prove this subtree, get the partial tree for the rightmost leaf of the
-                    // subtree. It's OK if we can only go as far as the tree size; we'll aggregate
-                    // whatever we can. Once we have the partial tree, we push in whatever is in
-                    // between the levels we just traversed.
-                    let ordinal = ((cur_index + 1) * (1 << cur_level) - 1).min(tree_size - 1);
-                    let partial_tree_for_node = get_block_merkle_tree_from_ordinal(self, ordinal)?;
-                    partial_tree_for_node.iter_path_from_bottom(|hash, l| {
-                        if l >= cur_level && l < level {
-                            path.push(MerklePathItem { hash, direction: Direction::Left });
-                        }
-                    });
-                }
-            }
-            // Walk right.
-            if remaining_size > 1 {
-                let right_sibling_index = index + 1;
-                let ordinal = ((right_sibling_index + 1) * (1 << level) - 1).min(tree_size - 1);
-                // It's possible the right sibling is actually zero, in which case we don't push
-                // anything to the path.
-                if ordinal >= right_sibling_index * (1 << level) {
-                    // To prove a right sibling, get the partial tree for the rightmost leaf of the
-                    // subtree, and also get the block hash of the rightmost leaf; combining these
-                    // two will give us the root of the subtree, i.e. the right sibling.
-                    let leaf_hash = self.get_block_hash_from_ordinal(ordinal)?;
-                    let mut subtree_root_hash = leaf_hash;
-                    if level > 0 {
-                        let partial_tree_for_sibling =
-                            get_block_merkle_tree_from_ordinal(self, ordinal)?;
-                        partial_tree_for_sibling.iter_path_from_bottom(|hash, l| {
-                            if l < level {
-                                subtree_root_hash = combine_hash(&hash, &subtree_root_hash);
-                            }
-                        });
-                    }
-                    path.push(MerklePathItem {
-                        hash: subtree_root_hash,
-                        direction: Direction::Right,
-                    });
-                }
-
-                index = (index + 1) / 2;
-                remaining_size = (remaining_size + 1) / 2;
-                level += 1;
-            }
-        }
-        Ok(path)
+        compute_merkle_path_by_ordinal(
+            leaf_index,
+            tree_size,
+            |ordinal| get_block_merkle_tree_from_ordinal(self, ordinal),
+            |ordinal| self.get_block_hash_from_ordinal(ordinal),
+        )
     }
 }
 
@@ -116,6 +57,78 @@ fn get_block_merkle_tree_from_ordinal(
 ) -> Result<Arc<PartialMerkleTree>, Error> {
     let block_hash = this.get_block_hash_from_ordinal(block_ordinal)?;
     this.get_block_merkle_tree(&block_hash)
+}
+
+/// Build the inclusion path for the leaf at `leaf_index` within a merkle tree of
+/// `tree_size` leaves, given ordinal-indexed access to each leaf hash and to the
+/// frontier (partial) tree as of each ordinal. Accesses no leaf below `leaf_index`
+/// nor any frontier beyond `tree_size`. Assumes `leaf_index < tree_size`.
+pub fn compute_merkle_path_by_ordinal(
+    leaf_index: u64,
+    tree_size: u64,
+    partial_tree_at_ordinal: impl Fn(u64) -> Result<Arc<PartialMerkleTree>, Error>,
+    leaf_hash_at_ordinal: impl Fn(u64) -> Result<CryptoHash, Error>,
+) -> Result<MerklePath, Error> {
+    let mut path = vec![];
+    let mut level: u64 = 0;
+    let mut index = leaf_index;
+    let mut remaining_size = tree_size;
+
+    while remaining_size > 1 {
+        // Walk left.
+        {
+            let cur_index = index;
+            let cur_level = level;
+            // Go up as long as we're the right child. This finds us a largest subtree for
+            // which our current node is the rightmost descendant of at the current level.
+            while remaining_size > 1 && index % 2 == 1 {
+                index /= 2;
+                remaining_size = (remaining_size + 1) / 2;
+                level += 1;
+            }
+            if level > cur_level {
+                // To prove this subtree, get the partial tree for the rightmost leaf of the
+                // subtree. It's OK if we can only go as far as the tree size; we'll aggregate
+                // whatever we can. Once we have the partial tree, we push in whatever is in
+                // between the levels we just traversed.
+                let ordinal = ((cur_index + 1) * (1 << cur_level) - 1).min(tree_size - 1);
+                let partial_tree_for_node = partial_tree_at_ordinal(ordinal)?;
+                partial_tree_for_node.iter_path_from_bottom(|hash, l| {
+                    if l >= cur_level && l < level {
+                        path.push(MerklePathItem { hash, direction: Direction::Left });
+                    }
+                });
+            }
+        }
+        // Walk right.
+        if remaining_size > 1 {
+            let right_sibling_index = index + 1;
+            let ordinal = ((right_sibling_index + 1) * (1 << level) - 1).min(tree_size - 1);
+            // It's possible the right sibling is actually zero, in which case we don't push
+            // anything to the path.
+            if ordinal >= right_sibling_index * (1 << level) {
+                // To prove a right sibling, get the partial tree for the rightmost leaf of the
+                // subtree, and also get the leaf hash of the rightmost leaf; combining these
+                // two will give us the root of the subtree, i.e. the right sibling.
+                let leaf_hash = leaf_hash_at_ordinal(ordinal)?;
+                let mut subtree_root_hash = leaf_hash;
+                if level > 0 {
+                    let partial_tree_for_sibling = partial_tree_at_ordinal(ordinal)?;
+                    partial_tree_for_sibling.iter_path_from_bottom(|hash, l| {
+                        if l < level {
+                            subtree_root_hash = combine_hash(&hash, &subtree_root_hash);
+                        }
+                    });
+                }
+                path.push(MerklePathItem { hash: subtree_root_hash, direction: Direction::Right });
+            }
+
+            index = (index + 1) / 2;
+            remaining_size = (remaining_size + 1) / 2;
+            level += 1;
+        }
+    }
+    Ok(path)
 }
 
 impl MerkleProofAccess for Store {

--- a/core/store/src/merkle_proof.rs
+++ b/core/store/src/merkle_proof.rs
@@ -62,13 +62,18 @@ fn get_block_merkle_tree_from_ordinal(
 /// Build the inclusion path for the leaf at `leaf_index` within a merkle tree of
 /// `tree_size` leaves, given ordinal-indexed access to each leaf hash and to the
 /// frontier (partial) tree as of each ordinal. Accesses no leaf below `leaf_index`
-/// nor any frontier beyond `tree_size`. Assumes `leaf_index < tree_size`.
+/// nor any frontier beyond `tree_size`. Errors if `leaf_index >= tree_size`.
 pub fn compute_merkle_path_by_ordinal(
     leaf_index: u64,
     tree_size: u64,
     partial_tree_at_ordinal: impl Fn(u64) -> Result<Arc<PartialMerkleTree>, Error>,
     leaf_hash_at_ordinal: impl Fn(u64) -> Result<CryptoHash, Error>,
 ) -> Result<MerklePath, Error> {
+    if leaf_index >= tree_size {
+        return Err(Error::Other(format!(
+            "leaf index {leaf_index} is ahead of tree size {tree_size}"
+        )));
+    }
     let mut path = vec![];
     let mut level: u64 = 0;
     let mut index = leaf_index;

--- a/integration-tests/src/tests/features/shard_split_validation.rs
+++ b/integration-tests/src/tests/features/shard_split_validation.rs
@@ -220,6 +220,8 @@ fn block_header_shard_split_validation() {
         forged_shard_split.clone(), // FORGED shard_split
         header.prev_last_certified_block_epoch_id().cloned(),
         header.spice_chunk_endorsement_stats().map(<[_]>::to_vec),
+        header.certified_block_merkle_root().cloned(),
+        header.last_certified_block().cloned(),
     );
 
     // Sanity: the forged header is V6 and carries the forged shard_split.

--- a/test-loop-tests/src/tests/spice/basic.rs
+++ b/test-loop-tests/src/tests/spice/basic.rs
@@ -15,17 +15,15 @@ use near_async::time::Duration;
 use near_chain::spice::core::get_last_certified_block_header;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::{GetBlock, ProcessTxRequest, Query, QueryError};
-use near_client_primitives::types::{GetBlockError, GetBlockProof, GetExecutionOutcome};
+use near_client_primitives::types::GetBlockError;
 use near_network::types::NetworkRequests;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::compute_root_from_path;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::{create_test_signer, create_user_test_signer};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
     AccountId, AccountInfo, Balance, BlockId, BlockReference, Finality, ShardId,
-    TransactionOrReceiptId,
 };
 use near_primitives::utils::get_block_shard_id_rev;
 use near_primitives::views::QueryRequest;
@@ -222,117 +220,6 @@ fn test_spice_chain_with_delayed_execution() {
     let view_account_result =
         env.node_for_account(&producer_account).view_account_query(&receiver).unwrap();
     assert_eq!(view_account_result.amount, Balance::from_near(1));
-}
-
-/// End-to-end light-client proof over spice certified results: submit a tx,
-/// fetch an `EXPERIMENTAL_light_client_proof`-style proof via the view client,
-/// and verify it the way a light client would — anchoring `block_proof` to the
-/// head's `certified_block_merkle_root` rather than `block_merkle_root`.
-#[test]
-#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_spice_light_client_proof() {
-    init_test_logger();
-
-    let sender = create_account_id("sender");
-    let receiver = create_account_id("receiver");
-
-    let num_producers = 2;
-    let num_validators = 1;
-    let validators_spec = create_validators_spec(num_producers, num_validators);
-    let clients = validators_spec_clients(&validators_spec);
-
-    let genesis = TestLoopBuilder::new_genesis_builder()
-        .validators_spec(validators_spec)
-        .add_user_account_simple(sender.clone(), Balance::from_near(10))
-        .add_user_account_simple(receiver.clone(), Balance::from_near(0))
-        .build();
-
-    let producer_account = clients[0].clone();
-    let mut env = TestLoopBuilder::new()
-        .genesis(genesis)
-        .epoch_config_store_from_genesis()
-        .clients(clients)
-        .build();
-
-    let block_hash = env.node_for_account(&producer_account).head().last_block_hash;
-    let tx = SignedTransaction::send_money(
-        1,
-        sender.clone(),
-        receiver.clone(),
-        &create_user_test_signer(&sender),
-        Balance::from_near(1),
-        block_hash,
-    );
-    let tx_hash = tx.get_hash();
-    env.runner_for_account(&producer_account).run_tx(tx, Duration::seconds(20));
-
-    // Run enough further blocks that the tx's block is fully certified and well
-    // inside the certified accumulator of a final head.
-    let target = env.node_for_account(&producer_account).head().height + 25;
-    env.runner_for_account(&producer_account).run_until_head_height(target);
-
-    // The head we prove against, and its committed certified-accumulator root.
-    let (light_client_head, head_certified_root) = {
-        let node = env.node_for_account(&producer_account);
-        let head = node.client().chain.final_head().unwrap().last_block_hash;
-        let root = *node
-            .client()
-            .chain
-            .get_block_header(&head)
-            .unwrap()
-            .certified_block_merkle_root()
-            .expect("spice head must commit certified_block_merkle_root");
-        (head, root)
-    };
-
-    let (outcome_proof, outcome_root_proof, block_header_lite, block_proof) = {
-        let node_data = env.get_node_data_by_account_id(&producer_account);
-        let view_client = env.test_loop.data.get_mut(&node_data.view_client_sender.actor_handle());
-        let outcome_response = view_client
-            .handle(GetExecutionOutcome {
-                id: TransactionOrReceiptId::Transaction {
-                    transaction_hash: tx_hash,
-                    sender_id: sender.clone(),
-                },
-            })
-            .unwrap();
-        let block_proof_response = view_client
-            .handle(GetBlockProof {
-                block_hash: outcome_response.outcome_proof.block_hash,
-                head_block_hash: light_client_head,
-            })
-            .unwrap();
-        (
-            outcome_response.outcome_proof,
-            outcome_response.outcome_root_proof,
-            block_proof_response.block_header_lite,
-            block_proof_response.proof,
-        )
-    };
-
-    // 1. Outcome -> shard outcome root -> the block's certified combined outcome root.
-    let outcome_hashes = outcome_proof.to_hashes();
-    let outcome_hash = CryptoHash::hash_borsh(&outcome_hashes);
-    let shard_outcome_root = compute_root_from_path(&outcome_proof.proof, outcome_hash);
-    let block_outcome_root =
-        compute_root_from_path(&outcome_root_proof, CryptoHash::hash_borsh(shard_outcome_root));
-    assert_eq!(
-        block_outcome_root, block_header_lite.inner_lite.outcome_root,
-        "reconstructed outcome root must match the certified outcome root in block_header_lite",
-    );
-
-    // 2. The certified roots are populated (not the production-time placeholders).
-    assert_ne!(block_header_lite.inner_lite.outcome_root, CryptoHash::default());
-    assert_ne!(block_header_lite.inner_lite.prev_state_root, CryptoHash::default());
-    assert!(block_header_lite.inner_lite.certified_block_merkle_root.is_some());
-
-    // 3. The certified leaf is included in the head's certified accumulator.
-    let leaf = block_header_lite.hash();
-    let computed_root = compute_root_from_path(&block_proof, leaf);
-    assert_eq!(
-        computed_root, head_certified_root,
-        "block proof must anchor the certified leaf to the head's certified_block_merkle_root",
-    );
 }
 
 /// Test that consensus cannot be more than one epoch ahead of certification.

--- a/test-loop-tests/src/tests/spice/basic.rs
+++ b/test-loop-tests/src/tests/spice/basic.rs
@@ -15,15 +15,17 @@ use near_async::time::Duration;
 use near_chain::spice::core::get_last_certified_block_header;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::{GetBlock, ProcessTxRequest, Query, QueryError};
-use near_client_primitives::types::GetBlockError;
+use near_client_primitives::types::{GetBlockError, GetBlockProof, GetExecutionOutcome};
 use near_network::types::NetworkRequests;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::compute_root_from_path;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::{create_test_signer, create_user_test_signer};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
     AccountId, AccountInfo, Balance, BlockId, BlockReference, Finality, ShardId,
+    TransactionOrReceiptId,
 };
 use near_primitives::utils::get_block_shard_id_rev;
 use near_primitives::views::QueryRequest;
@@ -220,6 +222,117 @@ fn test_spice_chain_with_delayed_execution() {
     let view_account_result =
         env.node_for_account(&producer_account).view_account_query(&receiver).unwrap();
     assert_eq!(view_account_result.amount, Balance::from_near(1));
+}
+
+/// End-to-end light-client proof over spice certified results: submit a tx,
+/// fetch an `EXPERIMENTAL_light_client_proof`-style proof via the view client,
+/// and verify it the way a light client would — anchoring `block_proof` to the
+/// head's `certified_block_merkle_root` rather than `block_merkle_root`.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_proof() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+
+    let num_producers = 2;
+    let num_validators = 1;
+    let validators_spec = create_validators_spec(num_producers, num_validators);
+    let clients = validators_spec_clients(&validators_spec);
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .validators_spec(validators_spec)
+        .add_user_account_simple(sender.clone(), Balance::from_near(10))
+        .add_user_account_simple(receiver.clone(), Balance::from_near(0))
+        .build();
+
+    let producer_account = clients[0].clone();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store_from_genesis()
+        .clients(clients)
+        .build();
+
+    let block_hash = env.node_for_account(&producer_account).head().last_block_hash;
+    let tx = SignedTransaction::send_money(
+        1,
+        sender.clone(),
+        receiver.clone(),
+        &create_user_test_signer(&sender),
+        Balance::from_near(1),
+        block_hash,
+    );
+    let tx_hash = tx.get_hash();
+    env.runner_for_account(&producer_account).run_tx(tx, Duration::seconds(20));
+
+    // Run enough further blocks that the tx's block is fully certified and well
+    // inside the certified accumulator of a final head.
+    let target = env.node_for_account(&producer_account).head().height + 25;
+    env.runner_for_account(&producer_account).run_until_head_height(target);
+
+    // The head we prove against, and its committed certified-accumulator root.
+    let (light_client_head, head_certified_root) = {
+        let node = env.node_for_account(&producer_account);
+        let head = node.client().chain.final_head().unwrap().last_block_hash;
+        let root = *node
+            .client()
+            .chain
+            .get_block_header(&head)
+            .unwrap()
+            .certified_block_merkle_root()
+            .expect("spice head must commit certified_block_merkle_root");
+        (head, root)
+    };
+
+    let (outcome_proof, outcome_root_proof, block_header_lite, block_proof) = {
+        let node_data = env.get_node_data_by_account_id(&producer_account);
+        let view_client = env.test_loop.data.get_mut(&node_data.view_client_sender.actor_handle());
+        let outcome_response = view_client
+            .handle(GetExecutionOutcome {
+                id: TransactionOrReceiptId::Transaction {
+                    transaction_hash: tx_hash,
+                    sender_id: sender.clone(),
+                },
+            })
+            .unwrap();
+        let block_proof_response = view_client
+            .handle(GetBlockProof {
+                block_hash: outcome_response.outcome_proof.block_hash,
+                head_block_hash: light_client_head,
+            })
+            .unwrap();
+        (
+            outcome_response.outcome_proof,
+            outcome_response.outcome_root_proof,
+            block_proof_response.block_header_lite,
+            block_proof_response.proof,
+        )
+    };
+
+    // 1. Outcome -> shard outcome root -> the block's certified combined outcome root.
+    let outcome_hashes = outcome_proof.to_hashes();
+    let outcome_hash = CryptoHash::hash_borsh(&outcome_hashes);
+    let shard_outcome_root = compute_root_from_path(&outcome_proof.proof, outcome_hash);
+    let block_outcome_root =
+        compute_root_from_path(&outcome_root_proof, CryptoHash::hash_borsh(shard_outcome_root));
+    assert_eq!(
+        block_outcome_root, block_header_lite.inner_lite.outcome_root,
+        "reconstructed outcome root must match the certified outcome root in block_header_lite",
+    );
+
+    // 2. The certified roots are populated (not the production-time placeholders).
+    assert_ne!(block_header_lite.inner_lite.outcome_root, CryptoHash::default());
+    assert_ne!(block_header_lite.inner_lite.prev_state_root, CryptoHash::default());
+    assert!(block_header_lite.inner_lite.certified_block_merkle_root.is_some());
+
+    // 3. The certified leaf is included in the head's certified accumulator.
+    let leaf = block_header_lite.hash();
+    let computed_root = compute_root_from_path(&block_proof, leaf);
+    assert_eq!(
+        computed_root, head_certified_root,
+        "block proof must anchor the certified leaf to the head's certified_block_merkle_root",
+    );
 }
 
 /// Test that consensus cannot be more than one epoch ahead of certification.

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -111,3 +111,56 @@ fn test_spice_light_client_proof() {
     let b_leaf = block_header_lite.hash();
     assert_eq!(compute_root_from_path(&block_proof, b_leaf), head_certified_root);
 }
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_cross_epoch() {
+    init_test_logger();
+
+    let mut env = TestLoopBuilder::new()
+        .validators_spec(create_validators_spec(2, 1))
+        .enable_rpc()
+        .epoch_length(5)
+        .build();
+
+    // The light client's last known block lives in this epoch.
+    env.rpc_runner().run_until_new_epoch();
+    let last_block_hash = env.rpc_node().head().last_block_hash;
+    let last_epoch_id = env.rpc_node().head().epoch_id;
+
+    // Move the head two epochs ahead. next_light_client_block must then return the stored
+    // epoch block for the in-between epoch, not a freshly computed head block.
+    env.rpc_runner().run_until_new_epoch();
+    let in_between_epoch_id = env.rpc_node().head().epoch_id;
+    env.rpc_runner().run_until_new_epoch();
+    assert_ne!(env.rpc_node().head().epoch_id, last_epoch_id);
+    assert_ne!(env.rpc_node().head().epoch_id, in_between_epoch_id);
+
+    let light_client_block = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetNextLightClientBlock { last_block_hash })
+        .unwrap()
+        .expect("cross-epoch next_light_client_block must return the stored epoch block");
+    // The stored block is the in-between epoch's, confirming the cross-epoch branch ran.
+    assert_eq!(light_client_block.inner_lite.epoch_id, in_between_epoch_id.0);
+
+    // A cross-epoch light-client block must carry the certified fields, equal to what the
+    // corresponding on-chain block header committed.
+    let certified_block_merkle_root = light_client_block
+        .inner_lite
+        .certified_block_merkle_root
+        .expect("cross-epoch light-client block must carry certified_block_merkle_root");
+    let last_certified_block = light_client_block
+        .inner_lite
+        .last_certified_block
+        .expect("cross-epoch light-client block must carry last_certified_block");
+    let header = env
+        .rpc_node()
+        .client()
+        .chain
+        .get_block_header_by_height(light_client_block.inner_lite.height)
+        .unwrap();
+    assert_eq!(Some(&certified_block_merkle_root), header.certified_block_merkle_root());
+    assert_eq!(Some(&last_certified_block), header.last_certified_block());
+}

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -30,7 +30,7 @@ fn test_spice_light_client_proof() {
     let tx = SignedTransaction::send_money(
         1,
         sender.clone(),
-        receiver.clone(),
+        receiver,
         &create_user_test_signer(&sender),
         Balance::from_near(1),
         env.rpc_node().head().last_block_hash,
@@ -44,10 +44,8 @@ fn test_spice_light_client_proof() {
     // accumulator the proof anchors to.
     env.rpc_runner().run_until_head_certifies(tx_height);
 
-    // Obtain the trusted head the way a light client does -- from
-    // next_light_client_block, which returns a final block by construction -- and take
-    // the certified anchor root from it. Its `last_block_hash` is the client's
-    // previously tracked head; use the head's prev.
+    // The trusted head + its certified anchor root, from next_light_client_block (which
+    // returns a final block). Pass the head's prev as the client's last tracked head.
     let final_head = env
         .rpc_node_mut()
         .view_client_actor()
@@ -76,7 +74,7 @@ fn test_spice_light_client_proof() {
         .handle(GetExecutionOutcome {
             id: TransactionOrReceiptId::Transaction {
                 transaction_hash: tx_hash,
-                sender_id: sender.clone(),
+                sender_id: sender,
             },
         })
         .unwrap();
@@ -93,9 +91,8 @@ fn test_spice_light_client_proof() {
     let block_header_lite = block_proof_response.block_header_lite;
     let block_proof = block_proof_response.proof;
 
-    // Verify the tx the way a light client does: chain two merkle inclusion proofs
-    // through the block B that executed it, with SPICE's certified accumulator standing
-    // in for block_merkle_root. Each proof recomputes a root from a leaf and a path:
+    // Verify like a light client: two merkle proofs chained through block B, the
+    // certified accumulator standing in for block_merkle_root:
     //
     //   tx outcome --outcome_proof--> B's certified outcome_root   (read from B's lite view)
     //   B's leaf   --block_proof----> head's certified accumulator  (trusted via the head)
@@ -108,8 +105,7 @@ fn test_spice_light_client_proof() {
     assert_eq!(b_outcome_root, block_header_lite.inner_lite.outcome_root);
 
     // 2. B is included in the certified accumulator the trusted head commits to.
-    // (B's whole reconstructed lite view -- certified state/outcome roots included -- is
-    // hashed into this leaf, so a faithful reconstruction is what makes the proof verify.)
+    // (B's whole reconstructed lite view is hashed into the leaf, so it's verified too.)
     let b_leaf = block_header_lite.hash();
     assert_eq!(compute_root_from_path(&block_proof, b_leaf), head_certified_root);
 }

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -1,0 +1,115 @@
+use crate::setup::builder::TestLoopBuilder;
+use crate::utils::account::{create_account_id, create_validators_spec};
+use near_async::messaging::Handler as _;
+use near_async::time::Duration;
+use near_client::GetBlock;
+use near_client_primitives::types::{GetBlockProof, GetExecutionOutcome, GetNextLightClientBlock};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::compute_root_from_path;
+use near_primitives::test_utils::create_user_test_signer;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::{Balance, BlockReference, Finality, TransactionOrReceiptId};
+use near_primitives::views::LightClientBlockLiteView;
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_proof() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+
+    let mut env = TestLoopBuilder::new()
+        .validators_spec(create_validators_spec(2, 1))
+        .enable_rpc()
+        .add_user_account(&sender, Balance::from_near(10))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+
+    let tx = SignedTransaction::send_money(
+        1,
+        sender.clone(),
+        receiver.clone(),
+        &create_user_test_signer(&sender),
+        Balance::from_near(1),
+        env.rpc_node().head().last_block_hash,
+    );
+    let tx_hash = tx.get_hash();
+    let outcome = env.rpc_runner().execute_tx(tx, Duration::seconds(20)).unwrap();
+    let tx_block_hash = outcome.transaction_outcome.block_hash;
+    let tx_height =
+        env.rpc_node().client().chain.get_block_header(&tx_block_hash).unwrap().height();
+    // Run until the head certifies the tx's block, so its leaf is in the certified
+    // accumulator the proof anchors to.
+    env.rpc_runner().run_until_head_certifies(tx_height);
+
+    // Obtain the trusted head the way a light client does -- from
+    // next_light_client_block, which returns a final block by construction -- and take
+    // the certified anchor root from it. Its `last_block_hash` is the client's
+    // previously tracked head; use the head's prev.
+    let final_head = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetBlock(BlockReference::Finality(Finality::Final)))
+        .unwrap();
+    let light_client_block = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetNextLightClientBlock { last_block_hash: final_head.header.prev_hash })
+        .unwrap()
+        .expect("next_light_client_block must return the certified head");
+    let head_certified_root = light_client_block
+        .inner_lite
+        .certified_block_merkle_root
+        .expect("light-client head must commit certified_block_merkle_root");
+    let light_client_head = LightClientBlockLiteView {
+        prev_block_hash: light_client_block.prev_block_hash,
+        inner_rest_hash: light_client_block.inner_rest_hash,
+        inner_lite: light_client_block.inner_lite.clone(),
+    }
+    .hash();
+
+    let outcome_response = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetExecutionOutcome {
+            id: TransactionOrReceiptId::Transaction {
+                transaction_hash: tx_hash,
+                sender_id: sender.clone(),
+            },
+        })
+        .unwrap();
+    let block_proof_response = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetBlockProof {
+            block_hash: outcome_response.outcome_proof.block_hash,
+            head_block_hash: light_client_head,
+        })
+        .unwrap();
+    let outcome_proof = outcome_response.outcome_proof;
+    let outcome_root_proof = outcome_response.outcome_root_proof;
+    let block_header_lite = block_proof_response.block_header_lite;
+    let block_proof = block_proof_response.proof;
+
+    // Verify the tx the way a light client does: chain two merkle inclusion proofs
+    // through the block B that executed it, with SPICE's certified accumulator standing
+    // in for block_merkle_root. Each proof recomputes a root from a leaf and a path:
+    //
+    //   tx outcome --outcome_proof--> B's certified outcome_root   (read from B's lite view)
+    //   B's leaf   --block_proof----> head's certified accumulator  (trusted via the head)
+
+    // 1. The tx's outcome is committed in B's certified outcome_root.
+    let outcome_hash = CryptoHash::hash_borsh(&outcome_proof.to_hashes());
+    let shard_outcome_root = compute_root_from_path(&outcome_proof.proof, outcome_hash);
+    let b_outcome_root =
+        compute_root_from_path(&outcome_root_proof, CryptoHash::hash_borsh(shard_outcome_root));
+    assert_eq!(b_outcome_root, block_header_lite.inner_lite.outcome_root);
+
+    // 2. B is included in the certified accumulator the trusted head commits to.
+    // (B's whole reconstructed lite view -- certified state/outcome roots included -- is
+    // hashed into this leaf, so a faithful reconstruction is what makes the proof verify.)
+    let b_leaf = block_header_lite.hash();
+    assert_eq!(compute_root_from_path(&block_proof, b_leaf), head_certified_root);
+}

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -40,9 +40,11 @@ fn test_spice_light_client_proof() {
     let tx_block_hash = outcome.transaction_outcome.block_hash;
     let tx_height =
         env.rpc_node().client().chain.get_block_header(&tx_block_hash).unwrap().height();
-    // Run until the head certifies the tx's block, so its leaf is in the certified
-    // accumulator the proof anchors to.
-    env.rpc_runner().run_until_head_certifies(tx_height);
+    // The proof anchors to the final head's prev, so run one block past the consensus
+    // head that certified the tx -- making that head the final head's prev.
+    env.rpc_runner().run_until_certified(tx_height);
+    let certified_head_height = env.rpc_node().head().height;
+    env.rpc_runner().run_until_final_head_height(certified_head_height + 1);
 
     // The trusted head + its certified anchor root, from next_light_client_block (which
     // returns a final block). Pass the head's prev as the client's last tracked head.

--- a/test-loop-tests/src/tests/spice/mod.rs
+++ b/test-loop-tests/src/tests/spice/mod.rs
@@ -1,4 +1,5 @@
 mod basic;
+mod light_client;
 mod malicious_chunk_producer;
 mod resharding;
 mod utils;

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -516,6 +516,32 @@ impl<'a> NodeRunner<'a> {
         );
     }
 
+    /// Run until the final head commits a `last_certified_block` at height >=
+    /// `height`. A light-client proof anchors to the final head's committed
+    /// certification (as of its prev), and `GetBlockProof` requires a final,
+    /// canonical head -- so this is the condition for such a proof over a tx at
+    /// `height` to be constructible.
+    pub fn run_until_head_certifies(&mut self, height: BlockHeight) {
+        let initial_height = self.head().height;
+        let height_diff = height.saturating_sub(initial_height) as usize;
+        // Certification trails consensus by the execution delay, and the final head
+        // trails consensus by the (currently observed) finality gap.
+        let extra = self.node_data.expected_execution_delay() as usize;
+        let finality_gap = self.head().height.saturating_sub(self.final_head().height) as usize;
+        let timeout = self.calculate_block_distance_timeout(height_diff + extra + finality_gap);
+        self.run_until(
+            |node| {
+                let chain = &node.client().chain;
+                let final_head = chain.final_head().unwrap().last_block_hash;
+                let header = chain.get_block_header(&final_head).unwrap();
+                header
+                    .last_certified_block()
+                    .is_some_and(|hash| chain.get_block_header(hash).unwrap().height() >= height)
+            },
+            timeout,
+        );
+    }
+
     pub fn run_until_new_epoch(&mut self) {
         let curr_epoch_id = self.head().epoch_id;
         let epoch_length = self.client().config.epoch_length as usize;

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -516,11 +516,8 @@ impl<'a> NodeRunner<'a> {
         );
     }
 
-    /// Run until the final head commits a `last_certified_block` at height >=
-    /// `height`. A light-client proof anchors to the final head's committed
-    /// certification (as of its prev), and `GetBlockProof` requires a final,
-    /// canonical head -- so this is the condition for such a proof over a tx at
-    /// `height` to be constructible.
+    /// Run until the final head's committed `last_certified_block` reaches `height` --
+    /// when a light-client proof for a tx at `height` becomes constructible.
     pub fn run_until_head_certifies(&mut self, height: BlockHeight) {
         let initial_height = self.head().height;
         let height_diff = height.saturating_sub(initial_height) as usize;

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -516,29 +516,6 @@ impl<'a> NodeRunner<'a> {
         );
     }
 
-    /// Run until the final head's committed `last_certified_block` reaches `height` --
-    /// when a light-client proof for a tx at `height` becomes constructible.
-    pub fn run_until_head_certifies(&mut self, height: BlockHeight) {
-        let initial_height = self.head().height;
-        let height_diff = height.saturating_sub(initial_height) as usize;
-        // Certification trails consensus by the execution delay, and the final head
-        // trails consensus by the (currently observed) finality gap.
-        let extra = self.node_data.expected_execution_delay() as usize;
-        let finality_gap = self.head().height.saturating_sub(self.final_head().height) as usize;
-        let timeout = self.calculate_block_distance_timeout(height_diff + extra + finality_gap);
-        self.run_until(
-            |node| {
-                let chain = &node.client().chain;
-                let final_head = chain.final_head().unwrap().last_block_hash;
-                let header = chain.get_block_header(&final_head).unwrap();
-                header
-                    .last_certified_block()
-                    .is_some_and(|hash| chain.get_block_header(hash).unwrap().height() >= height)
-            },
-            timeout,
-        );
-    }
-
     pub fn run_until_new_epoch(&mut self) {
         let curr_epoch_id = self.head().epoch_id;
         let epoch_length = self.client().config.epoch_length as usize;


### PR DESCRIPTION
Prepares SPICE for light clients. Because SPICE executes chunks asynchronously, block headers no longer carry post-execution state/outcome roots at production time, so a light client following only the header chain cannot reconstruct them.

This commits a `certified_block_merkle_root` in the V7 block header: a merkle accumulator over the reconstructed light-client lite view of every block whose execution results are certified. Light-client verification is unchanged from the classic path except that `block_proof` anchors to `certified_block_merkle_root` instead of `block_merkle_root`. The RPC reconstructs each certified block's lite view (certified state/outcome roots filled into the classic slots) on demand, so the `next_light_client_block` and `EXPERIMENTAL_light_client_proof` response shapes are preserved.

Storage is additive with no DB migration: the new view fields are borsh-skipped, and the accumulator plus a per-leaf-ordinal index for inclusion proofs live in new columns.

Includes an end-to-end test (`test_spice_light_client_proof`) that submits a transaction and verifies an execution-outcome proof against the head's `certified_block_merkle_root`.

Follow-ups not included here: updating the in-repo `neard verify-proof` CLI and `pytest/lib/lightclient.py` verifiers for the SPICE anchor, and regenerating `protocol_schema.toml`.