### PR TITLE
fix(spice): reject equivocating endorsements in core statements

### DIFF
--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -468,6 +468,7 @@ impl SpiceCoreReader {
             &SpiceChunkId,
             HashMap<ChunkExecutionResultHash, HashMap<&AccountId, Signature>>,
         > = HashMap::new();
+        let mut endorsed_chunk_accounts: HashSet<(&SpiceChunkId, &AccountId)> = HashSet::new();
         let mut block_execution_results = HashMap::new();
         let mut max_endorsed_height_created = HashMap::new();
 
@@ -476,12 +477,8 @@ impl SpiceCoreReader {
                 SpiceCoreStatement::Endorsement(endorsement) => {
                     let chunk_id = endorsement.chunk_id();
                     let account_id = endorsement.account_id();
-                    // TODO(spice): reject more than one endorsement per (chunk, account),
-                    // regardless of result hash. The dup check below is per result hash and
-                    // `waiting_on_endorsements` is not updated mid-loop, so a validator can
-                    // equivocate (endorse two results for one chunk) and count toward both.
-                    // Checking contents of waiting_on_endorsements makes sure that
-                    // chunk_id and account_id are valid.
+                    // Membership in waiting_on_endorsements also validates that chunk_id and
+                    // account_id are valid.
                     if !waiting_on_endorsements.contains(&(chunk_id, account_id)) {
                         return Err(InvalidCoreStatement {
                             index,
@@ -504,19 +501,21 @@ impl SpiceCoreReader {
                         return Err(InvalidCoreStatement { index, reason: "invalid signature" });
                     };
 
-                    if in_block_endorsements
-                        .entry(chunk_id)
-                        .or_default()
-                        .entry(signed_data.execution_result_hash.clone())
-                        .or_default()
-                        .insert(account_id, signature.clone())
-                        .is_some()
-                    {
+                    // Reject more than one endorsement per (chunk, account) regardless of result
+                    // hash, so an equivocating validator cannot count toward two results.
+                    if !endorsed_chunk_accounts.insert((chunk_id, account_id)) {
                         return Err(InvalidCoreStatement {
                             index,
                             reason: "duplicate endorsement",
                         });
                     }
+
+                    in_block_endorsements
+                        .entry(chunk_id)
+                        .or_default()
+                        .entry(signed_data.execution_result_hash.clone())
+                        .or_default()
+                        .insert(account_id, signature.clone());
                 }
                 SpiceCoreStatement::ChunkExecutionResult { chunk_id, execution_result } => {
                     if block_execution_results.insert(chunk_id, (execution_result, index)).is_some()

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -920,6 +920,43 @@ fn test_validate_core_statements_in_block_with_duplicate_endorsement() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_core_statements_in_block_with_equivocating_endorsement() {
+    let (mut chain, core_reader) = setup();
+    let genesis = chain.genesis_block();
+    let block = build_block(&mut chain, &genesis, vec![]);
+    process_block(&mut chain, block.clone());
+
+    let chunks = block.chunks();
+    let chunk_header = chunks.iter_raw().next().unwrap();
+    let validator = &test_validators()[0];
+
+    let endorsement = test_chunk_endorsement(validator, &block, chunk_header);
+    let signer = create_test_signer(validator);
+    let equivocating_endorsement = SpiceChunkEndorsement::new(
+        SpiceChunkId { block_hash: *block.hash(), shard_id: chunk_header.shard_id() },
+        invalid_execution_result_for_chunk(chunk_header),
+        &signer,
+    );
+
+    let next_block = build_block(
+        &mut chain,
+        &block,
+        vec![
+            endorsement_into_core_statement(endorsement),
+            endorsement_into_core_statement(equivocating_endorsement),
+        ],
+    );
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&next_block),
+        Err(InvalidSpiceCoreStatementsError::InvalidCoreStatement {
+            reason: "duplicate endorsement",
+            index: 1
+        })
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_validate_core_statements_in_block_with_duplicate_execution_result() {
     let (mut chain, core_reader) = setup();
     let genesis = chain.genesis_block();


### PR DESCRIPTION
`validate_core_statements_in_block` deduplicated endorsements per `(chunk, account, result_hash)`, so an equivocating validator could endorse two different execution results for the same chunk within a single block and count toward both tallies.

Dedup per `(chunk, account)` regardless of result hash instead, rejecting the second endorsement as a duplicate. Honest block producers are unaffected: they read endorsements from the `Endorsements` column, which holds a single slot per `(block, shard, account)`, so they never emit more than one endorsement per `(chunk, account)`.

Cross-block equivocation on the same chain was already prevented by the `missing_endorsements`/`present_endorsements` bookkeeping in `uncertified_chunks`; this closes the remaining single-block window.

Adds a test covering the equivocating-endorsement case.