### PR TITLE
test(spice): enable inflation and access-key-nonce tests under spice

### DIFF
--- a/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
@@ -45,8 +45,6 @@ fn check_tx_processing(
 
 /// Test that duplicate transactions are properly rejected.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_transaction_hash_collision() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
@@ -196,8 +194,6 @@ fn get_status_of_tx_hash_collision_for_near_implicit_account(
 
 /// Test that duplicate transactions from NEAR-implicit accounts are properly rejected.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_transaction_hash_collision_for_near_implicit_account_fail() {
     let secret_key = SecretKey::from_seed(KeyType::ED25519, "test");
     let public_key = secret_key.public_key();
@@ -261,8 +257,6 @@ fn test_chunk_transaction_validity() {
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_transaction_nonce_too_large() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);

--- a/test-loop-tests/src/tests/stake_nodes.rs
+++ b/test-loop-tests/src/tests/stake_nodes.rs
@@ -507,7 +507,6 @@ fn test_spice_uncertified_restake_prevents_stake_return() {
 /// Checks that during the first epoch, total_supply matches total_supply in genesis.
 /// Checks that during the second epoch, total_supply matches the expected inflation rate.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_inflation() {
     init_test_logger();
 


### PR DESCRIPTION
A handful of tests were marked `#[cfg_attr(feature = "protocol_feature_spice", ignore)]` (with a generic `TODO(spice-test): assess relevance`) while spice was being brought up. They now pass under spice, so this removes the `ignore` and the stale TODOs to run them in the spice CI lane.

- `test_inflation` (test-loop): passes now that spice feeds certified chunk-endorsement stats into the validator reward path (#15834). The endorsement uptime is credited again, so the resulting total supply matches the test's expected inflation exactly — no test changes needed beyond un-ignoring.
- `test_transaction_hash_collision`, `test_transaction_hash_collision_for_near_implicit_account_fail`, `test_transaction_nonce_too_large` (integration-tests `access_key_nonce_for_implicit_accounts`): transaction validity and access-key nonce replay protection execute identically under spice (the integration `TestEnv` drives spice's decoupled execution synchronously per block), so these pass unchanged.

Verified each passes under `--features test_features,protocol_feature_spice` without `--include-ignored`.