### PR TITLE
fix(spice): advance execution head on nodes tracking no shards

### DIFF
--- a/chain/client/src/spice/chunk_executor_actor/coordinator.rs
+++ b/chain/client/src/spice/chunk_executor_actor/coordinator.rs
@@ -187,13 +187,13 @@ impl ChunkExecutorActor {
         let block = self.chain_store.get_block(block_hash)?;
         let prev_block_hash = *block.header().prev_hash();
         self.reconcile_tracked_shards(&prev_block_hash)?;
-        // TODO(spice): handle a node tracking zero shards (e.g. a `NoShards` light
-        // client). With no executors here, nothing schedules an apply, so the
-        // runtime finalize trigger (`coordinator_post_apply`, fired on apply-done)
-        // never runs and the execution head only advances on the startup disk walk.
-        // The fix is to decouple the finalize trigger from apply-done.
         for executor in self.per_shard_executors.values_mut() {
             executor.handle_processed_block(&block);
+        }
+        // A node tracking zero shards schedules no applies, so the apply-done
+        // finalize trigger never fires; finalize here instead.
+        if self.all_tracked_shards_applied(block_hash)? {
+            self.finalize_block(block_hash)?;
         }
         Ok(())
     }

--- a/chain/client/src/spice/tests/chunk_executor_actor.rs
+++ b/chain/client/src/spice/tests/chunk_executor_actor.rs
@@ -767,12 +767,11 @@ fn test_final_execution_head_is_updated_when_tracking_no_shards() {
 
     let (outgoing_sc, mut outgoing_rc) = unbounded();
     let producer_signer = Arc::new(create_test_signer("producer"));
-    let validator_signer = Arc::new(create_test_signer("validator"));
     let shard_layout = ShardLayout::single_shard();
     let genesis = TestGenesisBuilder::new()
         .genesis_time_from_clock(&Clock::real())
         .shard_layout(shard_layout.clone())
-        .validators_spec(ValidatorsSpec::desired_roles(&["producer"], &["validator"]))
+        .validators_spec(ValidatorsSpec::desired_roles(&["producer"], &[]))
         .build();
 
     let mut actors = [
@@ -782,13 +781,23 @@ fn test_final_execution_head_is_updated_when_tracking_no_shards() {
             shard_layout.shard_uids().collect(),
             outgoing_sc.clone(),
         ),
+        // A node tracking zero shards, modeled as a non-validator so it is
+        // guaranteed to track none — a validator account would be pulled into the
+        // shard's chunk-producers settlement and track it.
         TestActor::new(
             genesis,
-            MutableConfigValue::new(Some(validator_signer), "validator_signer"),
+            MutableConfigValue::new(None, "validator_signer"),
             vec![],
             outgoing_sc,
         ),
     ];
+
+    // Precondition: actor[1] genuinely tracks zero shards.
+    let genesis_hash = *actors[1].chain.genesis_block().hash();
+    assert!(
+        actors[1].actor.shard_tracker.tracked_shard_uids(&genesis_hash).unwrap().is_empty(),
+        "actor[1] must track zero shards for this test to be meaningful",
+    );
 
     execute_blocks_until_final_execution_head_moves(&mut actors, &mut outgoing_rc);
     // Having final execution head updated even when we are tracking no shards is very useful for


### PR DESCRIPTION
## What changed

`ChunkExecutorActor::handle_processed_block` now finalizes a block directly when all of its tracked shards are already applied, in addition to the existing apply-done path. For a node tracking zero shards this gate is vacuously true, so every processed block finalizes and the execution heads (`spice_execution_head` / `spice_final_execution_head`) advance.

## Why

The execution heads previously advanced only through `coordinator_post_apply`, which runs off the apply-done callback. A node tracking zero shards — a light/RPC node, or a SPICE chunk validator that validates statelessly and holds no state — schedules no chunk applies, so that callback never fired and its execution head froze at the genesis-seeded value while consensus kept advancing.

A stuck execution head breaks everything keyed off it: RPC `find_first_executed_ancestor` (block/status queries) starts returning "no executed ancestor", the data distributor's work frontier stops moving, and the GC / flat-storage boundary stalls.

The heads don't need execution results to advance: `set_spice_execution_head` is forward-only, and `update_spice_final_execution_head` is driven by the block's `last_final_block` (consensus finality). So finalizing straight from block processing is sufficient and correct for a node that has no shards to execute.

## Why the existing test passed

`test_final_execution_head_is_updated_when_tracking_no_shards` already existed and passed on master — but it wasn't testing a zero-shard node. Its second actor was a chunk validator with `TrackedShardsConfig::Shards(vec![])`, but `ShardTracker::cares_about_shard` ignores the empty config when the account has validation duties, and in a single-shard layout that validator was pulled into the shard's chunk-producers settlement. So it actually tracked shard 0, applied chunks, and finalized through the normal apply-done path — the empty config was effectively overridden.

The test now models the zero-shard node as a non-validator (guaranteed to track no shards) and asserts that precondition explicitly. With this setup it fails on master (the node's final head stays at the genesis-seeded height while the producer advances to the next height) and passes with the fix.

## Why this approach

Finalize is consensus-finality-driven, so the apply-done coupling is just the hot-path trigger, not a requirement. Gating the new call on `all_tracked_shards_applied` — the same check `coordinator_post_apply` already uses — leaves the hot path untouched: a node that tracks shards hits the gate as false (the block isn't applied yet) and still finalizes via apply-done; only the zero-shard case finalizes here. The heads are forward-only and idempotent, so being driven from both places is harmless.
