### PR TITLE
chore(vm): remove old wasmparser version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5093,7 +5093,6 @@ dependencies = [
  "wasm-encoder 0.236.0",
  "wasm-smith",
  "wasmparser 0.236.1",
- "wasmparser 0.78.2",
  "wasmprinter 0.236.1",
  "wasmtime",
  "wat",
@@ -8716,12 +8715,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
-
-[[package]]
-name = "wasmparser"
-version = "0.78.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,8 +366,7 @@ url = "2.5.0"
 utoipa = "5.4"
 utoipa-swagger-ui = {version = "9", features = ["vendored"]}
 wasm-encoder = "0.236"
-wasmparser = "0.78" # TODO: unify at least the versions of wasmparser we have in our codebase
-wasmparser-236 = { package = "wasmparser", version = "0.236" }
+wasmparser-236 = { package = "wasmparser", version = "0.236" } # Exact version must not change without protocol change.
 wasmprinter = "0.236"
 wasm-smith = "0.236"
 wasmtime = { version = "45.0.0", default-features = false, features = [

--- a/deny.toml
+++ b/deny.toml
@@ -40,7 +40,6 @@ skip = [
     { name = "finite-wasm", version = "^0.5" },
 
     # wasm-tools
-    { name = "wasmparser", version = "=0.78.2" },
     { name = "wasmparser", version = "=0.99.0" },
     { name = "wasmparser", version = "=0.105.0" },
     { name = "wasmparser", version = "=0.228.0" },

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -40,7 +40,6 @@ tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 wasm-encoder = { workspace = true, features = ["wasmparser"], optional = true }
-wasmparser = { workspace = true, optional = true }
 wasmparser-236 = { workspace = true, optional = true }
 wasmtime = { workspace = true, features = [
     "call-hook",
@@ -83,7 +82,6 @@ prepare = [
     "finite-wasm",
     "finite-wasm-6",
     "wasm-encoder",
-    "wasmparser",
     "wasmparser-236",
     "prefix-sum-vec",
     "metrics",

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -52,6 +52,4 @@ pub(crate) const EXPORT_PREFIX: &str = "\0";
 #[doc(hidden)]
 pub mod internal {
     pub use crate::runner::VMKindExt;
-    #[cfg(feature = "prepare")]
-    pub use wasmparser;
 }


### PR DESCRIPTION
wasmparser v0.78 is no longer needed, as the protocol versions that depend on it are no longer supported.

This finally gets rid of the compilation warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: wasmparser v0.78.2
```

Redis v0.23.0 still triggers the same warning but that should be much easier to update.