### PR TITLE
feat(spice): add certified light-client header fields (schema)

### DIFF
--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -46,6 +46,8 @@ pub fn create_light_client_block_view(
         timestamp_nanosec: block_header.raw_timestamp(),
         next_bp_hash: *block_header.next_bp_hash(),
         block_merkle_root: *block_header.block_merkle_root(),
+        certified_block_merkle_root: block_header.certified_block_merkle_root().copied(),
+        last_certified_block: block_header.last_certified_block().copied(),
     };
     let inner_rest_hash = hash(&block_header.inner_rest_bytes());
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1164,6 +1164,9 @@ impl Client {
                 newly_certified_block_execution_results,
                 prev_last_certified_block_epoch_id,
                 spice_chunk_endorsement_stats,
+                // TODO(spice): set from the certified accumulator once it lands.
+                certified_block_merkle_root: CryptoHash::default(),
+                last_certified_block: CryptoHash::default(),
             })
         } else {
             None

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -265,6 +265,9 @@ impl Block {
             spice_info.as_ref().map(|info| info.prev_last_certified_block_epoch_id);
         let spice_chunk_endorsement_stats =
             spice_info.as_ref().map(|info| info.spice_chunk_endorsement_stats.clone());
+        let certified_block_merkle_root =
+            spice_info.as_ref().map(|info| info.certified_block_merkle_root);
+        let last_certified_block = spice_info.as_ref().map(|info| info.last_certified_block);
         let body = if let Some(spice_info) = spice_info {
             BlockBody::new_for_spice(chunks, vrf_value, vrf_proof, spice_info.core_statements)
         } else {
@@ -303,6 +306,8 @@ impl Block {
             shard_split,
             prev_last_certified_block_epoch_id,
             spice_chunk_endorsement_stats,
+            certified_block_merkle_root,
+            last_certified_block,
         );
 
         Self::new_block(header, body)
@@ -652,6 +657,10 @@ pub struct SpiceNewBlockProductionInfo {
     /// Accumulated per-validator endorsement stats for the epoch; non-empty
     /// only on the last block of an epoch.
     pub spice_chunk_endorsement_stats: Vec<SpiceChunkEndorsementStats>,
+    /// Certified-block merkle root committed in the header (as of prev block).
+    pub certified_block_merkle_root: CryptoHash,
+    /// Most recently certified block (as of prev block).
+    pub last_certified_block: CryptoHash,
 }
 
 /// Distinguishes between new and old chunks.

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -46,6 +46,34 @@ pub struct BlockHeaderInnerLite {
     pub block_merkle_root: CryptoHash,
 }
 
+/// Spice commits certified execution roots so light clients can verify them
+/// from the headers alone.
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Default,
+    ProtocolSchema,
+)]
+pub struct BlockHeaderInnerLiteV2 {
+    pub height: BlockHeight,
+    pub epoch_id: EpochId,
+    pub next_epoch_id: EpochId,
+    pub prev_state_root: MerkleHash,
+    pub prev_outcome_root: MerkleHash,
+    pub timestamp: u64,
+    pub next_bp_hash: CryptoHash,
+    pub block_merkle_root: CryptoHash,
+    /// Merkle root over the reconstructed light-client lite views of every
+    /// block whose spice execution results are certified.
+    pub certified_block_merkle_root: CryptoHash,
+    pub last_certified_block: CryptoHash,
+}
+
 #[derive(
     BorshSerialize, BorshDeserialize, serde::Serialize, Debug, Clone, Eq, PartialEq, ProtocolSchema,
 )]
@@ -680,7 +708,7 @@ pub struct BlockHeaderV7 {
     /// Inner part of the block header that gets hashed.
     /// It's split into two parts: one that is sent to light clients,
     /// and the other which contains the rest of information.
-    pub inner_lite: BlockHeaderInnerLite,
+    pub inner_lite: BlockHeaderInnerLiteV2,
     pub inner_rest: BlockHeaderInnerRestV7,
 
     /// Signature of the block producer.
@@ -823,6 +851,8 @@ impl BlockHeader {
         shard_split: Option<(ShardId, AccountId)>,
         prev_last_certified_block_epoch_id: Option<EpochId>,
         spice_chunk_endorsement_stats: Option<Vec<SpiceChunkEndorsementStats>>,
+        certified_block_merkle_root: Option<CryptoHash>,
+        last_certified_block: Option<CryptoHash>,
     ) -> Self {
         Self::new_impl(
             current_protocol_version,
@@ -856,6 +886,8 @@ impl BlockHeader {
             shard_split,
             prev_last_certified_block_epoch_id,
             spice_chunk_endorsement_stats,
+            certified_block_merkle_root,
+            last_certified_block,
         )
     }
 
@@ -892,6 +924,8 @@ impl BlockHeader {
         shard_split: Option<(ShardId, AccountId)>,
         prev_last_certified_block_epoch_id: Option<EpochId>,
         spice_chunk_endorsement_stats: Option<Vec<SpiceChunkEndorsementStats>>,
+        certified_block_merkle_root: Option<CryptoHash>,
+        last_certified_block: Option<CryptoHash>,
     ) -> Self {
         let header = Self::new_impl(
             epoch_protocol_version,
@@ -925,6 +959,8 @@ impl BlockHeader {
             shard_split,
             prev_last_certified_block_epoch_id,
             spice_chunk_endorsement_stats,
+            certified_block_merkle_root,
+            last_certified_block,
         );
         // Note: We do not panic but only log if the hash of the created header does not match the expected hash (From the view)
         // because there are tests that check if we can downgrade a BlockHeader's view a previous version, in which case the hash
@@ -968,6 +1004,8 @@ impl BlockHeader {
         shard_split: Option<(ShardId, AccountId)>,
         prev_last_certified_block_epoch_id: Option<EpochId>,
         spice_chunk_endorsement_stats: Option<Vec<SpiceChunkEndorsementStats>>,
+        certified_block_merkle_root: Option<CryptoHash>,
+        last_certified_block: Option<CryptoHash>,
     ) -> Self {
         let inner_lite = BlockHeaderInnerLite {
             height,
@@ -993,6 +1031,22 @@ impl BlockHeader {
             let spice_chunk_endorsement_stats = spice_chunk_endorsement_stats.expect(
                 "BlockHeaderV7 requires spice_chunk_endorsement_stats when Spice is enabled",
             );
+            let certified_block_merkle_root = certified_block_merkle_root
+                .expect("BlockHeaderV7 requires certified_block_merkle_root when Spice is enabled");
+            let last_certified_block = last_certified_block
+                .expect("BlockHeaderV7 requires last_certified_block when Spice is enabled");
+            let inner_lite = BlockHeaderInnerLiteV2 {
+                height,
+                epoch_id,
+                next_epoch_id,
+                prev_state_root,
+                prev_outcome_root: outcome_root,
+                timestamp,
+                next_bp_hash,
+                block_merkle_root,
+                certified_block_merkle_root,
+                last_certified_block,
+            };
             let inner_rest = BlockHeaderInnerRestV7 {
                 block_body_hash,
                 prev_chunk_outgoing_receipts_root,
@@ -1093,13 +1147,14 @@ impl BlockHeader {
     /// Exactly one of the `signer` and `signature` must be provided.
     /// If `signer` is given signs the header with given `prev_hash`, `inner_lite`, and `inner_rest` and returns the hash and signature of the header.
     /// If `signature` is given, uses the signature as is and only computes the hash.
-    fn compute_hash_and_sign<T>(
+    fn compute_hash_and_sign<L, T>(
         signature_source: SignatureSource,
         prev_hash: CryptoHash,
-        inner_lite: &BlockHeaderInnerLite,
+        inner_lite: &L,
         inner_rest: &T,
     ) -> (CryptoHash, Signature)
     where
+        L: BorshSerialize + ?Sized,
         T: BorshSerialize + ?Sized,
     {
         let hash = BlockHeader::compute_hash(
@@ -1140,6 +1195,10 @@ impl BlockHeader {
             } else {
                 None
             };
+        let genesis_certified_block_merkle_root =
+            ProtocolFeature::Spice.enabled(genesis_protocol_version).then(CryptoHash::default);
+        let genesis_last_certified_block =
+            ProtocolFeature::Spice.enabled(genesis_protocol_version).then(CryptoHash::default);
         Self::new_impl(
             genesis_protocol_version,
             genesis_protocol_version,
@@ -1172,6 +1231,8 @@ impl BlockHeader {
             None, // shard_split
             genesis_prev_last_certified_block_epoch_id,
             genesis_spice_chunk_endorsement_stats,
+            genesis_certified_block_merkle_root,
+            genesis_last_certified_block,
         )
     }
 
@@ -1677,15 +1738,20 @@ impl BlockHeader {
     }
 
     #[inline]
-    pub fn inner_lite(&self) -> &BlockHeaderInnerLite {
+    pub fn certified_block_merkle_root(&self) -> Option<&CryptoHash> {
         match self {
-            BlockHeader::BlockHeaderV1(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV2(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV3(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV4(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV5(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV6(header) => &header.inner_lite,
-            BlockHeader::BlockHeaderV7(header) => &header.inner_lite,
+            BlockHeader::BlockHeaderV7(header) => {
+                Some(&header.inner_lite.certified_block_merkle_root)
+            }
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn last_certified_block(&self) -> Option<&CryptoHash> {
+        match self {
+            BlockHeader::BlockHeaderV7(header) => Some(&header.inner_lite.last_certified_block),
+            _ => None,
         }
     }
 

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -939,6 +939,8 @@ pub struct TestBlockBuilder {
     newly_certified_block_execution_results: Vec<crate::types::BlockExecutionResults>,
     prev_last_certified_block_epoch_id: Option<EpochId>,
     spice_chunk_endorsement_stats: Vec<SpiceChunkEndorsementStats>,
+    certified_block_merkle_root: CryptoHash,
+    last_certified_block: CryptoHash,
 }
 
 #[cfg(feature = "clock")]
@@ -957,6 +959,13 @@ impl TestBlockBuilder {
             *prev_header.next_epoch_id()
         };
         let chunks_len = prev_chunks.len();
+        // Default the last certified block to genesis (no certification in most tests),
+        // carried forward from prev. Tests that certify set it explicitly.
+        let last_certified_block = if prev_header.is_genesis() {
+            *prev_header.hash()
+        } else {
+            prev_header.last_certified_block().copied().unwrap_or_else(|| *prev_header.hash())
+        };
         Self {
             clock,
             signer,
@@ -984,6 +993,8 @@ impl TestBlockBuilder {
                 None
             },
             spice_chunk_endorsement_stats: Vec::new(),
+            certified_block_merkle_root: CryptoHash::default(),
+            last_certified_block,
             prev_header,
         }
     }
@@ -1089,6 +1100,16 @@ impl TestBlockBuilder {
         self
     }
 
+    pub fn certified_block_merkle_root(mut self, root: CryptoHash) -> Self {
+        self.certified_block_merkle_root = root;
+        self
+    }
+
+    pub fn last_certified_block(mut self, block_hash: CryptoHash) -> Self {
+        self.last_certified_block = block_hash;
+        self
+    }
+
     pub fn spice_chunk_endorsement_stats(mut self, stats: Vec<SpiceChunkEndorsementStats>) -> Self {
         self.spice_chunk_endorsement_stats = stats;
         self
@@ -1146,6 +1167,8 @@ impl TestBlockBuilder {
                         .prev_last_certified_block_epoch_id
                         .expect("prev_last_certified_block_epoch_id not set for spice block"),
                     spice_chunk_endorsement_stats: self.spice_chunk_endorsement_stats,
+                    certified_block_merkle_root: self.certified_block_merkle_root,
+                    last_certified_block: self.last_certified_block,
                 }
             }),
         );

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -15,7 +15,7 @@ use crate::action::{
 };
 use crate::bandwidth_scheduler::BandwidthRequests;
 use crate::block::{Block, BlockHeader, Tip};
-use crate::block_header::BlockHeaderInnerLite;
+use crate::block_header::{BlockHeaderInnerLite, BlockHeaderInnerLiteV2};
 use crate::challenge::SlashedValidator;
 use crate::congestion_info::{CongestionInfo, CongestionInfoV1};
 use crate::errors::TxExecutionError;
@@ -931,6 +931,10 @@ pub struct BlockHeaderView {
     pub prev_last_certified_block_epoch_id: Option<EpochId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spice_chunk_endorsement_stats: Option<Vec<SpiceChunkEndorsementStats>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub certified_block_merkle_root: Option<CryptoHash>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_certified_block: Option<CryptoHash>,
 }
 
 impl From<&BlockHeader> for BlockHeaderView {
@@ -981,6 +985,8 @@ impl From<&BlockHeader> for BlockHeaderView {
             spice_chunk_endorsement_stats: header
                 .spice_chunk_endorsement_stats()
                 .map(<[SpiceChunkEndorsementStats]>::to_vec),
+            certified_block_merkle_root: header.certified_block_merkle_root().copied(),
+            last_certified_block: header.last_certified_block().copied(),
         }
     }
 }
@@ -1019,6 +1025,8 @@ impl From<BlockHeaderView> for BlockHeader {
             view.shard_split,
             view.prev_last_certified_block_epoch_id,
             view.spice_chunk_endorsement_stats,
+            view.certified_block_merkle_root,
+            view.last_certified_block,
         )
     }
 }
@@ -1052,21 +1060,31 @@ pub struct BlockHeaderInnerLiteView {
     pub next_bp_hash: CryptoHash,
     /// The merkle root of all the block hashes
     pub block_merkle_root: CryptoHash,
+    /// Spice: merkle root anchoring certified execution roots (`None` on older headers).
+    /// Borsh-skipped to keep the persisted `EpochLightClientBlocks` layout intact.
+    #[borsh(skip)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub certified_block_merkle_root: Option<CryptoHash>,
+    /// Spice: most recently certified block (`None` on older headers).
+    #[borsh(skip)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_certified_block: Option<CryptoHash>,
 }
 
 impl From<BlockHeader> for BlockHeaderInnerLiteView {
     fn from(header: BlockHeader) -> Self {
-        let inner_lite = header.inner_lite();
         BlockHeaderInnerLiteView {
-            height: inner_lite.height,
-            epoch_id: inner_lite.epoch_id.0,
-            next_epoch_id: inner_lite.next_epoch_id.0,
-            prev_state_root: inner_lite.prev_state_root,
-            outcome_root: inner_lite.prev_outcome_root,
-            timestamp: inner_lite.timestamp,
-            timestamp_nanosec: inner_lite.timestamp,
-            next_bp_hash: inner_lite.next_bp_hash,
-            block_merkle_root: inner_lite.block_merkle_root,
+            height: header.height(),
+            epoch_id: header.epoch_id().0,
+            next_epoch_id: header.next_epoch_id().0,
+            prev_state_root: *header.prev_state_root(),
+            outcome_root: *header.outcome_root(),
+            timestamp: header.raw_timestamp(),
+            timestamp_nanosec: header.raw_timestamp(),
+            next_bp_hash: *header.next_bp_hash(),
+            block_merkle_root: *header.block_merkle_root(),
+            certified_block_merkle_root: header.certified_block_merkle_root().copied(),
+            last_certified_block: header.last_certified_block().copied(),
         }
     }
 }
@@ -2713,14 +2731,28 @@ impl From<BlockHeader> for LightClientBlockLiteView {
 }
 impl LightClientBlockLiteView {
     pub fn hash(&self) -> CryptoHash {
-        let block_header_inner_lite: BlockHeaderInnerLite = self.inner_lite.clone().into();
-        combine_hash(
-            &combine_hash(
-                &hash(&borsh::to_vec(&block_header_inner_lite).unwrap()),
-                &self.inner_rest_hash,
-            ),
-            &self.prev_block_hash,
-        )
+        let inner_lite_hash = match self.inner_lite.certified_block_merkle_root {
+            Some(certified_block_merkle_root) => {
+                let inner_lite = BlockHeaderInnerLiteV2 {
+                    height: self.inner_lite.height,
+                    epoch_id: EpochId(self.inner_lite.epoch_id),
+                    next_epoch_id: EpochId(self.inner_lite.next_epoch_id),
+                    prev_state_root: self.inner_lite.prev_state_root,
+                    prev_outcome_root: self.inner_lite.outcome_root,
+                    timestamp: self.inner_lite.timestamp_nanosec,
+                    next_bp_hash: self.inner_lite.next_bp_hash,
+                    block_merkle_root: self.inner_lite.block_merkle_root,
+                    certified_block_merkle_root,
+                    last_certified_block: self.inner_lite.last_certified_block.unwrap_or_default(),
+                };
+                hash(&borsh::to_vec(&inner_lite).unwrap())
+            }
+            None => {
+                let inner_lite: BlockHeaderInnerLite = self.inner_lite.clone().into();
+                hash(&borsh::to_vec(&inner_lite).unwrap())
+            }
+        };
+        combine_hash(&combine_hash(&inner_lite_hash, &self.inner_rest_hash), &self.prev_block_hash)
     }
 }
 

--- a/integration-tests/src/tests/features/shard_split_validation.rs
+++ b/integration-tests/src/tests/features/shard_split_validation.rs
@@ -220,6 +220,8 @@ fn block_header_shard_split_validation() {
         forged_shard_split.clone(), // FORGED shard_split
         header.prev_last_certified_block_epoch_id().cloned(),
         header.spice_chunk_endorsement_stats().map(<[_]>::to_vec),
+        header.certified_block_merkle_root().cloned(),
+        header.last_certified_block().cloned(),
     );
 
     // Sanity: the forged header is V6 and carries the forged shard_split.


### PR DESCRIPTION
Adds the two spice light-client fields to the block header and threads them through, with **placeholder (default) production** — the real values come from the certified accumulator in a later PR of this stack (marked `TODO(spice)` in `client.rs`).

- `BlockHeaderInnerLiteV2` (= classic inner-lite + `certified_block_merkle_root` + `last_certified_block`); `BlockHeaderV7` switches to it; `compute_hash_and_sign` generalized over the inner-lite type.
- Replaces the unified `inner_lite()` accessor with `certified_block_merkle_root()` / `last_certified_block()` Option accessors.
- `BlockHeaderInnerLiteView` gains the two fields as `#[borsh(skip)]` + serde (keeps the persisted `EpochLightClientBlocks` layout intact); `LightClientBlockLiteView::hash()` is version-aware.
- Threads the fields through `Block::new`, `SpiceNewBlockProductionInfo`, `BlockHeaderView`, `TestBlockBuilder`.

No behavior change: nothing computes or validates the fields yet.

## Testing
- `near-primitives` unit tests; existing `near-chain` spice unit tests (placeholder production builds/processes spice blocks).

2/6 of the SPICE light-client stack (#15947). Base: #15962.