### PR TITLE
feat(spice): light-client execution and state proofs via reused header slots

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -290,6 +290,10 @@ pub enum Error {
     /// value recomputed from the chain.
     #[error("Invalid spice_chunk_endorsement_stats: {0}")]
     InvalidSpiceChunkEndorsementStats(String),
+    /// A spice block's `prev_state_root` / `prev_outcome_root` commitment slots don't
+    /// match the value recomputed from the predecessor's certified set.
+    #[error("Invalid spice commitment roots: {0}")]
+    InvalidSpiceCommitmentRoots(String),
     /// Anything else
     #[error("Other Error: {0}")]
     Other(String),
@@ -386,7 +390,8 @@ impl Error {
             | Error::BadHeaderForProtocolVersion(_)
             | Error::InvalidSpiceCoreStatements(_)
             | Error::InvalidPrevLastCertifiedBlockEpochId(_)
-            | Error::InvalidSpiceChunkEndorsementStats(_) => true,
+            | Error::InvalidSpiceChunkEndorsementStats(_)
+            | Error::InvalidSpiceCommitmentRoots(_) => true,
         }
     }
 
@@ -480,6 +485,7 @@ impl Error {
                 "invalid_prev_last_certified_block_epoch_id"
             }
             Error::InvalidSpiceChunkEndorsementStats(_) => "invalid_spice_chunk_endorsement_stats",
+            Error::InvalidSpiceCommitmentRoots(_) => "invalid_spice_commitment_roots",
         }
     }
 }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2568,6 +2568,7 @@ impl Chain {
             self.spice_core_reader.validate_core_statements_in_block(&block).map_err(Box::new)?;
             self.spice_core_reader.validate_prev_last_certified_block_epoch_id(header)?;
             self.spice_core_reader.validate_spice_chunk_endorsement_stats(header)?;
+            self.spice_core_reader.validate_light_client_commitment_roots(header)?;
         } else {
             if block.is_spice_block() {
                 return Err(Error::Other(

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -4,7 +4,8 @@ use crate::chain::collect_receipts_from_response;
 use crate::metrics::{SHARD_LAYOUT_NUM_SHARDS, SHARD_LAYOUT_VERSION};
 use crate::spice::chunk_application::apply_chunk_postprocessing;
 use crate::spice::core::{
-    record_spice_endorsement_stats_for_block, record_uncertified_chunks_for_block,
+    index_spice_certifier_for_canonical_block, record_spice_endorsement_stats_for_block,
+    record_uncertified_chunks_for_block,
 };
 use crate::store::utils::get_block_header_on_chain_by_height;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
@@ -314,6 +315,18 @@ impl<'a> ChainUpdate<'a> {
                 self.epoch_manager.as_ref(),
                 &block,
             )?;
+            // Header sync advances the header head (and the canonical height index)
+            // ahead of bodies, so this height may already be canonical when its body
+            // arrives here; index now. `update_height` re-points blocks a reorg makes canonical.
+            let is_canonical =
+                match self.chain_store_update.get_block_hash_by_height(block.header().height()) {
+                    Ok(hash) => hash == *block.hash(),
+                    Err(Error::DBNotFoundErr(_)) => false,
+                    Err(err) => return Err(err),
+                };
+            if is_canonical {
+                index_spice_certifier_for_canonical_block(&mut self.chain_store_update, &block)?;
+            }
         }
 
         // Update the chain head if it's the new tip

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -776,6 +776,7 @@ impl<'a> ChainStoreUpdate<'a> {
         }
         self.gc_col(DBCol::uncertified_chunks(), block_hash.as_ref());
         self.gc_col(DBCol::spice_endorsement_stats(), block_hash.as_ref());
+        self.gc_col(DBCol::spice_certifier_by_block(), block_hash.as_ref());
     }
 
     fn gc_trie_changes(

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -13,6 +13,7 @@ use near_primitives::shard_layout::ShardUId;
 use near_primitives::spice::chunk_endorsement::{
     SpiceEndorsementCoreStatement, SpiceStoredVerifiedEndorsement,
 };
+use near_primitives::spice::commitment::{CertifiedBlockInfo, compute_commitment_roots};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
@@ -425,6 +426,49 @@ impl SpiceCoreReader {
         Ok(())
     }
 
+    /// Per-shard certified outcome roots of `block_header`, sorted by `ShardId`
+    /// to match the commitment leaf's `outcome_root` (`merklize_outcome_roots`).
+    /// `None` if the block's execution results are not all available.
+    pub fn certified_block_shard_outcome_roots(
+        &self,
+        block_header: &BlockHeader,
+    ) -> Result<Option<Vec<(ShardId, CryptoHash)>>, Error> {
+        let Some(results) = self.get_block_execution_results(block_header)? else {
+            return Ok(None);
+        };
+        let mut roots: Vec<(ShardId, CryptoHash)> = results
+            .0
+            .iter()
+            .map(|(shard_id, result)| (*shard_id, *result.chunk_extra.outcome_root()))
+            .collect();
+        roots.sort_by_key(|(shard_id, _)| *shard_id);
+        Ok(Some(roots))
+    }
+
+    /// Recompute-and-compare the `prev_state_root` / `prev_outcome_root` commitment
+    /// slots against the predecessor's certified set. Rejects on mismatch.
+    pub fn validate_light_client_commitment_roots(
+        &self,
+        header: &BlockHeader,
+    ) -> Result<(), Error> {
+        let prev_header = self.chain_store.get_block_header(header.prev_hash())?;
+        let (expected_state_root, expected_outcome_root) =
+            self.light_client_commitment_roots(&prev_header)?;
+        if header.prev_state_root() != &expected_state_root {
+            return Err(Error::InvalidSpiceCommitmentRoots(format!(
+                "prev_state_root: expected {expected_state_root}, got {}",
+                header.prev_state_root()
+            )));
+        }
+        if header.outcome_root() != &expected_outcome_root {
+            return Err(Error::InvalidSpiceCommitmentRoots(format!(
+                "prev_outcome_root: expected {expected_outcome_root}, got {}",
+                header.outcome_root()
+            )));
+        }
+        Ok(())
+    }
+
     pub fn validate_core_statements_in_block(
         &self,
         block: &Block,
@@ -614,16 +658,13 @@ impl SpiceCoreReader {
         Ok(())
     }
 
-    /// Returns execution results for all blocks that become newly certified when
-    /// `core_statements_for_next_block` is applied to the current chain state.
-    /// The results are ordered oldest-first. When no new certification frontier
-    /// advancement occurs but the last certified block is genesis, returns genesis
-    /// execution results to bootstrap gas price computation.
-    pub fn get_newly_certified_block_execution_results_for_next_block(
+    /// Blocks newly certified by applying `core_statements_for_next_block` on top
+    /// of `block_header`, oldest-first. Empty when nothing is newly certified.
+    fn enumerate_newly_certified_blocks(
         &self,
         block_header: &BlockHeader,
         core_statements_for_next_block: &SpiceCoreStatements,
-    ) -> Result<Vec<BlockExecutionResults>, Error> {
+    ) -> Result<Vec<CertifiedBlockInfo>, Error> {
         // Find old last certified (before applying new core statements).
         let old_last_certified =
             get_last_certified_block_header(&self.chain_store, block_header.hash())?;
@@ -646,13 +687,6 @@ impl SpiceCoreReader {
             };
 
         if new_last_certified.hash() == old_last_certified.hash() {
-            if old_last_certified.is_genesis() {
-                // Genesis is certified by definition. Return its execution results so gas price
-                // is computed from genesis gas_limit until the first real certification.
-                return Ok(vec![BlockExecutionResults(
-                    self.get_execution_results_by_shard_id(&old_last_certified)?,
-                )]);
-            }
             return Ok(vec![]);
         }
         assert!(
@@ -710,9 +744,65 @@ impl SpiceCoreReader {
                 "should have found all shard's execution results for newly certified block {}",
                 block_hash,
             );
-            result.push(BlockExecutionResults(execution_results));
+            result.push(CertifiedBlockInfo {
+                block_hash: *block_hash,
+                block_height: block_header.height(),
+                execution_results: BlockExecutionResults(execution_results),
+            });
         }
         Ok(result)
+    }
+
+    /// Returns execution results for all blocks that become newly certified when
+    /// `core_statements_for_next_block` is applied to the current chain state.
+    /// The results are ordered oldest-first. When no new certification frontier
+    /// advancement occurs but the last certified block is genesis, returns genesis
+    /// execution results to bootstrap gas price computation.
+    pub fn get_newly_certified_block_execution_results_for_next_block(
+        &self,
+        block_header: &BlockHeader,
+        core_statements_for_next_block: &SpiceCoreStatements,
+    ) -> Result<Vec<BlockExecutionResults>, Error> {
+        let newly_certified =
+            self.enumerate_newly_certified_blocks(block_header, core_statements_for_next_block)?;
+        if !newly_certified.is_empty() {
+            return Ok(newly_certified.into_iter().map(|info| info.execution_results).collect());
+        }
+        let old_last_certified =
+            get_last_certified_block_header(&self.chain_store, block_header.hash())?;
+        if old_last_certified.is_genesis() {
+            return Ok(vec![BlockExecutionResults(
+                self.get_execution_results_by_shard_id(&old_last_certified)?,
+            )]);
+        }
+        Ok(vec![])
+    }
+
+    /// The two commitment roots a block `P` built on `prev_header` commits in its
+    /// `prev_state_root` / `prev_outcome_root` slots: the commitment over the
+    /// blocks `prev_header` newly certified (as-of-prev). Shared by production
+    /// and validation. Empty (genesis / pre-spice / certified nothing) gives
+    /// `default()` roots.
+    pub fn light_client_commitment_roots(
+        &self,
+        prev_header: &BlockHeader,
+    ) -> Result<(CryptoHash, CryptoHash), Error> {
+        Ok(compute_commitment_roots(&self.certified_blocks_committed_by(prev_header)?))
+    }
+
+    /// The blocks `certifier`'s core statements newly certify, with the identity
+    /// and execution results needed to rebuild their commitment leaves. This is
+    /// exactly the set committed in `certifier`'s canonical child's slots.
+    pub fn certified_blocks_committed_by(
+        &self,
+        certifier: &BlockHeader,
+    ) -> Result<Vec<CertifiedBlockInfo>, Error> {
+        if certifier.is_genesis() || !certifier.is_spice() {
+            return Ok(vec![]);
+        }
+        let block = self.chain_store.get_block(certifier.hash())?;
+        let prev_header = self.chain_store.get_block_header(certifier.prev_hash())?;
+        self.enumerate_newly_certified_blocks(&prev_header, block.spice_core_statements())
     }
 }
 
@@ -808,6 +898,38 @@ pub fn record_uncertified_chunks_for_block(
         block.header().hash().as_ref(),
         &uncertified_chunks,
     );
+    chain_store_update.merge(store_update);
+    Ok(())
+}
+
+/// Indexes `H -> block` for each block `H` whose execution results `block`'s core
+/// statements newly certify. Called only for canonical blocks; `set_ser`
+/// overwrites the prior certifier so a reorg's winning chain re-points the index.
+pub fn index_spice_certifier_for_canonical_block(
+    chain_store_update: &mut ChainStoreUpdate,
+    block: &Block,
+) -> Result<(), Error> {
+    // `block` certifies its parent's uncertified chunks; if the parent never recorded
+    // them (genesis, pre-spice, or a parent installed by state sync), nothing to index.
+    let prev_hash = block.header().prev_hash();
+    let store = chain_store_update.chain_store().store_ref();
+    if !store.exists(DBCol::uncertified_chunks(), prev_hash.as_ref()) {
+        return Ok(());
+    }
+    let prev_uncertified = get_uncertified_chunks(chain_store_update.chain_store(), prev_hash)?;
+    let newly_certified =
+        find_newly_certified_block_hashes(&prev_uncertified, block.spice_core_statements());
+    if newly_certified.is_empty() {
+        return Ok(());
+    }
+    let mut store_update = chain_store_update.chain_store().store_ref().store_update();
+    for certified_block_hash in newly_certified {
+        store_update.set_ser(
+            DBCol::spice_certifier_by_block(),
+            certified_block_hash.as_ref(),
+            block.hash(),
+        );
+    }
     chain_store_update.merge(store_update);
     Ok(())
 }

--- a/chain/chain/src/spice/light_client.rs
+++ b/chain/chain/src/spice/light_client.rs
@@ -1,0 +1,70 @@
+use crate::Chain;
+use near_chain_primitives::Error;
+use near_primitives::block::BlockHeader;
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::MerklePath;
+use near_primitives::spice::commitment::{outcome_commitment_proof, state_commitment_proof};
+use near_primitives::types::BlockHeight;
+use near_primitives::views::LightClientBlockLiteView;
+use near_store::merkle_proof::MerkleProofAccess as _;
+
+/// Inclusion of a certified block's execution commitment under a trusted head.
+/// The anchor block is the certifier's canonical child; its `prev_state_root` /
+/// `prev_outcome_root` slots carry the commitment over the certifier's set, and
+/// anchors into the head's `block_merkle_root` via the classic block proof.
+pub struct SpiceCommitmentProof {
+    pub anchor_block_lite: LightClientBlockLiteView,
+    pub anchor_block_proof: MerklePath,
+    pub commitment_height: BlockHeight,
+    pub state_commitment_proof: MerklePath,
+    pub outcome_commitment_proof: MerklePath,
+}
+
+impl Chain {
+    /// Proof that `certified_block_hash`'s execution commitment is anchored under
+    /// `head_block_hash`. `None` (fails closed) when the proof is not available yet: the
+    /// block is not certified on the canonical chain, or its anchor block (the certifier's
+    /// canonical child) does not exist yet. `Err` is reserved for chain access failures.
+    pub fn spice_commitment_proof(
+        &self,
+        certified_block_hash: &CryptoHash,
+        head_block_hash: &CryptoHash,
+    ) -> Result<Option<SpiceCommitmentProof>, Error> {
+        let Some(certifier_hash) = self.chain_store().spice_certifier(certified_block_hash) else {
+            return Ok(None);
+        };
+        let certifier_header = self.get_block_header(&certifier_hash)?;
+        let anchor_hash = match self.get_block_hash_by_height(certifier_header.height() + 1) {
+            Ok(anchor_hash) => anchor_hash,
+            Err(Error::DBNotFoundErr(_)) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let anchor_header = self.get_block_header(&anchor_hash)?;
+        if anchor_header.prev_hash() != &certifier_hash {
+            return Ok(None);
+        }
+
+        let certified = self.spice_core_reader.certified_blocks_committed_by(&certifier_header)?;
+        let Some((outcome_commitment_proof, _)) =
+            outcome_commitment_proof(&certified, certified_block_hash)
+        else {
+            return Ok(None);
+        };
+        let (state_commitment_proof, _) = state_commitment_proof(&certified, certified_block_hash)
+            .expect("state and outcome commitments cover the same blocks");
+
+        let commitment_height = self.get_block_header(certified_block_hash)?.height();
+        let anchor_block_lite = LightClientBlockLiteView::from(BlockHeader::clone(&anchor_header));
+        let anchor_block_proof = self.compute_past_block_proof_in_merkle_tree_of_later_block(
+            &anchor_hash,
+            head_block_hash,
+        )?;
+        Ok(Some(SpiceCommitmentProof {
+            anchor_block_lite,
+            anchor_block_proof,
+            commitment_height,
+            state_commitment_proof,
+            outcome_commitment_proof,
+        }))
+    }
+}

--- a/chain/chain/src/spice/mod.rs
+++ b/chain/chain/src/spice/mod.rs
@@ -4,6 +4,7 @@ pub mod chunk_application;
 pub mod chunk_validation;
 pub mod core;
 pub mod core_writer_actor;
+pub mod light_client;
 
 #[cfg(test)]
 mod tests;

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -12,6 +12,7 @@ use itertools::Itertools as _;
 use near_async::messaging::{Handler as _, IntoSender as _, noop};
 use near_async::time::Clock;
 use near_chain_configs::test_genesis::{TestGenesisBuilder, ValidatorsSpec};
+use near_chain_primitives::Error;
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::bandwidth_scheduler::BandwidthRequests;
@@ -1503,6 +1504,158 @@ fn test_get_newly_certified_block_execution_results_multi_block_incremental() {
     assert_eq!(block_execution_results(&b2), execution_results[0]);
 }
 
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_certifier_index_and_proof_happy_path() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let certifier = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, certifier.clone());
+    let anchor = build_block(&mut chain, &certifier, vec![]);
+    process_block(&mut chain, anchor.clone());
+    let head = build_block(&mut chain, &anchor, vec![]);
+    process_block(&mut chain, head.clone());
+
+    assert_eq!(chain.chain_store().spice_certifier(b1.hash()), Some(*certifier.hash()));
+    let proof = chain.spice_commitment_proof(b1.hash(), head.hash()).unwrap().unwrap();
+    assert_eq!(proof.anchor_block_lite.hash(), *anchor.hash());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_commitment_proof_fail_closed_for_uncertified_block() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+
+    assert_eq!(chain.chain_store().spice_certifier(b1.hash()), None);
+    assert!(chain.spice_commitment_proof(b1.hash(), b1.hash()).unwrap().is_none());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_certifier_index_ignores_losing_fork() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let certifier = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, certifier.clone());
+    let anchor = build_block(&mut chain, &certifier, vec![]);
+    process_block(&mut chain, anchor.clone());
+
+    // A losing sibling of `certifier` that also certifies b1 but never becomes canonical.
+    let losing_certifier = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, losing_certifier.clone());
+
+    assert_ne!(losing_certifier.hash(), certifier.hash());
+    assert_eq!(chain.chain_store().spice_certifier(b1.hash()), Some(*certifier.hash()));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_certifier_index_follows_winning_fork() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let certifier = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, certifier.clone());
+    assert_eq!(chain.chain_store().spice_certifier(b1.hash()), Some(*certifier.hash()));
+
+    // A competing branch that also certifies b1 and grows longer, winning the reorg.
+    let winning_certifier = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, winning_certifier.clone());
+    let mut tip = winning_certifier.clone();
+    for _ in 0..2 {
+        tip = build_block(&mut chain, &tip, vec![]);
+        process_block(&mut chain, tip.clone());
+    }
+
+    assert_ne!(winning_certifier.hash(), certifier.hash());
+    assert_eq!(
+        chain.get_block_hash_by_height(certifier.header().height()).unwrap(),
+        *winning_certifier.hash()
+    );
+    assert_eq!(chain.chain_store().spice_certifier(b1.hash()), Some(*winning_certifier.hash()));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_proof_anchor_follows_canonical_child() {
+    let (mut chain, _core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let certifier = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, certifier.clone());
+    let anchor = build_block(&mut chain, &certifier, vec![]);
+    process_block(&mut chain, anchor.clone());
+
+    // A competing child of the same certifier that wins: the certifier stays canonical,
+    // so the index is untouched and the proof re-derives the new canonical child.
+    let new_anchor = build_block(&mut chain, &certifier, vec![]);
+    process_block(&mut chain, new_anchor.clone());
+    let head = build_block(&mut chain, &new_anchor, vec![]);
+    process_block(&mut chain, head.clone());
+
+    assert_ne!(new_anchor.hash(), anchor.hash());
+    assert_eq!(
+        chain.get_block_hash_by_height(certifier.header().height()).unwrap(),
+        *certifier.hash()
+    );
+    assert_eq!(chain.chain_store().spice_certifier(b1.hash()), Some(*certifier.hash()));
+    let proof = chain.spice_commitment_proof(b1.hash(), head.hash()).unwrap().unwrap();
+    assert_eq!(proof.anchor_block_lite.hash(), *new_anchor.hash());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_commitment_roots_producer_equals_validator() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let certifier = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, certifier.clone());
+    // `anchor` commits over what `certifier` certified (as-of-prev).
+    let anchor = build_block(&mut chain, &certifier, vec![]);
+    process_block(&mut chain, anchor.clone());
+
+    let (state_root, outcome_root) =
+        core_reader.light_client_commitment_roots(certifier.header()).unwrap();
+    assert_eq!(anchor.header().prev_state_root(), &state_root);
+    assert_eq!(anchor.header().outcome_root(), &outcome_root);
+    assert_ne!(state_root, CryptoHash::default());
+    assert_ne!(outcome_root, CryptoHash::default());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_validation_rejects_invalid_commitment_roots() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let b1 = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, b1.clone());
+    let certifier = build_block(&mut chain, &b1, block_certification_core_statements(&b1));
+    process_block(&mut chain, certifier.clone());
+
+    // A block on `certifier` with wrong commitment slots: `certifier` certified b1, so
+    // the recomputed roots are non-default and the planted default slots mismatch.
+    let tampered = block_builder(&chain, &certifier)
+        .spice_commitment_roots(CryptoHash::default(), CryptoHash::default())
+        .spice_core_statements(vec![])
+        .build();
+
+    assert_matches!(
+        core_reader.validate_light_client_commitment_roots(tampered.header()),
+        Err(Error::InvalidSpiceCommitmentRoots(_))
+    );
+}
+
 fn block_execution_results(block: &Block) -> BlockExecutionResults {
     let mut results = HashMap::new();
     for chunk in block.chunks().iter_raw() {
@@ -1564,8 +1717,15 @@ fn block_builder(chain: &Chain, prev_block: &Block) -> TestBlockBuilder {
         .get_block_producer_info(prev_block.header().epoch_id(), prev_block.header().height() + 1)
         .unwrap();
     let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
+    // Defaults when prev is unprocessed: some tests build blocks only to feed
+    // validation directly, where the commitment roots are irrelevant.
+    let (prev_state_commitment_root, prev_outcome_commitment_root) = chain
+        .spice_core_reader
+        .light_client_commitment_roots(prev_block.header())
+        .unwrap_or_default();
     TestBlockBuilder::from_prev_block(Clock::real(), prev_block, signer)
         .chunks(get_fake_next_block_chunk_headers(&prev_block, chain.epoch_manager.as_ref()))
+        .spice_commitment_roots(prev_state_commitment_root, prev_outcome_commitment_root)
 }
 
 fn build_block(

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1,4 +1,5 @@
 use crate::spice::chunk_application::ChunkPersistenceConfig;
+use crate::spice::core::index_spice_certifier_for_canonical_block;
 use crate::types::{Block, BlockHeader, LatestKnown};
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::Utc;
@@ -834,6 +835,12 @@ impl ChainStore {
         // otherwise should be orphaned)
         !chain_store.get_blocks_to_catchup(prev_prev_hash).contains(prev_hash)
     }
+
+    /// The canonical block whose core statements certified `block_hash`. `None`
+    /// if the block is not yet certified on the canonical chain.
+    pub fn spice_certifier(&self, block_hash: &CryptoHash) -> Option<CryptoHash> {
+        self.store.store().get_ser(DBCol::spice_certifier_by_block(), block_hash.as_ref())
+    }
 }
 
 impl ChainStoreAccess for ChainStore {
@@ -1478,6 +1485,14 @@ impl<'a> ChainStoreUpdate<'a> {
             // At this point block_merkle_tree for header is already saved.
             let block_ordinal = self.get_block_merkle_tree(&header_hash)?.size();
             self.chain_store_cache_update.block_ordinal_to_hash.insert(block_ordinal, header_hash);
+            // Re-point the certifier index for each block that becomes canonical on reorg;
+            // its body is present from earlier processing. Header-only blocks (sync) are
+            // skipped, indexed when their own body is processed.
+            if header.is_spice() {
+                if let Ok(block) = self.chain_store().get_block(&header_hash) {
+                    index_spice_certifier_for_canonical_block(self, &block)?;
+                }
+            }
             match self.get_block_hash_by_height(header_height) {
                 Ok(cur_hash) if cur_hash == header_hash => {
                     // Found common ancestor.

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -3,6 +3,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::MerklePath;
 use near_primitives::network::PeerId;
 use near_primitives::sharding::ChunkHash;
+use near_primitives::spice::commitment::SpiceCommitmentProofView;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, BlockReference, EpochId, EpochReference,
     MaybeBlockId, ShardId, TransactionOrReceiptId,
@@ -863,12 +864,26 @@ pub struct GetBlockProofResponse {
     pub proof: MerklePath,
 }
 
+#[derive(Debug)]
+pub struct GetExecutionBlockProof {
+    pub block_hash: CryptoHash,
+    pub head_block_hash: CryptoHash,
+}
+
+pub struct ExecutionBlockProofResponse {
+    pub block_header_lite: LightClientBlockLiteView,
+    pub block_proof: MerklePath,
+    pub spice_commitment_proof: Option<SpiceCommitmentProofView>,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum GetBlockProofError {
     #[error(
         "Block either has never been observed on the node or has been garbage collected: {error_message}"
     )]
     UnknownBlock { error_message: String },
+    #[error("execution commitment proof for block {block_hash} is not available yet")]
+    ProofNotAvailable { block_hash: CryptoHash },
     #[error("Internal error: {error_message}")]
     InternalError { error_message: String },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1151,6 +1151,8 @@ impl Client {
                     prev_header,
                     &core_statements,
                 )?;
+            let (prev_state_commitment_root, prev_outcome_commitment_root) =
+                self.chain.spice_core_reader.light_client_commitment_roots(prev_header)?;
             let prev_last_certified_block_epoch_id = self
                 .chain
                 .spice_core_reader
@@ -1162,6 +1164,8 @@ impl Client {
             Some(SpiceNewBlockProductionInfo {
                 core_statements,
                 newly_certified_block_execution_results,
+                prev_state_commitment_root,
+                prev_outcome_commitment_root,
                 prev_last_certified_block_epoch_id,
                 spice_chunk_endorsement_stats,
             })

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -19,12 +19,12 @@ pub use near_chain::stateless_validation::processing_tracker::{
 };
 pub use near_client_primitives::debug::DebugStatus;
 pub use near_client_primitives::types::{
-    Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
-    GetChunkExtraExists, GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
-    GetExecutionOutcomesForBlock, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
-    GetNextLightClientBlock, GetProcessedReceiptIds, GetProtocolConfig, GetReceipt, GetReceiptToTx,
-    GetReceiptToTxResponse, GetShardChunk, GetSplitStorageInfo, GetStateChanges,
-    GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
+    Error, ExecutionBlockProofResponse, GetBlock, GetBlockProof, GetBlockProofResponse,
+    GetBlockWithMerkleTree, GetChunk, GetChunkExtraExists, GetClientConfig, GetExecutionBlockProof,
+    GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock, GetGasPrice,
+    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProcessedReceiptIds,
+    GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse, GetShardChunk,
+    GetSplitStorageInfo, GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
     GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
     QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
 };

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -264,6 +264,8 @@ pub fn create_chunk(
     };
     let epoch_sync_data_hash =
         client.epoch_manager.compute_epoch_sync_data_hash(last_block.hash()).unwrap();
+    let (prev_state_commitment_root, prev_outcome_commitment_root) =
+        client.chain.spice_core_reader.light_client_commitment_roots(last_block.header()).unwrap();
     let block = TestBlockBuilder::from_prev_block(client.clock.clone(), &last_block, signer)
         .height(next_height)
         .chunks(vec![encoded_chunk.cloned_header()])
@@ -271,6 +273,7 @@ pub fn create_chunk(
         .max_gas_price(Balance::from_yoctonear(100))
         .block_merkle_tree(&mut block_merkle_tree)
         .spice_chunk_endorsement_stats(spice_chunk_endorsement_stats)
+        .spice_commitment_roots(prev_state_commitment_root, prev_outcome_commitment_root)
         .epoch_sync_data_hash(epoch_sync_data_hash)
         .build();
     let chunk = ShardChunkWithEncoding::from_encoded_shard_chunk(encoded_chunk)

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -20,12 +20,13 @@ use near_chain::{
 use near_chain_configs::{ClientConfig, MutableValidatorSigner, ProtocolConfigView};
 use near_chain_primitives::error::EpochErrorResultToChainError;
 use near_client_primitives::types::{
-    Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError, GetBlockProofResponse,
-    GetBlockWithMerkleTree, GetChunkError, GetChunkExtraExists, GetExecutionOutcome,
-    GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError,
-    GetMaintenanceWindows, GetMaintenanceWindowsError, GetNextLightClientBlockError,
-    GetProcessedReceiptIds, GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError,
-    GetReceipt, GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
+    Error, ExecutionBlockProofResponse, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError,
+    GetBlockProofResponse, GetBlockWithMerkleTree, GetChunkError, GetChunkExtraExists,
+    GetExecutionBlockProof, GetExecutionOutcome, GetExecutionOutcomeError,
+    GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError, GetMaintenanceWindows,
+    GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProcessedReceiptIds,
+    GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError, GetReceipt,
+    GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
     GetSplitStorageInfo, GetSplitStorageInfoError, GetStateChangesError,
     GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
     GetValidatorInfoError, Query, QueryError, TxStatus, TxStatusError,
@@ -49,6 +50,7 @@ use near_primitives::network::AnnounceAccount;
 use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptOrigin, ReceiptToTxInfo};
 use near_primitives::shard_layout::{ShardLayout, ShardLayoutError};
 use near_primitives::sharding::ShardChunk;
+use near_primitives::spice::commitment::SpiceCommitmentProofView;
 use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockId, BlockReference, EpochHeight, EpochId, EpochReference,
@@ -1145,13 +1147,42 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
         match self.chain.get_execution_outcome(&id) {
             Ok(outcome) => {
                 let mut outcome_proof = outcome;
-                let epoch_id =
-                    *self.chain.get_block(&outcome_proof.block_hash)?.header().epoch_id();
+                let block_header =
+                    BlockHeader::clone(self.chain.get_block(&outcome_proof.block_hash)?.header());
+                let epoch_id = *block_header.epoch_id();
                 let shard_layout =
                     self.epoch_manager.get_shard_layout(&epoch_id).into_chain_error()?;
                 let target_shard_id =
                     account_id_to_shard_id(self.epoch_manager.as_ref(), &account_id, &epoch_id)
                         .into_chain_error()?;
+                if block_header.is_spice() {
+                    // SPICE: the proof anchors into the certified block's own outcome
+                    // root, not the next block's `prev_outcome_root`.
+                    let Some(shard_outcome_roots) = self
+                        .chain
+                        .spice_core_reader
+                        .certified_block_shard_outcome_roots(&block_header)?
+                    else {
+                        return Err(GetExecutionOutcomeError::NotConfirmed {
+                            transaction_or_receipt_id: id,
+                        });
+                    };
+                    let Some(index) = shard_outcome_roots
+                        .iter()
+                        .position(|(shard_id, _)| *shard_id == target_shard_id)
+                    else {
+                        return Err(GetExecutionOutcomeError::InconsistentState {
+                            number_or_shards: shard_outcome_roots.len(),
+                            execution_outcome_shard_id: target_shard_id,
+                        });
+                    };
+                    let roots: Vec<CryptoHash> =
+                        shard_outcome_roots.iter().map(|(_, root)| *root).collect();
+                    return Ok(GetExecutionOutcomeResponse {
+                        outcome_proof: outcome_proof.into(),
+                        outcome_root_proof: merklize(&roots).1[index].clone(),
+                    });
+                }
                 let target_shard_index = shard_layout
                     .get_shard_index(target_shard_id)
                     .map_err(Into::into)
@@ -1620,12 +1651,62 @@ impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> f
         let head_block_header = self.chain.get_block_header(&msg.head_block_hash)?;
         let head_block_header = BlockHeader::clone(&head_block_header);
         self.chain.check_blocks_final_and_canonical(&[block_header.clone(), head_block_header])?;
+        // A plain block-inclusion proof, valid for spice blocks too (their `block_hash`
+        // sits in the block merkle tree like any block). Execution anchoring lives in
+        // `GetExecutionBlockProof`.
         let block_header_lite = block_header.into();
         let proof = self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
             &msg.block_hash,
             &msg.head_block_hash,
         )?;
         Ok(GetBlockProofResponse { block_header_lite, proof })
+    }
+}
+
+impl Handler<GetExecutionBlockProof, Result<ExecutionBlockProofResponse, GetBlockProofError>>
+    for ViewClientActor
+{
+    fn handle(
+        &mut self,
+        msg: GetExecutionBlockProof,
+    ) -> Result<ExecutionBlockProofResponse, GetBlockProofError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetExecutionBlockProof"])
+            .start_timer();
+        let block_header = self.chain.get_block_header(&msg.block_hash)?;
+        let block_header = BlockHeader::clone(&block_header);
+        let head_block_header = self.chain.get_block_header(&msg.head_block_hash)?;
+        let head_block_header = BlockHeader::clone(&head_block_header);
+        self.chain.check_blocks_final_and_canonical(&[block_header.clone(), head_block_header])?;
+        if block_header.is_spice() {
+            // SPICE: anchor the execution commitment via the anchor block (the
+            // certifier's canonical child), not the certified block itself.
+            let Some(proof) =
+                self.chain.spice_commitment_proof(&msg.block_hash, &msg.head_block_hash)?
+            else {
+                return Err(GetBlockProofError::ProofNotAvailable { block_hash: msg.block_hash });
+            };
+            return Ok(ExecutionBlockProofResponse {
+                block_header_lite: proof.anchor_block_lite,
+                block_proof: proof.anchor_block_proof,
+                spice_commitment_proof: Some(SpiceCommitmentProofView {
+                    outcome_commitment_proof: proof.outcome_commitment_proof,
+                    state_commitment_proof: proof.state_commitment_proof,
+                    commitment_height: proof.commitment_height,
+                }),
+            });
+        }
+        let block_header_lite = block_header.into();
+        let block_proof = self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
+            &msg.block_hash,
+            &msg.head_block_hash,
+        )?;
+        Ok(ExecutionBlockProofResponse {
+            block_header_lite,
+            block_proof,
+            spice_commitment_proof: None,
+        })
     }
 }
 

--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -29,6 +29,11 @@ pub struct RpcLightClientExecutionProofResponse {
     pub outcome_root_proof: near_primitives::merkle::MerklePath,
     pub block_header_lite: near_primitives::views::LightClientBlockLiteView,
     pub block_proof: near_primitives::merkle::MerklePath,
+    /// Under SPICE, the execution-commitment proof anchoring the certified block via
+    /// its anchor block (`block_header_lite`). Absent for non-SPICE blocks.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub spice_commitment_proof:
+        Option<near_primitives::spice::commitment::SpiceCommitmentProofView>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -66,6 +71,8 @@ pub enum RpcLightClientProofError {
     },
     #[error("{transaction_or_receipt_id} has not been confirmed")]
     NotConfirmed { transaction_or_receipt_id: near_primitives::hash::CryptoHash },
+    #[error("execution commitment proof for block {block_hash} is not available yet")]
+    ProofNotAvailable { block_hash: near_primitives::hash::CryptoHash },
     #[error("{transaction_or_receipt_id} does not exist")]
     UnknownTransactionOrReceipt { transaction_or_receipt_id: near_primitives::hash::CryptoHash },
     #[error("Node doesn't track the shard where {transaction_or_receipt_id} is executed")]

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -84,6 +84,9 @@ impl RpcFrom<GetBlockProofError> for RpcLightClientProofError {
             GetBlockProofError::UnknownBlock { error_message } => {
                 Self::UnknownBlock { error_message }
             }
+            GetBlockProofError::ProofNotAvailable { block_hash } => {
+                Self::ProofNotAvailable { block_hash }
+            }
             GetBlockProofError::InternalError { error_message } => {
                 Self::InternalError { error_message }
             }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -14,12 +14,13 @@ use near_async::messaging::{AsyncSendError, AsyncSender, CanSend, CanSendAsync, 
 use near_async::time::{Clock, Duration};
 use near_chain_configs::{ClientConfig, GenesisConfig, ProtocolConfigView};
 use near_client::{
-    DebugStatus, GetBlock, GetBlockProof, GetBlockProofResponse, GetChunk, GetChunkExtraExists,
-    GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice,
-    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
-    GetReceiptToTx, GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock,
-    GetValidatorInfo, GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse,
-    Query as ClientQuery, QueryError, Status, StatusResponse, TxStatus, TxStatusError,
+    DebugStatus, ExecutionBlockProofResponse, GetBlock, GetBlockProof, GetBlockProofResponse,
+    GetChunk, GetChunkExtraExists, GetClientConfig, GetExecutionBlockProof, GetExecutionOutcome,
+    GetExecutionOutcomeResponse, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
+    GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse,
+    GetStateChanges, GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered,
+    ProcessTxRequest, ProcessTxResponse, Query as ClientQuery, QueryError, Status, StatusResponse,
+    TxStatus, TxStatusError,
 };
 use near_client_primitives::debug::{
     DebugBlockStatusQuery, DebugBlocksStartingMode, DebugStatusResponse,
@@ -445,6 +446,7 @@ pub struct ClientSenderForRpc(
 pub struct ViewClientSenderForRpc(
     AsyncSender<GetBlock, Result<BlockView, GetBlockError>>,
     AsyncSender<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>>,
+    AsyncSender<GetExecutionBlockProof, Result<ExecutionBlockProofResponse, GetBlockProofError>>,
     AsyncSender<GetChunk, Result<ChunkView, GetChunkError>>,
     AsyncSender<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>,
     AsyncSender<GetGasPrice, Result<GasPriceView, GetGasPriceError>>,
@@ -2360,8 +2362,8 @@ impl JsonRpcHandler {
         let execution_outcome_proof: near_client_primitives::types::GetExecutionOutcomeResponse =
             self.view_client_send(GetExecutionOutcome { id }).await?;
 
-        let block_proof: near_client_primitives::types::GetBlockProofResponse = self
-            .view_client_send(GetBlockProof {
+        let block_proof: ExecutionBlockProofResponse = self
+            .view_client_send(GetExecutionBlockProof {
                 block_hash: execution_outcome_proof.outcome_proof.block_hash,
                 head_block_hash: light_client_head,
             })
@@ -2371,7 +2373,8 @@ impl JsonRpcHandler {
             outcome_proof: execution_outcome_proof.outcome_proof,
             outcome_root_proof: execution_outcome_proof.outcome_root_proof,
             block_header_lite: block_proof.block_header_lite,
-            block_proof: block_proof.proof,
+            block_proof: block_proof.block_proof,
+            spice_commitment_proof: block_proof.spice_commitment_proof,
         })
     }
 

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -249,9 +249,8 @@ impl Block {
         ));
 
         let chunks_wrapper = Chunks::from_chunk_headers(&chunks, height);
-        let prev_state_root = if spice_info.is_some() {
-            // TODO(spice): include state root from the relevant previous executed block.
-            CryptoHash::default()
+        let prev_state_root = if let Some(spice_info) = spice_info.as_ref() {
+            spice_info.prev_state_commitment_root
         } else {
             chunks_wrapper.compute_state_root()
         };
@@ -259,7 +258,11 @@ impl Block {
             chunks_wrapper.compute_chunk_prev_outgoing_receipts_root();
         let chunk_headers_root = chunks_wrapper.compute_chunk_headers_root();
         let chunk_tx_root = chunks_wrapper.compute_chunk_tx_root();
-        let outcome_root = chunks_wrapper.compute_outcome_root();
+        let outcome_root = if let Some(spice_info) = spice_info.as_ref() {
+            spice_info.prev_outcome_commitment_root
+        } else {
+            chunks_wrapper.compute_outcome_root()
+        };
 
         let prev_last_certified_block_epoch_id =
             spice_info.as_ref().map(|info| info.prev_last_certified_block_epoch_id);
@@ -629,9 +632,13 @@ impl Block {
             return Err(InvalidTransactionRoot);
         }
 
-        let outcome_root = self.chunks().compute_outcome_root();
-        if self.header().outcome_root() != &outcome_root {
-            return Err(InvalidTransactionRoot);
+        // Spice repurposes `outcome_root` for the certified-block commitment, checked
+        // against the predecessor's certified set in `validate_light_client_commitment_roots`.
+        if !self.is_spice_block() {
+            let outcome_root = self.chunks().compute_outcome_root();
+            if self.header().outcome_root() != &outcome_root {
+                return Err(InvalidTransactionRoot);
+            }
         }
 
         // Check that chunk included root stored in the header matches the chunk included root of the chunks
@@ -648,6 +655,8 @@ impl Block {
 pub struct SpiceNewBlockProductionInfo {
     pub core_statements: SpiceCoreStatements,
     pub newly_certified_block_execution_results: Vec<BlockExecutionResults>,
+    pub prev_state_commitment_root: CryptoHash,
+    pub prev_outcome_commitment_root: CryptoHash,
     pub prev_last_certified_block_epoch_id: EpochId,
     /// Accumulated per-validator endorsement stats for the epoch; non-empty
     /// only on the last block of an epoch.

--- a/core/primitives/src/spice/commitment.rs
+++ b/core/primitives/src/spice/commitment.rs
@@ -1,0 +1,262 @@
+use crate::hash::CryptoHash;
+use crate::merkle::{MerklePath, merklize, verify_path};
+use crate::types::{BlockExecutionResults, BlockHeight, MerkleHash, ShardId};
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_schema_checker_lib::ProtocolSchema;
+
+/// Attributed commitment to a certified block's state root, a leaf of the
+/// `prev_state_root` commitment set. `state_root` is the merkle root over the block's
+/// per-shard certified state roots.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+pub struct StateCommitment {
+    pub block_hash: CryptoHash,
+    pub block_height: BlockHeight,
+    pub state_root: MerkleHash,
+}
+
+/// Attributed commitment to a certified block's outcome root, a leaf of the
+/// `prev_outcome_root` commitment set. `outcome_root` is the merkle root over the
+/// block's per-shard certified outcome roots.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+pub struct OutcomeCommitment {
+    pub block_hash: CryptoHash,
+    pub block_height: BlockHeight,
+    pub outcome_root: MerkleHash,
+}
+
+/// The SPICE execution-commitment proof carried alongside a block proof.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct SpiceCommitmentProofView {
+    pub outcome_commitment_proof: MerklePath,
+    pub state_commitment_proof: MerklePath,
+    /// The certified block's height, to rebuild the commitment leaves.
+    pub commitment_height: BlockHeight,
+}
+
+/// A block whose execution results became certified by some block's core
+/// statements, with the identity needed to build its commitment set leaves.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CertifiedBlockInfo {
+    pub block_hash: CryptoHash,
+    pub block_height: BlockHeight,
+    pub execution_results: BlockExecutionResults,
+}
+
+impl CertifiedBlockInfo {
+    pub fn state_commitment(&self) -> StateCommitment {
+        StateCommitment {
+            block_hash: self.block_hash,
+            block_height: self.block_height,
+            state_root: merklize_state_roots(&self.execution_results),
+        }
+    }
+
+    pub fn outcome_commitment(&self) -> OutcomeCommitment {
+        OutcomeCommitment {
+            block_hash: self.block_hash,
+            block_height: self.block_height,
+            outcome_root: merklize_outcome_roots(&self.execution_results),
+        }
+    }
+}
+
+/// Per-shard certified roots sorted by `ShardId`, mirroring the shard order of
+/// `Chunks::compute_state_root` / `compute_outcome_root`.
+fn shard_sorted_roots(
+    execution_results: &BlockExecutionResults,
+    select: impl Fn(&BlockExecutionResults, ShardId) -> MerkleHash,
+) -> Vec<MerkleHash> {
+    let mut shard_ids: Vec<ShardId> = execution_results.0.keys().copied().collect();
+    shard_ids.sort();
+    shard_ids.into_iter().map(|shard_id| select(execution_results, shard_id)).collect()
+}
+
+pub fn merklize_state_roots(execution_results: &BlockExecutionResults) -> MerkleHash {
+    let roots = shard_sorted_roots(execution_results, |results, shard_id| {
+        *results.0[&shard_id].chunk_extra.state_root()
+    });
+    merklize(&roots).0
+}
+
+pub fn merklize_outcome_roots(execution_results: &BlockExecutionResults) -> MerkleHash {
+    let roots = shard_sorted_roots(execution_results, |results, shard_id| {
+        *results.0[&shard_id].chunk_extra.outcome_root()
+    });
+    merklize(&roots).0
+}
+
+fn sorted_by_height(certified: &[CertifiedBlockInfo]) -> Vec<&CertifiedBlockInfo> {
+    let mut sorted: Vec<&CertifiedBlockInfo> = certified.iter().collect();
+    sorted.sort_by_key(|info| info.block_height);
+    sorted
+}
+
+pub fn state_commitments(certified: &[CertifiedBlockInfo]) -> Vec<StateCommitment> {
+    sorted_by_height(certified).into_iter().map(CertifiedBlockInfo::state_commitment).collect()
+}
+
+pub fn outcome_commitments(certified: &[CertifiedBlockInfo]) -> Vec<OutcomeCommitment> {
+    sorted_by_height(certified).into_iter().map(CertifiedBlockInfo::outcome_commitment).collect()
+}
+
+/// The two commitment set roots committed in an anchor block's `prev_state_root` /
+/// `prev_outcome_root` slots. Shared by production and validation so they cannot
+/// diverge on leaf bytes or order. An empty set yields `default()` roots.
+pub fn compute_commitment_roots(certified: &[CertifiedBlockInfo]) -> (CryptoHash, CryptoHash) {
+    (merklize(&state_commitments(certified)).0, merklize(&outcome_commitments(certified)).0)
+}
+
+/// Merkle path of `target_block_hash`'s outcome leaf within the commitment set root,
+/// alongside the rebuilt leaf. `None` if the block is not in the set.
+pub fn outcome_commitment_proof(
+    certified: &[CertifiedBlockInfo],
+    target_block_hash: &CryptoHash,
+) -> Option<(MerklePath, OutcomeCommitment)> {
+    let commitments = outcome_commitments(certified);
+    let index = commitments.iter().position(|c| &c.block_hash == target_block_hash)?;
+    let (_root, paths) = merklize(&commitments);
+    Some((paths[index].clone(), commitments[index].clone()))
+}
+
+/// State analog of [`outcome_commitment_proof`].
+pub fn state_commitment_proof(
+    certified: &[CertifiedBlockInfo],
+    target_block_hash: &CryptoHash,
+) -> Option<(MerklePath, StateCommitment)> {
+    let commitments = state_commitments(certified);
+    let index = commitments.iter().position(|c| &c.block_hash == target_block_hash)?;
+    let (_root, paths) = merklize(&commitments);
+    Some((paths[index].clone(), commitments[index].clone()))
+}
+
+pub fn verify_outcome_commitment(
+    commitment_root: MerkleHash,
+    commitment_proof: &MerklePath,
+    commitment: &OutcomeCommitment,
+) -> bool {
+    verify_path(commitment_root, commitment_proof, commitment)
+}
+
+pub fn verify_state_commitment(
+    commitment_root: MerkleHash,
+    commitment_proof: &MerklePath,
+    commitment: &StateCommitment,
+) -> bool {
+    verify_path(commitment_root, commitment_proof, commitment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bandwidth_scheduler::BandwidthRequests;
+    use crate::congestion_info::CongestionInfo;
+    use crate::types::chunk_extra::ChunkExtra;
+    use crate::types::{ChunkExecutionResult, Gas};
+    use near_primitives_core::types::Balance;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    #[derive(Clone, Copy)]
+    struct ShardRoots {
+        shard_id: u64,
+        // Dummy byte expanded to a `[byte; 32]` root hash; distinct bytes give distinct roots.
+        state_root_byte: u8,
+        outcome_root_byte: u8,
+    }
+
+    fn execution_results(shards: &[ShardRoots]) -> BlockExecutionResults {
+        let mut results = HashMap::new();
+        for shard in shards {
+            let chunk_extra = ChunkExtra::new(
+                &CryptoHash([shard.state_root_byte; 32]),
+                CryptoHash([shard.outcome_root_byte; 32]),
+                vec![],
+                Gas::ZERO,
+                Gas::ZERO,
+                Balance::ZERO,
+                Some(CongestionInfo::default()),
+                BandwidthRequests::empty(),
+                None,
+            );
+            let result =
+                ChunkExecutionResult { chunk_extra, outgoing_receipts_root: CryptoHash::default() };
+            results.insert(ShardId::new(shard.shard_id), Arc::new(result));
+        }
+        BlockExecutionResults(results)
+    }
+
+    // `num_blocks` distinct single-shard blocks; block `n` uses byte `n` for its
+    // hash, height, and roots (see `ShardRoots`).
+    fn generate_test_blocks(num_blocks: u8) -> Vec<CertifiedBlockInfo> {
+        (1..=num_blocks)
+            .map(|byte| CertifiedBlockInfo {
+                block_hash: CryptoHash([byte; 32]),
+                block_height: BlockHeight::from(byte),
+                execution_results: execution_results(&[ShardRoots {
+                    shard_id: 0,
+                    state_root_byte: byte,
+                    outcome_root_byte: byte + 1,
+                }]),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_empty_set_yields_default_roots() {
+        let (state_root, outcome_root) = compute_commitment_roots(&[]);
+        assert_eq!(state_root, CryptoHash::default());
+        assert_eq!(outcome_root, CryptoHash::default());
+    }
+
+    #[test]
+    fn test_per_shard_roots_sorted_by_shard_id() {
+        let shard_0 = ShardRoots { shard_id: 0, state_root_byte: 1, outcome_root_byte: 2 };
+        let shard_1 = ShardRoots { shard_id: 1, state_root_byte: 3, outcome_root_byte: 4 };
+        let ascending = execution_results(&[shard_0, shard_1]);
+        let descending = execution_results(&[shard_1, shard_0]);
+        assert_eq!(merklize_state_roots(&ascending), merklize_state_roots(&descending));
+        assert_eq!(merklize_outcome_roots(&ascending), merklize_outcome_roots(&descending));
+    }
+
+    #[test]
+    fn test_roots_independent_of_input_order() {
+        let blocks = generate_test_blocks(3);
+        let mut reversed = blocks.clone();
+        reversed.reverse();
+        assert_eq!(compute_commitment_roots(&blocks), compute_commitment_roots(&reversed));
+    }
+
+    #[test]
+    fn test_singleton_commitment_root_is_leaf_hash() {
+        let blocks = generate_test_blocks(1);
+        let (_state_root, outcome_root) = compute_commitment_roots(&blocks);
+        let (proof, leaf) = outcome_commitment_proof(&blocks, &blocks[0].block_hash).unwrap();
+        assert!(proof.is_empty());
+        assert_eq!(outcome_root, CryptoHash::hash_borsh(&leaf));
+    }
+
+    #[test]
+    fn test_commitment_proofs_verify_for_every_block() {
+        let blocks = generate_test_blocks(4);
+        let (state_root, outcome_root) = compute_commitment_roots(&blocks);
+        for block in &blocks {
+            let (outcome_proof, outcome_leaf) =
+                outcome_commitment_proof(&blocks, &block.block_hash).unwrap();
+            assert!(verify_outcome_commitment(outcome_root, &outcome_proof, &outcome_leaf));
+            assert_eq!(outcome_leaf, block.outcome_commitment());
+
+            let (state_proof, state_leaf) =
+                state_commitment_proof(&blocks, &block.block_hash).unwrap();
+            assert!(verify_state_commitment(state_root, &state_proof, &state_leaf));
+            assert_eq!(state_leaf, block.state_commitment());
+        }
+    }
+
+    #[test]
+    fn test_commitment_proof_absent_for_unknown_block() {
+        let blocks = generate_test_blocks(2);
+        let (committed, unknown) = blocks.split_at(1);
+        assert!(outcome_commitment_proof(committed, &unknown[0].block_hash).is_none());
+    }
+}

--- a/core/primitives/src/spice/mod.rs
+++ b/core/primitives/src/spice/mod.rs
@@ -1,3 +1,4 @@
 pub mod chunk_endorsement;
+pub mod commitment;
 pub mod partial_data;
 pub mod state_witness;

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -937,6 +937,7 @@ pub struct TestBlockBuilder {
     /// Iff `Some` spice block will be created.
     spice_core_statements: Option<crate::block_body::SpiceCoreStatements>,
     newly_certified_block_execution_results: Vec<crate::types::BlockExecutionResults>,
+    spice_commitment_roots: (CryptoHash, CryptoHash),
     prev_last_certified_block_epoch_id: Option<EpochId>,
     spice_chunk_endorsement_stats: Vec<SpiceChunkEndorsementStats>,
 }
@@ -977,6 +978,7 @@ impl TestBlockBuilder {
                 None
             },
             newly_certified_block_execution_results: vec![],
+            spice_commitment_roots: (CryptoHash::default(), CryptoHash::default()),
             prev_last_certified_block_epoch_id: if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION)
             {
                 Some(*prev_header.epoch_id())
@@ -1089,6 +1091,15 @@ impl TestBlockBuilder {
         self
     }
 
+    pub fn spice_commitment_roots(
+        mut self,
+        prev_state_commitment_root: CryptoHash,
+        prev_outcome_commitment_root: CryptoHash,
+    ) -> Self {
+        self.spice_commitment_roots = (prev_state_commitment_root, prev_outcome_commitment_root);
+        self
+    }
+
     pub fn spice_chunk_endorsement_stats(mut self, stats: Vec<SpiceChunkEndorsementStats>) -> Self {
         self.spice_chunk_endorsement_stats = stats;
         self
@@ -1138,10 +1149,14 @@ impl TestBlockBuilder {
             None,
             None,
             self.spice_core_statements.map(|core_statements| {
+                let (prev_state_commitment_root, prev_outcome_commitment_root) =
+                    self.spice_commitment_roots;
                 crate::block::SpiceNewBlockProductionInfo {
                     core_statements,
                     newly_certified_block_execution_results: self
                         .newly_certified_block_execution_results,
+                    prev_state_commitment_root,
+                    prev_outcome_commitment_root,
                     prev_last_certified_block_epoch_id: self
                         .prev_last_certified_block_epoch_id
                         .expect("prev_last_certified_block_epoch_id not set for spice block"),
@@ -1234,16 +1249,17 @@ impl Block {
         let headers_root = chunks.compute_chunk_headers_root().0;
         let tx_root = chunks.compute_chunk_tx_root();
         let prev_outgoing_receipts_root = chunks.compute_chunk_prev_outgoing_receipts_root();
-        let prev_state_root = if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-            CryptoHash::default()
-        } else {
-            chunks.compute_state_root()
-        };
+        // Under spice these slots hold the certified-block commitment, not a
+        // chunk-derived root, so preserve whatever the block already has.
+        let spice = ProtocolFeature::Spice.enabled(PROTOCOL_VERSION);
+        let prev_state_root =
+            if spice { *self.header().prev_state_root() } else { chunks.compute_state_root() };
+        let prev_outcome_root =
+            if spice { *self.header().outcome_root() } else { chunks.compute_outcome_root() };
         let chunk_mask = chunks
             .iter_raw()
             .map(|chunk| chunk.height_included() == self.header().height())
             .collect_vec();
-        let prev_outcome_root = chunks.compute_outcome_root();
         let body_hash = self.compute_block_body_hash().unwrap();
 
         self.mut_header().set_chunk_headers_root(headers_root);

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -399,6 +399,13 @@ pub enum DBCol {
     /// - *Content type*: `Vec<CodeHash>`
     #[cfg(feature = "protocol_feature_spice")]
     ContractAccesses,
+    /// For spice light clients, maps a certified block to the canonical block
+    /// whose core statements certified it. Re-pointed to the canonical certifier
+    /// on reorg. Used to locate the anchor block of a block's execution commitment.
+    /// - *Rows*: BlockHash (certified block H)
+    /// - *Content type*: BlockHash (certifier X)
+    #[cfg(feature = "protocol_feature_spice")]
+    SpiceCertifierByBlock,
     /// Pre-computed chunk producer for the chunk anchored at the given block (its
     /// grandparent), sampled at height `anchor.height+2` in the epoch after the anchor.
     /// Populated during header sync and block processing, gated behind `EarlyKickout`
@@ -601,6 +608,8 @@ impl DBCol {
             | DBCol::SpiceEndorsementStats => false,
             #[cfg(feature = "protocol_feature_spice")]
             | DBCol::ContractAccesses => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            | DBCol::SpiceCertifierByBlock => false,
             // TODO
             DBCol::ChallengedBlocks => false,
             DBCol::Misc => false,
@@ -714,6 +723,7 @@ impl DBCol {
             | DBCol::Endorsements
             | DBCol::ExecutionResults
             | DBCol::ReceiptProofs
+            | DBCol::SpiceCertifierByBlock
             | DBCol::SpiceEndorsementStats
             | DBCol::UncertifiedChunks
             | DBCol::UncertifiedExecutionResults
@@ -867,6 +877,8 @@ impl DBCol {
             DBCol::SpiceEndorsementStats => &[DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::ContractAccesses => &[DBKeyType::BlockHash, DBKeyType::ShardId],
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::SpiceCertifierByBlock => &[DBKeyType::BlockHash],
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => &[DBKeyType::BlockHash, DBKeyType::ShardId],
         }
@@ -924,6 +936,13 @@ impl DBCol {
     pub fn spice_endorsement_stats() -> DBCol {
         #[cfg(feature = "protocol_feature_spice")]
         return DBCol::SpiceEndorsementStats;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn spice_certifier_by_block() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::SpiceCertifierByBlock;
         #[cfg(not(feature = "protocol_feature_spice"))]
         panic!("Expected protocol_feature_spice to be enabled")
     }

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -1,0 +1,172 @@
+use crate::setup::builder::TestLoopBuilder;
+use crate::utils::account::create_account_id;
+use near_async::messaging::Handler as _;
+use near_async::time::Duration;
+use near_client::{GetExecutionBlockProof, GetExecutionOutcome, GetNextLightClientBlock};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::{CryptoHash, hash};
+use near_primitives::merkle::{compute_root_from_path, compute_root_from_path_and_item};
+use near_primitives::spice::commitment::{
+    OutcomeCommitment, SpiceCommitmentProofView, StateCommitment, merklize_state_roots,
+    verify_outcome_commitment, verify_state_commitment,
+};
+use near_primitives::transaction::PartialExecutionStatus;
+use near_primitives::types::{Balance, TransactionOrReceiptId};
+use near_primitives::views::{ExecutionOutcomeView, ExecutionStatusView, LightClientBlockLiteView};
+
+fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
+    let status = match &outcome.status {
+        ExecutionStatusView::Unknown => PartialExecutionStatus::Unknown,
+        ExecutionStatusView::SuccessValue(s) => PartialExecutionStatus::SuccessValue(s.clone()),
+        ExecutionStatusView::Failure(_) => PartialExecutionStatus::Failure,
+        ExecutionStatusView::SuccessReceiptId(id) => PartialExecutionStatus::SuccessReceiptId(*id),
+    };
+    let mut result = vec![CryptoHash::hash_borsh((
+        outcome.receipt_ids.clone(),
+        outcome.gas_burnt,
+        outcome.tokens_burnt,
+        outcome.executor_id.clone(),
+        status,
+    ))];
+    for log in &outcome.logs {
+        result.push(hash(log.as_bytes()));
+    }
+    result
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_execution_and_state_proof() {
+    init_test_logger();
+
+    let sender = create_account_id("sender");
+    let receiver = create_account_id("receiver");
+
+    let mut env = TestLoopBuilder::new()
+        .validators(2, 1)
+        .enable_rpc()
+        .add_user_account(&sender, Balance::from_near(10))
+        .add_user_account(&receiver, Balance::from_near(0))
+        .build();
+
+    // The light client's initial trusted head: whatever the chain head is at the start.
+    let initial_head_hash = env.rpc_node().head().last_block_hash;
+
+    let tx = env.rpc_node().tx_send_money(&sender, &receiver, Balance::from_near(1));
+    let tx_hash = tx.get_hash();
+    let outcome = env.rpc_runner().execute_tx(tx, Duration::seconds(20)).unwrap();
+    let tx_height = env
+        .rpc_node()
+        .client()
+        .chain
+        .get_block_header(&outcome.transaction_outcome.block_hash)
+        .unwrap()
+        .height();
+
+    // Certify the block the outcome lands in, then run a few more so the anchor block
+    // (the certifier's canonical child) exists and the trusted head is past it.
+    env.rpc_runner().run_until_certified(tx_height);
+    let head_after_certification = env.rpc_node().head().height;
+    env.rpc_runner().run_until_final_head_height(head_after_certification + 3);
+
+    let outcome_response = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetExecutionOutcome {
+            id: TransactionOrReceiptId::Transaction {
+                transaction_hash: tx_hash,
+                sender_id: sender,
+            },
+        })
+        .unwrap();
+    let outcome_block_hash = outcome_response.outcome_proof.block_hash;
+
+    // A light client learns its trusted head and that head's block_merkle_root by
+    // syncing a light client block from its initial head over RPC, not from the chain.
+    let light_client_block = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetNextLightClientBlock { last_block_hash: initial_head_hash })
+        .unwrap()
+        .unwrap();
+    let trusted_head_lite = LightClientBlockLiteView {
+        prev_block_hash: light_client_block.prev_block_hash,
+        inner_rest_hash: light_client_block.inner_rest_hash,
+        inner_lite: light_client_block.inner_lite.clone(),
+    };
+    let trusted_head_hash = trusted_head_lite.hash();
+    let trusted_block_merkle_root = light_client_block.inner_lite.block_merkle_root;
+
+    let block_proof_response = env
+        .rpc_node_mut()
+        .view_client_actor()
+        .handle(GetExecutionBlockProof {
+            block_hash: outcome_block_hash,
+            head_block_hash: trusted_head_hash,
+        })
+        .unwrap();
+
+    let anchor_block_lite = block_proof_response.block_header_lite;
+    let SpiceCommitmentProofView {
+        outcome_commitment_proof,
+        state_commitment_proof,
+        commitment_height,
+    } = block_proof_response.spice_commitment_proof.unwrap();
+
+    // outcome -> chunk_outcome_root (the certified block's outcome root for its shard).
+    let mut outcome_with_id_to_hash = vec![outcome_response.outcome_proof.id];
+    outcome_with_id_to_hash.extend(outcome_view_to_hashes(&outcome_response.outcome_proof.outcome));
+    let chunk_outcome_root = compute_root_from_path_and_item(
+        &outcome_response.outcome_proof.proof,
+        &outcome_with_id_to_hash,
+    );
+    // chunk_outcome_root -> the block's certified outcome root over all shards.
+    let outcome_root = compute_root_from_path(
+        &outcome_response.outcome_root_proof,
+        hash(chunk_outcome_root.as_ref()),
+    );
+    // rebuild the OutcomeCommitment leaf and prove it into the anchor block's outcome slot.
+    let outcome_leaf = OutcomeCommitment {
+        block_hash: outcome_block_hash,
+        block_height: commitment_height,
+        outcome_root,
+    };
+    assert!(verify_outcome_commitment(
+        anchor_block_lite.inner_lite.outcome_root,
+        &outcome_commitment_proof,
+        &outcome_leaf,
+    ));
+    // the anchor block proves into the trusted head's block_merkle_root.
+    let anchor_hash = anchor_block_lite.hash();
+    assert_eq!(
+        compute_root_from_path(&block_proof_response.block_proof, anchor_hash),
+        trusted_block_merkle_root,
+    );
+
+    // The state side commits the block's certified state root into the anchor block's
+    // `prev_state_root` slot; we read the root from the node rather than proving a value
+    // up to it.
+    // TODO(spice): prove a specific value (e.g. an account record) up to the state root
+    // via a trie proof, instead of reading the state root from the node.
+    let state_root = {
+        let node = env.rpc_node();
+        let chain = &node.client().chain;
+        let outcome_block_header = chain.get_block_header(&outcome_block_hash).unwrap();
+        let execution_results = chain
+            .spice_core_reader
+            .get_block_execution_results(&outcome_block_header)
+            .unwrap()
+            .unwrap();
+        merklize_state_roots(&execution_results)
+    };
+    let state_leaf = StateCommitment {
+        block_hash: outcome_block_hash,
+        block_height: commitment_height,
+        state_root,
+    };
+    assert!(verify_state_commitment(
+        anchor_block_lite.inner_lite.prev_state_root,
+        &state_commitment_proof,
+        &state_leaf,
+    ));
+}

--- a/test-loop-tests/src/tests/spice/mod.rs
+++ b/test-loop-tests/src/tests/spice/mod.rs
@@ -1,5 +1,6 @@
 mod basic;
 mod congestion;
+mod light_client;
 mod malicious_chunk_producer;
 mod resharding;
 mod utils;

--- a/test-utils/testlib/src/process_blocks.rs
+++ b/test-utils/testlib/src/process_blocks.rs
@@ -8,6 +8,12 @@ use near_primitives::{
 };
 
 pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
+    // Under spice these slots hold the certified-block commitment the block was produced
+    // with, independent of its chunks; preserve them instead of deriving from chunks.
+    let spice = ProtocolFeature::Spice.enabled(PROTOCOL_VERSION);
+    let spice_prev_state_root = *block.header().prev_state_root();
+    let spice_prev_outcome_root = *block.header().outcome_root();
+
     let chunk_headers = vec![prev_block.chunks()[0].clone()];
     let mut balance_burnt = Balance::ZERO;
     for chunk in block.chunks().iter_new() {
@@ -24,7 +30,8 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.prev_chunk_outgoing_receipts_root =
                 chunks.compute_chunk_prev_outgoing_receipts_root();
             header.inner_lite.prev_state_root = chunks.compute_state_root();
-            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
+            header.inner_lite.prev_outcome_root =
+                if spice { spice_prev_outcome_root } else { chunks.compute_outcome_root() };
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply =
@@ -36,7 +43,8 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.prev_chunk_outgoing_receipts_root =
                 chunks.compute_chunk_prev_outgoing_receipts_root();
             header.inner_lite.prev_state_root = chunks.compute_state_root();
-            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
+            header.inner_lite.prev_outcome_root =
+                if spice { spice_prev_outcome_root } else { chunks.compute_outcome_root() };
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply =
@@ -48,7 +56,8 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.prev_chunk_outgoing_receipts_root =
                 chunks.compute_chunk_prev_outgoing_receipts_root();
             header.inner_lite.prev_state_root = chunks.compute_state_root();
-            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
+            header.inner_lite.prev_outcome_root =
+                if spice { spice_prev_outcome_root } else { chunks.compute_outcome_root() };
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply =
@@ -60,7 +69,8 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.prev_chunk_outgoing_receipts_root =
                 chunks.compute_chunk_prev_outgoing_receipts_root();
             header.inner_lite.prev_state_root = chunks.compute_state_root();
-            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
+            header.inner_lite.prev_outcome_root =
+                if spice { spice_prev_outcome_root } else { chunks.compute_outcome_root() };
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply =
@@ -73,15 +83,16 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.chunk_tx_root = chunks.compute_chunk_tx_root();
             header.inner_rest.prev_chunk_outgoing_receipts_root =
                 chunks.compute_chunk_prev_outgoing_receipts_root();
-            if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-                header.inner_lite.prev_state_root = *prev_block.header().prev_state_root();
+            if spice {
+                header.inner_lite.prev_state_root = spice_prev_state_root;
             } else {
                 header.inner_lite.prev_state_root = chunks.compute_state_root();
                 header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
                 header.inner_rest.total_supply =
                     header.inner_rest.total_supply.checked_add(balance_burnt).unwrap();
             }
-            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
+            header.inner_lite.prev_outcome_root =
+                if spice { spice_prev_outcome_root } else { chunks.compute_outcome_root() };
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.block_body_hash = block_body_hash.unwrap();
             header.inner_rest.chunk_endorsements =
@@ -93,15 +104,16 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.chunk_tx_root = chunks.compute_chunk_tx_root();
             header.inner_rest.prev_chunk_outgoing_receipts_root =
                 chunks.compute_chunk_prev_outgoing_receipts_root();
-            if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-                header.inner_lite.prev_state_root = *prev_block.header().prev_state_root();
+            if spice {
+                header.inner_lite.prev_state_root = spice_prev_state_root;
             } else {
                 header.inner_lite.prev_state_root = chunks.compute_state_root();
                 header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
                 header.inner_rest.total_supply =
                     header.inner_rest.total_supply.checked_add(balance_burnt).unwrap();
             }
-            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
+            header.inner_lite.prev_outcome_root =
+                if spice { spice_prev_outcome_root } else { chunks.compute_outcome_root() };
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.block_body_hash = block_body_hash.unwrap();
             header.inner_rest.chunk_endorsements =
@@ -113,15 +125,16 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.chunk_tx_root = chunks.compute_chunk_tx_root();
             header.inner_rest.prev_chunk_outgoing_receipts_root =
                 chunks.compute_chunk_prev_outgoing_receipts_root();
-            if ProtocolFeature::Spice.enabled(PROTOCOL_VERSION) {
-                header.inner_lite.prev_state_root = *prev_block.header().prev_state_root();
+            if spice {
+                header.inner_lite.prev_state_root = spice_prev_state_root;
             } else {
                 header.inner_lite.prev_state_root = chunks.compute_state_root();
                 header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
                 header.inner_rest.total_supply =
                     header.inner_rest.total_supply.checked_add(balance_burnt).unwrap();
             }
-            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
+            header.inner_lite.prev_outcome_root =
+                if spice { spice_prev_outcome_root } else { chunks.compute_outcome_root() };
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.block_body_hash = block_body_hash.unwrap();
             header.inner_rest.chunk_endorsements =


### PR DESCRIPTION
Adds light-client execution and state proofs for SPICE blocks with no block-header schema change, by repurposing the two placeholder `inner_lite` slots (`prev_state_root` / `prev_outcome_root`) that a SPICE block already carries dead.

Each block commits, as-of its predecessor, a Merkle root over a mini-leaf (`{block_hash, block_height, root}`) per block the predecessor newly certified. Production and validation share one pure recompute-and-compare function, so they cannot diverge, and the consensus-following light-client path stays byte-identical.

- Commitment types and pure helpers in `core/primitives/src/spice/commitment.rs`.
- As-of-prev production threaded through `Block::produce`; recompute-and-compare validation wired into `preprocess_block`.
- Flat `SpiceCertifierByBlock` index mapping a certified block to its canonical certifier; the anchor block is derived at serve time, so child-swap reorgs need no index update. Garbage-collected with the rest of the spice core data.
- Proof generation (`Chain::spice_commitment_proof`) plus RPC: `EXPERIMENTAL_light_client_proof` carries the commitment proof, while `EXPERIMENTAL_light_client_block_proof` continues to prove plain block inclusion. Transient "proof not available yet" states map to a dedicated error rather than an internal error.
- Unit tests for fork safety (losing/winning fork, child-swap, reorg re-point), producer-equals-validator, and validation rejection, plus an end-to-end test through the RPC.

The state proof commits the certified state root without a trie-value sub-proof for now (same shape as the classic flow); a `TODO(spice)` tracks proving a concrete value up to it.