### PR TITLE
fix: build 48->49 epoch sync proof within the gc window

### DIFF
--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -1,9 +1,7 @@
 use crate::NearConfig;
 use near_chain::{Error, LatestKnown};
 use near_chain_configs::GenesisConfig;
-use near_epoch_manager::epoch_sync::{
-    derive_epoch_sync_proof_from_last_block, find_target_epoch_to_produce_proof_for,
-};
+use near_epoch_manager::epoch_sync;
 use near_primitives::chains::MAINNET;
 use near_primitives::epoch_sync::EpochSyncProof;
 use near_primitives::hash::CryptoHash;
@@ -358,6 +356,16 @@ fn write_sst_partition(
     Ok((sst_paths, count))
 }
 
+/// Test-only entry point exercising the epoch-sync-proof step of the 48->49
+/// migration directly.
+#[cfg(feature = "test_features")]
+pub fn test_only_update_epoch_sync_proof(
+    store: Store,
+    transaction_validity_period: BlockHeightDelta,
+) -> anyhow::Result<()> {
+    update_epoch_sync_proof(store, transaction_validity_period)
+}
+
 fn update_epoch_sync_proof(
     store: Store,
     transaction_validity_period: BlockHeightDelta,
@@ -376,15 +384,13 @@ fn update_epoch_sync_proof(
         store_update.commit();
     }
 
-    // Generate the epoch sync proof. On short chains (e.g. tests),
-    // find_target_epoch_to_produce_proof_for would walk past genesis — skip and let
-    // the runtime produce it later via extend_epoch_sync_proof.
     tracing::info!(target: "migrations", "generating latest epoch sync proof");
     let chain_store = store.chain_store();
     let final_head = chain_store.final_head()?;
     let genesis_height = chain_store.get_genesis_height();
     let current_epoch_start_height = epoch_store.get_epoch_start(&final_head.epoch_id)?;
     let chain_height_since_genesis = current_epoch_start_height.saturating_sub(genesis_height);
+    // Too few epochs after genesis to build a proof; the runtime produces one later.
     if chain_height_since_genesis < transaction_validity_period {
         tracing::info!(
             target: "migrations",
@@ -396,15 +402,29 @@ fn update_epoch_sync_proof(
         return Ok(());
     }
 
-    let last_block_hash =
-        find_target_epoch_to_produce_proof_for(&store, transaction_validity_period)?;
-
-    tracing::info!(target: "migrations", ?last_block_hash, "deriving epoch sync proof from last final block");
-    let proof = derive_epoch_sync_proof_from_last_block(&epoch_store, &last_block_hash, true)?;
-
-    tracing::info!(target: "migrations", "storing latest epoch sync proof");
-    let mut store_update = epoch_store.store_update();
-    store_update.set_epoch_sync_proof(&proof);
+    // Anchor at the current epoch (target head-2), like continuous epoch sync does at
+    // a boundary; this reads BlockInfo ~3 epochs back. find_target reaches ~4 back,
+    // which gc=3 has already collected: the startup crash `epoch block: <hash>`.
+    let head = chain_store.head()?;
+    let store_update = match epoch_sync::update_epoch_sync_proof(&epoch_store, &head.epoch_id) {
+        Ok(store_update) => store_update,
+        // Mid-epoch on gc=3, even head-2 reaches below the retained data. Seed the
+        // freshest retained epoch (head-1, always final); the runtime advances it later.
+        Err(Error::DBNotFoundErr(_)) => {
+            let head_block_info = epoch_store.get_block_info(&head.last_block_hash)?;
+            let head_epoch_first_header =
+                chain_store.get_block_header(head_block_info.epoch_first_block())?;
+            let proof = epoch_sync::derive_epoch_sync_proof_from_last_block(
+                &epoch_store,
+                head_epoch_first_header.prev_hash(),
+                true,
+            )?;
+            let mut store_update = epoch_store.store_update();
+            store_update.set_epoch_sync_proof(&proof);
+            store_update
+        }
+        Err(err) => return Err(err.into()),
+    };
     store_update.commit();
 
     Ok(())

--- a/test-loop-tests/src/tests/sync/migration_epoch_sync_proof.rs
+++ b/test-loop-tests/src/tests/sync/migration_epoch_sync_proof.rs
@@ -1,0 +1,130 @@
+use crate::setup::builder::TestLoopBuilder;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+use near_store::DBCol;
+use near_store::adapter::StoreAdapter;
+use std::collections::HashMap;
+
+/// Regression test for the 48->49 migration crashing on nodes with the minimum GC
+/// window (`gc_num_epochs_to_keep = 3`, common on RPC nodes) when upgrading to 2.13,
+/// with `DB Not Found Error: epoch block: <hash>`.
+///
+/// Epoch sync proof regeneration read BlockInfo that gc=3 had already collected. How
+/// far back it reaches depends on where in the epoch the node restarted, so the test
+/// covers restart at a boundary (canonical head-2 proof) and partway through an epoch
+/// (head-1 fallback). Each case rebuilds the pre-49 state, runs the migration (which
+/// must seed a proof, not defer), then runs forward so the runtime extends it.
+#[test]
+fn test_migration_48_to_49_epoch_sync_proof_min_gc() {
+    // DB_VERSION 49 and the proof machinery only exist with ContinuousEpochSync.
+    if !ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    init_test_logger();
+    for blocks_past_boundary in [0, 5, 9] {
+        check_migration_seeds_extendable_proof(blocks_past_boundary);
+    }
+}
+
+fn check_migration_seeds_extendable_proof(blocks_past_boundary: usize) {
+    let epoch_length = 10;
+    // The epoch manager caps this at `epoch_length * 2`; mainnet uses that maximum.
+    let transaction_validity_period = 2 * epoch_length;
+    let mut env = TestLoopBuilder::new()
+        .epoch_length(epoch_length)
+        .transaction_validity_period(transaction_validity_period)
+        .gc_num_epochs_to_keep(3)
+        .build();
+
+    // A pre-49 DB keeps all block headers from genesis, but 2.13 GCs them alongside
+    // BlockInfo at the same tail. Snapshot them as the chain advances, before GC
+    // trims them, so the pre-49 state (headers kept, BlockInfo gone) can be rebuilt.
+    let mut all_headers: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
+    for epoch in 0..=8 {
+        if epoch > 0 {
+            env.validator_runner().run_until_new_epoch();
+        }
+        let store = env.validator().client().chain.chain_store.store();
+        for (key, value) in store.iter(DBCol::BlockHeader) {
+            all_headers.insert(key.to_vec(), value.to_vec());
+        }
+    }
+    // Move `blocks_past_boundary` into the current epoch to vary the restart point.
+    if blocks_past_boundary > 0 {
+        env.validator_runner().run_for_number_of_blocks(blocks_past_boundary);
+        let store = env.validator().client().chain.chain_store.store();
+        for (key, value) in store.iter(DBCol::BlockHeader) {
+            all_headers.insert(key.to_vec(), value.to_vec());
+        }
+    }
+
+    let store = env.validator().client().chain.chain_store.store();
+    let genesis_height = store.chain_store().get_genesis_height();
+    let tail = store.chain_store().tail();
+    let head_height = store.chain_store().head().unwrap().height;
+    assert!(
+        tail > genesis_height + epoch_length,
+        "GC must have trimmed early blocks, else the bug condition is absent \
+         (genesis={genesis_height}, tail={tail}, head={head_height}, offset={blocks_past_boundary})"
+    );
+
+    // Rebuild the pre-49 state: headers back to genesis (BlockHeader is insert-only,
+    // hence the raw escape hatch), BlockInfo left GC'd, no compressed proof (so the
+    // migration regenerates from scratch rather than extending an existing one).
+    let mut store_update = store.store_update();
+    for (key, value) in &all_headers {
+        store_update.set_raw_bytes(DBCol::BlockHeader, key, value);
+    }
+    store_update.delete_all(DBCol::EpochSyncProof);
+    store_update.commit();
+    assert!(store.epoch_store().get_epoch_sync_proof().unwrap().is_none());
+
+    // Pre-fix, this returns `epoch block: <hash>` (always at a boundary, and once GC
+    // has trimmed one more epoch, partway through one too).
+    nearcore::migrations::test_only_update_epoch_sync_proof(
+        store.clone(),
+        transaction_validity_period,
+    )
+    .unwrap_or_else(|err| {
+        panic!("migration must not fail on gc=3 (offset={blocks_past_boundary}): {err}")
+    });
+
+    // The migration must produce the proof itself, not leave it for the runtime.
+    let proof_after_migration = store
+        .epoch_store()
+        .get_epoch_sync_proof()
+        .unwrap()
+        .expect("migration must store an epoch sync proof, not defer it");
+    let height_after_migration =
+        proof_after_migration.current_epoch.first_block_header_in_epoch.height();
+
+    // Run forward so the runtime's per-epoch update_epoch_sync_proof (chain_update.rs)
+    // extends the migration's proof at real epoch boundaries. Had the migration
+    // deferred instead, this is where the deferred crash would surface.
+    let head_before = env.validator().head().height;
+    for _ in 0..3 {
+        env.validator_runner().run_until_new_epoch();
+    }
+    assert!(
+        env.validator().head().height > head_before,
+        "chain must keep advancing (offset={blocks_past_boundary})"
+    );
+
+    let height_after_runtime = env
+        .validator()
+        .client()
+        .chain
+        .chain_store
+        .epoch_store()
+        .get_epoch_sync_proof()
+        .unwrap()
+        .expect("epoch sync proof must still exist after running forward")
+        .current_epoch
+        .first_block_header_in_epoch
+        .height();
+    assert!(
+        height_after_runtime > height_after_migration,
+        "runtime must extend the migration's proof (offset={blocks_past_boundary}, \
+         after_migration={height_after_migration}, after_runtime={height_after_runtime})"
+    );
+}

--- a/test-loop-tests/src/tests/sync/mod.rs
+++ b/test-loop-tests/src/tests/sync/mod.rs
@@ -2,6 +2,7 @@ mod continuous_epoch_sync;
 mod epoch_sync;
 mod far_horizon;
 mod gc;
+mod migration_epoch_sync_proof;
 mod near_horizon;
 mod state_sync;
 mod sync_then_catchup;


### PR DESCRIPTION
**Same as #15975**

Upgrading to 2.13 (DB 48->49) crashed at startup on nodes with `gc_num_epochs_to_keep = 3` with `DB Not Found Error: epoch block: <hash>`.

Cause: the migration regenerated the epoch sync proof via `find_target_epoch_to_produce_proof_for`, which anchors at the final head and reads BlockInfo ~4 epochs back, which gc=3 has already collected.

Fix: build the proof anchored at the current epoch (target head-2), the same way continuous epoch sync does at a boundary. If the node restarted mid-epoch, where even head-2's inputs are collected, fall back to the freshest fully retained epoch (head-1).
