### PR TITLE
feat(spice): commit and validate certified block merkle root

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1862,6 +1862,7 @@ impl Chain {
             self.should_produce_state_witness_for_this_or_next_epoch(block.header())?;
         let epoch_to_check = self.protocol_version_check;
         let sandbox_patch_gen = block_preprocess_info.sandbox_patch_generation;
+        let spice_core_reader = self.spice_core_reader.clone();
         let mut chain_update = self.chain_update();
         let block_hash = *block.hash();
         let new_head = chain_update.postprocess_block(
@@ -1869,6 +1870,7 @@ impl Chain {
             block_preprocess_info,
             apply_results,
             should_save_state_transition_data,
+            &spice_core_reader,
         )?;
         if new_head.is_some() {
             chain_update.check_protocol_version(&block_hash, epoch_to_check)?;
@@ -2569,6 +2571,7 @@ impl Chain {
             self.spice_core_reader.validate_core_statements_in_block(&block).map_err(Box::new)?;
             self.spice_core_reader.validate_prev_last_certified_block_epoch_id(header)?;
             self.spice_core_reader.validate_spice_chunk_endorsement_stats(header)?;
+            self.spice_core_reader.validate_certified_block_header_info(header)?;
         } else {
             if block.is_spice_block() {
                 return Err(Error::Other(

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -2,9 +2,10 @@ use crate::approval_verification::verify_approvals_and_threshold_orphan;
 use crate::block_processing_utils::BlockPreprocessInfo;
 use crate::chain::collect_receipts_from_response;
 use crate::metrics::{SHARD_LAYOUT_NUM_SHARDS, SHARD_LAYOUT_VERSION};
+use crate::spice::certified_accumulator::save_certified_block_merkle_tree_for_block;
 use crate::spice::chunk_application::apply_chunk_postprocessing;
 use crate::spice::core::{
-    record_spice_endorsement_stats_for_block, record_uncertified_chunks_for_block,
+    SpiceCoreReader, record_spice_endorsement_stats_for_block, record_uncertified_chunks_for_block,
 };
 use crate::store::utils::get_block_header_on_chain_by_height;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
@@ -228,6 +229,7 @@ impl<'a> ChainUpdate<'a> {
         block_preprocess_info: BlockPreprocessInfo,
         apply_chunks_results: Vec<(ShardId, Result<ShardUpdateResult, Error>)>,
         should_save_state_transition_data: bool,
+        spice_core_reader: &SpiceCoreReader,
     ) -> Result<Option<Tip>, Error> {
         let prev_hash = block.header().prev_hash();
         let results = apply_chunks_results.into_iter().map(|(shard_id, x)| {
@@ -312,6 +314,12 @@ impl<'a> ChainUpdate<'a> {
             record_spice_endorsement_stats_for_block(
                 &mut self.chain_store_update,
                 self.epoch_manager.as_ref(),
+                &block,
+            )?;
+            // Fork-local per-block certified accumulator state.
+            save_certified_block_merkle_tree_for_block(
+                &mut self.chain_store_update,
+                spice_core_reader,
                 &block,
             )?;
         }

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -2,10 +2,12 @@ use crate::ChainStoreAccess;
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::BlockHeader;
-use near_primitives::hash::hash;
+use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::types::EpochId;
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
-use near_primitives::views::{BlockHeaderInnerLiteView, LightClientBlockView};
+use near_primitives::views::{
+    BlockHeaderInnerLiteView, LightClientBlockLiteView, LightClientBlockView,
+};
 
 pub fn get_epoch_block_producers_view(
     epoch_id: &EpochId,
@@ -16,6 +18,33 @@ pub fn get_epoch_block_producers_view(
         .iter()
         .map(|x| x.clone().into())
         .collect::<Vec<_>>())
+}
+
+/// Light-client lite view of a certified spice block, with the certified roots in the
+/// classic `prev_state_root` / `outcome_root` slots. Its `hash()` is the accumulator leaf.
+pub fn reconstruct_certified_lite_view(
+    block_header: &BlockHeader,
+    certified_state_root: CryptoHash,
+    certified_outcome_root: CryptoHash,
+) -> LightClientBlockLiteView {
+    let inner_lite = BlockHeaderInnerLiteView {
+        height: block_header.height(),
+        epoch_id: block_header.epoch_id().0,
+        next_epoch_id: block_header.next_epoch_id().0,
+        prev_state_root: certified_state_root,
+        outcome_root: certified_outcome_root,
+        timestamp: block_header.raw_timestamp(),
+        timestamp_nanosec: block_header.raw_timestamp(),
+        next_bp_hash: *block_header.next_bp_hash(),
+        block_merkle_root: *block_header.block_merkle_root(),
+        certified_block_merkle_root: block_header.certified_block_merkle_root().copied(),
+        last_certified_block: block_header.last_certified_block().copied(),
+    };
+    LightClientBlockLiteView {
+        prev_block_hash: *block_header.prev_hash(),
+        inner_rest_hash: hash(&block_header.inner_rest_bytes()),
+        inner_lite,
+    }
 }
 
 /// Creates the `LightClientBlock` from the information in the chain store for a given block.

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -1,0 +1,71 @@
+//! A merkle tree, mirroring `block_merkle_tree`, over the reconstructed lite views
+//! of certified spice blocks. Its root is the header's `certified_block_merkle_root`.
+
+use crate::lightclient::reconstruct_certified_lite_view;
+use crate::spice::core::{SpiceCoreReader, find_newly_certified_block_hashes};
+use crate::{ChainStoreAccess, ChainStoreUpdate};
+use near_chain_primitives::Error;
+use near_primitives::block::Block;
+use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::types::{CertifiedBlockAccumulatorState, CertifiedBlockLeaf};
+use near_store::adapter::chain_store::ChainStoreAdapter;
+
+/// Builds and saves the fork-local certified accumulator state for `block` (prev's tree
+/// plus `block`'s newly-certified leaves), keyed by `block`'s hash.
+pub fn save_certified_block_merkle_tree_for_block(
+    chain_store_update: &mut ChainStoreUpdate,
+    reader: &SpiceCoreReader,
+    block: &Block,
+) -> Result<(), Error> {
+    let (tree, newly_certified_leaves) =
+        build_certified_block_merkle_tree(chain_store_update.chain_store(), reader, block)?;
+    chain_store_update.save_certified_block_merkle_tree(
+        *block.header().hash(),
+        CertifiedBlockAccumulatorState { tree, newly_certified_leaves },
+    );
+    Ok(())
+}
+
+/// Returns the certified accumulator tree as of `block`, plus one entry per
+/// newly-certified leaf.
+fn build_certified_block_merkle_tree(
+    chain_store: &ChainStoreAdapter,
+    reader: &SpiceCoreReader,
+    block: &Block,
+) -> Result<(PartialMerkleTree, Vec<CertifiedBlockLeaf>), Error> {
+    if block.header().is_genesis() {
+        return Ok((PartialMerkleTree::default(), vec![]));
+    }
+    let prev_hash = block.header().prev_hash();
+    let prev_header = chain_store.get_block_header(prev_hash)?;
+    // Genesis and the pre-spice block at the activation boundary anchor an empty accumulator.
+    let prev_tree = if prev_header.is_genesis() || !prev_header.is_spice() {
+        PartialMerkleTree::default()
+    } else {
+        chain_store.get_certified_block_merkle_tree(prev_hash)?
+    };
+    let prev_uncertified = reader.get_uncertified_chunks(prev_hash)?;
+    let newly_certified =
+        find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
+
+    let mut headers = Vec::with_capacity(newly_certified.len());
+    for block_hash in &newly_certified {
+        headers.push(chain_store.get_block_header(block_hash)?);
+    }
+    headers.sort_by_key(|header| header.height());
+
+    let mut tree = prev_tree;
+    let mut leaves = Vec::with_capacity(headers.len());
+    for header in &headers {
+        // The chunks this block certifies are still in its uncommitted statements,
+        // so the certifying block must overlay them onto the committed results.
+        let (state_root, outcome_root) =
+            reader.certified_block_roots_for_certifying_block(block, header)?.ok_or_else(|| {
+                Error::Other(format!("certified block {} missing execution results", header.hash()))
+            })?;
+        let leaf_hash = reconstruct_certified_lite_view(header, state_root, outcome_root).hash();
+        leaves.push(CertifiedBlockLeaf { certified_block_hash: *header.hash(), leaf_hash });
+        tree.insert(leaf_hash);
+    }
+    Ok((tree, leaves))
+}

--- a/chain/chain/src/spice/chunk_validation.rs
+++ b/chain/chain/src/spice/chunk_validation.rs
@@ -1156,9 +1156,17 @@ mod tests {
                 )
                 .unwrap();
             let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
+            let core_reader = &self.chain.spice_core_reader;
+            let prev_hash = prev_block.header().hash();
+            let certified_block_merkle_root =
+                core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
+            let last_certified_block =
+                core_reader.last_certified_block(prev_hash).unwrap_or_default();
             TestBlockBuilder::from_prev_block(Clock::real(), prev_block, signer)
                 .chunks(chunks)
                 .spice_core_statements(vec![])
+                .certified_block_merkle_root(certified_block_merkle_root)
+                .last_certified_block(last_certified_block)
                 .build()
         }
 

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -8,7 +8,7 @@ use near_primitives::epoch_info::EpochInfo;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::merklize;
+use near_primitives::merkle::{PartialMerkleTree, merklize};
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::spice::chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
@@ -346,6 +346,55 @@ impl SpiceCoreReader {
         Ok(self
             .certified_block_roots(block_hash, &last_certified)?
             .map(|(state_root, _)| state_root))
+    }
+
+    /// The certified-block tree as of `prev_hash` (empty for genesis or a pre-spice block
+    /// at the spice activation boundary).
+    fn prev_certified_block_merkle_tree(
+        &self,
+        prev_hash: &CryptoHash,
+    ) -> Result<PartialMerkleTree, Error> {
+        let prev_header = self.chain_store.get_block_header(prev_hash)?;
+        if prev_header.is_genesis() || !prev_header.is_spice() {
+            return Ok(PartialMerkleTree::default());
+        }
+        self.chain_store.get_certified_block_merkle_tree(prev_hash)
+    }
+
+    /// Certified-block merkle root for a block built on `prev_hash` (the tree as of
+    /// `prev_hash`), committed in its header.
+    pub fn certified_block_merkle_root(&self, prev_hash: &CryptoHash) -> Result<CryptoHash, Error> {
+        Ok(self.prev_certified_block_merkle_tree(prev_hash)?.root())
+    }
+
+    /// Hash of the last fully certified block as of `prev_hash`.
+    pub fn last_certified_block(&self, prev_hash: &CryptoHash) -> Result<CryptoHash, Error> {
+        Ok(*get_last_certified_block_header(&self.chain_store, prev_hash)?.hash())
+    }
+
+    pub fn validate_certified_block_header_info(&self, header: &BlockHeader) -> Result<(), Error> {
+        let prev_hash = header.prev_hash();
+
+        let actual_root = header.certified_block_merkle_root().ok_or_else(|| {
+            Error::Other("missing certified_block_merkle_root on spice block header".to_string())
+        })?;
+        let expected_root = self.certified_block_merkle_root(prev_hash)?;
+        if &expected_root != actual_root {
+            return Err(Error::Other(format!(
+                "invalid certified_block_merkle_root: expected {expected_root:?}, got {actual_root:?}"
+            )));
+        }
+
+        let actual_last = header.last_certified_block().ok_or_else(|| {
+            Error::Other("missing last_certified_block on spice block header".to_string())
+        })?;
+        let expected_last = self.last_certified_block(prev_hash)?;
+        if &expected_last != actual_last {
+            return Err(Error::Other(format!(
+                "invalid last_certified_block: expected {expected_last:?}, got {actual_last:?}"
+            )));
+        }
+        Ok(())
     }
 
     /// Walks the canonical ancestry backwards from `from_hash` down to (but excluding)

--- a/chain/chain/src/spice/mod.rs
+++ b/chain/chain/src/spice/mod.rs
@@ -1,4 +1,5 @@
 pub mod block_application;
+pub mod certified_accumulator;
 pub mod chain;
 pub mod chunk_application;
 pub mod chunk_validation;

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -236,6 +236,38 @@ fn test_last_certified_state_root_when_execution_results_column_is_partially_wri
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_certified_block_header_info_rejects_wrong_fields() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    // b2 certifies b1, so the certified fields as of b2 are non-default.
+    let b2 = build_block(&chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, b2.clone());
+
+    // A correctly built block on b2 validates.
+    let good = block_builder(&chain, &b2).spice_core_statements(vec![]).build();
+    core_reader.validate_certified_block_header_info(good.header()).unwrap();
+
+    // A wrong certified_block_merkle_root is rejected.
+    let bad_root = block_builder(&chain, &b2)
+        .certified_block_merkle_root(*b2.hash())
+        .spice_core_statements(vec![])
+        .build();
+    let err = core_reader.validate_certified_block_header_info(bad_root.header()).unwrap_err();
+    assert!(format!("{err:?}").contains("invalid certified_block_merkle_root"), "{err:?}");
+
+    // A wrong last_certified_block is rejected (its root is still correct).
+    let bad_last = block_builder(&chain, &b2)
+        .last_certified_block(*b2.hash())
+        .spice_core_statements(vec![])
+        .build();
+    let err = core_reader.validate_certified_block_header_info(bad_last.header()).unwrap_err();
+    assert!(format!("{err:?}").contains("invalid last_certified_block"), "{err:?}");
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_all_execution_results_exist_when_all_exist() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();
@@ -1564,8 +1596,15 @@ fn block_builder(chain: &Chain, prev_block: &Block) -> TestBlockBuilder {
         .get_block_producer_info(prev_block.header().epoch_id(), prev_block.header().height() + 1)
         .unwrap();
     let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
+    let core_reader = core_reader(chain);
+    let prev_hash = prev_block.header().hash();
+    let certified_block_merkle_root =
+        core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
+    let last_certified_block = core_reader.last_certified_block(prev_hash).unwrap_or_default();
     TestBlockBuilder::from_prev_block(Clock::real(), prev_block, signer)
         .chunks(get_fake_next_block_chunk_headers(&prev_block, chain.epoch_manager.as_ref()))
+        .certified_block_merkle_root(certified_block_merkle_root)
+        .last_certified_block(last_certified_block)
 }
 
 fn build_block(

--- a/chain/chain/src/spice/tests/core_writer_actor.rs
+++ b/chain/chain/src/spice/tests/core_writer_actor.rs
@@ -696,8 +696,15 @@ fn block_builder(chain: &Chain, prev_block: &Block) -> TestBlockBuilder {
         .get_block_producer_info(prev_block.header().epoch_id(), prev_block.header().height() + 1)
         .unwrap();
     let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
+    let core_reader = core_reader(chain);
+    let prev_hash = prev_block.header().hash();
+    let certified_block_merkle_root =
+        core_reader.certified_block_merkle_root(prev_hash).unwrap_or_default();
+    let last_certified_block = core_reader.last_certified_block(prev_hash).unwrap_or_default();
     TestBlockBuilder::from_prev_block(Clock::real(), prev_block, signer)
         .chunks(get_fake_next_block_chunk_headers(&prev_block, chain.epoch_manager.as_ref()))
+        .certified_block_merkle_root(certified_block_merkle_root)
+        .last_certified_block(last_certified_block)
 }
 
 fn build_block(

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -31,8 +31,8 @@ use near_primitives::trie_key::{TrieKey, trie_key_parsers};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    BlockHeight, BlockHeightDelta, EpochId, NumBlocks, ShardId, StateChanges, StateChangesExt,
-    StateChangesKinds, StateChangesKindsExt, StateChangesRequest,
+    BlockHeight, BlockHeightDelta, CertifiedBlockAccumulatorState, EpochId, NumBlocks, ShardId,
+    StateChanges, StateChangesExt, StateChangesKinds, StateChangesKindsExt, StateChangesRequest,
 };
 use near_primitives::utils::{
     get_block_shard_id, get_outcome_id_block_hash, get_outcome_id_block_hash_rev, index_to_bytes,
@@ -1050,6 +1050,7 @@ pub(crate) struct ChainStoreCacheUpdate {
     receipts: HashMap<CryptoHash, Arc<Receipt>>,
     block_refcounts: HashMap<CryptoHash, u64>,
     block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
+    certified_block_merkle_tree: HashMap<CryptoHash, Arc<CertifiedBlockAccumulatorState>>,
     block_ordinal_to_hash: HashMap<NumBlocks, CryptoHash>,
     processed_block_heights: HashSet<BlockHeight>,
     receipt_to_tx: Vec<(CryptoHash, ReceiptToTxInfo)>,
@@ -1600,6 +1601,16 @@ impl<'a> ChainStoreUpdate<'a> {
             .insert(block_hash, Arc::new(block_merkle_tree));
     }
 
+    pub fn save_certified_block_merkle_tree(
+        &mut self,
+        block_hash: CryptoHash,
+        state: CertifiedBlockAccumulatorState,
+    ) {
+        self.chain_store_cache_update
+            .certified_block_merkle_tree
+            .insert(block_hash, Arc::new(state));
+    }
+
     fn update_and_save_block_merkle_tree(&mut self, header: &BlockHeader) -> Result<(), Error> {
         if header.is_genesis() {
             self.save_block_merkle_tree(*header.hash(), PartialMerkleTree::default());
@@ -2146,6 +2157,15 @@ impl<'a> ChainStoreUpdate<'a> {
         }
         for (block_hash, block_merkle_tree) in &self.chain_store_cache_update.block_merkle_tree {
             store_update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_merkle_tree);
+        }
+        for (block_hash, certified_block_merkle_tree) in
+            &self.chain_store_cache_update.certified_block_merkle_tree
+        {
+            store_update.set_ser(
+                DBCol::certified_block_merkle_tree(),
+                block_hash.as_ref(),
+                certified_block_merkle_tree,
+            );
         }
         for (block_ordinal, block_hash) in &self.chain_store_cache_update.block_ordinal_to_hash {
             store_update.set_ser(DBCol::BlockOrdinal, &index_to_bytes(*block_ordinal), block_hash);

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1159,14 +1159,17 @@ impl Client {
                 .chain
                 .spice_core_reader
                 .spice_chunk_endorsement_stats_for_next_block(prev_header, height)?;
+            let certified_block_merkle_root =
+                self.chain.spice_core_reader.certified_block_merkle_root(prev_header.hash())?;
+            let last_certified_block =
+                self.chain.spice_core_reader.last_certified_block(prev_header.hash())?;
             Some(SpiceNewBlockProductionInfo {
                 core_statements,
                 newly_certified_block_execution_results,
                 prev_last_certified_block_epoch_id,
                 spice_chunk_endorsement_stats,
-                // TODO(spice): set from the certified accumulator once it lands.
-                certified_block_merkle_root: CryptoHash::default(),
-                last_certified_block: CryptoHash::default(),
+                certified_block_merkle_root,
+                last_certified_block,
             })
         } else {
             None

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -264,6 +264,18 @@ pub fn create_chunk(
     };
     let epoch_sync_data_hash =
         client.epoch_manager.compute_epoch_sync_data_hash(last_block.hash()).unwrap();
+    // The chain may have certified blocks by now, so take the certified header fields
+    // from the actual chain state rather than the builder's no-certification default.
+    let (certified_block_merkle_root, last_certified_block) =
+        if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
+            let reader = &client.chain.spice_core_reader;
+            (
+                reader.certified_block_merkle_root(last_block.hash()).unwrap(),
+                reader.last_certified_block(last_block.hash()).unwrap(),
+            )
+        } else {
+            (CryptoHash::default(), CryptoHash::default())
+        };
     let block = TestBlockBuilder::from_prev_block(client.clock.clone(), &last_block, signer)
         .height(next_height)
         .chunks(vec![encoded_chunk.cloned_header()])
@@ -272,6 +284,8 @@ pub fn create_chunk(
         .block_merkle_tree(&mut block_merkle_tree)
         .spice_chunk_endorsement_stats(spice_chunk_endorsement_stats)
         .epoch_sync_data_hash(epoch_sync_data_hash)
+        .certified_block_merkle_root(certified_block_merkle_root)
+        .last_certified_block(last_certified_block)
         .build();
     let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)
         .map_err(|(err, _)| err)

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -2,6 +2,7 @@ use self::chunk_extra::ChunkExtra;
 use crate::account::{AccessKey, Account};
 use crate::errors::EpochError;
 use crate::hash::CryptoHash;
+use crate::merkle::PartialMerkleTree;
 use crate::shard_layout::ShardLayout;
 use crate::spice::chunk_endorsement::SpiceStoredVerifiedEndorsement;
 use crate::trie_key::TrieKey;
@@ -1381,6 +1382,23 @@ pub struct SpiceUncertifiedChunkInfo {
     pub chunk_id: SpiceChunkId,
     pub missing_endorsements: Vec<AccountId>,
     pub present_endorsements: Vec<(AccountId, SpiceStoredVerifiedEndorsement)>,
+}
+
+/// Value of `DBCol::CertifiedBlockMerkleTree`: the certified accumulator as of a block
+/// (children build on `tree`) plus the leaves it newly certified. The leaves are indexed
+/// per-ordinal only when the block is canonical, so the ordinal index ignores forks.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, ProtocolSchema)]
+pub struct CertifiedBlockAccumulatorState {
+    pub tree: PartialMerkleTree,
+    pub newly_certified_leaves: Vec<CertifiedBlockLeaf>,
+}
+
+/// One certified-block leaf: the block it certifies and its reconstructed lite-view hash.
+/// The ordinal and frontier are derived on replay, so they are not stored.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, ProtocolSchema)]
+pub struct CertifiedBlockLeaf {
+    pub certified_block_hash: CryptoHash,
+    pub leaf_hash: CryptoHash,
 }
 
 /// Keeps the current status of a single yield/resume operation. Before yielding and after executing

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -14,7 +14,9 @@ use near_primitives::state_sync::{ShardStateSyncResponseHeader, StateHeaderKey};
 use near_primitives::transaction::{
     ExecutionOutcomeWithId, ExecutionOutcomeWithProof, SignedTransaction,
 };
-use near_primitives::types::{BlockHeight, EpochId, NumBlocks, ShardId};
+use near_primitives::types::{
+    BlockHeight, CertifiedBlockAccumulatorState, EpochId, NumBlocks, ShardId,
+};
 use near_primitives::utils::{
     get_block_shard_id, get_outcome_id_block_hash, get_receipt_proof_key,
     get_receipt_proof_target_shard_prefix, index_to_bytes,
@@ -304,6 +306,23 @@ impl ChainStoreAdapter {
             self.store.get_ser(DBCol::BlockMerkleTree, block_hash.as_ref()),
             format_args!("BLOCK MERKLE TREE: {}", block_hash),
         )
+    }
+
+    pub fn get_certified_block_merkle_state(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<CertifiedBlockAccumulatorState, Error> {
+        option_to_not_found(
+            self.store.get_ser(DBCol::certified_block_merkle_tree(), block_hash.as_ref()),
+            format_args!("CERTIFIED BLOCK MERKLE TREE: {}", block_hash),
+        )
+    }
+
+    pub fn get_certified_block_merkle_tree(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<PartialMerkleTree, Error> {
+        Ok(self.get_certified_block_merkle_state(block_hash)?.tree)
     }
 
     pub fn get_block_hash_from_ordinal(

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -187,7 +187,7 @@ pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
 fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
     // TODO(spice): decide how the reader handles spice columns.
     #[cfg(feature = "protocol_feature_spice")]
-    if col == DBCol::ReceiptProofs {
+    if matches!(col, DBCol::ReceiptProofs | DBCol::CertifiedBlockMerkleTree) {
         return true;
     }
     matches!(

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -207,6 +207,13 @@ pub enum DBCol {
     /// - *Rows*: BlockHash
     /// - *Column type*: PartialMerkleTree - MerklePath to the leaf + number of leaves in the whole tree.
     BlockMerkleTree,
+    /// Spice: like BlockMerkleTree but over reconstructed certified light-client block
+    /// hashes; anchors light-client proofs of certified execution results. Also carries
+    /// the leaves this block newly certified.
+    /// - *Rows*: BlockHash
+    /// - *Column type*: CertifiedBlockAccumulatorState
+    #[cfg(feature = "protocol_feature_spice")]
+    CertifiedBlockMerkleTree,
     /// Mapping from height to the set of Chunk Hashes that were included in the block at that height.
     /// - *Rows*: height (u64)
     /// - *Column type*: Vec<ChunkHash (CryptoHash)>
@@ -667,6 +674,8 @@ impl DBCol {
             | DBCol::StateSyncNewChunks
             // TODO(early-kickout): Make ChunkProducers a cold column when GC is implemented.
             => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockMerkleTree => false,
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => false,
         }
@@ -729,6 +738,8 @@ impl DBCol {
             | DBCol::EpochStart
             | DBCol::EpochSyncProof
             | DBCol::EpochValidatorInfo => GcPolicy::Permanent,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockMerkleTree => GcPolicy::Permanent,
 
             DBCol::AccountAnnouncements
             | DBCol::_BlockExtra
@@ -865,6 +876,8 @@ impl DBCol {
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::SpiceEndorsementStats => &[DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockMerkleTree => &[DBKeyType::BlockHash],
+            #[cfg(feature = "protocol_feature_spice")]
             DBCol::ContractAccesses => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => &[DBKeyType::BlockHash, DBKeyType::ShardId],
@@ -874,6 +887,13 @@ impl DBCol {
     pub fn witnesses() -> DBCol {
         #[cfg(feature = "protocol_feature_spice")]
         return DBCol::Witnesses;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn certified_block_merkle_tree() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::CertifiedBlockMerkleTree;
         #[cfg(not(feature = "protocol_feature_spice"))]
         panic!("Expected protocol_feature_spice to be enabled")
     }


### PR DESCRIPTION
Builds the fork-local certified-block merkle accumulator, commits its root in the header, and validates it on every spice block. The accumulator mirrors `block_merkle_tree` but over the reconstructed light-client lite views of certified blocks.

- New `CertifiedBlockMerkleTree` column + `CertifiedBlockAccumulatorState` / `CertifiedBlockLeaf` types; per-block `build_*` / `save_*_for_block` in `chain_update.rs::postprocess_block`.
- `reconstruct_certified_lite_view` (the leaf), the `prev_certified_block_merkle_tree` / `certified_block_merkle_root` / `last_certified_block` readers, and `validate_certified_block_header_info`.
- Production (`client.rs`) now sets the real root (replacing the placeholder); validation enforces it in `chain.rs`.

No per-ordinal index or inclusion proofs yet (next PR of the stack).

## Testing
- `test_validate_certified_block_header_info_rejects_wrong_fields`
- spice test-loop suite (`test_spice_chain` etc.): producer == validator agreement on the committed root across nodes.

4/6 of the SPICE light-client stack (#15947). Base: #15964.