### PR TITLE
fix(spice): wait for a shard's witness unless we apply it this epoch

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -850,15 +850,17 @@ impl SpiceDataDistributorActor {
         let block = self.chain_store.get_block(block_hash)?;
         let shard_layout = self.epoch_manager.get_shard_layout(&block.header().epoch_id())?;
 
+        // Shards whose chunk we apply (and thus self-endorse) for THIS block: the
+        // shards we care about in the block's own epoch. We must NOT include shards
+        // we only care about NEXT epoch (as `should_apply_chunk(IsCaughtUp, ..)`
+        // would): at an epoch boundary a shard rotating in next epoch has no prev
+        // state yet, so the executor cannot apply it here and produces no endorsement.
+        // Treating it as self-applied would make us skip requesting its witness too, leaving us unable to endorse it at all.
         let shards_we_apply: HashSet<ShardId> = shard_layout
             .shard_ids()
             .filter(|shard_id| {
                 let prev_hash = block.header().prev_hash();
-                self.shard_tracker.should_apply_chunk(
-                    ApplyChunksMode::IsCaughtUp,
-                    prev_hash,
-                    *shard_id,
-                )
+                self.shard_tracker.cares_about_shard(prev_hash, *shard_id)
             })
             .collect();
 

--- a/test-loop-tests/src/tests/congestion_control.rs
+++ b/test-loop-tests/src/tests/congestion_control.rs
@@ -161,10 +161,7 @@ fn setup(
         .add_user_accounts_simple(&accounts, Balance::from_near(1_000_000))
         .genesis_height(10000)
         .build();
-    // TODO(spice): Spice execution-certification does not yet support shuffling chunk-producer
-    // shard assignment across epoch boundaries: after the first boundary the prev
-    // block's execution results never get certified (MissingExecutionResults for
-    // all shards) and the chunk executor wedges.
+    // TODO(spice): enable shuffling shard assignment when state sync works with SPICE.
     let shuffle_shard_assignment = !ProtocolFeature::Spice.enabled(PROTOCOL_VERSION);
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(shuffle_shard_assignment)


### PR DESCRIPTION
A spice chunk validator produces its endorsement either by executing the shard itself (the chunk executor) or by validating the shard's witness. 
`start_waiting_on_data` skipped requesting a shard's witness whenever the shard was in `shards_we_apply`, but that set was computed with `should_apply_chunk(IsCaughtUp, ..)`, which also includes shards the node only cares about *next* epoch.

At an epoch boundary a shard rotating in next epoch has no prev state yet, so the executor cannot apply it and emits no endorsement — yet the node had already decided not to request its witness, rejecting the incoming one as `DataIsIrrelevant`. 
With chunk-producer shard-assignment shuffling this drops a (potentially high-stake) validator's endorsement.

Compute `shards_we_apply` from `cares_about_shard(prev_hash, ..)` (the block's own epoch) instead, so the node requests and validates the witness for any shard it does not actually apply this block. 
This is a no-op for stable single-shard tracking and track-all-shards nodes; it only differs when a node's tracked set changes between epochs (i.e. under shuffling).

Shuffling still can't be enabled for the congestion test: past the first boundary a rotated-in producer must obtain its new shard's state via state sync, which is not quite there yet for SPICE.
