### PR TITLE
chore(ci): post Claude PR review inline and add tunable REVIEW.md

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -66,51 +66,38 @@ PRIORITY CHECKS (report only if found):
    - Enforce all standards defined in [engineering-standards.md] (paraphrasing of code, repetitions, explaining common terminology, leaking context, explanation that should be a stand-alone issue)
 
 REVIEW STYLE:
-- Post each finding as an INLINE comment on the exact line it concerns (see HOW TO POST), not as one big top-level comment.
-- Keep each comment to 1–3 sentences. Prefer a probing question over an assertion, and include a concrete suggested fix or a ```suggestion``` block where it helps.
-- Report only issues worth the author's attention. Prefer fewer, higher-signal comments over volume.
+- Each finding becomes an INLINE comment on the exact line it concerns — so anchor every finding to a precise `path` + `line` (see OUTPUT), never one big top-level comment.
+- Keep each finding to 1–3 sentences. Prefer a probing question over an assertion, and include a concrete suggested fix or a ```suggestion``` block where it helps.
+- Report only issues worth the author's attention. Prefer fewer, higher-signal findings over volume.
 - Do NOT comment on anything CI already enforces (rustfmt, clippy, cspell), and do NOT restate what the diff shows.
 - The `<review_overrides>` block (REVIEW.md) defines repo-specific severity, what to skip, and the expected comment voice — it takes precedence over this file.
 
-HOW TO POST:
+OUTPUT:
 
-Post findings as inline review comments, one `gh api` call per finding. Do NOT
-use `gh pr review`: it can only post a top-level body plus an approve / request-
-changes / comment verdict — it cannot attach line-level comments — and the bot
-should not be approving or requesting changes anyway. The values `REPO`
-(`owner/name`), `PR NUMBER`, and `HEAD SHA` are given in `<pr_context>`
-(locally, resolve the SHA with `gh pr view <number> --json headRefOid --jq
-.headRefOid`).
+You have READ-ONLY tools. Do NOT attempt to post, comment, approve, or mutate
+anything — you have no tools to do so, and any such attempt will simply fail. A
+trusted workflow step posts your review from the structured output you return,
+so your only job is to return that output, validated against the enforced JSON
+schema:
 
-For each finding, anchor it to the changed line:
+- `findings`: an array, one entry per inline comment, each with:
+  - `path`: repo-relative file path (must be a file changed in the diff)
+  - `line`: the line in the PR's version of the file the comment anchors to
+  - `side`: `"RIGHT"` for added/context lines (default), `"LEFT"` only for a removed line
+  - `severity`: `"blocking"` or `"nit"`
+  - `body`: the comment text in the REVIEW.md voice. Do NOT prefix it with
+    `nit:`/`blocking` — the poster adds that. A ```suggestion``` block is fine;
+    if you include one, make sure it is valid Rust (balanced braces, correct
+    syntax) — a broken suggestion is worse than a prose comment.
+- `summary`: the single summary-comment text — per REVIEW.md "Summary shape":
+  one-line tally first, at most one sentence of context, ending with ✅ or ⚠️.
+  Do NOT reproduce the findings here; they are posted inline.
+- `verdict`: `"approve"` if nothing blocks the merge, else `"issues"`.
 
-```
-gh api --method POST \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  /repos/OWNER/REPO/pulls/PR_NUMBER/comments \
-  -f 'body=<one finding; prefix blocking ones with **blocking**, minor ones with nit:>' \
-  -f 'commit_id=HEAD_SHA' \
-  -f 'path=path/to/file.rs' \
-  -F 'line=LINE' \
-  -f 'side=RIGHT'
-```
-
-For a range, add `-F 'start_line=START' -f 'start_side=RIGHT'`. If a `line` is
-outside the diff the call fails — fall back to including that finding in the
-summary comment. If you include a suggested fix in a ```suggestion``` block,
-make sure it is valid Rust (balanced braces, correct syntax) — a broken
-suggestion is worse than a prose comment.
-
-SUMMARY:
-
-After the inline findings, post ONE top-level summary with `gh pr comment <number> --body '...'`:
-- Open with a one-line tally, e.g. `2 blocking, 3 nits` or `No blocking issues`.
-- Optionally one sentence on what the PR does, only if it helps the reader.
-- End with ✅ (nothing blocks merge) or ⚠️ (at least one blocking finding).
-- Do NOT reproduce the inline findings here — they are already on the lines.
-
-If the code is clean, skip inline comments and post only the summary: `lgtm ✅`.
+Anchor every finding to a real `file:line` you verified in the checked-out code;
+a `line` outside the diff will be dropped by the poster. If the code is clean,
+return an empty `findings` array, `summary` of `"lgtm ✅"`, and `verdict` of
+`"approve"`.
 
 Consult the repository's [CLAUDE.md], [CONTRIBUTING.md], and [AGENTS.md] for project-specific conventions.
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -75,10 +75,12 @@ REVIEW STYLE:
 HOW TO POST:
 
 Post findings as inline review comments, one `gh api` call per finding. Do NOT
-use `gh pr review` — the workflow token cannot approve or request changes. The
-values `REPO` (`owner/name`), `PR NUMBER`, and `HEAD SHA` are given in
-`<pr_context>` (locally, resolve the SHA with
-`gh pr view <number> --json headRefOid --jq .headRefOid`).
+use `gh pr review`: it can only post a top-level body plus an approve / request-
+changes / comment verdict — it cannot attach line-level comments — and the bot
+should not be approving or requesting changes anyway. The values `REPO`
+(`owner/name`), `PR NUMBER`, and `HEAD SHA` are given in `<pr_context>`
+(locally, resolve the SHA with `gh pr view <number> --json headRefOid --jq
+.headRefOid`).
 
 For each finding, anchor it to the changed line:
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -15,6 +15,7 @@ You are reviewing a Rust pull request. Produce a thorough, actionable review usi
 - If a PR number was given, use it; otherwise resolve the PR for the current branch with `gh pr view`.
 - Get the full diff with `gh pr diff <number>` and PR metadata with `gh pr view <number>`.
 - Review existing PR comments and discussions before giving feedback (`gh pr view <number> --comments`). When running in CI, existing discussions are provided inline alongside this rubric — read them there instead.
+- Read `REVIEW.md` at the repo root if present; its rules take precedence over this rubric. In CI it is provided inline as the `<review_overrides>` block.
 
 **IMPORTANT - CONTEXT AWARENESS:**
 - Do not duplicate points already raised in existing discussions
@@ -65,59 +66,51 @@ PRIORITY CHECKS (report only if found):
    - Enforce all standards defined in [engineering-standards.md] (paraphrasing of code, repetitions, explaining common terminology, leaking context, explanation that should be a stand-alone issue)
 
 REVIEW STYLE:
-- List only issues that should block the merge
-- Use bullet points, be direct and specific
-- Provide code suggestions for fixes when helpful
-- Flag code-comment quality issues per [engineering-standards.md]. The goal is to avoid comments that may become stale or add little value to the reader.
-- Do NOT comment on style, formatting, or naming unless it causes a bug.
-- Do NOT restate what the diff already shows
-- If no critical issues found: approve with a one-line summary
-- Sign off with: ✅ (approved) or ⚠️ (issues found)
+- Post each finding as an INLINE comment on the exact line it concerns (see HOW TO POST), not as one big top-level comment.
+- Keep each comment to 1–3 sentences. Prefer a probing question over an assertion, and include a concrete suggested fix or a ```suggestion``` block where it helps.
+- Report only issues worth the author's attention. Prefer fewer, higher-signal comments over volume.
+- Do NOT comment on anything CI already enforces (rustfmt, clippy, cspell), and do NOT restate what the diff shows.
+- The `<review_overrides>` block (REVIEW.md) defines repo-specific severity, what to skip, and the expected comment voice — it takes precedence over this file.
 
-REQUIRED OUTPUT STRUCTURE:
+HOW TO POST:
 
-The review body must follow this layout:
+Post findings as inline review comments, one `gh api` call per finding. Do NOT
+use `gh pr review` — the workflow token cannot approve or request changes. The
+values `REPO` (`owner/name`), `PR NUMBER`, and `HEAD SHA` are given in
+`<pr_context>` (locally, resolve the SHA with
+`gh pr view <number> --json headRefOid --jq .headRefOid`).
+
+For each finding, anchor it to the changed line:
 
 ```
-## Pull request overview
-
-<2–4 sentence narrative summary of what this PR does and why.>
-
-**Changes:**
-- <bullet list of substantive changes — group related edits>
-
-### Reviewed changes
-
-<details>
-<summary>Per-file summary</summary>
-
-| File | Description |
-| ---- | ----------- |
-| path/to/file.rs | What changed in this file |
-| ... | ... |
-
-</details>
-
-### Findings
-
-**Blocking** (must fix before merge):
-- `path/to/file.rs:LINE` — <description and concrete suggested fix>
-
-**Non-blocking** (nits, follow-ups, suggestions):
-- `path/to/file.rs:LINE` — <description>
-
-<Omit a category if empty.>
-
-<End with one of:>
-✅ Approved
-⚠️ Issues found
+gh api --method POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  /repos/OWNER/REPO/pulls/PR_NUMBER/comments \
+  -f 'body=<one finding; prefix blocking ones with **blocking**, minor ones with nit:>' \
+  -f 'commit_id=HEAD_SHA' \
+  -f 'path=path/to/file.rs' \
+  -F 'line=LINE' \
+  -f 'side=RIGHT'
 ```
 
-Anchor every finding with a `file:line` reference so reviewers can jump to the location.
+For a range, add `-F 'start_line=START' -f 'start_side=RIGHT'`. If a `line` is
+outside the diff the call fails — fall back to including that finding in the
+summary comment. If you include a suggested fix in a ```suggestion``` block,
+make sure it is valid Rust (balanced braces, correct syntax) — a broken
+suggestion is worse than a prose comment.
+
+SUMMARY:
+
+After the inline findings, post ONE top-level summary with `gh pr comment <number> --body '...'`:
+- Open with a one-line tally, e.g. `2 blocking, 3 nits` or `No blocking issues`.
+- Optionally one sentence on what the PR does, only if it helps the reader.
+- End with ✅ (nothing blocks merge) or ⚠️ (at least one blocking finding).
+- Do NOT reproduce the inline findings here — they are already on the lines.
+
+If the code is clean, skip inline comments and post only the summary: `lgtm ✅`.
 
 Consult the repository's [CLAUDE.md], [CONTRIBUTING.md], and [AGENTS.md] for project-specific conventions.
-Don't try to use `gh pr review` you don't have permissions for that and it will fail.
-Please always use `gh pr comment` to post your review instead.
 
 [CLAUDE.md]: ../../../CLAUDE.md
 [AGENTS.md]: ../../../AGENTS.md

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -44,33 +44,61 @@ jobs:
           # On pull_request events checkout defaults to the PR merge ref. On
           # issue_comment (@claude review) events it defaults to the base
           # branch, so Read/Grep would see base code instead of the PR — pin it
-          # to the PR merge ref explicitly.
+          # to the PR merge ref explicitly. This working tree is untrusted (PR
+          # author controlled); the reviewer only READS it, and all review
+          # policy is loaded separately from the trusted base revision below.
           ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
           fetch-depth: 1
           persist-credentials: false
 
-      - name: symlink fix workaround
+      - name: Resolve PR SHAs
+        id: pr-sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
-          # see https://github.com/anthropics/claude-code-action/issues/1205#issuecomment-4248704481
-          rm -f CLAUDE.md
-          cp -f AGENTS.md CLAUDE.md
+          DATA=$(gh api "/repos/${{ github.repository }}/pulls/$PR_NUMBER")
+          echo "head=$(printf '%s' "$DATA" | jq -r .head.sha)" >> "$GITHUB_OUTPUT"
+          echo "base=$(printf '%s' "$DATA" | jq -r .base.sha)" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch PR Comments Context
-        id: fetch-comments
+      - name: Load trusted review policy from base revision
+        id: policy
+        # SECURITY: the review policy (REVIEW.md, SKILL.md), the project context
+        # file, and the comment-fetch script are loaded from the PR's BASE commit
+        # — never from the PR checkout — so a PR author cannot rewrite the
+        # reviewer's own instructions to prompt-inject it. Files absent at base
+        # (e.g. REVIEW.md on a PR that introduces it) resolve to empty and are
+        # simply skipped.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ steps.pr-sha.outputs.base }}
+        run: |
+          mkdir -p /tmp/trusted
+          fetch() {
+            gh api "/repos/${{ github.repository }}/contents/$1?ref=$BASE_SHA" \
+              --jq '.content' 2>/dev/null | base64 -d > "$2" 2>/dev/null || true
+          }
+          fetch "REVIEW.md"                              /tmp/trusted/REVIEW.md
+          fetch ".claude/skills/pr-review/SKILL.md"      /tmp/trusted/SKILL.md
+          fetch "AGENTS.md"                              /tmp/trusted/AGENTS.md
+          fetch ".github/scripts/fetch-pr-comments.sh"   /tmp/trusted/fetch-pr-comments.sh
+          # claude-code-action auto-loads CLAUDE.md as context. Overwrite the
+          # PR-controlled copy with the trusted base AGENTS.md so it can't be
+          # used as an injection vector.
+          if [ -s /tmp/trusted/AGENTS.md ]; then cp /tmp/trusted/AGENTS.md CLAUDE.md; else rm -f CLAUDE.md; fi
+
+      - name: Fetch PR discussion context
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
-        run: bash .github/scripts/fetch-pr-comments.sh
-
-      - name: Get PR head SHA
-        id: pr-head
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
-          echo "sha=$(gh api /repos/${{ github.repository }}/pulls/$PR_NUMBER --jq .head.sha)" >> "$GITHUB_OUTPUT"
+          if [ -s /tmp/trusted/fetch-pr-comments.sh ]; then
+            bash /tmp/trusted/fetch-pr-comments.sh
+          else
+            echo "No prior discussion context available." > /tmp/pr_comments_context.txt
+          fi
 
       - name: Build review prompt
         id: build-prompt
@@ -81,7 +109,6 @@ jobs:
             echo '<pr_context>'
             echo "REPO: ${{ github.repository }}"
             echo "PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}"
-            echo "HEAD SHA: ${{ steps.pr-head.outputs.sha }}"
             echo 'LANGUAGE: Rust'
             echo '</pr_context>'
             echo ''
@@ -89,14 +116,16 @@ jobs:
             cat /tmp/pr_comments_context.txt
             echo '</existing_discussions>'
             echo ''
-            echo '<review_overrides priority="highest">'
-            echo 'Repository-specific overrides. These take precedence over the rubric'
-            echo 'in <review_instructions> wherever they conflict.'
-            cat REVIEW.md
-            echo '</review_overrides>'
-            echo ''
+            if [ -s /tmp/trusted/REVIEW.md ]; then
+              echo '<review_overrides priority="highest">'
+              echo 'Repository-specific overrides (loaded from the trusted base revision).'
+              echo 'These take precedence over the rubric in <review_instructions>.'
+              cat /tmp/trusted/REVIEW.md
+              echo '</review_overrides>'
+              echo ''
+            fi
             echo '<review_instructions>'
-            cat .claude/skills/pr-review/SKILL.md
+            cat /tmp/trusted/SKILL.md
             echo '</review_instructions>'
             echo "$DELIM"
           } >> "$GITHUB_ENV"
@@ -113,7 +142,53 @@ jobs:
           github_token: ${{ github.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ env.REVIEW_PROMPT }}
+          # SECURITY: read-only tools only. The agent processes untrusted PR
+          # content, so it is given no way to post or mutate anything — it
+          # returns findings as structured output (--json-schema), and the
+          # trusted "Post review" step below does the posting.
           claude_args: >-
             --model opus
             --effort xhigh
-            --allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"
+            --allowed-tools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
+            --json-schema '{"type":"object","properties":{"findings":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"line":{"type":"integer"},"side":{"type":"string","enum":["RIGHT","LEFT"]},"severity":{"type":"string","enum":["blocking","nit"]},"body":{"type":"string"}},"required":["path","line","severity","body"]}},"summary":{"type":"string"},"verdict":{"type":"string","enum":["approve","issues"]}},"required":["findings","summary","verdict"]}'
+
+      - name: Post review
+        # Trusted posting step: the agent has no write access, so all mutation
+        # of the PR happens here, from the validated structured output.
+        if: ${{ steps.key-check.outputs.present == 'true' && steps.claude-review.outputs.structured_output != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          HEAD_SHA: ${{ steps.pr-sha.outputs.head }}
+          # Passed via env (not inlined into the script) so the model-generated
+          # content cannot break out into shell.
+          STRUCTURED: ${{ steps.claude-review.outputs.structured_output }}
+        run: |
+          printf '%s' "$STRUCTURED" > /tmp/review.json
+          n=$(jq '.findings | length' /tmp/review.json)
+          posted=0
+          for i in $(seq 0 $((n - 1))); do
+            path=$(jq -r ".findings[$i].path" /tmp/review.json)
+            line=$(jq -r ".findings[$i].line" /tmp/review.json)
+            side=$(jq -r ".findings[$i].side // \"RIGHT\"" /tmp/review.json)
+            sev=$(jq -r ".findings[$i].severity" /tmp/review.json)
+            body=$(jq -r ".findings[$i].body" /tmp/review.json)
+            if [ "$sev" = "blocking" ]; then prefix="**blocking** "; else prefix="nit: "; fi
+            if gh api --method POST \
+                 -H "Accept: application/vnd.github+json" \
+                 -H "X-GitHub-Api-Version: 2022-11-28" \
+                 "/repos/$REPO/pulls/$PR_NUMBER/comments" \
+                 -f "body=${prefix}${body}" \
+                 -f "commit_id=$HEAD_SHA" \
+                 -f "path=$path" \
+                 -F "line=$line" \
+                 -f "side=$side" >/dev/null 2>&1; then
+              posted=$((posted + 1))
+            else
+              echo "::warning::could not post inline comment at $path:$line (line may be outside the diff)"
+            fi
+          done
+          summary=$(jq -r '.summary' /tmp/review.json)
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$summary"
+          echo "posted $posted/$n inline findings"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -64,6 +64,14 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: bash .github/scripts/fetch-pr-comments.sh
 
+      - name: Get PR head SHA
+        id: pr-head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          echo "sha=$(gh api /repos/${{ github.repository }}/pulls/$PR_NUMBER --jq .head.sha)" >> "$GITHUB_OUTPUT"
+
       - name: Build review prompt
         id: build-prompt
         run: |
@@ -73,12 +81,19 @@ jobs:
             echo '<pr_context>'
             echo "REPO: ${{ github.repository }}"
             echo "PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}"
+            echo "HEAD SHA: ${{ steps.pr-head.outputs.sha }}"
             echo 'LANGUAGE: Rust'
             echo '</pr_context>'
             echo ''
             echo '<existing_discussions>'
             cat /tmp/pr_comments_context.txt
             echo '</existing_discussions>'
+            echo ''
+            echo '<review_overrides priority="highest">'
+            echo 'Repository-specific overrides. These take precedence over the rubric'
+            echo 'in <review_instructions> wherever they conflict.'
+            cat REVIEW.md
+            echo '</review_overrides>'
             echo ''
             echo '<review_instructions>'
             cat .claude/skills/pr-review/SKILL.md
@@ -101,4 +116,4 @@ jobs:
           claude_args: >-
             --model opus
             --effort xhigh
-            --allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,162 @@
+# Review instructions
+
+These instructions take priority over the default review guidance. nearcore is
+the reference implementation of a live L1 blockchain: the bar for a blocking
+finding is "this could corrupt state, break consensus, or fail a rolling
+upgrade," not "this could be written more nicely." Optimize for signal — a
+review that surfaces one real correctness risk beats one that lists ten nits.
+
+## What "Important" (🔴) means here
+
+Reserve Important for findings that would break a running network or a node
+operator. Concretely:
+
+- **Consensus / protocol correctness** — logic that changes block/chunk
+  production, validation, or state transition in a way that could fork the
+  network or diverge between nodes.
+- **Protocol-version gating** — a behavior change that affects protocol output
+  but is not gated behind a `ProtocolFeature` / version check, so old and new
+  nodes would disagree at the same height.
+- **Backward compatibility** — changes to persisted state, on-disk column
+  formats, or borsh/network wire formats that aren't append-only or migration-
+  guarded, so a rolling upgrade (mixed old/new binaries) breaks.
+- **Determinism** — anything that makes execution non-deterministic across
+  builds or platforms (unchecked integer arithmetic that can overflow, float
+  reliance, iteration-order dependence, `HashMap` ordering in a consensus path).
+- **Gas / fee / economics accounting** — miscomputed costs, unbounded work not
+  charged for, or fee divergence from the runtime's authoritative accounting.
+- **New panics in node paths** — `unwrap`/`expect`/indexing/`unreachable!` on
+  attacker- or network-influenced input that can crash a validator. (Justified
+  `expect("why this is infallible")` on truly local invariants is fine.)
+- **Resource / DoS** — unbounded allocation, missing limits on
+  network-triggered work, blocking I/O on an async runtime, resource leaks.
+- **Data races / state consistency** — `Arc`/`Mutex` misuse, TOCTOU, partial
+  writes that leave inconsistent state.
+- **Security** — injection, secret/key material leaking through logs, debug
+  output, serialization, or error messages; missing zeroization of crypto
+  material.
+
+Everything else — naming, structure, idiom, documentation phrasing,
+micro-optimizations without a measured impact — is 🟡 Nit at most.
+
+## Cap the nits
+
+Report at most **5** Nit-level findings per review. If you found more, post the
+5 highest-value ones and add "plus N similar nits" as a count in the summary
+rather than inline. If everything you found is a Nit, open the summary with
+"No blocking issues."
+
+## Do not report
+
+- **Anything CI already enforces.** `rustfmt` formatting, `clippy` lints
+  (including `clippy::arithmetic_side_effects`), spellcheck (`cspell`), and type
+  errors are gated in CI. Do not comment on them — a green PR has already passed
+  or will fail loudly.
+- **Style micro-rules from `docs/practices/style.md`** (import granularity,
+  `as_ref`, `for_each` vs loops, `to_string` vs `format!`, etc.) and the Rust
+  conventions in `AGENTS.md` (fully-qualified paths, capitalized log messages).
+  These are real, but they are Nit-tier and clippy/review-bot territory already;
+  only raise one if the same violation appears repeatedly in the diff, and then
+  only as a single grouped nit.
+- **Generated / mechanical files**: `*.lock`, anything under a `gen`/`generated`
+  path, and `tools/protocol-schema-check/res/protocol_schema.toml` hash churn
+  (the schema-check job owns that).
+- **Test-only code** that intentionally violates production rules (test panics,
+  `unwrap` in tests, fixture shortcuts).
+- **Restating the diff.** Do not summarize what a hunk does back to its author
+  unless it's needed to explain a finding.
+
+## Always check (repo-specific)
+
+- Integer arithmetic in protocol/runtime paths uses checked/saturating/wrapping
+  ops **or** a `checked_*(...).expect("why safe")` documenting infallibility —
+  never bare `+ - * /` on values that could overflow.
+- A behavior change that affects protocol output is gated behind the appropriate
+  `ProtocolFeature` / protocol version.
+- New or changed persisted formats (DB columns, borsh structs, network messages)
+  are append-only or migration-safe across a mixed-binary rolling upgrade.
+- New non-trivial logic has a test that exercises the failure/edge path, not
+  just the happy path. Flag missing coverage on correctness-critical changes.
+- `unsafe` blocks carry a `// SAFETY:` comment stating the upheld invariants.
+
+## Comment quality is a first-class check
+
+The single most common thing nearcore reviewers flag (~1 in 5 acted-on
+comments) is code-comment quality. Apply the same scrutiny they do — and note
+that most of what they delete is exactly the kind of prose an LLM over-produces,
+so hold your own suggestions to the same bar:
+
+- Flag comments that **paraphrase the code** or restate what the next line does.
+- Flag comments that **will go stale**: references to "the old code", to PR
+  numbers ("as in PR5"), to "nightly-gated" status, to a test that may be
+  removed, or to transient migration state. ("Very easy to forget updating the
+  comment once we ungate stuff.")
+- Flag **verbose / hard-to-parse** comments and offer a one-line replacement.
+  Reviewers routinely turn a 4-line explanation into one line, or just ask
+  "do we need this comment?"
+- Flag comments that are **inaccurate** or **overstate** the invariant.
+- Do NOT write elaborate narrative comments in your own suggestions. Keep a
+  `// SAFETY:` or a "why" to a single line. Reviewers have explicitly pushed
+  back on the reviewer over-explaining.
+
+## Also weight these (the human reviewers do)
+
+- **Simplification / dedup**: repeated match arms or blocks → suggest a helper;
+  a large block that's mostly error handling → helper + early returns to expose
+  the business logic; a single-caller method → suggest inlining. Be concrete.
+- **Test coverage, as a question**: for correctness-critical changes, ask
+  whether the edge/failure path is tested and, when you can, propose the exact
+  test (a specific assert, a multi-shard case, a fork case).
+- **Encode invariants in types**: an always-`Some` `Option`, a use-level sort a
+  `BTreeMap`/`BTreeSet` would enforce, a non-exhaustive match to make explicit.
+- **Protocol idioms**: prefer `ProtocolFeature::X.enabled(PROTOCOL_VERSION)`
+  over ad-hoc conditional compilation; don't add per-feature bools to view types
+  that become an API-compat liability after the replay threshold.
+- **Metrics conventions**: use the common `shard_uid` label; don't add a metric
+  where a log line suffices.
+- **Determinism**: `HashMap` iteration order is randomized — flag it in any
+  consensus or testloop path that iterates rather than point-accesses.
+
+## How findings should read (the nearcore reviewer voice)
+
+Match how the core reviewers actually write. Their comments are short, hedged,
+and specific — over a third carry an explicit hedge marker.
+
+- **Ask, don't declare.** "Shouldn't this use `prev_prev_hash`?", "is this
+  correct when blocks arrive later than their receipts?" A probing question
+  invites the author's context, lands better than an assertion, and hedges your
+  own false positives.
+- **Be brief.** One to three sentences. A wall of text is a smell.
+- **Propose the concrete alternative.** A rename, an existing helper named
+  explicitly ("we have `run_until_executed_height`, can that be used?"), or a
+  ```suggestion``` block.
+- **Calibrate inline.** Prefix nits with `nit:`; add "up to you" / "low prio" /
+  "not blocking" when it's genuinely optional. Don't dress a preference as a
+  blocker.
+- **Skip the praise.** Humans say "nice!"; you don't need to. Lead with
+  substance.
+
+## Verification bar
+
+Only post a finding you can ground in the code. Behavior claims need a
+`file:line` citation in the actual source — not an inference from a function's
+name or a variable's spelling. If you cannot point at the line that makes the
+finding true, do not post it. When a finding depends on how the changed code
+interacts with surrounding code, use Read/Grep/Glob to confirm before posting.
+A false positive costs the author a wasted round trip, so bias toward silence
+when uncertain about a Nit and toward evidence when raising an Important.
+
+## Re-review convergence
+
+If the PR has already been reviewed (existing discussions are provided inline),
+do not re-raise resolved threads or restate prior points. On a re-review,
+suppress new Nits entirely and post only newly-introduced Important findings.
+A one-line follow-up fix should not attract a fresh wave of style comments.
+
+## Summary shape
+
+Open the review body with a one-line tally of what you found, e.g.
+`2 blocking, 3 nits` or `No blocking issues, 1 nit`. Lead with the blocking
+findings; put nits after. Every finding — blocking or nit — is anchored with a
+`file:line` reference so the reviewer can jump straight to it. End with `✅` if
+nothing blocks the merge or `⚠️` if there is at least one blocking finding.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,3 +1,5 @@
+<!-- cspell:words miscomputed TOCTOU zeroization ungate prio -->
+
 # Review instructions
 
 These instructions take priority over the default review guidance. nearcore is the reference implementation of a live L1 blockchain: the bar for a blocking finding is "this could corrupt state, break consensus, or fail a rolling upgrade," not "this could be written more nicely." Optimize for signal — a review that surfaces one real correctness risk beats one that lists ten nits.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,161 +1,80 @@
 # Review instructions
 
-These instructions take priority over the default review guidance. nearcore is
-the reference implementation of a live L1 blockchain: the bar for a blocking
-finding is "this could corrupt state, break consensus, or fail a rolling
-upgrade," not "this could be written more nicely." Optimize for signal — a
-review that surfaces one real correctness risk beats one that lists ten nits.
+These instructions take priority over the default review guidance. nearcore is the reference implementation of a live L1 blockchain: the bar for a blocking finding is "this could corrupt state, break consensus, or fail a rolling upgrade," not "this could be written more nicely." Optimize for signal — a review that surfaces one real correctness risk beats one that lists ten nits.
 
 ## What "Important" (🔴) means here
 
-Reserve Important for findings that would break a running network or a node
-operator. Concretely:
+Reserve Important for findings that would break a running network or a node operator. Concretely:
 
-- **Consensus / protocol correctness** — logic that changes block/chunk
-  production, validation, or state transition in a way that could fork the
-  network or diverge between nodes.
-- **Protocol-version gating** — a behavior change that affects protocol output
-  but is not gated behind a `ProtocolFeature` / version check, so old and new
-  nodes would disagree at the same height.
-- **Backward compatibility** — changes to persisted state, on-disk column
-  formats, or borsh/network wire formats that aren't append-only or
-  migration-guarded, so a rolling upgrade (mixed old/new binaries) breaks.
-- **Determinism** — anything that makes execution non-deterministic across
-  builds or platforms (unchecked integer arithmetic that can overflow, float
-  reliance, iteration-order dependence, `HashMap` ordering in a consensus path).
-- **Gas / fee / economics accounting** — miscomputed costs, unbounded work not
-  charged for, or fee divergence from the runtime's authoritative accounting.
-- **New panics in node paths** — `unwrap`/`expect`/indexing/`unreachable!` on
-  attacker- or network-influenced input that can crash a validator. (A justified
-  `expect("why this is infallible")` on a truly local invariant is fine.)
-- **Resource / DoS** — unbounded allocation, missing limits on network-triggered
-  work, blocking I/O on an async runtime, resource leaks.
-- **Data races / state consistency** — `Arc`/`Mutex` misuse, TOCTOU, partial
-  writes that leave inconsistent state.
-- **Security** — injection, secret/key material leaking through logs, debug
-  output, serialization, or error messages; missing zeroization of crypto
-  material.
+- **Consensus / protocol correctness** — logic that changes block/chunk production, validation, or state transition in a way that could fork the network or diverge between nodes.
+- **Protocol-version gating** — a behavior change that affects protocol output but is not gated behind a `ProtocolFeature` / version check, so old and new nodes would disagree at the same height.
+- **Backward compatibility** — changes to persisted state, on-disk column formats, or borsh/network wire formats that aren't append-only or migration-guarded, so a rolling upgrade (mixed old/new binaries) breaks.
+- **Determinism** — anything that makes execution non-deterministic across builds or platforms (unchecked integer arithmetic that can overflow, float reliance, iteration-order dependence, `HashMap` ordering in a consensus path).
+- **Gas / fee / economics accounting** — miscomputed costs, unbounded work not charged for, or fee divergence from the runtime's authoritative accounting.
+- **New panics in node paths** — `unwrap`/`expect`/indexing/`unreachable!` on attacker- or network-influenced input that can crash a validator. (A justified `expect("why this is infallible")` on a truly local invariant is fine.)
+- **Resource / DoS** — unbounded allocation, missing limits on network-triggered work, blocking I/O on an async runtime, resource leaks.
+- **Data races / state consistency** — `Arc`/`Mutex` misuse, TOCTOU, partial writes that leave inconsistent state.
+- **Security** — injection, secret/key material leaking through logs, debug output, serialization, or error messages; missing zeroization of crypto material.
 
-Everything else — naming, structure, idiom, documentation phrasing,
-micro-optimizations without a measured impact — is 🟡 Nit at most.
+Everything else — naming, structure, idiom, documentation phrasing, micro-optimizations without a measured impact — is 🟡 Nit at most.
 
 ## Cap the nits
 
-Report at most **5** Nit-level findings per review. If you found more, post the
-5 highest-value ones and add "plus N similar nits" as a count in the summary
-rather than inline. If everything you found is a Nit, open the summary with "No
-blocking issues."
+Report at most **5** Nit-level findings per review. If you found more, post the 5 highest-value ones and add "plus N similar nits" as a count in the summary rather than inline. If everything you found is a Nit, open the summary with "No blocking issues."
 
 ## Do not report
 
-- **Anything CI already enforces.** `rustfmt` formatting, `clippy` lints
-  (including `clippy::arithmetic_side_effects`), spellcheck (`cspell`), and type
-  errors are gated in CI. Do not comment on them — a green PR has already passed
-  or will fail loudly.
-- **Style micro-rules from `docs/practices/style.md`** (import granularity,
-  `as_ref`, `for_each` vs loops, `to_string` vs `format!`, etc.) and the Rust
-  conventions in `AGENTS.md` (fully-qualified paths, capitalized log messages).
-  These are real but Nit-tier; only raise one if the same violation appears
-  repeatedly in the diff, and then as a single grouped nit.
-- **Generated / mechanical files**: `*.lock`, anything under a `gen`/`generated`
-  path, and `tools/protocol-schema-check/res/protocol_schema.toml` hash churn
-  (the schema-check job owns that).
-- **Test-only code** that intentionally violates production rules (test panics,
-  `unwrap` in tests, fixture shortcuts).
-- **Restating the diff.** Do not summarize what a hunk does back to its author
-  unless it's needed to explain a finding.
+- **Anything CI already enforces.** `rustfmt` formatting, `clippy` lints (including `clippy::arithmetic_side_effects`), spellcheck (`cspell`), and type errors are gated in CI. Do not comment on them — a green PR has already passed or will fail loudly.
+- **Style micro-rules from `docs/practices/style.md`** (import granularity, `as_ref`, `for_each` vs loops, `to_string` vs `format!`, etc.) and the Rust conventions in `AGENTS.md` (fully-qualified paths, capitalized log messages). These are real but Nit-tier; only raise one if the same violation appears repeatedly in the diff, and then as a single grouped nit.
+- **Generated / mechanical files**: `*.lock`, anything under a `gen`/`generated` path, and `tools/protocol-schema-check/res/protocol_schema.toml` hash churn (the schema-check job owns that).
+- **Test-only code** that intentionally violates production rules (test panics, `unwrap` in tests, fixture shortcuts).
+- **Restating the diff.** Do not summarize what a hunk does back to its author unless it's needed to explain a finding.
 
 ## Always check (repo-specific)
 
-- Integer arithmetic in protocol/runtime paths uses checked/saturating/wrapping
-  ops **or** a `checked_*(...).expect("why safe")` documenting infallibility —
-  never bare `+ - * /` on values that could overflow.
-- A behavior change that affects protocol output is gated behind the appropriate
-  `ProtocolFeature` / protocol version.
-- New or changed persisted formats (DB columns, borsh structs, network messages)
-  are append-only or migration-safe across a mixed-binary rolling upgrade.
-- New non-trivial logic has a test that exercises the failure/edge path, not
-  just the happy path. Flag missing coverage on correctness-critical changes.
+- Integer arithmetic in protocol/runtime paths uses checked/saturating/wrapping ops **or** a `checked_*(...).expect("why safe")` documenting infallibility — never bare `+ - * /` on values that could overflow.
+- A behavior change that affects protocol output is gated behind the appropriate `ProtocolFeature` / protocol version.
+- New or changed persisted formats (DB columns, borsh structs, network messages) are append-only or migration-safe across a mixed-binary rolling upgrade.
+- New non-trivial logic has a test that exercises the failure/edge path, not just the happy path. Flag missing coverage on correctness-critical changes.
 - `unsafe` blocks carry a `// SAFETY:` comment stating the upheld invariants.
 
 ## Comment quality is a first-class check
 
-The single most common thing nearcore reviewers flag (~1 in 5 acted-on comments)
-is code-comment quality. Apply the same scrutiny they do — and note that most of
-what they delete is exactly the kind of prose an LLM over-produces, so hold your
-own suggestions to the same bar:
+The single most common thing nearcore reviewers flag (~1 in 5 acted-on comments) is code-comment quality. Apply the same scrutiny they do — and note that most of what they delete is exactly the kind of prose an LLM over-produces, so hold your own suggestions to the same bar:
 
 - Flag comments that **paraphrase the code** or restate what the next line does.
-- Flag comments that **will go stale**: references to "the old code", to PR
-  numbers ("as in PR5"), to "nightly-gated" status, to a test that may be
-  removed, or to transient migration state. ("Very easy to forget updating the
-  comment once we ungate stuff.")
-- Flag **verbose / hard-to-parse** comments and offer a one-line replacement.
-  Reviewers routinely turn a 4-line explanation into one line, or just ask "do
-  we need this comment?"
+- Flag comments that **will go stale**: references to "the old code", to PR numbers ("as in PR5"), to "nightly-gated" status, to a test that may be removed, or to transient migration state. ("Very easy to forget updating the comment once we ungate stuff.")
+- Flag **verbose / hard-to-parse** comments and offer a one-line replacement. Reviewers routinely turn a 4-line explanation into one line, or just ask "do we need this comment?"
 - Flag comments that are **inaccurate** or **overstate** the invariant.
-- Do NOT write elaborate narrative comments in your own suggestions. Keep a `//
-  SAFETY:` or a "why" to a single line. Reviewers have explicitly pushed back on
-  the reviewer over-explaining.
+- Do NOT write elaborate narrative comments in your own suggestions. Keep a `// SAFETY:` or a "why" to a single line. Reviewers have explicitly pushed back on the reviewer over-explaining.
 
 ## Also weight these (the human reviewers do)
 
-- **Simplification / dedup**: repeated match arms or blocks → suggest a helper;
-  a large block that's mostly error handling → helper + early returns to expose
-  the business logic; a single-caller method → suggest inlining. Be concrete.
-- **Test coverage, as a question**: for correctness-critical changes, ask
-  whether the edge/failure path is tested and, when you can, propose the exact
-  test (a specific assert, a multi-shard case, a fork case).
-- **Encode invariants in types**: an always-`Some` `Option`, a use-level sort a
-  `BTreeMap`/`BTreeSet` would enforce, a non-exhaustive match to make explicit.
-- **Protocol idioms**: prefer `ProtocolFeature::X.enabled(PROTOCOL_VERSION)`
-  over ad-hoc conditional compilation; don't add per-feature bools to view types
-  that become an API-compat liability after the replay threshold.
-- **Metrics conventions**: use the common `shard_uid` label; don't add a metric
-  where a log line suffices.
-- **Determinism**: `HashMap` iteration order is randomized — flag it in any
-  consensus or testloop path that iterates rather than point-accesses.
+- **Simplification / dedup**: repeated match arms or blocks → suggest a helper; a large block that's mostly error handling → helper + early returns to expose the business logic; a single-caller method → suggest inlining. Be concrete.
+- **Test coverage, as a question**: for correctness-critical changes, ask whether the edge/failure path is tested and, when you can, propose the exact test (a specific assert, a multi-shard case, a fork case).
+- **Encode invariants in types**: an always-`Some` `Option`, a use-level sort a `BTreeMap`/`BTreeSet` would enforce, a non-exhaustive match to make explicit.
+- **Protocol idioms**: prefer `ProtocolFeature::X.enabled(PROTOCOL_VERSION)` over ad-hoc conditional compilation; don't add per-feature bools to view types that become an API-compat liability after the replay threshold.
+- **Metrics conventions**: use the common `shard_uid` label; don't add a metric where a log line suffices.
+- **Determinism**: `HashMap` iteration order is randomized — flag it in any consensus or testloop path that iterates rather than point-accesses.
 
 ## How findings should read (the nearcore reviewer voice)
 
-Match how the core reviewers actually write. Their comments are short, hedged,
-and specific — over a third carry an explicit hedge marker.
+Match how the core reviewers actually write. Their comments are short, hedged, and specific — over a third carry an explicit hedge marker.
 
-- **Ask, don't declare.** "Shouldn't this use `prev_prev_hash`?", "is this
-  correct when blocks arrive later than their receipts?" A probing question
-  invites the author's context, lands better than an assertion, and hedges your
-  own false positives.
+- **Ask, don't declare.** "Shouldn't this use `prev_prev_hash`?", "is this correct when blocks arrive later than their receipts?" A probing question invites the author's context, lands better than an assertion, and hedges your own false positives.
 - **Be brief.** One to three sentences. A wall of text is a smell.
-- **Propose the concrete alternative.** A rename, an existing helper named
-  explicitly ("we have `run_until_executed_height`, can that be used?"), or a
-  ```suggestion``` block.
-- **Calibrate inline.** Prefix nits with `nit:`; add "up to you" / "low prio" /
-  "not blocking" when it's genuinely optional. Don't dress a preference as a
-  blocker.
-- **Skip the praise.** Humans say "nice!"; you don't need to. Lead with
-  substance.
+- **Propose the concrete alternative.** A rename, an existing helper named explicitly ("we have `run_until_executed_height`, can that be used?"), or a ```suggestion``` block.
+- **Calibrate inline.** Prefix nits with `nit:`; add "up to you" / "low prio" / "not blocking" when it's genuinely optional. Don't dress a preference as a blocker.
+- **Skip the praise.** Humans say "nice!"; you don't need to. Lead with substance.
 
 ## Verification bar
 
-Only post a finding you can ground in the code. Behavior claims need a
-`file:line` citation in the actual source — not an inference from a function's
-name or a variable's spelling. If you cannot point at the line that makes the
-finding true, do not post it. When a finding depends on how the changed code
-interacts with surrounding code, use Read/Grep/Glob to confirm before posting. A
-false positive costs the author a wasted round trip, so bias toward silence when
-uncertain about a Nit and toward evidence when raising an Important.
+Only post a finding you can ground in the code. Behavior claims need a `file:line` citation in the actual source — not an inference from a function's name or a variable's spelling. If you cannot point at the line that makes the finding true, do not post it. When a finding depends on how the changed code interacts with surrounding code, use Read/Grep/Glob to confirm before posting. A false positive costs the author a wasted round trip, so bias toward silence when uncertain about a Nit and toward evidence when raising an Important.
 
 ## Re-review convergence
 
-If the PR has already been reviewed (existing discussions are provided inline),
-do not re-raise resolved threads or restate prior points. On a re-review,
-suppress new Nits entirely and post only newly-introduced Important findings. A
-one-line follow-up fix should not attract a fresh wave of style comments.
+If the PR has already been reviewed (existing discussions are provided inline), do not re-raise resolved threads or restate prior points. On a re-review, suppress new Nits entirely and post only newly-introduced Important findings. A one-line follow-up fix should not attract a fresh wave of style comments.
 
 ## Summary shape
 
-The findings themselves are posted inline on their lines — the summary comment
-does not repeat them. Open the summary with a one-line tally, e.g. `2 blocking,
-3 nits` or `No blocking issues`. Add at most one sentence on what the PR does,
-and only if it helps the reader. End with `✅` if nothing blocks the merge or
-`⚠️` if there is at least one blocking finding.
+The findings themselves are posted inline on their lines — the summary comment does not repeat them. Open the summary with a one-line tally, e.g. `2 blocking, 3 nits` or `No blocking issues`. Add at most one sentence on what the PR does, and only if it helps the reader. End with `✅` if nothing blocks the merge or `⚠️` if there is at least one blocking finding.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -18,18 +18,18 @@ operator. Concretely:
   but is not gated behind a `ProtocolFeature` / version check, so old and new
   nodes would disagree at the same height.
 - **Backward compatibility** — changes to persisted state, on-disk column
-  formats, or borsh/network wire formats that aren't append-only or migration-
-  guarded, so a rolling upgrade (mixed old/new binaries) breaks.
+  formats, or borsh/network wire formats that aren't append-only or
+  migration-guarded, so a rolling upgrade (mixed old/new binaries) breaks.
 - **Determinism** — anything that makes execution non-deterministic across
   builds or platforms (unchecked integer arithmetic that can overflow, float
   reliance, iteration-order dependence, `HashMap` ordering in a consensus path).
 - **Gas / fee / economics accounting** — miscomputed costs, unbounded work not
   charged for, or fee divergence from the runtime's authoritative accounting.
 - **New panics in node paths** — `unwrap`/`expect`/indexing/`unreachable!` on
-  attacker- or network-influenced input that can crash a validator. (Justified
-  `expect("why this is infallible")` on truly local invariants is fine.)
-- **Resource / DoS** — unbounded allocation, missing limits on
-  network-triggered work, blocking I/O on an async runtime, resource leaks.
+  attacker- or network-influenced input that can crash a validator. (A justified
+  `expect("why this is infallible")` on a truly local invariant is fine.)
+- **Resource / DoS** — unbounded allocation, missing limits on network-triggered
+  work, blocking I/O on an async runtime, resource leaks.
 - **Data races / state consistency** — `Arc`/`Mutex` misuse, TOCTOU, partial
   writes that leave inconsistent state.
 - **Security** — injection, secret/key material leaking through logs, debug
@@ -43,8 +43,8 @@ micro-optimizations without a measured impact — is 🟡 Nit at most.
 
 Report at most **5** Nit-level findings per review. If you found more, post the
 5 highest-value ones and add "plus N similar nits" as a count in the summary
-rather than inline. If everything you found is a Nit, open the summary with
-"No blocking issues."
+rather than inline. If everything you found is a Nit, open the summary with "No
+blocking issues."
 
 ## Do not report
 
@@ -55,9 +55,8 @@ rather than inline. If everything you found is a Nit, open the summary with
 - **Style micro-rules from `docs/practices/style.md`** (import granularity,
   `as_ref`, `for_each` vs loops, `to_string` vs `format!`, etc.) and the Rust
   conventions in `AGENTS.md` (fully-qualified paths, capitalized log messages).
-  These are real, but they are Nit-tier and clippy/review-bot territory already;
-  only raise one if the same violation appears repeatedly in the diff, and then
-  only as a single grouped nit.
+  These are real but Nit-tier; only raise one if the same violation appears
+  repeatedly in the diff, and then as a single grouped nit.
 - **Generated / mechanical files**: `*.lock`, anything under a `gen`/`generated`
   path, and `tools/protocol-schema-check/res/protocol_schema.toml` hash churn
   (the schema-check job owns that).
@@ -81,10 +80,10 @@ rather than inline. If everything you found is a Nit, open the summary with
 
 ## Comment quality is a first-class check
 
-The single most common thing nearcore reviewers flag (~1 in 5 acted-on
-comments) is code-comment quality. Apply the same scrutiny they do — and note
-that most of what they delete is exactly the kind of prose an LLM over-produces,
-so hold your own suggestions to the same bar:
+The single most common thing nearcore reviewers flag (~1 in 5 acted-on comments)
+is code-comment quality. Apply the same scrutiny they do — and note that most of
+what they delete is exactly the kind of prose an LLM over-produces, so hold your
+own suggestions to the same bar:
 
 - Flag comments that **paraphrase the code** or restate what the next line does.
 - Flag comments that **will go stale**: references to "the old code", to PR
@@ -92,12 +91,12 @@ so hold your own suggestions to the same bar:
   removed, or to transient migration state. ("Very easy to forget updating the
   comment once we ungate stuff.")
 - Flag **verbose / hard-to-parse** comments and offer a one-line replacement.
-  Reviewers routinely turn a 4-line explanation into one line, or just ask
-  "do we need this comment?"
+  Reviewers routinely turn a 4-line explanation into one line, or just ask "do
+  we need this comment?"
 - Flag comments that are **inaccurate** or **overstate** the invariant.
-- Do NOT write elaborate narrative comments in your own suggestions. Keep a
-  `// SAFETY:` or a "why" to a single line. Reviewers have explicitly pushed
-  back on the reviewer over-explaining.
+- Do NOT write elaborate narrative comments in your own suggestions. Keep a `//
+  SAFETY:` or a "why" to a single line. Reviewers have explicitly pushed back on
+  the reviewer over-explaining.
 
 ## Also weight these (the human reviewers do)
 
@@ -142,21 +141,21 @@ Only post a finding you can ground in the code. Behavior claims need a
 `file:line` citation in the actual source — not an inference from a function's
 name or a variable's spelling. If you cannot point at the line that makes the
 finding true, do not post it. When a finding depends on how the changed code
-interacts with surrounding code, use Read/Grep/Glob to confirm before posting.
-A false positive costs the author a wasted round trip, so bias toward silence
-when uncertain about a Nit and toward evidence when raising an Important.
+interacts with surrounding code, use Read/Grep/Glob to confirm before posting. A
+false positive costs the author a wasted round trip, so bias toward silence when
+uncertain about a Nit and toward evidence when raising an Important.
 
 ## Re-review convergence
 
 If the PR has already been reviewed (existing discussions are provided inline),
 do not re-raise resolved threads or restate prior points. On a re-review,
-suppress new Nits entirely and post only newly-introduced Important findings.
-A one-line follow-up fix should not attract a fresh wave of style comments.
+suppress new Nits entirely and post only newly-introduced Important findings. A
+one-line follow-up fix should not attract a fresh wave of style comments.
 
 ## Summary shape
 
-Open the review body with a one-line tally of what you found, e.g.
-`2 blocking, 3 nits` or `No blocking issues, 1 nit`. Lead with the blocking
-findings; put nits after. Every finding — blocking or nit — is anchored with a
-`file:line` reference so the reviewer can jump straight to it. End with `✅` if
-nothing blocks the merge or `⚠️` if there is at least one blocking finding.
+The findings themselves are posted inline on their lines — the summary comment
+does not repeat them. Open the summary with a one-line tally, e.g. `2 blocking,
+3 nits` or `No blocking issues`. Add at most one sentence on what the PR does,
+and only if it helps the reader. End with `✅` if nothing blocks the merge or
+`⚠️` if there is at least one blocking finding.


### PR DESCRIPTION
Retunes the `@claude` PR reviewer so its feedback is easier to act on, and adds a single file (`REVIEW.md`) to control what it flags.

## What changed

1. **`REVIEW.md` (new)** — a repo-root file that overrides review behavior. It recalibrates 🔴 *blocking* around blockchain-node failure modes (consensus correctness, protocol-version gating, rolling-upgrade / state-migration safety, determinism, gas accounting, node-crashing panics), tells the reviewer to skip anything CI already enforces (`rustfmt`/`clippy`/`cspell`), caps nits, adds an evidence bar, and defines the short/hedged reviewer voice. The workflow injects it as a highest-priority `<review_overrides>` block. It's also the exact file Anthropic's managed Code Review reads, so the same knob keeps working if we ever switch to that.

2. **Post findings inline.** The reviewer now posts each finding as an inline comment on the exact line (via `gh api .../pulls/N/comments`) plus one short summary comment, instead of a single wall-of-text top-level comment. Adds `Bash(gh api:*)` to the allowed tools and fetches the PR head SHA for `commit_id`. It still can't approve or request changes (no `gh pr review`).

3. **`SKILL.md`.** Replaces the mandatory PR-overview + per-file-table output with the inline-posting instructions, and points the rubric at `REVIEW.md`.

## Why

The previous reviewer posts one big comment and approves the large majority of PRs with mostly nitpicks, so it's easy to tune out. The underlying analysis is good (Opus, `xhigh`) — the gap is delivery and calibration. `REVIEW.md`'s priorities and voice come from a pilot over the last ~150 merged PRs (146 acted-on human review comments): the largest slice of human review effort goes to **code-comment quality** and **simplification/dedup**, and comments are overwhelmingly **short hedged questions** rather than declarations. The reviewer is retuned to match, and told not to produce the verbose prose reviewers spend the most time deleting.

## Testing

Dry-ran the new reviewer in a clean-context subagent (Opus, read-only so it couldn't post) against a real open PR — **#16064** — before flipping it on. See the comment below for the before/after on the same PR.

Marking this PR ready-for-review also triggers the workflow to review *this* PR end-to-end: `pull_request` events use the branch's own workflow, so this exercises the inline `gh api` posting and head-SHA wiring for real (the review will land on the `.md`/`.yml` diff here).
