### PR TITLE
test(spice): honor configured chunk producer seats in tests

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -8,6 +8,7 @@ use crate::{ApplyChunksSpawner, DoomslugThresholdMode};
 use crate::{BlockProcessingArtifact, Provenance};
 use near_async::messaging::{IntoMultiSender, noop};
 use near_async::time::Clock;
+use near_chain_configs::test_genesis::TestEpochConfigBuilder;
 use near_chain_configs::{Genesis, MutableConfigValue};
 use near_chain_primitives::Error;
 use near_epoch_manager::shard_tracker::ShardTracker;
@@ -64,7 +65,12 @@ pub fn get_chain_with_genesis(clock: Clock, genesis: Genesis) -> Chain {
     let tempdir = tempfile::tempdir().unwrap();
     initialize_genesis_state(store.clone(), &genesis, Some(tempdir.path()));
     let chain_genesis = ChainGenesis::new(&genesis.config);
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
+    let epoch_config_store = TestEpochConfigBuilder::build_store_from_genesis(&genesis);
+    let epoch_manager = EpochManager::new_arc_handle_from_epoch_config_store(
+        store.clone(),
+        &genesis.config,
+        epoch_config_store,
+    );
     let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
     let runtime =
         NightshadeRuntime::test(tempdir.path(), store, &genesis.config, epoch_manager.clone());

--- a/chain/client/src/spice/tests/chunk_executor_actor.rs
+++ b/chain/client/src/spice/tests/chunk_executor_actor.rs
@@ -767,11 +767,12 @@ fn test_final_execution_head_is_updated_when_tracking_no_shards() {
 
     let (outgoing_sc, mut outgoing_rc) = unbounded();
     let producer_signer = Arc::new(create_test_signer("producer"));
+    let validator_signer = Arc::new(create_test_signer("validator"));
     let shard_layout = ShardLayout::single_shard();
     let genesis = TestGenesisBuilder::new()
         .genesis_time_from_clock(&Clock::real())
         .shard_layout(shard_layout.clone())
-        .validators_spec(ValidatorsSpec::desired_roles(&["producer"], &[]))
+        .validators_spec(ValidatorsSpec::desired_roles(&["producer"], &["validator"]))
         .build();
 
     let mut actors = [
@@ -781,12 +782,9 @@ fn test_final_execution_head_is_updated_when_tracking_no_shards() {
             shard_layout.shard_uids().collect(),
             outgoing_sc.clone(),
         ),
-        // A node tracking zero shards, modeled as a non-validator so it is
-        // guaranteed to track none — a validator account would be pulled into the
-        // shard's chunk-producers settlement and track it.
         TestActor::new(
             genesis,
-            MutableConfigValue::new(None, "validator_signer"),
+            MutableConfigValue::new(Some(validator_signer), "validator_signer"),
             vec![],
             outgoing_sc,
         ),

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -151,10 +151,15 @@ fn new_test_witness(block: &Block) -> SpiceChunkStateWitness {
 }
 
 fn setup(num_chunk_producers: usize, num_validators: usize) -> (Genesis, Chain) {
-    init_test_logger();
+    setup_with_shard_layout(num_chunk_producers, num_validators, ShardLayout::multi_shard(2, 0))
+}
 
-    let num_shards = 2;
-    let shard_layout = ShardLayout::multi_shard(num_shards, 0);
+fn setup_with_shard_layout(
+    num_chunk_producers: usize,
+    num_validators: usize,
+    shard_layout: ShardLayout,
+) -> (Genesis, Chain) {
+    init_test_logger();
 
     let block_and_chunk_producers =
         (0..num_chunk_producers).map(|i| format!("test-producer-{i}")).collect_vec();
@@ -339,6 +344,17 @@ fn witness_validator_account(chain: &Chain) -> AccountId {
     let block = latest_block(chain);
     let witness = new_test_witness(&block);
     witness_validators(chain, &block, &witness).into_iter().next().unwrap()
+}
+
+fn non_producer_witness_validator_account(chain: &Chain) -> AccountId {
+    let block = latest_block(chain);
+    let witness = new_test_witness(&block);
+    let producers: HashSet<_> =
+        witness_producer_accounts(chain, &block, &witness).into_iter().collect();
+    witness_validators(chain, &block, &witness)
+        .into_iter()
+        .find(|validator| !producers.contains(validator))
+        .unwrap()
 }
 
 fn producers_of_receipt_proof(
@@ -598,11 +614,6 @@ test_witness_distribution! {
     with_100_producers_10_validators(100, 10)
     with_100_producers_100_validators(100, 100)
     with_100_producers_1000_validators(100, 1000)
-    with_5000_producers_1_validator(5000, 1)
-    with_5000_producers_10_validators(5000, 10)
-    with_5000_producers_100_validators(5000, 100)
-    with_5000_producers_1000_validators(5000, 1000)
-    with_5000_producers_4000_validators(5000, 4000)
 }
 
 fn test_receipts_can_be_reconstructed_impl(num_chunk_producers: usize) {
@@ -722,8 +733,6 @@ test_receipts_distribution! {
     with_20_producers(20)
     with_50_producers(50)
     with_100_producers(100)
-    with_500_producers(500)
-    with_5000_producers(5000)
 }
 
 fn drain_outgoing_partial_data(
@@ -1424,10 +1433,10 @@ fn test_incoming_data_is_processed_with_block_arriving_late() {
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_requesting_witnesses_from_forks_on_start() {
-    let (_genesis, mut chain) = setup(1, 1);
+    let (_genesis, mut chain) = setup_with_shard_layout(1, 1, ShardLayout::single_shard());
     let block = latest_block(&chain);
     let shard_id = witness_shard_id(&block);
-    let validator = witness_validator_account(&chain);
+    let validator = non_producer_witness_validator_account(&chain);
 
     let next_block = produce_block(&mut chain, &block);
     let next_next_block = produce_block(&mut chain, &next_block);


### PR DESCRIPTION
`get_chain_with_genesis` built the EpochManager via `EpochManager::new_arc_handle` with chain_id `"test"`, which routes to `EpochConfig::genesis_test` and hardcodes `num_chunk_producer_seats = 100`, ignoring the seats derived from `ValidatorsSpec`. Spice tests configured with chunk-validators-only accounts silently had those accounts pulled into the chunk-producers settlement, so a node with `TrackedShardsConfig::Shards(vec![])` still tracked shards.

This builds the `EpochConfigStore` from the genesis (the same path the test-loop framework uses) so the configured chunk-producer seats are honored.

Follow-up adjustments to the now-genuine spice tests:
- `test_final_execution_head_is_updated_when_tracking_no_shards` now uses a real chunk-validator-only node that tracks zero shards (relies on the finalize fix from #15973).
- Dropped `data_distributor_actor` parametrizations with unrealistic producer counts (500/5000) that exceed the Reed-Solomon 256-shard cap, since the witness/receipts are encoded into one part per chunk producer per shard.
- `test_requesting_witnesses_from_forks_on_start` uses a single-shard layout and a non-producer validator to match its single-shard assumption.