### PR TITLE
fix(test): actually use split store in test_split_storage_archival_node_sync

### DIFF
--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -353,6 +353,15 @@ impl TestLoopNetworkSharedState {
         guard.account_to_peer_id.get(account_id).unwrap().clone()
     }
 
+    /// Check whether the given account's peer is marked as archival.
+    fn is_account_archival(&self, account_id: &AccountId) -> bool {
+        let guard = self.0.lock();
+        guard
+            .account_to_peer_id
+            .get(account_id)
+            .is_some_and(|peer_id| guard.archival_peer_ids.contains(peer_id))
+    }
+
     fn is_peer_link_disallowed(
         guard: &MutexGuard<TestLoopNetworkSharedStateInner>,
         from: &PeerId,
@@ -733,7 +742,23 @@ fn network_message_to_shards_manager_handler(
         NetworkRequests::PartialEncodedChunkRequest { target, request, .. } => {
             let my_peer_id = shared_state.account_to_peer_id(&my_account_id);
             let route_back = shared_state.generate_route_back(&my_peer_id);
-            let target = target.account_id.unwrap();
+            let original_target = target.account_id.unwrap();
+            // When only_archival is set and the original target account is not archival, route to
+            // an archival node. This mirrors production behavior where the peer manager filters for
+            // archival peers.
+            let target =
+                if target.only_archival && !shared_state.is_account_archival(&original_target) {
+                    shared_state
+                        .accounts()
+                        .iter()
+                        .find(|account| {
+                            **account != my_account_id && shared_state.is_account_archival(account)
+                        })
+                        .cloned()
+                        .unwrap_or_else(|| original_target.clone())
+                } else {
+                    original_target
+                };
             assert!(target != my_account_id, "Sending message to self not supported.");
             shared_state.senders_for_account(&my_account_id, &target).shards_manager_sender.send(
                 ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunkRequest {

--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -374,9 +374,7 @@ impl TestLoopNetworkSharedState {
 
     /// Returns true if `account_id` is archival and tracks `shard_id` per its
     /// `tracked_shards_config`. Variants that depend on the epoch layout
-    /// (`Accounts`, `Schedule`, `ShadowValidator`) can't be resolved here, so
-    /// this returns false for them — the caller falls back to the original
-    /// target in that case, mirroring production's two-attempt fallback.
+    /// (`Accounts`, `Schedule`, `ShadowValidator`) are not implemented for now.
     fn archival_account_tracks_shard(&self, account_id: &AccountId, shard_id: ShardId) -> bool {
         let guard = self.0.lock();
         let Some(peer_id) = guard.account_to_peer_id.get(account_id) else { return false };
@@ -387,13 +385,12 @@ impl TestLoopNetworkSharedState {
         match config {
             TrackedShardsConfig::AllShards => true,
             TrackedShardsConfig::Shards(uids) => uids.iter().any(|uid| uid.shard_id() == shard_id),
+            TrackedShardsConfig::NoShards => false,
             // Variants that depend on the current epoch layout can't be
-            // resolved without the epoch manager; treat as not-tracking so
-            // the caller falls back to the original target.
-            TrackedShardsConfig::NoShards
-            | TrackedShardsConfig::ShadowValidator(_)
+            // resolved without the epoch manager
+            TrackedShardsConfig::ShadowValidator(_)
             | TrackedShardsConfig::Accounts(_)
-            | TrackedShardsConfig::Schedule(_) => false,
+            | TrackedShardsConfig::Schedule(_) => unimplemented!(),
         }
     }
 

--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -7,6 +7,7 @@ use near_async::test_loop::sender::TestLoopSender;
 use near_async::time::{Clock, Duration};
 use near_async::{MultiSend, MultiSenderFrom};
 use near_chain::{Block, BlockHeader};
+use near_chain_configs::TrackedShardsConfig;
 use near_client::spice::data_distributor_actor::SpiceDistributorOutgoingReceipts;
 use near_client::{BlockApproval, BlockResponse, SetNetworkInfo};
 use near_network::client::{
@@ -35,7 +36,7 @@ use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
 use near_primitives::genesis::GenesisId;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_primitives::types::AccountId;
+use near_primitives::types::{AccountId, ShardId};
 use parking_lot::{Mutex, MutexGuard};
 use std::collections::{BTreeMap, BTreeSet, btree_map};
 use std::sync::Arc;
@@ -238,6 +239,8 @@ struct TestLoopNetworkSharedStateInner {
     route_back: BTreeMap<CryptoHash, PeerId>,
     disallowed_peer_links: BTreeMap<PeerId, BTreeSet<PeerId>>,
     archival_peer_ids: BTreeSet<PeerId>,
+    /// Per-account tracked-shards config, populated when a client is added.
+    tracked_shards_config: BTreeMap<AccountId, TrackedShardsConfig>,
 }
 
 /// Senders available for the networking layer, for one node in the test loop.
@@ -293,6 +296,7 @@ impl TestLoopNetworkSharedState {
             route_back: BTreeMap::new(),
             disallowed_peer_links: BTreeMap::new(),
             archival_peer_ids: BTreeSet::new(),
+            tracked_shards_config: BTreeMap::new(),
         };
         Self(Arc::new(Mutex::new(inner)))
     }
@@ -336,6 +340,12 @@ impl TestLoopNetworkSharedState {
         );
     }
 
+    /// Records the per-account tracked-shards config. Call after `add_client`.
+    pub fn set_tracked_shards_config(&self, account_id: &AccountId, config: TrackedShardsConfig) {
+        let mut guard = self.0.lock();
+        guard.tracked_shards_config.insert(account_id.clone(), config);
+    }
+
     /// Stops processing of requests from `from` peer to `to` peer.
     pub fn disallow_requests(&self, from: PeerId, to: PeerId) {
         let mut guard = self.0.lock();
@@ -360,6 +370,31 @@ impl TestLoopNetworkSharedState {
             .account_to_peer_id
             .get(account_id)
             .is_some_and(|peer_id| guard.archival_peer_ids.contains(peer_id))
+    }
+
+    /// Returns true if `account_id` is archival and tracks `shard_id` per its
+    /// `tracked_shards_config`. Variants that depend on the epoch layout
+    /// (`Accounts`, `Schedule`, `ShadowValidator`) can't be resolved here, so
+    /// this returns false for them — the caller falls back to the original
+    /// target in that case, mirroring production's two-attempt fallback.
+    fn archival_account_tracks_shard(&self, account_id: &AccountId, shard_id: ShardId) -> bool {
+        let guard = self.0.lock();
+        let Some(peer_id) = guard.account_to_peer_id.get(account_id) else { return false };
+        if !guard.archival_peer_ids.contains(peer_id) {
+            return false;
+        }
+        let Some(config) = guard.tracked_shards_config.get(account_id) else { return false };
+        match config {
+            TrackedShardsConfig::AllShards => true,
+            TrackedShardsConfig::Shards(uids) => uids.iter().any(|uid| uid.shard_id() == shard_id),
+            // Variants that depend on the current epoch layout can't be
+            // resolved without the epoch manager; treat as not-tracking so
+            // the caller falls back to the original target.
+            TrackedShardsConfig::NoShards
+            | TrackedShardsConfig::ShadowValidator(_)
+            | TrackedShardsConfig::Accounts(_)
+            | TrackedShardsConfig::Schedule(_) => false,
+        }
     }
 
     fn is_peer_link_disallowed(
@@ -743,22 +778,27 @@ fn network_message_to_shards_manager_handler(
             let my_peer_id = shared_state.account_to_peer_id(&my_account_id);
             let route_back = shared_state.generate_route_back(&my_peer_id);
             let original_target = target.account_id.unwrap();
-            // When only_archival is set and the original target account is not archival, route to
-            // an archival node. This mirrors production behavior where the peer manager filters for
-            // archival peers.
-            let target =
-                if target.only_archival && !shared_state.is_account_archival(&original_target) {
-                    shared_state
-                        .accounts()
-                        .iter()
-                        .find(|account| {
-                            **account != my_account_id && shared_state.is_account_archival(account)
-                        })
-                        .cloned()
-                        .unwrap_or_else(|| original_target.clone())
-                } else {
-                    original_target
-                };
+            // When only_archival is set, production's peer manager first tries
+            // archival peers that track the requested shard, and falls back to
+            // the original target account if none does (the second attempt with
+            // `!prefer_peer` in peer_manager_actor.rs sends directly to
+            // `target.account_id`). Mirror that here so an archival-only
+            // routing doesn't drop requests for shards no archival tracks.
+            let target = if target.only_archival
+                && !shared_state.is_account_archival(&original_target)
+            {
+                shared_state
+                    .accounts()
+                    .iter()
+                    .find(|account| {
+                        **account != my_account_id
+                            && shared_state.archival_account_tracks_shard(account, target.shard_id)
+                    })
+                    .cloned()
+                    .unwrap_or_else(|| original_target.clone())
+            } else {
+                original_target
+            };
             assert!(target != my_account_id, "Sending message to self not supported.");
             shared_state.senders_for_account(&my_account_id, &target).shards_manager_sender.send(
                 ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunkRequest {

--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -301,7 +301,7 @@ impl TestLoopNetworkSharedState {
         Self(Arc::new(Mutex::new(inner)))
     }
 
-    pub fn add_client<'a, D>(&self, data: &'a D)
+    pub fn add_client<'a, D>(&self, data: &'a D, tracked_shards_config: TrackedShardsConfig)
     where
         AccountId: From<&'a D>,
         PeerId: From<&'a D>,
@@ -319,7 +319,7 @@ impl TestLoopNetworkSharedState {
         let peer_id = PeerId::from(data);
 
         let mut guard = self.0.lock();
-        guard.account_to_peer_id.insert(account_id, peer_id.clone());
+        guard.account_to_peer_id.insert(account_id.clone(), peer_id.clone());
         guard.senders.insert(
             peer_id,
             Arc::new(OneClientSenders {
@@ -338,12 +338,7 @@ impl TestLoopNetworkSharedState {
                 spice_core_writer_sender: Sender::<SpiceChunkEndorsementMessage>::from(data),
             }),
         );
-    }
-
-    /// Records the per-account tracked-shards config. Call after `add_client`.
-    pub fn set_tracked_shards_config(&self, account_id: &AccountId, config: TrackedShardsConfig) {
-        let mut guard = self.0.lock();
-        guard.tracked_shards_config.insert(account_id.clone(), config);
+        guard.tracked_shards_config.insert(account_id, tracked_shards_config);
     }
 
     /// Stops processing of requests from `from` peer to `to` peer.

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -255,6 +255,7 @@ pub fn setup_client(
 
     let head = client.chain.head().unwrap();
     let header_head = client.chain.header_head().unwrap();
+    let chunks_store = storage.split_store.clone().unwrap_or_else(|| storage.hot_store.clone());
     let shards_manager = ShardsManagerActor::new(
         test_loop.clock(),
         validator_signer.clone(),
@@ -263,7 +264,7 @@ pub fn setup_client(
         shard_tracker.clone(),
         network_adapter.as_sender(),
         client_adapter.as_sender(),
-        storage.hot_store.chunk_store(),
+        chunks_store.chunk_store(),
         <_>::clone(&head),
         <_>::clone(&header_head),
         Duration::milliseconds(100),

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -614,8 +614,7 @@ pub fn setup_client(
     // Add the client to the network shared state before returning data
     // Note that this can potentially overwrite an existing client with the same account_id
     // and all new messages would be redirected to the new client.
-    network_shared_state.add_client(&node_data);
-    network_shared_state.set_tracked_shards_config(&node_data.account_id, tracked_shards_config);
+    network_shared_state.add_client(&node_data, tracked_shards_config);
     if is_archival {
         network_shared_state.mark_archival(&node_data.peer_id);
     }

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -519,6 +519,7 @@ pub fn setup_client(
         runtime_adapter.store().chain_store(),
     )));
 
+    let tracked_shards_config = client_config.tracked_shards_config.clone();
     let state_sync_dumper = StateSyncDumper {
         clock: test_loop.clock(),
         client_config,
@@ -614,6 +615,7 @@ pub fn setup_client(
     // Note that this can potentially overwrite an existing client with the same account_id
     // and all new messages would be redirected to the new client.
     network_shared_state.add_client(&node_data);
+    network_shared_state.set_tracked_shards_config(&node_data.account_id, tracked_shards_config);
     if is_archival {
         network_shared_state.mark_archival(&node_data.peer_id);
     }


### PR DESCRIPTION
`test_split_storage_archival_node_sync` is meant to test a scenario when one archival node syncs from another and the chunks are fetched from the cold storage. It turns out that TestLoop creates the `ShardsManagerActor` with hot store only, so it was not able to fetch chunks from the cold store at all. It fetched them from the in-memory cache which keeps chunks for the last 128 heights.

I had to modify the test loop networking code to respect the `target.only_archival` flag and route the chunk requests to archival nodes. It's a bit different from the [real PeerManagerActor code](https://github.com/near/nearcore/blob/715e0f9a3bec96d93eadff406a85c0bfd7b57e26/chain/network/src/peer_manager/peer_manager_actor.rs#L1127), but it should be good enough for the test. 

Btw I wonder if this would work across a resharding boundary. Peer's tracked_shards from the new epoch are different and it might decide that there are no nodes which are able to serve requests for the shards from the previous layout.