### PR TITLE
fix(testloop): combine conditional ignore predicates

### DIFF
--- a/test-loop-tests/src/tests/resharding_v3.rs
+++ b/test-loop-tests/src/tests/resharding_v3.rs
@@ -1860,9 +1860,8 @@ fn slow_test_resharding_v3_yield_resume() {
 
 #[test]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
-#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 // See `slow_test_resharding_v3_yield_resume` for the non-x86_64 caveat.
-#[cfg_attr(not(target_arch = "x86_64"), ignore)]
+#[cfg_attr(any(feature = "protocol_feature_spice", not(target_arch = "x86_64")), ignore)]
 fn slow_test_resharding_v3_yield_resume_with_id() {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();


### PR DESCRIPTION
## Why this small fix exists

While validating query-only JSON-RPC batching on an Apple M4 Pro Mac mini, the required repository-wide check

    RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets

failed in an unrelated test-loop test. slow_test_resharding_v3_yield_resume_with_id had two independent conditional ignore attributes: one for Spice and one for non-x86_64 targets. On Apple Silicon with all features enabled, both conditions were true, so Rust saw two #[ignore] attributes on the same test and emitted a warning promoted to an error.

That left the batching work in an awkward state: its focused and complete JSON-RPC tests could pass, and its binary could run successfully on a fully synced testnet RPC node, but the branch could not honestly clear nearcore's full clippy gate.

## What changes

This combines the two predicates into one conditional ignore:

    #[cfg_attr(any(feature = "protocol_feature_spice", not(target_arch = "x86_64")), ignore)]

The test remains ignored whenever either original condition applies. Its runtime behavior, test body, and behavior on x86_64 non-Spice builds are unchanged.

## How this relates to JSON-RPC batching

This PR does not implement batching and does not close #10528. It removes the unrelated Apple Silicon validation blocker so the forthcoming query-only batching PR can remain focused, rebase onto clean master, and pass the exact all-features/all-targets clippy command required before review.

The batching PR will carry the actual JSON-RPC protocol changes, safety limits, raw HTTP and sharded-routing coverage, documentation, and the localnet and fully synced testnet evidence. Keeping those changes separate makes both reviews smaller and clearer.

Related batching request: https://github.com/near/nearcore/issues/10528

## Validation

- focused test discovery completed successfully, with the conditionally ignored test reported once
- cargo fmt and git diff --check passed
- RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets passed on native arm64 Apple Silicon
