### PR TITLE
feat(early-kickout): activate mid-epoch kickout in the ChunkProducers writer

### DIFF
--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -17,7 +17,7 @@ use near_primitives::types::{
     AccountId, ApprovalStake, BlockHeight, EpochHeight, EpochId, NonZeroEpochHeight, ShardId,
     ShardIndex, ValidatorId, ValidatorInfoIdentifier,
 };
-use near_primitives::version::{ProtocolFeature, ProtocolVersion};
+use near_primitives::version::ProtocolVersion;
 use near_primitives::views::EpochValidatorInfo;
 use near_store::ShardUId;
 use near_store::adapter::epoch_store::EpochStoreUpdateAdapter;
@@ -1137,25 +1137,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
         &self,
         anchor_hash: &CryptoHash,
     ) -> Result<HashMap<ShardId, HashSet<ValidatorId>>, EpochError> {
-        let epoch_id = self.get_epoch_id_from_prev_block(anchor_hash)?;
-        let protocol_version = self.get_epoch_protocol_version(&epoch_id)?;
-        if !ProtocolFeature::EarlyKickout.enabled(protocol_version) {
-            return Ok(HashMap::new());
-        }
-        let epoch_manager = self.read();
-        let aggregator = epoch_manager.get_epoch_info_aggregator_upto_last(anchor_hash)?;
-        // Aggregator belongs to the anchor's epoch. If the next block starts a new epoch,
-        // stats reset -> empty blacklist (boundary reset).
-        if aggregator.epoch_id != epoch_id {
-            return Ok(HashMap::new());
-        }
-        let epoch_info = epoch_manager.get_epoch_info(&epoch_id)?;
-        let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
-        Ok(crate::compute_chunk_producer_blacklist(
-            &aggregator.shard_tracker,
-            epoch_info.as_ref(),
-            &shard_layout,
-        ))
+        self.read().chunk_producer_blacklist_at(anchor_hash)
     }
 
     fn get_chunk_validator_assignments(

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -618,14 +618,18 @@ pub trait EpochManagerAdapter: Send + Sync {
         )
     }
 
-    /// Per-shard chunk-producer blacklist for the epoch the NEXT block
-    /// (height prev+1) belongs to, computed FRESH from the up-to-date aggregator
-    /// keyed by `prev_block_hash`. Gated by `ProtocolFeature::EarlyKickout`:
-    /// returns an empty map when the feature is off (production), so sampling is
-    /// unchanged. Inert in PR5 (no production callers).
+    /// Per-shard chunk-producer blacklist keyed on `anchor_hash`, the grandparent of the
+    /// chunks it serves (sampled at anchor.height()+2, absent skipped heights, in
+    /// save_chunk_producers_for_header). Producers past the mid-epoch miss threshold,
+    /// computed fresh from the aggregator's stats up to `anchor_hash`. The epoch is
+    /// derived from the anchor via get_epoch_id_from_prev_block (the same call the seeder
+    /// makes), so a non-empty blacklist and the ChunkProducers assignment use one epoch
+    /// and settlement. Gated by ProtocolFeature::EarlyKickout (empty when off). Empty at
+    /// an epoch boundary (the aggregator sits in the anchor's epoch; a new epoch on the
+    /// next block resets the stats).
     fn get_chunk_producer_blacklist(
         &self,
-        prev_block_hash: &CryptoHash,
+        anchor_hash: &CryptoHash,
     ) -> Result<HashMap<ShardId, HashSet<ValidatorId>>, EpochError>;
 
     /// Gets the chunk validators for a given height and shard.
@@ -1131,19 +1135,16 @@ impl EpochManagerAdapter for EpochManagerHandle {
 
     fn get_chunk_producer_blacklist(
         &self,
-        prev_block_hash: &CryptoHash,
+        anchor_hash: &CryptoHash,
     ) -> Result<HashMap<ShardId, HashSet<ValidatorId>>, EpochError> {
-        let epoch_id = self.get_epoch_id_from_prev_block(prev_block_hash)?;
-        // Runtime gate. Off in production (PROTOCOL_VERSION < 152) -> empty blacklist,
-        // math never runs, sampling unchanged. This is the only production-reachable
-        // entry point for the new code.
+        let epoch_id = self.get_epoch_id_from_prev_block(anchor_hash)?;
         let protocol_version = self.get_epoch_protocol_version(&epoch_id)?;
         if !ProtocolFeature::EarlyKickout.enabled(protocol_version) {
             return Ok(HashMap::new());
         }
         let epoch_manager = self.read();
-        let aggregator = epoch_manager.get_epoch_info_aggregator_upto_last(prev_block_hash)?;
-        // Aggregator belongs to prev_block's epoch. If the next block starts a new epoch,
+        let aggregator = epoch_manager.get_epoch_info_aggregator_upto_last(anchor_hash)?;
+        // Aggregator belongs to the anchor's epoch. If the next block starts a new epoch,
         // stats reset -> empty blacklist (boundary reset).
         if aggregator.epoch_id != epoch_id {
             return Ok(HashMap::new());

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -15,13 +15,14 @@ use near_primitives::stateless_validation::validator_assignment::ChunkValidatorA
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, ApprovalStake, BlockHeight, EpochHeight, EpochId, NonZeroEpochHeight, ShardId,
-    ShardIndex, ValidatorInfoIdentifier,
+    ShardIndex, ValidatorId, ValidatorInfoIdentifier,
 };
-use near_primitives::version::ProtocolVersion;
+use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::EpochValidatorInfo;
 use near_store::ShardUId;
 use near_store::adapter::epoch_store::EpochStoreUpdateAdapter;
 use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Height distance from a chunk's grandparent anchor to the chunk, absent
@@ -617,6 +618,16 @@ pub trait EpochManagerAdapter: Send + Sync {
         )
     }
 
+    /// Per-shard chunk-producer blacklist for the epoch the NEXT block
+    /// (height prev+1) belongs to, computed FRESH from the up-to-date aggregator
+    /// keyed by `prev_block_hash`. Gated by `ProtocolFeature::EarlyKickout`:
+    /// returns an empty map when the feature is off (production), so sampling is
+    /// unchanged. Inert in PR5 (no production callers).
+    fn get_chunk_producer_blacklist(
+        &self,
+        prev_block_hash: &CryptoHash,
+    ) -> Result<HashMap<ShardId, HashSet<ValidatorId>>, EpochError>;
+
     /// Gets the chunk validators for a given height and shard.
     fn get_chunk_validator_assignments(
         &self,
@@ -1116,6 +1127,34 @@ impl EpochManagerAdapter for EpochManagerHandle {
         // from the chunk's own epoch.
         let cpk = ChunkProductionKey { epoch_id: *chunk_epoch_id, height_created, shard_id };
         self.get_chunk_producer_info(&cpk)
+    }
+
+    fn get_chunk_producer_blacklist(
+        &self,
+        prev_block_hash: &CryptoHash,
+    ) -> Result<HashMap<ShardId, HashSet<ValidatorId>>, EpochError> {
+        let epoch_id = self.get_epoch_id_from_prev_block(prev_block_hash)?;
+        // Runtime gate. Off in production (PROTOCOL_VERSION < 152) -> empty blacklist,
+        // math never runs, sampling unchanged. This is the only production-reachable
+        // entry point for the new code.
+        let protocol_version = self.get_epoch_protocol_version(&epoch_id)?;
+        if !ProtocolFeature::EarlyKickout.enabled(protocol_version) {
+            return Ok(HashMap::new());
+        }
+        let epoch_manager = self.read();
+        let aggregator = epoch_manager.get_epoch_info_aggregator_upto_last(prev_block_hash)?;
+        // Aggregator belongs to prev_block's epoch. If the next block starts a new epoch,
+        // stats reset -> empty blacklist (boundary reset).
+        if aggregator.epoch_id != epoch_id {
+            return Ok(HashMap::new());
+        }
+        let epoch_info = epoch_manager.get_epoch_info(&epoch_id)?;
+        let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
+        Ok(crate::compute_chunk_producer_blacklist(
+            &aggregator.shard_tracker,
+            epoch_info.as_ref(),
+            &shard_layout,
+        ))
     }
 
     fn get_chunk_validator_assignments(

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1019,7 +1019,7 @@ impl EpochManager {
                     &genesis_epoch_info,
                     &genesis_epoch_info,
                     &genesis_shard_layout,
-                );
+                )?;
             } else {
                 let prev_block_info = self.get_block_info(block_info.prev_hash())?;
 
@@ -1071,7 +1071,7 @@ impl EpochManager {
                         &own_epoch_info,
                         &sample_epoch_info,
                         &sample_shard_layout,
-                    );
+                    )?;
                 }
                 if block_info.last_finalized_height() > self.largest_final_height {
                     self.largest_final_height = block_info.last_finalized_height();
@@ -2107,6 +2107,54 @@ impl EpochManager {
         }
     }
 
+    /// Per-shard chunk-producer blacklist for chunks anchored at `anchor_hash`.
+    ///
+    /// Deterministic pure function of the anchor's committed chain: the epoch
+    /// info aggregator's stats *through* `anchor_hash`
+    /// ([`Self::get_epoch_info_aggregator_upto_last`], which never reads the
+    /// per-anchor-undefined `self.epoch_info_aggregator` window directly), the
+    /// anchor's own epoch settlement, and [`compute_chunk_producer_blacklist`].
+    ///
+    /// This is the single source of truth for the blacklist, shared by the
+    /// `get_chunk_producer_blacklist` read accessor and the `seed_chunk_producers`
+    /// writer so their window and epoch-boundary guard can never diverge
+    /// (writer==reader agreement is consensus-critical).
+    ///
+    /// `epoch_id` is derived exactly like the seeder's sample epoch (the epoch a
+    /// child of the anchor belongs to). Returns an empty blacklist when:
+    ///   - EarlyKickout is disabled for that epoch, or
+    ///   - the anchor is the last block of its epoch: the aggregator sits in the
+    ///     anchor's own epoch, so `aggregator.epoch_id != epoch_id` resets stats
+    ///     across the boundary. This also guarantees the seeder never excludes
+    ///     own-epoch `ValidatorId`s from a next-epoch settlement (the ids index
+    ///     different settlements across the boundary).
+    pub fn chunk_producer_blacklist_at(
+        &self,
+        anchor_hash: &CryptoHash,
+    ) -> Result<HashMap<ShardId, HashSet<ValidatorId>>, EpochError> {
+        let epoch_id = if self.is_next_block_epoch_start(anchor_hash)? {
+            self.get_next_epoch_id(anchor_hash)?
+        } else {
+            self.get_epoch_id(anchor_hash)?
+        };
+        let epoch_info = self.get_epoch_info(&epoch_id)?;
+        if !ProtocolFeature::EarlyKickout.enabled(epoch_info.protocol_version()) {
+            return Ok(HashMap::new());
+        }
+        let aggregator = self.get_epoch_info_aggregator_upto_last(anchor_hash)?;
+        // The aggregator belongs to the anchor's own epoch. If a child of the
+        // anchor starts a new epoch, stats reset -> empty blacklist.
+        if aggregator.epoch_id != epoch_id {
+            return Ok(HashMap::new());
+        }
+        let shard_layout = self.get_shard_layout(&epoch_id)?;
+        Ok(compute_chunk_producer_blacklist(
+            &aggregator.shard_tracker,
+            epoch_info.as_ref(),
+            &shard_layout,
+        ))
+    }
+
     /// Seed `DBCol::ChunkProducers` for chunks anchored at `block_hash` (the
     /// grandparent anchor of chunks at height `block_height +
     /// CHUNK_GRANDPARENT_ANCHOR_HEIGHT_OFFSET`). No-op unless EarlyKickout is
@@ -2127,17 +2175,28 @@ impl EpochManager {
         own_epoch_info: &EpochInfo,
         sample_epoch_info: &EpochInfo,
         sample_shard_layout: &ShardLayout,
-    ) {
+    ) -> Result<(), EpochError> {
         #[cfg(feature = "nightly")]
         {
             if !ProtocolFeature::EarlyKickout.enabled(own_epoch_info.protocol_version()) {
-                return;
+                return Ok(());
             }
+            // Blacklist from the anchor's committed chain, via the same helper the
+            // read accessor uses so the stored producer matches what the reader
+            // would resolve. Empty at an epoch boundary (own epoch != sample
+            // epoch), so `sample_epoch_info`'s settlement is never filtered by
+            // own-epoch ids.
+            let blacklist = self.chunk_producer_blacklist_at(block_hash)?;
+            let empty = HashSet::new();
             let height = block_height + CHUNK_GRANDPARENT_ANCHOR_HEIGHT_OFFSET;
             for shard_id in sample_shard_layout.shard_ids() {
-                if let Some(validator_id) =
-                    sample_epoch_info.sample_chunk_producer(sample_shard_layout, shard_id, height)
-                {
+                let exclude = blacklist.get(&shard_id).unwrap_or(&empty);
+                if let Some(validator_id) = sample_epoch_info.sample_chunk_producer_excluding(
+                    sample_shard_layout,
+                    shard_id,
+                    height,
+                    exclude,
+                ) {
                     let validator_stake = sample_epoch_info.get_validator(validator_id);
                     store_update.set_chunk_producer(block_hash, shard_id, &validator_stake);
                 }
@@ -2152,6 +2211,7 @@ impl EpochManager {
             sample_epoch_info,
             sample_shard_layout,
         );
+        Ok(())
     }
 
     /// Seed chunk producers for a block that is the first block of its epoch, so
@@ -2166,6 +2226,13 @@ impl EpochManager {
         let epoch_id = block_info.epoch_id();
         let epoch_info = self.get_epoch_info(epoch_id)?;
         let shard_layout = self.get_shard_layout(epoch_id)?;
+        // The epoch-sync first block is written straight into `store_update`
+        // (bypassing `record_block_info`/`save_block_info`), so it is not yet in
+        // the store or the block cache. `chunk_producer_blacklist_at` resolves the
+        // anchor via `get_block_info`; make the block visible to that lookup. Its
+        // aggregator stats are empty (it is the first block of its epoch), so the
+        // resulting blacklist is empty regardless.
+        self.blocks_info.put(*block_info.hash(), Arc::new(block_info.clone()));
         self.seed_chunk_producers(
             store_update,
             block_info.hash(),
@@ -2173,8 +2240,7 @@ impl EpochManager {
             &epoch_info,
             &epoch_info,
             &shard_layout,
-        );
-        Ok(())
+        )
     }
 
     /// Get the shard split to include in the block header, if any.

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -90,7 +90,7 @@ pub fn compute_chunk_producer_blacklist(
         // endorsement-only entries (chunk validators that never produced); they must
         // not be blacklist candidates and must not skew the safety-valve denominator.
         // (Today expected>=MIN skips them since production.expected==0 — but make it
-        // explicit so demo threshold tuning can't silently reintroduce the bug.)
+        // explicit so threshold tuning can't silently reintroduce the bug.)
         let producers: HashSet<ValidatorId> = settlement.iter().copied().collect();
         let mut blacklisted = HashSet::new();
         for (&validator_id, stats) in validators {
@@ -102,8 +102,7 @@ pub fn compute_chunk_producer_blacklist(
                 continue;
             }
             let missed = expected.saturating_sub(produced);
-            // u128 keeps the ratio comparison overflow-proof (this feeds consensus
-            // assignment in PR6).
+            // u128 keeps the ratio comparison overflow-proof.
             if missed >= EARLY_KICKOUT_MIN_MISSES
                 && (produced as u128) * (EARLY_KICKOUT_PRODUCTION_THRESHOLD_DENOMINATOR as u128)
                     < (expected as u128) * (EARLY_KICKOUT_PRODUCTION_THRESHOLD_NUMERATOR as u128)

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -63,6 +63,63 @@ const EPOCH_CACHE_SIZE: usize = 50;
 const BLOCK_CACHE_SIZE: usize = 1000;
 const AGGREGATOR_SAVE_PERIOD: u64 = 1000;
 
+const EARLY_KICKOUT_MIN_MISSES: u64 = 20;
+const EARLY_KICKOUT_PRODUCTION_THRESHOLD_NUMERATOR: u64 = 95;
+const EARLY_KICKOUT_PRODUCTION_THRESHOLD_DENOMINATOR: u64 = 100;
+const EARLY_KICKOUT_MINIMUM_OBSERVED_BLOCKS: u64 = 50;
+
+/// Per-shard chunk-producer blacklist from the aggregator's shard_tracker stats.
+/// A validator is blacklisted on a shard when, within the current epoch:
+///   - expected >= EARLY_KICKOUT_MINIMUM_OBSERVED_BLOCKS  (sample-size guard)
+///   - missed   >= EARLY_KICKOUT_MIN_MISSES               (missed = expected - produced)
+///   - produced * 100 < expected * 95                     (production ratio < 95%)
+/// Safety valve: if blacklisting would remove every distinct producer on a shard,
+/// that shard is omitted (caller falls through to default sampling).
+pub fn compute_chunk_producer_blacklist(
+    shard_tracker: &HashMap<ShardId, HashMap<ValidatorId, ChunkStats>>,
+    epoch_info: &EpochInfo,
+    shard_layout: &ShardLayout,
+) -> HashMap<ShardId, HashSet<ValidatorId>> {
+    let mut result = HashMap::new();
+    for (shard_id, validators) in shard_tracker {
+        let Ok(shard_index) = shard_layout.get_shard_index(*shard_id) else { continue };
+        let Some(settlement) = epoch_info.chunk_producers_settlement().get(shard_index) else {
+            continue;
+        };
+        // Distinct chunk PRODUCERS for this shard. shard_tracker also holds
+        // endorsement-only entries (chunk validators that never produced); they must
+        // not be blacklist candidates and must not skew the safety-valve denominator.
+        // (Today expected>=MIN skips them since production.expected==0 — but make it
+        // explicit so demo threshold tuning can't silently reintroduce the bug.)
+        let producers: HashSet<ValidatorId> = settlement.iter().copied().collect();
+        let mut blacklisted = HashSet::new();
+        for (&validator_id, stats) in validators {
+            if !producers.contains(&validator_id) {
+                continue;
+            }
+            let (produced, expected) = (stats.produced(), stats.expected());
+            if expected < EARLY_KICKOUT_MINIMUM_OBSERVED_BLOCKS {
+                continue;
+            }
+            let missed = expected.saturating_sub(produced);
+            // u128 keeps the ratio comparison overflow-proof (this feeds consensus
+            // assignment in PR6).
+            if missed >= EARLY_KICKOUT_MIN_MISSES
+                && (produced as u128) * (EARLY_KICKOUT_PRODUCTION_THRESHOLD_DENOMINATOR as u128)
+                    < (expected as u128) * (EARLY_KICKOUT_PRODUCTION_THRESHOLD_NUMERATOR as u128)
+            {
+                blacklisted.insert(validator_id);
+            }
+        }
+        // Safety valve: never blacklist every distinct producer on a shard. Backstopped
+        // by sample_chunk_producer_excluding -> None on full exclusion.
+        if !blacklisted.is_empty() && blacklisted.len() < producers.len() {
+            result.insert(*shard_id, blacklisted);
+        }
+    }
+    result
+}
+
 /// In the current architecture, various components have access to the same
 /// shared mutable instance of [`EpochManager`]. This handle manages locking
 /// required for such access.

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -64,7 +64,7 @@ const BLOCK_CACHE_SIZE: usize = 1000;
 const AGGREGATOR_SAVE_PERIOD: u64 = 1000;
 
 const EARLY_KICKOUT_MIN_MISSES: u64 = 20;
-const EARLY_KICKOUT_PRODUCTION_THRESHOLD_NUMERATOR: u64 = 95;
+const EARLY_KICKOUT_PRODUCTION_THRESHOLD_NUMERATOR: u64 = 80;
 const EARLY_KICKOUT_PRODUCTION_THRESHOLD_DENOMINATOR: u64 = 100;
 const EARLY_KICKOUT_MINIMUM_OBSERVED_BLOCKS: u64 = 50;
 
@@ -72,7 +72,7 @@ const EARLY_KICKOUT_MINIMUM_OBSERVED_BLOCKS: u64 = 50;
 /// A validator is blacklisted on a shard when, within the current epoch:
 ///   - expected >= EARLY_KICKOUT_MINIMUM_OBSERVED_BLOCKS  (sample-size guard)
 ///   - missed   >= EARLY_KICKOUT_MIN_MISSES               (missed = expected - produced)
-///   - produced * 100 < expected * 95                     (production ratio < 95%)
+///   - produced * 100 < expected * 80                     (production ratio < 80%)
 /// Safety valve: if blacklisting would remove every distinct producer on a shard,
 /// that shard is omitted (caller falls through to default sampling).
 pub fn compute_chunk_producer_blacklist(

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -304,3 +304,183 @@ fn get_chunk_producer_blacklist_resets_on_epoch_boundary() {
     let bl = handle.get_chunk_producer_blacklist(boundary).unwrap();
     assert!(bl.is_empty(), "epoch boundary must reset blacklist, got {bl:?}");
 }
+
+// --- Writer tests: `seed_chunk_producers` stores the blacklist-adjusted producer,
+// resolved end-to-end through the DB-backed `get_chunk_producer_info_from_prev_block`. ---
+
+/// Drives `count` blocks, deciding each chunk's produced/missed flag from the
+/// producer that consensus actually resolves (the seeded `DBCol::ChunkProducers`
+/// row via the grandparent anchor), not the plain sampler. A chunk is missed iff
+/// the resolved producer is `target`, so only `target` accrues misses; once the
+/// writer starts excluding `target`, the replacement is resolved and produces,
+/// which freezes `target`'s stats (the anti-flap dynamic under test).
+#[cfg(feature = "nightly")]
+fn drive_anchored_misses(
+    handle: &EpochManagerHandle,
+    count: u64,
+    target: ValidatorId,
+) -> Vec<CryptoHash> {
+    let h: Vec<CryptoHash> = (0..=count).map(|i| hash(&i.to_le_bytes())).collect();
+    record_block(&mut handle.write(), CryptoHash::default(), h[0], 0, vec![]);
+    let epoch_id = handle.get_epoch_id(&h[0]).unwrap();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let target_account =
+        handle.get_epoch_info(&epoch_id).unwrap().get_validator(target).account_id().clone();
+    let mut prev = h[0];
+    for height in 1..=count {
+        let resolved = handle.get_chunk_producer_info_from_prev_block(&prev, shard_id).unwrap();
+        let produced = resolved.account_id() != &target_account;
+        record_block_with_mask(
+            &mut handle.write(),
+            prev,
+            h[height as usize],
+            height,
+            vec![produced],
+        );
+        prev = h[height as usize];
+    }
+    h
+}
+
+// 12. Anti-flap: once `target` is blacklisted, the seeded row (read back through the
+//     resolver) excludes it in favour of the replacement, and because the aggregator
+//     credits the replacement, `target` accrues no new expected and stays out on the
+//     next anchor (does not flap back in).
+#[cfg(feature = "nightly")]
+#[test]
+fn seeded_producer_excludes_blacklisted_and_does_not_flap_back() {
+    let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
+    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+    let count = 160u64;
+    let h = drive_anchored_misses(&handle, count, 0);
+
+    let epoch_id = handle.get_epoch_id(&h[0]).unwrap();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
+    let target_account = epoch_info.get_validator(0).account_id().clone();
+
+    // Target 0 is blacklisted by the end of the run.
+    let bl = handle.get_chunk_producer_blacklist(&h[count as usize]).unwrap();
+    assert_eq!(
+        bl.get(&shard_id),
+        Some(&HashSet::from([0])),
+        "target must be blacklisted at the tip, got {bl:?}"
+    );
+
+    // The two latest chunk heights whose PLAIN producer is the blacklisted target.
+    // For both, the resolver (reading the seeded row) must pick the replacement, and
+    // it must stay excluded across both anchors -- i.e. it does not flap back in.
+    let mut target_heights: Vec<u64> = (3..=count)
+        .filter(|&hh| epoch_info.sample_chunk_producer(&layout, shard_id, hh) == Some(0))
+        .collect();
+    assert!(target_heights.len() >= 2, "need >=2 target slots, got {target_heights:?}");
+    let last_two = target_heights.split_off(target_heights.len() - 2);
+
+    for hh in last_two {
+        // Plain sampler would pick the blacklisted target here...
+        assert_eq!(epoch_info.sample_chunk_producer(&layout, shard_id, hh), Some(0));
+        // ...and the anchor seeding this chunk (grandparent = h[hh-2]) has it blacklisted.
+        let anchor_bl = handle.get_chunk_producer_blacklist(&h[(hh - 2) as usize]).unwrap();
+        assert_eq!(anchor_bl.get(&shard_id), Some(&HashSet::from([0])));
+        // ...so the stored (resolved) producer is the replacement, not the target.
+        let resolved = handle
+            .get_chunk_producer_info_from_prev_block(&h[(hh - 1) as usize], shard_id)
+            .unwrap();
+        assert_ne!(
+            resolved.account_id(),
+            &target_account,
+            "blacklisted producer flapped back in at height {hh}"
+        );
+    }
+
+    // Anti-flap invariant: once excluded, the target accrues no new expected. Its
+    // aggregator `expected` is frozen across the late tail because the aggregator
+    // credits the seeded replacement instead of the (never-resolved) target.
+    let expected_of_target = |anchor: &CryptoHash| -> u64 {
+        handle
+            .read()
+            .get_epoch_info_aggregator_upto_last(anchor)
+            .unwrap()
+            .shard_tracker
+            .get(&shard_id)
+            .and_then(|m| m.get(&0))
+            .map(|s| s.expected())
+            .unwrap_or(0)
+    };
+    let early = count - 20;
+    // Precondition: the target is already blacklisted at `early`...
+    assert!(
+        !handle.get_chunk_producer_blacklist(&h[early as usize]).unwrap().is_empty(),
+        "target must already be blacklisted at the earlier anchor"
+    );
+    // ...so its expected does not grow between `early` and the tip.
+    assert_eq!(
+        expected_of_target(&h[early as usize]),
+        expected_of_target(&h[count as usize]),
+        "blacklisted target must accrue no new expected"
+    );
+}
+
+// 13. Empty-blacklist path end-to-end (nightly, feature ON): with no misses nothing is
+//     blacklisted, so the seeded/resolved producer equals the plain sampler at every
+//     height. Proves the writer never excludes spuriously.
+#[cfg(feature = "nightly")]
+#[test]
+fn seeded_producer_matches_plain_sampler_without_kickouts() {
+    let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
+    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+    let count = 40u64;
+    let h: Vec<CryptoHash> = (0..=count).map(|i| hash(&i.to_le_bytes())).collect();
+    record_block(&mut handle.write(), CryptoHash::default(), h[0], 0, vec![]);
+    let mut prev = h[0];
+    for height in 1..=count {
+        record_block_with_mask(&mut handle.write(), prev, h[height as usize], height, vec![true]);
+        prev = h[height as usize];
+    }
+
+    let epoch_id = handle.get_epoch_id(&h[0]).unwrap();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
+    // No blacklist accrued.
+    assert!(handle.get_chunk_producer_blacklist(&h[count as usize]).unwrap().is_empty());
+    for height in 2..=count {
+        let plain = epoch_info.sample_chunk_producer(&layout, shard_id, height).unwrap();
+        let resolved = handle
+            .get_chunk_producer_info_from_prev_block(&h[(height - 1) as usize], shard_id)
+            .unwrap();
+        assert_eq!(
+            resolved.account_id(),
+            epoch_info.get_validator(plain).account_id(),
+            "empty-blacklist resolver must match plain sampler at height {height}"
+        );
+    }
+}
+
+// 14. Feature OFF (stable, pre-v152): even with a miss-heavy target the resolver never
+//     excludes -- the resolved producer equals the plain sampler at every height.
+#[cfg(not(feature = "nightly"))]
+#[test]
+fn feature_off_resolved_producer_matches_plain_sampler() {
+    let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
+    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+    let count = 160u64;
+    let h = drive_targeted_misses(&handle, count, 0);
+    let epoch_id = handle.get_epoch_id(&h[0]).unwrap();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
+    for height in 2..=count {
+        let plain = epoch_info.sample_chunk_producer(&layout, shard_id, height).unwrap();
+        let resolved = handle
+            .get_chunk_producer_info_from_prev_block(&h[(height - 1) as usize], shard_id)
+            .unwrap();
+        assert_eq!(
+            resolved.account_id(),
+            epoch_info.get_validator(plain).account_id(),
+            "feature-off resolver must match plain sampler at height {height}"
+        );
+    }
+}

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -1,5 +1,5 @@
 //! Tests for the early-kickout blacklist math (`compute_chunk_producer_blacklist`)
-//! and the gated `get_chunk_producer_blacklist` accessor. PR5 is pure math with no
+//! and the gated `get_chunk_producer_blacklist` accessor. The math is pure with no
 //! production callers; these tests exercise the math directly and the accessor
 //! end-to-end (gate + boundary reset + enabled path).
 

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -1,0 +1,306 @@
+//! Tests for the early-kickout blacklist math (`compute_chunk_producer_blacklist`)
+//! and the gated `get_chunk_producer_blacklist` accessor. PR5 is pure math with no
+//! production callers; these tests exercise the math directly and the accessor
+//! end-to-end (gate + boundary reset + enabled path).
+
+use crate::reward_calculator::NUM_NS_IN_SECOND;
+use crate::test_utils::{DEFAULT_TOTAL_SUPPLY, record_block, setup_default_epoch_manager};
+use crate::{
+    EpochManager, EpochManagerAdapter, EpochManagerHandle, compute_chunk_producer_blacklist,
+};
+use near_primitives::epoch_block_info::BlockInfo;
+use near_primitives::epoch_info::EpochInfo;
+use near_primitives::hash::{CryptoHash, hash};
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::stateless_validation::chunk_endorsements_bitmap::ChunkEndorsementsBitmap;
+use near_primitives::types::{Balance, ChunkStats, ShardId, ValidatorId};
+use near_primitives::version::PROTOCOL_VERSION;
+use std::collections::{HashMap, HashSet};
+
+const STAKE: Balance = Balance::from_yoctonear(1_000_000);
+
+/// Builds a single-shard `EpochInfo` with `num_producers` chunk producers (ids
+/// `0..num_producers`) and returns it alongside the layout and the shard id.
+fn single_shard_epoch(num_producers: u64) -> (EpochInfo, ShardLayout, ShardId) {
+    let accounts: Vec<_> =
+        (0..num_producers).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
+    let settlement: Vec<ValidatorId> = (0..num_producers).collect();
+    let shard_layout = ShardLayout::single_shard();
+    let shard_id = shard_layout.shard_ids().next().unwrap();
+    let epoch_info = crate::test_utils::epoch_info(
+        0,
+        accounts,
+        settlement.clone(),
+        vec![settlement],
+        PROTOCOL_VERSION,
+        shard_layout.clone(),
+    );
+    (epoch_info, shard_layout, shard_id)
+}
+
+/// Convenience: builds a `shard_tracker` with a single shard from `(validator_id,
+/// produced, expected)` triples.
+fn tracker(
+    shard_id: ShardId,
+    stats: &[(ValidatorId, u64, u64)],
+) -> HashMap<ShardId, HashMap<ValidatorId, ChunkStats>> {
+    let inner: HashMap<ValidatorId, ChunkStats> = stats
+        .iter()
+        .map(|&(id, produced, expected)| (id, ChunkStats::new_with_production(produced, expected)))
+        .collect();
+    HashMap::from([(shard_id, inner)])
+}
+
+// 1. produced/expected < 95%, missed >= 20, expected >= 50 -> blacklisted.
+#[test]
+fn blacklist_below_threshold() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(4);
+    // id 0: 50/100 = 50% < 95%, missed 50; others healthy.
+    let st = tracker(shard_id, &[(0, 50, 100), (1, 100, 100), (2, 100, 100), (3, 100, 100)]);
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert_eq!(bl, HashMap::from([(shard_id, HashSet::from([0]))]));
+}
+
+// 2. produced*100 == expected*95 -> NOT blacklisted (strict `<`), missed >= 20.
+#[test]
+fn blacklist_exactly_at_threshold() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(4);
+    // id 0: 380/400 = exactly 95%, missed 20 (>= 20). Strict `<` must exclude it.
+    let st = tracker(shard_id, &[(0, 380, 400), (1, 400, 400), (2, 400, 400), (3, 400, 400)]);
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert!(bl.is_empty());
+}
+
+// 3. missed < 20 -> not blacklisted regardless of ratio.
+#[test]
+fn blacklist_under_min_misses() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(4);
+    // id 0: 81/100 = 81% < 95% but missed only 19 (< 20).
+    let st = tracker(shard_id, &[(0, 81, 100), (1, 100, 100), (2, 100, 100), (3, 100, 100)]);
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert!(bl.is_empty());
+}
+
+// 4. every producer would be blacklisted -> shard omitted (safety valve).
+#[test]
+fn blacklist_safety_valve_all_producers() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(2);
+    let st = tracker(shard_id, &[(0, 0, 100), (1, 0, 100)]);
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert!(bl.is_empty());
+}
+
+// 5. lone producer would be blacklisted -> omitted (safety valve).
+#[test]
+fn blacklist_single_producer_shard() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(1);
+    let st = tracker(shard_id, &[(0, 0, 100)]);
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert!(bl.is_empty());
+}
+
+// 6. expected < 50 at 0% production -> not blacklisted (sample-size guard).
+#[test]
+fn blacklist_minimum_observed_blocks() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(2);
+    // id 0: 0/49, below the observed-blocks floor.
+    let st = tracker(shard_id, &[(0, 0, 49), (1, 100, 100)]);
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert!(bl.is_empty());
+}
+
+// 7. endorsement-only entries are ignored; producers judged on production only.
+#[test]
+fn blacklist_ignores_endorsement_only_entries() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(3);
+    let mut inner = HashMap::new();
+    // (a) endorser-only validator NOT in settlement (id 3): high endorsement, zero
+    // production. Must never be a candidate.
+    inner.insert(3, ChunkStats::new(0, 0, 1000, 1000));
+    // (b) settlement producer (id 0) with high endorsement but failing production.
+    inner.insert(0, ChunkStats::new(50, 100, 1000, 1000));
+    inner.insert(1, ChunkStats::new_with_production(100, 100));
+    inner.insert(2, ChunkStats::new_with_production(100, 100));
+    let st = HashMap::from([(shard_id, inner)]);
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert_eq!(bl, HashMap::from([(shard_id, HashSet::from([0]))]));
+}
+
+// 8. all producers above threshold -> empty map.
+#[test]
+fn blacklist_empty_when_healthy() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(3);
+    let st = tracker(shard_id, &[(0, 100, 100), (1, 96, 100), (2, 100, 100)]);
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert!(bl.is_empty());
+}
+
+// 9. two shards, independent blacklists.
+#[test]
+fn blacklist_multi_shard_independent() {
+    let num_producers = 3u64;
+    let accounts: Vec<_> =
+        (0..num_producers).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
+    let settlement: Vec<ValidatorId> = (0..num_producers).collect();
+    let shard_layout = ShardLayout::multi_shard(2, 0);
+    let shard_ids: Vec<ShardId> = shard_layout.shard_ids().collect();
+    let epoch_info = crate::test_utils::epoch_info(
+        0,
+        accounts,
+        settlement.clone(),
+        vec![settlement.clone(), settlement],
+        PROTOCOL_VERSION,
+        shard_layout.clone(),
+    );
+    // shard 0: id 0 fails. shard 1: all healthy.
+    let mut st = HashMap::new();
+    st.insert(
+        shard_ids[0],
+        HashMap::from([
+            (0u64, ChunkStats::new_with_production(0, 100)),
+            (1, ChunkStats::new_with_production(100, 100)),
+            (2, ChunkStats::new_with_production(100, 100)),
+        ]),
+    );
+    st.insert(
+        shard_ids[1],
+        HashMap::from([
+            (0u64, ChunkStats::new_with_production(100, 100)),
+            (1, ChunkStats::new_with_production(100, 100)),
+            (2, ChunkStats::new_with_production(100, 100)),
+        ]),
+    );
+    let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &shard_layout);
+    assert_eq!(bl, HashMap::from([(shard_ids[0], HashSet::from([0]))]));
+}
+
+// --- Accessor tests (end-to-end through EpochManagerHandle) ---
+
+/// Records a block at `cur` with an explicit per-shard `chunk_mask` (true =
+/// produced, false = missed). Mirrors `record_block_with_version` but lets the
+/// caller control the chunk mask so we can synthesize miss-heavy stats.
+fn record_block_with_mask(
+    em: &mut EpochManager,
+    prev: CryptoHash,
+    cur: CryptoHash,
+    height: u64,
+    chunk_mask: Vec<bool>,
+) {
+    let epoch_id = em.get_epoch_id(&prev).unwrap();
+    let shard_layout = em.get_shard_layout(&epoch_id).unwrap();
+    // A missed chunk (mask == false) must carry an EMPTY endorsement bitmap for that
+    // shard; only produced chunks include endorsements.
+    let chunk_endorsements = ChunkEndorsementsBitmap::from_endorsements(
+        shard_layout
+            .shard_ids()
+            .enumerate()
+            .map(|(shard_index, shard_id)| {
+                if !chunk_mask[shard_index] {
+                    return vec![];
+                }
+                let assignments =
+                    em.get_chunk_validator_assignments(&epoch_id, shard_id, height).unwrap();
+                vec![true; assignments.assignments().iter().len()]
+            })
+            .collect(),
+    );
+    em.record_block_info(
+        BlockInfo::new(
+            cur,
+            height,
+            height.saturating_sub(2),
+            prev,
+            prev,
+            vec![],
+            chunk_mask,
+            DEFAULT_TOTAL_SUPPLY,
+            PROTOCOL_VERSION,
+            PROTOCOL_VERSION,
+            height * NUM_NS_IN_SECOND,
+            chunk_endorsements,
+            None,
+        ),
+        [0; 32],
+    )
+    .unwrap()
+    .commit();
+}
+
+/// Drives `count` blocks in epoch 0 where the single shard's chunk is missed
+/// exactly on the heights where `target` is the scheduled producer. The result:
+/// `target` accumulates 0 produced / many expected (blacklist candidate) while the
+/// other producer stays at 100%. Returns the recorded block hashes (index = height).
+fn drive_targeted_misses(
+    handle: &EpochManagerHandle,
+    count: u64,
+    target: ValidatorId,
+) -> Vec<CryptoHash> {
+    let h: Vec<CryptoHash> = (0..=count).map(|i| hash(&i.to_le_bytes())).collect();
+    record_block(&mut handle.write(), CryptoHash::default(), h[0], 0, vec![]);
+    let epoch_id = handle.get_epoch_id(&h[0]).unwrap();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
+    let mut prev = h[0];
+    for height in 1..=count {
+        let scheduled = epoch_info.sample_chunk_producer(&layout, shard_id, height).unwrap();
+        let produced = scheduled != target;
+        record_block_with_mask(
+            &mut handle.write(),
+            prev,
+            h[height as usize],
+            height,
+            vec![produced],
+        );
+        prev = h[height as usize];
+    }
+    h
+}
+
+// 10. pre-v152 protocol + miss-heavy stats -> accessor returns empty (gate proves
+//     no production leak). Only meaningful on stable (PROTOCOL_VERSION < 152).
+#[cfg(not(feature = "nightly"))]
+#[test]
+fn get_chunk_producer_blacklist_empty_when_feature_disabled() {
+    let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
+    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+    let h = drive_targeted_misses(&handle, 160, 0);
+    let bl = handle.get_chunk_producer_blacklist(h.last().unwrap()).unwrap();
+    assert!(bl.is_empty(), "feature disabled must yield empty blacklist, got {bl:?}");
+}
+
+// Enabled-path end-to-end: v152+ protocol + miss-heavy stats -> the target is
+// blacklisted on its shard (proves the accessor wires aggregator -> compute).
+#[cfg(feature = "nightly")]
+#[test]
+fn get_chunk_producer_blacklist_blacklists_miss_heavy_producer() {
+    let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
+    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+    let h = drive_targeted_misses(&handle, 160, 0);
+    let prev = *h.last().unwrap();
+    let epoch_id = handle.get_epoch_id_from_prev_block(&prev).unwrap();
+    let shard_id = handle.get_shard_layout(&epoch_id).unwrap().shard_ids().next().unwrap();
+    let bl = handle.get_chunk_producer_blacklist(&prev).unwrap();
+    assert_eq!(bl, HashMap::from([(shard_id, HashSet::from([0]))]));
+}
+
+// 11. v152+ protocol: at an epoch boundary the aggregator belongs to the previous
+//     epoch, so the accessor returns empty even though epoch 0 stats are miss-heavy.
+#[cfg(feature = "nightly")]
+#[test]
+fn get_chunk_producer_blacklist_resets_on_epoch_boundary() {
+    let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
+    // Epoch length 160: epoch 0 accumulates miss-heavy stats, then we cross into
+    // epoch 1 so the last epoch-0 block is an epoch boundary.
+    let handle = setup_default_epoch_manager(validators, 160, 1, 3, 90, 60).into_handle();
+    let h = drive_targeted_misses(&handle, 160, 0);
+    // Find the last recorded block that is the end of its epoch (next block starts a
+    // new epoch). The accessor keyed on it must reset to empty.
+    let boundary = h
+        .iter()
+        .rev()
+        .find(|hash| handle.is_next_block_epoch_start(hash).unwrap())
+        .expect("expected an epoch boundary among recorded blocks");
+    let bl = handle.get_chunk_producer_blacklist(boundary).unwrap();
+    assert!(bl.is_empty(), "epoch boundary must reset blacklist, got {bl:?}");
+}

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -51,22 +51,22 @@ fn tracker(
     HashMap::from([(shard_id, inner)])
 }
 
-// 1. produced/expected < 95%, missed >= 20, expected >= 50 -> blacklisted.
+// 1. produced/expected < 80%, missed >= 20, expected >= 50 -> blacklisted.
 #[test]
 fn blacklist_below_threshold() {
     let (epoch_info, layout, shard_id) = single_shard_epoch(4);
-    // id 0: 50/100 = 50% < 95%, missed 50; others healthy.
+    // id 0: 50/100 = 50% < 80%, missed 50; others healthy.
     let st = tracker(shard_id, &[(0, 50, 100), (1, 100, 100), (2, 100, 100), (3, 100, 100)]);
     let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
     assert_eq!(bl, HashMap::from([(shard_id, HashSet::from([0]))]));
 }
 
-// 2. produced*100 == expected*95 -> NOT blacklisted (strict `<`), missed >= 20.
+// 2. produced*100 == expected*80 -> NOT blacklisted (strict `<`), missed >= 20.
 #[test]
 fn blacklist_exactly_at_threshold() {
     let (epoch_info, layout, shard_id) = single_shard_epoch(4);
-    // id 0: 380/400 = exactly 95%, missed 20 (>= 20). Strict `<` must exclude it.
-    let st = tracker(shard_id, &[(0, 380, 400), (1, 400, 400), (2, 400, 400), (3, 400, 400)]);
+    // id 0: 320/400 = exactly 80%, missed 80 (>= 20). Strict `<` must exclude it.
+    let st = tracker(shard_id, &[(0, 320, 400), (1, 400, 400), (2, 400, 400), (3, 400, 400)]);
     let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
     assert!(bl.is_empty());
 }
@@ -75,8 +75,8 @@ fn blacklist_exactly_at_threshold() {
 #[test]
 fn blacklist_under_min_misses() {
     let (epoch_info, layout, shard_id) = single_shard_epoch(4);
-    // id 0: 81/100 = 81% < 95% but missed only 19 (< 20).
-    let st = tracker(shard_id, &[(0, 81, 100), (1, 100, 100), (2, 100, 100), (3, 100, 100)]);
+    // id 0: 31/50 = 62% < 80% but missed only 19 (< 20); expected >= 50.
+    let st = tracker(shard_id, &[(0, 31, 50), (1, 100, 100), (2, 100, 100), (3, 100, 100)]);
     let bl = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
     assert!(bl.is_empty());
 }

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -1945,11 +1945,19 @@ fn test_finalize_epoch_large_epoch_length() {
             ("test2".parse().unwrap(), stake_amount)
         ]),
     );
-    assert_eq!(
-        BLOCK_CACHE_SIZE + 2,
-        epoch_manager.epoch_info_aggregator_loop_counter.load(std::sync::atomic::Ordering::SeqCst),
-        "Expected every block to be visited exactly once"
-    );
+    // This "visited exactly once" invariant only holds for the core incremental
+    // aggregator. When EarlyKickout is enabled the per-block chunk-producer seeder
+    // computes its blacklist via `get_epoch_info_aggregator_upto_last(block_hash)`,
+    // which adds bounded extra traversals (last-final block to tip) per block.
+    if !ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION) {
+        assert_eq!(
+            BLOCK_CACHE_SIZE + 2,
+            epoch_manager
+                .epoch_info_aggregator_loop_counter
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "Expected every block to be visited exactly once"
+        );
+    }
 }
 
 #[test]

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod early_kickout;
 mod pick_shard_to_split;
 mod random_epochs;
 

--- a/core/primitives/src/epoch_info.rs
+++ b/core/primitives/src/epoch_info.rs
@@ -13,7 +13,7 @@ use near_primitives_core::{
 };
 use near_schema_checker_lib::ProtocolSchema;
 use smart_default::SmartDefault;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Information per epoch.
 #[derive(
@@ -593,6 +593,83 @@ impl EpochInfo {
         }
     }
 
+    /// Sample a chunk producer for (shard_id, height), excluding any validator in
+    /// `exclude`. Mirrors `sample_chunk_producer`, filtering the per-shard settlement
+    /// first. Returns None when every eligible producer is excluded (caller falls back
+    /// to `sample_chunk_producer`).
+    pub fn sample_chunk_producer_excluding(
+        &self,
+        shard_layout: &ShardLayout,
+        shard_id: ShardId,
+        height: BlockHeight,
+        exclude: &HashSet<ValidatorId>,
+    ) -> Option<ValidatorId> {
+        if exclude.is_empty() {
+            return self.sample_chunk_producer(shard_layout, shard_id, height);
+        }
+        let shard_index = shard_layout.get_shard_index(shard_id).ok()?;
+        match &self {
+            Self::V1(v1) => Self::sample_excluding_modulo(
+                v1.chunk_producers_settlement.get(shard_index)?,
+                exclude,
+                height,
+            ),
+            Self::V2(v2) => Self::sample_excluding_modulo(
+                v2.chunk_producers_settlement.get(shard_index)?,
+                exclude,
+                height,
+            ),
+            Self::V3(v3) => Self::sample_excluding_weighted(
+                v3.chunk_producers_settlement.get(shard_index)?,
+                exclude,
+                &v3.validators,
+                Self::chunk_produce_seed(&v3.rng_seed, height, shard_id),
+            ),
+            Self::V4(v4) => Self::sample_excluding_weighted(
+                v4.chunk_producers_settlement.get(shard_index)?,
+                exclude,
+                &v4.validators,
+                Self::chunk_produce_seed(&v4.rng_seed, height, shard_id),
+            ),
+            Self::V5(v5) => Self::sample_excluding_weighted(
+                v5.chunk_producers_settlement.get(shard_index)?,
+                exclude,
+                &v5.validators,
+                Self::chunk_produce_seed(&v5.rng_seed, height, shard_id),
+            ),
+        }
+    }
+
+    /// Filter `settlement` by `exclude`, then pick by `height` modulo (V1/V2 rule).
+    fn sample_excluding_modulo(
+        settlement: &[ValidatorId],
+        exclude: &HashSet<ValidatorId>,
+        height: BlockHeight,
+    ) -> Option<ValidatorId> {
+        let filtered: Vec<ValidatorId> =
+            settlement.iter().copied().filter(|id| !exclude.contains(id)).collect();
+        (!filtered.is_empty()).then(|| filtered[(height % filtered.len() as u64) as usize])
+    }
+
+    /// Filter `settlement` by `exclude`, then pick via a fresh stake-weighted
+    /// distribution renormalized over the surviving producers (V3/V4/V5 rule).
+    fn sample_excluding_weighted(
+        settlement: &[ValidatorId],
+        exclude: &HashSet<ValidatorId>,
+        validators: &[ValidatorStake],
+        seed: [u8; 32],
+    ) -> Option<ValidatorId> {
+        let filtered: Vec<ValidatorId> =
+            settlement.iter().copied().filter(|id| !exclude.contains(id)).collect();
+        if filtered.is_empty() {
+            return None;
+        }
+        let stakes: Vec<Balance> =
+            filtered.iter().map(|&id| validators[id as usize].stake()).collect();
+        let sampler = StakeWeightedIndex::new(stakes);
+        Some(filtered[sampler.sample(seed)])
+    }
+
     #[cfg(feature = "rand")]
     pub fn sample_chunk_validators(
         &self,
@@ -721,4 +798,179 @@ pub struct EpochInfoV1 {
     /// Current protocol version during this epoch.
     #[default(PROTOCOL_VERSION)]
     pub protocol_version: ProtocolVersion,
+}
+
+#[cfg(test)]
+mod sample_excluding_tests {
+    use super::{EpochInfo, EpochInfoV1, EpochInfoV2, EpochInfoV3, EpochInfoV4, EpochInfoV5};
+    use crate::rand::StakeWeightedIndex;
+    use crate::shard_layout::ShardLayout;
+    use crate::types::validator_stake::ValidatorStake;
+    use crate::validator_mandates::ValidatorMandates;
+    use near_crypto::{KeyType, SecretKey};
+    use near_primitives_core::types::{Balance, BlockHeight, ShardId, ValidatorId};
+    use near_primitives_core::version::PROTOCOL_VERSION;
+    use std::collections::HashSet;
+
+    const SEED: [u8; 32] = [7; 32];
+
+    fn validators(stakes: &[u128]) -> Vec<ValidatorStake> {
+        stakes
+            .iter()
+            .enumerate()
+            .map(|(i, &s)| {
+                let account_id: crate::types::AccountId = format!("test{i}").parse().unwrap();
+                let public_key =
+                    SecretKey::from_seed(KeyType::ED25519, account_id.as_ref()).public_key();
+                ValidatorStake::new(account_id, public_key, Balance::from_yoctonear(s))
+            })
+            .collect()
+    }
+
+    /// Single-shard layout plus its shard id.
+    fn layout() -> (ShardLayout, ShardId) {
+        let layout = ShardLayout::single_shard();
+        let shard_id = layout.shard_ids().next().unwrap();
+        (layout, shard_id)
+    }
+
+    fn v1(settlement: Vec<ValidatorId>) -> EpochInfo {
+        EpochInfo::V1(EpochInfoV1 {
+            chunk_producers_settlement: vec![settlement],
+            ..Default::default()
+        })
+    }
+
+    fn v2(settlement: Vec<ValidatorId>) -> EpochInfo {
+        EpochInfo::V2(EpochInfoV2 {
+            chunk_producers_settlement: vec![settlement],
+            ..Default::default()
+        })
+    }
+
+    fn sampler(settlement: &[ValidatorId], vs: &[ValidatorStake]) -> StakeWeightedIndex {
+        StakeWeightedIndex::new(settlement.iter().map(|&id| vs[id as usize].stake()).collect())
+    }
+
+    fn v3(settlement: Vec<ValidatorId>, vs: Vec<ValidatorStake>) -> EpochInfo {
+        let cp_sampler = sampler(&settlement, &vs);
+        EpochInfo::V3(EpochInfoV3 {
+            validators: vs,
+            chunk_producers_settlement: vec![settlement],
+            rng_seed: SEED,
+            chunk_producers_sampler: vec![cp_sampler],
+            ..Default::default()
+        })
+    }
+
+    fn v4(settlement: Vec<ValidatorId>, vs: Vec<ValidatorStake>) -> EpochInfo {
+        let cp_sampler = sampler(&settlement, &vs);
+        EpochInfo::V4(EpochInfoV4 {
+            validators: vs,
+            chunk_producers_settlement: vec![settlement],
+            rng_seed: SEED,
+            chunk_producers_sampler: vec![cp_sampler],
+            ..Default::default()
+        })
+    }
+
+    fn v5(settlement: Vec<ValidatorId>, vs: Vec<ValidatorStake>) -> EpochInfo {
+        let cp_sampler = sampler(&settlement, &vs);
+        EpochInfo::V5(EpochInfoV5 {
+            epoch_height: 0,
+            validators: vs,
+            validator_to_index: Default::default(),
+            block_producers_settlement: vec![],
+            chunk_producers_settlement: vec![settlement],
+            stake_change: Default::default(),
+            validator_reward: Default::default(),
+            validator_kickout: Default::default(),
+            minted_amount: Balance::ZERO,
+            seat_price: Balance::ZERO,
+            protocol_version: PROTOCOL_VERSION,
+            shard_layout: ShardLayout::single_shard(),
+            last_resharding: None,
+            rng_seed: SEED,
+            block_producers_sampler: StakeWeightedIndex::default(),
+            chunk_producers_sampler: vec![cp_sampler],
+            validator_mandates: ValidatorMandates::default(),
+        })
+    }
+
+    /// For a two-producer settlement, excluding the default producer must yield the
+    /// single survivor (exact, seed-independent) across every EpochInfo variant.
+    #[test]
+    fn sample_chunk_producer_excluding_variants() {
+        let (sl, shard_id) = layout();
+        let height: BlockHeight = 1;
+        let stakes = [1_000_000u128, 3_000_000];
+        let vs = validators(&stakes);
+        let variants = [
+            v1(vec![0, 1]),
+            v2(vec![0, 1]),
+            v3(vec![0, 1], vs.clone()),
+            v4(vec![0, 1], vs.clone()),
+            v5(vec![0, 1], vs),
+        ];
+        for ei in variants {
+            let default = ei.sample_chunk_producer(&sl, shard_id, height).unwrap();
+            let exclude = HashSet::from([default]);
+            let survivor = if default == 0 { 1 } else { 0 };
+            assert_eq!(
+                ei.sample_chunk_producer_excluding(&sl, shard_id, height, &exclude),
+                Some(survivor),
+                "variant {ei:?} excluding default {default} should leave {survivor}",
+            );
+        }
+    }
+
+    /// Empty `exclude` must delegate to `sample_chunk_producer` (modulo + weighted).
+    #[test]
+    fn sample_chunk_producer_excluding_empty_delegates() {
+        let (sl, shard_id) = layout();
+        let vs = validators(&[1_000_000, 2_000_000, 3_000_000]);
+        let empty = HashSet::new();
+        for ei in [v2(vec![0, 1, 2]), v5(vec![0, 1, 2], vs)] {
+            for height in 0..10 {
+                assert_eq!(
+                    ei.sample_chunk_producer_excluding(&sl, shard_id, height, &empty),
+                    ei.sample_chunk_producer(&sl, shard_id, height),
+                );
+            }
+        }
+    }
+
+    /// Excluding every producer returns `None` (the caller's fallback signal).
+    #[test]
+    fn sample_chunk_producer_excluding_all_returns_none() {
+        let (sl, shard_id) = layout();
+        let vs = validators(&[1_000_000, 2_000_000]);
+        let exclude = HashSet::from([0, 1]);
+        for ei in [v1(vec![0, 1]), v5(vec![0, 1], vs)] {
+            assert_eq!(ei.sample_chunk_producer_excluding(&sl, shard_id, 3, &exclude), None);
+        }
+    }
+
+    /// Weighted path: deterministic across calls, and the survivor matches an
+    /// independently reconstructed renormalized distribution over the survivors.
+    #[test]
+    fn sample_chunk_producer_excluding_deterministic() {
+        let (sl, shard_id) = layout();
+        let stakes = [1_000_000u128, 2_000_000, 5_000_000];
+        let vs = validators(&stakes);
+        let ei = v5(vec![0, 1, 2], vs.clone());
+        let exclude = HashSet::from([0]);
+        let height: BlockHeight = 4;
+
+        let first = ei.sample_chunk_producer_excluding(&sl, shard_id, height, &exclude);
+        let second = ei.sample_chunk_producer_excluding(&sl, shard_id, height, &exclude);
+        assert_eq!(first, second);
+
+        // Independently rebuild the renormalized distribution over survivors [1, 2].
+        let survivors: Vec<ValidatorId> = vec![1, 2];
+        let survivor_stakes = survivors.iter().map(|&id| vs[id as usize].stake()).collect();
+        let expected_index = StakeWeightedIndex::new(survivor_stakes)
+            .sample(EpochInfo::chunk_produce_seed(&SEED, height, shard_id));
+        assert_eq!(first, Some(survivors[expected_index]));
+    }
 }

--- a/core/primitives/src/epoch_info.rs
+++ b/core/primitives/src/epoch_info.rs
@@ -648,7 +648,10 @@ impl EpochInfo {
     ) -> Option<ValidatorId> {
         let filtered: Vec<ValidatorId> =
             settlement.iter().copied().filter(|id| !exclude.contains(id)).collect();
-        (!filtered.is_empty()).then(|| filtered[(height % filtered.len() as u64) as usize])
+        if filtered.is_empty() {
+            return None;
+        }
+        Some(filtered[(height % filtered.len() as u64) as usize])
     }
 
     /// Filter `settlement` by `exclude`, then pick via a fresh stake-weighted


### PR DESCRIPTION
## KEYSTONE — activates early-kickout consensus behavior (nightly). Review the diff carefully before merge.

Makes the `DBCol::ChunkProducers` writer blacklist-aware so it stores the reassigned (non-kicked) producer. Writer-only: the aggregator and reader already consume the stored row unchanged.

## Base / stacking
Branched from `master` with #15841's ADDITIVE blacklist math cherry-picked on top (3 commits: `compute_chunk_producer_blacklist`, `sample_chunk_producer_excluding`, the accessor + tests). Does NOT pull #15841's stale pre-#15944 writer. Carries #15841's math until #15841 lands on master, then this retargets. The last commit (`07e2a264c`) is the only net-new change; the rest is #15841.

## The change (writer only)
`seed_chunk_producers` now samples via `sample_chunk_producer_excluding(blacklist)`. The blacklist is computed by a shared `EpochManager::chunk_producer_blacklist_at(anchor)` that BOTH the writer and the read accessor `get_chunk_producer_blacklist` route through, so their stats window and epoch-boundary guard cannot diverge.

## Determinism (consensus-critical; settled via a Claude+Codex debate)
The window is anchor-keyed: `get_epoch_info_aggregator_upto_last(block_hash)` — a deterministic pure function of the anchor's committed chain. It is NOT the mutable running `self.epoch_info_aggregator` (whose advance is gated on a finality gain, so it would be stale/undefined per-anchor and could fork). The seeder is not reordered relative to the conditional aggregator advance. Empty blacklist at: epoch boundary (`aggregator.epoch_id != anchor epoch` -> own-epoch ids never filter next-epoch settlement), genesis, epoch-sync first block (provably below the 50-observation guard), and feature-off (byte-identical when disabled; `sample_chunk_producer_excluding(&empty) == sample_chunk_producer`).

## Aggregator untouched
It already reads `DBCol::ChunkProducers` and credits the stored producer (`update_tail`), so once the writer stores the adjusted producer, kickout-stat attribution follows for free — no aggregator edit, no forward-recompute.

## Tests
`cargo test -p near-epoch-manager --features nightly -- early_kickout` -> 13 passed, 0 failed. Full nightly 119/0, stable 114/0. `cargo fmt` clean. New tests: anti-flap (blacklisted producer stays out, no flap-back), empty-blacklist == plain sampler, feature-off == plain sampler.

## Perf note
With the feature ON, each block record runs one `get_epoch_info_aggregator_upto_last(block_hash)` traversal (last-final -> tip, O(finality lag), bounded). This relaxed an exact-loop-count assertion in `test_finalize_epoch_large_epoch_length` to the feature-off case (the core incremental aggregator is unchanged). Candidate for caching later.

Codex adversarial gate: SOUND (determinism, cross-epoch id-space, feature-off, aggregator-untouched, epoch-sync all verified). Draft: do not merge before #15841 (and #15932 for real activation).