### PR TITLE
feat(early-kickout): garbage collect ChunkProducers with block data

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -512,9 +512,8 @@ impl<'a> ChainStoreUpdate<'a> {
                 store_update.delete(DBCol::BlockHeader, key);
                 self.merge(store_update);
 
-                // ChunkProducers rows are written per header (header sync and block
-                // processing) keyed by (block_hash, shard_id). Prefix-scan by the header hash
-                // to delete every shard's row regardless of layout; nightly-only.
+                // A ChunkProducers row is keyed by (block_hash, shard_id); the header-hash
+                // prefix matches every shard's row for this header.
                 #[cfg(feature = "nightly")]
                 {
                     let cp_keys: Vec<Box<[u8]>> = self
@@ -569,11 +568,9 @@ impl<'a> ChainStoreUpdate<'a> {
                 // TODO #3488: enable
                 //self.gc_col(DBCol::BlockHeader, header_hash.as_bytes());
 
-                // ChunkProducers rows are written per header (header sync + block
-                // processing), keyed by (block_hash, shard_id). Delete them here before
-                // HeaderHashesByHeight is dropped, so header-only anchors (fork siblings,
-                // synced-ahead headers that never get a body) don't orphan rows. The
-                // block-hash prefix matches every shard_id row for this hash. Nightly-only.
+                // Delete the header's ChunkProducers rows before the height index is dropped,
+                // else header-only hashes (never given a body, so never seen by
+                // clear_block_data) orphan their rows. Prefix matches every shard's row.
                 #[cfg(feature = "nightly")]
                 {
                     let cp_keys: Vec<Box<[u8]>> = self
@@ -926,9 +923,8 @@ impl<'a> ChainStoreUpdate<'a> {
             self.merge(store_update);
         }
 
-        // ChunkProducers rows are deleted in clear_header_data_for_heights below, which covers
-        // the head_height..=header_head_height range: this head, its fork siblings, and every
-        // header-only anchor synced above it.
+        // ChunkProducers rows for the cleared heights are deleted in
+        // clear_header_data_for_heights below.
 
         // 2. Delete block_hash-indexed data
         self.gc_col(DBCol::Block, block_hash.as_bytes());

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -502,6 +502,20 @@ impl ChainStore {
 }
 
 impl<'a> ChainStoreUpdate<'a> {
+    /// GC every ChunkProducers row anchored at `header_hash`. Rows are keyed by
+    /// (block_hash, shard_id); the header hash prefixes all shards' rows.
+    #[cfg(feature = "nightly")]
+    fn gc_chunk_producers_for_header(&mut self, header_hash: &CryptoHash) {
+        let cp_keys: Vec<Box<[u8]>> = self
+            .store()
+            .iter_prefix(DBCol::ChunkProducers, header_hash.as_bytes())
+            .map(|(key, _)| key)
+            .collect();
+        for cp_key in cp_keys {
+            self.gc_col(DBCol::ChunkProducers, &cp_key);
+        }
+    }
+
     fn clear_header_data_for_heights(&mut self, start: BlockHeight, end: BlockHeight) {
         for height in start..=end {
             let header_hashes = self.chain_store().get_all_header_hashes_by_height(height);
@@ -512,19 +526,8 @@ impl<'a> ChainStoreUpdate<'a> {
                 store_update.delete(DBCol::BlockHeader, key);
                 self.merge(store_update);
 
-                // A ChunkProducers row is keyed by (block_hash, shard_id); the header-hash
-                // prefix matches every shard's row for this header.
                 #[cfg(feature = "nightly")]
-                {
-                    let cp_keys: Vec<Box<[u8]>> = self
-                        .store()
-                        .iter_prefix(DBCol::ChunkProducers, header_hash.as_bytes())
-                        .map(|(key, _)| key)
-                        .collect();
-                    for cp_key in cp_keys {
-                        self.gc_col(DBCol::ChunkProducers, &cp_key);
-                    }
-                }
+                self.gc_chunk_producers_for_header(&header_hash);
             }
             let key = index_to_bytes(height);
             self.gc_col(DBCol::HeaderHashesByHeight, &key);
@@ -570,18 +573,9 @@ impl<'a> ChainStoreUpdate<'a> {
 
                 // Delete the header's ChunkProducers rows before the height index is dropped,
                 // else header-only hashes (never given a body, so never seen by
-                // clear_block_data) orphan their rows. Prefix matches every shard's row.
+                // clear_block_data) orphan their rows.
                 #[cfg(feature = "nightly")]
-                {
-                    let cp_keys: Vec<Box<[u8]>> = self
-                        .store()
-                        .iter_prefix(DBCol::ChunkProducers, _header_hash.as_bytes())
-                        .map(|(key, _)| key)
-                        .collect();
-                    for cp_key in cp_keys {
-                        self.gc_col(DBCol::ChunkProducers, &cp_key);
-                    }
-                }
+                self.gc_chunk_producers_for_header(&_header_hash);
             }
 
             // 4. Delete chunks_tail-related data

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -514,7 +514,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
                 // ChunkProducers rows are written per header (header sync and block
                 // processing) keyed by (block_hash, shard_id). Prefix-scan by the header hash
-                // to delete every shard's row layout-agnostically; nightly-only.
+                // to delete every shard's row regardless of layout; nightly-only.
                 #[cfg(feature = "nightly")]
                 {
                     let cp_keys: Vec<Box<[u8]>> = self

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -686,6 +686,12 @@ impl<'a> ChainStoreUpdate<'a> {
         for shard_uid in self.get_shard_uids_to_gc(epoch_manager, &block_hash) {
             let block_shard_uid = get_block_shard_uid(&block_hash, &shard_uid);
             self.gc_col(DBCol::ChunkExtra, &block_shard_uid);
+            // ChunkProducers is keyed by ShardId (not ShardUId); insert-only, nightly-only.
+            #[cfg(feature = "nightly")]
+            self.gc_col(
+                DBCol::ChunkProducers,
+                &get_block_shard_id(&block_hash, shard_uid.shard_id()),
+            );
         }
 
         // 3. Delete block_hash-indexed data
@@ -883,6 +889,17 @@ impl<'a> ChainStoreUpdate<'a> {
             let mut store_update = self.store().store_update();
             store_update.flat_store_update().remove_delta(shard_uid, block_hash);
             self.merge(store_update);
+        }
+
+        // ChunkProducers is keyed by the epoch-after-anchor layout, so iterate the
+        // this-epoch ∪ next-epoch shard set (mirrors clear_block_data) to avoid leaking
+        // next-layout rows at a resharding boundary. Keyed by ShardId; nightly-only.
+        #[cfg(feature = "nightly")]
+        for shard_uid in self.get_shard_uids_to_gc(epoch_manager, &block_hash) {
+            self.gc_col(
+                DBCol::ChunkProducers,
+                &get_block_shard_id(&block_hash, shard_uid.shard_id()),
+            );
         }
 
         // 2. Delete block_hash-indexed data

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -502,13 +502,17 @@ impl ChainStore {
 }
 
 impl<'a> ChainStoreUpdate<'a> {
-    /// GC every ChunkProducers row anchored at `header_hash`. Rows are keyed by
-    /// (block_hash, shard_id); the header hash prefixes all shards' rows.
+    /// GC every ChunkProducers row anchored at this block/header hash. Rows are keyed by
+    /// (block_hash, shard_id), so the hash prefixes all shards' rows.
+    ///
+    /// Callers: `clear_block_data` (canonical/fork block) and `clear_head_block_data` (undo
+    /// head) delete alongside the block's own `BlockInfo`; `clear_chunk_data_and_headers` uses
+    /// it for header-only hashes that never got a body (their `BlockInfo` persists).
     #[cfg(feature = "nightly")]
-    fn gc_chunk_producers_for_header(&mut self, header_hash: &CryptoHash) {
+    fn gc_chunk_producers_for_block(&mut self, block_hash: &CryptoHash) {
         let cp_keys: Vec<Box<[u8]>> = self
             .store()
-            .iter_prefix(DBCol::ChunkProducers, header_hash.as_bytes())
+            .iter_prefix(DBCol::ChunkProducers, block_hash.as_bytes())
             .map(|(key, _)| key)
             .collect();
         for cp_key in cp_keys {
@@ -572,7 +576,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 // else header-only hashes (never given a body, so never seen by
                 // clear_block_data) orphan their rows.
                 #[cfg(feature = "nightly")]
-                self.gc_chunk_producers_for_header(&header_hash);
+                self.gc_chunk_producers_for_block(&header_hash);
                 #[cfg(not(feature = "nightly"))]
                 let _ = header_hash;
             }
@@ -711,13 +715,12 @@ impl<'a> ChainStoreUpdate<'a> {
         for shard_uid in self.get_shard_uids_to_gc(epoch_manager, &block_hash) {
             let block_shard_uid = get_block_shard_uid(&block_hash, &shard_uid);
             self.gc_col(DBCol::ChunkExtra, &block_shard_uid);
-            // ChunkProducers is keyed by ShardId (not ShardUId); insert-only, nightly-only.
-            #[cfg(feature = "nightly")]
-            self.gc_col(
-                DBCol::ChunkProducers,
-                &get_block_shard_id(&block_hash, shard_uid.shard_id()),
-            );
         }
+        // ChunkProducers is keyed by ShardId, not ShardUId; the get_shard_uids_to_gc union can
+        // hold two UIDs sharing one ShardId at a reshard boundary, which would enqueue the same
+        // delete twice. Prefix-scan by block hash deletes each row once, next-layout rows too.
+        #[cfg(feature = "nightly")]
+        self.gc_chunk_producers_for_block(&block_hash);
 
         // 3. Delete block_hash-indexed data
         self.gc_col(DBCol::Block, block_hash.as_bytes());
@@ -933,11 +936,14 @@ impl<'a> ChainStoreUpdate<'a> {
         self.gc_col(DBCol::BlockRefCount, block_hash.as_bytes());
         self.gc_outcomes(&block);
         self.gc_col(DBCol::BlockInfo, block_hash.as_bytes());
-        // ChunkProducers mirrors BlockInfo: both are seeded together in
-        // record_block_info_impl and must be deleted together. The column is
-        // insert-only, so the stale row must go before re-processing re-seeds it.
+        // Delete this head's ChunkProducers row because its BlockInfo is deleted here; the two
+        // are seeded together in record_block_info_impl. The column is insert-only, so the
+        // stale row must go before re-processing re-seeds it. This "together" rule holds
+        // per-live-block, not universally: the below-tail header sweep in
+        // clear_chunk_data_and_headers deletes header-only rows whose BlockInfo legitimately
+        // persists (those heights are never re-synced).
         #[cfg(feature = "nightly")]
-        self.gc_chunk_producers_for_header(&block_hash);
+        self.gc_chunk_producers_for_block(&block_hash);
         self.gc_col(DBCol::StateDlInfos, block_hash.as_bytes());
         self.gc_col(DBCol::StateSyncNewChunks, block_hash.as_bytes());
 

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -532,7 +532,10 @@ impl<'a> ChainStoreUpdate<'a> {
         }
     }
 
-    fn clear_chunk_data_and_headers(&mut self, min_chunk_height: BlockHeight) -> Result<(), Error> {
+    pub(crate) fn clear_chunk_data_and_headers(
+        &mut self,
+        min_chunk_height: BlockHeight,
+    ) -> Result<(), Error> {
         let chunk_tail = self.chunk_tail();
         for height in chunk_tail..min_chunk_height {
             let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height);
@@ -565,6 +568,23 @@ impl<'a> ChainStoreUpdate<'a> {
                 // 3. Delete header_hash-indexed data
                 // TODO #3488: enable
                 //self.gc_col(DBCol::BlockHeader, header_hash.as_bytes());
+
+                // ChunkProducers rows are written per header (header sync + block
+                // processing), keyed by (block_hash, shard_id). Delete them here before
+                // HeaderHashesByHeight is dropped, so header-only anchors (fork siblings,
+                // synced-ahead headers that never get a body) don't orphan rows. The
+                // block-hash prefix matches every shard_id row for this hash. Nightly-only.
+                #[cfg(feature = "nightly")]
+                {
+                    let cp_keys: Vec<Box<[u8]>> = self
+                        .store()
+                        .iter_prefix(DBCol::ChunkProducers, _header_hash.as_bytes())
+                        .map(|(key, _)| key)
+                        .collect();
+                    for cp_key in cp_keys {
+                        self.gc_col(DBCol::ChunkProducers, &cp_key);
+                    }
+                }
             }
 
             // 4. Delete chunks_tail-related data

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -511,6 +511,21 @@ impl<'a> ChainStoreUpdate<'a> {
                 let key: &[u8] = header_hash.as_bytes();
                 store_update.delete(DBCol::BlockHeader, key);
                 self.merge(store_update);
+
+                // ChunkProducers rows are written per header (header sync and block
+                // processing) keyed by (block_hash, shard_id). Prefix-scan by the header hash
+                // to delete every shard's row layout-agnostically; nightly-only.
+                #[cfg(feature = "nightly")]
+                {
+                    let cp_keys: Vec<Box<[u8]>> = self
+                        .store()
+                        .iter_prefix(DBCol::ChunkProducers, header_hash.as_bytes())
+                        .map(|(key, _)| key)
+                        .collect();
+                    for cp_key in cp_keys {
+                        self.gc_col(DBCol::ChunkProducers, &cp_key);
+                    }
+                }
             }
             let key = index_to_bytes(height);
             self.gc_col(DBCol::HeaderHashesByHeight, &key);
@@ -891,16 +906,9 @@ impl<'a> ChainStoreUpdate<'a> {
             self.merge(store_update);
         }
 
-        // ChunkProducers is keyed by the epoch-after-anchor layout, so iterate the
-        // this-epoch ∪ next-epoch shard set (mirrors clear_block_data) to avoid leaking
-        // next-layout rows at a resharding boundary. Keyed by ShardId; nightly-only.
-        #[cfg(feature = "nightly")]
-        for shard_uid in self.get_shard_uids_to_gc(epoch_manager, &block_hash) {
-            self.gc_col(
-                DBCol::ChunkProducers,
-                &get_block_shard_id(&block_hash, shard_uid.shard_id()),
-            );
-        }
+        // ChunkProducers rows are deleted in clear_header_data_for_heights below, which covers
+        // the head_height..=header_head_height range: this head, its fork siblings, and every
+        // header-only anchor synced above it.
 
         // 2. Delete block_hash-indexed data
         self.gc_col(DBCol::Block, block_hash.as_bytes());

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -525,9 +525,6 @@ impl<'a> ChainStoreUpdate<'a> {
                 let key: &[u8] = header_hash.as_bytes();
                 store_update.delete(DBCol::BlockHeader, key);
                 self.merge(store_update);
-
-                #[cfg(feature = "nightly")]
-                self.gc_chunk_producers_for_header(&header_hash);
             }
             let key = index_to_bytes(height);
             self.gc_col(DBCol::HeaderHashesByHeight, &key);
@@ -919,11 +916,6 @@ impl<'a> ChainStoreUpdate<'a> {
             self.merge(store_update);
         }
 
-        // ChunkProducers rows for the cleared heights are deleted in
-        // clear_header_data_for_heights below; this head's own hash is in
-        // HeaderHashesByHeight[head_height] (recorded when it was saved), so that
-        // range covers the body head too, not just header-only anchors above it.
-
         // 2. Delete block_hash-indexed data
         self.gc_col(DBCol::Block, block_hash.as_bytes());
         self.gc_col(DBCol::NextBlockHashes, block_hash.as_bytes());
@@ -941,6 +933,11 @@ impl<'a> ChainStoreUpdate<'a> {
         self.gc_col(DBCol::BlockRefCount, block_hash.as_bytes());
         self.gc_outcomes(&block);
         self.gc_col(DBCol::BlockInfo, block_hash.as_bytes());
+        // ChunkProducers mirrors BlockInfo: both are seeded together in
+        // record_block_info_impl and must be deleted together. The column is
+        // insert-only, so the stale row must go before re-processing re-seeds it.
+        #[cfg(feature = "nightly")]
+        self.gc_chunk_producers_for_header(&block_hash);
         self.gc_col(DBCol::StateDlInfos, block_hash.as_bytes());
         self.gc_col(DBCol::StateSyncNewChunks, block_hash.as_bytes());
 

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -566,7 +566,7 @@ impl<'a> ChainStoreUpdate<'a> {
             }
 
             let header_hashes = self.chain_store().get_all_header_hashes_by_height(height);
-            for _header_hash in header_hashes {
+            for header_hash in header_hashes {
                 // 3. Delete header_hash-indexed data
                 // TODO #3488: enable
                 //self.gc_col(DBCol::BlockHeader, header_hash.as_bytes());
@@ -575,7 +575,9 @@ impl<'a> ChainStoreUpdate<'a> {
                 // else header-only hashes (never given a body, so never seen by
                 // clear_block_data) orphan their rows.
                 #[cfg(feature = "nightly")]
-                self.gc_chunk_producers_for_header(&_header_hash);
+                self.gc_chunk_producers_for_header(&header_hash);
+                #[cfg(not(feature = "nightly"))]
+                let _ = header_hash;
             }
 
             // 4. Delete chunks_tail-related data
@@ -918,7 +920,9 @@ impl<'a> ChainStoreUpdate<'a> {
         }
 
         // ChunkProducers rows for the cleared heights are deleted in
-        // clear_header_data_for_heights below.
+        // clear_header_data_for_heights below; this head's own hash is in
+        // HeaderHashesByHeight[head_height] (recorded when it was saved), so that
+        // range covers the body head too, not just header-only anchors above it.
 
         // 2. Delete block_hash-indexed data
         self.gc_col(DBCol::Block, block_hash.as_bytes());

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -502,12 +502,10 @@ impl ChainStore {
 }
 
 impl<'a> ChainStoreUpdate<'a> {
-    /// GC every ChunkProducers row anchored at this block/header hash. Rows are keyed by
-    /// (block_hash, shard_id), so the hash prefixes all shards' rows.
-    ///
-    /// Callers: `clear_block_data` (canonical/fork block) and `clear_head_block_data` (undo
-    /// head) delete alongside the block's own `BlockInfo`; `clear_chunk_data_and_headers` uses
-    /// it for header-only hashes that never got a body (their `BlockInfo` persists).
+    /// GC every ChunkProducers row anchored at `block_hash`. Rows are keyed by
+    /// (block_hash, shard_id), so the hash prefixes all shards' rows. Callers delete alongside
+    /// the block's `BlockInfo`, except the `clear_chunk_data_and_headers` sweep, which uses it
+    /// for header-only hashes that never got a body (their `BlockInfo` persists).
     #[cfg(feature = "nightly")]
     fn gc_chunk_producers_for_block(&mut self, block_hash: &CryptoHash) {
         let cp_keys: Vec<Box<[u8]>> = self
@@ -936,12 +934,9 @@ impl<'a> ChainStoreUpdate<'a> {
         self.gc_col(DBCol::BlockRefCount, block_hash.as_bytes());
         self.gc_outcomes(&block);
         self.gc_col(DBCol::BlockInfo, block_hash.as_bytes());
-        // Delete this head's ChunkProducers row because its BlockInfo is deleted here; the two
-        // are seeded together in record_block_info_impl. The column is insert-only, so the
-        // stale row must go before re-processing re-seeds it. This "together" rule holds
-        // per-live-block, not universally: the below-tail header sweep in
-        // clear_chunk_data_and_headers deletes header-only rows whose BlockInfo legitimately
-        // persists (those heights are never re-synced).
+        // ChunkProducers is seeded together with BlockInfo (see record_block_info_impl), so
+        // delete it here alongside BlockInfo. Insert-only, so the stale row must go before
+        // re-processing re-seeds it.
         #[cfg(feature = "nightly")]
         self.gc_chunk_producers_for_block(&block_hash);
         self.gc_col(DBCol::StateDlInfos, block_hash.as_bytes());

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -433,8 +433,7 @@ mod tests {
     }
 
     /// Hot GC deletes a below-boundary anchor's ChunkProducers rows while retaining rows for
-    /// anchors that later blocks still resolve against. Drives clear_block_data directly (mirrors
-    /// garbage_collection::tests::test_clear_old_data_fixed_height) so the cleared block is exact.
+    /// anchors that later blocks still resolve against.
     #[test]
     fn test_chunk_producers_garbage_collected_with_block() {
         init_test_logger();
@@ -442,7 +441,6 @@ mod tests {
         clock.advance(Duration::milliseconds(3444));
         let (mut chain, epoch_manager, _, signer) = setup(clock.clock());
 
-        // setup() uses epoch_length 1000, so all blocks share one epoch and one shard.
         let mut hashes = vec![*chain.genesis().hash()];
         for _ in 0..9 {
             let prev_hash = *chain.head_header().unwrap().hash();
@@ -465,7 +463,6 @@ mod tests {
                 .get_ser(DBCol::ChunkProducers, &get_block_shard_id(anchor, shard_id))
         };
 
-        // Every anchor has a row before GC.
         for anchor in &hashes {
             assert!(row(&chain, anchor).is_some(), "row should exist before GC for {anchor}");
         }
@@ -545,7 +542,6 @@ mod tests {
                 .get_ser(DBCol::ChunkProducers, &get_block_shard_id(anchor, shard_id))
         };
 
-        // The body head (3) and the header-only anchors (4, 5) all have rows before the undo.
         for anchor in [blocks[3].hash(), blocks[4].hash(), blocks[5].hash()] {
             for shard_id in shard_layout.shard_ids() {
                 assert!(row(&chain, anchor, shard_id).is_some(), "row should exist for {anchor}");
@@ -556,7 +552,6 @@ mod tests {
         store_update.clear_head_block_data(epoch_manager.as_ref()).unwrap();
         store_update.commit().unwrap();
 
-        // Body head + header-only anchors are all cleared; nothing orphaned.
         for anchor in [blocks[3].hash(), blocks[4].hash(), blocks[5].hash()] {
             for shard_id in shard_layout.shard_ids() {
                 assert!(
@@ -579,7 +574,6 @@ mod tests {
         clock.advance(Duration::milliseconds(3444));
         let (mut chain, epoch_manager, _, signer) = setup(clock.clock());
 
-        // Canonical chain: genesis + blocks 1..=6.
         let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap()];
         for i in 0..6 {
             let prev = blocks[i].clone();

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -478,15 +478,13 @@ mod tests {
             .unwrap();
         store_update.commit().unwrap();
 
-        // The reassigned prev (hashes[4]) is the anchor actually cleared, NOT the input hash.
         assert!(
             row(&chain, &cleared_anchor).is_none(),
             "below-boundary anchor row must be deleted"
         );
         assert!(row(&chain, &input_hash).is_some(), "canonical GC clears prev, not the input hash");
 
-        // A higher anchor's row is retained and still resolves for its child chunk. The chunk
-        // built on hashes[7] anchors on its grandparent hashes[6].
+        // The chunk built on hashes[7] anchors on its grandparent hashes[6].
         assert!(row(&chain, &hashes[6]).is_some(), "above-boundary anchor row must be retained");
         assert!(
             epoch_manager.get_chunk_producer_info_from_prev_block(&hashes[7], shard_id).is_ok(),
@@ -527,9 +525,8 @@ mod tests {
         assert_ne!(fork_hash, hashes[3], "fork must differ from canonical block 3");
         chain.process_block_test(fork).unwrap();
 
-        // Keep this a real fork-GC case: the block is off the canonical chain (head did not
-        // switch to it) and is a leaf (built last, nothing on top), which is what
-        // clear_forks_data clears.
+        // Confirm the fork is off the canonical chain (head did not switch to it), so
+        // GCMode::Fork applies.
         assert_ne!(
             chain.head().unwrap().last_block_hash,
             fork_hash,
@@ -561,8 +558,8 @@ mod tests {
     /// clear_head_block_data (the undo-block path) deletes ChunkProducers exactly where it
     /// deletes BlockInfo: for the body head only. Header-only anchors above the body head keep
     /// both their BlockInfo and their ChunkProducers rows, so the rows stay valid and survive a
-    /// header re-sync (the reviewer's concern). Mirroring BlockInfo lets re-processing the body
-    /// head re-seed its row cleanly.
+    /// header re-sync. Mirroring BlockInfo lets re-processing the body head re-seed its row
+    /// cleanly.
     #[test]
     fn test_chunk_producers_garbage_collected_on_undo_block() {
         init_test_logger();
@@ -626,8 +623,8 @@ mod tests {
                 blocks[3].hash()
             );
         }
-        // Header-only anchors (blocks[4], blocks[5]) keep their BlockInfo, so their rows must
-        // be retained — deleting them would orphan rows whose BlockInfo is still present.
+        // Header-only anchors keep their BlockInfo, so their ChunkProducers rows must stay
+        // paired (retained).
         for anchor in [blocks[4].hash(), blocks[5].hash()] {
             for shard_id in shard_layout.shard_ids() {
                 assert!(
@@ -637,13 +634,13 @@ mod tests {
             }
         }
 
-        // Reviewer's re-sync: re-syncing the headers must keep the header-only rows valid. This
-        // is cache-independent (the rows were never deleted). We deliberately do not assert the
-        // body head re-seeds in-process: record_block_info_impl gates on has_block_info, which
-        // reads the epoch-manager blocks_info LRU cache before the store; clear_head_block_data
-        // only deletes BlockInfo from the store, not the cache, so has_block_info(body_head) may
-        // still be true here and the seeder is skipped. The real tools/undo-block runs with a
-        // fresh EpochManager (empty cache) and re-seeds correctly there.
+        // Re-syncing the headers must keep the header-only rows valid (cache-independent: the
+        // rows were never deleted). Do not assert the body head re-seeds in-process:
+        // record_block_info_impl gates on has_block_info, which reads the epoch-manager
+        // blocks_info LRU cache before the store; clear_head_block_data deletes BlockInfo only
+        // from the store, so has_block_info(body_head) may still be true and the seeder is
+        // skipped. tools/undo-block runs a fresh EpochManager (empty cache) and re-seeds
+        // correctly.
         chain
             .sync_block_headers(blocks[3..=5].iter().map(|b| b.header().clone().into()).collect())
             .unwrap();

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "nightly")]
 mod tests {
+    use crate::Chain;
     use crate::ChainStoreAccess;
     use crate::garbage_collection::GCMode;
     use crate::test_utils::{setup, setup_with_tx_validity_period};
@@ -456,7 +457,7 @@ mod tests {
         let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
         let shard_id = shard_layout.shard_ids().next().unwrap();
 
-        let row = |chain: &crate::Chain, anchor: &CryptoHash| -> Option<ValidatorStake> {
+        let row = |chain: &Chain, anchor: &CryptoHash| -> Option<ValidatorStake> {
             chain
                 .chain_store()
                 .store()
@@ -535,7 +536,7 @@ mod tests {
         let epoch_id = epoch_manager.get_epoch_id_from_prev_block(blocks[1].hash()).unwrap();
         let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
 
-        let row = |chain: &crate::Chain, anchor: &CryptoHash, shard_id| -> Option<ValidatorStake> {
+        let row = |chain: &Chain, anchor: &CryptoHash, shard_id| -> Option<ValidatorStake> {
             chain
                 .chain_store()
                 .store()
@@ -614,7 +615,7 @@ mod tests {
         );
         store_update.commit();
 
-        let fork_row = |chain: &crate::Chain| -> Option<ValidatorStake> {
+        let fork_row = |chain: &Chain| -> Option<ValidatorStake> {
             chain
                 .chain_store()
                 .store()

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -494,10 +494,11 @@ mod tests {
         );
     }
 
-    /// clear_head_block_data (the undo-block path) deletes ChunkProducers rows for the body
-    /// head AND every header-only anchor synced above it. Header sync writes a row per header,
-    /// so a body-head-only delete would orphan the header-only rows; the prefix-scan in
-    /// clear_header_data_for_heights covers the whole head..=header_head range.
+    /// clear_head_block_data (the undo-block path) deletes ChunkProducers exactly where it
+    /// deletes BlockInfo: for the body head only. Header-only anchors above the body head keep
+    /// both their BlockInfo and their ChunkProducers rows, so the rows stay valid and survive a
+    /// header re-sync (the reviewer's concern). Mirroring BlockInfo lets re-processing the body
+    /// head re-seed its row cleanly.
     #[test]
     fn test_chunk_producers_garbage_collected_on_undo_block() {
         init_test_logger();
@@ -553,11 +554,40 @@ mod tests {
         store_update.clear_head_block_data(epoch_manager.as_ref()).unwrap();
         store_update.commit().unwrap();
 
-        for anchor in [blocks[3].hash(), blocks[4].hash(), blocks[5].hash()] {
+        // Body head (blocks[3]) row is deleted alongside its BlockInfo.
+        for shard_id in shard_layout.shard_ids() {
+            assert!(
+                row(&chain, blocks[3].hash(), shard_id).is_none(),
+                "undo-block must delete ChunkProducers for the body head {}",
+                blocks[3].hash()
+            );
+        }
+        // Header-only anchors (blocks[4], blocks[5]) keep their BlockInfo, so their rows must
+        // be retained — deleting them would orphan rows whose BlockInfo is still present.
+        for anchor in [blocks[4].hash(), blocks[5].hash()] {
             for shard_id in shard_layout.shard_ids() {
                 assert!(
-                    row(&chain, anchor, shard_id).is_none(),
-                    "undo-block must delete ChunkProducers for {anchor}"
+                    row(&chain, anchor, shard_id).is_some(),
+                    "undo-block must retain ChunkProducers for header-only anchor {anchor}"
+                );
+            }
+        }
+
+        // Reviewer's re-sync: re-syncing the headers must keep the header-only rows valid. This
+        // is cache-independent (the rows were never deleted). We deliberately do not assert the
+        // body head re-seeds in-process: record_block_info_impl gates on has_block_info, which
+        // reads the epoch-manager blocks_info LRU cache before the store; clear_head_block_data
+        // only deletes BlockInfo from the store, not the cache, so has_block_info(body_head) may
+        // still be true here and the seeder is skipped. The real tools/undo-block runs with a
+        // fresh EpochManager (empty cache) and re-seeds correctly there.
+        chain
+            .sync_block_headers(blocks[3..=5].iter().map(|b| b.header().clone().into()).collect())
+            .unwrap();
+        for anchor in [blocks[4].hash(), blocks[5].hash()] {
+            for shard_id in shard_layout.shard_ids() {
+                assert!(
+                    row(&chain, anchor, shard_id).is_some(),
+                    "header re-sync must keep ChunkProducers for header-only anchor {anchor}"
                 );
             }
         }

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -494,6 +494,70 @@ mod tests {
         );
     }
 
+    /// GCMode::Fork deletes a fork block's ChunkProducers rows too. The delete lives in the
+    /// shared clear_block_data body, so Fork and Canonical run the same line today; this is a
+    /// regression guard in case the two ever stop sharing it.
+    #[test]
+    fn test_chunk_producers_garbage_collected_on_fork() {
+        init_test_logger();
+        let clock = FakeClock::new(Utc::from_unix_timestamp(1601510400).unwrap());
+        clock.advance(Duration::milliseconds(3444));
+        let (mut chain, epoch_manager, _, signer) = setup(clock.clock());
+
+        // Canonical chain: genesis + blocks 1..=3 (head = height 3).
+        let mut hashes = vec![*chain.genesis().hash()];
+        for _ in 0..3 {
+            let prev_hash = *chain.head_header().unwrap().hash();
+            let prev = chain.get_block(&prev_hash).unwrap();
+            clock.advance(Duration::milliseconds(1));
+            let block =
+                TestBlockBuilder::from_prev_block(clock.clock(), &prev, signer.clone()).build();
+            hashes.push(*block.hash());
+            chain.process_block_test(block).unwrap();
+        }
+
+        // Fork sibling with a body at height 3 (built on canonical block 2, distinct clock tick
+        // so its hash differs from block 3). It is a leaf, so its refcount is 0 and it can be
+        // cleared as a fork.
+        let parent = chain.get_block(&hashes[2]).unwrap();
+        clock.advance(Duration::milliseconds(1));
+        let fork = TestBlockBuilder::from_prev_block(clock.clock(), &parent, signer).build();
+        let fork_hash = *fork.hash();
+        assert_eq!(fork.header().height(), 3, "fork sibling must be at height 3");
+        assert_ne!(fork_hash, hashes[3], "fork must differ from canonical block 3");
+        chain.process_block_test(fork).unwrap();
+
+        // Keep this a real fork-GC case: the block is off the canonical chain (head did not
+        // switch to it) and is a leaf (built last, nothing on top), which is what
+        // clear_forks_data clears.
+        assert_ne!(
+            chain.head().unwrap().last_block_hash,
+            fork_hash,
+            "fork must not be the canonical head"
+        );
+
+        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(&hashes[1]).unwrap();
+        let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
+        let shard_id = shard_layout.shard_ids().next().unwrap();
+        let row = |chain: &Chain| -> Option<ValidatorStake> {
+            chain
+                .chain_store()
+                .store()
+                .get_ser(DBCol::ChunkProducers, &get_block_shard_id(&fork_hash, shard_id))
+        };
+        assert!(row(&chain).is_some(), "fork's row should exist before GC");
+
+        // GCMode::Fork clears the given block directly (no prev reassignment).
+        let tries = chain.runtime_adapter.get_tries();
+        let mut store_update = chain.mut_chain_store().store_update();
+        store_update
+            .clear_block_data(epoch_manager.as_ref(), fork_hash, GCMode::Fork(tries))
+            .unwrap();
+        store_update.commit().unwrap();
+
+        assert!(row(&chain).is_none(), "fork block's ChunkProducers rows must be deleted");
+    }
+
     /// clear_head_block_data (the undo-block path) deletes ChunkProducers exactly where it
     /// deletes BlockInfo: for the body head only. Header-only anchors above the body head keep
     /// both their BlockInfo and their ChunkProducers rows, so the rows stay valid and survive a

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -496,6 +496,77 @@ mod tests {
         );
     }
 
+    /// clear_head_block_data (the undo-block path) deletes ChunkProducers rows for the body
+    /// head AND every header-only anchor synced above it. Header sync writes a row per header,
+    /// so a body-head-only delete would orphan the header-only rows; the prefix-scan in
+    /// clear_header_data_for_heights covers the whole head..=header_head range.
+    #[test]
+    fn test_chunk_producers_garbage_collected_on_undo_block() {
+        init_test_logger();
+        let clock = FakeClock::new(Utc::from_unix_timestamp(1601510400).unwrap());
+        clock.advance(Duration::milliseconds(3444));
+        let (mut chain, epoch_manager, _, signer) = setup(clock.clock());
+
+        // Build a chain sharing one merkle tree so the header-only blocks validate on sync.
+        let genesis = chain.get_block(&chain.genesis().hash().clone()).unwrap();
+        let mut blocks = vec![genesis];
+        let mut block_merkle_tree = PartialMerkleTree::default();
+        for i in 0..5 {
+            clock.advance(Duration::milliseconds(1));
+            let epoch_sync_data_hash = if blocks[i].header().is_genesis() {
+                epoch_manager.compute_epoch_sync_data_hash(blocks[i].hash()).unwrap()
+            } else {
+                None
+            };
+            blocks.push(
+                TestBlockBuilder::from_prev_block(clock.clock(), &blocks[i], signer.clone())
+                    .block_merkle_tree(&mut block_merkle_tree)
+                    .epoch_sync_data_hash(epoch_sync_data_hash)
+                    .build(),
+            );
+        }
+
+        // Process bodies for heights 1..=3 (body head becomes height 3).
+        for block in &blocks[1..=3] {
+            chain.process_block_test(block.clone()).unwrap();
+        }
+        // Sync only the headers for heights 4..=5 (header_head advances past the body head).
+        chain
+            .sync_block_headers(blocks[4..=5].iter().map(|b| b.header().clone().into()).collect())
+            .unwrap();
+
+        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(blocks[1].hash()).unwrap();
+        let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
+
+        let row = |chain: &crate::Chain, anchor: &CryptoHash, shard_id| -> Option<ValidatorStake> {
+            chain
+                .chain_store()
+                .store()
+                .get_ser(DBCol::ChunkProducers, &get_block_shard_id(anchor, shard_id))
+        };
+
+        // The body head (3) and the header-only anchors (4, 5) all have rows before the undo.
+        for anchor in [blocks[3].hash(), blocks[4].hash(), blocks[5].hash()] {
+            for shard_id in shard_layout.shard_ids() {
+                assert!(row(&chain, anchor, shard_id).is_some(), "row should exist for {anchor}");
+            }
+        }
+
+        let mut store_update = chain.mut_chain_store().store_update();
+        store_update.clear_head_block_data(epoch_manager.as_ref()).unwrap();
+        store_update.commit().unwrap();
+
+        // Body head + header-only anchors are all cleared; nothing orphaned.
+        for anchor in [blocks[3].hash(), blocks[4].hash(), blocks[5].hash()] {
+            for shard_id in shard_layout.shard_ids() {
+                assert!(
+                    row(&chain, anchor, shard_id).is_none(),
+                    "undo-block must delete ChunkProducers for {anchor}"
+                );
+            }
+        }
+    }
+
     /// Resolution errors on a missing anchor DB row under EarlyKickout (strict read).
     #[test]
     fn test_resolution_errors_on_anchor_db_miss() {

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -567,6 +567,81 @@ mod tests {
         }
     }
 
+    /// Normal canonical GC deletes ChunkProducers rows for header-only hashes (fork
+    /// siblings, synced-ahead headers never given a body). Those rows are seeded per header
+    /// but are not covered by clear_block_data (which only clears block-body hashes); the
+    /// clear_chunk_data_and_headers sweep must delete them before HeaderHashesByHeight is
+    /// dropped, else they orphan permanently once the height index is gone.
+    #[test]
+    fn test_chunk_producers_garbage_collected_for_header_only_fork() {
+        init_test_logger();
+        let clock = FakeClock::new(Utc::from_unix_timestamp(1601510400).unwrap());
+        clock.advance(Duration::milliseconds(3444));
+        let (mut chain, epoch_manager, _, signer) = setup(clock.clock());
+
+        // Canonical chain: genesis + blocks 1..=6.
+        let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap()];
+        for i in 0..6 {
+            let prev = blocks[i].clone();
+            clock.advance(Duration::milliseconds(1));
+            let block =
+                TestBlockBuilder::from_prev_block(clock.clock(), &prev, signer.clone()).build();
+            blocks.push(block.clone());
+            chain.process_block_test(block).unwrap();
+        }
+
+        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(blocks[1].hash()).unwrap();
+        let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
+        let shard_id = shard_layout.shard_ids().next().unwrap();
+
+        // Header-only fork sibling at height 2, built on canonical block 1 with a distinct clock
+        // tick so it has a different hash than canonical block 2. No body is ever processed.
+        clock.advance(Duration::milliseconds(1));
+        let fork = TestBlockBuilder::from_prev_block(clock.clock(), &blocks[1], signer).build();
+        let fork_hash = *fork.hash();
+        assert_eq!(fork.header().height(), 2, "fork sibling must be at height 2");
+        assert_ne!(fork_hash, *blocks[2].hash(), "fork must differ from canonical block 2");
+
+        // Mirror what header sync writes: the header (adds fork_hash to HeaderHashesByHeight[2])
+        // plus a ChunkProducers row keyed by (fork_hash, shard_id).
+        let mut store_update = chain.mut_chain_store().store_update();
+        store_update.save_block_header(fork.header().clone()).unwrap();
+        store_update.commit().unwrap();
+        let sentinel = ValidatorStake::new(
+            "fork-cp".parse().unwrap(),
+            PublicKey::empty(KeyType::ED25519),
+            Balance::from_yoctonear(1),
+        );
+        let mut store_update = chain.chain_store().store().store_update();
+        store_update.insert_ser(
+            DBCol::ChunkProducers,
+            &get_block_shard_id(&fork_hash, shard_id),
+            &sentinel,
+        );
+        store_update.commit();
+
+        let fork_row = |chain: &crate::Chain| -> Option<ValidatorStake> {
+            chain
+                .chain_store()
+                .store()
+                .get_ser(DBCol::ChunkProducers, &get_block_shard_id(&fork_hash, shard_id))
+        };
+        assert!(fork_row(&chain).is_some(), "fork's row should exist before the sweep");
+
+        // Drive the header sweep directly over heights chunk_tail(0)..4 (exclusive), covering
+        // height 2. In TestBlockBuilder chains min_chunk_height stays 0 (blocks reuse the genesis
+        // chunk), so a full clear_data never advances the sweep; calling it directly is the
+        // deterministic way to exercise the header-only deletion.
+        let mut store_update = chain.mut_chain_store().store_update();
+        store_update.clear_chunk_data_and_headers(4).unwrap();
+        store_update.commit().unwrap();
+
+        assert!(
+            fork_row(&chain).is_none(),
+            "header-only fork's ChunkProducers row must be deleted by the header sweep"
+        );
+    }
+
     /// Resolution errors on a missing anchor DB row under EarlyKickout (strict read).
     #[test]
     fn test_resolution_errors_on_anchor_db_miss() {

--- a/chain/chain/src/tests/chunk_producers.rs
+++ b/chain/chain/src/tests/chunk_producers.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "nightly")]
 mod tests {
     use crate::ChainStoreAccess;
+    use crate::garbage_collection::GCMode;
     use crate::test_utils::{setup, setup_with_tx_validity_period};
     use near_async::time::{Duration, FakeClock, Utc};
     use near_crypto::{KeyType, PublicKey};
@@ -429,6 +430,70 @@ mod tests {
                 .unwrap();
             assert_eq!(resolved.account_id(), canonical.account_id());
         }
+    }
+
+    /// Hot GC deletes a below-boundary anchor's ChunkProducers rows while retaining rows for
+    /// anchors that later blocks still resolve against. Drives clear_block_data directly (mirrors
+    /// garbage_collection::tests::test_clear_old_data_fixed_height) so the cleared block is exact.
+    #[test]
+    fn test_chunk_producers_garbage_collected_with_block() {
+        init_test_logger();
+        let clock = FakeClock::new(Utc::from_unix_timestamp(1601510400).unwrap());
+        clock.advance(Duration::milliseconds(3444));
+        let (mut chain, epoch_manager, _, signer) = setup(clock.clock());
+
+        // setup() uses epoch_length 1000, so all blocks share one epoch and one shard.
+        let mut hashes = vec![*chain.genesis().hash()];
+        for _ in 0..9 {
+            let prev_hash = *chain.head_header().unwrap().hash();
+            let prev = chain.get_block(&prev_hash).unwrap();
+            clock.advance(Duration::milliseconds(1));
+            let block =
+                TestBlockBuilder::from_prev_block(clock.clock(), &prev, signer.clone()).build();
+            hashes.push(*block.hash());
+            chain.process_block_test(block).unwrap();
+        }
+
+        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(&hashes[1]).unwrap();
+        let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
+        let shard_id = shard_layout.shard_ids().next().unwrap();
+
+        let row = |chain: &crate::Chain, anchor: &CryptoHash| -> Option<ValidatorStake> {
+            chain
+                .chain_store()
+                .store()
+                .get_ser(DBCol::ChunkProducers, &get_block_shard_id(anchor, shard_id))
+        };
+
+        // Every anchor has a row before GC.
+        for anchor in &hashes {
+            assert!(row(&chain, anchor).is_some(), "row should exist before GC for {anchor}");
+        }
+
+        // GCMode::Canonical clears block_hash.prev, so passing hashes[5] clears anchor hashes[4].
+        let cleared_anchor = hashes[4];
+        let input_hash = hashes[5];
+        let tries = chain.runtime_adapter.get_tries();
+        let mut store_update = chain.mut_chain_store().store_update();
+        store_update
+            .clear_block_data(epoch_manager.as_ref(), input_hash, GCMode::Canonical(tries))
+            .unwrap();
+        store_update.commit().unwrap();
+
+        // The reassigned prev (hashes[4]) is the anchor actually cleared, NOT the input hash.
+        assert!(
+            row(&chain, &cleared_anchor).is_none(),
+            "below-boundary anchor row must be deleted"
+        );
+        assert!(row(&chain, &input_hash).is_some(), "canonical GC clears prev, not the input hash");
+
+        // A higher anchor's row is retained and still resolves for its child chunk. The chunk
+        // built on hashes[7] anchors on its grandparent hashes[6].
+        assert!(row(&chain, &hashes[6]).is_some(), "above-boundary anchor row must be retained");
+        assert!(
+            epoch_manager.get_chunk_producer_info_from_prev_block(&hashes[7], shard_id).is_ok(),
+            "retained anchor must still resolve"
+        );
     }
 
     /// Resolution errors on a missing anchor DB row under EarlyKickout (strict read).

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -759,9 +759,9 @@ impl DBCol {
             | DBCol::StateSyncHashes
             | DBCol::_TransactionRefCount
             | DBCol::_TransactionResult => GcPolicy::Other,
-            // GC'd with the anchor block's data in clear_block_data: a row for anchor A is
-            // dropped once A falls below the GC boundary, far below the near-head consensus
-            // read horizon (a chunk's grandparent anchor is head-2), so no live read is lost.
+            // GC'd with the anchor block/header it belongs to: a row for anchor A is dropped
+            // once A falls below the GC boundary, far below the near-head consensus read
+            // horizon (a chunk's grandparent anchor is head-2), so no live read is lost.
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => GcPolicy::Delete,
         }

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -759,13 +759,11 @@ impl DBCol {
             | DBCol::StateSyncHashes
             | DBCol::_TransactionRefCount
             | DBCol::_TransactionResult => GcPolicy::Other,
-            // ChunkProducers is not garbage collected. Once dynamic chunk producer
-            // sampling ships, historical assignments cannot be recomputed.
-            // TODO(early-kickout): before moving to stable, add a GC strategy
-            // (e.g. retain only canonical-chain entries or entries within a sliding window)
-            // to prevent unbounded disk growth on long-running nodes.
+            // GC'd with the anchor block's data in clear_block_data: a row for anchor A is
+            // dropped once A falls below the GC boundary, far below the near-head consensus
+            // read horizon (a chunk's grandparent anchor is head-2), so no live read is lost.
             #[cfg(feature = "nightly")]
-            DBCol::ChunkProducers => GcPolicy::Other,
+            DBCol::ChunkProducers => GcPolicy::Delete,
         }
     }
 

--- a/test-loop-tests/src/tests/chunk_producers.rs
+++ b/test-loop-tests/src/tests/chunk_producers.rs
@@ -209,9 +209,9 @@ mod cold_storage_tests {
         let reshard_done_height = env.archival_node().head().height;
         env.archival_runner().run_until_head_height(reshard_done_height + 4);
 
-        // Capture the anchors + their hot ChunkProducers rows now, BEFORE hot GC removes them
-        // (this PR GCs the ChunkProducers rows together with the anchor's block data, so they
-        // must be read before the GC tail reaches the anchor).
+        // Capture the anchors + their hot ChunkProducers rows now, before hot GC removes them:
+        // the rows are GC'd together with the anchor's block data, so read them before the GC
+        // tail reaches the anchor.
         let (mid_height, expected) = {
             let node = env.archival_node();
             let client = node.client();
@@ -362,9 +362,8 @@ mod hot_gc_tests {
             key
         };
 
-        // Advance far enough that the GC tail passes the old anchor. Reaching this height at all
-        // proves no in-window row was wrongly evicted (an eviction would stall via
-        // ChunkProducerNotInDB).
+        // Advance until the GC tail passes the old anchor. Reaching this height proves no
+        // in-window row was wrongly evicted (an eviction would stall via ChunkProducerNotInDB).
         let target_height = (GC_NUM_EPOCHS_TO_KEEP + 4) * EPOCH_LENGTH;
         env.validator_runner().run_until_head_height(target_height);
 

--- a/test-loop-tests/src/tests/chunk_producers.rs
+++ b/test-loop-tests/src/tests/chunk_producers.rs
@@ -330,6 +330,7 @@ mod hot_gc_tests {
     const GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
 
     #[test]
+    // TODO(spice-test): assess relevance for spice.
     #[cfg_attr(feature = "protocol_feature_spice", ignore)]
     fn test_chunk_producers_garbage_collected() {
         init_test_logger();

--- a/test-loop-tests/src/tests/chunk_producers.rs
+++ b/test-loop-tests/src/tests/chunk_producers.rs
@@ -209,9 +209,9 @@ mod cold_storage_tests {
         let reshard_done_height = env.archival_node().head().height;
         env.archival_runner().run_until_head_height(reshard_done_height + 4);
 
-        // Capture the anchors + their hot ChunkProducers rows now, BEFORE hot GC removes the
-        // block headers (ChunkProducers rows themselves are never GC'd in this PR, but the
-        // block-header lookups used to locate the anchors would fail once GC catches up).
+        // Capture the anchors + their hot ChunkProducers rows now, BEFORE hot GC removes them
+        // (this PR GCs the ChunkProducers rows together with the anchor's block data, so they
+        // must be read before the GC tail reaches the anchor).
         let (mid_height, expected) = {
             let node = env.archival_node();
             let client = node.client();

--- a/test-loop-tests/src/tests/chunk_producers.rs
+++ b/test-loop-tests/src/tests/chunk_producers.rs
@@ -306,10 +306,9 @@ mod cold_storage_tests {
 }
 
 /// `DBCol::ChunkProducers` rows are hot-garbage-collected with the anchor block's data: a
-/// below-tail anchor's rows disappear (disk stays bounded) while an in-window anchor's rows
-/// survive and still resolve. The chain advancing past the GC boundary is the deterministic
-/// stand-in for the `miss_db_entry == 0` canary: a wrongly-evicted in-window row would surface
-/// as `ChunkProducerNotInDB` and stall `run_until_head_height`.
+/// below-tail anchor's rows disappear while an in-window anchor's rows survive and still
+/// resolve. A wrongly-evicted in-window row would surface as `ChunkProducerNotInDB` and stall
+/// the chain, so reaching the target height at all is the liveness check.
 #[cfg(feature = "nightly")]
 mod hot_gc_tests {
     use crate::setup::builder::TestLoopBuilder;
@@ -331,7 +330,6 @@ mod hot_gc_tests {
     const GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
 
     #[test]
-    // TestBlockBuilder-independent, but keep parity with the cold-store test's spice guard.
     #[cfg_attr(feature = "protocol_feature_spice", ignore)]
     fn test_chunk_producers_garbage_collected() {
         init_test_logger();
@@ -373,12 +371,11 @@ mod hot_gc_tests {
         let chain = &node.client().chain;
         let epoch_manager = node.client().epoch_manager.clone();
 
-        // Below-tail anchor's rows are gone: disk stays bounded.
         let old_row: Option<ValidatorStake> = node.store().get_ser(DBCol::ChunkProducers, &old_key);
         assert!(old_row.is_none(), "below-tail anchor's row must be garbage collected");
 
-        // An in-window anchor's rows survive and still resolve. The chunk built on `child`
-        // (height anchor+1) anchors on its grandparent `anchor`.
+        // A chunk built on `child` anchors on its grandparent `anchor` (height anchor+1's
+        // grandparent), so the retained anchor's row must still resolve.
         let head_height = node.head().height;
         let anchor_height = head_height - 3;
         let anchor_hash = chain.get_block_hash_by_height(anchor_height).unwrap();
@@ -398,7 +395,7 @@ mod hot_gc_tests {
     /// leak: clear_block_data iterates get_shard_uids_to_gc (this-epoch ∪ next-epoch), so every
     /// next-layout row for the boundary anchor is dropped once it falls below the GC tail.
     #[test]
-    // TODO(spice-test): assess relevance for spice; keep parity with the cold-store test guard.
+    // TODO(spice-test): assess relevance for spice.
     #[cfg_attr(feature = "protocol_feature_spice", ignore)]
     fn test_chunk_producers_garbage_collected_at_reshard_boundary() {
         init_test_logger();

--- a/test-loop-tests/src/tests/chunk_producers.rs
+++ b/test-loop-tests/src/tests/chunk_producers.rs
@@ -304,3 +304,201 @@ mod cold_storage_tests {
         }
     }
 }
+
+/// `DBCol::ChunkProducers` rows are hot-garbage-collected with the anchor block's data: a
+/// below-tail anchor's rows disappear (disk stays bounded) while an in-window anchor's rows
+/// survive and still resolve. The chain advancing past the GC boundary is the deterministic
+/// stand-in for the `miss_db_entry == 0` canary: a wrongly-evicted in-window row would surface
+/// as `ChunkProducerNotInDB` and stall `run_until_head_height`.
+#[cfg(feature = "nightly")]
+mod hot_gc_tests {
+    use crate::setup::builder::TestLoopBuilder;
+    use crate::utils::setups::derive_new_epoch_config_from_boundary;
+    use near_async::time::Duration;
+    use near_chain_configs::test_genesis::TestEpochConfigBuilder;
+    use near_o11y::testonly::init_test_logger;
+    use near_primitives::epoch_manager::EpochConfigStore;
+    use near_primitives::shard_layout::ShardLayout;
+    use near_primitives::types::validator_stake::ValidatorStake;
+    use near_primitives::types::{AccountId, ShardId};
+    use near_primitives::utils::get_block_shard_id;
+    use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+    use near_store::DBCol;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    const EPOCH_LENGTH: u64 = 5;
+    const GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
+
+    #[test]
+    // TestBlockBuilder-independent, but keep parity with the cold-store test's spice guard.
+    #[cfg_attr(feature = "protocol_feature_spice", ignore)]
+    fn test_chunk_producers_garbage_collected() {
+        init_test_logger();
+
+        // Rows are only written when EarlyKickout is enabled; fail loud otherwise.
+        assert!(
+            ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION),
+            "test requires EarlyKickout enabled at PROTOCOL_VERSION"
+        );
+
+        let shard_layout = ShardLayout::single_shard();
+        let shard_id = ShardId::new(0);
+        let mut env = TestLoopBuilder::new()
+            .shard_layout(shard_layout)
+            .epoch_length(EPOCH_LENGTH)
+            .gc_num_epochs_to_keep(GC_NUM_EPOCHS_TO_KEEP)
+            .build();
+
+        // Record a low-height anchor's key while its block header still exists.
+        env.validator_runner().run_until_head_height(2 * EPOCH_LENGTH);
+        let old_anchor_height = EPOCH_LENGTH - 1;
+        let old_key = {
+            let node = env.validator();
+            let old_anchor_hash =
+                node.client().chain.get_block_hash_by_height(old_anchor_height).unwrap();
+            let key = get_block_shard_id(&old_anchor_hash, shard_id);
+            let row: Option<ValidatorStake> = node.store().get_ser(DBCol::ChunkProducers, &key);
+            assert!(row.is_some(), "row should exist before GC for the old anchor");
+            key
+        };
+
+        // Advance far enough that the GC tail passes the old anchor. Reaching this height at all
+        // proves no in-window row was wrongly evicted (an eviction would stall via
+        // ChunkProducerNotInDB).
+        let target_height = (GC_NUM_EPOCHS_TO_KEEP + 4) * EPOCH_LENGTH;
+        env.validator_runner().run_until_head_height(target_height);
+
+        let node = env.validator();
+        let chain = &node.client().chain;
+        let epoch_manager = node.client().epoch_manager.clone();
+
+        // Below-tail anchor's rows are gone: disk stays bounded.
+        let old_row: Option<ValidatorStake> = node.store().get_ser(DBCol::ChunkProducers, &old_key);
+        assert!(old_row.is_none(), "below-tail anchor's row must be garbage collected");
+
+        // An in-window anchor's rows survive and still resolve. The chunk built on `child`
+        // (height anchor+1) anchors on its grandparent `anchor`.
+        let head_height = node.head().height;
+        let anchor_height = head_height - 3;
+        let anchor_hash = chain.get_block_hash_by_height(anchor_height).unwrap();
+        let child_hash = chain.get_block_hash_by_height(anchor_height + 1).unwrap();
+        let in_window: Option<ValidatorStake> = node
+            .store()
+            .get_ser(DBCol::ChunkProducers, &get_block_shard_id(&anchor_hash, shard_id));
+        assert!(in_window.is_some(), "in-window anchor's row must be retained");
+        assert!(
+            epoch_manager.get_chunk_producer_info_from_prev_block(&child_hash, shard_id).is_ok(),
+            "retained in-window anchor must still resolve"
+        );
+    }
+
+    /// Hot GC deletes a reshard-boundary anchor's rows, which are keyed by the NEXT
+    /// (post-reshard) epoch's shard_ids. This is the case a naive own-epoch-layout delete would
+    /// leak: clear_block_data iterates get_shard_uids_to_gc (this-epoch ∪ next-epoch), so every
+    /// next-layout row for the boundary anchor is dropped once it falls below the GC tail.
+    #[test]
+    // TODO(spice-test): assess relevance for spice; keep parity with the cold-store test guard.
+    #[cfg_attr(feature = "protocol_feature_spice", ignore)]
+    fn test_chunk_producers_garbage_collected_at_reshard_boundary() {
+        init_test_logger();
+
+        // The boundary anchor lives in the pre-reshard (PROTOCOL_VERSION - 1) epoch, so its rows
+        // are only written if EarlyKickout is enabled there.
+        assert!(
+            ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION - 1),
+            "test requires EarlyKickout enabled at PROTOCOL_VERSION - 1 (the pre-reshard epoch)"
+        );
+
+        // Shard layout that grows at the protocol upgrade boundary.
+        let version = 3;
+        let base_shard_layout = ShardLayout::multi_shard(3, version);
+        let boundary_account: AccountId = "boundary".parse().unwrap();
+        let base_epoch_config = TestEpochConfigBuilder::new()
+            .shard_layout(base_shard_layout.clone())
+            .epoch_length(EPOCH_LENGTH)
+            .build();
+        let (new_epoch_config, new_shard_layout) =
+            derive_new_epoch_config_from_boundary(&base_epoch_config, &boundary_account);
+        assert!(
+            new_shard_layout.shard_ids().count() > base_shard_layout.shard_ids().count(),
+            "reshard should increase the shard count"
+        );
+        let epoch_config_store = EpochConfigStore::test(BTreeMap::from_iter([
+            (PROTOCOL_VERSION - 1, Arc::new(base_epoch_config)),
+            (PROTOCOL_VERSION, Arc::new(new_epoch_config)),
+        ]));
+
+        let mut env = TestLoopBuilder::new()
+            .shard_layout(base_shard_layout.clone())
+            .protocol_version(PROTOCOL_VERSION - 1)
+            .epoch_length(EPOCH_LENGTH)
+            .gc_num_epochs_to_keep(GC_NUM_EPOCHS_TO_KEEP)
+            .epoch_config_store(epoch_config_store)
+            .build();
+
+        // Run until resharding completes.
+        env.validator_runner().run_until(
+            |node| {
+                let epoch_id = node.head().epoch_id;
+                node.client().epoch_manager.get_shard_layout(&epoch_id).unwrap() == new_shard_layout
+            },
+            Duration::seconds((4 * EPOCH_LENGTH) as i64),
+        );
+        let reshard_done_height = env.validator().head().height;
+        env.validator_runner().run_until_head_height(reshard_done_height + 4);
+
+        // Capture the boundary anchor + its next-layout row keys BEFORE GC removes the block.
+        let (boundary_hash, boundary_keys) = {
+            let node = env.validator();
+            let client = node.client();
+            let chain = &client.chain;
+            let epoch_manager = client.epoch_manager.clone();
+            let store = node.store();
+
+            // Boundary anchor: last block of the pre-reshard epoch.
+            let mut block_hash = chain.head().unwrap().last_block_hash;
+            let boundary_hash = loop {
+                let header = chain.get_block_header(&block_hash).unwrap();
+                let shard_layout = epoch_manager.get_shard_layout(header.epoch_id()).unwrap();
+                if shard_layout == base_shard_layout {
+                    break *header.hash();
+                }
+                block_hash = *header.prev_hash();
+            };
+            assert!(
+                epoch_manager.is_next_block_epoch_start(&boundary_hash).unwrap(),
+                "boundary block should be the last block of the pre-reshard epoch"
+            );
+
+            // Rows keyed by the NEXT (post-reshard) layout's shard_ids.
+            let mut keys = Vec::new();
+            for shard_id in new_shard_layout.shard_ids() {
+                let key = get_block_shard_id(&boundary_hash, shard_id);
+                let row: Option<ValidatorStake> = store.get_ser(DBCol::ChunkProducers, &key);
+                assert!(
+                    row.is_some(),
+                    "boundary next-layout row must exist before GC, shard {shard_id}"
+                );
+                keys.push(key);
+            }
+            (boundary_hash, keys)
+        };
+
+        // Advance well past the boundary so the GC tail deletes its block data.
+        let target_height = reshard_done_height + EPOCH_LENGTH * (GC_NUM_EPOCHS_TO_KEEP + 2);
+        env.validator_runner().run_until_head_height(target_height);
+
+        let node = env.validator();
+        // Sanity: the boundary block itself is GC'd, so the row absence below is a real delete
+        // (not a never-existed vacuous pass).
+        assert!(
+            node.client().chain.get_block(&boundary_hash).is_err(),
+            "boundary block should be garbage collected by now"
+        );
+        for key in &boundary_keys {
+            let row: Option<ValidatorStake> = node.store().get_ser(DBCol::ChunkProducers, key);
+            assert!(row.is_none(), "boundary next-layout row must be garbage collected: {key:?}");
+        }
+    }
+}


### PR DESCRIPTION
PR2 of a 3-PR stack for `DBCol::ChunkProducers` (nightly-only, EarlyKickout). PR1 (#16012, makes the column cold) is merged; this PR is based on master. #16046 adds cloud archival support.

## Problem

`DBCol::ChunkProducers` was never garbage collected (`GcPolicy::Other`), so it grew unbounded on long-running nodes.

## Change

Add hot GC now that PR1 made the column cold, so archival nodes copy each row to the cold DB before hot GC deletes it (no history loss).

- Flip `GcPolicy::Other` to `GcPolicy::Delete`. This and the delete calls land in one commit because `gc_col` panics on `GcPolicy::Other`.
- `clear_block_data`: delete the anchor block's rows, folded into the existing `get_shard_uids_to_gc` `ChunkExtra` loop. The key is built fresh via `get_block_shard_id(block_hash, shard_uid.shard_id())` because `ChunkProducers` is keyed by `ShardId`, not `ShardUId`.
- Header-only anchors: header sync writes a row per header, so fork siblings and headers synced ahead of their body have rows that the block-keyed `clear_block_data` never sees. Delete those in the header-GC paths by prefix-scanning `ChunkProducers` by header hash: `clear_chunk_data_and_headers` (normal canonical GC, over `chunk_tail..min_chunk_height`) and `clear_header_data_for_heights` (undo-block, over `head_height..=header_head_height`).

## Why it is safe

The consensus reader `get_chunk_producer_info_anchored` returns `ChunkProducerNotInDB` (no sampler fallback) when a same-epoch anchor row is missing. A chunk at height H anchors on its grandparent (H-2), so a row must survive while any block up to A+2 is near head.

- `clear_block_data` runs only for blocks below `gc_stop_height` (`gc_num_epochs_to_keep` epochs behind final head, computed from the body head), far below the near-head read horizon.
- The normal header-GC sweep (`clear_chunk_data_and_headers`) is bounded by `chunk_tail..min_chunk_height`, which never exceeds the tail, so it also stays far below head. Normal GC never sweeps up to `header_head`.
- The only path that deletes up to `header_head` is undo-block (`clear_header_data_for_heights` via `clear_head_block_data`), a manual rollback that discards those headers and blocks. A kept block H still finds its anchor H-2; H+2 needs H only after H is reprocessed, which rewrites the row.
- Old-fork validation after GC is unsupported and not new: `Block`, `BlockInfo`, and `ChunkExtra` for those blocks are deleted by the same pass.

## Tests (nightly)

Unit (`chain/chain/src/tests/chunk_producers.rs`):
- `test_chunk_producers_garbage_collected_with_block`: `clear_block_data` deletes a below-boundary anchor's rows while a higher anchor's rows are retained and still resolve; canonical GC clears `block_hash.prev`, not the input hash.
- `test_chunk_producers_garbage_collected_on_undo_block`: undo-block clears the body head and every header-only anchor synced above it (header_head past the body head), nothing orphaned.
- `test_chunk_producers_garbage_collected_for_header_only_fork`: normal canonical GC deletes rows for header-only hashes (fork siblings / synced-ahead headers never given a body).

Test-loop (`test-loop-tests/src/tests/chunk_producers.rs`):
- `test_chunk_producers_garbage_collected`: single-shard hot GC. A below-tail anchor's rows are deleted; an in-window anchor's rows survive and resolve; the chain advancing past the GC boundary is the deterministic stand-in for the no-stall canary.
- `test_chunk_producers_garbage_collected_at_reshard_boundary`: the boundary anchor's rows, keyed by the next (post-reshard) layout, are all deleted once it falls below the GC tail.

Green: near-chain nightly `chunk_producers` and `garbage_collection`, near-store cloud classification, test-loop `chunk_producers`, `garbage_collection`, `processed_receipts_gc`. Codex reviewed the header-path deletion for over-eviction with no findings.

## Known limitation

Cloud archival support implemented here #16046
