### PR TITLE
chore(store): assert gas key access keys have nonce 0

### DIFF
--- a/core/store/src/utils/mod.rs
+++ b/core/store/src/utils/mod.rs
@@ -357,6 +357,11 @@ pub fn set_access_key_by_handle(
     key_handle: PublicKeyHandle,
     access_key: &AccessKey,
 ) {
+    debug_assert!(
+        access_key.gas_key_info().is_none() || access_key.nonce == 0,
+        "gas key access key must have nonce 0, got {}",
+        access_key.nonce
+    );
     set(state_update, TrieKey::access_key(account_id, key_handle), access_key);
 }
 


### PR DESCRIPTION
Add a `debug_assert!` to `set_access_key_by_handle` verifying that any access key carrying gas key permission (`GasKeyFullAccess` or `GasKeyFunctionCall`) is stored with `nonce == 0`. Gas keys track nonces per-index separately, so the access key's own nonce should always be 0.