### PR TITLE
fix(indexer): tolerate missing local receipts on forked chains

### DIFF
--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -88,6 +88,12 @@ pub struct IndexerConfig {
     pub finality: Finality,
     /// Tells whether to validate the genesis file before starting
     pub validate_genesis: bool,
+    /// Skip a local-receipt execution outcome whose receipt cannot be found,
+    /// instead of failing the streamer. This happens on forked chains: the
+    /// receipt is inherited in the fork genesis state, but the block that
+    /// produced it predates the fork genesis and is not part of this chain.
+    /// Keep false on mainnet, where a missing receipt is a real bug.
+    pub tolerate_missing_local_receipts: bool,
 }
 
 impl IndexerConfig {

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -41,6 +41,7 @@ pub async fn build_streamer_message(
     client: &IndexerViewClientFetcher,
     block: BlockView,
     shard_tracker: &ShardTracker,
+    tolerate_missing_local_receipts: bool,
 ) -> Result<StreamerMessage, FailedToFetchData> {
     let _timer = metrics::BUILD_STREAMER_MESSAGE_TIME.start_timer();
     let chunks = client.fetch_block_new_chunks(&block, shard_tracker).await?;
@@ -124,8 +125,19 @@ pub async fn build_streamer_message(
 
             let IndexerExecutionOutcomeWithOptionalReceipt { execution_outcome, receipt } = outcome;
             let Some(receipt) = receipt else {
-                // A receipt-execution outcome must have its receipt. A `None` here is
-                // unexpected; return an error so the streamer handles the error.
+                // A forked chain inherits receipts in its genesis state whose
+                // producing block predates the fork genesis and is absent here.
+                // Skip such outcomes when configured; otherwise a missing receipt
+                // is unexpected and we surface it as an error.
+                if tolerate_missing_local_receipts {
+                    tracing::warn!(
+                        target: INDEXER,
+                        receipt_id = %execution_outcome.id,
+                        block_hash = %block.header.hash,
+                        "receipt not found for execution outcome, skipping it (expected on forked chains)",
+                    );
+                    continue;
+                }
                 return Err(FailedToFetchData::String(format!(
                     "missing receipt for execution outcome {} in block {}",
                     execution_outcome.id, block.header.hash,
@@ -337,8 +349,13 @@ pub async fn start(
                 }
             };
 
-            let streamer_message =
-                Box::pin(build_streamer_message(&view_client, block, &shard_tracker)).await;
+            let streamer_message = Box::pin(build_streamer_message(
+                &view_client,
+                block,
+                &shard_tracker,
+                indexer_config.tolerate_missing_local_receipts,
+            ))
+            .await;
             let streamer_message = match streamer_message {
                 Ok(streamer_message) => {
                     build_streamer_message_attempts = 0;

--- a/test-loop-tests/src/tests/indexer.rs
+++ b/test-loop-tests/src/tests/indexer.rs
@@ -473,6 +473,7 @@ fn start_indexer_with_shard_tracker(
         await_for_node_synced: AwaitForNodeSyncedEnum::StreamWhileSyncing,
         finality: Finality::None,
         validate_genesis: false,
+        tolerate_missing_local_receipts: false,
     };
 
     let store_config =

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -274,6 +274,7 @@ async fn main() -> Result<()> {
                 await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync,
                 finality: near_primitives::types::Finality::Final,
                 validate_genesis: true,
+                tolerate_missing_local_receipts: false,
             };
             let tokio_runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -2032,6 +2032,9 @@ impl<T: ChainAccess> TxMirror<T> {
             await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::StreamWhileSyncing,
             finality: Finality::Final,
             validate_genesis: false,
+            // The target is a forked chain; receipts inherited in its genesis
+            // state have no producing block on this chain, so skip them.
+            tolerate_missing_local_receipts: true,
         };
         let near_config =
             indexer_config.load_near_config().context("failed to load near config").unwrap();


### PR DESCRIPTION
On a forked network (forknet/mocknet), the chain's genesis is the fork block and there is no pre-fork block history. The fork carries state, including the delayed-receipt queue, so a delayed local receipt inherited from real mainnet can execute a few blocks after genesis. Its execution outcome then refers to a receipt whose producing transaction was in a pre-fork block that does not exist on this chain.

When the indexer builds a streamer message for such a block, it cannot find that local receipt. On 2.13 it walked back through prior blocks to genesis and panicked ("reached genesis and failed to find local receipt"), killing the node; on master it returns an error that the streamer retries until it asserts. Either way the mirror traffic node dies.

This adds an `IndexerConfig.tolerate_missing_local_receipts` flag. When set, an execution outcome whose receipt cannot be found is logged and skipped instead of failing the streamer. The mirror target indexer, which runs over the forked chain, sets it. It stays off everywhere else, so on mainnet a missing receipt still surfaces as an error, where it indicates a real bug.