### PR TITLE
fix(crypto): feature-gate aws-lc-rs so near-crypto builds for wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,7 @@ near-cloud-archive-tool = { path = "tools/cloud-archive" }
 near-cold-store-tool = { path = "tools/cold-store", package = "cold-store-tool" }
 near-config-utils = { path = "utils/config" }
 nearcore = { path = "nearcore" }
-near-crypto = { path = "core/crypto", default-features = false }
+near-crypto = { path = "core/crypto", default-features = false, features = ["aws-lc-rs"] }
 near-dyn-configs = { path = "core/dyn-configs" }
 near-epoch-manager = { path = "chain/epoch-manager" }
 near-external-storage = { path = "core/external-storage" }

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -12,7 +12,7 @@ publish = true
 workspace = true
 
 [dependencies]
-aws-lc-rs.workspace = true
+aws-lc-rs = { workspace = true, optional = true }
 blake2.workspace = true
 borsh.workspace = true
 bs58.workspace = true
@@ -58,7 +58,7 @@ name = "ml_dsa_worst_case"
 harness = false
 
 [features]
-default = ["rand"]
+default = ["rand", "aws-lc-rs"]
 rand = ["secp256k1/rand", "rand/getrandom", "ed25519-dalek/rand_core"]
 rand-std = ["secp256k1/rand-std"]
 protocol_schema = [

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -1393,6 +1393,7 @@ mod tests {
     use super::{KeyType, PublicKey, SecretKey, Signature};
 
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_sign_verify() {
         for key_type in [KeyType::ED25519, KeyType::SECP256K1, KeyType::MLDSA65] {
@@ -1489,6 +1490,7 @@ mod tests {
     }
 
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_borsh_serialization() {
         use borsh::BorshDeserialize;
@@ -1523,6 +1525,7 @@ mod tests {
     /// `1 + ML_DSA_65_PUBLIC_KEY_LENGTH = 1953` bytes (one tag byte + the
     /// raw key bytes), and the leading tag must be `2`.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_borsh_tag_and_length() {
         use super::ML_DSA_65_PUBLIC_KEY_LENGTH;
@@ -1537,6 +1540,7 @@ mod tests {
     /// input length ≤ 65). ML-DSA-65 pubkeys are 1952 bytes; encoding them
     /// must work in both display and parse-roundtrip.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_display_roundtrip() {
         let sk = SecretKey::from_seed(KeyType::MLDSA65, "display-test");
@@ -1570,6 +1574,7 @@ mod tests {
 
     /// ML-DSA-65 verify must reject a signature produced by a different key.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_wrong_key_rejected() {
         use sha2::Digest;
@@ -1583,6 +1588,7 @@ mod tests {
 
     /// Tampering with the message must invalidate the signature.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_tampered_message_rejected() {
         use sha2::Digest;
@@ -1597,6 +1603,7 @@ mod tests {
 
     /// Tampering with the signature bytes must cause verify to return false.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_tampered_signature_rejected() {
         use borsh::BorshDeserialize;
@@ -1614,6 +1621,7 @@ mod tests {
 
     /// `from_seed` must be deterministic - same seed in, same key out.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_from_seed_deterministic() {
         let sk1 = SecretKey::from_seed(KeyType::MLDSA65, "deterministic-seed");
@@ -1624,6 +1632,7 @@ mod tests {
     /// Cross-scheme verification must always fail (signature.verify against a
     /// different-curve pubkey returns false, never panics).
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_cross_scheme_verify_returns_false() {
         use sha2::Digest;
@@ -1642,6 +1651,7 @@ mod tests {
 
     /// Verify pubkey/signature length invariants for ML-DSA-65.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_byte_lengths() {
         use super::{ML_DSA_65_PUBLIC_KEY_LENGTH, ML_DSA_65_SIGNATURE_LENGTH};
@@ -1685,6 +1695,7 @@ mod tests {
     /// `MlDsa65PublicKey::to_public_key_handle()` must be deterministic, 32 bytes,
     /// and distinct between different keys.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_pubkey_hash_deterministic() {
         let pk1 = SecretKey::from_seed(KeyType::MLDSA65, "hash-1").public_key();
@@ -1750,6 +1761,7 @@ mod tests {
     /// hash) must never decode as a `PublicKey`, and tag 2 (the full
     /// ML-DSA-65 pubkey) must never decode as a `PublicKeyHandle`.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_reserved_tags_rejected_both_ways() {
         use super::{KeyTag, PublicKeyHandle};
@@ -1771,6 +1783,7 @@ mod tests {
     /// `PublicKeyHandle::trie_id_len` matches the hash size for ML-DSA-65 and
     /// the borsh length for the other schemes.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_key_handle_trie_id_len_per_scheme() {
         use super::PublicKeyHandle;
@@ -1815,6 +1828,7 @@ mod tests {
     /// across versions must always agree on the same (pk, msg, sig)
     /// triple. The round-trip below catches verify regressions.
     #[cfg(feature = "rand")]
+    #[cfg(feature = "aws-lc-rs")]
     #[test]
     fn test_ml_dsa_65_known_answer() {
         const KAT_SEED: &str = "kat-seed-v1";

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -1170,7 +1170,7 @@ impl Signature {
                 #[cfg(not(feature = "aws-lc-rs"))]
                 {
                     let _ = (signature, public_key);
-                    unimplemented!("ML-DSA-65 requires the aws-lc-rs feature")
+                    false
                 }
             }
             _ => false,

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -1,6 +1,8 @@
 use crate::hash_domain::HashDomainTag;
 use crate::util::try_fixed_array;
+#[cfg(feature = "aws-lc-rs")]
 use aws_lc_rs::signature::UnparsedPublicKey;
+#[cfg(feature = "aws-lc-rs")]
 use aws_lc_rs::unstable::signature::{ML_DSA_65, ML_DSA_65_SIGNING, PqdsaKeyPair};
 use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_dalek::ed25519::signature::{Signer, Verifier};
@@ -783,9 +785,16 @@ impl SecretKey {
             }
             KeyType::SECP256K1 => SecretKey::SECP256K1(secp256k1::SecretKey::new(&mut OsRng)),
             KeyType::MLDSA65 => {
-                let kp =
-                    PqdsaKeyPair::generate(&ML_DSA_65_SIGNING).expect("ML-DSA-65 keygen failed");
-                SecretKey::MLDSA65(ml_dsa_65_secret_from_keypair(&kp))
+                #[cfg(feature = "aws-lc-rs")]
+                {
+                    let kp = PqdsaKeyPair::generate(&ML_DSA_65_SIGNING)
+                        .expect("ML-DSA-65 keygen failed");
+                    SecretKey::MLDSA65(ml_dsa_65_secret_from_keypair(&kp))
+                }
+                #[cfg(not(feature = "aws-lc-rs"))]
+                {
+                    unimplemented!("ML-DSA-65 requires the aws-lc-rs feature")
+                }
             }
         }
     }
@@ -810,12 +819,21 @@ impl SecretKey {
             }
 
             SecretKey::MLDSA65(secret_key) => {
-                let kp = PqdsaKeyPair::from_raw_private_key(&ML_DSA_65_SIGNING, &secret_key.0[..])
-                    .expect("invalid ML-DSA-65 raw private key");
-                let mut sig_buf = Box::new([0u8; ML_DSA_65_SIGNATURE_LENGTH]);
-                let n = kp.sign(data, sig_buf.as_mut()).expect("ML-DSA-65 sign failed");
-                debug_assert_eq!(n, ML_DSA_65_SIGNATURE_LENGTH);
-                Signature::MLDSA65(MlDsa65Signature(sig_buf))
+                #[cfg(feature = "aws-lc-rs")]
+                {
+                    let kp =
+                        PqdsaKeyPair::from_raw_private_key(&ML_DSA_65_SIGNING, &secret_key.0[..])
+                            .expect("invalid ML-DSA-65 raw private key");
+                    let mut sig_buf = Box::new([0u8; ML_DSA_65_SIGNATURE_LENGTH]);
+                    let n = kp.sign(data, sig_buf.as_mut()).expect("ML-DSA-65 sign failed");
+                    debug_assert_eq!(n, ML_DSA_65_SIGNATURE_LENGTH);
+                    Signature::MLDSA65(MlDsa65Signature(sig_buf))
+                }
+                #[cfg(not(feature = "aws-lc-rs"))]
+                {
+                    let _ = secret_key;
+                    unimplemented!("ML-DSA-65 requires the aws-lc-rs feature")
+                }
             }
         }
     }
@@ -833,13 +851,22 @@ impl SecretKey {
                 PublicKey::SECP256K1(public_key)
             }
             SecretKey::MLDSA65(secret_key) => {
-                let kp = PqdsaKeyPair::from_raw_private_key(&ML_DSA_65_SIGNING, &secret_key.0[..])
-                    .expect("invalid ML-DSA-65 raw private key");
-                use aws_lc_rs::signature::KeyPair;
-                let pk_bytes: &[u8] = kp.public_key().as_ref();
-                let mut buf = Box::new([0u8; ML_DSA_65_PUBLIC_KEY_LENGTH]);
-                buf.copy_from_slice(pk_bytes);
-                PublicKey::MLDSA65(MlDsa65PublicKey(buf))
+                #[cfg(feature = "aws-lc-rs")]
+                {
+                    let kp =
+                        PqdsaKeyPair::from_raw_private_key(&ML_DSA_65_SIGNING, &secret_key.0[..])
+                            .expect("invalid ML-DSA-65 raw private key");
+                    use aws_lc_rs::signature::KeyPair;
+                    let pk_bytes: &[u8] = kp.public_key().as_ref();
+                    let mut buf = Box::new([0u8; ML_DSA_65_PUBLIC_KEY_LENGTH]);
+                    buf.copy_from_slice(pk_bytes);
+                    PublicKey::MLDSA65(MlDsa65PublicKey(buf))
+                }
+                #[cfg(not(feature = "aws-lc-rs"))]
+                {
+                    let _ = secret_key;
+                    unimplemented!("ML-DSA-65 requires the aws-lc-rs feature")
+                }
             }
         }
     }
@@ -854,6 +881,7 @@ impl SecretKey {
 
 /// Helper: extract the 4032-byte raw private key from a freshly-generated keypair.
 #[cfg(feature = "rand")]
+#[cfg(feature = "aws-lc-rs")]
 fn ml_dsa_65_secret_from_keypair(kp: &PqdsaKeyPair) -> MlDsa65SecretKey {
     use aws_lc_rs::encoding::{AsRawBytes, PqdsaPrivateKeyRaw};
     let raw: PqdsaPrivateKeyRaw<'static> =
@@ -867,6 +895,7 @@ fn ml_dsa_65_secret_from_keypair(kp: &PqdsaKeyPair) -> MlDsa65SecretKey {
 
 /// Helper: build an `MlDsa65SecretKey` from a 32-byte seed (deterministic).
 #[cfg(feature = "rand")]
+#[cfg(feature = "aws-lc-rs")]
 fn ml_dsa_65_secret_from_seed(
     seed: &[u8; ML_DSA_65_SEED_LENGTH],
 ) -> Result<MlDsa65SecretKey, crate::errors::ParseKeyError> {
@@ -886,6 +915,7 @@ fn ml_dsa_65_secret_from_seed(
 ///
 /// Wraps `aws_lc_rs::unstable::signature::PqdsaKeyPair::from_seed`.
 #[cfg(feature = "rand")]
+#[cfg(feature = "aws-lc-rs")]
 pub fn ml_dsa_65_from_seed(
     seed: &[u8; ML_DSA_65_SEED_LENGTH],
 ) -> Result<SecretKey, crate::errors::ParseKeyError> {
@@ -922,6 +952,7 @@ impl FromStr for SecretKey {
                 // private key by handing them to the library. Catches
                 // malformed-but-correct-length blobs at parse time
                 // rather than blowing up later in `sign()`.
+                #[cfg(feature = "aws-lc-rs")]
                 PqdsaKeyPair::from_raw_private_key(&ML_DSA_65_SIGNING, &data[..])
                     .map_err(|err| Self::Err::InvalidData { error_message: err.to_string() })?;
                 Self::MLDSA65(MlDsa65SecretKey(Box::new(data)))
@@ -1131,8 +1162,16 @@ impl Signature {
                 SECP256K1.verify_ecdsa(&message, &sig, &pub_key).is_ok()
             }
             (Signature::MLDSA65(signature), PublicKey::MLDSA65(public_key)) => {
-                let unparsed = UnparsedPublicKey::new(&ML_DSA_65, &public_key.0[..]);
-                unparsed.verify(data, &signature.0[..]).is_ok()
+                #[cfg(feature = "aws-lc-rs")]
+                {
+                    let unparsed = UnparsedPublicKey::new(&ML_DSA_65, &public_key.0[..]);
+                    unparsed.verify(data, &signature.0[..]).is_ok()
+                }
+                #[cfg(not(feature = "aws-lc-rs"))]
+                {
+                    let _ = (signature, public_key);
+                    unimplemented!("ML-DSA-65 requires the aws-lc-rs feature")
+                }
             }
             _ => false,
         }

--- a/core/crypto/src/test_utils.rs
+++ b/core/crypto/src/test_utils.rs
@@ -1,10 +1,11 @@
+#[cfg(feature = "rand")]
+#[cfg(feature = "aws-lc-rs")]
+use crate::signature::ml_dsa_65_from_seed;
 use crate::signature::{
     KeyType, ML_DSA_65_SIGNATURE_LENGTH, MlDsa65Signature, PublicKey, SecretKey,
 };
 #[cfg(feature = "rand")]
-use crate::signature::{
-    ML_DSA_65_PUBLIC_KEY_LENGTH, ML_DSA_65_SEED_LENGTH, MlDsa65PublicKey, ml_dsa_65_from_seed,
-};
+use crate::signature::{ML_DSA_65_PUBLIC_KEY_LENGTH, ML_DSA_65_SEED_LENGTH, MlDsa65PublicKey};
 use crate::{InMemorySigner, Signature};
 
 #[cfg(feature = "rand")]
@@ -57,9 +58,17 @@ impl PublicKey {
                 PublicKey::SECP256K1(secret_key.public_key().unwrap_as_secp256k1().clone())
             }
             KeyType::MLDSA65 => {
-                let seed_bytes = ml_dsa_65_seed_bytes_from_str(seed);
-                let sk = ml_dsa_65_from_seed(&seed_bytes).expect("ML-DSA-65 from_seed failed");
-                sk.public_key()
+                #[cfg(feature = "aws-lc-rs")]
+                {
+                    let seed_bytes = ml_dsa_65_seed_bytes_from_str(seed);
+                    let sk = ml_dsa_65_from_seed(&seed_bytes).expect("ML-DSA-65 from_seed failed");
+                    sk.public_key()
+                }
+                #[cfg(not(feature = "aws-lc-rs"))]
+                {
+                    let _ = seed;
+                    unimplemented!("ML-DSA-65 requires the aws-lc-rs feature")
+                }
             }
         }
     }
@@ -75,8 +84,16 @@ impl SecretKey {
             }
             KeyType::SECP256K1 => SecretKey::SECP256K1(secp256k1_secret_key_from_seed(seed)),
             KeyType::MLDSA65 => {
-                let seed_bytes = ml_dsa_65_seed_bytes_from_str(seed);
-                ml_dsa_65_from_seed(&seed_bytes).expect("ML-DSA-65 from_seed failed")
+                #[cfg(feature = "aws-lc-rs")]
+                {
+                    let seed_bytes = ml_dsa_65_seed_bytes_from_str(seed);
+                    ml_dsa_65_from_seed(&seed_bytes).expect("ML-DSA-65 from_seed failed")
+                }
+                #[cfg(not(feature = "aws-lc-rs"))]
+                {
+                    let _ = seed;
+                    unimplemented!("ML-DSA-65 requires the aws-lc-rs feature")
+                }
             }
         }
     }


### PR DESCRIPTION
Makes `aws-lc-rs` optional (still default-on) in near-crypto: the ML-DSA types and parsing stay unconditional, only sign/verify/keygen need the backend, so wasm32 consumers build again with default features off and node builds are unchanged.
Fixes #16112.