### PR TITLE
feat(cloud-archive): archive across the resharding boundary

### DIFF
--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -403,6 +403,7 @@ impl CloudArchivalWriter {
         batch_range: &BatchRange,
     ) -> Result<Option<CryptoHash>, near_chain_primitives::Error> {
         let chain_store = self.hot_store.chain_store();
+        let mut epoch_ending = None;
         for height in batch_range.start()..=batch_range.end() {
             let block_hash = match chain_store.get_block_hash_by_height(height) {
                 Ok(hash) => hash,
@@ -410,10 +411,14 @@ impl CloudArchivalWriter {
                 Err(other) => return Err(other),
             };
             if self.epoch_manager.is_next_block_epoch_start(&block_hash)? {
-                return Ok(Some(block_hash));
+                assert!(
+                    epoch_ending.is_none(),
+                    "batch_size < epoch_length guarantees at most one epoch boundary per batch"
+                );
+                epoch_ending = Some(block_hash);
             }
         }
-        Ok(None)
+        Ok(epoch_ending)
     }
 
     /// Archives the block batch if the local block head is behind `batch_range.end()`.
@@ -446,7 +451,7 @@ impl CloudArchivalWriter {
         shard_layout: &ShardLayout,
         tracked_shards: &[ShardUId],
         epoch_ending_block_hash: Option<CryptoHash>,
-    ) -> Result<Vec<ShardId>, CloudArchivingError> {
+    ) -> Result<Vec<(ShardId, BlockHeight)>, CloudArchivingError> {
         let shard_batches = self.shard_batches_to_archive(
             batch_range,
             shard_layout,
@@ -473,7 +478,7 @@ impl CloudArchivalWriter {
                 .archive_shard_batch(&self.hot_store, &shard_layout, &batch_range, shard_uid)
                 .await?;
             self.cloud_storage.update_cloud_shard_head(shard_id, batch_range.end()).await?;
-            advanced_shards.push(shard_id);
+            advanced_shards.push((shard_id, batch_range.end()));
         }
         Ok(advanced_shards)
     }
@@ -492,13 +497,20 @@ impl CloudArchivalWriter {
             Some(block_hash) => self.resharding_info(block_hash)?,
             None => None,
         };
-        let Some(resharding_info) = resharding_info else {
-            // No resharding: every tracked shard covers the whole batch.
+        // A resharding block at the batch's last height leaves the whole batch in
+        // the old epoch, so treat it as no resharding.
+        let Some(resharding_info) =
+            resharding_info.filter(|info| info.resharding_block_height < batch_range.end())
+        else {
+            // No resharding within the batch: every tracked shard covers the whole batch.
             return Ok(tracked_shards
                 .iter()
                 .map(|&uid| (uid, shard_layout.clone(), *batch_range))
                 .collect());
         };
+        // Carried-over shards keep their ShardUId and are read under the old layout
+        // across the boundary, which assumes a resharding keeps the layout version
+        // stable. A new shard layout version must re-verify this assumption.
         let resharding_block = resharding_info.resharding_block_height;
         let new_tracked_shards = self
             .shard_tracker
@@ -856,13 +868,15 @@ impl CloudArchivalWriter {
     }
 
     /// Advances local heads after archiving at `height`. Only updates heads for
-    /// components that were actually behind. Always advances CLOUD_MIN_HEAD.
+    /// components that were actually behind. Always advances CLOUD_MIN_HEAD. An
+    /// individual shard head may end below `height` when it is a parent shard
+    /// ending at the resharding boundary.
     /// Atomically advances `CLOUD_PREV_EPOCH_END` when an epoch ended in the batch.
     fn advance_local_heads(
         &self,
         height: BlockHeight,
         block_advanced: bool,
-        advanced_shard_ids: &[ShardId],
+        advanced_shards: &[(ShardId, BlockHeight)],
         new_prev_epoch_end: Option<CryptoHash>,
     ) -> Result<(), near_chain_primitives::Error> {
         let height_bytes = borsh::to_vec(&height).unwrap();
@@ -870,8 +884,9 @@ impl CloudArchivalWriter {
         if block_advanced {
             transaction.set(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY.to_vec(), height_bytes.clone());
         }
-        for &shard_id in advanced_shard_ids {
-            transaction.set(DBCol::BlockMisc, cloud_shard_head_key(shard_id), height_bytes.clone());
+        for &(shard_id, shard_head) in advanced_shards {
+            let shard_head_bytes = borsh::to_vec(&shard_head).unwrap();
+            transaction.set(DBCol::BlockMisc, cloud_shard_head_key(shard_id), shard_head_bytes);
         }
         transaction.set(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY.to_vec(), height_bytes);
         if let Some(new_prev_epoch_end) = new_prev_epoch_end {

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -459,10 +459,10 @@ impl CloudArchivalWriter {
             epoch_ending_block_hash,
         )?;
         let mut advanced_shards = Vec::new();
-        for (shard_uid, shard_layout, batch_range) in shard_batches {
+        for (shard_uid, shard_batch_layout, shard_batch_range) in shard_batches {
             let shard_id = shard_uid.shard_id();
             let lagging = match self.get_local_shard_head(shard_id)? {
-                Some(head) => head < batch_range.end(),
+                Some(head) => head < shard_batch_range.end(),
                 None => true,
             };
             if !lagging {
@@ -471,14 +471,19 @@ impl CloudArchivalWriter {
             // TODO(cloud_archival): Race condition between this check and the upload below.
             // Will be replaced with ifGenerationMatch:0 atomic uploads + hash metadata verification.
             let ext_head = self.cloud_storage.retrieve_cloud_shard_head_if_exists(shard_id).await?;
-            if ext_head.is_some_and(|h| h >= batch_range.end()) {
+            if ext_head.is_some_and(|h| h >= shard_batch_range.end()) {
                 continue;
             }
             self.cloud_storage
-                .archive_shard_batch(&self.hot_store, &shard_layout, &batch_range, shard_uid)
+                .archive_shard_batch(
+                    &self.hot_store,
+                    &shard_batch_layout,
+                    &shard_batch_range,
+                    shard_uid,
+                )
                 .await?;
-            self.cloud_storage.update_cloud_shard_head(shard_id, batch_range.end()).await?;
-            advanced_shards.push((shard_id, batch_range.end()));
+            self.cloud_storage.update_cloud_shard_head(shard_id, shard_batch_range.end()).await?;
+            advanced_shards.push((shard_id, shard_batch_range.end()));
         }
         Ok(advanced_shards)
     }
@@ -492,7 +497,7 @@ impl CloudArchivalWriter {
         shard_layout: &ShardLayout,
         tracked_shards: &[ShardUId],
         epoch_ending_block_hash: Option<CryptoHash>,
-    ) -> Result<Vec<(ShardUId, ShardLayout, BatchRange)>, near_chain_primitives::Error> {
+    ) -> Result<Vec<(ShardUId, ShardLayout, BatchRange)>, CloudArchivingError> {
         let resharding_info = match epoch_ending_block_hash {
             Some(block_hash) => self.resharding_info(block_hash)?,
             None => None,
@@ -508,9 +513,16 @@ impl CloudArchivalWriter {
                 .map(|&uid| (uid, shard_layout.clone(), *batch_range))
                 .collect());
         };
-        // Carried-over shards keep their ShardUId and are read under the old layout
-        // across the boundary, which assumes a resharding keeps the layout version
-        // stable. A new shard layout version must re-verify this assumption.
+        // A carried-over shard keeps its ShardUId and is read under the old layout
+        // across the boundary, which holds only when a resharding keeps the layout
+        // version stable. A new version requires re-checking this handling, so a
+        // version-changing resharding errors out instead.
+        if resharding_info.new_layout.version() != shard_layout.version() {
+            return Err(CloudArchivingError::ReshardingLayoutVersionChanged {
+                old: shard_layout.version(),
+                new: resharding_info.new_layout.version(),
+            });
+        }
         let resharding_block = resharding_info.resharding_block_height;
         let new_tracked_shards = self
             .shard_tracker

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -10,7 +10,7 @@ use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::types::{BlockHeight, EpochId, ShardId};
 use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::CloudStorage;
 use near_store::archive::cloud_storage::archive::CloudArchivingError;
@@ -125,6 +125,16 @@ struct ResolvedInitState {
     shard_heads: Vec<(ShardId, BlockHeight)>,
     min_height: BlockHeight,
     prev_epoch_end: BlockHeight,
+}
+
+/// Information about a resharding the writer archives across.
+struct ReshardingInfo {
+    /// The last block of the pre-resharding epoch, where the layout changes.
+    resharding_block_height: BlockHeight,
+    /// The epoch that takes effect after the resharding.
+    new_epoch_id: EpochId,
+    /// The shard layout that takes effect after the resharding.
+    new_layout: ShardLayout,
 }
 
 /// Creates the cloud archival writer if it is configured.
@@ -326,12 +336,12 @@ impl CloudArchivalWriter {
         &self,
         batch_range: &BatchRange,
     ) -> Result<(), CloudArchivingError> {
-        // TODO(cloud_archival): support resharding.
         let prev_epoch_end = self.get_local_prev_epoch_end()?;
         let epoch_id = self.epoch_manager.get_next_epoch_id(&prev_epoch_end)?;
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         let tracked_shards =
             self.shard_tracker.get_tracked_shards_for_non_validator_in_epoch(&epoch_id)?;
+        let epoch_ending_block_hash = self.find_epoch_ending_in_batch(batch_range)?;
 
         let block_advanced = if self.config.archive_block_data {
             self.archive_block_batch_if_lagging(batch_range).await?
@@ -339,11 +349,15 @@ impl CloudArchivalWriter {
             false
         };
         let advanced_shards = self
-            .archive_shard_batches_if_lagging(batch_range, &shard_layout, &tracked_shards)
+            .archive_shard_batches_if_lagging(
+                batch_range,
+                &shard_layout,
+                &tracked_shards,
+                epoch_ending_block_hash,
+            )
             .await?;
-        let new_prev_epoch_end = self.find_epoch_ending_in_batch(batch_range)?;
         if self.config.archive_block_data {
-            if let Some(last_block_hash) = new_prev_epoch_end {
+            if let Some(last_block_hash) = epoch_ending_block_hash {
                 self.archive_ending_epoch_data(last_block_hash).await?;
             }
         }
@@ -351,9 +365,25 @@ impl CloudArchivalWriter {
             batch_range.end(),
             block_advanced,
             &advanced_shards,
-            new_prev_epoch_end,
+            epoch_ending_block_hash,
         )?;
         Ok(())
+    }
+
+    /// The resharding at the given block, if any.
+    fn resharding_info(
+        &self,
+        block_hash: CryptoHash,
+    ) -> Result<Option<ReshardingInfo>, near_chain_primitives::Error> {
+        // A resharding boundary is an epoch boundary where the shard layout changes.
+        if !self.epoch_manager.is_resharding_boundary(&block_hash)? {
+            return Ok(None);
+        }
+        let resharding_block_height = self.epoch_manager.get_block_info(&block_hash)?.height();
+        let new_epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&block_hash)?;
+        let new_layout = self.epoch_manager.get_shard_layout(&new_epoch_id)?;
+        let resharding_info = ReshardingInfo { resharding_block_height, new_epoch_id, new_layout };
+        Ok(Some(resharding_info))
     }
 
     /// Uploads epoch data for the epoch whose last block is `last_block_hash`.
@@ -415,9 +445,16 @@ impl CloudArchivalWriter {
         batch_range: &BatchRange,
         shard_layout: &ShardLayout,
         tracked_shards: &[ShardUId],
+        epoch_ending_block_hash: Option<CryptoHash>,
     ) -> Result<Vec<ShardId>, CloudArchivingError> {
+        let shard_batches = self.shard_batches_to_archive(
+            batch_range,
+            shard_layout,
+            tracked_shards,
+            epoch_ending_block_hash,
+        )?;
         let mut advanced_shards = Vec::new();
-        for shard_uid in tracked_shards {
+        for (shard_uid, shard_layout, batch_range) in shard_batches {
             let shard_id = shard_uid.shard_id();
             let lagging = match self.get_local_shard_head(shard_id)? {
                 Some(head) => head < batch_range.end(),
@@ -433,12 +470,61 @@ impl CloudArchivalWriter {
                 continue;
             }
             self.cloud_storage
-                .archive_shard_batch(&self.hot_store, shard_layout, batch_range, *shard_uid)
+                .archive_shard_batch(&self.hot_store, &shard_layout, &batch_range, shard_uid)
                 .await?;
             self.cloud_storage.update_cloud_shard_head(shard_id, batch_range.end()).await?;
             advanced_shards.push(shard_id);
         }
         Ok(advanced_shards)
+    }
+
+    /// The shards to archive with the layout and height range each batch covers.
+    /// Across a resharding a removed parent ends at the boundary, the new child
+    /// shards start after it, and the survivors cover the whole batch.
+    fn shard_batches_to_archive(
+        &self,
+        batch_range: &BatchRange,
+        shard_layout: &ShardLayout,
+        tracked_shards: &[ShardUId],
+        epoch_ending_block_hash: Option<CryptoHash>,
+    ) -> Result<Vec<(ShardUId, ShardLayout, BatchRange)>, near_chain_primitives::Error> {
+        let resharding_info = match epoch_ending_block_hash {
+            Some(block_hash) => self.resharding_info(block_hash)?,
+            None => None,
+        };
+        let Some(resharding_info) = resharding_info else {
+            // No resharding: every tracked shard covers the whole batch.
+            return Ok(tracked_shards
+                .iter()
+                .map(|&uid| (uid, shard_layout.clone(), *batch_range))
+                .collect());
+        };
+        let resharding_block = resharding_info.resharding_block_height;
+        let new_tracked_shards = self
+            .shard_tracker
+            .get_tracked_shards_for_non_validator_in_epoch(&resharding_info.new_epoch_id)?;
+
+        let mut shard_batches = Vec::new();
+        for &shard_uid in tracked_shards {
+            // A removed parent ends at the boundary; a carried-over shard keeps the
+            // old layout across it, since the resharding leaves its account mapping unchanged.
+            // TODO(cloud_archival): test carried-over reconstruction across the boundary.
+            let batch_end = if new_tracked_shards.contains(&shard_uid) {
+                batch_range.end()
+            } else {
+                resharding_block
+            };
+            let range = BatchRange::new(batch_range.start(), batch_end);
+            shard_batches.push((shard_uid, shard_layout.clone(), range));
+        }
+        let child_range = BatchRange::new(resharding_block + 1, batch_range.end());
+        for &child_uid in &new_tracked_shards {
+            // New child shards are tracked after the resharding but not before.
+            if !tracked_shards.contains(&child_uid) {
+                shard_batches.push((child_uid, resharding_info.new_layout.clone(), child_range));
+            }
+        }
+        Ok(shard_batches)
     }
 
     /// Initializes the cloud archive writer: validates bucket config and

--- a/core/store/src/archive/cloud_storage/archive.rs
+++ b/core/store/src/archive/cloud_storage/archive.rs
@@ -8,7 +8,7 @@ use crate::archive::cloud_storage::file_id::{CloudStorageFileID, ListableCloudDi
 use crate::archive::cloud_storage::retrieve::CloudRetrievalError;
 use crate::archive::cloud_storage::shards::build_shard_batch;
 use near_primitives::errors::EpochError;
-use near_primitives::shard_layout::{ShardLayout, ShardUId};
+use near_primitives::shard_layout::{ShardLayout, ShardUId, ShardVersion};
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
 
 /// Error surfaced while archiving data or performing sanity checks.
@@ -26,6 +26,10 @@ pub enum CloudArchivingError {
     RetrievalError { error: CloudRetrievalError },
     #[error("Bucket config mismatch: local {local:?} != remote {remote:?}")]
     ConfigMismatch { local: BucketConfig, remote: BucketConfig },
+    #[error(
+        "resharding changed the shard layout version from {old} to {new}; cloud archival's carried-over shard handling must be reviewed for the new version"
+    )]
+    ReshardingLayoutVersionChanged { old: ShardVersion, new: ShardVersion },
 }
 
 impl From<std::io::Error> for CloudArchivingError {

--- a/core/store/src/archive/cloud_storage/batch.rs
+++ b/core/store/src/archive/cloud_storage/batch.rs
@@ -4,8 +4,7 @@
 //! keyed in cloud paths by the window's `BatchId`. The heights actually
 //! covered live inside the blob and may be narrower than the window for a
 //! partial first batch (genesis / fresh init / new child shard post-
-//! resharding). TODO(cloud_archival, resharding): a parent shard's last
-//! batch can also end early at a reshard boundary.
+//! resharding).
 
 use near_primitives::types::BlockHeight;
 
@@ -48,7 +47,6 @@ impl BatchRange {
 /// height, or a pre-archive cut for genesis / fresh init / resharded
 /// child). Starts at `height + 1` and ends at the next batch-aligned
 /// boundary.
-/// TODO(cloud_archival, resharding): also end early at reshard boundaries.
 pub fn compute_next_batch(height: BlockHeight, batch_size: u32) -> BatchRange {
     let batch_size = batch_size as u64;
     let start = height + 1;

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -1372,11 +1372,9 @@ fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
 /// A shard the resharding removes ends its batch at the resharding block and the
 /// new child shard starts the next, while the shards and blocks that survive the
 /// resharding span it in one batch, so a `BatchId` never names two batches.
-// TODO(cloud_archival): un-ignore once the writer archives across a resharding
-// boundary. Today a batch that spans the boundary is archived under the
-// pre-split layout and aborts on a shard missing from the other layout.
-#[ignore = "needs the resharding-boundary writer fix"]
 #[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_writer_resharding_batch_boundary() {
     let boundary_account: AccountId = "boundary".parse().unwrap();
     let mut h = CloudArchiveHarness::builder().with_resharding(boundary_account.clone()).build();

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -3,10 +3,10 @@ use crate::setup::drop_condition::DropCondition;
 use crate::setup::env::TestLoopEnv;
 use crate::utils::account::archival_account_id;
 use crate::utils::cloud_archival::{
-    WriterConfig, add_writer_node, apply_writer_settings, assert_reader_writer_parity,
-    bootstrap_reader, check_account_balance, check_data_at_height_for_shards,
-    gc_and_heads_sanity_checks, get_cloud_head, get_cloud_storage, get_writer_handle,
-    run_node_until, run_until_cloud_head_above, run_until_resharding_sync_hash_recorded,
+    ReshardingInfo, WriterConfig, add_writer_node, apply_writer_settings,
+    assert_reader_writer_parity, bootstrap_reader, check_account_balance,
+    check_data_at_height_for_shards, gc_and_heads_sanity_checks, get_cloud_head, get_cloud_storage,
+    get_writer_handle, run_node_until, run_until_one_epoch_after_resharding,
     simulate_lagging_shard, snapshots_sanity_check, stop_and_restart_node,
 };
 use crate::utils::setups::derive_new_epoch_config_from_boundary;
@@ -29,6 +29,7 @@ use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, inde
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::bucket_config::BucketConfig;
+use near_store::db::cloud_shard_head_key;
 use near_store::flat::FlatStorageManager;
 use near_store::{
     DBCol, KeyForStateChanges, ShardTries, ShardUId, StateSnapshotConfig, Store, TrieConfig,
@@ -53,6 +54,8 @@ struct CloudArchiveHarness {
     reader_id: Option<AccountId>,
     /// Post-resharding shard layout when `with_resharding` was used.
     new_shard_layout: Option<ShardLayout>,
+    /// Boundary account passed to `with_resharding`.
+    resharding_boundary: Option<AccountId>,
 }
 
 struct CloudArchiveHarnessBuilder {
@@ -65,6 +68,8 @@ struct CloudArchiveHarnessBuilder {
     dropped_chunks_by_shard: HashMap<ShardId, Vec<bool>>,
     /// Boundary account for a static resharding split.
     resharding_boundary: Option<AccountId>,
+    /// Cloud archival batch size in blocks.
+    batch_size: u32,
 }
 
 impl CloudArchiveHarnessBuilder {
@@ -122,6 +127,11 @@ impl CloudArchiveHarnessBuilder {
         self
     }
 
+    fn batch_size(mut self, batch_size: u32) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
     fn build(self) -> CloudArchiveHarness {
         let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
         let archival_kind =
@@ -137,9 +147,7 @@ impl CloudArchiveHarnessBuilder {
             .add_user_account(&user_account, CloudArchiveHarness::USER_BALANCE)
             .enable_archival_node(archival_kind)
             .gc_num_epochs_to_keep(self.gc_num_epochs_to_keep)
-            .bucket_config(BucketConfig::with_batch_size_for_test(
-                CloudArchiveHarness::TEST_BATCH_SIZE,
-            ))
+            .bucket_config(BucketConfig::with_batch_size_for_test(self.batch_size))
             .config_modifier(move |config, _client_index| {
                 if !config.archive {
                     return;
@@ -200,6 +208,7 @@ impl CloudArchiveHarnessBuilder {
             snapshot_every_n_epochs,
             reader_id: None,
             new_shard_layout,
+            resharding_boundary: self.resharding_boundary,
         }
     }
 }
@@ -224,6 +233,7 @@ impl CloudArchiveHarness {
             dropped_block_heights: HashSet::new(),
             dropped_chunks_by_shard: HashMap::new(),
             resharding_boundary: None,
+            batch_size: Self::TEST_BATCH_SIZE,
         }
     }
 
@@ -240,21 +250,19 @@ impl CloudArchiveHarness {
         self.new_shard_layout.as_ref().expect("with_resharding required")
     }
 
-    /// Runs until the resharding epoch's sync hash is recorded, then returns the
-    /// resharding block height.
-    fn run_until_resharding_sync_hash_recorded(&mut self, timeout: Duration) -> BlockHeight {
+    /// Runs the chain one epoch past the resharding.
+    fn run_until_one_epoch_after_resharding(&mut self) -> ReshardingInfo {
         let new_layout = self.new_shard_layout().clone();
-        run_until_resharding_sync_hash_recorded(
+        let base_layout = Self::default_shard_layout();
+        let boundary = self.resharding_boundary.clone().expect("with_resharding required");
+        run_until_one_epoch_after_resharding(
             &mut self.env,
             &self.archival_id,
+            &base_layout,
             &new_layout,
-            timeout,
+            &boundary,
+            self.epoch_length,
         )
-    }
-
-    /// Runs until the writer's cloud head exceeds `min_height`.
-    fn run_until_cloud_head_above(&mut self, min_height: BlockHeight, timeout: Duration) {
-        run_until_cloud_head_above(&mut self.env, &self.archival_id, min_height, timeout);
     }
 
     fn pause_writer(&self) {
@@ -1377,47 +1385,91 @@ fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_writer_resharding_batch_boundary() {
     let boundary_account: AccountId = "boundary".parse().unwrap();
-    let mut h = CloudArchiveHarness::builder().with_resharding(boundary_account.clone()).build();
-    let timeout = Duration::seconds((5 * h.epoch_length) as i64);
+    let mut h = CloudArchiveHarness::builder().with_resharding(boundary_account).build();
 
-    let resharding_block_height = h.run_until_resharding_sync_hash_recorded(timeout);
-    h.run_until_cloud_head_above(resharding_block_height + h.epoch_length, timeout);
+    // resharding data
+    let r = h.run_until_one_epoch_after_resharding();
 
     let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
-    let base_layout = CloudArchiveHarness::default_shard_layout();
-    let parent_shard = base_layout.account_id_to_shard_id(&boundary_account);
-    let child_shard = h.new_shard_layout().account_id_to_shard_id(&boundary_account);
-    let carried_shard = base_layout
-        .shard_ids()
-        .find(|shard_id| *shard_id != parent_shard)
-        .expect("layout has a shard other than the resharding parent");
-
     let shard_batch =
         |height, shard| cloud_storage.get_shard_batch_for_height(height, shard).unwrap();
     let spans_boundary = |start: BlockHeight, end: BlockHeight| {
-        start <= resharding_block_height && end > resharding_block_height
+        start <= r.resharding_block_height && end > r.resharding_block_height
     };
 
     assert_eq!(
-        shard_batch(resharding_block_height, parent_shard).end_height(),
-        resharding_block_height,
+        shard_batch(r.resharding_block_height, r.parent_shard).end_height(),
+        r.resharding_block_height,
         "removed parent shard batch must end at the resharding block"
     );
     assert_eq!(
-        shard_batch(resharding_block_height + 1, child_shard).start_height(),
-        resharding_block_height + 1,
+        shard_batch(r.resharding_block_height + 1, r.child_shard).start_height(),
+        r.resharding_block_height + 1,
         "new child shard batch must start after the resharding block"
     );
-    let carried_batch = shard_batch(resharding_block_height, carried_shard);
+    let carried_batch = shard_batch(r.resharding_block_height, r.carried_shard);
     assert!(
         spans_boundary(carried_batch.start_height(), carried_batch.end_height()),
         "carried-over shard batch must span the resharding boundary"
     );
-    let block_batch = cloud_storage.get_block_batch_for_height(resharding_block_height).unwrap();
+    let block_batch = cloud_storage.get_block_batch_for_height(r.resharding_block_height).unwrap();
     assert!(
         spans_boundary(block_batch.start_height(), block_batch.end_height()),
         "block batch must span the resharding boundary"
     );
 
+    let parent_local_head = h
+        .writer_store()
+        .get_ser::<BlockHeight>(DBCol::BlockMisc, &cloud_shard_head_key(r.parent_shard))
+        .expect("removed parent shard head recorded");
+    assert_eq!(
+        parent_local_head, r.resharding_block_height,
+        "removed parent's local head must match its cloud head at the resharding block"
+    );
+
     h.shutdown();
+}
+
+/// A resharding whose block is the last height of a batch leaves the whole batch
+/// in the old epoch, so the writer archives every shard for the whole batch under
+/// the old layout and the new child shards begin in the next batch.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_writer_resharding_on_batch_boundary() {
+    let boundary_account: AccountId = "boundary".parse().unwrap();
+    // batch_size 1 puts every block in its own batch, so the resharding block is
+    // always the end of its batch.
+    let mut h =
+        CloudArchiveHarness::builder().with_resharding(boundary_account).batch_size(1).build();
+
+    // resharding data
+    let r = h.run_until_one_epoch_after_resharding();
+
+    let cloud_storage = get_cloud_storage(&h.env, &h.archival_id);
+    let shard_batch =
+        |height, shard| cloud_storage.get_shard_batch_for_height(height, shard).unwrap();
+
+    assert_eq!(
+        shard_batch(r.resharding_block_height, r.parent_shard).end_height(),
+        r.resharding_block_height,
+        "removed parent shard batch must end at the resharding block"
+    );
+    assert_eq!(
+        shard_batch(r.resharding_block_height + 1, r.child_shard).start_height(),
+        r.resharding_block_height + 1,
+        "new child shard batch must start in the next batch, after the boundary"
+    );
+
+    h.shutdown();
+}
+
+/// The resharding writer matches carried-over shards by ShardUId and reads them
+/// under the old layout across the boundary, which assumes a resharding keeps the
+/// shard layout version stable. Listing every version forces that assumption to be
+/// re-verified when a new one lands.
+#[test]
+fn test_cloud_archival_writer_resharding_known_shard_layout_versions() {
+    match CloudArchiveHarness::default_shard_layout() {
+        ShardLayout::V0(_) | ShardLayout::V1(_) | ShardLayout::V2(_) | ShardLayout::V3(_) => {}
+    }
 }

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -47,51 +47,53 @@ pub fn run_node_until(env: &mut TestLoopEnv, account_id: &AccountId, target_heig
     env.runner_for_account(account_id).run_until_head_height(target_height);
 }
 
-/// Runs until the head epoch has shard layout `new_layout` and its sync hash is
-/// recorded, then returns the resharding block height (the last block of the
-/// epoch before the split).
-pub fn run_until_resharding_sync_hash_recorded(
+/// Resharding data observed by a test.
+pub struct ReshardingInfo {
+    /// The last block of the epoch before the split.
+    pub resharding_block_height: BlockHeight,
+    /// The shard the resharding removes.
+    pub parent_shard: ShardId,
+    /// One of the new child shards.
+    pub child_shard: ShardId,
+    /// A shard the resharding leaves unchanged.
+    pub carried_shard: ShardId,
+}
+
+/// Runs the chain one epoch past the resharding to `new_layout`.
+pub fn run_until_one_epoch_after_resharding(
     env: &mut TestLoopEnv,
     archival_id: &AccountId,
+    base_layout: &ShardLayout,
     new_layout: &ShardLayout,
-    timeout: Duration,
-) -> BlockHeight {
+    boundary: &AccountId,
+    epoch_length: BlockHeightDelta,
+) -> ReshardingInfo {
+    let timeout = Duration::seconds((5 * epoch_length) as i64);
     env.runner_for_account(archival_id).run_until(
         |node| {
             let epoch_id = node.head().epoch_id;
-            let layout = node.client().epoch_manager.get_shard_layout(&epoch_id).unwrap();
-            if layout != *new_layout {
-                return false;
-            }
-            let chain_store = node.client().chain.chain_store().store().chain_store();
-            chain_store.get_current_epoch_sync_hash(&epoch_id).is_some()
+            node.client().epoch_manager.get_shard_layout(&epoch_id).unwrap() == *new_layout
         },
         timeout,
     );
     let node = env.node_for_account(archival_id);
     let epoch_manager = &node.client().epoch_manager;
     let head = node.head().last_block_hash;
+    // Follow prev_hash to the old epoch's last block; it can sit below
+    // epoch_start - 1 when slots before the epoch start are skipped.
     let epoch_first = *epoch_manager.get_block_info(&head).unwrap().epoch_first_block();
     let resharding_block = *epoch_manager.get_block_info(&epoch_first).unwrap().prev_hash();
-    epoch_manager.get_block_info(&resharding_block).unwrap().height()
-}
+    let resharding_block_height = epoch_manager.get_block_info(&resharding_block).unwrap().height();
 
-/// Runs until the writer's `CLOUD_MIN_HEAD` exceeds `min_height`.
-pub fn run_until_cloud_head_above(
-    env: &mut TestLoopEnv,
-    archival_id: &AccountId,
-    min_height: BlockHeight,
-    timeout: Duration,
-) {
-    env.runner_for_account(archival_id).run_until(
-        move |node| {
-            let store = node.client().chain.chain_store().store();
-            let cloud_head: BlockHeight =
-                store.get_ser(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY).unwrap_or(0);
-            cloud_head > min_height
-        },
-        timeout,
-    );
+    run_node_until(env, archival_id, resharding_block_height + epoch_length);
+
+    let parent_shard = base_layout.account_id_to_shard_id(boundary);
+    let child_shard = new_layout.account_id_to_shard_id(boundary);
+    let carried_shard = base_layout
+        .shard_ids()
+        .find(|shard_id| *shard_id != parent_shard)
+        .expect("layout has a shard other than the resharding parent");
+    ReshardingInfo { resharding_block_height, parent_shard, child_shard, carried_shard }
 }
 
 fn execute_future<F: Future>(fut: F) -> F::Output {


### PR DESCRIPTION
The cloud-archival writer used one shard layout and one epoch's tracked shards for a whole batch. When a batch spans a resharding boundary, a removed parent shard has no chunk in the post-boundary blocks (those carry the child shards), so building its shard data fails with "shard {id} chunk not found" and archival aborts at the boundary.

`shard_batches_to_archive` now gives each shard its own range and layout across the boundary:
- removed parent: ends at the resharding block, old layout;
- new child: starts the next block, new layout;
- carried-over shard: spans the whole batch, old layout.

The carried-over shard must not be split at the boundary: a shard batch is keyed by `(shard_id, BatchId)`, and the `BatchId` names the whole window, so two sub-ranges of the same shard would write to the same key and overwrite each other. Reading the whole window under the old layout is correct because the resharding leaves the shard's `ShardUId` and account range unchanged. A batch ending exactly at the resharding block contains only pre-split blocks, so it is archived as an ordinary non-resharding batch.

Local cloud heads advance per shard to each shard's own archived end, so a parent that stops at the resharding block keeps its head there while the block head moves to the batch end.

Un-ignored `test_cloud_archival_writer_resharding_batch_boundary`; added `test_cloud_archival_writer_resharding_on_batch_boundary` for the boundary-at-batch-end case and `test_cloud_archival_writer_resharding_known_shard_layout_versions` to gate the assumption that a resharding keeps the shard layout version stable.