### PR TITLE
fix(ci): isolate Claude review setup from pull request code

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -25,7 +25,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       # secrets are not allowed in step-level `if:` expressions, so record the
@@ -41,19 +40,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
-          # On pull_request events checkout defaults to the PR merge ref. On
-          # issue_comment (@claude review) events it defaults to the base
-          # branch, so Read/Grep would see base code instead of the PR — pin it
-          # to the PR merge ref explicitly.
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
+          # Fetch comments and review instructions only from the trusted base
+          # branch. A fork PR can modify either script in its merge ref.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
           persist-credentials: false
-
-      - name: symlink fix workaround
-        run: |
-          # see https://github.com/anthropics/claude-code-action/issues/1205#issuecomment-4248704481
-          rm -f CLAUDE.md
-          cp -f AGENTS.md CLAUDE.md
 
       - name: Fetch PR Comments Context
         id: fetch-comments
@@ -85,6 +76,19 @@ jobs:
             echo '</review_instructions>'
             echo "$DELIM"
           } >> "$GITHUB_ENV"
+
+      - name: Checkout pull request
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: symlink fix workaround
+        run: |
+          # see https://github.com/anthropics/claude-code-action/issues/1205#issuecomment-4248704481
+          rm -f CLAUDE.md
+          cp -f AGENTS.md CLAUDE.md
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
### Motivation

- Address a CI credential-exposure vulnerability where an `issue_comment`-triggered run checked out a PR-controlled merge ref and then executed `.github/scripts/fetch-pr-comments.sh` with `GH_TOKEN` and OIDC scope, allowing forked PRs to run attacker-controlled code with repository credentials.

### Description

- Modify `.github/workflows/claude-pr-review.yml` to isolate trusted setup from PR-controlled code.
- Remove the unnecessary `id-token: write` permission from the job to eliminate OIDC token access.
- Change the initial checkout to the trusted `github.event.repository.default_branch` so comment-fetching and review-instruction loading run from the base branch.
- Defer checking out the PR merge ref by adding a dedicated `Checkout pull request` step after building the prompt and after credentialed repository scripts have completed, and move the symlink workaround to run after that checkout.

### Testing

- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-pr-review.yml", aliases: true); puts "valid YAML"'` which reported valid YAML.
- Ran `git diff --check` with no problems reported and committed the change successfully.
- Ran repository-wide `RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets` which started successfully but was not completed because this is a YAML-only change and compiling the full workspace is long; no Rust changes were required by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a655e12fa7c8329b167a72b768bf370)