### PR TITLE
feat(spice): light-client chunk-execution proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,6 +4444,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.18",
  "time",
 ]

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -5,11 +5,12 @@ use near_primitives::network::PeerId;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, BlockReference, EpochId, EpochReference,
-    MaybeBlockId, ShardId, TransactionOrReceiptId,
+    MaybeBlockId, ShardId, SpiceChunkId, TransactionOrReceiptId,
 };
 use near_primitives::views::{
-    EpochSyncStatusView, ExecutionOutcomeWithIdView, LightClientBlockLiteView, QueryRequest,
-    StateChangesRequestView, StateSyncStatusView, SyncStatusView, TxStatusView,
+    ChunkExecutionProofView, EpochSyncStatusView, ExecutionOutcomeWithIdView,
+    LightClientBlockLiteView, QueryRequest, StateChangesRequestView, StateItem, StateProofTarget,
+    StateSyncStatusView, SyncStatusView, TxStatusView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 use near_time::Duration;
@@ -912,6 +913,78 @@ impl From<near_chain_primitives::error::Error> for GetBlockProofError {
                 Self::InternalError { error_message }
             }
             err => Self::Unreachable { error_message: err.to_string() },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GetLightClientChunkExecutionProof {
+    pub chunk_id: SpiceChunkId,
+    pub light_client_head: CryptoHash,
+}
+
+#[derive(Debug)]
+pub struct GetLightClientExecutionOutcomeProof {
+    pub id: TransactionOrReceiptId,
+    pub light_client_head: CryptoHash,
+}
+
+#[derive(Debug)]
+pub struct GetLightClientExecutionOutcomeProofResponse {
+    pub chunk_execution_proof: ChunkExecutionProofView,
+    pub outcome_proof: ExecutionOutcomeWithIdView,
+}
+
+#[derive(Debug)]
+pub struct GetLightClientStateProof {
+    pub chunk_id: SpiceChunkId,
+    pub target: StateProofTarget,
+    pub light_client_head: CryptoHash,
+}
+
+#[derive(Debug)]
+pub struct GetLightClientStateProofResponse {
+    pub chunk_execution_proof: ChunkExecutionProofView,
+    pub value: Option<StateItem>,
+    pub state_proof: Vec<Arc<[u8]>>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetLightClientProofError {
+    #[error("chunk {chunk_id:?} is not yet certified")]
+    ChunkNotCertified { chunk_id: SpiceChunkId },
+    #[error(
+        "light client head at height {head_height} is behind the block certifying chunk \
+         {chunk_id:?}, which needs head height >= {required_head_height}"
+    )]
+    LightClientHeadTooOld {
+        chunk_id: SpiceChunkId,
+        required_head_height: BlockHeight,
+        head_height: BlockHeight,
+    },
+    #[error(
+        "Block either has never been observed on the node or has been garbage collected: \
+         {error_message}"
+    )]
+    UnknownBlock { error_message: String },
+    #[error("{transaction_or_receipt_id} does not exist")]
+    UnknownTransactionOrReceipt { transaction_or_receipt_id: CryptoHash },
+    #[error("node does not track shard {shard_id}")]
+    ShardNotTracked { shard_id: ShardId },
+    #[error("Internal error: {error_message}")]
+    InternalError { error_message: String },
+}
+
+impl From<near_chain_primitives::error::Error> for GetLightClientProofError {
+    fn from(error: near_chain_primitives::error::Error) -> Self {
+        match error {
+            near_chain_primitives::error::Error::DBNotFoundErr(error_message) => {
+                Self::UnknownBlock { error_message }
+            }
+            near_chain_primitives::error::Error::IOErr(error) => {
+                Self::InternalError { error_message: error.to_string() }
+            }
+            err => Self::InternalError { error_message: err.to_string() },
         }
     }
 }

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -5,11 +5,11 @@ use near_primitives::network::PeerId;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, BlockReference, EpochId, EpochReference,
-    MaybeBlockId, ShardId, SpiceChunkId, TransactionOrReceiptId,
+    MaybeBlockId, ShardId, SpiceChunkId, StoreValue, TransactionOrReceiptId,
 };
 use near_primitives::views::{
     ChunkExecutionProofView, EpochSyncStatusView, ExecutionOutcomeWithIdView,
-    LightClientBlockLiteView, QueryRequest, StateChangesRequestView, StateItem, StateProofTarget,
+    LightClientBlockLiteView, QueryRequest, StateChangesRequestView, StateProofTarget,
     StateSyncStatusView, SyncStatusView, TxStatusView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
@@ -945,7 +945,7 @@ pub struct GetLightClientStateProof {
 #[derive(Debug)]
 pub struct GetLightClientStateProofResponse {
     pub chunk_execution_proof: ChunkExecutionProofView,
-    pub value: Option<StateItem>,
+    pub value: Option<StoreValue>,
     pub state_proof: Vec<Arc<[u8]>>,
 }
 

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -21,10 +21,12 @@ pub use near_client_primitives::debug::DebugStatus;
 pub use near_client_primitives::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
     GetChunkExtraExists, GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
-    GetExecutionOutcomesForBlock, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
-    GetNextLightClientBlock, GetProcessedReceiptIds, GetProtocolConfig, GetReceipt, GetReceiptToTx,
-    GetReceiptToTxResponse, GetShardChunk, GetSplitStorageInfo, GetStateChanges,
-    GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
+    GetExecutionOutcomesForBlock, GetGasPrice, GetLightClientChunkExecutionProof,
+    GetLightClientExecutionOutcomeProof, GetLightClientExecutionOutcomeProofResponse,
+    GetLightClientProofError, GetLightClientStateProof, GetLightClientStateProofResponse,
+    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProcessedReceiptIds,
+    GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse, GetShardChunk,
+    GetSplitStorageInfo, GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
     GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
     QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError, TxStatusOutcome,
 };

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -23,9 +23,12 @@ use near_client_primitives::types::{
     Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError, GetBlockProofResponse,
     GetBlockWithMerkleTree, GetChunkError, GetChunkExtraExists, GetExecutionOutcome,
     GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError,
-    GetMaintenanceWindows, GetMaintenanceWindowsError, GetNextLightClientBlockError,
-    GetProcessedReceiptIds, GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError,
-    GetReceipt, GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
+    GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
+    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError,
+    GetLightClientStateProof, GetLightClientStateProofResponse, GetMaintenanceWindows,
+    GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProcessedReceiptIds,
+    GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError, GetReceipt,
+    GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
     GetSplitStorageInfo, GetSplitStorageInfoError, GetStateChangesError,
     GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
     GetValidatorInfoError, Query, QueryError, TxStatus, TxStatusError, TxStatusOutcome,
@@ -49,22 +52,25 @@ use near_primitives::network::AnnounceAccount;
 use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptOrigin, ReceiptToTxInfo};
 use near_primitives::shard_layout::{ShardLayout, ShardLayoutError};
 use near_primitives::sharding::ShardChunk;
+use near_primitives::state::PartialState;
 use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{
-    AccountId, BlockHeight, BlockId, BlockReference, EpochHeight, EpochId, EpochReference,
-    Finality, MaybeBlockId, ShardId, SyncCheckpoint, TransactionOrReceiptId,
-    ValidatorInfoIdentifier,
+    AccountId, BlockHeight, BlockId, BlockReference, ChunkExecutionRoots, EpochHeight, EpochId,
+    EpochReference, Finality, MaybeBlockId, ShardId, SpiceChunkId, SyncCheckpoint,
+    TransactionOrReceiptId, ValidatorInfoIdentifier, sorted_chunk_execution_roots,
 };
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
-    BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView, ExecutionStatusView,
-    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockView,
-    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, SplitStorageInfoView,
-    StateChangesKindsView, StateChangesView, TxExecutionStatus, TxStatusView,
+    BlockView, ChunkExecutionProofView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
+    ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView,
+    LightClientBlockLiteView, LightClientBlockView, MaintenanceWindowsView, QueryRequest,
+    QueryResponse, ReceiptView, SplitStorageInfoView, StateChangesKindsView, StateChangesView,
+    StateItem, TxExecutionStatus, TxStatusView,
 };
 use near_store::adapter::StoreAdapter as _;
 use near_store::merkle_proof::MerkleProofAccess;
+use near_store::trie::AccessOptions;
 use near_store::{COLD_HEAD_KEY, DBCol, FINAL_HEAD_KEY, HEAD_KEY};
 use parking_lot::RwLock;
 use std::cmp::Ordering;
@@ -1617,6 +1623,184 @@ impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> f
             &msg.head_block_hash,
         )?;
         Ok(GetBlockProofResponse { block_header_lite, proof })
+    }
+}
+
+impl ViewClientActor {
+    /// Builds a light-client proof that a chunk's certified execution roots are
+    /// committed by the block certifying them, and that this block is in the
+    /// block merkle tree of a final `light_client_head`.
+    fn build_chunk_execution_proof(
+        &self,
+        chunk_id: &SpiceChunkId,
+        light_client_head: &CryptoHash,
+    ) -> Result<ChunkExecutionProofView, GetLightClientProofError> {
+        let Some(certifying_block_hash) =
+            self.runtime.store().chain_store().get_chunk_certifying_block(chunk_id)
+        else {
+            return Err(GetLightClientProofError::ChunkNotCertified { chunk_id: chunk_id.clone() });
+        };
+
+        let head_header = self.chain.get_block_header(light_client_head)?;
+        self.chain.check_blocks_final_and_canonical(&[BlockHeader::clone(&head_header)]).map_err(
+            |error| GetLightClientProofError::InternalError {
+                error_message: format!("light client head is not final and canonical: {error}"),
+            },
+        )?;
+
+        let certifying_block = self.chain.get_block(&certifying_block_hash)?;
+        let certifying_height = certifying_block.header().height();
+        let head_height = head_header.height();
+        // The head must be strictly after the certifying block: the block merkle
+        // proof recomputes the head's block_merkle_root from the certifying block,
+        // and that root commits only to blocks before the head.
+        if head_height <= certifying_height {
+            return Err(GetLightClientProofError::LightClientHeadTooOld {
+                chunk_id: chunk_id.clone(),
+                required_head_height: certifying_height + 1,
+                head_height,
+            });
+        }
+
+        let leaves = sorted_chunk_execution_roots(
+            certifying_block.spice_core_statements().iter_execution_results(),
+        );
+        let Some(index) = leaves.iter().position(|leaf| leaf.chunk_id() == chunk_id) else {
+            return Err(GetLightClientProofError::ChunkNotCertified { chunk_id: chunk_id.clone() });
+        };
+        let (root, paths) = merklize(&leaves);
+        debug_assert_eq!(
+            Some(root),
+            certifying_block.header().chunk_execution_root(),
+            "recomputed chunk_execution_root disagrees with the certifying block's committed root",
+        );
+        let roots = leaves[index].clone();
+        let roots_proof = paths[index].clone();
+
+        let certifying_block_header_lite =
+            LightClientBlockLiteView::from(BlockHeader::clone(certifying_block.header()));
+        let certifying_block_proof =
+            self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
+                &certifying_block_hash,
+                light_client_head,
+            )?;
+
+        Ok(ChunkExecutionProofView {
+            roots,
+            roots_proof,
+            certifying_block_header_lite,
+            certifying_block_proof,
+        })
+    }
+}
+
+impl
+    Handler<
+        GetLightClientChunkExecutionProof,
+        Result<ChunkExecutionProofView, GetLightClientProofError>,
+    > for ViewClientActor
+{
+    fn handle(
+        &mut self,
+        msg: GetLightClientChunkExecutionProof,
+    ) -> Result<ChunkExecutionProofView, GetLightClientProofError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetLightClientChunkExecutionProof"])
+            .start_timer();
+        self.build_chunk_execution_proof(&msg.chunk_id, &msg.light_client_head)
+    }
+}
+
+impl
+    Handler<
+        GetLightClientExecutionOutcomeProof,
+        Result<GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError>,
+    > for ViewClientActor
+{
+    fn handle(
+        &mut self,
+        msg: GetLightClientExecutionOutcomeProof,
+    ) -> Result<GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetLightClientExecutionOutcomeProof"])
+            .start_timer();
+        let (id, account_id) = match msg.id {
+            TransactionOrReceiptId::Transaction { transaction_hash, sender_id } => {
+                (transaction_hash, sender_id)
+            }
+            TransactionOrReceiptId::Receipt { receipt_id, receiver_id } => {
+                (receipt_id, receiver_id)
+            }
+        };
+        let outcome = match self.chain.get_execution_outcome(&id) {
+            Ok(outcome) => outcome,
+            Err(near_chain::Error::DBNotFoundErr(_)) => {
+                return Err(GetLightClientProofError::UnknownTransactionOrReceipt {
+                    transaction_or_receipt_id: id,
+                });
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let block_hash = outcome.block_hash;
+        let epoch_id = *self.chain.get_block_header(&block_hash)?.epoch_id();
+        let shard_id = account_id_to_shard_id(self.epoch_manager.as_ref(), &account_id, &epoch_id)
+            .into_chain_error()?;
+        let chunk_id = SpiceChunkId { block_hash, shard_id };
+        let chunk_execution_proof =
+            self.build_chunk_execution_proof(&chunk_id, &msg.light_client_head)?;
+        Ok(GetLightClientExecutionOutcomeProofResponse {
+            chunk_execution_proof,
+            outcome_proof: outcome.into(),
+        })
+    }
+}
+
+impl
+    Handler<
+        GetLightClientStateProof,
+        Result<GetLightClientStateProofResponse, GetLightClientProofError>,
+    > for ViewClientActor
+{
+    fn handle(
+        &mut self,
+        msg: GetLightClientStateProof,
+    ) -> Result<GetLightClientStateProofResponse, GetLightClientProofError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetLightClientStateProof"])
+            .start_timer();
+        let chunk_execution_proof =
+            self.build_chunk_execution_proof(&msg.chunk_id, &msg.light_client_head)?;
+        let ChunkExecutionRoots::V1(roots) = &chunk_execution_proof.roots;
+        let state_root = roots.state_root;
+
+        let shard_id = msg.chunk_id.shard_id;
+        if !self.shard_tracker.cares_about_shard(&msg.chunk_id.block_hash, shard_id) {
+            return Err(GetLightClientProofError::ShardNotTracked { shard_id });
+        }
+        let epoch_id = *self.chain.get_block_header(&msg.chunk_id.block_hash)?.epoch_id();
+        let shard_uid =
+            shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, &epoch_id).into_chain_error()?;
+
+        let trie = self
+            .runtime
+            .get_tries()
+            .get_view_trie_for_shard(shard_uid, state_root)
+            .recording_reads_new_recorder();
+        let trie_key = msg.target.to_trie_key().to_vec();
+        let value = trie.get(&trie_key, AccessOptions::DEFAULT).map_err(|error| {
+            GetLightClientProofError::InternalError { error_message: error.to_string() }
+        })?;
+        let Some(partial_storage) = trie.recorded_storage() else {
+            return Err(GetLightClientProofError::InternalError {
+                error_message: "trie did not record a state proof".to_string(),
+            });
+        };
+        let PartialState::TrieValues(state_proof) = partial_storage.nodes;
+        let value = value.map(|value| StateItem { key: trie_key.into(), value: value.into() });
+        Ok(GetLightClientStateProofResponse { chunk_execution_proof, value, state_proof })
     }
 }
 

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -56,7 +56,7 @@ use near_primitives::state::PartialState;
 use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockId, BlockReference, ChunkExecutionRoots, EpochHeight, EpochId,
-    EpochReference, Finality, MaybeBlockId, ShardId, SpiceChunkId, SyncCheckpoint,
+    EpochReference, Finality, MaybeBlockId, ShardId, SpiceChunkId, StoreValue, SyncCheckpoint,
     TransactionOrReceiptId, ValidatorInfoIdentifier, sorted_chunk_execution_roots,
 };
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
@@ -66,7 +66,7 @@ use near_primitives::views::{
     ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView,
     LightClientBlockLiteView, LightClientBlockView, MaintenanceWindowsView, QueryRequest,
     QueryResponse, ReceiptView, SplitStorageInfoView, StateChangesKindsView, StateChangesView,
-    StateItem, TxExecutionStatus, TxStatusView,
+    TxExecutionStatus, TxStatusView,
 };
 use near_store::adapter::StoreAdapter as _;
 use near_store::merkle_proof::MerkleProofAccess;
@@ -1799,7 +1799,7 @@ impl
             });
         };
         let PartialState::TrieValues(state_proof) = partial_storage.nodes;
-        let value = value.map(|value| StateItem { key: trie_key.into(), value: value.into() });
+        let value = value.map(StoreValue::from);
         Ok(GetLightClientStateProofResponse { chunk_execution_proof, value, state_proof })
     }
 }

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 arbitrary.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 schemars = { workspace = true, optional = true }
 thiserror.workspace = true
 time.workspace = true

--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -88,7 +88,7 @@ pub struct RpcLightClientStateProofRequest {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RpcLightClientStateProofResponse {
     pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
-    pub value: Option<near_primitives::views::StateItem>,
+    pub value: Option<near_primitives::types::StoreValue>,
     #[serde_as(as = "Vec<Base64>")]
     #[cfg_attr(feature = "schemars", schemars(with = "Vec<String>"))]
     pub state_proof: Vec<Arc<[u8]>>,

--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -1,4 +1,6 @@
 use serde_json::Value;
+use serde_with::base64::Base64;
+use serde_with::serde_as;
 use std::sync::Arc;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -45,6 +47,53 @@ pub struct RpcLightClientBlockProofResponse {
     pub block_proof: near_primitives::merkle::MerklePath,
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientChunkExecutionProofRequest {
+    pub chunk_id: near_primitives::types::SpiceChunkId,
+    pub light_client_head: near_primitives::hash::CryptoHash,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientChunkExecutionProofResponse {
+    pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientExecutionOutcomeProofRequest {
+    #[serde(flatten)]
+    pub id: near_primitives::types::TransactionOrReceiptId,
+    pub light_client_head: near_primitives::hash::CryptoHash,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientExecutionOutcomeProofResponse {
+    pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
+    pub outcome_proof: near_primitives::views::ExecutionOutcomeWithIdView,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientStateProofRequest {
+    pub chunk_id: near_primitives::types::SpiceChunkId,
+    pub target: near_primitives::views::StateProofTarget,
+    pub light_client_head: near_primitives::hash::CryptoHash,
+}
+
+#[serde_as]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientStateProofResponse {
+    pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
+    pub value: Option<near_primitives::views::StateItem>,
+    #[serde_as(as = "Vec<Base64>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Vec<String>"))]
+    pub state_proof: Vec<Arc<[u8]>>,
+}
+
 #[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
@@ -72,6 +121,19 @@ pub enum RpcLightClientProofError {
     UnavailableShard {
         transaction_or_receipt_id: near_primitives::hash::CryptoHash,
         shard_id: near_primitives::types::ShardId,
+    },
+    #[error("node does not track shard {shard_id}")]
+    ShardNotTracked { shard_id: near_primitives::types::ShardId },
+    #[error("chunk {chunk_id:?} is not yet certified")]
+    ChunkNotCertified { chunk_id: near_primitives::types::SpiceChunkId },
+    #[error(
+        "light client head at height {head_height} is behind the block certifying chunk \
+         {chunk_id:?}, which needs head height >= {required_head_height}"
+    )]
+    LightClientHeadTooOld {
+        chunk_id: near_primitives::types::SpiceChunkId,
+        required_head_height: near_primitives::types::BlockHeight,
+        head_height: near_primitives::types::BlockHeight,
     },
     #[error("Internal error: {error_message}")]
     InternalError { error_message: String },

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -1,13 +1,15 @@
 use super::{Params, RpcFrom, RpcRequest};
 use near_async::messaging::AsyncSendError;
 use near_client_primitives::types::{
-    GetBlockProofError, GetExecutionOutcomeError, GetNextLightClientBlockError,
+    GetBlockProofError, GetExecutionOutcomeError, GetLightClientProofError,
+    GetNextLightClientBlockError,
 };
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::light_client::{
-    RpcLightClientBlockProofRequest, RpcLightClientExecutionProofRequest,
+    RpcLightClientBlockProofRequest, RpcLightClientChunkExecutionProofRequest,
+    RpcLightClientExecutionOutcomeProofRequest, RpcLightClientExecutionProofRequest,
     RpcLightClientNextBlockError, RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse,
-    RpcLightClientProofError,
+    RpcLightClientProofError, RpcLightClientStateProofRequest,
 };
 use near_primitives::views::LightClientBlockView;
 use serde_json::Value;
@@ -30,6 +32,51 @@ impl RpcRequest for RpcLightClientNextBlockRequest {
 impl RpcRequest for RpcLightClientBlockProofRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
         Params::parse(value)
+    }
+}
+
+impl RpcRequest for RpcLightClientChunkExecutionProofRequest {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
+        Params::parse(value)
+    }
+}
+
+impl RpcRequest for RpcLightClientExecutionOutcomeProofRequest {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
+        Params::parse(value)
+    }
+}
+
+impl RpcRequest for RpcLightClientStateProofRequest {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
+        Params::parse(value)
+    }
+}
+
+impl RpcFrom<GetLightClientProofError> for RpcLightClientProofError {
+    fn rpc_from(error: GetLightClientProofError) -> Self {
+        match error {
+            GetLightClientProofError::ChunkNotCertified { chunk_id } => {
+                Self::ChunkNotCertified { chunk_id }
+            }
+            GetLightClientProofError::LightClientHeadTooOld {
+                chunk_id,
+                required_head_height,
+                head_height,
+            } => Self::LightClientHeadTooOld { chunk_id, required_head_height, head_height },
+            GetLightClientProofError::UnknownBlock { error_message } => {
+                Self::UnknownBlock { error_message }
+            }
+            GetLightClientProofError::UnknownTransactionOrReceipt { transaction_or_receipt_id } => {
+                Self::UnknownTransactionOrReceipt { transaction_or_receipt_id }
+            }
+            GetLightClientProofError::ShardNotTracked { shard_id } => {
+                Self::ShardNotTracked { shard_id }
+            }
+            GetLightClientProofError::InternalError { error_message } => {
+                Self::InternalError { error_message }
+            }
+        }
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -16,11 +16,13 @@ use near_chain_configs::{ClientConfig, GenesisConfig, ProtocolConfigView};
 use near_client::{
     DebugStatus, GetBlock, GetBlockProof, GetBlockProofResponse, GetChunk, GetChunkExtraExists,
     GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice,
-    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
-    GetReceiptToTx, GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock,
-    GetValidatorInfo, GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse,
-    Query as ClientQuery, QueryError, Status, StatusResponse, TxStatus, TxStatusError,
-    TxStatusOutcome,
+    GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
+    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError,
+    GetLightClientStateProof, GetLightClientStateProofResponse, GetMaintenanceWindows,
+    GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetReceiptToTx,
+    GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo,
+    GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse, Query as ClientQuery, QueryError,
+    Status, StatusResponse, TxStatus, TxStatusError, TxStatusOutcome,
 };
 use near_client_primitives::debug::{
     DebugBlockStatusQuery, DebugBlocksStartingMode, DebugStatusResponse,
@@ -93,10 +95,10 @@ use near_primitives::types::{
 };
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
-    BlockView, ChunkView, EpochValidatorInfo, GasPriceView, LightClientBlockView,
-    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, SplitStorageInfoView,
-    StateChangeKindView, StateChangesKindsView, StateChangesRequestView, StateChangesView,
-    TxExecutionStatus,
+    BlockView, ChunkExecutionProofView, ChunkView, EpochValidatorInfo, GasPriceView,
+    LightClientBlockView, MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView,
+    SplitStorageInfoView, StateChangeKindView, StateChangesKindsView, StateChangesRequestView,
+    StateChangesView, TxExecutionStatus,
 };
 use parking_lot::RwLock;
 use serde_json::{Value, json};
@@ -457,6 +459,18 @@ pub struct ViewClientSenderForRpc(
     AsyncSender<GetBlock, Result<BlockView, GetBlockError>>,
     AsyncSender<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>>,
     AsyncSender<GetChunk, Result<ChunkView, GetChunkError>>,
+    AsyncSender<
+        GetLightClientChunkExecutionProof,
+        Result<ChunkExecutionProofView, GetLightClientProofError>,
+    >,
+    AsyncSender<
+        GetLightClientExecutionOutcomeProof,
+        Result<GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError>,
+    >,
+    AsyncSender<
+        GetLightClientStateProof,
+        Result<GetLightClientStateProofResponse, GetLightClientProofError>,
+    >,
     AsyncSender<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>,
     AsyncSender<GetGasPrice, Result<GasPriceView, GetGasPriceError>>,
     AsyncSender<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanceWindowsError>>,
@@ -763,6 +777,21 @@ impl JsonRpcHandler {
             }
             "EXPERIMENTAL_light_client_block_proof" => {
                 process_method_call(request, |params| self.light_client_block_proof(params)).await
+            }
+            "EXPERIMENTAL_light_client_chunk_execution_proof" => {
+                process_method_call(request, |params| {
+                    self.light_client_chunk_execution_proof(params)
+                })
+                .await
+            }
+            "EXPERIMENTAL_light_client_execution_outcome_proof" => {
+                process_method_call(request, |params| {
+                    self.light_client_execution_outcome_proof(params)
+                })
+                .await
+            }
+            "EXPERIMENTAL_light_client_state_proof" => {
+                process_method_call(request, |params| self.light_client_state_proof(params)).await
             }
             "EXPERIMENTAL_protocol_config" => {
                 process_method_call(request, |params| self.protocol_config(params)).await
@@ -2476,6 +2505,69 @@ impl JsonRpcHandler {
         Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientBlockProofResponse {
             block_header_lite: block_proof.block_header_lite,
             block_proof: block_proof.proof,
+        })
+    }
+
+    async fn light_client_chunk_execution_proof(
+        &self,
+        request: near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofRequest,
+    ) -> Result<
+        near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofResponse,
+        near_jsonrpc_primitives::types::light_client::RpcLightClientProofError,
+    > {
+        let near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofRequest {
+            chunk_id,
+            light_client_head,
+        } = request;
+        let chunk_execution_proof: ChunkExecutionProofView = self
+            .view_client_send(GetLightClientChunkExecutionProof { chunk_id, light_client_head })
+            .await?;
+        Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofResponse {
+            chunk_execution_proof,
+        })
+    }
+
+    async fn light_client_execution_outcome_proof(
+        &self,
+        request: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionOutcomeProofRequest,
+    ) -> Result<
+        near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionOutcomeProofResponse,
+        near_jsonrpc_primitives::types::light_client::RpcLightClientProofError,
+    > {
+        let near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionOutcomeProofRequest {
+            id,
+            light_client_head,
+        } = request;
+        let response: GetLightClientExecutionOutcomeProofResponse = self
+            .view_client_send(GetLightClientExecutionOutcomeProof { id, light_client_head })
+            .await?;
+        Ok(
+            near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionOutcomeProofResponse {
+                chunk_execution_proof: response.chunk_execution_proof,
+                outcome_proof: response.outcome_proof,
+            },
+        )
+    }
+
+    async fn light_client_state_proof(
+        &self,
+        request: near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofRequest,
+    ) -> Result<
+        near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofResponse,
+        near_jsonrpc_primitives::types::light_client::RpcLightClientProofError,
+    > {
+        let near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofRequest {
+            chunk_id,
+            target,
+            light_client_head,
+        } = request;
+        let response: GetLightClientStateProofResponse = self
+            .view_client_send(GetLightClientStateProof { chunk_id, target, light_client_head })
+            .await?;
+        Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofResponse {
+            chunk_execution_proof: response.chunk_execution_proof,
+            value: response.value,
+            state_proof: response.state_proof,
         })
     }
 

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1340,8 +1340,11 @@ pub struct StateChangesForShard {
     Ord,
     BorshSerialize,
     BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
     ProtocolSchema,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SpiceChunkId {
     pub block_hash: CryptoHash,
     pub shard_id: ShardId,
@@ -1357,12 +1360,34 @@ pub struct ChunkExecutionResult {
 /// Merkle leaf committing to a single chunk's certified execution roots.
 /// The `chunk_execution_root` in a spice block header is the merkle root over
 /// these leaves, sorted by `chunk_id`.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    ProtocolSchema,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ChunkExecutionRoots {
     V1(ChunkExecutionRootsV1),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    ProtocolSchema,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ChunkExecutionRootsV1 {
     pub chunk_id: SpiceChunkId,
     pub state_root: CryptoHash,
@@ -1390,16 +1415,24 @@ impl ChunkExecutionRoots {
     }
 }
 
-/// Merkle root over the block's certified chunk execution results, sorted by `chunk_id`.
-pub fn compute_chunk_execution_root<'a>(
+/// Leaves for the block's certified chunk execution results, sorted by `chunk_id`.
+pub fn sorted_chunk_execution_roots<'a>(
     execution_results: impl Iterator<Item = (&'a SpiceChunkId, &'a ChunkExecutionResult)>,
-) -> CryptoHash {
+) -> Vec<ChunkExecutionRoots> {
     let mut leaves: Vec<ChunkExecutionRoots> = execution_results
         .map(|(chunk_id, execution_result)| {
             ChunkExecutionRoots::from_execution_result(chunk_id, execution_result)
         })
         .collect();
     leaves.sort_by(|a, b| a.chunk_id().cmp(b.chunk_id()));
+    leaves
+}
+
+/// Merkle root over the block's certified chunk execution results, sorted by `chunk_id`.
+pub fn compute_chunk_execution_root<'a>(
+    execution_results: impl Iterator<Item = (&'a SpiceChunkId, &'a ChunkExecutionResult)>,
+) -> CryptoHash {
+    let leaves = sorted_chunk_execution_roots(execution_results);
     merklize(&leaves).0
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -40,12 +40,13 @@ use crate::transaction::{
     ExecutionStatus, FunctionCallAction, NonceMode, PartialExecutionOutcome,
     PartialExecutionStatus, SignedTransaction, StakeAction, TransferAction,
 };
+use crate::trie_key::TrieKey;
 use crate::trie_split::TrieSplit;
 use crate::types::{
-    AccountId, AccountWithPublicKey, Balance, BlockHeight, EpochHeight, EpochId, FunctionArgs, Gas,
-    Nonce, NumBlocks, ShardId, SpiceChunkEndorsementStats, StateChangeCause, StateChangeKind,
-    StateChangeValue, StateChangeWithCause, StateChangesRequest, StateRoot, StorageUsage, StoreKey,
-    StoreValue, ValidatorKickoutReason,
+    AccountId, AccountWithPublicKey, Balance, BlockHeight, ChunkExecutionRoots, EpochHeight,
+    EpochId, FunctionArgs, Gas, Nonce, NumBlocks, ShardId, SpiceChunkEndorsementStats,
+    StateChangeCause, StateChangeKind, StateChangeValue, StateChangeWithCause, StateChangesRequest,
+    StateRoot, StorageUsage, StoreKey, StoreValue, ValidatorKickoutReason,
 };
 use crate::version::{ProtocolVersion, Version};
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -2766,6 +2767,51 @@ impl LightClientBlockLiteView {
             &combine_hash(&hash(&inner_lite_bytes), &self.inner_rest_hash),
             &self.prev_block_hash,
         )
+    }
+}
+
+/// Proof that a chunk's certified execution roots are committed by a spice block
+/// that a light client can trust via its `light_client_head`.
+///
+/// `roots_proof` recomputes the certifying block's `chunk_execution_root` from the leaf;
+/// `certifying_block_proof` places the certifying block into the head's block merkle tree.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct ChunkExecutionProofView {
+    pub roots: ChunkExecutionRoots,
+    pub roots_proof: MerklePath,
+    pub certifying_block_header_lite: LightClientBlockLiteView,
+    pub certifying_block_proof: MerklePath,
+}
+
+/// Which piece of a shard's state a light-client state proof targets.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(tag = "target_type", rename_all = "snake_case")]
+pub enum StateProofTarget {
+    Account { account_id: AccountId },
+    ContractCode { account_id: AccountId },
+    ContractData { account_id: AccountId, key: StoreKey },
+    AccessKey { account_id: AccountId, public_key: PublicKey },
+}
+
+impl StateProofTarget {
+    pub fn to_trie_key(&self) -> TrieKey {
+        match self {
+            StateProofTarget::Account { account_id } => {
+                TrieKey::Account { account_id: account_id.clone() }
+            }
+            StateProofTarget::ContractCode { account_id } => {
+                TrieKey::ContractCode { account_id: account_id.clone() }
+            }
+            StateProofTarget::ContractData { account_id, key } => {
+                TrieKey::ContractData { account_id: account_id.clone(), key: key.clone().into() }
+            }
+            StateProofTarget::AccessKey { account_id, public_key } => TrieKey::AccessKey {
+                account_id: account_id.clone(),
+                key_handle: public_key.clone().into(),
+            },
+        }
     }
 }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -36,6 +36,7 @@ pub mod genesis;
 pub mod merkle_proof;
 pub mod metrics;
 mod node_storage;
+pub mod spice_proof_verifier;
 mod store;
 pub mod trie;
 mod utils;

--- a/core/store/src/spice_proof_verifier.rs
+++ b/core/store/src/spice_proof_verifier.rs
@@ -1,0 +1,96 @@
+//! Verification for SPICE light-client chunk-execution proofs.
+//!
+//! A light client trusts a final head and its block merkle root. These functions
+//! recompute that root from a served proof without trusting the serving node.
+
+use crate::trie::AccessOptions;
+use crate::{PartialStorage, Trie};
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::{compute_root_from_path, compute_root_from_path_and_item};
+use near_primitives::state::{PartialState, TrieValue};
+use near_primitives::types::ChunkExecutionRoots;
+use near_primitives::views::{
+    ChunkExecutionProofView, ExecutionOutcomeWithIdView, StateItem, StateProofTarget,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum SpiceProofVerificationError {
+    #[error("certifying block header does not commit a chunk_execution_root")]
+    MissingChunkExecutionRoot,
+    #[error("roots proof does not recompute the certifying block's chunk_execution_root")]
+    InvalidRootsProof,
+    #[error("certifying block is not committed in the light client head's block merkle root")]
+    InvalidBlockProof,
+    #[error("execution outcome proof does not recompute the chunk's outcome_root")]
+    InvalidOutcomeProof,
+    #[error("state proof does not reconstruct the claimed value at the chunk's state_root")]
+    InvalidStateProof,
+    #[error("state proof trie access failed: {0}")]
+    TrieError(String),
+}
+
+/// Checks that the chunk's execution roots are committed by a block that the
+/// trusted `light_client_head_block_merkle_root` includes.
+pub fn verify_chunk_execution_proof(
+    proof: &ChunkExecutionProofView,
+    light_client_head_block_merkle_root: &CryptoHash,
+) -> Result<(), SpiceProofVerificationError> {
+    let committed_chunk_execution_root = proof
+        .certifying_block_header_lite
+        .inner_lite
+        .chunk_execution_root
+        .ok_or(SpiceProofVerificationError::MissingChunkExecutionRoot)?;
+
+    let computed_chunk_execution_root =
+        compute_root_from_path_and_item(&proof.roots_proof, &proof.roots);
+    if computed_chunk_execution_root != committed_chunk_execution_root {
+        return Err(SpiceProofVerificationError::InvalidRootsProof);
+    }
+
+    let certifying_block_hash = proof.certifying_block_header_lite.hash();
+    let computed_head_root =
+        compute_root_from_path(&proof.certifying_block_proof, certifying_block_hash);
+    if &computed_head_root != light_client_head_block_merkle_root {
+        return Err(SpiceProofVerificationError::InvalidBlockProof);
+    }
+    Ok(())
+}
+
+/// Checks that the outcome hashes to a value committed by the chunk's
+/// `outcome_root`. Call after [`verify_chunk_execution_proof`] to bind `roots` to
+/// the trusted head.
+pub fn verify_execution_outcome_proof(
+    outcome_proof: &ExecutionOutcomeWithIdView,
+    roots: &ChunkExecutionRoots,
+) -> Result<(), SpiceProofVerificationError> {
+    let ChunkExecutionRoots::V1(roots) = roots;
+    let outcome_hash = CryptoHash::hash_borsh(outcome_proof.to_hashes());
+    let computed_outcome_root = compute_root_from_path(&outcome_proof.proof, outcome_hash);
+    if computed_outcome_root != roots.outcome_root {
+        return Err(SpiceProofVerificationError::InvalidOutcomeProof);
+    }
+    Ok(())
+}
+
+/// Verifies a state trie proof against the chunk's `state_root`: reconstructs the
+/// trie from `state_proof` and checks the claimed `value` for `target`. Call after
+/// [`verify_chunk_execution_proof`] to bind `roots` to the trusted head.
+pub fn verify_state_proof(
+    target: &StateProofTarget,
+    value: Option<&StateItem>,
+    state_proof: &[TrieValue],
+    roots: &ChunkExecutionRoots,
+) -> Result<(), SpiceProofVerificationError> {
+    let ChunkExecutionRoots::V1(roots) = roots;
+    let partial_storage = PartialStorage { nodes: PartialState::TrieValues(state_proof.to_vec()) };
+    let trie = Trie::from_recorded_storage(partial_storage, roots.state_root, false);
+    let trie_key = target.to_trie_key().to_vec();
+    let recovered_value = trie
+        .get(&trie_key, AccessOptions::DEFAULT)
+        .map_err(|error| SpiceProofVerificationError::TrieError(error.to_string()))?;
+    let claimed_value: Option<Vec<u8>> = value.map(|item| item.value.clone().into());
+    if recovered_value != claimed_value {
+        return Err(SpiceProofVerificationError::InvalidStateProof);
+    }
+    Ok(())
+}

--- a/core/store/src/spice_proof_verifier.rs
+++ b/core/store/src/spice_proof_verifier.rs
@@ -8,9 +8,9 @@ use crate::{PartialStorage, Trie};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{compute_root_from_path, compute_root_from_path_and_item};
 use near_primitives::state::{PartialState, TrieValue};
-use near_primitives::types::ChunkExecutionRoots;
+use near_primitives::types::{ChunkExecutionRoots, StoreValue};
 use near_primitives::views::{
-    ChunkExecutionProofView, ExecutionOutcomeWithIdView, StateItem, StateProofTarget,
+    ChunkExecutionProofView, ExecutionOutcomeWithIdView, StateProofTarget,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -77,7 +77,7 @@ pub fn verify_execution_outcome_proof(
 /// [`verify_chunk_execution_proof`] to bind `roots` to the trusted head.
 pub fn verify_state_proof(
     target: &StateProofTarget,
-    value: Option<&StateItem>,
+    value: Option<&StoreValue>,
     state_proof: &[TrieValue],
     roots: &ChunkExecutionRoots,
 ) -> Result<(), SpiceProofVerificationError> {
@@ -88,7 +88,7 @@ pub fn verify_state_proof(
     let recovered_value = trie
         .get(&trie_key, AccessOptions::DEFAULT)
         .map_err(|error| SpiceProofVerificationError::TrieError(error.to_string()))?;
-    let claimed_value: Option<Vec<u8>> = value.map(|item| item.value.clone().into());
+    let claimed_value: Option<Vec<u8>> = value.map(|value| value.clone().into());
     if recovered_value != claimed_value {
         return Err(SpiceProofVerificationError::InvalidStateProof);
     }

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -1,0 +1,237 @@
+use crate::setup::builder::TestLoopBuilder;
+use crate::utils::account::create_account_id;
+use assert_matches::assert_matches;
+use borsh::BorshDeserialize as _;
+use near_async::messaging::Handler as _;
+use near_async::time::Duration;
+use near_client::{
+    GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
+    GetLightClientStateProof,
+};
+use near_client_primitives::types::GetLightClientProofError;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::account::Account;
+use near_primitives::block::BlockHeader;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{
+    Balance, ChunkExecutionRoots, ChunkExecutionRootsV1, Gas, SpiceChunkId, TransactionOrReceiptId,
+};
+use near_primitives::views::{
+    ChunkExecutionProofView, ExecutionStatusView, LightClientBlockLiteView, StateProofTarget,
+};
+use near_store::spice_proof_verifier::{
+    SpiceProofVerificationError, verify_chunk_execution_proof, verify_execution_outcome_proof,
+    verify_state_proof,
+};
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_chunk_execution_proofs() {
+    init_test_logger();
+
+    let contract_account = create_account_id("contract");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 0)
+        .add_user_accounts([&contract_account], Balance::from_near(10))
+        .build();
+
+    let deploy_tx = env.validator().tx_deploy_test_contract(&contract_account);
+    env.validator_runner().run_tx(deploy_tx, Duration::seconds(20));
+
+    // rs_contract's write_key_value reads input as `key_bytes || value(u64 LE)` and
+    // does storage_write(key, value), so this creates a provable ContractData entry.
+    let storage_key = b"spice_key".to_vec();
+    let storage_value: u64 = 42;
+    let mut call_args = storage_key.clone();
+    call_args.extend_from_slice(&storage_value.to_le_bytes());
+    let call_tx = env.validator().tx_call(
+        &contract_account,
+        &contract_account,
+        "write_key_value",
+        call_args,
+        Balance::ZERO,
+        Gas::from_teragas(300),
+    );
+    let call_tx_hash = call_tx.get_hash();
+    env.validator_runner().run_tx(call_tx, Duration::seconds(20));
+    let receipt_id = env.validator().tx_receipt_id(call_tx_hash);
+
+    // Certify the chain through the current tip, then let finality advance strictly
+    // past it. The handler serves from the certifying-block index (written at
+    // finality), and the head must be strictly after a chunk's certifying block for
+    // the block merkle proof to recompute the head's block_merkle_root from it.
+    let tip_height = env.validator().head().height;
+    env.validator_runner().run_until_certified(tip_height);
+    let certified_head_height = env.validator().head().height;
+    env.validator_runner().run_until_final_head_height(certified_head_height + 1);
+
+    let light_client_head = env.validator().final_head().last_block_hash;
+    let head_header = env.validator().client().chain.get_block_header(&light_client_head).unwrap();
+    let trusted_block_merkle_root = *head_header.block_merkle_root();
+
+    // Outcome proof for the contract call's receipt. The handler resolves the chunk
+    // it executed in; that chunk_id anchors the chunk-execution and state proofs.
+    let outcome_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientExecutionOutcomeProof {
+            id: TransactionOrReceiptId::Receipt {
+                receipt_id,
+                receiver_id: contract_account.clone(),
+            },
+            light_client_head,
+        })
+        .unwrap();
+
+    verify_chunk_execution_proof(
+        &outcome_response.chunk_execution_proof,
+        &trusted_block_merkle_root,
+    )
+    .unwrap();
+    verify_execution_outcome_proof(
+        &outcome_response.outcome_proof,
+        &outcome_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+
+    // A server lying about the result must be rejected: changing the outcome status
+    // changes the outcome hash, which then does not recompute the chunk's outcome_root.
+    let mut tampered_outcome = outcome_response.outcome_proof.clone();
+    tampered_outcome.outcome.status = ExecutionStatusView::SuccessValue(b"forged result".to_vec());
+    assert_matches!(
+        verify_execution_outcome_proof(
+            &tampered_outcome,
+            &outcome_response.chunk_execution_proof.roots,
+        ),
+        Err(SpiceProofVerificationError::InvalidOutcomeProof)
+    );
+
+    // The chunk the receipt executed in, resolved by the outcome handler; it anchors
+    // the chunk-execution and state proofs below.
+    let chunk_id = outcome_response.chunk_execution_proof.roots.chunk_id().clone();
+
+    // Chunk-execution proof for the same chunk.
+    let chunk_proof: ChunkExecutionProofView = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientChunkExecutionProof { chunk_id: chunk_id.clone(), light_client_head })
+        .unwrap();
+    verify_chunk_execution_proof(&chunk_proof, &trusted_block_merkle_root).unwrap();
+
+    // Tampering a committed root no longer recomputes the chunk_execution_root.
+    let ChunkExecutionRoots::V1(good_roots) = &chunk_proof.roots;
+    let mut tampered_proof = chunk_proof.clone();
+    tampered_proof.roots = ChunkExecutionRoots::V1(ChunkExecutionRootsV1 {
+        state_root: CryptoHash::hash_bytes(b"tampered state root"),
+        ..good_roots.clone()
+    });
+    assert_matches!(
+        verify_chunk_execution_proof(&tampered_proof, &trusted_block_merkle_root),
+        Err(SpiceProofVerificationError::InvalidRootsProof)
+    );
+
+    // A correct proof must not verify against a wrong trusted root.
+    let wrong_root = CryptoHash::hash_bytes(b"not the head block merkle root");
+    assert_matches!(
+        verify_chunk_execution_proof(&chunk_proof, &wrong_root),
+        Err(SpiceProofVerificationError::InvalidBlockProof)
+    );
+
+    // The contract account's record and the storage entry it wrote both live in this
+    // chunk's shard at the certified state_root, so both are provable against it.
+
+    // Account record proves the deployed contract and a gas-reduced balance.
+    let account_target = StateProofTarget::Account { account_id: contract_account.clone() };
+    let account_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: account_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    verify_state_proof(
+        &account_target,
+        account_response.value.as_ref(),
+        &account_response.state_proof,
+        &account_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+    let account_bytes: Vec<u8> =
+        account_response.value.clone().expect("contract account must be present").value.into();
+    let account = Account::try_from_slice(&account_bytes).unwrap();
+    assert_eq!(
+        account.local_contract_hash(),
+        Some(CryptoHash::hash_bytes(near_test_contracts::rs_contract()))
+    );
+    assert!(account.amount() > Balance::ZERO);
+    assert!(account.amount() < Balance::from_near(10), "deploy and call gas should reduce balance");
+
+    // The contract-data key/value we wrote is present and proves the exact value.
+    let data_target = StateProofTarget::ContractData {
+        account_id: contract_account.clone(),
+        key: storage_key.clone().into(),
+    };
+    let data_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: data_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    let proved_value: Vec<u8> =
+        data_response.value.clone().expect("contract data must be present").value.into();
+    assert_eq!(proved_value, storage_value.to_le_bytes());
+    verify_state_proof(
+        &data_target,
+        data_response.value.as_ref(),
+        &data_response.state_proof,
+        &data_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+
+    // Tampering the claimed value must be rejected by the trie proof.
+    let mut tampered_value = data_response.value.clone().unwrap();
+    tampered_value.value = b"tampered contract data".to_vec().into();
+    assert_matches!(
+        verify_state_proof(
+            &data_target,
+            Some(&tampered_value),
+            &data_response.state_proof,
+            &data_response.chunk_execution_proof.roots,
+        ),
+        Err(SpiceProofVerificationError::InvalidStateProof)
+    );
+
+    // A not-yet-certified chunk (in the non-final head block) is not served.
+    let head_block = env.validator().head_block();
+    let uncertified_chunk_id =
+        SpiceChunkId { block_hash: *head_block.hash(), shard_id: chunk_id.shard_id };
+    let result =
+        env.validator_mut().view_client_actor().handle(GetLightClientChunkExecutionProof {
+            chunk_id: uncertified_chunk_id,
+            light_client_head,
+        });
+    assert_matches!(result, Err(GetLightClientProofError::ChunkNotCertified { .. }));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_block_lite_view_hash() {
+    init_test_logger();
+
+    // `build()` warms up, so the chain already has produced a block.
+    let env = TestLoopBuilder::new().validators(1, 0).build();
+
+    // The verifier derives the certifying block's hash by calling
+    // LightClientBlockLiteView::hash(), so that reconstruction (rebuilding the spice
+    // header's inner-lite, including chunk_execution_root) must equal the real hash.
+    let block = env.validator().head_block();
+    assert_eq!(
+        LightClientBlockLiteView::from(BlockHeader::clone(block.header())).hash(),
+        *block.header().hash(),
+    );
+}

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -14,7 +14,8 @@ use near_primitives::account::Account;
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{
-    Balance, ChunkExecutionRoots, ChunkExecutionRootsV1, Gas, SpiceChunkId, TransactionOrReceiptId,
+    Balance, ChunkExecutionRoots, ChunkExecutionRootsV1, Gas, SpiceChunkId, StoreValue,
+    TransactionOrReceiptId,
 };
 use near_primitives::views::{
     ChunkExecutionProofView, ExecutionStatusView, LightClientBlockLiteView, StateProofTarget,
@@ -159,7 +160,7 @@ fn test_spice_light_client_chunk_execution_proofs() {
     )
     .unwrap();
     let account_bytes: Vec<u8> =
-        account_response.value.clone().expect("contract account must be present").value.into();
+        account_response.value.clone().expect("contract account must be present").into();
     let account = Account::try_from_slice(&account_bytes).unwrap();
     assert_eq!(
         account.local_contract_hash(),
@@ -183,7 +184,7 @@ fn test_spice_light_client_chunk_execution_proofs() {
         })
         .unwrap();
     let proved_value: Vec<u8> =
-        data_response.value.clone().expect("contract data must be present").value.into();
+        data_response.value.clone().expect("contract data must be present").into();
     assert_eq!(proved_value, storage_value.to_le_bytes());
     verify_state_proof(
         &data_target,
@@ -194,8 +195,7 @@ fn test_spice_light_client_chunk_execution_proofs() {
     .unwrap();
 
     // Tampering the claimed value must be rejected by the trie proof.
-    let mut tampered_value = data_response.value.clone().unwrap();
-    tampered_value.value = b"tampered contract data".to_vec().into();
+    let tampered_value: StoreValue = b"tampered contract data".to_vec().into();
     assert_matches!(
         verify_state_proof(
             &data_target,

--- a/test-loop-tests/src/tests/spice/mod.rs
+++ b/test-loop-tests/src/tests/spice/mod.rs
@@ -2,6 +2,7 @@ mod basic;
 mod congestion;
 mod core_statement_limit;
 mod garbage_collection;
+mod light_client;
 mod malicious_chunk_producer;
 mod resharding;
 mod utils;


### PR DESCRIPTION
Adds SPICE light-client execution proofs over RPC, chunk-oriented, plus a single verifier importable by the neard CLI and tests.

Three experimental JSON-RPC methods, served only against a final `light_client_head`:
- `EXPERIMENTAL_light_client_chunk_execution_proof` — a chunk's certified execution roots (`ChunkExecutionProofView`): the `{state_root, outcome_root, outgoing_receipts_root}` leaf, its merkle path to the certifying block's `chunk_execution_root`, the certifying block's `LightClientBlockLiteView`, and a block-merkle proof into the head.
- `EXPERIMENTAL_light_client_execution_outcome_proof` — the above plus the transaction/receipt `ExecutionOutcomeWithIdView`, whose own merkle path recomputes the chunk's `outcome_root`.
- `EXPERIMENTAL_light_client_state_proof` — the above plus a value and trie proof for an account / contract code / contract data / access key at the chunk's `state_root`.

The verifier (`core/store/src/spice_proof_verifier.rs`) recomputes a served proof up to the trusted head's `block_merkle_root` without trusting the serving node: `verify_chunk_execution_proof`, `verify_execution_outcome_proof`, `verify_state_proof`.

Serving resolves the chunk's certifying block via the certifying-block index, recomputes the roots merkle path, builds the block-merkle proof, and reads the state trie with recorded reads. New errors: `ChunkNotCertified`, `LightClientHeadTooOld`, `ShardNotTracked`.

Known limitation: the new methods are not yet in the OpenAPI spec.