### PR TITLE
feat(spice): support the near-indexer under decoupled execution

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -652,8 +652,14 @@ impl<'a> ChainStoreUpdate<'a> {
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).expect("epoch id must exist");
 
         // 2. Delete shard_id-indexed data (Receipts, State Headers and Parts, etc.)
+        let is_spice_block = ProtocolFeature::Spice.enabled(
+            epoch_manager.get_epoch_protocol_version(epoch_id).expect("epoch id must exist"),
+        );
         for shard_id in shard_layout.shard_ids() {
             let block_shard_id = get_block_shard_id(&block_hash, shard_id);
+            if is_spice_block {
+                self.gc_spice_outgoing_receipt_bodies(&block_hash, shard_id);
+            }
             self.gc_outgoing_receipts(&block_hash, shard_id);
             self.gc_processed_receipt_ids(&block_hash, shard_id);
             self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
@@ -846,6 +852,9 @@ impl<'a> ChainStoreUpdate<'a> {
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).expect("epoch id must exist");
 
         // 1. Delete shard_id-indexed data (TrieChanges, Receipts, ChunkExtra, State Headers and Parts, FlatStorage data)
+        let is_spice_block = ProtocolFeature::Spice.enabled(
+            epoch_manager.get_epoch_protocol_version(epoch_id).expect("epoch id must exist"),
+        );
         for shard_id in shard_layout.shard_ids() {
             let shard_uid = shard_id_to_uid(epoch_manager, shard_id, epoch_id).unwrap();
             let block_shard_id = get_block_shard_uid(&block_hash, &shard_uid);
@@ -854,6 +863,9 @@ impl<'a> ChainStoreUpdate<'a> {
             self.gc_col(DBCol::TrieChanges, &block_shard_id);
 
             // delete Receipts
+            if is_spice_block {
+                self.gc_spice_outgoing_receipt_bodies(&block_hash, shard_id);
+            }
             self.gc_outgoing_receipts(&block_hash, shard_id);
             self.gc_processed_receipt_ids(&block_hash, shard_id);
             self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
@@ -1000,6 +1012,16 @@ impl<'a> ChainStoreUpdate<'a> {
         let key = get_block_shard_id(block_hash, shard_id);
         store_update.delete(DBCol::OutgoingReceipts, &key);
         self.merge(store_update);
+    }
+
+    /// Matching decrement for the `DBCol::Receipts` refcount the spice executor
+    /// bumps per produced receipt; non-spice balances via the partial-chunk GC.
+    /// Must run before `gc_outgoing_receipts` deletes the `OutgoingReceipts` it reads.
+    fn gc_spice_outgoing_receipt_bodies(&mut self, block_hash: &CryptoHash, shard_id: ShardId) {
+        let Ok(receipts) = self.get_outgoing_receipts(block_hash, shard_id) else { return };
+        for receipt in receipts.iter() {
+            self.gc_col(DBCol::Receipts, receipt.receipt_id().as_bytes());
+        }
     }
 
     fn gc_processed_receipt_ids(&mut self, block_hash: &CryptoHash, shard_id: ShardId) {

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -2249,8 +2249,7 @@ impl<'a> ChainStoreUpdate<'a> {
 }
 
 fn save_receipt(store_update: &mut StoreUpdate, receipt: &Receipt) {
-    let bytes = borsh::to_vec(&receipt).expect("borsh cannot fail");
-    store_update.increment_refcount(DBCol::Receipts, receipt.get_hash().as_ref(), &bytes);
+    store_update.chain_store_update().save_receipt(receipt);
 }
 
 #[cfg(test)]

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -11,7 +11,7 @@ use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;
-use near_primitives::receipt::ProcessedReceiptMetadata;
+use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt};
 use near_primitives::shard_layout::get_block_shard_uid_rev;
 use near_primitives::sharding::{ChunkHash, PartialEncodedChunk, ShardChunk, StateSyncInfo};
 use near_primitives::state_sync::{ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey};
@@ -314,6 +314,17 @@ impl StoreValidator {
                         col,
                     );
                 }
+                DBCol::OutgoingReceipts => {
+                    let (block_hash, shard_id) = get_block_shard_id_rev(key_ref)?;
+                    let receipts: Vec<Receipt> = BorshDeserialize::try_from_slice(value_ref)?;
+                    // Spice counts these produced-receipt bodies toward the Receipts refcount.
+                    self.check(
+                        &validate::outgoing_receipt_bodies_exist_in_receipts,
+                        &(block_hash, shard_id),
+                        receipts.as_slice(),
+                        col,
+                    );
+                }
                 DBCol::Transactions => {
                     let (_value, rc) = refcount::decode_value_with_rc(value_ref);
                     let tx_hash = CryptoHash::try_from(key_ref)?;
@@ -359,12 +370,12 @@ impl StoreValidator {
         }
 
         // Main loop.
-        // Custom sort: PartialChunks and ProcessedReceiptIds must be
-        // validated before Receipts so that receipt refcounts are fully
+        // Custom sort: PartialChunks, ProcessedReceiptIds and OutgoingReceipts
+        // must be validated before Receipts so that receipt refcounts are fully
         // populated before we check them against the Receipts column.
         let mut cols: Vec<DBCol> = DBCol::iter().collect();
         cols.sort_by_key(|col| match col {
-            DBCol::PartialChunks | DBCol::ProcessedReceiptIds => 0,
+            DBCol::PartialChunks | DBCol::ProcessedReceiptIds | DBCol::OutgoingReceipts => 0,
             other => 1 + other.into_usize(),
         });
         for col in cols {

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -12,6 +12,7 @@ use near_primitives::transaction::{ExecutionOutcomeWithProof, SignedTransaction}
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
 use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
+use near_primitives::version::ProtocolFeature;
 use near_store::{
     CHUNK_TAIL_KEY, DBCol, FORK_TAIL_KEY, HEAD_KEY, HEADER_HEAD_KEY, TAIL_KEY, TrieChanges,
 };
@@ -296,6 +297,39 @@ pub(crate) fn partial_chunk_receipts_exist_in_receipts(
             // This is verified later when we verify the Receipts column.
             *sv.inner.receipt_refcount.entry(*receipt.receipt_id()).or_insert(0) += 1;
         }
+    }
+    Ok(())
+}
+
+/// Spice analog of `partial_chunk_receipts_exist_in_receipts`: spice's produced
+/// receipts are referenced via `DBCol::OutgoingReceipts`, not a partial chunk, so
+/// count those toward the receipt refcount. No-op for non-spice blocks.
+pub(crate) fn outgoing_receipt_bodies_exist_in_receipts(
+    sv: &mut StoreValidator,
+    key: &(CryptoHash, ShardId),
+    receipts: &[Receipt],
+) -> Result<(), StoreValidatorError> {
+    let (block_hash, _shard_id) = key;
+    // A consistent store GCs OutgoingReceipts alongside its block, so a missing
+    // header (or epoch) shouldn't happen here; skip rather than error if it does.
+    let Some(header) = sv.store.get_ser::<BlockHeader>(DBCol::BlockHeader, block_hash.as_ref())
+    else {
+        return Ok(());
+    };
+    let Ok(protocol_version) = sv.epoch_manager.get_epoch_protocol_version(header.epoch_id())
+    else {
+        return Ok(());
+    };
+    if !ProtocolFeature::Spice.enabled(protocol_version) {
+        return Ok(());
+    }
+    for receipt in receipts {
+        unwrap_or_err_db!(
+            sv.store.get_ser::<Receipt>(DBCol::Receipts, receipt.receipt_id().as_bytes()),
+            "OutgoingReceipts has {:?} but it doesn't exist in Receipts column",
+            receipt
+        );
+        *sv.inner.receipt_refcount.entry(*receipt.receipt_id()).or_insert(0) += 1;
     }
     Ok(())
 }

--- a/chain/client/src/spice/chunk_executor_actor/per_shard.rs
+++ b/chain/client/src/spice/chunk_executor_actor/per_shard.rs
@@ -45,8 +45,8 @@ use near_primitives::types::{
 };
 use near_primitives::validator_signer::ValidatorSigner;
 use near_store::ShardUId;
-use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use node_runtime::SignedValidPeriodTransactions;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
@@ -473,6 +473,15 @@ impl PerShardChunkExecutor {
         }
         // RPC nodes skip endorsement/distribution above; persistence below still runs.
         let mut store_update = self.chain_store.store().store_update();
+        // The chain path persists produced-receipt bodies when it saves the
+        // partial chunk; spice chunks are tx-only, so persist them here instead so
+        // they stay fetchable by id once consumed as incoming receipts later. Same
+        // `store_update` as the `ChunkExtra` write below, so a replay that finds
+        // the chunk extra skips this and avoids double-incrementing the refcount.
+        // The matching decrement is `gc_spice_outgoing_receipt_bodies`.
+        for receipt in &new_chunk_result.apply_result.outgoing_receipts {
+            store_update.chain_store_update().save_receipt(receipt);
+        }
         apply_chunk_postprocessing(
             &mut store_update,
             self.runtime_adapter.as_ref(),

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -13,7 +13,6 @@ use near_indexer_primitives::{
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::ReceiptSource;
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
-use near_primitives::version::ProtocolFeature;
 use near_primitives::views::{BlockView, ChunkView, ReceiptView};
 use rocksdb::DB;
 use std::collections::HashMap;
@@ -46,7 +45,6 @@ pub async fn build_streamer_message(
     let chunks = client.fetch_block_new_chunks(&block, shard_tracker).await?;
 
     let protocol_config_view = client.fetch_protocol_config(block.header.hash).await?;
-    let protocol_version = protocol_config_view.protocol_version;
     let shard_ids = protocol_config_view.shard_layout.shard_ids();
     let gas_price = if block.header.prev_hash == CryptoHash::default() {
         block.header.gas_price
@@ -68,11 +66,6 @@ pub async fn build_streamer_message(
             state_changes: state_changes.remove(&shard_id).unwrap_or_default(),
         })
         .collect::<Vec<_>>();
-
-    // TODO(spice): Add indexer support for spice.
-    if ProtocolFeature::Spice.enabled(protocol_version) {
-        return Ok(StreamerMessage { block, shards: indexer_shards });
-    }
 
     for chunk in chunks {
         let ChunkView { transactions, author, header, receipts: chunk_prev_outgoing_receipts } =

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -485,6 +485,13 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
         );
     }
 
+    /// Increments the refcount of the receipt body in the `DBCol::Receipts`
+    /// rc-column, keyed by receipt hash, so the receipt stays fetchable by id.
+    pub fn save_receipt(&mut self, receipt: &Receipt) {
+        let bytes = borsh::to_vec(receipt).expect("borsh cannot fail");
+        self.store_update.increment_refcount(DBCol::Receipts, receipt.get_hash().as_ref(), &bytes);
+    }
+
     /// Writes the `ProcessedReceiptIds` metadata index and increments the
     /// refcount of each processed `Receipt` (the `DBCol::Receipts` rc-column).
     /// The caller builds `metadata` (including any `ReceiptToTxGc` markers gated

--- a/test-loop-tests/src/tests/indexer.rs
+++ b/test-loop-tests/src/tests/indexer.rs
@@ -42,8 +42,6 @@ fn test_indexer_basic() {
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_indexer_local_receipt() {
     init_test_logger();
 
@@ -92,8 +90,6 @@ fn test_indexer_local_receipt() {
 /// the GC test only checks that the receipt is *stored*, while this test needs
 /// the callback to *execute* so the indexer has an outcome to index.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_indexer_instant_receipt() {
     init_test_logger();
 
@@ -191,8 +187,6 @@ fn test_indexer_instant_receipt() {
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_indexer_delayed_local_receipt() {
     init_test_logger();
 
@@ -212,7 +206,9 @@ fn test_indexer_delayed_local_receipt() {
     let last_tx_outcome = env
         .validator_runner()
         .run_until_outcome_available(last_tx.get_hash(), Duration::seconds(2));
-    let last_tx_included_height = env.validator().head().height;
+    // Under spice the consensus head runs ahead of execution, so the height at
+    // which the outcome actually landed is the execution head, not `head()`.
+    let last_tx_executed_height = env.validator().last_executed().height;
     let ExecutionStatus::SuccessReceiptId(last_tx_receipt_id) =
         last_tx_outcome.outcome_with_id.outcome.status
     else {
@@ -221,8 +217,8 @@ fn test_indexer_delayed_local_receipt() {
     let last_tx_receipt_outcome = env
         .validator_runner()
         .run_until_outcome_available(last_tx_receipt_id, Duration::seconds(2));
-    let last_tx_receipt_executed_height = env.validator().head().height;
-    assert_eq!(last_tx_receipt_executed_height, last_tx_included_height + 2);
+    let last_tx_receipt_executed_height = env.validator().last_executed().height;
+    assert_eq!(last_tx_receipt_executed_height, last_tx_executed_height + 2);
 
     let mut indexer_receiver =
         start_indexer(&env, SyncModeEnum::BlockHeight(last_tx_receipt_executed_height));
@@ -245,8 +241,6 @@ fn test_indexer_delayed_local_receipt() {
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_indexer_failed_local_tx() {
     init_test_logger();
 
@@ -280,8 +274,6 @@ fn test_indexer_failed_local_tx() {
 }
 
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_indexer_deploy_contract_local_tx() {
     init_test_logger();
     let mut env = setup();
@@ -291,7 +283,9 @@ fn test_indexer_deploy_contract_local_tx() {
     // that actually contains the tx; back off by that amount to land on the tx block.
     let extra_refund_block =
         if ProtocolFeature::AccountCostIncrease.enabled(PROTOCOL_VERSION) { 1 } else { 0 };
-    let deploy_contract_height = env.validator().head().height - extra_refund_block;
+    // Under spice the consensus head runs ahead of execution; the deploy block is
+    // tracked by the execution head, not `head()`.
+    let deploy_contract_height = env.validator().last_executed().height - extra_refund_block;
 
     let mut indexer_receiver =
         start_indexer(&env, SyncModeEnum::BlockHeight(deploy_contract_height));
@@ -319,8 +313,6 @@ fn test_indexer_deploy_contract_local_tx() {
 /// new metadata variant exists to surface, since the receiver account is
 /// `user_account` but the actually-executed code lives at the global hash.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_indexer_global_contract_function_call_metadata() {
     init_test_logger();
 
@@ -390,8 +382,6 @@ fn test_indexer_global_contract_function_call_metadata() {
 /// that the indexer returns receipt execution outcomes in the same order
 /// as the corresponding transactions, which is the execution order.
 #[test]
-// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_indexer_receipt_execution_outcomes_order() {
     init_test_logger();
 
@@ -406,9 +396,11 @@ fn test_indexer_receipt_execution_outcomes_order() {
     // Wait for all transactions to be included and local receipts executed.
     let last_tx = txs.last().unwrap();
     env.validator_runner().run_until_outcome_available(last_tx.get_hash(), Duration::seconds(5));
-    let tx_included_height = env.validator().head().height;
+    // Under spice the consensus head runs ahead of execution; the txs land in the
+    // block tracked by the execution head, not `head()`.
+    let tx_executed_height = env.validator().last_executed().height;
 
-    let mut indexer_receiver = start_indexer(&env, SyncModeEnum::BlockHeight(tx_included_height));
+    let mut indexer_receiver = start_indexer(&env, SyncModeEnum::BlockHeight(tx_executed_height));
     let msg = receive_indexer_message(&mut env, &mut indexer_receiver);
     let indexer_shard = &msg.shards[0];
     let indexer_chunk = indexer_shard.chunk.as_ref().unwrap();

--- a/test-loop-tests/src/tests/processed_receipts_gc.rs
+++ b/test-loop-tests/src/tests/processed_receipts_gc.rs
@@ -166,6 +166,89 @@ fn test_processed_receipt_ids_gc() {
     );
 }
 
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_outgoing_receipt_bodies_gc() {
+    init_test_logger();
+
+    let user_account = create_account_id("account0");
+    let mut env = TestLoopBuilder::new()
+        .epoch_length(EPOCH_LENGTH)
+        .add_user_account(&user_account, Balance::from_near(1_000_000))
+        .gc_num_epochs_to_keep(GC_NUM_EPOCHS_TO_KEEP)
+        .build();
+
+    // Deploy the test contract and call a function; executing the resulting local
+    // receipt produces an outgoing gas-refund receipt.
+    let deploy_tx = env.validator().tx_deploy_test_contract(&user_account);
+    env.validator_runner().run_tx(deploy_tx, Duration::seconds(5));
+
+    let call_tx = env.validator().tx_call(
+        &user_account,
+        &user_account,
+        "log_something",
+        vec![],
+        Balance::ZERO,
+        Gas::from_teragas(100),
+    );
+    let call_tx_hash = call_tx.get_hash();
+    env.validator().submit_tx(call_tx);
+    let tx_outcome =
+        env.validator_runner().run_until_outcome_available(call_tx_hash, Duration::seconds(5));
+    let [local_receipt_id] = tx_outcome.outcome_with_id.outcome.receipt_ids[..] else {
+        panic!("expected single receipt from transaction")
+    };
+    // Wait for the local receipt to execute: that is the chunk that produces the
+    // outgoing receipts we care about.
+    let local_outcome =
+        env.validator_runner().run_until_outcome_available(local_receipt_id, Duration::seconds(5));
+    let produced_block_hash = local_outcome.block_hash;
+    let shard_id = ShardId::new(0);
+    let outgoing_key = get_block_shard_id(&produced_block_hash, shard_id);
+
+    // Every produced (outgoing) receipt body must be fetchable by id in
+    // DBCol::Receipts.
+    let store = env.validator().store();
+    let outgoing = store
+        .get_ser::<Vec<Receipt>>(DBCol::OutgoingReceipts, &outgoing_key)
+        .expect("outgoing receipts should exist for the receipt-execution block");
+    assert!(!outgoing.is_empty(), "expected at least one produced (outgoing) receipt");
+    for receipt in &outgoing {
+        assert!(
+            store.get(DBCol::Receipts, receipt.receipt_id().as_ref()).is_some(),
+            "produced receipt {:?} body should be fetchable by id in DBCol::Receipts",
+            receipt.receipt_id(),
+        );
+    }
+    let outgoing_ids: Vec<CryptoHash> = outgoing.iter().map(|r| *r.receipt_id()).collect();
+
+    #[cfg(feature = "test_features")]
+    env.validator_mut().validate_store();
+
+    // Run enough epochs for GC to clear the producing block.
+    let num_blocks = EPOCH_LENGTH * GC_NUM_EPOCHS_TO_KEEP + 1;
+    env.validator_runner().run_for_number_of_blocks(num_blocks as usize);
+
+    // The index and the produced-receipt bodies should be gone: the GC decrement
+    // brought each refcount to zero. These receipts are outgoing-only (refcount 1)
+    // for this call; `validate_store` is the general refcount-balance check.
+    let store = env.validator().store();
+    assert!(
+        store.get(DBCol::OutgoingReceipts, &outgoing_key).is_none(),
+        "OutgoingReceipts index should be garbage collected",
+    );
+    for id in &outgoing_ids {
+        assert!(
+            store.get(DBCol::Receipts, id.as_ref()).is_none(),
+            "produced receipt {:?} body should be garbage collected",
+            id,
+        );
+    }
+
+    #[cfg(feature = "test_features")]
+    env.validator_mut().validate_store();
+}
+
 /// Tests that ReceiptToTx entries are saved for local receipts, instant receipts, and
 /// transaction→receipt mappings, then properly garbage collected.
 ///


### PR DESCRIPTION
Makes the near-indexer stream real data under spice (decoupled execution) instead of empty per-shard shells, and fills the receipt-persistence gap that surfaced once it did.

- Indexer: `build_streamer_message` no longer short-circuits under spice; the existing per-chunk loop runs unchanged. Under spice the view client already resolves `Finality::None` to the first executed ancestor, so the streamer only ever builds messages for already-executed blocks.
- Receipt bodies: spice chunks are tx-only, so the chain path's partial-chunk save never writes produced-receipt bodies to `DBCol::Receipts`, leaving `get_receipt` returning `None` for incoming receipts (e.g. gas refunds) that the indexer needs. The spice chunk executor now persists produced-receipt bodies by id, with a matching GC decrement (`gc_spice_outgoing_receipt_bodies`) and store-validator accounting so the `DBCol::Receipts` refcount stays balanced. All three legs are spice-gated per block; the non-spice path is unchanged.
- Tests: enables the seven previously spice-ignored `test_indexer_*` tests (three now anchor on the execution head rather than the consensus `head()`), and adds `test_spice_outgoing_receipt_bodies_gc` covering persist → GC with `validate_store` on both sides.