### PR TITLE
feat(early-kickout): add slot_reassigned_total rollout metric

### DIFF
--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -2181,6 +2181,7 @@ impl EpochManager {
             if !ProtocolFeature::EarlyKickout.enabled(own_epoch_info.protocol_version()) {
                 return Ok(());
             }
+            use crate::metrics::EARLY_KICKOUT_SLOT_REASSIGNED;
             // Blacklist from the anchor's committed chain, via the same helper the
             // read accessor uses so the stored producer matches what the reader
             // would resolve. Empty at an epoch boundary (own epoch != sample
@@ -2191,12 +2192,35 @@ impl EpochManager {
             let height = block_height + CHUNK_GRANDPARENT_ANCHOR_HEIGHT_OFFSET;
             for shard_id in sample_shard_layout.shard_ids() {
                 let exclude = blacklist.get(&shard_id).unwrap_or(&empty);
-                if let Some(validator_id) = sample_epoch_info.sample_chunk_producer_excluding(
+                let stored = sample_epoch_info.sample_chunk_producer_excluding(
                     sample_shard_layout,
                     shard_id,
                     height,
                     exclude,
-                ) {
+                );
+                if let Some(validator_id) = stored {
+                    // Rollout signal: count this seeded write when the blacklist
+                    // actually moved the slot, i.e. the stored producer differs from
+                    // what plain sampling would have chosen. Skipped when `exclude` is
+                    // empty because `sample_chunk_producer_excluding` then returns the
+                    // plain sample verbatim (no move possible, and the extra sample
+                    // call would be redundant). On the full-exclusion valve edge the
+                    // excluding sampler returns `None`, so no row is written and no
+                    // reassignment is counted. Both samples come from
+                    // `sample_epoch_info`, so comparing `ValidatorId`s compares
+                    // producer identity.
+                    if !exclude.is_empty()
+                        && stored
+                            != sample_epoch_info.sample_chunk_producer(
+                                sample_shard_layout,
+                                shard_id,
+                                height,
+                            )
+                    {
+                        EARLY_KICKOUT_SLOT_REASSIGNED
+                            .with_label_values(&[&shard_id.to_string()])
+                            .inc();
+                    }
                     let validator_stake = sample_epoch_info.get_validator(validator_id);
                     store_update.set_chunk_producer(block_hash, shard_id, &validator_stake);
                 }

--- a/chain/epoch-manager/src/metrics.rs
+++ b/chain/epoch-manager/src/metrics.rs
@@ -39,3 +39,16 @@ pub(crate) static RESHARDING_ASSIGNMENT_STRATEGY: LazyLock<IntCounterVec> = Lazy
     )
     .unwrap()
 });
+
+// Only the early-kickout seeding path touches this counter, and that path is
+// nightly-only; gate the static so non-nightly builds don't carry a dead symbol.
+#[cfg(feature = "nightly")]
+pub(crate) static EARLY_KICKOUT_SLOT_REASSIGNED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_early_kickout_slot_reassigned_total",
+        "Number of seeded chunk-producer rows where the early-kickout blacklist moved the \
+         slot to a different producer than plain sampling would have chosen",
+        &["shard_id"],
+    )
+    .unwrap()
+});

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -17,6 +17,9 @@ use near_primitives::types::{Balance, ChunkStats, ShardId, ValidatorId};
 use near_primitives::version::PROTOCOL_VERSION;
 use std::collections::{HashMap, HashSet};
 
+#[cfg(feature = "nightly")]
+use crate::metrics::EARLY_KICKOUT_SLOT_REASSIGNED;
+
 const STAKE: Balance = Balance::from_yoctonear(1_000_000);
 
 /// Builds a single-shard `EpochInfo` with `num_producers` chunk producers (ids
@@ -483,4 +486,144 @@ fn feature_off_resolved_producer_matches_plain_sampler() {
             "feature-off resolver must match plain sampler at height {height}"
         );
     }
+}
+
+// --- Metric test: `near_early_kickout_slot_reassigned_total` counts seeded writes the
+// blacklist actually moved, once per write, bounded to the `shard_id` label. ---
+
+/// Reads the process-global reassignment counter for one shard.
+#[cfg(feature = "nightly")]
+fn slot_reassigned_total(shard_id: ShardId) -> u64 {
+    EARLY_KICKOUT_SLOT_REASSIGNED.with_label_values(&[&shard_id.to_string()]).get()
+}
+
+/// Multi-shard variant of `drive_anchored_misses`: records heights `start..=end`,
+/// missing only `target_shard`'s chunk and only when its *resolved* (seeded)
+/// producer is `target`; every other shard always produces. So `target` accrues
+/// misses solely on `target_shard`, which is the only shard that blacklists. The
+/// aggregator credits the resolved producer, so once `target` is excluded its stats
+/// freeze (anti-flap), keeping the blacklist stable. `hashes[i]` is the block at
+/// height `i`; genesis (`hashes[0]`) must already be recorded.
+#[cfg(feature = "nightly")]
+fn drive_anchored_misses_on_shard(
+    handle: &EpochManagerHandle,
+    hashes: &[CryptoHash],
+    start: u64,
+    end: u64,
+    target: ValidatorId,
+    target_shard: ShardId,
+) {
+    let epoch_id = handle.get_epoch_id(&hashes[0]).unwrap();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let target_account =
+        handle.get_epoch_info(&epoch_id).unwrap().get_validator(target).account_id().clone();
+    for height in start..=end {
+        let prev = hashes[(height - 1) as usize];
+        let mask: Vec<bool> = layout
+            .shard_ids()
+            .map(|sid| {
+                if sid != target_shard {
+                    return true;
+                }
+                let resolved = handle.get_chunk_producer_info_from_prev_block(&prev, sid).unwrap();
+                resolved.account_id() != &target_account
+            })
+            .collect();
+        record_block_with_mask(&mut handle.write(), prev, hashes[height as usize], height, mask);
+    }
+}
+
+// 15. Rollout metric: with a producer blacklisted on one shard, the counter for that
+//     shard increments exactly once per seeded write that the blacklist actually
+//     moved (stored producer != plain sampler), and a healthy shard never increments.
+//     Isolated on non-zero shard labels so the process-global counter is not shared
+//     with the single-shard writer tests above (which only touch shard 0).
+#[cfg(feature = "nightly")]
+#[test]
+fn slot_reassigned_metric_counts_reassignments() {
+    let validators: Vec<_> = (0..6).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
+    let handle = setup_default_epoch_manager(validators, 10_000, 3, 3, 90, 60).into_handle();
+    let count = 160u64;
+
+    let h: Vec<CryptoHash> = (0..=count).map(|i| hash(&i.to_le_bytes())).collect();
+    record_block(&mut handle.write(), CryptoHash::default(), h[0], 0, vec![]);
+
+    let epoch_id = handle.get_epoch_id(&h[0]).unwrap();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
+
+    // Pick a shard to reassign and a shard to keep healthy, both non-zero so their
+    // counters are never shared with the single-shard tests. The target shard needs
+    // >= 2 distinct producers (else the safety valve vetoes blacklisting); the target
+    // validator is one of its producers so it accrues misses there.
+    let distinct = |s: ShardId| -> HashSet<ValidatorId> {
+        let idx = layout.get_shard_index(s).unwrap();
+        epoch_info.chunk_producers_settlement()[idx].iter().copied().collect()
+    };
+    let non_zero: Vec<ShardId> = layout.shard_ids().filter(|s| *s != ShardId::new(0)).collect();
+    let target_shard = *non_zero
+        .iter()
+        .find(|&&s| distinct(s).len() >= 2)
+        .expect("need a non-zero shard with >=2 producers");
+    let target: ValidatorId = *distinct(target_shard).iter().min().unwrap();
+    let healthy_shard =
+        *non_zero.iter().find(|&&s| s != target_shard).expect("need a second non-zero shard");
+
+    // Captured after genesis: genesis seeds chunk height 2 with an empty blacklist, so
+    // it can never reassign and is excluded from both the window and the oracle below.
+    let before_target = slot_reassigned_total(target_shard);
+    let before_healthy = slot_reassigned_total(healthy_shard);
+
+    // Phase 1 records h[1..=count-2], seeding chunk heights 3..=count. The window
+    // `mid - before` therefore matches the seeded rows we can read back (each needs its
+    // child block, recorded in phase 2).
+    drive_anchored_misses_on_shard(&handle, &h, 1, count - 2, target, target_shard);
+    let mid_target = slot_reassigned_total(target_shard);
+    let mid_healthy = slot_reassigned_total(healthy_shard);
+    // Phase 2 records the tail so anchor h[count-2]'s row is readable via child h[count-1].
+    drive_anchored_misses_on_shard(&handle, &h, count - 1, count, target, target_shard);
+
+    // The target is blacklisted on its shard; the healthy shard never is.
+    let bl = handle.get_chunk_producer_blacklist(&h[(count - 2) as usize]).unwrap();
+    assert_eq!(
+        bl.get(&target_shard),
+        Some(&HashSet::from([target])),
+        "target must be blacklisted on the target shard, got {bl:?}"
+    );
+    assert!(bl.get(&healthy_shard).is_none(), "healthy shard must not be blacklisted, got {bl:?}");
+
+    // Independent oracle over the readable seed writes (chunk heights 3..=count, anchors
+    // h[1..=count-2]): a write reassigned iff the actually-stored producer differs from
+    // the plain sampler. The healthy shard must equal the plain sampler everywhere.
+    let mut reassigned = 0u64;
+    for hh in 3..=count {
+        let child = &h[(hh - 1) as usize];
+
+        let plain = epoch_info.sample_chunk_producer(&layout, target_shard, hh).unwrap();
+        let stored = handle.get_chunk_producer_info_from_prev_block(child, target_shard).unwrap();
+        if stored.account_id() != epoch_info.get_validator(plain).account_id() {
+            reassigned += 1;
+        }
+
+        let plain_h = epoch_info.sample_chunk_producer(&layout, healthy_shard, hh).unwrap();
+        let stored_h =
+            handle.get_chunk_producer_info_from_prev_block(child, healthy_shard).unwrap();
+        assert_eq!(
+            stored_h.account_id(),
+            epoch_info.get_validator(plain_h).account_id(),
+            "healthy shard seed must match plain sampler at height {hh}"
+        );
+    }
+
+    assert!(reassigned >= 1, "scenario must drive at least one reassignment");
+    assert_eq!(
+        mid_target - before_target,
+        reassigned,
+        "reassigned counter must equal the moved seed writes on the target shard"
+    );
+    assert_eq!(
+        mid_healthy - before_healthy,
+        0,
+        "healthy shard counter must not increment when nothing is reassigned"
+    );
 }


### PR DESCRIPTION
Stacked on Task 1 (#16038, branch `stedfn/early-kickout/enable-writer-blacklist`).

## What
Adds `near_early_kickout_slot_reassigned_total{shard_id}` counter (metrics.rs), `.inc()` once per seeded `ChunkProducers` write where the blacklist actually moved the slot: the blacklist-adjusted `sample_chunk_producer_excluding` differs from the plain `sample_chunk_producer` for that shard/height. This is THE rollout signal for kickout: how often a slot is actually reassigned.

- Emitted only at the seed write (`seed_chunk_producers`), never from the aggregator walk.
- Label cardinality bounded to `shard_id`.
- Gated on the nightly + EarlyKickout path; feature-off byte-identical.
- Full-exclusion valve edge: increment only inside `if let Some(stored)`, so no spurious count.

## Tests
`cargo test -p near-epoch-manager --features nightly -- early_kickout` -> 14 passed, 0 failed. `slot_reassigned_metric_counts_reassignments` drives a real reassignment and asserts the counter delta is exactly 1 for the reassigned shard and 0 for a healthy shard. Stable 11/0. `cargo fmt` clean.

Codex adversarial gate: SOUND. Draft: base is Task 1's branch; do not merge before #16038 (and #15841).