### PR TITLE
chore(ci): bump anyhow to 1.0.103 to fix cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
Bump `anyhow` from 1.0.102 to 1.0.103 to clear RUSTSEC-2026-0190 ("Unsoundness in `Error::downcast_mut()`"), which fails the Cargo Audit CI job under `cargo audit -D warnings`.

The advisory was published 2026-06-25 and affects all `anyhow` versions before 1.0.103. Lockfile-only change.