### PR TITLE
refactor(o11y): gate the opentelemetry otlp exporter behind a feature

### DIFF
--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -46,7 +46,7 @@ time.workspace = true
 
 near-async.workspace = true
 near-fmt.workspace = true
-near-o11y.workspace = true
+near-o11y = { workspace = true, features = ["otlp"] }
 near-chain-configs.workspace = true
 near-crypto.workspace = true
 near-primitives = { workspace = true, features = ["rand", "solomon", "clock", "test_utils"] }

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -18,10 +18,10 @@ near-primitives-core.workspace = true
 
 base64.workspace = true
 clap.workspace = true
-opentelemetry.workspace = true
-opentelemetry_sdk.workspace = true
-opentelemetry-otlp.workspace = true
-opentelemetry-semantic-conventions.workspace = true
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true }
 prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -29,7 +29,7 @@ strum = { workspace = true, optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
-tracing-opentelemetry.workspace = true
+tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
@@ -43,6 +43,16 @@ nightly = [
     "near-primitives-core/nightly",
 ]
 io_trace = ["near-fmt", "strum"]
+# Enables exporting spans/traces to an external collector via the OpenTelemetry
+# OTLP exporter. Off by default so consumers that only need logging/metrics don't
+# pull in the (heavy) opentelemetry + tonic + prost exporter stack.
+otlp = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry-semantic-conventions",
+    "dep:tracing-opentelemetry",
+]
 sandbox = []
 # You can use these features when building the workspace to disable instrumentation at relevant
 # levels workspace-wide.

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -4,9 +4,12 @@
 pub use env_filter::{BuildEnvFilterError, EnvFilterBuilder};
 pub use opentelemetry::OpenTelemetryLevel;
 pub use reload::{reload, reload_log_config};
+#[cfg(feature = "otlp")]
+pub use subscriber::default_subscriber_with_opentelemetry;
 #[cfg(feature = "io_trace")]
 pub use subscriber::make_io_tracing_layer;
-pub use subscriber::{Options, default_subscriber, default_subscriber_with_opentelemetry};
+pub use subscriber::{Options, default_subscriber};
+#[cfg(feature = "otlp")]
 pub use tracing_opentelemetry::OpenTelemetrySpanExt;
 pub use {tracing, tracing_appender, tracing_subscriber};
 

--- a/core/o11y/src/opentelemetry.rs
+++ b/core/o11y/src/opentelemetry.rs
@@ -1,14 +1,26 @@
+#[cfg(feature = "otlp")]
 use crate::reload::TracingLayer;
+#[cfg(feature = "otlp")]
 use near_crypto::PublicKey;
+#[cfg(feature = "otlp")]
 use near_primitives_core::types::AccountId;
+#[cfg(feature = "otlp")]
 use opentelemetry::KeyValue;
+#[cfg(feature = "otlp")]
 use opentelemetry::trace::TracerProvider;
+#[cfg(feature = "otlp")]
 use opentelemetry_sdk::Resource;
+#[cfg(feature = "otlp")]
 use opentelemetry_sdk::trace::{BatchSpanProcessor, RandomIdGenerator, Sampler, SdkTracerProvider};
+#[cfg(feature = "otlp")]
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use tracing_subscriber::EnvFilter;
+#[cfg(feature = "otlp")]
 use tracing_subscriber::layer::SubscriberExt;
+#[cfg(feature = "otlp")]
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::{EnvFilter, Layer, reload};
+#[cfg(feature = "otlp")]
+use tracing_subscriber::{Layer, reload};
 
 // Doesn't define WARN and ERROR, because the highest verbosity of spans is INFO.
 #[derive(Copy, Clone, Debug, Default, clap::ValueEnum)]
@@ -24,6 +36,7 @@ pub enum OpenTelemetryLevel {
 //
 // NB: this function is `async` because `tonic` (gRPC server) requires a tokio context to
 // register timers and channels and whatnot.
+#[cfg(feature = "otlp")]
 pub(crate) async fn add_opentelemetry_layer<S>(
     opentelemetry_level: OpenTelemetryLevel,
     chain_id: String,

--- a/core/o11y/src/reload.rs
+++ b/core/o11y/src/reload.rs
@@ -1,8 +1,10 @@
 use crate::opentelemetry::get_opentelemetry_filter;
 use crate::{BuildEnvFilterError, EnvFilterBuilder, OpenTelemetryLevel, log_config, log_counter};
+#[cfg(feature = "otlp")]
 use opentelemetry_sdk::trace::Tracer;
 use std::sync::OnceLock;
 use tracing_appender::non_blocking::NonBlocking;
+#[cfg(feature = "otlp")]
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::filter::Filtered;
 use tracing_subscriber::layer::Layered;
@@ -37,11 +39,13 @@ pub(crate) type SimpleLogLayer<Inner, W> = Layered<
     Inner,
 >;
 
+#[cfg(feature = "otlp")]
 pub(crate) type TracingLayer<Inner> = Layered<
     Filtered<OpenTelemetryLayer<Inner, Tracer>, reload::Layer<EnvFilter, Inner>, Inner>,
     Inner,
 >;
 
+#[cfg(feature = "otlp")]
 pub(crate) fn set_log_layer_handle(
     handle: Handle<EnvFilter, log_counter::LogCountingLayer<Registry>>,
 ) {
@@ -50,6 +54,7 @@ pub(crate) fn set_log_layer_handle(
         .unwrap_or_else(|_| panic!("Failed to set Log Layer Filter"));
 }
 
+#[cfg(feature = "otlp")]
 pub(crate) fn set_otlp_layer_handle(
     handle: Handle<EnvFilter, LogLayer<log_counter::LogCountingLayer<Registry>>>,
 ) {
@@ -58,6 +63,7 @@ pub(crate) fn set_otlp_layer_handle(
         .unwrap_or_else(|_| panic!("Failed to set OTLP Layer Filter"));
 }
 
+#[cfg(feature = "otlp")]
 pub(crate) fn set_default_otlp_level(level: OpenTelemetryLevel) {
     // Record the initial tracing level specified as a command-line flag. Use this recorded value to
     // reset opentelemetry filter when the LogConfig file gets deleted.

--- a/core/o11y/src/subscriber.rs
+++ b/core/o11y/src/subscriber.rs
@@ -1,16 +1,24 @@
+#[cfg(feature = "otlp")]
 use crate::opentelemetry::add_opentelemetry_layer;
+use crate::reload::SimpleLogLayer;
+#[cfg(feature = "otlp")]
 use crate::reload::{
-    LogLayer, SimpleLogLayer, set_default_otlp_level, set_log_layer_handle, set_otlp_layer_handle,
+    LogLayer, set_default_otlp_level, set_log_layer_handle, set_otlp_layer_handle,
 };
 use crate::{OpenTelemetryLevel, log_counter};
+#[cfg(feature = "otlp")]
 use near_crypto::PublicKey;
+#[cfg(feature = "otlp")]
 use near_primitives_core::types::AccountId;
 use std::path::PathBuf;
 use tracing::subscriber::DefaultGuard;
+#[cfg(feature = "otlp")]
 use tracing_appender::non_blocking::NonBlocking;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::{EnvFilter, Layer, fmt, reload};
+#[cfg(feature = "otlp")]
+use tracing_subscriber::reload;
+use tracing_subscriber::{EnvFilter, Layer, fmt};
 
 /// The resource representing a registered subscriber.
 ///
@@ -125,6 +133,7 @@ fn get_fmt_span(with_span_events: bool) -> fmt::format::FmtSpan {
     }
 }
 
+#[cfg(feature = "otlp")]
 fn add_non_blocking_log_layer<S>(
     filter: EnvFilter,
     writer: NonBlocking,
@@ -236,6 +245,7 @@ pub fn default_subscriber(
 ///
 /// The subscriber enables logging, tracing and io tracing.
 /// Subscriber creation needs an async runtime.
+#[cfg(feature = "otlp")]
 pub async fn default_subscriber_with_opentelemetry(
     env_filter: EnvFilter,
     options: &Options,

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -43,7 +43,7 @@ near-fork-network.workspace = true
 near-jsonrpc-primitives.workspace = true
 near-mirror.workspace = true
 near-network.workspace = true
-near-o11y.workspace = true
+near-o11y = { workspace = true, features = ["otlp"] }
 near-ping.workspace = true
 near-primitives.workspace = true
 near-replay-archive-tool.workspace = true

--- a/tools/fork-network/Cargo.toml
+++ b/tools/fork-network/Cargo.toml
@@ -30,7 +30,7 @@ near-chain.workspace = true
 near-crypto.workspace = true
 near-epoch-manager.workspace = true
 near-mirror.workspace = true
-near-o11y.workspace = true
+near-o11y = { workspace = true, features = ["otlp"] }
 near-parameters.workspace = true
 near-primitives.workspace = true
 near-store.workspace = true


### PR DESCRIPTION
### Why

`near-o11y` pulled the full OpenTelemetry OTLP exporter stack (`opentelemetry*`, `tonic`, `prost`, `hyper`, `tokio`, …) **unconditionally**, so every consumer that only needs logging/metrics paid for it — most visibly `near-vm-runner` (default `metrics` feature) and anything downstream like `near-sdk`'s `unit-testing`.

### Fix

Gate the exporter behind a non-default **`otlp`** feature: the five opentelemetry deps become `optional`, and exporter-only code (`add_opentelemetry_layer`, `default_subscriber_with_opentelemetry`, `OpenTelemetrySpanExt`, the OTLP reload handles) is `#[cfg(feature = "otlp")]`. Metrics, logging, `Options`, and `reload` stay always-on with unchanged signatures. `neard`, `tools/fork-network`, and `chain/network` enable `near-o11y/otlp`, so **node behavior is unchanged**.

Verified `cargo check -D warnings` for near-o11y (both configs) and both consumer crates.

_Downstream counterpart: near/near-sdk-rs#1611._
