### PR TITLE
chore(deps): group dependabot security updates for side modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+# Dependabot configuration for nearcore.
+#
+# We do NOT run Dependabot *version* updates — only *security* updates (driven
+# by published advisories). Every `updates` entry below sets
+# `open-pull-requests-limit: 0`, which disables version-update PRs while leaving
+# security updates active (security updates have a separate internal cap of 10
+# open PRs that this limit does not affect).
+#
+# Goal: cut the noise from per-dependency security PRs in the side modules by
+# grouping them into a single PR per module set, WITHOUT touching the root
+# workspace. See each entry for details.
+#
+# Note: `schedule.interval` is a required field but only governs version
+# updates (which are off here). It does NOT delay security updates — those are
+# triggered by advisory publication and open ~immediately regardless of the
+# interval. The root workspace is listed (rather than omitted) so it is
+# unambiguously covered and its policy is explicit.
+version: 2
+updates:
+  # --- npm: debug-ui (debugging tool, does not ship in neard) ---
+  # Highest-volume source of Dependabot PRs. Consolidate every security bump
+  # into one PR.
+  - package-ecosystem: "npm"
+    directory: "/tools/debug-ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      debug-ui-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # --- cargo: side modules (separate manifests, none ship in neard) ---
+  # Each of these has its own Cargo.toml / Cargo.lock outside the root
+  # workspace (benchmarks and tracing are explicitly `exclude`d in the root
+  # Cargo.toml): benchmarks, test/wallet contracts, the standalone tracing
+  # crate, etc. Their advisories carry near-zero real exposure, so consolidate
+  # them into a single grouped PR rather than one-per-dependency.
+  - package-ecosystem: "cargo"
+    directories:
+      - "/benchmarks/synth-bm"
+      - "/benchmarks/continuous/db/tool"
+      - "/runtime/near-wallet-contract/implementation"
+      - "/runtime/near-test-contracts/sharded-contract"
+      - "/pytest/tools/mirror/contract"
+      - "/tracing"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      cargo-side-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # --- pip: standalone python tooling (does not ship in neard) ---
+  # debug_scripts and pytest are standalone python tooling, both handled by the
+  # `pip` ecosystem. Consolidate into one grouped PR.
+  - package-ecosystem: "pip"
+    directories:
+      - "/debug_scripts"
+      - "/pytest"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      pip-side-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # --- cargo: root workspace (neard) — INTENTIONALLY NOT GROUPED ---
+  # These dependencies ship in the node, and some cannot be bumped casually:
+  # e.g. wasmtime is tied to runtime execution and an upgrade can force a
+  # protocol-version change, so even a "security" bump needs deliberate review.
+  # Runtime dependency updates in general are subtle and must be evaluated one
+  # at a time. We therefore leave the root workspace UNGROUPED so each advisory
+  # arrives as its own PR that can be reviewed (and accepted/deferred)
+  # individually — never bundled all-or-nothing with unrelated bumps.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Background

nearcore has no `dependabot.yml`, so Dependabot *version* updates are off — everything it opens is a **security update** driven by a published advisory (GHSA/CVE/RUSTSEC). That's working as intended, but the PRs land one-per-dependency and the volume has gotten noisy:

- ~95 security PRs since Jan 2025, bursty (18 in Feb, 14 in Mar, 13 in May).
- Dependabot security updates have a hard internal cap of **10 open PRs that cannot be raised** — and we're sitting at exactly 10 right now, so newly-published advisories start queuing behind the backlog instead of being opened.

Most of that volume is low-priority. Breakdown since Jan 2025:

| Ecosystem | Module | PRs | Ships in neard? |
|---|---|---:|---|
| npm | `/tools/debug-ui` | 44 | no (debug tool) |
| cargo | `/runtime/near-wallet-contract/implementation` | 14 | no |
| cargo | `/benchmarks/synth-bm` | 14 | no |
| cargo | **root workspace** | **13** | **yes** |
| cargo | `/tracing`, `/benchmarks/continuous/db/tool`, `/runtime/near-test-contracts/sharded-contract`, `/pytest/tools/mirror/contract` | ~6 | no |
| pip | `/debug_scripts`, `/pytest` | 3 | no |

The side modules (debug-ui, benchmarks, test/wallet contracts, the standalone tracing crate, python tooling) don't ship in `neard`, so their advisories carry near-zero real exposure — yet each still spawns its own PR.

## What this does

Adds `.github/dependabot.yml` that **groups security updates for the side modules into one PR per module set, and intentionally leaves the root workspace ungrouped**:

- npm `/tools/debug-ui` → one grouped PR
- cargo side modules (synth-bm, continuous db tool, wallet-contract impl, sharded-contract, mirror contract, tracing) → one grouped PR
- pip (`/debug_scripts` Pipfile, `/pytest` requirements) → one grouped PR
- cargo **root workspace** (`/`) → **not grouped**, stays one PR per dependency

Every entry sets `open-pull-requests-limit: 0`, so this does **not** enable version updates — only security-update grouping changes. Collapsing the side-module backlog also frees up most of the 10-PR cap so root-workspace advisories aren't starved.

## Why the root workspace is left ungrouped

The root workspace is the code that ships in `neard`, and some of its dependencies cannot be bumped casually:

- **wasmtime** is tied to runtime execution; upgrading it can force a protocol-version change, so even a security bump needs deliberate, standalone review — it is not "just update it."
- Runtime dependency updates in general are subtle and have to be evaluated one at a time.

Grouping would bundle a protocol-affecting wasmtime bump with unrelated trivial bumps into a single all-or-nothing PR. We want the opposite: each root-workspace advisory as its own PR that can be reviewed, accepted, or deferred individually.

## Notes

- This relies on the config file alone. The repo-level "Grouped security updates" Settings toggle must stay **OFF** — that toggle groups every directory in an ecosystem, which would pull the root workspace in too.
- Grouped PRs are all-or-nothing on CI: if one bump in a group breaks CI, that PR is blocked until fixed. Acceptable for the side modules, and another reason the root workspace is excluded.
