### PR TITLE
feat(spice): light-client RPC proof serving + e2e tests

### DIFF
--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -50,9 +50,10 @@ use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptOrigin,
 use near_primitives::shard_layout::{ShardLayout, ShardLayoutError};
 use near_primitives::sharding::ShardChunk;
 use near_primitives::stateless_validation::ChunkProductionKey;
+use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockId, BlockReference, EpochHeight, EpochId, EpochReference,
-    Finality, MaybeBlockId, ShardId, SyncCheckpoint, TransactionOrReceiptId,
+    Finality, MaybeBlockId, ShardId, ShardIndex, SyncCheckpoint, TransactionOrReceiptId,
     ValidatorInfoIdentifier,
 };
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
@@ -1107,7 +1108,30 @@ impl
             if ret.inner_lite.height <= last_height { Ok(None) } else { Ok(Some(Arc::new(ret))) }
         } else {
             match self.chain.chain_store().get_epoch_light_client_block(&last_next_epoch_id.0) {
-                Ok(light_block) => Ok(Some(light_block)),
+                Ok(light_block) => {
+                    let epoch_id = EpochId(light_block.inner_lite.epoch_id);
+                    let protocol_version = self
+                        .epoch_manager
+                        .get_epoch_protocol_version(&epoch_id)
+                        .into_chain_error()?;
+                    if !ProtocolFeature::Spice.enabled(protocol_version) {
+                        return Ok(Some(light_block));
+                    }
+                    // The persisted view borsh-skips the certified fields; read them from
+                    // the block's own header. It is retained as long as the light client's
+                    // last block is, so it is present whenever this branch can serve.
+                    let block_hash = self
+                        .chain
+                        .chain_store()
+                        .get_block_hash_by_height(light_block.inner_lite.height)?;
+                    let header = self.chain.get_block_header(&block_hash)?;
+                    let mut light_block = LightClientBlockView::clone(&light_block);
+                    light_block.inner_lite.certified_block_merkle_root =
+                        header.certified_block_merkle_root().copied();
+                    light_block.inner_lite.last_certified_block =
+                        header.last_certified_block().copied();
+                    Ok(Some(Arc::new(light_block)))
+                }
                 Err(e) => {
                     if let near_chain::Error::DBNotFoundErr(_) = e {
                         Ok(None)
@@ -1118,6 +1142,34 @@ impl
             }
         }
     }
+}
+
+/// `GetExecutionOutcome` for a spice block: the certified outcome root lives in the
+/// outcome's own block, not the next block (classic `prev_outcome_root`), so resolve
+/// against it without advancing.
+fn spice_execution_outcome_response(
+    chain: &Chain,
+    outcome_proof: ExecutionOutcomeWithIdAndProof,
+    outcome_block_header: &BlockHeader,
+    target_shard_id: ShardId,
+    target_shard_index: ShardIndex,
+    id: CryptoHash,
+) -> Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError> {
+    let context = chain.head()?.last_block_hash;
+    let outcome_roots = chain
+        .spice_core_reader
+        .certified_block_shard_outcome_roots(&context, outcome_block_header)?
+        .ok_or(GetExecutionOutcomeError::NotConfirmed { transaction_or_receipt_id: id })?;
+    if target_shard_index >= outcome_roots.len() {
+        return Err(GetExecutionOutcomeError::InconsistentState {
+            number_or_shards: outcome_roots.len(),
+            execution_outcome_shard_id: target_shard_id,
+        });
+    }
+    Ok(GetExecutionOutcomeResponse {
+        outcome_proof: outcome_proof.into(),
+        outcome_root_proof: merklize(&outcome_roots).1[target_shard_index].clone(),
+    })
 }
 
 impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>
@@ -1153,6 +1205,18 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
                     .get_shard_index(target_shard_id)
                     .map_err(Into::into)
                     .into_chain_error()?;
+                let outcome_block_header =
+                    self.chain.get_block_header(&outcome_proof.block_hash)?;
+                if outcome_block_header.is_spice() {
+                    return spice_execution_outcome_response(
+                        &self.chain,
+                        outcome_proof,
+                        &outcome_block_header,
+                        target_shard_id,
+                        target_shard_index,
+                        id,
+                    );
+                }
                 let res = self.chain.get_next_block_hash_with_new_chunk(
                     &outcome_proof.block_hash,
                     target_shard_id,
@@ -1617,11 +1681,17 @@ impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> f
         let head_block_header = self.chain.get_block_header(&msg.head_block_hash)?;
         let head_block_header = BlockHeader::clone(&head_block_header);
         self.chain.check_blocks_final_and_canonical(&[block_header.clone(), head_block_header])?;
-        let block_header_lite = block_header.into();
-        let proof = self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
-            &msg.block_hash,
-            &msg.head_block_hash,
-        )?;
+        let (block_header_lite, proof) = if block_header.is_spice() {
+            // Spice: reconstruct with certified roots and anchor to the certified accumulator.
+            self.chain.spice_block_header_lite_and_proof(&msg.block_hash, &msg.head_block_hash)?
+        } else {
+            let block_header_lite = block_header.into();
+            let proof = self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
+                &msg.block_hash,
+                &msg.head_block_hash,
+            )?;
+            (block_header_lite, proof)
+        };
         Ok(GetBlockProofResponse { block_header_lite, proof })
     }
 }

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -1,0 +1,166 @@
+use crate::setup::builder::TestLoopBuilder;
+use crate::utils::account::{create_account_id, create_validators_spec};
+use near_async::messaging::Handler as _;
+use near_async::time::Duration;
+use near_client::GetBlock;
+use near_client_primitives::types::{GetBlockProof, GetExecutionOutcome, GetNextLightClientBlock};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::compute_root_from_path;
+use near_primitives::test_utils::create_user_test_signer;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::{Balance, BlockReference, Finality, TransactionOrReceiptId};
+use near_primitives::views::LightClientBlockLiteView;
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_proof() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+
+    let mut env = TestLoopBuilder::new()
+        .validators_spec(create_validators_spec(2, 1))
+        .enable_rpc()
+        .add_user_account(&sender, Balance::from_near(10))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+
+    let tx = SignedTransaction::send_money(
+        1,
+        sender.clone(),
+        receiver,
+        &create_user_test_signer(&sender),
+        Balance::from_near(1),
+        env.rpc_node().head().last_block_hash,
+    );
+    let tx_hash = tx.get_hash();
+    let outcome = env.rpc_runner().execute_tx(tx, Duration::seconds(20)).unwrap();
+    let tx_block_hash = outcome.transaction_outcome.block_hash;
+    let tx_height =
+        env.rpc_node().client().chain.get_block_header(&tx_block_hash).unwrap().height();
+    // The proof anchors to the final head's prev, so run one block past the consensus
+    // head that certified the tx -- making that head the final head's prev.
+    env.rpc_runner().run_until_certified(tx_height);
+    let certified_head_height = env.rpc_node().head().height;
+    env.rpc_runner().run_until_final_head_height(certified_head_height + 1);
+
+    // The trusted head + its certified anchor root, from next_light_client_block (which
+    // returns a final block). Pass the head's prev as the client's last tracked head.
+    let final_head = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetBlock(BlockReference::Finality(Finality::Final)))
+        .unwrap();
+    let light_client_block = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetNextLightClientBlock { last_block_hash: final_head.header.prev_hash })
+        .unwrap()
+        .expect("next_light_client_block must return the certified head");
+    let head_certified_root = light_client_block
+        .inner_lite
+        .certified_block_merkle_root
+        .expect("light-client head must commit certified_block_merkle_root");
+    let light_client_head = LightClientBlockLiteView {
+        prev_block_hash: light_client_block.prev_block_hash,
+        inner_rest_hash: light_client_block.inner_rest_hash,
+        inner_lite: light_client_block.inner_lite.clone(),
+    }
+    .hash();
+
+    let outcome_response = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetExecutionOutcome {
+            id: TransactionOrReceiptId::Transaction {
+                transaction_hash: tx_hash,
+                sender_id: sender,
+            },
+        })
+        .unwrap();
+    let block_proof_response = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetBlockProof {
+            block_hash: outcome_response.outcome_proof.block_hash,
+            head_block_hash: light_client_head,
+        })
+        .unwrap();
+    let outcome_proof = outcome_response.outcome_proof;
+    let outcome_root_proof = outcome_response.outcome_root_proof;
+    let block_header_lite = block_proof_response.block_header_lite;
+    let block_proof = block_proof_response.proof;
+
+    // Verify like a light client: two merkle proofs chained through block B, the
+    // certified accumulator standing in for block_merkle_root:
+    //
+    //   tx outcome --outcome_proof--> B's certified outcome_root   (read from B's lite view)
+    //   B's leaf   --block_proof----> head's certified accumulator  (trusted via the head)
+
+    // 1. The tx's outcome is committed in B's certified outcome_root.
+    let outcome_hash = CryptoHash::hash_borsh(&outcome_proof.to_hashes());
+    let shard_outcome_root = compute_root_from_path(&outcome_proof.proof, outcome_hash);
+    let b_outcome_root =
+        compute_root_from_path(&outcome_root_proof, CryptoHash::hash_borsh(shard_outcome_root));
+    assert_eq!(b_outcome_root, block_header_lite.inner_lite.outcome_root);
+
+    // 2. B is included in the certified accumulator the trusted head commits to.
+    // (B's whole reconstructed lite view is hashed into the leaf, so it's verified too.)
+    let b_leaf = block_header_lite.hash();
+    assert_eq!(compute_root_from_path(&block_proof, b_leaf), head_certified_root);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_cross_epoch() {
+    init_test_logger();
+
+    let mut env = TestLoopBuilder::new()
+        .validators_spec(create_validators_spec(2, 1))
+        .enable_rpc()
+        .epoch_length(5)
+        .build();
+
+    // The light client's last known block lives in this epoch.
+    env.rpc_runner().run_until_new_epoch();
+    let last_block_hash = env.rpc_node().head().last_block_hash;
+    let last_epoch_id = env.rpc_node().head().epoch_id;
+
+    // Move the head two epochs ahead. next_light_client_block must then return the stored
+    // epoch block for the in-between epoch, not a freshly computed head block.
+    env.rpc_runner().run_until_new_epoch();
+    let in_between_epoch_id = env.rpc_node().head().epoch_id;
+    env.rpc_runner().run_until_new_epoch();
+    assert_ne!(env.rpc_node().head().epoch_id, last_epoch_id);
+    assert_ne!(env.rpc_node().head().epoch_id, in_between_epoch_id);
+
+    let light_client_block = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetNextLightClientBlock { last_block_hash })
+        .unwrap()
+        .expect("cross-epoch next_light_client_block must return the stored epoch block");
+    // The stored block is the in-between epoch's, confirming the cross-epoch branch ran.
+    assert_eq!(light_client_block.inner_lite.epoch_id, in_between_epoch_id.0);
+
+    // A cross-epoch light-client block must carry the certified fields, equal to what the
+    // corresponding on-chain block header committed.
+    let certified_block_merkle_root = light_client_block
+        .inner_lite
+        .certified_block_merkle_root
+        .expect("cross-epoch light-client block must carry certified_block_merkle_root");
+    let last_certified_block = light_client_block
+        .inner_lite
+        .last_certified_block
+        .expect("cross-epoch light-client block must carry last_certified_block");
+    let header = env
+        .rpc_node()
+        .client()
+        .chain
+        .get_block_header_by_height(light_client_block.inner_lite.height)
+        .unwrap();
+    assert_eq!(Some(&certified_block_merkle_root), header.certified_block_merkle_root());
+    assert_eq!(Some(&last_certified_block), header.last_certified_block());
+}

--- a/test-loop-tests/src/tests/spice/mod.rs
+++ b/test-loop-tests/src/tests/spice/mod.rs
@@ -1,4 +1,5 @@
 mod basic;
+mod light_client;
 mod malicious_chunk_producer;
 mod resharding;
 mod utils;


### PR DESCRIPTION
Serves spice light-client proofs over RPC and adds end-to-end coverage.

- `GetBlockProof`: for spice blocks, reconstructs `block_header_lite` with certified roots and anchors the proof to the certified accumulator (`Chain::spice_block_header_lite_and_proof`).
- `GetExecutionOutcome`: resolves the certified outcome root against the outcome's own block (spice executes asynchronously, so it is not carried one block later as `prev_outcome_root`).
- `next_light_client_block`: the cross-epoch branch returns a stored epoch block whose persisted view borsh-skips the certified fields; they are spliced back from the block's own header.

## Testing
- `test_spice_light_client_proof`: submits a tx, fetches `GetExecutionOutcome` + `GetBlockProof`, and verifies the two-step proof (outcome -> certified outcome_root; certified leaf -> head's certified accumulator root) the way a light client would.
- `test_spice_light_client_cross_epoch`: a cross-epoch light-client block carries the certified fields equal to the on-chain header.

6/6 (final) of the SPICE light-client stack (#15947). Base: #15966.