### PR TITLE
fix(early-kickout): write EpochStart on epoch sync + end-to-end tests

### DIFF
--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -300,9 +300,10 @@ impl EpochSync {
             &mut store_update.epoch_store_update(),
             &first_block_info_in_epoch,
         )?;
-        // `record_block_info` is also the only writer of `EpochStart`. Without this row the
-        // early-kickout grace check sees the synced epoch as permanently just-started, never
-        // forms the blacklist, and mis-attributes chunk production for the whole epoch.
+        // `record_block_info`, which epoch sync bypasses, is otherwise the only
+        // block-processing writer of `EpochStart`. Without this row the early-kickout grace
+        // check sees the synced epoch as permanently just-started, never forms the
+        // blacklist, and mis-attributes chunk production for the whole epoch.
         store_update
             .epoch_store_update()
             .set_epoch_start(last_header.epoch_id(), last_header.height());

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -300,6 +300,12 @@ impl EpochSync {
             &mut store_update.epoch_store_update(),
             &first_block_info_in_epoch,
         )?;
+        // `record_block_info` is also the only writer of `EpochStart`. Without this row the
+        // early-kickout grace check sees the synced epoch as permanently just-started, never
+        // forms the blacklist, and mis-attributes chunk production for the whole epoch.
+        store_update
+            .epoch_store_update()
+            .set_epoch_start(last_header.epoch_id(), last_header.height());
         store_update.chain_store_update().set_block_ordinal(
             proof.current_epoch.partial_merkle_tree_for_first_block.size(),
             last_header.hash(),

--- a/chain/epoch-manager/Cargo.toml
+++ b/chain/epoch-manager/Cargo.toml
@@ -41,6 +41,9 @@ default = ["near-primitives/rand"]
 protocol_feature_spice = [
     "near-store/protocol_feature_spice"
 ]
+# Exposes `set_early_kickout_thresholds_for_testing`. Strictly additive: without it the
+# early-kickout gates read the plain production constants.
+test_features = []
 nightly = [
     "near-chain-configs/nightly",
     "near-o11y/nightly",

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -70,6 +70,106 @@ const EARLY_KICKOUT_PRODUCTION_THRESHOLD_DENOMINATOR: u64 = 100;
 /// anchor is at least this many blocks into the epoch. Absorbs upgrade-restart downtime.
 const EARLY_KICKOUT_EPOCH_GRACE_BLOCKS: u64 = 1000;
 
+/// Miss floor for the blacklist. Always the production constant unless this is a
+/// `test_features` build; see [`early_kickout_min_misses`] below.
+#[cfg(not(feature = "test_features"))]
+fn early_kickout_min_misses() -> u64 {
+    EARLY_KICKOUT_MIN_MISSES
+}
+
+/// Start-of-epoch grace. Always the production constant unless this is a `test_features`
+/// build; see [`early_kickout_epoch_grace_blocks`] below.
+#[cfg(not(feature = "test_features"))]
+fn early_kickout_epoch_grace_blocks() -> u64 {
+    EARLY_KICKOUT_EPOCH_GRACE_BLOCKS
+}
+
+/// Test-only overrides for the two early-kickout thresholds.
+///
+/// Reaching the production gate (100 misses past a 1000-block grace) takes ~1100 blocks,
+/// which a test-loop chain cannot afford. These knobs let a test shrink both so the gate
+/// trips in tens of blocks. The exact production values stay proven by the epoch-manager
+/// unit tests, which build without `test_features` and therefore read the plain consts.
+///
+/// Thread-local, not process-global, on purpose: `cargo test` runs test functions on
+/// parallel threads within one process, while a test-loop chain executes entirely on the
+/// thread that drives its event loop. Thread-local state therefore isolates each test
+/// exactly, where a global would leak a lowered grace into every concurrently running
+/// test-loop test and silently start reassigning producers there.
+#[cfg(feature = "test_features")]
+use std::marker::PhantomData;
+
+#[cfg(feature = "test_features")]
+mod early_kickout_test_thresholds {
+    use std::cell::Cell;
+
+    thread_local! {
+        static MIN_MISSES: Cell<u64> = const { Cell::new(super::EARLY_KICKOUT_MIN_MISSES) };
+        static EPOCH_GRACE_BLOCKS: Cell<u64> =
+            const { Cell::new(super::EARLY_KICKOUT_EPOCH_GRACE_BLOCKS) };
+    }
+
+    pub(super) fn min_misses() -> u64 {
+        MIN_MISSES.get()
+    }
+
+    pub(super) fn epoch_grace_blocks() -> u64 {
+        EPOCH_GRACE_BLOCKS.get()
+    }
+
+    pub(super) fn swap(min_misses: u64, epoch_grace_blocks: u64) -> (u64, u64) {
+        (MIN_MISSES.replace(min_misses), EPOCH_GRACE_BLOCKS.replace(epoch_grace_blocks))
+    }
+}
+
+#[cfg(feature = "test_features")]
+fn early_kickout_min_misses() -> u64 {
+    early_kickout_test_thresholds::min_misses()
+}
+
+#[cfg(feature = "test_features")]
+fn early_kickout_epoch_grace_blocks() -> u64 {
+    early_kickout_test_thresholds::epoch_grace_blocks()
+}
+
+/// Restores the early-kickout thresholds this thread had before
+/// [`set_early_kickout_thresholds_for_testing`] was called. Dropping on unwind is what
+/// keeps a panicking test from leaking its lowered thresholds into the next test when
+/// the harness reuses the thread (`--test-threads=1`).
+///
+/// Deliberately `!Send`: the override lives in thread-local state, so a guard dropped on
+/// a different thread would restore THAT thread's thresholds and leave the installing
+/// thread lowered forever — exactly the leak the guard exists to prevent.
+#[cfg(feature = "test_features")]
+#[must_use = "the override only lasts as long as this guard is alive"]
+pub struct EarlyKickoutThresholdGuard {
+    prev_min_misses: u64,
+    prev_epoch_grace_blocks: u64,
+    _not_send: PhantomData<*const ()>,
+}
+
+#[cfg(feature = "test_features")]
+impl Drop for EarlyKickoutThresholdGuard {
+    fn drop(&mut self) {
+        early_kickout_test_thresholds::swap(self.prev_min_misses, self.prev_epoch_grace_blocks);
+    }
+}
+
+/// Overrides the early-kickout thresholds for the CALLING THREAD, which for a test-loop
+/// test is the thread the whole chain runs on. `None` keeps the production constant. Call
+/// before the chain starts producing blocks and hold the returned guard for the whole test.
+#[cfg(feature = "test_features")]
+pub fn set_early_kickout_thresholds_for_testing(
+    min_misses: Option<u64>,
+    epoch_grace_blocks: Option<u64>,
+) -> EarlyKickoutThresholdGuard {
+    let (prev_min_misses, prev_epoch_grace_blocks) = early_kickout_test_thresholds::swap(
+        min_misses.unwrap_or(EARLY_KICKOUT_MIN_MISSES),
+        epoch_grace_blocks.unwrap_or(EARLY_KICKOUT_EPOCH_GRACE_BLOCKS),
+    );
+    EarlyKickoutThresholdGuard { prev_min_misses, prev_epoch_grace_blocks, _not_send: PhantomData }
+}
+
 /// Per-shard observability for the blacklist computation. Emitted once at the
 /// seeder (the production write path); the accessor recomputes on every read and
 /// must not emit, or it would double-count.
@@ -134,7 +234,7 @@ pub fn compute_chunk_producer_blacklist(
             let (produced, expected) = (stats.produced(), stats.expected());
             let missed = expected.saturating_sub(produced);
             // u128 keeps the ratio comparison overflow-proof.
-            if missed >= EARLY_KICKOUT_MIN_MISSES
+            if missed >= early_kickout_min_misses()
                 && (produced as u128) * (EARLY_KICKOUT_PRODUCTION_THRESHOLD_DENOMINATOR as u128)
                     < (expected as u128) * (EARLY_KICKOUT_PRODUCTION_THRESHOLD_NUMERATOR as u128)
             {
@@ -193,7 +293,7 @@ pub(crate) fn blacklist_for_epoch(
     if aggregator.epoch_id != *target_epoch_id {
         return ChunkProducerBlacklist::empty();
     }
-    if blocks_into_epoch < EARLY_KICKOUT_EPOCH_GRACE_BLOCKS {
+    if blocks_into_epoch < early_kickout_epoch_grace_blocks() {
         return ChunkProducerBlacklist::empty();
     }
     compute_chunk_producer_blacklist(&aggregator.shard_tracker, epoch_info, shard_layout)

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -40,6 +40,8 @@ use primitive_types::U256;
 use reward_calculator::ValidatorOnlineThresholds;
 pub use shard_assignment::AssignmentStrategy;
 use std::collections::{BTreeMap, HashMap, HashSet};
+#[cfg(feature = "test_features")]
+use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
 pub use validator_selection::proposals_to_epoch_info;
@@ -71,14 +73,14 @@ const EARLY_KICKOUT_PRODUCTION_THRESHOLD_DENOMINATOR: u64 = 100;
 const EARLY_KICKOUT_EPOCH_GRACE_BLOCKS: u64 = 1000;
 
 /// Miss floor for the blacklist. Always the production constant unless this is a
-/// `test_features` build; see [`early_kickout_min_misses`] below.
+/// `test_features` build; see the `early_kickout_test_thresholds` module below.
 #[cfg(not(feature = "test_features"))]
 fn early_kickout_min_misses() -> u64 {
     EARLY_KICKOUT_MIN_MISSES
 }
 
 /// Start-of-epoch grace. Always the production constant unless this is a `test_features`
-/// build; see [`early_kickout_epoch_grace_blocks`] below.
+/// build; see the `early_kickout_test_thresholds` module below.
 #[cfg(not(feature = "test_features"))]
 fn early_kickout_epoch_grace_blocks() -> u64 {
     EARLY_KICKOUT_EPOCH_GRACE_BLOCKS
@@ -88,8 +90,9 @@ fn early_kickout_epoch_grace_blocks() -> u64 {
 ///
 /// Reaching the production gate (100 misses past a 1000-block grace) takes ~1100 blocks,
 /// which a test-loop chain cannot afford. These knobs let a test shrink both so the gate
-/// trips in tens of blocks. The exact production values stay proven by the epoch-manager
-/// unit tests, which build without `test_features` and therefore read the plain consts.
+/// trips in tens of blocks. The thread-local defaults are the production constants, so
+/// any build carrying `test_features` (the CI test runs enable it workspace-wide)
+/// behaves identically until a test explicitly installs an override.
 ///
 /// Thread-local, not process-global, on purpose: `cargo test` runs test functions on
 /// parallel threads within one process, while a test-loop chain executes entirely on the
@@ -97,16 +100,14 @@ fn early_kickout_epoch_grace_blocks() -> u64 {
 /// exactly, where a global would leak a lowered grace into every concurrently running
 /// test-loop test and silently start reassigning producers there.
 #[cfg(feature = "test_features")]
-use std::marker::PhantomData;
-
-#[cfg(feature = "test_features")]
 mod early_kickout_test_thresholds {
+    use super::{EARLY_KICKOUT_EPOCH_GRACE_BLOCKS, EARLY_KICKOUT_MIN_MISSES};
     use std::cell::Cell;
 
     thread_local! {
-        static MIN_MISSES: Cell<u64> = const { Cell::new(super::EARLY_KICKOUT_MIN_MISSES) };
+        static MIN_MISSES: Cell<u64> = const { Cell::new(EARLY_KICKOUT_MIN_MISSES) };
         static EPOCH_GRACE_BLOCKS: Cell<u64> =
-            const { Cell::new(super::EARLY_KICKOUT_EPOCH_GRACE_BLOCKS) };
+            const { Cell::new(EARLY_KICKOUT_EPOCH_GRACE_BLOCKS) };
     }
 
     pub(super) fn min_misses() -> u64 {
@@ -158,6 +159,9 @@ impl Drop for EarlyKickoutThresholdGuard {
 /// Overrides the early-kickout thresholds for the CALLING THREAD, which for a test-loop
 /// test is the thread the whole chain runs on. `None` keeps the production constant. Call
 /// before the chain starts producing blocks and hold the returned guard for the whole test.
+///
+/// Never expose this through a runtime control (e.g. an adversarial RPC): overriding on a
+/// live node would give each thread its own consensus math.
 #[cfg(feature = "test_features")]
 pub fn set_early_kickout_thresholds_for_testing(
     min_misses: Option<u64>,
@@ -168,6 +172,62 @@ pub fn set_early_kickout_thresholds_for_testing(
         epoch_grace_blocks.unwrap_or(EARLY_KICKOUT_EPOCH_GRACE_BLOCKS),
     );
     EarlyKickoutThresholdGuard { prev_min_misses, prev_epoch_grace_blocks, _not_send: PhantomData }
+}
+
+/// The guard's restore-on-drop is itself a safety mechanism (it is what keeps a panicking
+/// test from leaking lowered thresholds into the next test on the same thread), so it gets
+/// direct coverage here rather than relying on the e2e tests' happy path.
+#[cfg(all(test, feature = "test_features"))]
+mod early_kickout_threshold_override_tests {
+    use super::{
+        EARLY_KICKOUT_EPOCH_GRACE_BLOCKS, EARLY_KICKOUT_MIN_MISSES,
+        early_kickout_epoch_grace_blocks, early_kickout_min_misses,
+        set_early_kickout_thresholds_for_testing,
+    };
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    #[test]
+    fn test_override_and_restore() {
+        assert_eq!(early_kickout_min_misses(), EARLY_KICKOUT_MIN_MISSES);
+        assert_eq!(early_kickout_epoch_grace_blocks(), EARLY_KICKOUT_EPOCH_GRACE_BLOCKS);
+        {
+            let _guard = set_early_kickout_thresholds_for_testing(Some(5), Some(20));
+            assert_eq!(early_kickout_min_misses(), 5);
+            assert_eq!(early_kickout_epoch_grace_blocks(), 20);
+        }
+        assert_eq!(early_kickout_min_misses(), EARLY_KICKOUT_MIN_MISSES);
+        assert_eq!(early_kickout_epoch_grace_blocks(), EARLY_KICKOUT_EPOCH_GRACE_BLOCKS);
+    }
+
+    #[test]
+    fn test_none_keeps_production_constant() {
+        let _guard = set_early_kickout_thresholds_for_testing(Some(7), None);
+        assert_eq!(early_kickout_min_misses(), 7);
+        assert_eq!(early_kickout_epoch_grace_blocks(), EARLY_KICKOUT_EPOCH_GRACE_BLOCKS);
+    }
+
+    #[test]
+    fn test_nested_overrides_restore_lifo() {
+        let _outer = set_early_kickout_thresholds_for_testing(Some(5), Some(20));
+        {
+            let _inner = set_early_kickout_thresholds_for_testing(Some(3), Some(10));
+            assert_eq!(early_kickout_min_misses(), 3);
+            assert_eq!(early_kickout_epoch_grace_blocks(), 10);
+        }
+        assert_eq!(early_kickout_min_misses(), 5);
+        assert_eq!(early_kickout_epoch_grace_blocks(), 20);
+    }
+
+    #[test]
+    fn test_panic_unwind_restores_thresholds() {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = set_early_kickout_thresholds_for_testing(Some(5), Some(20));
+            panic!("panic with a live guard");
+        }));
+        assert!(result.is_err());
+        assert_eq!(early_kickout_min_misses(), EARLY_KICKOUT_MIN_MISSES);
+        assert_eq!(early_kickout_epoch_grace_blocks(), EARLY_KICKOUT_EPOCH_GRACE_BLOCKS);
+    }
 }
 
 /// Per-shard observability for the blacklist computation. Emitted once at the

--- a/test-loop-tests/Cargo.toml
+++ b/test-loop-tests/Cargo.toml
@@ -77,6 +77,7 @@ protocol_feature_spice = [
 ]
 test_features = [
     "nearcore/test_features",
+    "near-epoch-manager/test_features",
     "near-store/test_features",
     "near-vm-runner/test_features",
     "near-test-contracts/test_features",

--- a/test-loop-tests/src/tests/early_kickout_e2e.rs
+++ b/test-loop-tests/src/tests/early_kickout_e2e.rs
@@ -1,0 +1,585 @@
+//! End-to-end tests for early (mid-epoch) chunk producer kickout.
+//!
+//! `ProtocolFeature::EarlyKickout` (nightly) tracks each chunk producer's
+//! production stats within an epoch and, once a producer crosses the
+//! mid-epoch thresholds, excludes it from the `DBCol::ChunkProducers`
+//! assignment for the chunks anchored at later blocks. The excluded slot is
+//! reassigned to a healthy replacement. These tests drive the whole pipeline
+//! over a live test-loop chain:
+//!
+//! * `test_early_kickout_reassignment` — induce a real production miss with the
+//!   adversarial chunk-skip message and assert the offending slot is reassigned
+//!   while the shard keeps producing chunks (liveness).
+//! * `test_early_kickout_epoch_sync_bootstrap` — a fresh node epoch-syncs into a
+//!   network that ALREADY has an active reassignment and must resolve chunk
+//!   producers consistently with the full validators, with no
+//!   `ChunkProducerNotInDB` errors.
+//!
+//! Both require `nightly` (feature gate) and `test_features` (adversarial
+//! messages, plus the threshold override below).
+//!
+//! Production trips the blacklist at 100 misses accumulated past a 1000-block
+//! start-of-epoch grace, which is ~1100 blocks — far more than a test-loop chain
+//! can run. Both tests therefore shrink both thresholds through
+//! `set_early_kickout_thresholds_for_testing` so the gate trips in tens of
+//! blocks. The exact production values (100 / 80% / 1000) stay proven by the
+//! epoch-manager unit tests, which build without `test_features`; what these
+//! tests prove is the end-to-end wiring, which the thresholds do not affect.
+
+use crate::setup::builder::TestLoopBuilder;
+use crate::tests::sync::util::{TEST_EPOCH_SYNC_HORIZON, far_horizon_height};
+use crate::utils::account::{
+    create_account_id, create_validator_id, create_validators_spec, validators_spec_clients,
+};
+use near_async::time::Duration;
+use near_chain_configs::TrackedShardsConfig;
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
+use near_client::NetworkAdversarialMessage;
+use near_client::client_actor::AdvProduceChunksMode;
+use near_epoch_manager::set_early_kickout_thresholds_for_testing;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::test_utils::create_test_signer;
+use near_primitives::types::validator_stake::ValidatorStake;
+use near_primitives::types::{AccountInfo, Balance, ValidatorInfoIdentifier};
+use near_primitives::utils::get_block_shard_id;
+use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+use near_store::DBCol;
+
+/// Grace window used by both tests, in blocks into the epoch. Small enough that a
+/// test-loop chain clears it in seconds, large enough that the first blocks of an
+/// epoch still cannot blacklist anyone.
+const TEST_EPOCH_GRACE_BLOCKS: u64 = 20;
+/// Miss floor used by both tests. A target holding ~half its shard's slots reaches
+/// this within ~10 heights of leaving the grace window.
+const TEST_MIN_MISSES: u64 = 5;
+
+/// Test A — flagship reassignment test.
+///
+/// Setup: 4 block+chunk producers over 2 shards (balance-shards puts 2
+/// producers on each shard, so blacklisting one always leaves a clean
+/// replacement and never trips the all-blacklisted safety valve),
+/// `kickouts_standard_80_percent`, and an epoch long enough that the induced
+/// miss crosses the mid-epoch thresholds well before the epoch boundary.
+///
+/// We stop one producer's chunk production with the adversarial message; its
+/// assigned chunks are missed. Once the anchor is past the grace window and the
+/// target has missed at least `TEST_MIN_MISSES` chunks at under 80% production,
+/// it is blacklisted on its shard and the chunks it would have produced are
+/// reassigned. We assert (a) the miss-induced reassignment (the stored producer
+/// for the target's own scheduled slots is a different validator) and (b)
+/// liveness (the shard keeps producing chunks after the reassignment).
+#[test]
+fn test_early_kickout_reassignment() {
+    init_test_logger();
+
+    assert!(
+        ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION),
+        "test requires EarlyKickout enabled for the genesis protocol version"
+    );
+
+    // Shrink the gate for this thread; the whole test-loop chain runs on it. The guard
+    // restores the production values when the test ends, panic or not.
+    let _thresholds = set_early_kickout_thresholds_for_testing(
+        Some(TEST_MIN_MISSES),
+        Some(TEST_EPOCH_GRACE_BLOCKS),
+    );
+
+    // A 50%-share producer clears the grace and the miss floor within ~40 heights.
+    // A 200-block epoch leaves comfortable margin so the reassignment lands
+    // mid-epoch, before the standard end-of-epoch kickout.
+    let epoch_length = 200;
+    let validators_spec = create_validators_spec(4, 0);
+    let clients = validators_spec_clients(&validators_spec);
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .shard_layout(ShardLayout::multi_shard(2, 1))
+        .validators_spec(validators_spec)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+        .kickouts_standard_80_percent()
+        .build_store_for_genesis_protocol_version();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(clients)
+        .build();
+
+    let epoch_manager = env.node(0).client().epoch_manager.clone();
+
+    // Pick a chunk producer on a shard that has at least one other producer, so
+    // blacklisting it leaves a clean replacement (avoids the all-blacklisted
+    // safety valve, which would suppress reassignment).
+    let target_account = {
+        let head = env.node(0).head();
+        let epoch_info = epoch_manager.get_epoch_info(&head.epoch_id).unwrap();
+        let shard_layout = epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
+        let target_id = shard_layout
+            .shard_ids()
+            .find_map(|shard_id| {
+                let index = shard_layout.get_shard_index(shard_id).unwrap();
+                let producers = &epoch_info.chunk_producers_settlement()[index];
+                (producers.len() >= 2).then(|| producers[0])
+            })
+            .expect("need a shard with >= 2 chunk producers for a clean replacement");
+        epoch_info.get_validator(target_id).account_id().clone()
+    };
+
+    // Stop the target's chunk production. Its assigned chunks start being missed
+    // so its production ratio falls below the early-kickout threshold.
+    env.runner_for_account(&target_account).send_adversarial_message(
+        NetworkAdversarialMessage::AdvProduceChunks(AdvProduceChunksMode::StopProduce),
+    );
+
+    // Condition-based wait (no fixed heights): run until the mid-epoch kickout
+    // math blacklists the target on some shard, which requires the anchor to be
+    // past the grace window with at least `TEST_MIN_MISSES` misses at under 80%.
+    {
+        let em = epoch_manager.clone();
+        let target = target_account.clone();
+        env.node_runner(0).run_until(
+            move |node| {
+                let final_head = node.final_head();
+                let Ok(epoch_info) = em.get_epoch_info(&final_head.epoch_id) else {
+                    return false;
+                };
+                let Some(&target_id) = epoch_info.get_validator_id(&target) else {
+                    return false;
+                };
+                let Ok(blacklist) = em.get_chunk_producer_blacklist(&final_head.last_block_hash)
+                else {
+                    return false;
+                };
+                blacklist.values().any(|excluded| excluded.contains(&target_id))
+            },
+            Duration::seconds(300),
+        );
+    }
+
+    let trigger_head = env.node(0).head().height;
+    let trigger_epoch_id = env.node(0).final_head().epoch_id;
+
+    // The reassignment only materializes in chunks whose grandparent anchor was
+    // produced after the blacklist formed. Advance further (still within the same
+    // long epoch) so those chunks exist, then assert the reassignment + liveness.
+    env.node_runner(0).run_for_number_of_blocks(20);
+
+    let observe = env.node(0);
+    assert_eq!(
+        observe.head().epoch_id,
+        trigger_epoch_id,
+        "reassignment window must stay in the triggering epoch"
+    );
+    let final_head = observe.final_head();
+    let epoch_id = final_head.epoch_id;
+    let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
+    let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
+    let target_id = *epoch_info
+        .get_validator_id(&target_account)
+        .expect("target must still be a validator in the triggering epoch");
+
+    // Locate the target's shard and confirm a replacement remains.
+    let target_shard = shard_layout
+        .shard_ids()
+        .find(|&shard_id| {
+            let index = shard_layout.get_shard_index(shard_id).unwrap();
+            epoch_info.chunk_producers_settlement()[index].contains(&target_id)
+        })
+        .expect("target must be a chunk producer");
+    let target_shard_index = shard_layout.get_shard_index(target_shard).unwrap();
+    assert!(
+        epoch_info.chunk_producers_settlement()[target_shard_index].len() >= 2,
+        "target shard must retain a non-blacklisted producer (safety-valve guard)"
+    );
+
+    let blacklist =
+        epoch_manager.get_chunk_producer_blacklist(&final_head.last_block_hash).unwrap();
+    assert!(
+        blacklist.get(&target_shard).is_some_and(|excluded| excluded.contains(&target_id)),
+        "target must be blacklisted on shard {target_shard}"
+    );
+
+    let epoch_start = epoch_manager.get_epoch_start_height(&final_head.last_block_hash).unwrap();
+    let chain = &observe.client().chain;
+
+    // For the target's own scheduled slots (where the plain schedule picks it),
+    // the DB-backed resolver must return a DIFFERENT validator once the
+    // grandparent anchor has the target blacklisted. Mirrors the epoch-manager
+    // anti-flap unit test, end-to-end over the real chain.
+    let mut reassigned_slots = 0u32;
+    let mut height = final_head.height;
+    while height > epoch_start + 2 && reassigned_slots < 2 {
+        let is_target_slot = epoch_info.sample_chunk_producer(&shard_layout, target_shard, height)
+            == Some(target_id);
+        if is_target_slot {
+            if let (Ok(anchor_hash), Ok(prev_hash)) = (
+                chain.get_block_hash_by_height(height - 2),
+                chain.get_block_hash_by_height(height - 1),
+            ) {
+                let anchor_blacklist =
+                    epoch_manager.get_chunk_producer_blacklist(&anchor_hash).unwrap();
+                let anchor_blacklists_target = anchor_blacklist
+                    .get(&target_shard)
+                    .is_some_and(|excluded| excluded.contains(&target_id));
+                if anchor_blacklists_target {
+                    let resolved = epoch_manager
+                        .get_chunk_producer_info_from_prev_block(&prev_hash, target_shard)
+                        .unwrap();
+                    assert_ne!(
+                        resolved.account_id(),
+                        &target_account,
+                        "chunk at height {height} on shard {target_shard} must be \
+                         reassigned away from the blacklisted producer"
+                    );
+                    reassigned_slots += 1;
+                }
+            }
+        }
+        height -= 1;
+    }
+    assert!(
+        reassigned_slots >= 1,
+        "expected at least one miss-induced reassignment of the target's slots"
+    );
+
+    // Liveness: after the reassignment the shard keeps producing chunks (does not
+    // stall). Every height in a post-reassignment window (whose anchor blacklists
+    // the target) must carry the offending shard's chunk.
+    for height in (trigger_head + 3)..=(trigger_head + 15) {
+        let block = chain.get_block_by_height(height).unwrap();
+        assert!(
+            block.header().chunk_mask()[target_shard_index],
+            "shard chunk missing at height {height} after reassignment (shard stalled)"
+        );
+    }
+}
+
+/// Test C — epoch-sync bootstrap into a network with an ACTIVE reassignment.
+///
+/// A fresh node bootstraps via epoch sync into a running EarlyKickout network in
+/// which a chunk producer is ALREADY blacklisted (its slot reassigned) before the
+/// node joins. This exercises the bootstrap path against a network with active
+/// kickout and checks that the synced node resolves chunk producers consistently
+/// with the full validators, with no `ChunkProducerNotInDB` errors and no
+/// divergence.
+///
+/// Setup uses skewed stakes so one producer dominates its shard's chunk sampling
+/// (accumulating misses quickly) while still sharing the shard with a healthy
+/// replacement. Standard kickout thresholds are left at 0 so the target is never
+/// removed at an epoch boundary; the early-kickout math keeps it blacklisted
+/// mid-epoch, so the reassignment recurs every epoch.
+///
+/// The bootstrap property is checked two ways: (1) across the synced epoch — from
+/// the epoch-sync-seeded first block to the catch-up head — the node's
+/// `ChunkProducers` rows and aggregator-derived validator stats match the source,
+/// which pins the blacklist-activation height and the reassigned producer per
+/// shard; and (2) after the node catches up, across a post-sync window with the
+/// reassignment active it resolves every shard with no `ChunkProducerNotInDB`,
+/// agrees with the source, and reproduces >= 1 real reassignment.
+///
+/// The 151->152 activation edge is intentionally not exercised here (see Test A
+/// rationale); it is covered by the epoch-manager unit tests and the cold-storage
+/// boundary test.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_early_kickout_epoch_sync_bootstrap() {
+    init_test_logger();
+
+    assert!(
+        ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION),
+        "test requires EarlyKickout enabled for the genesis protocol version"
+    );
+
+    // Shrink the gate for this thread; the whole test-loop chain runs on it. The guard
+    // restores the production values when the test ends, panic or not.
+    let _thresholds = set_early_kickout_thresholds_for_testing(
+        Some(TEST_MIN_MISSES),
+        Some(TEST_EPOCH_GRACE_BLOCKS),
+    );
+
+    let epoch_length = 100;
+    let target_account = create_validator_id(0);
+
+    // Skewed stakes: validator0 dominates chunk-producer sampling on its shard
+    // (~90% of slots), so it clears the grace and the miss floor within ~30
+    // heights of each epoch start, while the shard still holds a healthy
+    // replacement.
+    let stakes = [1_000_000u128, 100_000, 100_000, 100_000];
+    let validators: Vec<AccountInfo> = (0..4)
+        .map(|i| {
+            let account_id = create_validator_id(i);
+            AccountInfo {
+                public_key: create_test_signer(account_id.as_str()).public_key(),
+                account_id,
+                amount: Balance::from_near(stakes[i]),
+            }
+        })
+        .collect();
+    let validators_spec = ValidatorsSpec::raw(validators, 4, 4, 0);
+    let clients = validators_spec_clients(&validators_spec);
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .shard_layout(ShardLayout::multi_shard(2, 1))
+        .validators_spec(validators_spec)
+        .build();
+    // `from_genesis` leaves all kickout thresholds at 0 (no standard kickout).
+    let epoch_config_store =
+        TestEpochConfigBuilder::from_genesis(&genesis).build_store_for_genesis_protocol_version();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(clients)
+        .build();
+
+    let source_em = env.node(0).client().epoch_manager.clone();
+
+    // induce the reassignment BEFORE the fresh node joins, so it syncs into a
+    // network that already has an active kickout. StopProduce is permanent, so the
+    // target keeps missing and (kickout thresholds at 0 -> never standard-kicked)
+    // stays blacklisted in every epoch it accumulates enough misses.
+    env.runner_for_account(&target_account).send_adversarial_message(
+        NetworkAdversarialMessage::AdvProduceChunks(AdvProduceChunksMode::StopProduce),
+    );
+
+    // Run several epochs so (a) a fresh node is beyond the epoch-sync horizon,
+    // forcing the far-horizon path, and (b) the target is blacklisted in the current
+    // epoch. `far_horizon_height` is the same depth the sync tests use; anything
+    // shallower makes the epoch-sync proof itself invalid ("need at least two epochs
+    // in all_epochs") and silently degrades this into a header-sync-from-genesis
+    // test. The condition wait then guarantees the blacklist has actually formed.
+    env.node_runner(0).run_until_head_height(far_horizon_height(epoch_length));
+    {
+        let em = source_em.clone();
+        let target = target_account.clone();
+        env.node_runner(0).run_until(
+            move |node| {
+                let final_head = node.final_head();
+                let Ok(epoch_info) = em.get_epoch_info(&final_head.epoch_id) else {
+                    return false;
+                };
+                let Some(&target_id) = epoch_info.get_validator_id(&target) else {
+                    return false;
+                };
+                let Ok(blacklist) = em.get_chunk_producer_blacklist(&final_head.last_block_hash)
+                else {
+                    return false;
+                };
+                blacklist.values().any(|excluded| excluded.contains(&target_id))
+            },
+            Duration::seconds(300),
+        );
+    }
+
+    // Add a fresh non-validator node that must bootstrap from genesis while the
+    // reassignment is active on the network.
+    let new_account = create_account_id("ek_sync_node");
+    let node_state = env
+        .node_state_builder()
+        .account_id(&new_account)
+        .config_modifier(|config| {
+            config.tracked_shards_config = TrackedShardsConfig::AllShards;
+            config.epoch_sync.epoch_sync_horizon_num_epochs = TEST_EPOCH_SYNC_HORIZON;
+        })
+        .build();
+    env.add_node("ek_sync_node", node_state);
+    let new_node_idx = env.node_datas.len() - 1;
+    let synced_em = env.node(new_node_idx).client().epoch_manager.clone();
+
+    // Bring the fresh node to the network tip (epoch sync -> header -> state ->
+    // block). The network keeps advancing (and the target keeps missing) while it
+    // bootstraps, so the node syncs into a live, kicking network.
+    {
+        let synced_handle = env.node_datas[new_node_idx].client_sender.actor_handle();
+        let source_handle = env.node_datas[0].client_sender.actor_handle();
+        env.test_loop.run_until(
+            |data| {
+                data.get(&synced_handle).client.chain.head().unwrap().height
+                    == data.get(&source_handle).client.chain.head().unwrap().height
+            },
+            Duration::seconds(200),
+        );
+    }
+
+    // Confirm it really epoch-synced (skipped old epochs) rather than
+    // block-syncing every block from genesis.
+    let synced_tail = env.node(new_node_idx).tail();
+    assert!(
+        synced_tail > epoch_length,
+        "synced node tail {synced_tail} should be past the first epoch (epoch sync skips blocks)"
+    );
+
+    // Assertion 1: across the synced epoch — from the epoch-sync-seeded first block
+    // up to the catch-up head — the fresh node's `ChunkProducers` rows and its
+    // aggregator-derived per-validator stats match the source. "Node joined" alone
+    // is too weak: attribution can diverge (crediting the kicked-out producer for
+    // chunks its replacement made) well before a wrong `next_bp_hash` surfaces, so
+    // compare the raw rows and the stats built from them directly. This window
+    // contains the blacklist activation, so row equality also pins the activation
+    // height and the reassigned producer per shard.
+    {
+        let synced = env.node(new_node_idx);
+        let source = env.node(0);
+        let synced_head = synced.head();
+        let epoch_start = synced_em.get_epoch_start_height(&synced_head.last_block_hash).unwrap();
+        let shard_layout = synced_em.get_shard_layout(&synced_head.epoch_id).unwrap();
+        for height in epoch_start..=synced_head.height {
+            // Skipped heights have no canonical block on either node.
+            let Ok(block_hash) = synced.client().chain.get_block_hash_by_height(height) else {
+                continue;
+            };
+            for shard_id in shard_layout.shard_ids() {
+                let key = get_block_shard_id(&block_hash, shard_id);
+                let synced_row: Option<ValidatorStake> =
+                    synced.store().get_ser(DBCol::ChunkProducers, &key);
+                let source_row: Option<ValidatorStake> =
+                    source.store().get_ser(DBCol::ChunkProducers, &key);
+                assert!(
+                    synced_row.is_some(),
+                    "ChunkProducers row missing on synced node at height {height} shard {shard_id}"
+                );
+                assert_eq!(
+                    synced_row, source_row,
+                    "ChunkProducers row diverged from source at height {height} shard {shard_id}"
+                );
+            }
+        }
+        // Aggregator parity at the synced node's final head: the per-validator
+        // produced/expected stats are what feed `next_bp_hash`, and on the synced
+        // node this read also exercises the `EpochStart` row that only exists
+        // because epoch sync now writes it.
+        let final_head = synced.final_head();
+        assert_eq!(
+            final_head.epoch_id, synced_head.epoch_id,
+            "parity probe expects the final head inside the synced epoch"
+        );
+        let synced_info = synced_em
+            .get_validator_info(ValidatorInfoIdentifier::BlockHash(final_head.last_block_hash))
+            .expect("synced node must compute validator info for the synced epoch");
+        let source_info = source_em
+            .get_validator_info(ValidatorInfoIdentifier::BlockHash(final_head.last_block_hash))
+            .unwrap();
+        assert_eq!(
+            synced_info.current_validators, source_info.current_validators,
+            "aggregator-derived validator stats diverged between synced node and source"
+        );
+    }
+
+    // Let the follower live through a FRESH epoch from its start, so its aggregator
+    // covers that whole epoch (matching the source's; avoids the partial
+    // mid-epoch-sync aggregator artifact). Capture that epoch, then wait for the
+    // persistent miss to re-blacklist the target WITHIN it (finalized). Pinning to
+    // `observe_epoch` is essential: the trailing final_head still sits in the prior
+    // epoch (where the target was already blacklisted) right after the boundary, so
+    // an unpinned wait would return immediately, before this epoch clears its own
+    // grace window. Blacklist observed on the full-aggregator source.
+    env.node_runner(new_node_idx).run_until_new_epoch();
+    let observe_epoch = env.node(new_node_idx).head().epoch_id;
+    {
+        let em = source_em.clone();
+        let target = target_account.clone();
+        env.node_runner(new_node_idx).run_until(
+            move |node| {
+                let final_head = node.final_head();
+                if final_head.epoch_id != observe_epoch {
+                    return false;
+                }
+                let Ok(epoch_info) = em.get_epoch_info(&final_head.epoch_id) else {
+                    return false;
+                };
+                let Some(&target_id) = epoch_info.get_validator_id(&target) else {
+                    return false;
+                };
+                let Ok(blacklist) = em.get_chunk_producer_blacklist(&final_head.last_block_hash)
+                else {
+                    return false;
+                };
+                blacklist.values().any(|excluded| excluded.contains(&target_id))
+            },
+            Duration::seconds(300),
+        );
+    }
+    // Post-blacklist runway so many of the target's own slots have a grandparent
+    // anchor that blacklists it (still within the same epoch: ~30 + 20 < 100).
+    env.node_runner(new_node_idx).run_for_number_of_blocks(20);
+
+    // Assertion 2: scan the current (fully-processed) epoch on the FOLLOWER for the
+    // target's own scheduled slots whose grandparent anchor blacklists it (blacklist
+    // observed on the full-aggregator source, never the follower's partial one). For
+    // each, the follower's DB-backed resolver must (a) agree with the source and (b)
+    // return a DIFFERENT validator than the blacklisted target. Mirrors Test A's
+    // proven scan, cross-checked follower-vs-source.
+    let synced = env.node(new_node_idx);
+    let synced_head = synced.head();
+    let epoch_id = synced_head.epoch_id;
+    let epoch_start = synced_em.get_epoch_start_height(&synced_head.last_block_hash).unwrap();
+    let shard_layout = synced_em.get_shard_layout(&epoch_id).unwrap();
+    let source_epoch_info = source_em.get_epoch_info(&epoch_id).unwrap();
+    let target_id = *source_epoch_info
+        .get_validator_id(&target_account)
+        .expect("target must be a validator in the observed epoch");
+    let target_shard = shard_layout
+        .shard_ids()
+        .find(|&shard_id| {
+            let index = shard_layout.get_shard_index(shard_id).unwrap();
+            source_epoch_info.chunk_producers_settlement()[index].contains(&target_id)
+        })
+        .expect("target must be a chunk producer");
+    let synced_chain = &synced.client().chain;
+
+    let mut reassigned = 0u32;
+    let mut target_slots = 0u32;
+    let mut blacklisting_anchors = 0u32;
+    let mut height = synced_head.height;
+    while height > epoch_start + 2 && reassigned < 2 {
+        let is_target_slot =
+            source_epoch_info.sample_chunk_producer(&shard_layout, target_shard, height)
+                == Some(target_id);
+        if is_target_slot {
+            target_slots += 1;
+            if let (Ok(anchor_hash), Ok(prev_hash)) = (
+                synced_chain.get_block_hash_by_height(height - 2),
+                synced_chain.get_block_hash_by_height(height - 1),
+            ) {
+                let anchor_blacklist =
+                    source_em.get_chunk_producer_blacklist(&anchor_hash).unwrap();
+                if anchor_blacklist
+                    .get(&target_shard)
+                    .is_some_and(|excluded| excluded.contains(&target_id))
+                {
+                    blacklisting_anchors += 1;
+                    let synced_resolved = synced_em
+                        .get_chunk_producer_info_from_prev_block(&prev_hash, target_shard)
+                        .unwrap_or_else(|e| {
+                            panic!(
+                                "synced node failed to resolve chunk producer \
+                                 (shard {target_shard}, height {height}): {e:?}"
+                            )
+                        });
+                    let source_resolved = source_em
+                        .get_chunk_producer_info_from_prev_block(&prev_hash, target_shard)
+                        .unwrap();
+                    assert_eq!(
+                        synced_resolved.account_id(),
+                        source_resolved.account_id(),
+                        "synced node diverged from source at height {height} shard {target_shard}"
+                    );
+                    assert_ne!(
+                        synced_resolved.account_id(),
+                        &target_account,
+                        "chunk at height {height} shard {target_shard} must be reassigned \
+                         away from the blacklisted target"
+                    );
+                    reassigned += 1;
+                }
+            }
+        }
+        height -= 1;
+    }
+    assert!(
+        reassigned >= 1,
+        "synced node must reproduce at least one blacklist-driven reassignment \
+         (epoch_start={epoch_start}, head={}, target_slots={target_slots}, \
+          blacklisting_anchors={blacklisting_anchors})",
+        synced_head.height
+    );
+}

--- a/test-loop-tests/src/tests/early_kickout_e2e.rs
+++ b/test-loop-tests/src/tests/early_kickout_e2e.rs
@@ -10,9 +10,9 @@
 //! * `test_early_kickout_reassignment` — induce a real production miss with the
 //!   adversarial chunk-skip message and assert the offending slot is reassigned
 //!   while the shard keeps producing chunks (liveness).
-//! * `test_early_kickout_epoch_sync_bootstrap` — a fresh node epoch-syncs into a
-//!   network that ALREADY has an active reassignment and must resolve chunk
-//!   producers consistently with the full validators, with no
+//! * `slow_test_early_kickout_epoch_sync_bootstrap` — a fresh node epoch-syncs
+//!   into a network that ALREADY has an active reassignment and must resolve
+//!   chunk producers consistently with the full validators, with no
 //!   `ChunkProducerNotInDB` errors.
 //!
 //! Both require `nightly` (feature gate) and `test_features` (adversarial
@@ -31,6 +31,7 @@ use crate::tests::sync::util::{TEST_EPOCH_SYNC_HORIZON, far_horizon_height};
 use crate::utils::account::{
     create_account_id, create_validator_id, create_validators_spec, validators_spec_clients,
 };
+use borsh::BorshDeserialize;
 use near_async::time::Duration;
 use near_chain_configs::TrackedShardsConfig;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
@@ -38,13 +39,15 @@ use near_client::NetworkAdversarialMessage;
 use near_client::client_actor::AdvProduceChunksMode;
 use near_epoch_manager::set_early_kickout_thresholds_for_testing;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{AccountInfo, Balance, ValidatorInfoIdentifier};
+use near_primitives::types::{AccountInfo, Balance, BlockHeight, EpochId, ValidatorInfoIdentifier};
 use near_primitives::utils::get_block_shard_id;
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::DBCol;
+use std::collections::HashSet;
 
 /// Grace window used by both tests, in blocks into the epoch. Small enough that a
 /// test-loop chain clears it in seconds, large enough that the first blocks of an
@@ -269,20 +272,24 @@ fn test_early_kickout_reassignment() {
 /// removed at an epoch boundary; the early-kickout math keeps it blacklisted
 /// mid-epoch, so the reassignment recurs every epoch.
 ///
-/// The bootstrap property is checked two ways: (1) across the synced epoch — from
-/// the epoch-sync-seeded first block to the catch-up head — the node's
-/// `ChunkProducers` rows and aggregator-derived validator stats match the source,
-/// which pins the blacklist-activation height and the reassigned producer per
-/// shard; and (2) after the node catches up, across a post-sync window with the
-/// reassignment active it resolves every shard with no `ChunkProducerNotInDB`,
-/// agrees with the source, and reproduces >= 1 real reassignment.
+/// The bootstrap property is checked three ways: (0) immediately after the
+/// epoch-sync proof applies, the `EpochStart` row it writes for the synced epoch
+/// exists and matches the source — without the fix the test dies here, in
+/// seconds, instead of timing out on catch-up; (1) after catch-up, walking the
+/// canonical chain from the head back to the epoch-sync-seeded first block,
+/// every `ChunkProducers` row matches the source — across the synced epoch this
+/// pins the blacklist-activation height and the reassigned producer per shard —
+/// and the synced epoch's validator stats (which feed `next_bp_hash`) match the
+/// source; and (2) across a post-sync window with the reassignment active the
+/// node resolves every shard with no `ChunkProducerNotInDB`, agrees with the
+/// source, and reproduces >= 1 real reassignment.
 ///
 /// The 151->152 activation edge is intentionally not exercised here (see Test A
 /// rationale); it is covered by the epoch-manager unit tests and the cold-storage
 /// boundary test.
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
-fn test_early_kickout_epoch_sync_bootstrap() {
+fn slow_test_early_kickout_epoch_sync_bootstrap() {
     init_test_logger();
 
     assert!(
@@ -385,6 +392,47 @@ fn test_early_kickout_epoch_sync_bootstrap() {
     let new_node_idx = env.node_datas.len() - 1;
     let synced_em = env.node(new_node_idx).client().epoch_manager.clone();
 
+    // Wait for the epoch-sync proof to apply: the follower's header head jumps from
+    // genesis into the synced epoch (or past it — header sync applies whole batches
+    // per event) in the same event that commits the proof's store update.
+    {
+        let synced_handle = env.node_datas[new_node_idx].client_sender.actor_handle();
+        env.test_loop.run_until(
+            |data| {
+                data.get(&synced_handle).client.chain.header_head().unwrap().height > epoch_length
+            },
+            Duration::seconds(200),
+        );
+    }
+
+    // Assertion 0: the synced epoch's `EpochStart` row. It is the min-height row on
+    // the follower: a fresh node has none before epoch sync (genesis writes none),
+    // `apply_validated_proof` writes exactly one, and header sync only adds rows for
+    // later epochs. The `height > 0` filter keeps the derivation correct even if a
+    // genesis row ever appears. Without the fix there is no row at all and the test
+    // fails HERE, in seconds, instead of timing out on catch-up.
+    let (synced_epoch_id, synced_epoch_start) = {
+        let synced_store = env.node(new_node_idx).store();
+        let (epoch_id, height) = synced_store
+            .iter(DBCol::EpochStart)
+            .map(|(key, value)| {
+                let epoch_id = EpochId(CryptoHash::try_from(&key[..]).unwrap());
+                let height = BlockHeight::try_from_slice(&value).unwrap();
+                (epoch_id, height)
+            })
+            .filter(|(_, height)| *height > 0)
+            .min_by_key(|(_, height)| *height)
+            .expect("epoch sync wrote no EpochStart row for the synced epoch");
+        let source_height: Option<BlockHeight> =
+            env.node(0).store().get_ser(DBCol::EpochStart, epoch_id.as_ref());
+        assert_eq!(
+            source_height,
+            Some(height),
+            "seeded EpochStart height disagrees with the source for epoch {epoch_id:?}"
+        );
+        (epoch_id, height)
+    };
+
     // Bring the fresh node to the network tip (epoch sync -> header -> state ->
     // block). The network keeps advancing (and the target keeps missing) while it
     // bootstraps, so the node syncs into a live, kicking network.
@@ -408,59 +456,138 @@ fn test_early_kickout_epoch_sync_bootstrap() {
         "synced node tail {synced_tail} should be past the first epoch (epoch sync skips blocks)"
     );
 
-    // Assertion 1: across the synced epoch — from the epoch-sync-seeded first block
-    // up to the catch-up head — the fresh node's `ChunkProducers` rows and its
-    // aggregator-derived per-validator stats match the source. "Node joined" alone
-    // is too weak: attribution can diverge (crediting the kicked-out producer for
-    // chunks its replacement made) well before a wrong `next_bp_hash` surfaces, so
-    // compare the raw rows and the stats built from them directly. This window
-    // contains the blacklist activation, so row equality also pins the activation
-    // height and the reassigned producer per shard.
+    // Assertion 1: walk the canonical chain from the catch-up head back to the
+    // epoch-sync-seeded first block, comparing every `ChunkProducers` row against
+    // the source. "Node joined" alone is too weak: attribution can diverge
+    // (crediting the kicked-out producer for chunks its replacement made) well
+    // before a wrong `next_bp_hash` surfaces. Across the synced epoch, row parity
+    // pins the blacklist-activation height and the reassigned producer per shard;
+    // later epochs cover each re-activation up to the head. The walk uses headers
+    // (not the height index): header-synced heights have no canonical-index entry.
+    // This must stay the FIRST assertion after catch-up — retention GC deletes
+    // header-only hashes' rows once their heights leave the GC window, and the
+    // synced epoch has about one epoch of margin here.
     {
         let synced = env.node(new_node_idx);
         let source = env.node(0);
-        let synced_head = synced.head();
-        let epoch_start = synced_em.get_epoch_start_height(&synced_head.last_block_hash).unwrap();
-        let shard_layout = synced_em.get_shard_layout(&synced_head.epoch_id).unwrap();
-        for height in epoch_start..=synced_head.height {
-            // Skipped heights have no canonical block on either node.
-            let Ok(block_hash) = synced.client().chain.get_block_hash_by_height(height) else {
-                continue;
-            };
+        let final_head = synced.final_head();
+        let synced_chain = &synced.client().chain;
+        let synced_epoch_info = synced_em.get_epoch_info(&synced_epoch_id).unwrap();
+
+        // Heights walked inside the synced epoch, for the offset check below.
+        let mut synced_epoch_heights = HashSet::new();
+        let mut reassigned_rows = 0u32;
+        let mut hash = final_head.last_block_hash;
+        loop {
+            let header = synced_chain.get_block_header(&hash).unwrap_or_else(|e| {
+                panic!("header walk broke at {hash} before the synced epoch start: {e:?}")
+            });
+            let height = header.height();
+            assert!(
+                height >= synced_epoch_start,
+                "walk stepped below the synced epoch start {synced_epoch_start} without \
+                 landing on it (reached {height}); wrong fork or missing seeded block"
+            );
+            let in_synced_epoch = header.epoch_id() == &synced_epoch_id;
+            let shard_layout = synced_em.get_shard_layout(header.epoch_id()).unwrap();
             for shard_id in shard_layout.shard_ids() {
-                let key = get_block_shard_id(&block_hash, shard_id);
+                let key = get_block_shard_id(&hash, shard_id);
                 let synced_row: Option<ValidatorStake> =
                     synced.store().get_ser(DBCol::ChunkProducers, &key);
                 let source_row: Option<ValidatorStake> =
                     source.store().get_ser(DBCol::ChunkProducers, &key);
                 assert!(
                     synced_row.is_some(),
-                    "ChunkProducers row missing on synced node at height {height} shard {shard_id}"
+                    "ChunkProducers row missing on the synced node at height {height} shard \
+                     {shard_id} (a GC'd range means this assertion ran too late in the test)"
                 );
                 assert_eq!(
                     synced_row, source_row,
-                    "ChunkProducers row diverged from source at height {height} shard {shard_id}"
+                    "ChunkProducers row diverged from the source at height {height} shard \
+                     {shard_id}"
                 );
+                // Reassignment pin: a row differing from the PLAIN schedule proves the
+                // blacklist was active for that anchor. Rows sample the producer at
+                // anchor height + 2, so only anchors whose sample height stays inside
+                // the synced epoch count (the walk visits height + 2 before height).
+                if in_synced_epoch && synced_epoch_heights.contains(&(height + 2)) {
+                    let planned = synced_epoch_info
+                        .sample_chunk_producer(&shard_layout, shard_id, height + 2)
+                        .map(|id| synced_epoch_info.get_validator(id).account_id().clone());
+                    if synced_row.as_ref().map(|stake| stake.account_id()) != planned.as_ref() {
+                        reassigned_rows += 1;
+                    }
+                }
             }
+            if in_synced_epoch {
+                synced_epoch_heights.insert(height);
+            }
+            if height == synced_epoch_start {
+                assert!(
+                    in_synced_epoch,
+                    "block at the synced epoch start height belongs to {:?}, expected {:?}",
+                    header.epoch_id(),
+                    synced_epoch_id
+                );
+                break;
+            }
+            hash = *header.prev_hash();
         }
-        // Aggregator parity at the synced node's final head: the per-validator
-        // produced/expected stats are what feed `next_bp_hash`, and on the synced
-        // node this read also exercises the `EpochStart` row that only exists
-        // because epoch sync now writes it.
-        let final_head = synced.final_head();
-        assert_eq!(
-            final_head.epoch_id, synced_head.epoch_id,
-            "parity probe expects the final head inside the synced epoch"
+        assert!(
+            synced_epoch_heights.len() as u64 >= epoch_length / 2,
+            "synced-epoch coverage too thin: {} headers walked",
+            synced_epoch_heights.len()
         );
-        let synced_info = synced_em
-            .get_validator_info(ValidatorInfoIdentifier::BlockHash(final_head.last_block_hash))
-            .expect("synced node must compute validator info for the synced epoch");
+        assert!(
+            reassigned_rows >= 1,
+            "no blacklist-driven reassignment found in the synced epoch's rows \
+             ({} headers walked)",
+            synced_epoch_heights.len()
+        );
+
+        // Aggregator-derived validator stats for the SYNCED epoch: the
+        // produced/expected stats feed rewards and thus `next_bp_hash`. On the
+        // follower, `get_validator_info(EpochId)` resolves the epoch start through
+        // the `EpochStart` row that only exists because epoch sync now writes it.
+        let synced_info =
+            synced_em.get_validator_info(ValidatorInfoIdentifier::EpochId(synced_epoch_id)).expect(
+                "synced node must compute validator info for the synced epoch \
+                 (EpochOutOfBounds means the seeded EpochStart row is missing)",
+            );
         let source_info = source_em
-            .get_validator_info(ValidatorInfoIdentifier::BlockHash(final_head.last_block_hash))
+            .get_validator_info(ValidatorInfoIdentifier::EpochId(synced_epoch_id))
             .unwrap();
         assert_eq!(
             synced_info.current_validators, source_info.current_validators,
-            "aggregator-derived validator stats diverged between synced node and source"
+            "synced-epoch validator stats diverged between synced node and source"
+        );
+        // Raw epoch-summary parity: `current_validators` flattens the summary; the
+        // raw row also covers kickouts, proposals and stats wholesale.
+        let synced_summary = synced
+            .store()
+            .get(DBCol::EpochValidatorInfo, synced_epoch_id.as_ref())
+            .map(|slice| slice.to_vec());
+        let source_summary = source
+            .store()
+            .get(DBCol::EpochValidatorInfo, synced_epoch_id.as_ref())
+            .map(|slice| slice.to_vec());
+        assert!(synced_summary.is_some(), "synced node has no epoch summary for the synced epoch");
+        assert_eq!(
+            synced_summary, source_summary,
+            "EpochValidatorInfo summary diverged for the synced epoch"
+        );
+        // Live-aggregator parity at the catch-up head. The head epoch's `EpochStart`
+        // row comes from normal header processing, not the fix; this complements the
+        // synced-epoch summary check above.
+        let head_info = synced_em
+            .get_validator_info(ValidatorInfoIdentifier::BlockHash(final_head.last_block_hash))
+            .unwrap();
+        let source_head_info = source_em
+            .get_validator_info(ValidatorInfoIdentifier::BlockHash(final_head.last_block_hash))
+            .unwrap();
+        assert_eq!(
+            head_info.current_validators, source_head_info.current_validators,
+            "aggregator-derived validator stats diverged at the catch-up head"
         );
     }
 

--- a/test-loop-tests/src/tests/early_kickout_e2e.rs
+++ b/test-loop-tests/src/tests/early_kickout_e2e.rs
@@ -22,32 +22,40 @@
 //! start-of-epoch grace, which is ~1100 blocks — far more than a test-loop chain
 //! can run. Both tests therefore shrink both thresholds through
 //! `set_early_kickout_thresholds_for_testing` so the gate trips in tens of
-//! blocks. The exact production values (100 / 80% / 1000) stay proven by the
-//! epoch-manager unit tests, which build without `test_features`; what these
-//! tests prove is the end-to-end wiring, which the thresholds do not affect.
+//! blocks. The overrides are thread-local with production-constant defaults, so
+//! nothing outside these tests is affected; the exact production values
+//! (100 / 80% / 1000) stay covered by the epoch-manager unit tests, which never
+//! install an override. What these tests prove is the end-to-end wiring, which
+//! the thresholds do not affect.
 
 use crate::setup::builder::TestLoopBuilder;
 use crate::tests::sync::util::{TEST_EPOCH_SYNC_HORIZON, far_horizon_height};
 use crate::utils::account::{
     create_account_id, create_validator_id, create_validators_spec, validators_spec_clients,
 };
+use crate::utils::node::NodeRunner;
 use borsh::BorshDeserialize;
 use near_async::time::Duration;
 use near_chain_configs::TrackedShardsConfig;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::NetworkAdversarialMessage;
 use near_client::client_actor::AdvProduceChunksMode;
-use near_epoch_manager::set_early_kickout_thresholds_for_testing;
+use near_epoch_manager::{
+    EarlyKickoutThresholdGuard, EpochManagerAdapter, set_early_kickout_thresholds_for_testing,
+};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{AccountInfo, Balance, BlockHeight, EpochId, ValidatorInfoIdentifier};
+use near_primitives::types::{
+    AccountId, AccountInfo, Balance, BlockHeight, EpochId, ValidatorInfoIdentifier,
+};
 use near_primitives::utils::get_block_shard_id;
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::DBCol;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 /// Grace window used by both tests, in blocks into the epoch. Small enough that a
 /// test-loop chain clears it in seconds, large enough that the first blocks of an
@@ -57,7 +65,54 @@ const TEST_EPOCH_GRACE_BLOCKS: u64 = 20;
 /// this within ~10 heights of leaving the grace window.
 const TEST_MIN_MISSES: u64 = 5;
 
-/// Test A — flagship reassignment test.
+/// Asserts `EarlyKickout` is enabled for the genesis protocol version, then shrinks the
+/// early-kickout gate for the calling thread — which is the thread the whole test-loop
+/// chain runs on. Hold the returned guard for the whole test; it restores the production
+/// values when dropped, panic or not.
+fn shrink_early_kickout_gate() -> EarlyKickoutThresholdGuard {
+    assert!(
+        ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION),
+        "test requires EarlyKickout enabled for the genesis protocol version"
+    );
+    set_early_kickout_thresholds_for_testing(Some(TEST_MIN_MISSES), Some(TEST_EPOCH_GRACE_BLOCKS))
+}
+
+/// Runs the node until `target` is blacklisted on some shard at the node's final head,
+/// per `epoch_manager`'s aggregator view. With `pin_epoch`, final heads outside that
+/// epoch are ignored, so the wait cannot be satisfied by a stale blacklist from a prior
+/// epoch.
+fn run_until_target_blacklisted(
+    runner: &mut NodeRunner<'_>,
+    epoch_manager: &Arc<dyn EpochManagerAdapter>,
+    target: &AccountId,
+    pin_epoch: Option<EpochId>,
+) {
+    let epoch_manager = epoch_manager.clone();
+    let target = target.clone();
+    runner.run_until(
+        move |node| {
+            let final_head = node.final_head();
+            if pin_epoch.is_some_and(|pin| final_head.epoch_id != pin) {
+                return false;
+            }
+            let Ok(epoch_info) = epoch_manager.get_epoch_info(&final_head.epoch_id) else {
+                return false;
+            };
+            let Some(&target_id) = epoch_info.get_validator_id(&target) else {
+                return false;
+            };
+            let Ok(blacklist) =
+                epoch_manager.get_chunk_producer_blacklist(&final_head.last_block_hash)
+            else {
+                return false;
+            };
+            blacklist.values().any(|excluded| excluded.contains(&target_id))
+        },
+        Duration::seconds(300),
+    );
+}
+
+/// Flagship reassignment test.
 ///
 /// Setup: 4 block+chunk producers over 2 shards (balance-shards puts 2
 /// producers on each shard, so blacklisting one always leaves a clean
@@ -76,17 +131,7 @@ const TEST_MIN_MISSES: u64 = 5;
 fn test_early_kickout_reassignment() {
     init_test_logger();
 
-    assert!(
-        ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION),
-        "test requires EarlyKickout enabled for the genesis protocol version"
-    );
-
-    // Shrink the gate for this thread; the whole test-loop chain runs on it. The guard
-    // restores the production values when the test ends, panic or not.
-    let _thresholds = set_early_kickout_thresholds_for_testing(
-        Some(TEST_MIN_MISSES),
-        Some(TEST_EPOCH_GRACE_BLOCKS),
-    );
+    let _thresholds = shrink_early_kickout_gate();
 
     // A 50%-share producer clears the grace and the miss floor within ~40 heights.
     // A 200-block epoch leaves comfortable margin so the reassignment lands
@@ -137,27 +182,7 @@ fn test_early_kickout_reassignment() {
     // Condition-based wait (no fixed heights): run until the mid-epoch kickout
     // math blacklists the target on some shard, which requires the anchor to be
     // past the grace window with at least `TEST_MIN_MISSES` misses at under 80%.
-    {
-        let em = epoch_manager.clone();
-        let target = target_account.clone();
-        env.node_runner(0).run_until(
-            move |node| {
-                let final_head = node.final_head();
-                let Ok(epoch_info) = em.get_epoch_info(&final_head.epoch_id) else {
-                    return false;
-                };
-                let Some(&target_id) = epoch_info.get_validator_id(&target) else {
-                    return false;
-                };
-                let Ok(blacklist) = em.get_chunk_producer_blacklist(&final_head.last_block_hash)
-                else {
-                    return false;
-                };
-                blacklist.values().any(|excluded| excluded.contains(&target_id))
-            },
-            Duration::seconds(300),
-        );
-    }
+    run_until_target_blacklisted(&mut env.node_runner(0), &epoch_manager, &target_account, None);
 
     let trigger_head = env.node(0).head().height;
     let trigger_epoch_id = env.node(0).final_head().epoch_id;
@@ -246,18 +271,25 @@ fn test_early_kickout_reassignment() {
     );
 
     // Liveness: after the reassignment the shard keeps producing chunks (does not
-    // stall). Every height in a post-reassignment window (whose anchor blacklists
-    // the target) must carry the offending shard's chunk.
+    // stall). Every block in a post-reassignment window (whose anchor blacklists
+    // the target) must carry the offending shard's chunk. Tolerate skipped block
+    // heights (only chunk production is stopped, but stay robust to scheduling
+    // changes) while requiring enough blocks for the window to stay meaningful.
+    let mut liveness_blocks = 0u32;
     for height in (trigger_head + 3)..=(trigger_head + 15) {
-        let block = chain.get_block_by_height(height).unwrap();
+        let Ok(block) = chain.get_block_by_height(height) else {
+            continue;
+        };
+        liveness_blocks += 1;
         assert!(
             block.header().chunk_mask()[target_shard_index],
             "shard chunk missing at height {height} after reassignment (shard stalled)"
         );
     }
+    assert!(liveness_blocks >= 10, "liveness window too thin: only {liveness_blocks} blocks found");
 }
 
-/// Test C — epoch-sync bootstrap into a network with an ACTIVE reassignment.
+/// Epoch-sync bootstrap into a network with an ACTIVE reassignment.
 ///
 /// A fresh node bootstraps via epoch sync into a running EarlyKickout network in
 /// which a chunk producer is ALREADY blacklisted (its slot reassigned) before the
@@ -284,25 +316,14 @@ fn test_early_kickout_reassignment() {
 /// node resolves every shard with no `ChunkProducerNotInDB`, agrees with the
 /// source, and reproduces >= 1 real reassignment.
 ///
-/// The 151->152 activation edge is intentionally not exercised here (see Test A
-/// rationale); it is covered by the epoch-manager unit tests and the cold-storage
-/// boundary test.
+/// The 151->152 activation edge is intentionally not exercised here; it is
+/// covered by the epoch-manager unit tests and the cold-storage boundary test.
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn slow_test_early_kickout_epoch_sync_bootstrap() {
     init_test_logger();
 
-    assert!(
-        ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION),
-        "test requires EarlyKickout enabled for the genesis protocol version"
-    );
-
-    // Shrink the gate for this thread; the whole test-loop chain runs on it. The guard
-    // restores the production values when the test ends, panic or not.
-    let _thresholds = set_early_kickout_thresholds_for_testing(
-        Some(TEST_MIN_MISSES),
-        Some(TEST_EPOCH_GRACE_BLOCKS),
-    );
+    let _thresholds = shrink_early_kickout_gate();
 
     let epoch_length = 100;
     let target_account = create_validator_id(0);
@@ -355,27 +376,7 @@ fn slow_test_early_kickout_epoch_sync_bootstrap() {
     // in all_epochs") and silently degrades this into a header-sync-from-genesis
     // test. The condition wait then guarantees the blacklist has actually formed.
     env.node_runner(0).run_until_head_height(far_horizon_height(epoch_length));
-    {
-        let em = source_em.clone();
-        let target = target_account.clone();
-        env.node_runner(0).run_until(
-            move |node| {
-                let final_head = node.final_head();
-                let Ok(epoch_info) = em.get_epoch_info(&final_head.epoch_id) else {
-                    return false;
-                };
-                let Some(&target_id) = epoch_info.get_validator_id(&target) else {
-                    return false;
-                };
-                let Ok(blacklist) = em.get_chunk_producer_blacklist(&final_head.last_block_hash)
-                else {
-                    return false;
-                };
-                blacklist.values().any(|excluded| excluded.contains(&target_id))
-            },
-            Duration::seconds(300),
-        );
-    }
+    run_until_target_blacklisted(&mut env.node_runner(0), &source_em, &target_account, None);
 
     // Add a fresh non-validator node that must bootstrap from genesis while the
     // reassignment is active on the network.
@@ -432,6 +433,13 @@ fn slow_test_early_kickout_epoch_sync_bootstrap() {
         );
         (epoch_id, height)
     };
+    // If epoch sync silently degraded into header sync from genesis, the min-height row
+    // would be an early epoch's row (written by header processing) and the assertions
+    // below would target the wrong epoch. Fail fast here instead.
+    assert!(
+        synced_epoch_start > epoch_length,
+        "seeded epoch starts at {synced_epoch_start} - epoch sync did not run"
+    );
 
     // Bring the fresh node to the network tip (epoch sync -> header -> state ->
     // block). The network keeps advancing (and the target keeps missing) while it
@@ -506,16 +514,28 @@ fn slow_test_early_kickout_epoch_sync_bootstrap() {
                     "ChunkProducers row diverged from the source at height {height} shard \
                      {shard_id}"
                 );
-                // Reassignment pin: a row differing from the PLAIN schedule proves the
-                // blacklist was active for that anchor. Rows sample the producer at
-                // anchor height + 2, so only anchors whose sample height stays inside
-                // the synced epoch count (the walk visits height + 2 before height).
+                // Reassignment pin: the TARGET's own slots deviating from the plain
+                // schedule proves the blacklist was active for that anchor; only the
+                // target misses chunks, so healthy producers' slots must never deviate
+                // (negative path). Rows sample the producer at anchor height + 2, so
+                // only anchors whose sample height stays inside the synced epoch count
+                // (the walk visits height + 2 before height).
                 if in_synced_epoch && synced_epoch_heights.contains(&(height + 2)) {
                     let planned = synced_epoch_info
                         .sample_chunk_producer(&shard_layout, shard_id, height + 2)
                         .map(|id| synced_epoch_info.get_validator(id).account_id().clone());
-                    if synced_row.as_ref().map(|stake| stake.account_id()) != planned.as_ref() {
-                        reassigned_rows += 1;
+                    let stored = synced_row.as_ref().map(|stake| stake.account_id());
+                    if planned.as_ref() == Some(&target_account) {
+                        if stored != planned.as_ref() {
+                            reassigned_rows += 1;
+                        }
+                    } else {
+                        assert_eq!(
+                            stored,
+                            planned.as_ref(),
+                            "healthy producer's slot reassigned at height {} shard {shard_id}",
+                            height + 2
+                        );
                     }
                 }
             }
@@ -601,30 +621,12 @@ fn slow_test_early_kickout_epoch_sync_bootstrap() {
     // grace window. Blacklist observed on the full-aggregator source.
     env.node_runner(new_node_idx).run_until_new_epoch();
     let observe_epoch = env.node(new_node_idx).head().epoch_id;
-    {
-        let em = source_em.clone();
-        let target = target_account.clone();
-        env.node_runner(new_node_idx).run_until(
-            move |node| {
-                let final_head = node.final_head();
-                if final_head.epoch_id != observe_epoch {
-                    return false;
-                }
-                let Ok(epoch_info) = em.get_epoch_info(&final_head.epoch_id) else {
-                    return false;
-                };
-                let Some(&target_id) = epoch_info.get_validator_id(&target) else {
-                    return false;
-                };
-                let Ok(blacklist) = em.get_chunk_producer_blacklist(&final_head.last_block_hash)
-                else {
-                    return false;
-                };
-                blacklist.values().any(|excluded| excluded.contains(&target_id))
-            },
-            Duration::seconds(300),
-        );
-    }
+    run_until_target_blacklisted(
+        &mut env.node_runner(new_node_idx),
+        &source_em,
+        &target_account,
+        Some(observe_epoch),
+    );
     // Post-blacklist runway so many of the target's own slots have a grandparent
     // anchor that blacklists it (still within the same epoch: ~30 + 20 < 100).
     env.node_runner(new_node_idx).run_for_number_of_blocks(20);

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -28,6 +28,8 @@ mod deterministic_account_id;
 #[cfg(feature = "test_features")]
 mod doomslug;
 mod earliest_available;
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+mod early_kickout_e2e;
 mod early_prepare_transactions;
 mod fix_chunk_producer_stake_threshold;
 mod fix_stake_threshold;


### PR DESCRIPTION
The epoch-sync bootstrap test reproduced a real consensus divergence: a node that epoch-syncs while an early-kickout reassignment is active never joins the network (InvalidNextBPHash on every header batch).

Root cause: `apply_validated_proof` bypasses `record_block_info`, the only writer of `DBCol::EpochStart`. The missing row makes the early-kickout grace check treat the synced epoch as permanently just-started, so the blacklist never forms on the synced node and its aggregator credits the kicked-out producer with chunks the replacement made.

- fix: write the `EpochStart` row for the synced epoch alongside its first `BlockInfo`
- test seam: `test_features`-gated thread-local override lowering the miss floor and start-of-epoch grace, so the gate trips in tens of blocks. The defaults are the production constants, so builds carrying the feature behave identically until a test installs an override; unit tests pin the guard's restore (drop, nesting, panic unwind)
- e2e tests (supersede #16058): `test_early_kickout_reassignment` and `slow_test_early_kickout_epoch_sync_bootstrap`. The bootstrap test asserts the seeded `EpochStart` row right after the proof applies (without the fix it fails there in seconds) and that epoch sync actually ran, walks `ChunkProducers` rows from the catch-up head back to the seeded first block against the source, requires a blacklist-driven reassignment of the target's slots inside the synced epoch while healthy producers' slots stay on the plain schedule, and compares the synced epoch's validator info and raw epoch summary.

Both tests pass (2/2); without the fix the bootstrap test fails at the seeded-row assertion.
