### PR TITLE
refactor: simplify snapshot host shard-cache bookkeeping

### DIFF
--- a/chain/network/src/snapshot_hosts/mod.rs
+++ b/chain/network/src/snapshot_hosts/mod.rs
@@ -178,19 +178,34 @@ impl Inner {
         Some(d)
     }
 
+    /// Adds the peer to the shard-specific caches, but only if the info matches
+    /// the sync hash we are currently syncing.
+    fn add_to_shard_hosts(&mut self, info: &SnapshotHostInfo) {
+        if self.current_state_sync_hash.as_ref() != Some(&info.sync_hash) {
+            return;
+        }
+        for shard_id in &info.shards {
+            self.hosts_for_shard.entry(*shard_id).or_default().insert(info.peer_id.clone());
+        }
+    }
+
+    fn remove_from_shard_hosts(&mut self, peer_id: &PeerId) {
+        for hosts in self.hosts_for_shard.values_mut() {
+            hosts.remove(peer_id);
+        }
+    }
+
     /// Ingests a new SnapshotHostInfo into the cache
     /// assumes that the SnapshotHostInfo is valid and new
     fn insert(&mut self, d: &Arc<SnapshotHostInfo>) {
-        // If we have an active state sync and this info matches its sync hash, add it to the shard-specific caches
-        if self.current_state_sync_hash.as_ref() == Some(&d.sync_hash) {
-            for shard_id in &d.shards {
-                self.hosts_for_shard
-                    .entry(*shard_id)
-                    .or_insert(HashSet::default())
-                    .insert(d.peer_id.clone());
+        self.add_to_shard_hosts(d.as_ref());
+        // `push` returns a different peer on eviction, or `d` itself on a
+        // same-key update; only an eviction should leave the shard caches.
+        if let Some((displaced, _)) = self.hosts.push(d.peer_id.clone(), d.clone()) {
+            if displaced != d.peer_id {
+                self.remove_from_shard_hosts(&displaced);
             }
         }
-        self.hosts.push(d.peer_id.clone(), d.clone());
     }
 
     /// Updates the current state sync hash. This is called when a local state sync request is initiated.
@@ -206,15 +221,9 @@ impl Inner {
         self.peer_selector.clear();
 
         // Rebuild the shard-specific caches with hosts that match the new sync hash
-        for (_, info) in &self.hosts {
-            if info.sync_hash == *sync_hash {
-                for shard_id in &info.shards {
-                    self.hosts_for_shard
-                        .entry(*shard_id)
-                        .or_insert(HashSet::default())
-                        .insert(info.peer_id.clone());
-                }
-            }
+        let known_hosts: Vec<_> = self.hosts.iter().map(|(_, info)| info.clone()).collect();
+        for info in &known_hosts {
+            self.add_to_shard_hosts(info.as_ref());
         }
     }
 
@@ -235,6 +244,8 @@ impl Inner {
             let Some((peer_id, info)) = self.hosts.pop_lru() else { break };
             if info.epoch_height >= min_epoch_to_keep {
                 new_hosts.push(peer_id, info);
+            } else {
+                self.remove_from_shard_hosts(&peer_id);
             }
         }
         self.hosts = new_hosts;
@@ -419,5 +430,10 @@ impl SnapshotHostsCache {
     pub(crate) fn has_selector(&self, shard_id: ShardId, part_id: u64) -> bool {
         let inner = self.0.lock();
         inner.peer_selector.contains_key(&(shard_id, part_id))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shard_host_peers(&self) -> HashSet<PeerId> {
+        self.0.lock().hosts_for_shard.values().flatten().cloned().collect()
     }
 }

--- a/chain/network/src/snapshot_hosts/tests.rs
+++ b/chain/network/src/snapshot_hosts/tests.rs
@@ -204,6 +204,12 @@ async fn test_lru_eviction() {
     assert_eq!([&info1].as_set(), unwrap(&res).as_set());
     assert_eq!([&info0, &info1].as_set(), cache.get_hosts().iter().collect::<HashSet<_>>());
 
+    // Activate the sync hash so that the shard-specific host caches are populated.
+    // All hosts here share epoch height 123, hence the same sync hash.
+    let sync_hash = CryptoHash::hash_borsh(123u64);
+    cache.select_host_for_header(&sync_hash, ShardId::new(2));
+    assert_eq!([&peer0, &peer1].as_set(), cache.shard_host_peers().iter().collect::<HashSet<_>>());
+
     // insert past capacity
     let info2 = Arc::new(make_snapshot_host_info(&peer2, 123, sid_vec(&[1, 3]), &key2));
     let res = cache.insert(vec![info2.clone()]).await;
@@ -211,6 +217,62 @@ async fn test_lru_eviction() {
     assert_eq!([&info2].as_set(), unwrap(&res).as_set());
     // check that the oldest data was evicted
     assert_eq!([&info1, &info2].as_set(), cache.get_hosts().iter().collect::<HashSet<_>>());
+    // the evicted host must not linger in the shard-specific caches either
+    assert_eq!([&peer1, &peer2].as_set(), cache.shard_host_peers().iter().collect::<HashSet<_>>());
+}
+
+#[tokio::test]
+async fn test_update_keeps_shard_hosts() {
+    init_test_logger();
+    let mut rng = make_rng(2947294234);
+    let rng = &mut rng;
+
+    let key0 = data::make_secret_key(rng);
+    let peer0 = PeerId::new(key0.public_key());
+
+    let config = Config { snapshot_hosts_cache_size: 100, part_selection_cache_batch_size: 1 };
+    let cache = SnapshotHostsCache::new(config);
+
+    let sid_vec = |v: &[u64]| v.iter().cloned().map(Into::into).collect_vec();
+
+    let info0 = Arc::new(make_snapshot_host_info(&peer0, 123, sid_vec(&[0, 1]), &key0));
+    cache.insert(vec![info0.clone()]).await;
+    let sync_hash = CryptoHash::hash_borsh(123u64);
+    cache.select_host_for_header(&sync_hash, ShardId::new(0));
+    assert_eq!([&peer0].as_set(), cache.shard_host_peers().iter().collect::<HashSet<_>>());
+
+    // Re-inserting the same peer displaces only its own previous entry, which is
+    // not an eviction and must not drop it from the shard caches.
+    let info0_new = Arc::new(make_snapshot_host_info(&peer0, 124, sid_vec(&[0, 1]), &key0));
+    cache.insert(vec![info0_new.clone()]).await;
+    assert_eq!([&peer0].as_set(), cache.shard_host_peers().iter().collect::<HashSet<_>>());
+}
+
+#[tokio::test]
+async fn test_discard_removes_shard_hosts() {
+    init_test_logger();
+    let mut rng = make_rng(2947294234);
+    let rng = &mut rng;
+
+    let key0 = data::make_secret_key(rng);
+    let peer0 = PeerId::new(key0.public_key());
+
+    let config = Config { snapshot_hosts_cache_size: 100, part_selection_cache_batch_size: 1 };
+    let cache = SnapshotHostsCache::new_with_epoch_retention_window(config, 1);
+
+    let sid_vec = |v: &[u64]| v.iter().cloned().map(Into::into).collect_vec();
+
+    let info0 = Arc::new(make_snapshot_host_info(&peer0, 123, sid_vec(&[0, 1]), &key0));
+    cache.insert(vec![info0.clone()]).await;
+    let sync_hash = CryptoHash::hash_borsh(123u64);
+    cache.select_host_for_header(&sync_hash, ShardId::new(0));
+    assert_eq!([&peer0].as_set(), cache.shard_host_peers().iter().collect::<HashSet<_>>());
+
+    // Advancing the epoch past the retention window discards peer0, which must
+    // also disappear from the shard caches.
+    cache.set_current_epoch_height(125);
+    assert!(cache.get_hosts().is_empty());
+    assert!(cache.shard_host_peers().is_empty());
 }
 
 // In each test, we will have a list of these, where they will indicate the function we


### PR DESCRIPTION
Small cleanup of the snapshot host cache: refactor code into shared helpers and keeps `hosts_for_shard` consistent with the bounded hosts cache when entries are evicted or discarded.