### PR TITLE
doc: document view_state pagination fields

### DIFF
--- a/chain/jsonrpc-primitives/src/types/view_state.rs
+++ b/chain/jsonrpc-primitives/src/types/view_state.rs
@@ -10,8 +10,10 @@ pub struct RpcViewStateRequest {
     pub prefix: near_primitives::types::StoreKey,
     #[serde(default)]
     pub include_proof: bool,
+    /// Resume listing after this key (exclusive); must start with `prefix`.
     #[serde(default, rename = "after_key_base64")]
     pub after_key: Option<near_primitives::types::StoreKey>,
+    /// Maximum number of entries to return in this page.
     #[serde(default)]
     pub limit: Option<NonZeroU32>,
 }

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -19291,7 +19291,8 @@
                 "nullable": true
               }
             ],
-            "default": null
+            "default": null,
+            "description": "Resume listing after this key (exclusive); must start with `prefix`."
           },
           "include_proof": {
             "default": false,
@@ -19299,6 +19300,7 @@
           },
           "limit": {
             "default": null,
+            "description": "Maximum number of entries to return in this page.",
             "format": "uint32",
             "minimum": 1,
             "nullable": true,
@@ -19337,7 +19339,8 @@
                 ],
                 "nullable": true
               }
-            ]
+            ],
+            "description": "Cursor to resume from: present when more entries remain, absent when the listing is complete."
           },
           "proof": {
             "items": {
@@ -21534,7 +21537,8 @@
                 ],
                 "nullable": true
               }
-            ]
+            ],
+            "description": "Cursor to resume from: present when more entries remain, absent when the listing is complete."
           },
           "proof": {
             "items": {

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -10303,6 +10303,7 @@
               },
               "after_key_base64": {
                 "default": null,
+                "description": "Resume listing after this key (exclusive); must start with `prefix`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/StoreKey"
@@ -10321,6 +10322,7 @@
               },
               "limit": {
                 "default": null,
+                "description": "Maximum number of entries to return in this page.",
                 "format": "uint32",
                 "minimum": 1,
                 "type": [
@@ -10347,6 +10349,7 @@
               },
               "after_key_base64": {
                 "default": null,
+                "description": "Resume listing after this key (exclusive); must start with `prefix`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/StoreKey"
@@ -10365,6 +10368,7 @@
               },
               "limit": {
                 "default": null,
+                "description": "Maximum number of entries to return in this page.",
                 "format": "uint32",
                 "minimum": 1,
                 "type": [
@@ -10391,6 +10395,7 @@
               },
               "after_key_base64": {
                 "default": null,
+                "description": "Resume listing after this key (exclusive); must start with `prefix`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/StoreKey"
@@ -10406,6 +10411,7 @@
               },
               "limit": {
                 "default": null,
+                "description": "Maximum number of entries to return in this page.",
                 "format": "uint32",
                 "minimum": 1,
                 "type": [
@@ -10444,6 +10450,7 @@
             "type": "integer"
           },
           "last_key": {
+            "description": "Cursor to resume from: present when more entries remain, absent when the listing is complete.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/StoreKey"
@@ -13999,6 +14006,7 @@
           "required": false,
           "schema": {
             "default": null,
+            "description": "Resume listing after this key (exclusive); must start with `prefix`.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/StoreKey"
@@ -14036,6 +14044,7 @@
           "required": false,
           "schema": {
             "default": null,
+            "description": "Maximum number of entries to return in this page.",
             "format": "uint32",
             "minimum": 1,
             "type": [

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -281,6 +281,7 @@ pub struct ViewStateResult {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[cfg_attr(feature = "schemars", schemars(with = "Vec<String>"))]
     pub proof: Vec<Arc<[u8]>>,
+    /// Cursor to resume from: present when more entries remain, absent when the listing is complete.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_key: Option<StoreKey>,
 }


### PR DESCRIPTION
RpcViewStateRequest::{after_key, limit} and ViewStateResult::last_key shipped without doc comments, so schemars leaves their OpenAPI/OpenRPC descriptions empty. Add terse docs and regenerate the specs.

Addresses #16069