### PR TITLE
test(state-sync): improve state sync nayduck test flakiness

### DIFF
--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -311,6 +311,7 @@ def poll_blocks(node: cluster.LocalNode,
                 *,
                 timeout: float = 120,
                 poll_interval: float = 0.25,
+                tolerate_connection_errors: bool = False,
                 __target: typing.Optional[int] = None,
                 **kw) -> typing.Iterable[cluster.BlockId]:
     """Polls a node about the latest block and yields it when it changes.
@@ -327,6 +328,11 @@ def poll_blocks(node: cluster.LocalNode,
         timeout: Total timeout from the first status request sent to the node.
         poll_interval: How long to wait in seconds between each status request
             sent to the node.
+        tolerate_connection_errors: If True, a `ConnectionError` raised while
+            querying the node (e.g. its RPC is briefly down because it restarted
+            its own process during state sync) is swallowed and polling continues
+            until the node responds again or `timeout` is reached.  Defaults to
+            False, which propagates the error immediately.
         kw: Keyword arguments passed to `BaseDone.get_latest_block` method.
     Yields:
         A `cluster.BlockId` object for each time node’s latest block
@@ -342,7 +348,13 @@ def poll_blocks(node: cluster.LocalNode,
     previous = -1
 
     while time.monotonic() < end:
-        latest = node.get_latest_block(**kw)
+        try:
+            latest = node.get_latest_block(**kw)
+        except ConnectionError:
+            if not tolerate_connection_errors:
+                raise
+            time.sleep(poll_interval)
+            continue
         if latest.height != previous:
             if __target:
                 msg = f'{latest}  (waiting for #{__target})'

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -13,6 +13,7 @@ import subprocess
 from prometheus_client.parser import text_string_to_metric_families
 from retrying import retry
 from rc import gcloud
+from geventhttpclient import useragent
 
 import cluster
 import transaction
@@ -328,12 +329,15 @@ def poll_blocks(node: cluster.LocalNode,
         timeout: Total timeout from the first status request sent to the node.
         poll_interval: How long to wait in seconds between each status request
             sent to the node.
-        tolerate_connection_errors: If True, a `ConnectionError` raised while
+        tolerate_connection_errors: If True, a connection error raised while
             querying the node (e.g. its RPC is briefly down because it restarted
             its own process during state sync) is swallowed and polling continues
-            until the node responds again or `timeout` is reached.  Defaults to
-            False, which propagates the error immediately.
-        kw: Keyword arguments passed to `BaseDone.get_latest_block` method.
+            until the node responds again or `timeout` is reached.  This covers
+            both the built-in `ConnectionError` and `geventhttpclient`'s own
+            `useragent.ConnectionError` (retries exceeded, bad status, empty
+            response).  Defaults to False, which propagates the error immediately.
+        kw: Keyword arguments passed to `cluster.BaseNode.get_latest_block`
+            method.
     Yields:
         A `cluster.BlockId` object for each time node’s latest block
         changes including the first block when function starts.  Note that there
@@ -350,7 +354,7 @@ def poll_blocks(node: cluster.LocalNode,
     while time.monotonic() < end:
         try:
             latest = node.get_latest_block(**kw)
-        except ConnectionError:
+        except (ConnectionError, useragent.ConnectionError):
             if not tolerate_connection_errors:
                 raise
             time.sleep(poll_interval)

--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -109,12 +109,18 @@ node4.stop_checking_store()
 
 metrics4 = utils.MetricsTracker(node4)
 
-# Wait for the freshly-started node's RPC to come up before polling it. Under
-# load it can take well over the few seconds a fixed sleep would allow, and an
-# unready RPC makes the poll below fail with a connection-refused error.
+# Wait for the freshly-started node's RPC to come up before polling it, so a
+# genuinely dead node fails fast here rather than spinning until TIMEOUT below.
 node4.wait_for_rpc(timeout=30)
 
-for block_height, _ in utils.poll_blocks(node4, timeout=TIMEOUT):
+# node4 can drop its RPC again *during* catch-up: when its state-sync hash goes
+# stale it writes an epoch-sync-data-reset marker and re-execs neard, which
+# briefly closes the RPC. Tolerate that connection error and keep polling.
+for block_height, _ in utils.poll_blocks(
+        node4,
+        timeout=TIMEOUT,
+        tolerate_connection_errors=True,
+):
     assert time.time() - started < TIMEOUT, "Waiting for node 4 to catch up"
 
     if mode == 'manytx' and ctx.get_balances() == ctx.expected_balances:


### PR DESCRIPTION
The test might have be flaky due to node restarting because of stale sync hash and continuous epoch sync trigger. Fixing it by ignoring connection errors when polling.

I'm not sure if this is the same flakiness that happens in nayduck but it shouldn't hurt.