### PR TITLE
feat(spice): certified accumulator ordinal index + inclusion proofs

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -6,7 +6,7 @@ use crate::block_processing_utils::{
 use crate::blocks_delay_tracker::BlocksDelayTracker;
 use crate::chain_update::ChainUpdate;
 use crate::crypto_hash_timer::CryptoHashTimer;
-use crate::lightclient::get_epoch_block_producers_view;
+use crate::lightclient::{get_epoch_block_producers_view, reconstruct_certified_lite_view};
 use crate::missing_chunks::{MissingChunksPool, OptimisticBlockChunksPool};
 use crate::orphan::{Orphan, OrphanBlockPool};
 use crate::pending::PendingBlocksPool;
@@ -18,6 +18,7 @@ use crate::signature_verification::{
     verify_block_header_signature_with_epoch_manager, verify_block_vrf,
     verify_chunk_header_signature_by_hash,
 };
+use crate::spice::certified_accumulator::compute_certified_block_proof;
 use crate::spice::core::SpiceCoreReader;
 use crate::state_snapshot_actor::SnapshotCallbacks;
 use crate::state_sync::ChainStateSyncAdapter;
@@ -64,7 +65,7 @@ use near_primitives::challenge::ChunkProofs;
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::{CryptoHash, hash};
-use near_primitives::merkle::{PartialMerkleTree, merklize};
+use near_primitives::merkle::{MerklePath, PartialMerkleTree, merklize};
 use near_primitives::optimistic_block::{
     BlockToApply, CachedShardUpdateKey, OptimisticBlock, OptimisticBlockKeySource,
 };
@@ -89,7 +90,7 @@ use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::{
     BlockStatusView, DroppedReason, ExecutionOutcomeWithIdView, ExecutionStatusView,
     FinalExecutionOutcomeView, FinalExecutionOutcomeWithReceiptView, FinalExecutionStatus,
-    LightClientBlockView, SignedTransactionView,
+    LightClientBlockLiteView, LightClientBlockView, SignedTransactionView,
 };
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
@@ -702,6 +703,29 @@ impl Chain {
             get_epoch_block_producers_view(final_block_header.next_epoch_id(), epoch_manager)?;
 
         create_light_client_block_view(&final_block_header, chain_store, Some(next_block_producers))
+    }
+
+    /// Spice: `block_header_lite` (reconstructed with certified roots) and the proof of
+    /// `block_hash`'s leaf, anchored to `head_block_hash`'s `certified_block_merkle_root`.
+    pub fn spice_block_header_lite_and_proof(
+        &self,
+        block_hash: &CryptoHash,
+        head_block_hash: &CryptoHash,
+    ) -> Result<(LightClientBlockLiteView, MerklePath), Error> {
+        let block_header = self.get_block_header(block_hash)?;
+        let (state_root, outcome_root) = self
+            .spice_core_reader
+            .certified_block_roots(head_block_hash, &block_header)?
+            .ok_or_else(|| Error::Other(format!("block {block_hash} is not certified")))?;
+        let block_header_lite =
+            reconstruct_certified_lite_view(&block_header, state_root, outcome_root);
+        let leaf_ordinal = self.chain_store().get_certified_block_leaf_ordinal(block_hash)?;
+        // The header commits the certified accumulator as of its prev, so the proof
+        // anchors to the tree as of `head`'s prev.
+        let head_prev = *self.get_block_header(head_block_hash)?.prev_hash();
+        let tree_size = self.chain_store().get_certified_block_merkle_tree(&head_prev)?.size();
+        let proof = compute_certified_block_proof(self.chain_store(), leaf_ordinal, tree_size)?;
+        Ok((block_header_lite, proof))
     }
 
     pub fn save_block(&mut self, block: MaybeValidated<Arc<Block>>) -> Result<(), Error> {

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -316,12 +316,25 @@ impl<'a> ChainUpdate<'a> {
                 self.epoch_manager.as_ref(),
                 &block,
             )?;
-            // Fork-local per-block certified accumulator state.
+            // Fork-local per-block state. Its leaves are indexed into the canonical ordinal index
+            // only when the block is canonical: here at body processing (the header head can be
+            // ahead from header sync), and via `update_height` for reorg in-between blocks.
             save_certified_block_merkle_tree_for_block(
                 &mut self.chain_store_update,
                 spice_core_reader,
                 &block,
             )?;
+            // No canonical block at this height yet means this block is not (currently) canonical.
+            let is_canonical =
+                match self.chain_store_update.get_block_hash_by_height(block.header().height()) {
+                    Ok(hash) => hash == *block.hash(),
+                    Err(Error::DBNotFoundErr(_)) => false,
+                    Err(err) => return Err(err),
+                };
+            if is_canonical {
+                self.chain_store_update
+                    .index_canonical_certified_leaves(block.hash(), block.header().prev_hash())?;
+            }
         }
 
         // Update the chain head if it's the new tip

--- a/chain/chain/src/spice/certified_accumulator.rs
+++ b/chain/chain/src/spice/certified_accumulator.rs
@@ -6,12 +6,15 @@ use crate::spice::core::{SpiceCoreReader, find_newly_certified_block_hashes};
 use crate::{ChainStoreAccess, ChainStoreUpdate};
 use near_chain_primitives::Error;
 use near_primitives::block::Block;
-use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::types::{CertifiedBlockAccumulatorState, CertifiedBlockLeaf};
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use near_store::merkle_proof::compute_merkle_path_by_ordinal;
+use std::sync::Arc;
 
 /// Builds and saves the fork-local certified accumulator state for `block` (prev's tree
-/// plus `block`'s newly-certified leaves), keyed by `block`'s hash.
+/// plus `block`'s newly-certified leaves), keyed by `block`'s hash. The per-ordinal index
+/// is written only for canonical blocks (see `index_canonical_certified_leaves`).
 pub fn save_certified_block_merkle_tree_for_block(
     chain_store_update: &mut ChainStoreUpdate,
     reader: &SpiceCoreReader,
@@ -68,4 +71,22 @@ fn build_certified_block_merkle_tree(
         tree.insert(leaf_hash);
     }
     Ok((tree, leaves))
+}
+
+/// Inclusion proof of the certified leaf at `leaf_ordinal` within the certified
+/// accumulator of size `tree_size`, reading the per-ordinal frontier+leaf from
+/// `CertifiedAccumulatorByOrdinal`.
+pub fn compute_certified_block_proof(
+    chain_store: &ChainStoreAdapter,
+    leaf_ordinal: u64,
+    tree_size: u64,
+) -> Result<MerklePath, Error> {
+    // TODO(spice-perf): each ordinal row is read twice (frontier + leaf). Consider a
+    // per-call cache so it is fetched once.
+    compute_merkle_path_by_ordinal(
+        leaf_ordinal,
+        tree_size,
+        |ordinal| Ok(Arc::new(chain_store.get_certified_accumulator_by_ordinal(ordinal)?.0)),
+        |ordinal| Ok(chain_store.get_certified_accumulator_by_ordinal(ordinal)?.1),
+    )
 }

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -21,7 +21,7 @@ use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::merklize;
+use near_primitives::merkle::{compute_root_from_path, merklize};
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::ShardChunkHeader;
@@ -232,6 +232,84 @@ fn test_last_certified_state_root_when_execution_results_column_is_partially_wri
 
     let root = core_reader.last_certified_state_root(b2.hash()).unwrap();
     assert_eq!(root, Some(expected));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_certified_block_proof_unaffected_by_side_fork() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    // Canonical: b2 certifies b1 (ordinal 0), b3 certifies b2 (ordinal 1); b4 commits
+    // certified_block_merkle_root = root([leaf(b1), leaf(b2)]).
+    let b1 = build_block(&chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let b2 = build_block(&chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, b2.clone());
+    let b3 = build_block(&chain, &b2, block_certification_core_statements(&b2));
+    process_block(&mut chain, b3.clone());
+    let b4 = build_block(&chain, &b3, vec![]);
+    process_block(&mut chain, b4.clone());
+
+    let certified_root = *b4.header().certified_block_merkle_root().unwrap();
+    let (lite, proof) = chain.spice_block_header_lite_and_proof(b1.hash(), b4.hash()).unwrap();
+    assert_eq!(compute_root_from_path(&proof, lite.hash()), certified_root);
+
+    // A side fork re-certifies b2 with different roots: a sibling of b3 (same prev b2)
+    // whose leaf at ordinal 1 differs, processed after the canonical head.
+    let fork_state_root = *b1.hash();
+    let y = build_block(
+        &chain,
+        &b2,
+        block_certification_core_statements_with_state_root(&b2, fork_state_root),
+    );
+    process_block(&mut chain, y);
+
+    // The side fork must not corrupt the canonical accumulator; the proof still verifies.
+    let (lite, proof) = chain.spice_block_header_lite_and_proof(b1.hash(), b4.hash()).unwrap();
+    assert_eq!(compute_root_from_path(&proof, lite.hash()), certified_root);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_certified_block_proof_follows_reorg() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+
+    // Canonical b-chain: b2 certifies b1, b3 anchors root([leaf(b1)]).
+    let b1 = build_block(&chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let b2 = build_block(&chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, b2.clone());
+    let b3 = build_block(&chain, &b2, vec![]);
+    process_block(&mut chain, b3.clone());
+    assert_eq!(chain.head().unwrap().last_block_hash, *b3.hash());
+
+    let b_root = *b3.header().certified_block_merkle_root().unwrap();
+    let (b_lite, b_proof) = chain.spice_block_header_lite_and_proof(b1.hash(), b3.hash()).unwrap();
+    assert_eq!(compute_root_from_path(&b_proof, b_lite.hash()), b_root);
+
+    // Heavier fork off b1 re-certifies b1 with a different root, then overtakes.
+    let fork_state_root = *b2.hash();
+    let c2 = build_block(
+        &chain,
+        &b1,
+        block_certification_core_statements_with_state_root(&b1, fork_state_root),
+    );
+    process_block(&mut chain, c2.clone());
+    let c3 = build_block(&chain, &c2, vec![]);
+    process_block(&mut chain, c3.clone());
+    let c4 = build_block(&chain, &c3, vec![]);
+    process_block(&mut chain, c4.clone());
+    assert_eq!(chain.head().unwrap().last_block_hash, *c4.hash());
+
+    // The reorg re-points the canonical ordinal index to the fork's leaf for b1, so a
+    // proof anchored to the new head verifies against the fork's root and differing leaf.
+    let c_root = *c4.header().certified_block_merkle_root().unwrap();
+    let (c_lite, c_proof) = chain.spice_block_header_lite_and_proof(b1.hash(), c4.hash()).unwrap();
+    assert_eq!(compute_root_from_path(&c_proof, c_lite.hash()), c_root);
+    assert_ne!(c_lite.hash(), b_lite.hash());
+    assert_ne!(c_root, b_root);
 }
 
 #[test]
@@ -1586,6 +1664,32 @@ fn block_certification_core_statements_with_wrong_endorser(
             chunk_id: SpiceChunkId { block_hash: *block.hash(), shard_id: chunk.shard_id() },
             execution_result: test_execution_result_for_chunk(chunk),
         });
+    }
+    core_statements
+}
+
+/// Like `block_certification_core_statements`, but certifies with a chosen state root so
+/// the produced leaf differs (used to forge a divergent side-fork certification).
+fn block_certification_core_statements_with_state_root(
+    block: &Block,
+    state_root: CryptoHash,
+) -> Vec<SpiceCoreStatement> {
+    let validators = test_validators();
+    let mut core_statements = Vec::new();
+    for chunk in block.chunks().iter_raw() {
+        let execution_result = ChunkExecutionResult {
+            chunk_extra: ChunkExtra::new_with_only_state_root(&state_root),
+            outgoing_receipts_root: CryptoHash::default(),
+        };
+        let chunk_id = SpiceChunkId { block_hash: *block.hash(), shard_id: chunk.shard_id() };
+        for validator in &validators {
+            let signer = create_test_signer(validator);
+            let endorsement =
+                SpiceChunkEndorsement::new(chunk_id.clone(), execution_result.clone(), &signer);
+            core_statements.push(endorsement_into_core_statement(endorsement));
+        }
+        core_statements
+            .push(SpiceCoreStatement::ChunkExecutionResult { chunk_id, execution_result });
     }
     core_statements
 }

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1051,6 +1051,8 @@ pub(crate) struct ChainStoreCacheUpdate {
     block_refcounts: HashMap<CryptoHash, u64>,
     block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
     certified_block_merkle_tree: HashMap<CryptoHash, Arc<CertifiedBlockAccumulatorState>>,
+    certified_accumulator_by_ordinal: HashMap<u64, (PartialMerkleTree, CryptoHash)>,
+    certified_block_leaf_ordinal: HashMap<CryptoHash, u64>,
     block_ordinal_to_hash: HashMap<NumBlocks, CryptoHash>,
     processed_block_heights: HashSet<BlockHeight>,
     receipt_to_tx: Vec<(CryptoHash, ReceiptToTxInfo)>,
@@ -1479,6 +1481,11 @@ impl<'a> ChainStoreUpdate<'a> {
             // At this point block_merkle_tree for header is already saved.
             let block_ordinal = self.get_block_merkle_tree(&header_hash)?.size();
             self.chain_store_cache_update.block_ordinal_to_hash.insert(block_ordinal, header_hash);
+            // Re-point the certified accumulator's ordinal index for canonical spice blocks.
+            // The per-block state is fork-local; the ordinal index follows the canonical chain.
+            if header.is_spice() {
+                self.index_canonical_certified_leaves(&header_hash, &header_prev_hash)?;
+            }
             match self.get_block_hash_by_height(header_height) {
                 Ok(cur_hash) if cur_hash == header_hash => {
                     // Found common ancestor.
@@ -1609,6 +1616,66 @@ impl<'a> ChainStoreUpdate<'a> {
         self.chain_store_cache_update
             .certified_block_merkle_tree
             .insert(block_hash, Arc::new(state));
+    }
+
+    fn get_certified_block_merkle_state(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<CertifiedBlockAccumulatorState, Error> {
+        if let Some(state) =
+            self.chain_store_cache_update.certified_block_merkle_tree.get(block_hash)
+        {
+            Ok(state.as_ref().clone())
+        } else {
+            self.chain_store.get_certified_block_merkle_state(block_hash)
+        }
+    }
+
+    /// Points the per-ordinal certified index at `block_hash`'s leaves. Each frontier is
+    /// rebuilt onto the prev block's tree, so only leaf hashes are stored per block. Missing
+    /// state means nothing to index yet (genesis, or a header synced ahead of its body).
+    pub(crate) fn index_canonical_certified_leaves(
+        &mut self,
+        block_hash: &CryptoHash,
+        prev_hash: &CryptoHash,
+    ) -> Result<(), Error> {
+        let leaves = match self.get_certified_block_merkle_state(block_hash) {
+            Ok(state) => state.newly_certified_leaves,
+            Err(Error::DBNotFoundErr(_)) => return Ok(()),
+            Err(err) => return Err(err),
+        };
+        if leaves.is_empty() {
+            return Ok(());
+        }
+        let prev_header = self.get_block_header(prev_hash)?;
+        // Genesis and the pre-spice activation-boundary block anchor an empty accumulator.
+        let mut frontier = if prev_header.is_genesis() || !prev_header.is_spice() {
+            PartialMerkleTree::default()
+        } else {
+            self.get_certified_block_merkle_state(prev_hash)?.tree
+        };
+        for leaf in leaves {
+            let ordinal = frontier.size();
+            self.save_certified_accumulator_entry(ordinal, frontier.clone(), leaf.leaf_hash);
+            self.save_certified_block_leaf_ordinal(leaf.certified_block_hash, ordinal);
+            frontier.insert(leaf.leaf_hash);
+        }
+        Ok(())
+    }
+
+    pub fn save_certified_accumulator_entry(
+        &mut self,
+        ordinal: u64,
+        frontier: PartialMerkleTree,
+        leaf: CryptoHash,
+    ) {
+        self.chain_store_cache_update
+            .certified_accumulator_by_ordinal
+            .insert(ordinal, (frontier, leaf));
+    }
+
+    pub fn save_certified_block_leaf_ordinal(&mut self, block_hash: CryptoHash, ordinal: u64) {
+        self.chain_store_cache_update.certified_block_leaf_ordinal.insert(block_hash, ordinal);
     }
 
     fn update_and_save_block_merkle_tree(&mut self, header: &BlockHeader) -> Result<(), Error> {
@@ -2165,6 +2232,20 @@ impl<'a> ChainStoreUpdate<'a> {
                 DBCol::certified_block_merkle_tree(),
                 block_hash.as_ref(),
                 certified_block_merkle_tree,
+            );
+        }
+        for (ordinal, entry) in &self.chain_store_cache_update.certified_accumulator_by_ordinal {
+            store_update.set_ser(
+                DBCol::certified_accumulator_by_ordinal(),
+                &index_to_bytes(*ordinal),
+                entry,
+            );
+        }
+        for (block_hash, ordinal) in &self.chain_store_cache_update.certified_block_leaf_ordinal {
+            store_update.set_ser(
+                DBCol::certified_block_leaf_ordinal(),
+                block_hash.as_ref(),
+                ordinal,
             );
         }
         for (block_ordinal, block_hash) in &self.chain_store_cache_update.block_ordinal_to_hash {

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -325,6 +325,24 @@ impl ChainStoreAdapter {
         Ok(self.get_certified_block_merkle_state(block_hash)?.tree)
     }
 
+    /// (frontier before leaf `ordinal`, leaf hash at `ordinal`) in the certified accumulator.
+    pub fn get_certified_accumulator_by_ordinal(
+        &self,
+        ordinal: u64,
+    ) -> Result<(PartialMerkleTree, CryptoHash), Error> {
+        option_to_not_found(
+            self.store.get_ser(DBCol::certified_accumulator_by_ordinal(), &index_to_bytes(ordinal)),
+            format_args!("CERTIFIED ACCUMULATOR BY ORDINAL: {}", ordinal),
+        )
+    }
+
+    pub fn get_certified_block_leaf_ordinal(&self, block_hash: &CryptoHash) -> Result<u64, Error> {
+        option_to_not_found(
+            self.store.get_ser(DBCol::certified_block_leaf_ordinal(), block_hash.as_ref()),
+            format_args!("CERTIFIED BLOCK LEAF ORDINAL: {}", block_hash),
+        )
+    }
+
     pub fn get_block_hash_from_ordinal(
         &self,
         block_ordinal: NumBlocks,

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -187,7 +187,13 @@ pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
 fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
     // TODO(spice): decide how the reader handles spice columns.
     #[cfg(feature = "protocol_feature_spice")]
-    if matches!(col, DBCol::ReceiptProofs | DBCol::CertifiedBlockMerkleTree) {
+    if matches!(
+        col,
+        DBCol::ReceiptProofs
+            | DBCol::CertifiedBlockMerkleTree
+            | DBCol::CertifiedAccumulatorByOrdinal
+            | DBCol::CertifiedBlockLeafOrdinal
+    ) {
         return true;
     }
     matches!(

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -209,11 +209,24 @@ pub enum DBCol {
     BlockMerkleTree,
     /// Spice: like BlockMerkleTree but over reconstructed certified light-client block
     /// hashes; anchors light-client proofs of certified execution results. Also carries
-    /// the leaves this block newly certified.
+    /// the leaves this block newly certified, replayed into the per-ordinal index on
+    /// canonicalization.
     /// - *Rows*: BlockHash
     /// - *Column type*: CertifiedBlockAccumulatorState
     #[cfg(feature = "protocol_feature_spice")]
     CertifiedBlockMerkleTree,
+    /// Spice: per certified-leaf ordinal, the accumulator frontier before that
+    /// leaf plus the leaf hash. Enables light-client inclusion proofs.
+    /// - *Rows*: certified ordinal (u64)
+    /// - *Column type*: (PartialMerkleTree, CryptoHash)
+    #[cfg(feature = "protocol_feature_spice")]
+    CertifiedAccumulatorByOrdinal,
+    /// Spice: a block's position (certified ordinal) in the certified
+    /// accumulator. Present once the block's execution is certified.
+    /// - *Rows*: BlockHash
+    /// - *Column type*: u64
+    #[cfg(feature = "protocol_feature_spice")]
+    CertifiedBlockLeafOrdinal,
     /// Mapping from height to the set of Chunk Hashes that were included in the block at that height.
     /// - *Rows*: height (u64)
     /// - *Column type*: Vec<ChunkHash (CryptoHash)>
@@ -676,6 +689,10 @@ impl DBCol {
             => false,
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::CertifiedBlockMerkleTree => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedAccumulatorByOrdinal => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockLeafOrdinal => false,
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => false,
         }
@@ -740,6 +757,10 @@ impl DBCol {
             | DBCol::EpochValidatorInfo => GcPolicy::Permanent,
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::CertifiedBlockMerkleTree => GcPolicy::Permanent,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedAccumulatorByOrdinal => GcPolicy::Permanent,
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockLeafOrdinal => GcPolicy::Permanent,
 
             DBCol::AccountAnnouncements
             | DBCol::_BlockExtra
@@ -878,6 +899,10 @@ impl DBCol {
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::CertifiedBlockMerkleTree => &[DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedAccumulatorByOrdinal => &[DBKeyType::BlockOrdinal],
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::CertifiedBlockLeafOrdinal => &[DBKeyType::BlockHash],
+            #[cfg(feature = "protocol_feature_spice")]
             DBCol::ContractAccesses => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => &[DBKeyType::BlockHash, DBKeyType::ShardId],
@@ -894,6 +919,20 @@ impl DBCol {
     pub fn certified_block_merkle_tree() -> DBCol {
         #[cfg(feature = "protocol_feature_spice")]
         return DBCol::CertifiedBlockMerkleTree;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn certified_accumulator_by_ordinal() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::CertifiedAccumulatorByOrdinal;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn certified_block_leaf_ordinal() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::CertifiedBlockLeafOrdinal;
         #[cfg(not(feature = "protocol_feature_spice"))]
         panic!("Expected protocol_feature_spice to be enabled")
     }


### PR DESCRIPTION
Adds the canonical per-ordinal index over the certified accumulator and the light-client inclusion-proof generation anchored to it.

- Two columns: `CertifiedAccumulatorByOrdinal` (ordinal -> frontier-before-leaf + leaf hash) and `CertifiedBlockLeafOrdinal` (block -> ordinal).
- `index_canonical_certified_leaves`: re-points the ordinal index along the canonical chain only (from `postprocess_block` when the block is canonical, and from `update_height`'s reorg walk), so orphaned forks can't pollute proofs.
- `compute_certified_block_proof` (reusing the shared `compute_merkle_path_by_ordinal` helper) and `Chain::spice_block_header_lite_and_proof`.

## Testing
- `test_certified_block_proof_unaffected_by_side_fork`: a losing fork re-certifies a block with different roots; the canonical proof still verifies.
- `test_certified_block_proof_follows_reorg`: a heavier fork wins and the ordinal index re-points; a proof against the new head verifies against the fork's root and differing leaf.

5/6 of the SPICE light-client stack (#15947). Base: #15965.