### PR TITLE
chore(deps): remove outdated exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,7 +428,5 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.hashbrown]
 opt-level = 3
-[profile.dev.package.dynasmrt]
-opt-level = 3
 [profile.dev.package."*"]
 opt-level = 1

--- a/cspell.json
+++ b/cspell.json
@@ -133,7 +133,6 @@
         "doomslugs",
         "dryrun",
         "dynasm",
-        "dynasmrt",
         "ellipsifies",
         "ellipsify",
         "Errno",

--- a/deny.toml
+++ b/deny.toml
@@ -36,11 +36,9 @@ deny = [
 skip = [
     # wasmer and wasmtime
     { name = "memoffset", version = "=0.6.5" },
-    { name = "memoffset", version = "=0.8.0" },
     { name = "finite-wasm", version = "^0.5" },
 
     # wasm-tools
-    { name = "wasmparser", version = "=0.99.0" },
     { name = "wasmparser", version = "=0.105.0" },
     { name = "wasmparser", version = "=0.228.0" },
     { name = "wasmparser", version = "=0.236.1" },
@@ -64,9 +62,6 @@ skip = [
     { name = "rand_core", version = "<0.9" },
     { name = "rand_chacha", version = "<0.9" },
     { name = "getrandom", version = "^0.2" },
-
-    # criterion, rocksdb depend on this older version of the crate.
-    { name = "rustc-hash", version = "<2" },
 
     # bindgen (build-dep of librocksdb-sys) pulls an older itertools.
     { name = "itertools", version = "<0.14" },

--- a/deny.toml
+++ b/deny.toml
@@ -49,9 +49,6 @@ skip = [
     { name = "wasmprinter", version = "=0.2.57" },
     { name = "wasmprinter", version = "=0.236.1" },
 
-    # wasmer 0.17.x
-    { name = "target-lexicon", version = "^0.12.0" },
-
     # many crates haven't updated to syn 2.0 yet.
     { name = "syn", version = "=1.0.103" },
     { name = "heck", version = "=0.4.0" },
@@ -125,8 +122,6 @@ skip = [
     # rust-s3 brings in older versions of these via minidom/rxml/attohttpc
     { name = "quick-xml", version = "^0.32" },
     { name = "quick-xml", version = "^0.36" },
-    { name = "windows-registry", version = "^0.4" },
-    { name = "windows-strings", version = "^0.3" },
 
     # ring and rustls pull in untrusted 0.7; aws-lc-rs (and other newer crates)
     # pull in untrusted 0.9. Both are tiny and serve the same purpose; the
@@ -137,10 +132,6 @@ skip = [
     # okApi uses mostly schemars 0.8 for now, though it's not necessary
     { name = "schemars", version = "^0.8" },
     { name = "schemars_derive", version = "^0.8" },
-
-    # Bolero depends on outdated versions of these
-    { name = "gimli", version = "=0.31.1" },
-    { name = "object", version = "=0.36.5" },
 
     { name = "bytesize", version = "=1.1.0" },
     { name = "num-bigint", version = "=0.3.3" },


### PR DESCRIPTION
Following the removal of NearVm from the code base, a bunch of excpetion in dependencies are no longer needed.