### PR TITLE
fix(stateless-validation): resolve resharding layouts from the local boundary block

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -677,6 +677,12 @@ pub fn validate_chunk_state_witness_impl(
         .into_iter()
         .zip(state_witness.implicit_transitions().into_iter())
     {
+        let transition_block_hash = match &implicit_transition_params {
+            ImplicitTransitionParams::ApplyOldChunk(..) => transition.block_hash,
+            ImplicitTransitionParams::Resharding(_, _, _, boundary_block_hash) => {
+                *boundary_block_hash
+            }
+        };
         let (shard_uid, new_state_root, new_congestion_info) = match implicit_transition_params {
             ImplicitTransitionParams::ApplyOldChunk(block, shard_uid) => {
                 let shard_context = ShardContext { shard_uid, should_apply_chunk: false };
@@ -716,14 +722,8 @@ pub fn validate_chunk_state_witness_impl(
                 // important to do this step before the `retain_split_shard`
                 // because only the parent trie has the needed information.
                 //
-                // Resolve the epochs (and thus shard layouts) from the locally
-                // determined boundary block, not the unvalidated witness hash,
-                // as the producer does in `ReshardingManager::process_...`. Using the
-                // main-transition `block_hash` here is wrong: if the parent shard
-                // produced no chunk in the last old-layout epoch, that block lies
-                // in an earlier epoch and resolves to the old layout, so the
-                // child's new shard id is absent and validation fails with
-                // `InvalidShardId`, permanently halting the resharded shard.
+                // The boundary block is the last block of the old epoch. Resolve
+                // both shard layouts from it, matching the producer.
                 let epoch_id = epoch_manager.get_epoch_id(&boundary_block_hash)?;
                 let parent_shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
                 let parent_congestion_info = chunk_extra.congestion_info();
@@ -755,7 +755,7 @@ pub fn validate_chunk_state_witness_impl(
             return Err(Error::InvalidChunkStateWitness(format!(
                 "Post state root {:?} for implicit transition at block {:?} to shard {:?}, does not match expected state root {:?}",
                 chunk_extra.state_root(),
-                transition.block_hash,
+                transition_block_hash,
                 shard_uid,
                 transition.post_state_root
             )));

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -105,8 +105,9 @@ pub enum ImplicitTransitionParams {
     /// of that chunk and its shard.
     ApplyOldChunk(ApplyChunkBlockContext, ShardUId),
     /// Transition resulted from resharding. Defined by boundary account, mode
-    /// saying which of child shards to retain, and parent shard uid.
-    Resharding(AccountId, RetainMode, ShardUId),
+    /// saying which of child shards to retain, parent shard uid, and the
+    /// locally determined boundary block hash.
+    Resharding(AccountId, RetainMode, ShardUId, CryptoHash),
 }
 
 struct StateWitnessBlockRange {
@@ -292,12 +293,14 @@ fn get_resharding_transition(
             params.boundary_account,
             RetainMode::Left,
             shard_uid,
+            *prev_header.hash(),
         )))
     } else if params.right_child_shard == shard_uid {
         Ok(Some(ImplicitTransitionParams::Resharding(
             params.boundary_account,
             RetainMode::Right,
             shard_uid,
+            *prev_header.hash(),
         )))
     } else {
         Ok(None)
@@ -703,7 +706,14 @@ pub fn validate_chunk_state_witness_impl(
                 boundary_account,
                 retain_mode,
                 child_shard_uid,
+                boundary_block_hash,
             ) => {
+                if transition.block_hash != boundary_block_hash {
+                    return Err(Error::InvalidChunkStateWitness(format!(
+                        "implicit resharding transition block hash mismatch: expected {boundary_block_hash:?}, found {:?}",
+                        transition.block_hash
+                    )));
+                }
                 let old_root = *chunk_extra.state_root();
                 let partial_storage = PartialStorage { nodes: transition.base_state.clone() };
                 let parent_trie = Trie::from_recorded_storage(partial_storage, old_root, true);
@@ -720,11 +730,11 @@ pub fn validate_chunk_state_witness_impl(
                 // in an earlier epoch and resolves to the old layout, so the
                 // child's new shard id is absent and validation fails with
                 // `InvalidShardId`, permanently halting the resharded shard.
-                let epoch_id = epoch_manager.get_epoch_id(&transition.block_hash)?;
+                let epoch_id = epoch_manager.get_epoch_id(&boundary_block_hash)?;
                 let parent_shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
                 let parent_congestion_info = chunk_extra.congestion_info();
 
-                let child_epoch_id = epoch_manager.get_next_epoch_id(&transition.block_hash)?;
+                let child_epoch_id = epoch_manager.get_next_epoch_id(&boundary_block_hash)?;
                 let child_shard_layout = epoch_manager.get_shard_layout(&child_epoch_id)?;
                 let child_congestion_info = ReshardingManager::get_child_congestion_info(
                     &parent_trie,

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -105,7 +105,7 @@ pub enum ImplicitTransitionParams {
     /// of that chunk and its shard.
     ApplyOldChunk(ApplyChunkBlockContext, ShardUId),
     /// Transition resulted from resharding. Defined by boundary account, mode
-    /// saying which of child shards to retain, parent shard uid, and the
+    /// saying which of child shards to retain, child shard uid, and the
     /// locally determined boundary block hash.
     Resharding(AccountId, RetainMode, ShardUId, CryptoHash),
 }
@@ -708,12 +708,6 @@ pub fn validate_chunk_state_witness_impl(
                 child_shard_uid,
                 boundary_block_hash,
             ) => {
-                if transition.block_hash != boundary_block_hash {
-                    return Err(Error::InvalidChunkStateWitness(format!(
-                        "implicit resharding transition block hash mismatch: expected {boundary_block_hash:?}, found {:?}",
-                        transition.block_hash
-                    )));
-                }
                 let old_root = *chunk_extra.state_root();
                 let partial_storage = PartialStorage { nodes: transition.base_state.clone() };
                 let parent_trie = Trie::from_recorded_storage(partial_storage, old_root, true);
@@ -722,9 +716,9 @@ pub fn validate_chunk_state_witness_impl(
                 // important to do this step before the `retain_split_shard`
                 // because only the parent trie has the needed information.
                 //
-                // Resolve the epochs (and thus shard layouts) from the resharding
-                // transition's own block, i.e. the boundary block, exactly as the
-                // producer does in `ReshardingManager::process_...`. Using the
+                // Resolve the epochs (and thus shard layouts) from the locally
+                // determined boundary block, not the unvalidated witness hash,
+                // as the producer does in `ReshardingManager::process_...`. Using the
                 // main-transition `block_hash` here is wrong: if the parent shard
                 // produced no chunk in the last old-layout epoch, that block lies
                 // in an earlier epoch and resolves to the old layout, so the


### PR DESCRIPTION
### Motivation

#16068 fixed a real halting bug, but it resolved the parent and child shard layouts from `transition.block_hash` — a `ChunkStateTransition` field that arrives with the witness and isn't validated anywhere, since the only cross-check on implicit transitions is the count comparison. So whatever a chunk producer puts there decides which layouts the congestion-info computation runs against. The validator already determines the right block locally, so there's no reason to take it from the witness.

This is master-only. 2.13.x resolves the layouts from the locally derived main-transition `block_hash` and #16068 landed after the 2.13 branch cut, so no released binary is affected.

### Description

`ImplicitTransitionParams::Resharding` now carries the boundary block hash that `get_resharding_transition` already determined locally — `*prev_header.hash()`, the same block the producer records — and `validate_chunk_state_witness_impl` resolves `epoch_id` and `child_epoch_id` from it. `transition.block_hash` is no longer read on this path at all, rather than compared against the local hash and then ignored, so there's no new witness-rejection condition. #16068's fix is otherwise unchanged: same block, just derived locally. Also corrects the variant doc comment — the `ShardUId` field is the child shard uid, not the parent's.

### Testing

`slow_test_resharding_parent_missing_full_epoch_before_split`, the regression test from #16068, passes. `cargo check --package near-chain --features test_features` and `RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets` are clean.

Follow-up for a separate PR: `get_child_congestion_info_not_finalized` signals inconsistent input by panicking rather than returning an error, which is worth converting regardless of this change.
