### PR TITLE
feat(spice): re-encode consistency check on received partial data

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -65,6 +65,7 @@ use near_store::{TrieDBStorage, TrieStorage};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
+use std::io;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -105,9 +106,9 @@ pub(crate) enum Error {
     #[error("data is irrelevant")]
     DataIsIrrelevant(SpiceDataIdentifier),
     #[error("error decoding the data: {0}")]
-    DecodeError(std::io::Error),
+    DecodeError(io::Error),
     #[error("store io error")]
-    StoreIoError(std::io::Error),
+    StoreIoError(io::Error),
     #[error("other error: {0}")]
     Other(&'static str),
 }
@@ -649,7 +650,7 @@ impl SpiceDataDistributorActor {
         &mut self,
         id: &SpiceDataIdentifier,
         commitment: &SpiceDataCommitment,
-        decode_result: Result<SpiceData, std::io::Error>,
+        decode_result: Result<SpiceData, io::Error>,
         total_parts: usize,
         encoded_length: u64,
     ) -> Result<(), Error> {

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -84,10 +84,8 @@ pub(crate) enum Error {
     InvalidDecodedWitnessBlockHash,
     #[error("part doesn't match commitment root")]
     InvalidCommitmentRoot,
-    #[error("decoded data doesn't match commitment hash")]
-    InvalidCommitmentHash,
-    #[error("recomputed root doesn't match commitment root")]
-    RecomputedRootMismatch,
+    #[error("recomputed commitment doesn't match received commitment")]
+    RecomputedCommitmentMismatch,
     #[error("receipt proof id to_shard_id is invalid")]
     InvalidReceiptToShardId,
     #[error("decoded receipt proof to_shard_id is invalid")]
@@ -622,29 +620,44 @@ impl SpiceDataDistributorActor {
             return Ok(());
         };
 
-        // A bad commitment can still decode (or fail to decode) to data we cannot use. Drop only
-        // the offending commitment so the periodic request loop keeps fetching the real data for
-        // this id from other producers.
-        let data = match decode_result {
-            Ok(data) => data,
-            Err(err) => {
-                self.stop_waiting_on_commitment(&id, &commitment);
-                return Err(Error::DecodeError(err));
-            }
-        };
-
-        let data_hash = hash(&borsh::to_vec(&data).unwrap());
-        if data_hash != commitment.hash {
-            return Err(Error::InvalidCommitmentHash);
+        // A bad commitment can decode (or fail to decode) to data we cannot use. On any failure
+        // drop only the offending commitment so the periodic request loop keeps fetching the real
+        // data for this id from other producers; only a clean accept clears the whole id.
+        if let Err(err) = self.validate_and_forward_decoded(
+            &id,
+            &commitment,
+            decode_result,
+            total_parts,
+            encoded_length,
+        ) {
+            self.stop_waiting_on_commitment(&id, &commitment);
+            return Err(err);
         }
 
-        // Parts can individually verify against commitment.root and decode to hash-matching data
-        // while not being the canonical encoding of that root. Re-encode and require the recomputed
-        // root to match so all correct recipients converge on the same data.
-        let recomputed_root = self.encode_distribution_data(&data, total_parts).commitment.root;
-        if recomputed_root != commitment.root {
-            self.stop_waiting_on_commitment(&id, &commitment);
-            return Err(Error::RecomputedRootMismatch);
+        tracing::debug!(target: "spice_data_distribution", ?id, ?commitment, "decoded data; stop waiting");
+        self.waiting_on_data.remove(&id);
+        self.recently_decoded_data.push(id, ());
+        Ok(())
+    }
+
+    fn validate_and_forward_decoded(
+        &mut self,
+        id: &SpiceDataIdentifier,
+        commitment: &SpiceDataCommitment,
+        decode_result: Result<SpiceData, std::io::Error>,
+        total_parts: usize,
+        encoded_length: u64,
+    ) -> Result<(), Error> {
+        let data = decode_result.map_err(Error::DecodeError)?;
+
+        // Parts can individually verify against commitment.root and decode to data that is not the
+        // canonical encoding of the commitment. Re-encode and require the whole recomputed
+        // commitment to match (hash, root, and encoded_length), so all correct recipients converge
+        // on the same data and the attacker-supplied encoded_length is canonically validated before
+        // it flows downstream. This subsumes a standalone hash check.
+        let recomputed = self.encode_distribution_data(&data, total_parts).commitment;
+        if recomputed != *commitment {
+            return Err(Error::RecomputedCommitmentMismatch);
         }
 
         match data {
@@ -654,17 +667,19 @@ impl SpiceDataDistributorActor {
                 else {
                     return Err(Error::IdAndDataMismatch);
                 };
-                if to_shard_id != receipt_proof.1.to_shard_id {
+                if *to_shard_id != receipt_proof.1.to_shard_id {
                     return Err(Error::InvalidDecodedReceiptToShardId);
                 }
-                if from_shard_id != receipt_proof.1.from_shard_id {
+                if *from_shard_id != receipt_proof.1.from_shard_id {
                     return Err(Error::InvalidDecodedReceiptFromShardId);
                 }
-                self.executor_sender
-                    .send(ExecutorIncomingUnverifiedReceipts { receipt_proof, block_hash });
+                self.executor_sender.send(ExecutorIncomingUnverifiedReceipts {
+                    receipt_proof,
+                    block_hash: *block_hash,
+                });
             }
             SpiceData::StateWitness(witness) => {
-                let SpiceDataIdentifier::Witness { block_hash, shard_id } = &id else {
+                let SpiceDataIdentifier::Witness { block_hash, shard_id } = id else {
                     return Err(Error::IdAndDataMismatch);
                 };
                 let chunk_id = witness.chunk_id();
@@ -683,10 +698,6 @@ impl SpiceDataDistributorActor {
                 );
             }
         }
-
-        tracing::debug!(target: "spice_data_distribution", ?id, ?commitment, "decoded data; stop waiting");
-        self.waiting_on_data.remove(&id);
-        self.recently_decoded_data.push(id, ());
         Ok(())
     }
 

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -65,7 +65,6 @@ use near_store::{TrieDBStorage, TrieStorage};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
-use std::io;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -106,9 +105,9 @@ pub(crate) enum Error {
     #[error("data is irrelevant")]
     DataIsIrrelevant(SpiceDataIdentifier),
     #[error("error decoding the data: {0}")]
-    DecodeError(io::Error),
+    DecodeError(std::io::Error),
     #[error("store io error")]
-    StoreIoError(io::Error),
+    StoreIoError(std::io::Error),
     #[error("other error: {0}")]
     Other(&'static str),
 }
@@ -650,7 +649,7 @@ impl SpiceDataDistributorActor {
         &mut self,
         id: &SpiceDataIdentifier,
         commitment: &SpiceDataCommitment,
-        decode_result: Result<SpiceData, io::Error>,
+        decode_result: Result<SpiceData, std::io::Error>,
         total_parts: usize,
         encoded_length: u64,
     ) -> Result<(), Error> {

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -575,10 +575,12 @@ impl SpiceDataDistributorActor {
         // TODO(spice): Check that encoded_length isn't too large.
         let encoded_length = commitment.encoded_length;
         let total_parts = producers.len();
-        // TODO(spice): Bound the number of commitments tracked per id and evict stale entries. A
-        // misbehaving producer can otherwise grow this map: entries are created before the per-part
-        // merkle check below (a failed check leaves an empty entry behind), and valid commitments
-        // that never gather enough parts to decode are never dropped.
+        // TODO(spice): Bound this per-id commitment map; a misbehaving producer can grow it
+        // unboundedly. (a) entries are created before the per-part merkle check below, so a failed
+        // check leaves an empty entry behind: verify proofs before or_insert_with. (b) valid
+        // commitments that never gather enough parts to decode are never dropped: needs a per-id cap
+        // and an eviction signal (entries carry no age today, e.g. tie to head-driven pruning or to
+        // corroboration by multiple producers).
         let entry = data_parts.entry(commitment.clone()).or_insert_with(|| {
             let encoder = self.rs_encoders.entry(total_parts);
             DataPartsEntry {
@@ -624,9 +626,8 @@ impl SpiceDataDistributorActor {
             return Ok(());
         };
 
-        // A bad commitment can decode (or fail to decode) to data we cannot use. On any failure
-        // drop only the offending commitment so the periodic request loop keeps fetching the real
-        // data for this id from other producers; only a clean accept clears the whole id.
+        // On any failure drop only this commitment and keep the id, so the request loop keeps
+        // fetching from other producers; only a clean accept clears the whole id.
         if let Err(err) = self.validate_and_forward_decoded(
             &id,
             &commitment,
@@ -654,11 +655,11 @@ impl SpiceDataDistributorActor {
     ) -> Result<(), Error> {
         let data = decode_result.map_err(Error::DecodeError)?;
 
-        // Parts can individually verify against commitment.root and decode to data that is not the
-        // canonical encoding of the commitment. Re-encode and require the whole recomputed
-        // commitment to match (hash, root, and encoded_length), so all correct recipients converge
-        // on the same data and the attacker-supplied encoded_length is canonically validated before
-        // it flows downstream. This subsumes a standalone hash check.
+        // Parts can individually verify against commitment.root yet decode to data that is not the
+        // canonical encoding of the commitment. Require the recomputed commitment to match (hash,
+        // root, and encoded_length) so the decoded data is the canonical encoding of the received
+        // commitment and the attacker-supplied encoded_length is validated before it flows
+        // downstream.
         let recomputed = self.encode_distribution_data(&data, total_parts).commitment;
         if recomputed != *commitment {
             return Err(Error::RecomputedCommitmentMismatch);

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -575,6 +575,10 @@ impl SpiceDataDistributorActor {
         // TODO(spice): Check that encoded_length isn't too large.
         let encoded_length = commitment.encoded_length;
         let total_parts = producers.len();
+        // TODO(spice): Bound the number of commitments tracked per id and evict stale entries. A
+        // misbehaving producer can otherwise grow this map: entries are created before the per-part
+        // merkle check below (a failed check leaves an empty entry behind), and valid commitments
+        // that never gather enough parts to decode are never dropped.
         let entry = data_parts.entry(commitment.clone()).or_insert_with(|| {
             let encoder = self.rs_encoders.entry(total_parts);
             DataPartsEntry {

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -86,6 +86,8 @@ pub(crate) enum Error {
     InvalidCommitmentRoot,
     #[error("decoded data doesn't match commitment hash")]
     InvalidCommitmentHash,
+    #[error("recomputed root doesn't match commitment root")]
+    RecomputedRootMismatch,
     #[error("receipt proof id to_shard_id is invalid")]
     InvalidReceiptToShardId,
     #[error("decoded receipt proof to_shard_id is invalid")]
@@ -581,9 +583,9 @@ impl SpiceDataDistributorActor {
                 tracker: ReedSolomonPartsTracker::new(encoder, encoded_length as usize),
             }
         });
-        let mut decoded = false;
+        let mut decode_result = None;
         for SpiceDataPart { part_ord, part, merkle_proof } in parts {
-            if decoded {
+            if decode_result.is_some() {
                 break;
             }
             if !verify_path_with_index(
@@ -609,67 +611,95 @@ impl SpiceDataDistributorActor {
                         "verification with merkle_proof passed, but part_ord is still invalid",
                     ));
                 }
-                reed_solomon::InsertPartResult::Decoded(Ok(data)) => {
-                    decoded = true;
-                    let data_hash = hash(&borsh::to_vec(&data).unwrap());
-                    if data_hash != commitment.hash {
-                        return Err(Error::InvalidCommitmentHash);
-                    }
-                    match data {
-                        SpiceData::ReceiptProof(receipt_proof) => {
-                            let SpiceDataIdentifier::ReceiptProof {
-                                block_hash,
-                                from_shard_id,
-                                to_shard_id,
-                            } = id
-                            else {
-                                return Err(Error::IdAndDataMismatch);
-                            };
-                            if to_shard_id != receipt_proof.1.to_shard_id {
-                                return Err(Error::InvalidDecodedReceiptToShardId);
-                            }
-                            if from_shard_id != receipt_proof.1.from_shard_id {
-                                return Err(Error::InvalidDecodedReceiptFromShardId);
-                            }
-                            self.executor_sender.send(ExecutorIncomingUnverifiedReceipts {
-                                receipt_proof,
-                                block_hash,
-                            });
-                        }
-                        SpiceData::StateWitness(witness) => {
-                            let SpiceDataIdentifier::Witness { block_hash, shard_id } = &id else {
-                                return Err(Error::IdAndDataMismatch);
-                            };
-                            let chunk_id = witness.chunk_id();
-                            if &chunk_id.shard_id != shard_id {
-                                return Err(Error::InvalidDecodedWitnessShardId);
-                            }
-                            if &chunk_id.block_hash != block_hash {
-                                return Err(Error::InvalidDecodedWitnessBlockHash);
-                            }
-                            self.witness_validator_sender.send(
-                                SpiceChunkStateWitnessMessage {
-                                    witness: *witness,
-                                    raw_witness_size: encoded_length as usize,
-                                }
-                                .span_wrap(),
-                            );
-                        }
-                    }
-                }
-                reed_solomon::InsertPartResult::Decoded(Err(err)) => {
-                    return Err(Error::DecodeError(err));
+                reed_solomon::InsertPartResult::Decoded(result) => {
+                    decode_result = Some(result);
                 }
             }
         }
-        if decoded {
-            // TODO(spice): Handle the possibility of receiving invalid data in
-            // which case we would need to keep requesting it.
-            tracing::debug!(target: "spice_data_distribution", ?id, ?commitment, "decoded data; stop waiting");
-            self.waiting_on_data.remove(&id);
-            self.recently_decoded_data.push(id, ());
+
+        // Not enough parts yet; keep the accumulated parts and wait for more.
+        let Some(decode_result) = decode_result else {
+            return Ok(());
+        };
+
+        // A bad commitment can still decode (or fail to decode) to data we cannot use. Drop only
+        // the offending commitment so the periodic request loop keeps fetching the real data for
+        // this id from other producers.
+        let data = match decode_result {
+            Ok(data) => data,
+            Err(err) => {
+                self.stop_waiting_on_commitment(&id, &commitment);
+                return Err(Error::DecodeError(err));
+            }
+        };
+
+        let data_hash = hash(&borsh::to_vec(&data).unwrap());
+        if data_hash != commitment.hash {
+            return Err(Error::InvalidCommitmentHash);
         }
+
+        // Parts can individually verify against commitment.root and decode to hash-matching data
+        // while not being the canonical encoding of that root. Re-encode and require the recomputed
+        // root to match so all correct recipients converge on the same data.
+        let recomputed_root = self.encode_distribution_data(&data, total_parts).commitment.root;
+        if recomputed_root != commitment.root {
+            self.stop_waiting_on_commitment(&id, &commitment);
+            return Err(Error::RecomputedRootMismatch);
+        }
+
+        match data {
+            SpiceData::ReceiptProof(receipt_proof) => {
+                let SpiceDataIdentifier::ReceiptProof { block_hash, from_shard_id, to_shard_id } =
+                    id
+                else {
+                    return Err(Error::IdAndDataMismatch);
+                };
+                if to_shard_id != receipt_proof.1.to_shard_id {
+                    return Err(Error::InvalidDecodedReceiptToShardId);
+                }
+                if from_shard_id != receipt_proof.1.from_shard_id {
+                    return Err(Error::InvalidDecodedReceiptFromShardId);
+                }
+                self.executor_sender
+                    .send(ExecutorIncomingUnverifiedReceipts { receipt_proof, block_hash });
+            }
+            SpiceData::StateWitness(witness) => {
+                let SpiceDataIdentifier::Witness { block_hash, shard_id } = &id else {
+                    return Err(Error::IdAndDataMismatch);
+                };
+                let chunk_id = witness.chunk_id();
+                if &chunk_id.shard_id != shard_id {
+                    return Err(Error::InvalidDecodedWitnessShardId);
+                }
+                if &chunk_id.block_hash != block_hash {
+                    return Err(Error::InvalidDecodedWitnessBlockHash);
+                }
+                self.witness_validator_sender.send(
+                    SpiceChunkStateWitnessMessage {
+                        witness: *witness,
+                        raw_witness_size: encoded_length as usize,
+                    }
+                    .span_wrap(),
+                );
+            }
+        }
+
+        tracing::debug!(target: "spice_data_distribution", ?id, ?commitment, "decoded data; stop waiting");
+        self.waiting_on_data.remove(&id);
+        self.recently_decoded_data.push(id, ());
         Ok(())
+    }
+
+    /// Drops a single bad commitment for an id while leaving the id in `waiting_on_data`, so the
+    /// request loop keeps fetching the correct data from other producers.
+    fn stop_waiting_on_commitment(
+        &mut self,
+        id: &SpiceDataIdentifier,
+        commitment: &SpiceDataCommitment,
+    ) {
+        if let Some(data_parts) = self.waiting_on_data.get_mut(id) {
+            data_parts.remove(commitment);
+        }
     }
 
     fn is_data_known(&self, me: &AccountId, block: &Block, id: &SpiceDataIdentifier) -> bool {
@@ -834,6 +864,16 @@ impl SpiceDataDistributorActor {
     #[cfg(test)]
     pub(crate) fn pending_partial_data_size(&self) -> usize {
         self.pending_partial_data.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_waiting_on_data(&self, id: &SpiceDataIdentifier) -> bool {
+        self.waiting_on_data.contains_key(id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn num_commitments_waiting_on(&self, id: &SpiceDataIdentifier) -> usize {
+        self.waiting_on_data.get(id).map_or(0, |commitments| commitments.len())
     }
 
     // TODO(spice): Implement a state machine to track all the data we produce or may need. This

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -906,7 +906,7 @@ test_invalid_incoming_partial_data! {
         commitment.root = CryptoHash::default();
         SpicePartialDataBuilder::from_verified(default).commitment(commitment).build()
     })
-    data_does_not_match_commitment_hash(Error::InvalidCommitmentHash, receipt_proof_incoming_data, default, {
+    data_does_not_match_commitment_hash(Error::RecomputedCommitmentMismatch, receipt_proof_incoming_data, default, {
         let mut commitment = default.commitment.clone();
         commitment.hash = CryptoHash::default();
         SpicePartialDataBuilder::from_verified(default).commitment(commitment).build()
@@ -1063,6 +1063,7 @@ fn test_incoming_partial_data_for_receipts_with_non_matching_from_shard_id() {
     let (_genesis, chain) = setup(4, 0);
     let block = latest_block(&chain);
     let (incoming_data, recipient) = receipt_proof_incoming_data(&chain, &block);
+    let data_id = data_into_verified(incoming_data.data.clone()).id;
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &recipient);
     {
@@ -1089,6 +1090,9 @@ fn test_incoming_partial_data_for_receipts_with_non_matching_from_shard_id() {
             result,
             Err(ReceiveDataError::ReceivingDataWithBlock(Error::InvalidDecodedReceiptFromShardId))
         );
+        // The decoded-but-wrong-shard commitment is dropped while the id keeps waiting.
+        assert!(actor.is_waiting_on_data(&data_id));
+        assert_eq!(actor.num_commitments_waiting_on(&data_id), 0);
     }
     actor.handle(incoming_data);
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
@@ -2469,7 +2473,7 @@ fn test_incoming_partial_data_with_recomputed_root_mismatch() {
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
     assert_matches!(
         result,
-        Err(ReceiveDataError::ReceivingDataWithBlock(Error::RecomputedRootMismatch))
+        Err(ReceiveDataError::ReceivingDataWithBlock(Error::RecomputedCommitmentMismatch))
     );
     // The bad commitment is dropped but we keep waiting on the id to request the real data.
     assert!(actor.is_waiting_on_data(&data_id));
@@ -2510,6 +2514,34 @@ fn test_keep_requesting_after_invalid_decode() {
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
     assert_matches!(result, Err(ReceiveDataError::ReceivingDataWithBlock(Error::DecodeError(_))));
     // The bad commitment is dropped but we keep waiting on the id to request the real data.
+    assert!(actor.is_waiting_on_data(&data_id));
+    assert_eq!(actor.num_commitments_waiting_on(&data_id), 0);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_keep_requesting_after_commitment_hash_mismatch() {
+    let (_genesis, chain) = setup(2, 0);
+    let block = latest_block(&chain);
+
+    let (incoming_data, recipient) = receipt_proof_incoming_data(&chain, &block);
+    let default = data_into_verified(incoming_data.data);
+    let data_id = default.id.clone();
+
+    let mut commitment = default.commitment.clone();
+    commitment.hash = CryptoHash::default();
+    let partial_data =
+        SpicePartialDataBuilder::from_verified(default).commitment(commitment).build();
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &recipient);
+    let result = actor.receive_data(partial_data);
+    assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
+    assert_matches!(
+        result,
+        Err(ReceiveDataError::ReceivingDataWithBlock(Error::RecomputedCommitmentMismatch))
+    );
+    // A decoded-but-invalid commitment must not linger in the per-id map.
     assert!(actor.is_waiting_on_data(&data_id));
     assert_eq!(actor.num_commitments_waiting_on(&data_id), 0);
 }

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -2405,3 +2405,111 @@ fn test_contract_code_request_happy_path() {
     assert_eq!(&*decoded_contracts[0].0, contract_bytes.as_slice());
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
 }
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_incoming_partial_data_with_recomputed_root_mismatch() {
+    // Needs at least two producers for the from_shard so a parity part exists to corrupt.
+    let (genesis, chain) = setup(4, 0);
+    let block = latest_block(&chain);
+    let recipient_chain = new_chain(&chain, &genesis);
+
+    let receipt_proof = new_test_receipt_proof(&block);
+    let mut store_update = chain.chain_store.store().store_update();
+    save_receipt_proof(&mut store_update, block.hash(), &receipt_proof);
+    store_update.commit();
+
+    let producer = producers_of_receipt_proof(&chain, &block, &receipt_proof).swap_remove(0);
+    let (_incoming_data, recipient) = receipt_proof_incoming_data(&chain, &block);
+    let data_id = SpiceDataIdentifier::ReceiptProof {
+        block_hash: *block.hash(),
+        from_shard_id: receipt_proof.1.from_shard_id,
+        to_shard_id: receipt_proof.1.to_shard_id,
+    };
+
+    // Obtain the canonical commitment together with all parts from the producer.
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut producer_actor = new_actor_for_account(outgoing_sc, &chain, &producer);
+    producer_actor
+        .handle(SpicePartialDataRequest { data_id: data_id.clone(), requester: recipient.clone() });
+    let (canonical_data, _recipients) =
+        drain_outgoing_partial_data(&mut outgoing_rc).swap_remove(0);
+    let canonical = data_into_verified(canonical_data);
+
+    // Corrupt a parity part (not needed to decode part 0) and re-merklize. The data part still
+    // decodes to canonical hash-matching data, but the committed root is no longer canonical.
+    let mut boxed_parts: Vec<Box<[u8]>> =
+        canonical.parts.iter().map(|part| part.part.clone()).collect();
+    boxed_parts[1] = {
+        let mut bytes = boxed_parts[1].to_vec();
+        bytes.push(0xff);
+        bytes.into_boxed_slice()
+    };
+    let (tampered_root, tampered_proofs) = merklize(&boxed_parts);
+    assert_ne!(tampered_root, canonical.commitment.root);
+
+    let data_part = SpiceDataPart {
+        part_ord: 0,
+        part: canonical.parts[0].part.clone(),
+        merkle_proof: tampered_proofs[0].clone(),
+    };
+    let tampered_commitment = SpiceDataCommitment {
+        hash: canonical.commitment.hash,
+        root: tampered_root,
+        encoded_length: canonical.commitment.encoded_length,
+    };
+    let partial_data = SpicePartialDataBuilder::from_verified(canonical)
+        .commitment(tampered_commitment)
+        .parts(vec![data_part])
+        .build();
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &recipient_chain, &recipient);
+    let result = actor.receive_data(partial_data);
+    assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
+    assert_matches!(
+        result,
+        Err(ReceiveDataError::ReceivingDataWithBlock(Error::RecomputedRootMismatch))
+    );
+    // The bad commitment is dropped but we keep waiting on the id to request the real data.
+    assert!(actor.is_waiting_on_data(&data_id));
+    assert_eq!(actor.num_commitments_waiting_on(&data_id), 0);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_keep_requesting_after_invalid_decode() {
+    let (_genesis, chain) = setup(2, 0);
+    let block = latest_block(&chain);
+
+    let (incoming_data, recipient) = receipt_proof_incoming_data(&chain, &block);
+    let default = data_into_verified(incoming_data.data);
+    let data_id = default.id.clone();
+
+    let bad_data = "bad data";
+    let mut boxed_parts: Vec<Box<[u8]>> =
+        vec![borsh::to_vec(&bad_data).unwrap().into_boxed_slice()];
+    let data_hash = hash(&borsh::to_vec(&bad_data).unwrap());
+    let (root, mut proofs) = merklize(&boxed_parts);
+    let partial_data = SpicePartialDataBuilder::from_verified(default)
+        .commitment(SpiceDataCommitment {
+            hash: data_hash,
+            root,
+            encoded_length: bad_data.len() as u64,
+        })
+        .parts(vec![SpiceDataPart {
+            part_ord: 0,
+            part: boxed_parts.swap_remove(0),
+            merkle_proof: proofs.swap_remove(0),
+        }])
+        .build();
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &recipient);
+    let result = actor.receive_data(partial_data);
+    assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
+    assert_matches!(result, Err(ReceiveDataError::ReceivingDataWithBlock(Error::DecodeError(_))));
+    // The bad commitment is dropped but we keep waiting on the id to request the real data.
+    assert!(actor.is_waiting_on_data(&data_id));
+    assert_eq!(actor.num_commitments_waiting_on(&data_id), 0);
+}

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -2444,6 +2444,7 @@ fn test_incoming_partial_data_with_recomputed_root_mismatch() {
     // decodes to canonical hash-matching data, but the committed root is no longer canonical.
     let mut boxed_parts: Vec<Box<[u8]>> =
         canonical.parts.iter().map(|part| part.part.clone()).collect();
+    assert!(boxed_parts.len() > 1, "test needs a parity part to corrupt");
     boxed_parts[1] = {
         let mut bytes = boxed_parts[1].to_vec();
         bytes.push(0xff);
@@ -2491,15 +2492,15 @@ fn test_keep_requesting_after_invalid_decode() {
     let data_id = default.id.clone();
 
     let bad_data = "bad data";
-    let mut boxed_parts: Vec<Box<[u8]>> =
-        vec![borsh::to_vec(&bad_data).unwrap().into_boxed_slice()];
-    let data_hash = hash(&borsh::to_vec(&bad_data).unwrap());
+    let encoded = borsh::to_vec(&bad_data).unwrap();
+    let mut boxed_parts: Vec<Box<[u8]>> = vec![encoded.clone().into_boxed_slice()];
+    let data_hash = hash(&encoded);
     let (root, mut proofs) = merklize(&boxed_parts);
     let partial_data = SpicePartialDataBuilder::from_verified(default)
         .commitment(SpiceDataCommitment {
             hash: data_hash,
             root,
-            encoded_length: bad_data.len() as u64,
+            encoded_length: encoded.len() as u64,
         })
         .parts(vec![SpiceDataPart {
             part_ord: 0,

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -906,7 +906,7 @@ test_invalid_incoming_partial_data! {
         commitment.root = CryptoHash::default();
         SpicePartialDataBuilder::from_verified(default).commitment(commitment).build()
     })
-    data_does_not_match_commitment_hash(Error::RecomputedCommitmentMismatch, receipt_proof_incoming_data, default, {
+    data_does_not_match_commitment(Error::RecomputedCommitmentMismatch, receipt_proof_incoming_data, default, {
         let mut commitment = default.commitment.clone();
         commitment.hash = CryptoHash::default();
         SpicePartialDataBuilder::from_verified(default).commitment(commitment).build()


### PR DESCRIPTION
After decoding reassembled partial data, re-encode the decoded data and require the whole recomputed `SpiceDataCommitment` (hash, root, and encoded_length) to match the received commitment before forwarding it to the executor / witness validator. Previously the recipient accepted on per-part Merkle proofs plus `hash(data) == commitment.hash` only; a producer could commit to a root whose parts decode to hash-matching but non-canonical data, so correct recipients were not guaranteed to converge on the same data. Comparing the full commitment also canonically validates the attacker-supplied `encoded_length`, which flows downstream as `raw_witness_size` and as the decode buffer size. Mismatches are rejected with `RecomputedCommitmentMismatch`.

On any post-decode failure (failed decode, commitment mismatch, or id/shard/block mismatch), drop only the offending commitment from `waiting_on_data` and keep the id, so the periodic request loop keeps fetching the real data for that id from other producers. Only a clean accept clears the whole id.

Adds a TODO for a remaining gap: the per-id commitment map is unbounded, so a misbehaving producer can still grow it with commitments that fail the Merkle check or never gather enough parts to decode. Bounding it (cap plus eviction) is left as follow-up.

Behind `protocol_feature_spice`.