### PR TITLE
chore(ci): fix cargo-audit for crossbeam-epoch and cxx advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -35,4 +35,10 @@ ignore = [
     # S3/cloud-storage XML responses, not untrusted input. Remove once the upstream S3 crates upgrade.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+
+    # RUSTSEC-2026-0202: cxx `let_cxx_string!` unsoundness, no fixed release yet. cxx is only in
+    # the lockfile via iana-time-zone-haiku (chrono's Haiku-OS-only timezone backend), which never
+    # compiles on any platform nearcore builds for, so the unsound macro is unreachable in every
+    # artifact. Remove once cxx ships a fix and the chain picks it up.
+    "RUSTSEC-2026-0202",
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -35,10 +35,4 @@ ignore = [
     # S3/cloud-storage XML responses, not untrusted input. Remove once the upstream S3 crates upgrade.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
-
-    # RUSTSEC-2026-0202: cxx `let_cxx_string!` unsoundness, no fixed release yet. cxx is only in
-    # the lockfile via iana-time-zone-haiku (chrono's Haiku-OS-only timezone backend), which never
-    # compiles on any platform nearcore builds for, so the unsound macro is unreachable in every
-    # artifact. Remove once cxx ships a fix and the chain picks it up.
-    "RUSTSEC-2026-0202",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,16 +1108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width 0.1.9",
-]
-
-[[package]]
 name = "cold-store-tool"
 version = "0.0.0"
 dependencies = [
@@ -1648,50 +1638,6 @@ name = "curve25519-dalek-derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3014,12 +2960,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -3663,15 +3608,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -7117,12 +7053,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sec1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,15 +1519,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
- "scopeguard",
 ]
 
 [[package]]
@@ -3837,15 +3833,6 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]


### PR DESCRIPTION
Two RustSec advisories published 2026-07-05/06 fail `Cargo Audit` on every PR.

- RUSTSEC-2026-0204: bump `crossbeam-epoch` 0.9.14 → 0.9.20 (patched release, lockfile-only).
- RUSTSEC-2026-0202: update `iana-time-zone-haiku` 0.1.1 → 0.1.2, which dropped its `cxx` dependency, removing `cxx` (and seven support crates) from the lockfile entirely.

Same shape as #16015.