### PR TITLE
refactor(store): remove dead per-shard persistence methods

### DIFF
--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -9,10 +9,8 @@ use near_primitives::block::Tip;
 use near_primitives::chunk_apply_stats::{ChunkApplyStats, ChunkApplyStatsV1};
 use near_primitives::errors::{EpochError, InvalidTxError};
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::{MerklePath, PartialMerkleTree};
-use near_primitives::receipt::{
-    ProcessedReceipt, ProcessedReceiptMetadata, Receipt, ReceiptSource, ReceiptToTxInfo,
-};
+use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt};
 use near_primitives::shard_layout::{ShardLayout, ShardUId, get_block_shard_uid};
 use near_primitives::sharding::{
     ArcedShardChunk, ChunkHash, EncodedShardChunk, PartialEncodedChunk, ReceiptProof, ShardChunk,
@@ -35,8 +33,7 @@ use near_primitives::types::{
     StateChangesKinds, StateChangesKindsExt, StateChangesRequest,
 };
 use near_primitives::utils::{
-    get_block_shard_id, get_outcome_id_block_hash, get_outcome_id_block_hash_rev, index_to_bytes,
-    to_timestamp,
+    get_block_shard_id, get_outcome_id_block_hash_rev, index_to_bytes, to_timestamp,
 };
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::LightClientBlockView;
@@ -1040,11 +1037,7 @@ pub(crate) struct ChainStoreCacheUpdate {
     next_block_hashes: HashMap<CryptoHash, CryptoHash>,
     epoch_light_client_blocks: HashMap<CryptoHash, Arc<LightClientBlockView>>,
     outgoing_receipts: HashMap<(CryptoHash, ShardId), Arc<Vec<Receipt>>>,
-    processed_receipt_ids: HashMap<(CryptoHash, ShardId), Arc<Vec<ProcessedReceiptMetadata>>>,
-    processed_receipts_to_save: Vec<Receipt>,
     incoming_receipts: HashMap<(CryptoHash, ShardId), Arc<Vec<ReceiptProof>>>,
-    outcomes: HashMap<(CryptoHash, CryptoHash), ExecutionOutcomeWithProof>,
-    outcome_ids: HashMap<(CryptoHash, ShardId), Vec<CryptoHash>>,
     invalid_chunks: HashMap<ChunkHash, Arc<EncodedShardChunk>>,
     transactions: HashMap<CryptoHash, Arc<SignedTransaction>>,
     receipts: HashMap<CryptoHash, Arc<Receipt>>,
@@ -1052,7 +1045,6 @@ pub(crate) struct ChainStoreCacheUpdate {
     block_merkle_tree: HashMap<CryptoHash, Arc<PartialMerkleTree>>,
     block_ordinal_to_hash: HashMap<NumBlocks, CryptoHash>,
     processed_block_heights: HashSet<BlockHeight>,
-    receipt_to_tx: Vec<(CryptoHash, ReceiptToTxInfo)>,
     chunk_producers: HashMap<(CryptoHash, ShardId), ValidatorStake>,
 }
 
@@ -1339,13 +1331,7 @@ impl<'a> ChainStoreAccess for ChainStoreUpdate<'a> {
         block_hash: &CryptoHash,
         shard_id: ShardId,
     ) -> Result<Arc<Vec<ProcessedReceiptMetadata>>, Error> {
-        if let Some(metadata) =
-            self.chain_store_cache_update.processed_receipt_ids.get(&(*block_hash, shard_id))
-        {
-            Ok(Arc::clone(metadata))
-        } else {
-            self.chain_store.get_processed_receipt_ids(block_hash, shard_id)
-        }
+        self.chain_store.get_processed_receipt_ids(block_hash, shard_id)
     }
 
     /// Get receipts produced for block with given hash.
@@ -1645,30 +1631,6 @@ impl<'a> ChainStoreUpdate<'a> {
             .insert((*hash, shard_id), Arc::new(outgoing_receipts));
     }
 
-    pub fn save_processed_receipt_ids(
-        &mut self,
-        hash: &CryptoHash,
-        shard_id: ShardId,
-        processed_receipts: Vec<ProcessedReceipt>,
-        receipt_to_tx_ids: Vec<CryptoHash>,
-    ) {
-        let mut metadata: Vec<ProcessedReceiptMetadata> = processed_receipts
-            .iter()
-            .map(|pr| ProcessedReceiptMetadata::new(*pr.receipt.receipt_id(), pr.source.clone()))
-            .collect();
-        if self.chain_store.save_receipt_to_tx {
-            for id in receipt_to_tx_ids {
-                metadata.push(ProcessedReceiptMetadata::new(id, ReceiptSource::ReceiptToTxGc));
-            }
-        }
-        self.chain_store_cache_update
-            .processed_receipts_to_save
-            .extend(processed_receipts.into_iter().map(|pr| pr.receipt));
-        self.chain_store_cache_update
-            .processed_receipt_ids
-            .insert((*hash, shard_id), Arc::new(metadata));
-    }
-
     pub fn save_incoming_receipt(
         &mut self,
         hash: &CryptoHash,
@@ -1676,36 +1638,6 @@ impl<'a> ChainStoreUpdate<'a> {
         receipt_proof: Arc<Vec<ReceiptProof>>,
     ) {
         self.chain_store_cache_update.incoming_receipts.insert((*hash, shard_id), receipt_proof);
-    }
-
-    pub fn save_outcomes_with_proofs(
-        &mut self,
-        block_hash: &CryptoHash,
-        shard_id: ShardId,
-        outcomes: Vec<ExecutionOutcomeWithId>,
-        proofs: Vec<MerklePath>,
-    ) {
-        // The OutcomeIds index is needed for GC of TransactionResultForBlock entries.
-        // ReceiptToTx GC is handled separately via ProcessedReceiptIds.
-        if !self.chain_store.save_tx_outcomes {
-            return;
-        }
-        let mut outcome_ids = Vec::with_capacity(outcomes.len());
-        for (outcome_with_id, proof) in outcomes.into_iter().zip(proofs.into_iter()) {
-            outcome_ids.push(outcome_with_id.id);
-            self.chain_store_cache_update.outcomes.insert(
-                (outcome_with_id.id, *block_hash),
-                ExecutionOutcomeWithProof { outcome: outcome_with_id.outcome, proof },
-            );
-        }
-        self.chain_store_cache_update.outcome_ids.insert((*block_hash, shard_id), outcome_ids);
-    }
-
-    pub fn save_receipt_to_tx(&mut self, receipt_to_tx: Vec<(CryptoHash, ReceiptToTxInfo)>) {
-        if !self.chain_store.save_receipt_to_tx {
-            return;
-        }
-        self.chain_store_cache_update.receipt_to_tx.extend(receipt_to_tx);
     }
 
     pub fn save_trie_changes(&mut self, block_hash: CryptoHash, trie_changes: WrappedTrieChanges) {
@@ -2057,47 +1989,6 @@ impl<'a> ChainStoreUpdate<'a> {
                     &get_block_shard_id(block_hash, *shard_id),
                     receipt,
                 );
-            }
-
-            for ((block_hash, shard_id), metadata) in
-                &self.chain_store_cache_update.processed_receipt_ids
-            {
-                store_update.set_ser(
-                    DBCol::ProcessedReceiptIds,
-                    &get_block_shard_id(block_hash, *shard_id),
-                    metadata,
-                );
-            }
-            for receipt in &self.chain_store_cache_update.processed_receipts_to_save {
-                save_receipt(&mut store_update, receipt);
-            }
-        }
-
-        {
-            let _span = tracing::trace_span!(target: "store", "write_outcomes").entered();
-
-            for ((outcome_id, block_hash), outcome_with_proof) in
-                &self.chain_store_cache_update.outcomes
-            {
-                store_update.insert_ser(
-                    DBCol::TransactionResultForBlock,
-                    &get_outcome_id_block_hash(outcome_id, block_hash),
-                    &outcome_with_proof,
-                );
-            }
-            for ((block_hash, shard_id), ids) in &self.chain_store_cache_update.outcome_ids {
-                store_update.set_ser(
-                    DBCol::OutcomeIds,
-                    &get_block_shard_id(block_hash, *shard_id),
-                    &ids,
-                );
-            }
-        }
-
-        {
-            let _span = tracing::trace_span!(target: "store", "write_receipt_to_tx").entered();
-            for (receipt_id, info) in &self.chain_store_cache_update.receipt_to_tx {
-                store_update.insert_ser(DBCol::ReceiptToTx, receipt_id.as_ref(), info);
             }
         }
 


### PR DESCRIPTION
`ChainStoreUpdate::save_processed_receipt_ids`, `save_outcomes_with_proofs`, and `save_receipt_to_tx` lost their only callers when #15819 migrated the chain-side chunk-apply path onto the shared `apply_chunk_postprocessing` helper, which writes those columns directly through the low-level store adapter instead of staging them in `ChainStoreUpdate`'s cache. Since they're `pub fn` on a `pub struct`, rustc's `dead_code` lint never flagged them.

This removes the three methods, the `ChainStoreCacheUpdate` fields they populated (`processed_receipt_ids`, `processed_receipts_to_save`, `outcomes`, `outcome_ids`, `receipt_to_tx`), the now-empty `finalize()` drain loops for those columns, and the dead cache-check inside `get_processed_receipt_ids` (which always missed since nothing populates the cache anymore).