### PR TITLE
feat(early-kickout): make ChunkProducers a cold column

### DIFF
--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -190,6 +190,13 @@ fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
     if col == DBCol::ReceiptProofs {
         return true;
     }
+    // TODO(early-kickout): move ChunkProducers to is_cloud_archive_reader_bootstrapped once it is
+    // wired into cloud ShardData serialization + reader reconstruction (at stabilization, when the
+    // column becomes non-nightly).
+    #[cfg(feature = "nightly")]
+    if col == DBCol::ChunkProducers {
+        return true;
+    }
     matches!(
         col,
         // DB-level metadata; the reader maintains its own.

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -108,6 +108,10 @@ pub fn update_cold_db(
                         )
                     } else if col == DBCol::StateChanges {
                         copy_state_changes_from_store(cold_db, &hot_store, block_hash_key)
+                    } else if let Some(res) =
+                        maybe_copy_chunk_producers(col, cold_db, &hot_store, block_hash_key)
+                    {
+                        res
                     } else {
                         let keys = combine_keys(&key_type_to_keys, &col.key_type());
                         copy_from_store(cold_db, &hot_store, col, keys)
@@ -127,6 +131,38 @@ pub fn update_cold_db(
                 )
         })?;
     Ok(())
+}
+
+// Copy ChunkProducers by prefix-scan on the block hash. Returns Some(result) if it
+// handled `col`, else None. The nightly-only DBCol variant is confined to this fn.
+#[cfg(feature = "nightly")]
+fn maybe_copy_chunk_producers(
+    col: DBCol,
+    cold_db: &ColdDB,
+    hot_store: &Store,
+    block_hash_key: &[u8],
+) -> Option<io::Result<()>> {
+    if col != DBCol::ChunkProducers {
+        return None;
+    }
+    // Keyed (anchor_hash, shard_id) using the epoch-AFTER-anchor layout, which differs from
+    // `shard_layout` (the anchor's own epoch) at a resharding boundary. Prefix-scan by block
+    // hash so boundary rows keyed by next-epoch shard_ids are copied, not just own-epoch ones.
+    let keys: Vec<Vec<u8>> = hot_store
+        .iter_prefix(DBCol::ChunkProducers, block_hash_key)
+        .map(|(k, _)| k.to_vec())
+        .collect();
+    Some(copy_from_store(cold_db, hot_store, col, keys))
+}
+
+#[cfg(not(feature = "nightly"))]
+fn maybe_copy_chunk_producers(
+    _col: DBCol,
+    _cold_db: &ColdDB,
+    _hot_store: &Store,
+    _block_hash_key: &[u8],
+) -> Option<io::Result<()>> {
+    None
 }
 
 // Correctly set the key and value on DBTransaction, taking reference counting

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -56,6 +56,11 @@ pub trait ColdMigrationStore {
 /// 1. add it to `DBCol::is_cold` list
 /// 2. define `DBCol::key_type` for it (if it isn't already defined)
 /// 3. add new clause in `get_keys_from_store` for new key types used for this column (if there are any)
+/// The `get_keys_from_store` path derives the `ShardId` component from the copied block's own
+/// epoch layout. If a column's rows are keyed by a different layout (e.g. the epoch-after-anchor
+/// layout, as `ChunkProducers` is), that derivation picks the wrong shard_ids at a resharding
+/// boundary and misses rows. Copy such a column by prefix-scanning the block hash instead
+/// (see `maybe_copy_chunk_producers` and `copy_state_changes_from_store`).
 /// When `resharding_block_hash` is `Some`, it indicates a resharding boundary:
 /// the shard UID mapping is updated for cold store and the TrieChanges from
 /// the resharding block (previous block) are also copied.

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -155,7 +155,7 @@ fn maybe_copy_chunk_producers(
     // hash so boundary rows keyed by next-epoch shard_ids are copied, not just own-epoch ones.
     let keys: Vec<Vec<u8>> = hot_store
         .iter_prefix(DBCol::ChunkProducers, block_hash_key)
-        .map(|(k, _)| k.to_vec())
+        .map(|(k, _)| k.into_vec())
         .collect();
     Some(copy_from_store(cold_db, hot_store, col, keys))
 }

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -153,11 +153,15 @@ fn maybe_copy_chunk_producers(
     // Keyed (anchor_hash, shard_id) using the epoch-AFTER-anchor layout, which differs from
     // `shard_layout` (the anchor's own epoch) at a resharding boundary. Prefix-scan by block
     // hash so boundary rows keyed by next-epoch shard_ids are copied, not just own-epoch ones.
-    let keys: Vec<Vec<u8>> = hot_store
-        .iter_prefix(DBCol::ChunkProducers, block_hash_key)
-        .map(|(k, _)| k.into_vec())
-        .collect();
-    Some(copy_from_store(cold_db, hot_store, col, keys))
+    // ChunkProducers is not rc, so write values straight from the scan (no re-read), mirroring
+    // `copy_state_changes_from_store`. `into_vec` avoids copying the boxed slices.
+    let mut transaction = DBTransaction::new();
+    for (key, value) in hot_store.iter_prefix(col, block_hash_key) {
+        metrics::COLD_MIGRATION_READS.with_label_values(&[<&str>::from(col)]).inc();
+        transaction.set(col, key.into_vec(), value.into_vec());
+    }
+    cold_db.write(transaction);
+    Some(Ok(()))
 }
 
 #[cfg(not(feature = "nightly"))]

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -666,10 +666,9 @@ impl DBCol {
             | DBCol::EpochSyncProof
             | DBCol::StateSyncHashes
             | DBCol::StateSyncNewChunks
-            // TODO(early-kickout): Make ChunkProducers a cold column when GC is implemented.
             => false,
             #[cfg(feature = "nightly")]
-            DBCol::ChunkProducers => false,
+            DBCol::ChunkProducers => true,
         }
     }
 

--- a/test-loop-tests/src/tests/chunk_producers.rs
+++ b/test-loop-tests/src/tests/chunk_producers.rs
@@ -125,3 +125,180 @@ mod tests {
         }
     }
 }
+
+/// `DBCol::ChunkProducers` rows are copied to the cold store by the prefix-scan special
+/// case, for both a mid-epoch anchor (own-epoch layout == child-epoch layout) and a
+/// reshard-boundary anchor (rows keyed by the NEXT epoch's layout). The boundary anchor is
+/// the case the generic own-epoch `combine_keys` copy would miss; the special case handles
+/// both. The mid-epoch anchor guards that non-boundary anchors are copied too.
+#[cfg(feature = "nightly")]
+mod cold_storage_tests {
+    use crate::setup::builder::{ArchivalKind, TestLoopBuilder};
+    use crate::utils::setups::derive_new_epoch_config_from_boundary;
+    use near_async::messaging::Handler;
+    use near_async::time::Duration;
+    use near_chain_configs::test_genesis::TestEpochConfigBuilder;
+    use near_client::GetSplitStorageInfo;
+    use near_o11y::testonly::init_test_logger;
+    use near_primitives::epoch_manager::EpochConfigStore;
+    use near_primitives::shard_layout::ShardLayout;
+    use near_primitives::types::AccountId;
+    use near_primitives::types::validator_stake::ValidatorStake;
+    use near_primitives::utils::get_block_shard_id;
+    use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+    use near_store::DBCol;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    const EPOCH_LENGTH: u64 = 6;
+    const GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
+
+    #[test]
+    fn test_chunk_producers_copied_to_cold_store() {
+        init_test_logger();
+
+        // The boundary anchor lives in the pre-reshard (PROTOCOL_VERSION - 1) epoch, so its
+        // ChunkProducers rows are only written if EarlyKickout is enabled there. Assert the
+        // dependency up front so a version regression fails fast with a clear reason rather
+        // than surfacing later as a missing-row panic.
+        assert!(
+            ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION - 1),
+            "test requires EarlyKickout enabled at PROTOCOL_VERSION - 1 (the pre-reshard epoch)"
+        );
+
+        // Shard layout that reshards (grows) at the protocol upgrade boundary.
+        let version = 3;
+        let base_shard_layout = ShardLayout::multi_shard(3, version);
+        let boundary_account: AccountId = "boundary".parse().unwrap();
+
+        let base_epoch_config = TestEpochConfigBuilder::new()
+            .shard_layout(base_shard_layout.clone())
+            .epoch_length(EPOCH_LENGTH)
+            .build();
+        let (new_epoch_config, new_shard_layout) =
+            derive_new_epoch_config_from_boundary(&base_epoch_config, &boundary_account);
+        assert!(
+            new_shard_layout.shard_ids().count() > base_shard_layout.shard_ids().count(),
+            "reshard should increase the shard count"
+        );
+        let epoch_config_store = EpochConfigStore::test(BTreeMap::from_iter([
+            (PROTOCOL_VERSION - 1, Arc::new(base_epoch_config)),
+            (PROTOCOL_VERSION, Arc::new(new_epoch_config)),
+        ]));
+
+        let mut env = TestLoopBuilder::new()
+            .shard_layout(base_shard_layout.clone())
+            .protocol_version(PROTOCOL_VERSION - 1)
+            .epoch_length(EPOCH_LENGTH)
+            .enable_archival_node(ArchivalKind::Cold)
+            .epoch_config_store(epoch_config_store)
+            .gc_num_epochs_to_keep(GC_NUM_EPOCHS_TO_KEEP)
+            .build();
+
+        // Run until resharding completes, then a few blocks further so the mid-epoch anchor
+        // (boundary + 2) has been produced.
+        env.archival_runner().run_until(
+            |node| {
+                let epoch_id = node.head().epoch_id;
+                node.client().epoch_manager.get_shard_layout(&epoch_id).unwrap() == new_shard_layout
+            },
+            Duration::seconds((4 * EPOCH_LENGTH) as i64),
+        );
+        let reshard_done_height = env.archival_node().head().height;
+        env.archival_runner().run_until_head_height(reshard_done_height + 4);
+
+        // Capture the anchors + their hot ChunkProducers rows now, BEFORE hot GC removes the
+        // block headers (ChunkProducers rows themselves are never GC'd in this PR, but the
+        // block-header lookups used to locate the anchors would fail once GC catches up).
+        let (mid_height, expected) = {
+            let node = env.archival_node();
+            let client = node.client();
+            let chain = &client.chain;
+            let epoch_manager = client.epoch_manager.clone();
+            let hot_store = node.store();
+
+            // Boundary anchor B: last block of the pre-reshard epoch. Its ChunkProducers rows
+            // are keyed by the NEXT (post-reshard) epoch's shard_ids.
+            let mut block_hash = client.chain.head().unwrap().last_block_hash;
+            let boundary_block_hash = loop {
+                let header = chain.get_block_header(&block_hash).unwrap();
+                let shard_layout = epoch_manager.get_shard_layout(header.epoch_id()).unwrap();
+                if shard_layout == base_shard_layout {
+                    break *header.hash();
+                }
+                block_hash = *header.prev_hash();
+            };
+            assert!(
+                epoch_manager.is_next_block_epoch_start(&boundary_block_hash).unwrap(),
+                "boundary block should be the last block of the pre-reshard epoch"
+            );
+            let boundary_height = chain.get_block_header(&boundary_block_hash).unwrap().height();
+
+            // Mid-epoch anchor A: a block well inside the post-reshard epoch, so its own-epoch
+            // layout equals its child-epoch layout (no reshard between anchor and its chunks).
+            let mid_height = boundary_height + 2;
+            let mid_block_hash = chain.get_block_hash_by_height(mid_height).unwrap();
+            assert!(
+                !epoch_manager.is_next_block_epoch_start(&mid_block_hash).unwrap(),
+                "mid-epoch anchor must not be an epoch's last block"
+            );
+            let mid_epoch_id = epoch_manager.get_epoch_id(&mid_block_hash).unwrap();
+            assert_eq!(
+                epoch_manager.get_shard_layout(&mid_epoch_id).unwrap(),
+                new_shard_layout,
+                "mid-epoch anchor should be in the post-reshard layout"
+            );
+
+            // Both anchors resolve to rows keyed by the post-reshard layout's shard_ids.
+            let mut expected: Vec<(Vec<u8>, ValidatorStake)> = Vec::new();
+            for anchor_hash in [boundary_block_hash, mid_block_hash] {
+                for shard_id in new_shard_layout.shard_ids() {
+                    let key = get_block_shard_id(&anchor_hash, shard_id);
+                    let hot: Option<ValidatorStake> =
+                        hot_store.get_ser(DBCol::ChunkProducers, &key);
+                    // Loud failure if EarlyKickout is not enabled (no rows would be written),
+                    // rather than a vacuously passing cold check.
+                    let hot = hot.unwrap_or_else(|| {
+                        panic!(
+                            "hot ChunkProducers row missing for anchor {anchor_hash} shard {shard_id}; \
+                             is EarlyKickout enabled for this protocol version?"
+                        )
+                    });
+                    expected.push((key, hot));
+                }
+            }
+            (mid_height, expected)
+        };
+
+        // Advance well past the anchors so the cold copy loop has processed them.
+        let target_height = reshard_done_height + EPOCH_LENGTH * (GC_NUM_EPOCHS_TO_KEEP + 2);
+        env.archival_runner().run_until_head_height(target_height);
+
+        // Cold head must have advanced past the anchors, else the cold check is vacuous.
+        let cold_head_height = {
+            let info =
+                env.archival_node_mut().view_client_actor().handle(GetSplitStorageInfo {}).unwrap();
+            info.cold_head_height.expect("cold head should be set")
+        };
+        assert!(
+            cold_head_height >= mid_height,
+            "cold head ({cold_head_height}) should have passed the anchors (up to height {mid_height})"
+        );
+
+        // Cold DB handle (same pattern as `resharding_cold_storage.rs`).
+        let archival_idx = env.archival_data_idx();
+        let cold_store_sender = env.node_datas[archival_idx].cold_store_sender.as_ref().unwrap();
+        let cold_store_actor = env.test_loop.data.get(&cold_store_sender.actor_handle());
+        let cold_db = cold_store_actor.get_cold_db();
+        let cold_store = cold_db.as_store();
+
+        for (key, hot) in expected {
+            let cold: Option<ValidatorStake> = cold_store.get_ser(DBCol::ChunkProducers, &key);
+            assert_eq!(
+                cold.as_ref(),
+                Some(&hot),
+                "cold ChunkProducers row must match hot for key {key:?}"
+            );
+        }
+    }
+}

--- a/test-loop-tests/src/tests/chunk_producers.rs
+++ b/test-loop-tests/src/tests/chunk_producers.rs
@@ -154,6 +154,8 @@ mod cold_storage_tests {
     const GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
 
     #[test]
+    // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+    #[cfg_attr(feature = "protocol_feature_spice", ignore)]
     fn test_chunk_producers_copied_to_cold_store() {
         init_test_logger();
 


### PR DESCRIPTION
Makes `DBCol::ChunkProducers` a cold column so archival nodes retain its rows once hot GC is added (follow-up PR). Nightly-only. No GC policy or DB_VERSION change.

- `is_cold()` returns true for ChunkProducers.
- `update_cold_db` copies ChunkProducers via a prefix scan on the block hash. The generic copy derives shard_ids from the block's own epoch layout, but the writer keys rows by the epoch-after-anchor layout, so at a resharding boundary the generic path would miss rows keyed by the next layout.
- Classifies ChunkProducers as cloud-archive `skipped` for now; cloud reconstruction is deferred to stabilization.
- Adds a cold-copy test covering a reshard-boundary anchor and a mid-epoch anchor.

Part 1 of a 2-PR stack; PR2 adds hot GC.