### PR TITLE
chore: log chain height on startup

### DIFF
--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -638,24 +638,19 @@ pub async fn start_with_config_and_synchronization_impl(
         spice_client_config,
     );
 
-    if let Err(err) = (|| -> anyhow::Result<()> {
-        let head = storage.get_hot_store().chain_store().head()?;
-        let epoch_info = epoch_manager.get_epoch_info(&head.epoch_id)?;
-        let epoch_start_height = epoch_manager.get_epoch_start_height(&head.last_block_hash)?;
-        tracing::info!(
-            target: "near",
-            block_height = head.height,
-            block_hash = %head.last_block_hash,
-            epoch_id = ?head.epoch_id,
-            epoch_height = epoch_info.epoch_height(),
-            epoch_start_height,
-            protocol_version = epoch_info.protocol_version(),
-            "starting from chain head",
-        );
-        Ok(())
-    })() {
-        tracing::warn!(target: "near", ?err, "could not log startup block/epoch info");
-    }
+    let head = storage.get_hot_store().chain_store().head()?;
+    let epoch_info = epoch_manager.get_epoch_info(&head.epoch_id)?;
+    let epoch_start_height = epoch_manager.get_epoch_start_height(&head.last_block_hash)?;
+    tracing::info!(
+        target: "near",
+        block_height = head.height,
+        block_hash = %head.last_block_hash,
+        epoch_id = ?head.epoch_id,
+        epoch_height = epoch_info.epoch_height(),
+        epoch_start_height,
+        protocol_version = epoch_info.protocol_version(),
+        "starting from chain head",
+    );
 
     // Spawn after start_client so that Chain::new has initialized FINAL_HEAD_KEY in the store.
     spawn_trie_metrics_loop(

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -637,6 +637,26 @@ pub async fn start_with_config_and_synchronization_impl(
         block_notification_watch_sender,
         spice_client_config,
     );
+
+    if let Err(err) = (|| -> anyhow::Result<()> {
+        let head = storage.get_hot_store().chain_store().head()?;
+        let epoch_info = epoch_manager.get_epoch_info(&head.epoch_id)?;
+        let epoch_start_height = epoch_manager.get_epoch_start_height(&head.last_block_hash)?;
+        tracing::info!(
+            target: "near",
+            block_height = head.height,
+            block_hash = %head.last_block_hash,
+            epoch_id = ?head.epoch_id,
+            epoch_height = epoch_info.epoch_height(),
+            epoch_start_height,
+            protocol_version = epoch_info.protocol_version(),
+            "starting from chain head",
+        );
+        Ok(())
+    })() {
+        tracing::warn!(target: "near", ?err, "could not log startup block/epoch info");
+    }
+
     // Spawn after start_client so that Chain::new has initialized FINAL_HEAD_KEY in the store.
     spawn_trie_metrics_loop(
         actor_system.clone(),


### PR DESCRIPTION
Fixes #11139

On startup there was no default-visible indication of which block/epoch a node resumed from. This adds a one-time log line in the node bring-up path reporting the chain head:

```
INFO near: starting from chain head block_height=46 block_hash=BkUGC2YUW8GK5U6v9vcvtYg3PFKP38p54ihbT5ZYcRrx epoch_id=EpochId(11111111111111111111111111111111) epoch_height=1 epoch_start_height=1 protocol_version=86
```