### PR TITLE
doc(vm-runner): document high-s acceptance in p256_verify

### DIFF
--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -1885,6 +1885,28 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
     /// * If any of the signature, message or public key arguments are out of
     ///   memory bounds, returns [`HostError::MemoryAccessViolation`]
     ///
+    /// # Malleability
+    ///
+    /// ECDSA signatures are malleable: if `(r, s)` verifies, so does
+    /// `(r, n - s)`, and this function accepts both. It delegates to a
+    /// FIPS 186-5 compliant implementation and does not enforce low-s
+    /// normalization (low-s is a Bitcoin convention from BIP-62, not an ECDSA
+    /// requirement). This is deliberate: WebAuthn does not require low-s and
+    /// real authenticators — notably Apple's Secure Enclave — routinely emit
+    /// high-s signatures, so rejecting them would break passkey flows.
+    /// Ethereum's RIP-7212 `P256VERIFY` precompile makes the same choice, and
+    /// unlike `ecrecover` this function takes no malleability flag.
+    ///
+    /// Malleability only matters to callers that use the signature bytes
+    /// themselves for uniqueness or replay protection. Such callers must either
+    /// enforce low-s themselves — with the raw `r || s` encoding, `s` is bytes
+    /// 32..64 big-endian, so the check is a lexicographic comparison against
+    /// ⌊n/2⌋ =
+    /// `0x7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8` — or
+    /// have clients normalize `s = n - s` before submission. This behavior is
+    /// pinned by `test_p256_verify_wycheproof_high_s_accepted`; changing it
+    /// would be protocol-breaking.
+    ///
     /// # Cost
     ///
     /// Each input can either be in memory or in a register. Set the length of

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -1,3 +1,4 @@
+// cspell:words wycheproof
 use super::context::VMContext;
 use super::dependencies::{External, MemSlice, MemoryLike};
 use super::errors::{FunctionCallError, InconsistentStateError};

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -1902,6 +1902,27 @@ pub fn ed25519_verify(
 /// * If any of the signature, message or public key arguments are out of
 ///   memory bounds, returns [`HostError::MemoryAccessViolation`]
 ///
+/// # Malleability
+///
+/// ECDSA signatures are malleable: if `(r, s)` verifies, so does `(r, n - s)`,
+/// and this function accepts both. It delegates to a FIPS 186-5 compliant
+/// implementation and does not enforce low-s normalization (low-s is a Bitcoin
+/// convention from BIP-62, not an ECDSA requirement). This is deliberate:
+/// WebAuthn does not require low-s and real authenticators — notably Apple's
+/// Secure Enclave — routinely emit high-s signatures, so rejecting them would
+/// break passkey flows. Ethereum's RIP-7212 `P256VERIFY` precompile makes the
+/// same choice, and unlike `ecrecover` this function takes no malleability
+/// flag.
+///
+/// Malleability only matters to callers that use the signature bytes themselves
+/// for uniqueness or replay protection. Such callers must either enforce low-s
+/// themselves — with the raw `r || s` encoding, `s` is bytes 32..64 big-endian,
+/// so the check is a lexicographic comparison against ⌊n/2⌋ =
+/// `0x7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8` — or
+/// have clients normalize `s = n - s` before submission. This behavior is
+/// pinned by `test_p256_verify_wycheproof_high_s_accepted`; changing it would
+/// be protocol-breaking.
+///
 /// # Cost
 ///
 /// Each input can either be in memory or in a register. Set the length of

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -1,3 +1,4 @@
+// cspell:words wycheproof
 // Many host functions take `memory: &mut [u8]` for a uniform signature even
 // when they don't write to memory.
 #![allow(clippy::needless_pass_by_ref_mut)]


### PR DESCRIPTION
`p256_verify` accepts high-s signatures by design — it delegates to a FIPS 186-5 compliant implementation and does not enforce low-s normalization, because WebAuthn authenticators (notably Apple's Secure Enclave) routinely emit high-s and Ethereum's RIP-7212 `P256VERIFY` precompile makes the same choice. The rustdoc was silent on this; the only written note lived in the header of `test_p256_verify_wycheproof.rs`.

This adds a `# Malleability` section to the `p256_verify` rustdoc (both the `logic` and `wasmtime_runner` copies), spelling out the behavior, why it is intentional, and what callers relying on signature-byte uniqueness must do (enforce low-s against ⌊n/2⌋ or normalize client-side). Doc-only; no behavior change.

Refs: [NEP-635](https://github.com/near/NEPs/pull/635), [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md).