### PR TITLE
fix(network): cap pre-auth shard-id lists to prevent decode-time oom

### DIFF
--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -180,6 +180,17 @@ pub const MAX_ACCOUNT_DATA_SIZE_BYTES: usize = 10000; // 10kB
 /// increase the receive limit in one release then increase the send limit in the next.
 pub const MAX_SHARDS_PER_SNAPSHOT_HOST_INFO: usize = 512;
 
+/// Limit on the number of shard ids in a peer's [`PeerChainInfoV2::tracked_shards`] sent during
+/// the handshake. Reached pre-authentication on raw TCP, so the cap is tight: mainnet has 9
+/// shards today; 128 leaves ~14x headroom for future resharding. Rejecting a handshake whose
+/// `tracked_shards` exceeds this cap prevents an unauthenticated peer from forcing
+/// multi-GB `Vec<ShardId>` allocations during handshake parsing.
+///
+/// Warning: this is a receive-side cap. It is safe to tighten unilaterally because honest
+/// peers send at most the network's actual shard count (today: 9). Loosening it later would
+/// require the same send/receive-skew handling described for `MAX_SHARDS_PER_SNAPSHOT_HOST_INFO`.
+pub const MAX_TRACKED_SHARDS_PER_PEER: usize = 128;
+
 impl VersionedAccountData {
     /// Serializes AccountData to proto and signs it using `signer`.
     /// Panics if AccountData.account_id doesn't match signer.validator_id(),

--- a/chain/network/src/network_protocol/proto_conv/handshake.rs
+++ b/chain/network/src/network_protocol/proto_conv/handshake.rs
@@ -1,5 +1,6 @@
 /// Conversion functions for `Handshake` messages.
 use super::*;
+use crate::network_protocol::MAX_TRACKED_SHARDS_PER_PEER;
 use crate::network_protocol::proto;
 use crate::network_protocol::{Handshake, HandshakeFailureReason};
 use crate::network_protocol::{PeerChainInfoV2, PeerInfo};
@@ -34,10 +35,18 @@ impl TryFrom<&proto::GenesisId> for GenesisId {
 pub enum ParsePeerChainInfoV2Error {
     #[error("genesis_id {0}")]
     GenesisId(ParseRequiredError<ParseGenesisIdError>),
+    #[error("tracked_shards: {count} > {max} (MAX_TRACKED_SHARDS_PER_PEER)")]
+    TooManyTrackedShards { count: usize, max: usize },
 }
 
 impl From<&PeerChainInfoV2> for proto::PeerChainInfo {
     fn from(x: &PeerChainInfoV2) -> Self {
+        debug_assert!(
+            x.tracked_shards.len() <= MAX_TRACKED_SHARDS_PER_PEER,
+            "tracked_shards length {} exceeds MAX_TRACKED_SHARDS_PER_PEER ({})",
+            x.tracked_shards.len(),
+            MAX_TRACKED_SHARDS_PER_PEER,
+        );
         Self {
             genesis_id: MF::some((&x.genesis_id).into()),
             height: x.height,
@@ -51,6 +60,12 @@ impl From<&PeerChainInfoV2> for proto::PeerChainInfo {
 impl TryFrom<&proto::PeerChainInfo> for PeerChainInfoV2 {
     type Error = ParsePeerChainInfoV2Error;
     fn try_from(p: &proto::PeerChainInfo) -> Result<Self, Self::Error> {
+        if p.tracked_shards.len() > MAX_TRACKED_SHARDS_PER_PEER {
+            return Err(Self::Error::TooManyTrackedShards {
+                count: p.tracked_shards.len(),
+                max: MAX_TRACKED_SHARDS_PER_PEER,
+            });
+        }
         Ok(Self {
             genesis_id: try_from_required(&p.genesis_id).map_err(Self::Error::GenesisId)?,
             height: p.height,

--- a/chain/network/src/network_protocol/proto_conv/mod.rs
+++ b/chain/network/src/network_protocol/proto_conv/mod.rs
@@ -11,7 +11,7 @@ mod util;
 use self::time::*;
 use account_key::*;
 use crypto::*;
-use handshake::*;
+pub(crate) use handshake::*;
 use net::*;
 pub(crate) use peer_message::*;
 use util::*;

--- a/chain/network/src/network_protocol/proto_conv/peer_message.rs
+++ b/chain/network/src/network_protocol/proto_conv/peer_message.rs
@@ -4,8 +4,8 @@ use crate::network_protocol::proto::peer_message::Message_type as ProtoMT;
 use crate::network_protocol::proto::{self};
 use crate::network_protocol::state_sync::{SnapshotHostInfo, SyncSnapshotHosts};
 use crate::network_protocol::{
-    Disconnect, PeerMessage, PeersRequest, PeersResponse, RoutedMessageV3, RoutingTableUpdate,
-    SyncAccountsData, TieredMessageBody,
+    Disconnect, MAX_SHARDS_PER_SNAPSHOT_HOST_INFO, PeerMessage, PeersRequest, PeersResponse,
+    RoutedMessageV3, RoutingTableUpdate, SyncAccountsData, TieredMessageBody,
 };
 use crate::network_protocol::{PeerIdOrHash, RoutedMessageV1};
 use crate::types::StateResponseInfo;
@@ -109,6 +109,8 @@ pub enum ParseSnapshotHostInfoError {
     SyncHash(ParseRequiredError<ParseCryptoHashError>),
     #[error("signature {0}")]
     Signature(ParseRequiredError<ParseSignatureError>),
+    #[error("shards: {count} > {max} (MAX_SHARDS_PER_SNAPSHOT_HOST_INFO)")]
+    TooManyShards { count: usize, max: usize },
 }
 
 impl From<&SnapshotHostInfo> for proto::SnapshotHostInfo {
@@ -127,6 +129,16 @@ impl From<&SnapshotHostInfo> for proto::SnapshotHostInfo {
 impl TryFrom<&proto::SnapshotHostInfo> for SnapshotHostInfo {
     type Error = ParseSnapshotHostInfoError;
     fn try_from(x: &proto::SnapshotHostInfo) -> Result<Self, Self::Error> {
+        // Reject before the per-shard `Vec<ShardId>` allocation. This message is decoded
+        // pre-authentication, so an unbounded `shards` list would let any peer force
+        // multi-GB allocations from a single message. `verify()` also checks this cap, but
+        // only after decoding, which is too late. Mirrors the tracked_shards handshake cap.
+        if x.shards.len() > MAX_SHARDS_PER_SNAPSHOT_HOST_INFO {
+            return Err(Self::Error::TooManyShards {
+                count: x.shards.len(),
+                max: MAX_SHARDS_PER_SNAPSHOT_HOST_INFO,
+            });
+        }
         Ok(Self {
             peer_id: try_from_required(&x.peer_id).map_err(Self::Error::PeerId)?,
             sync_hash: try_from_required(&x.sync_hash).map_err(Self::Error::SyncHash)?,

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -468,3 +468,36 @@ mod versioned_witness_tests {
         assert_eq!(wrapped_fwd_v2.variant(), "VersionedPartialEncodedStateWitnessForward");
     }
 }
+
+#[test]
+fn snapshot_host_info_too_many_shards() {
+    use crate::network_protocol::MAX_SHARDS_PER_SNAPSHOT_HOST_INFO;
+    use crate::network_protocol::proto;
+    use crate::network_protocol::proto_conv::ParseSnapshotHostInfoError;
+    use crate::network_protocol::state_sync::SnapshotHostInfo;
+
+    let mut rng = make_rng(2847510394);
+    // A host info with empty shards, so converting it to proto does not trip the
+    // send-side debug_assert. We then set `shards` on the proto directly.
+    let signer = data::make_secret_key(&mut rng);
+    let peer_id = PeerId::new(signer.public_key());
+    let info = SnapshotHostInfo::new(peer_id, CryptoHash::default(), 0, vec![], &signer);
+    let base = proto::SnapshotHostInfo::from(&info);
+
+    // len == cap: must succeed.
+    let mut ok_proto = base.clone();
+    ok_proto.shards = (0..MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64).collect();
+    let parsed = SnapshotHostInfo::try_from(&ok_proto).expect("at-cap parse should succeed");
+    assert_eq!(parsed.shards.len(), MAX_SHARDS_PER_SNAPSHOT_HOST_INFO);
+
+    // len == cap + 1: must fail with TooManyShards, before any per-shard allocation.
+    let mut too_many = base;
+    too_many.shards = (0..=MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64).collect();
+    match SnapshotHostInfo::try_from(&too_many) {
+        Err(ParseSnapshotHostInfoError::TooManyShards { count, max }) => {
+            assert_eq!(count, MAX_SHARDS_PER_SNAPSHOT_HOST_INFO + 1);
+            assert_eq!(max, MAX_SHARDS_PER_SNAPSHOT_HOST_INFO);
+        }
+        other => panic!("expected TooManyShards, got: {other:?}"),
+    }
+}

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -59,6 +59,37 @@ fn bad_account_data_size() {
 }
 
 #[test]
+fn handshake_tracked_shards_too_many() {
+    use crate::network_protocol::MAX_TRACKED_SHARDS_PER_PEER;
+    use crate::network_protocol::proto;
+    use crate::network_protocol::proto_conv::ParsePeerChainInfoV2Error;
+
+    let mut rng = make_rng(8475629384);
+    let mut clock = time::FakeClock::default();
+    let chain = data::Chain::make(&mut clock, &mut rng, 12);
+    // `get_peer_chain_info` returns a `PeerChainInfoV2` with empty `tracked_shards`,
+    // so converting it to proto does not trip the send-side debug_assert.
+    let base = proto::PeerChainInfo::from(&chain.get_peer_chain_info());
+
+    // len == cap: must succeed.
+    let mut ok_proto = base.clone();
+    ok_proto.tracked_shards = (0..MAX_TRACKED_SHARDS_PER_PEER as u64).collect();
+    let parsed = PeerChainInfoV2::try_from(&ok_proto).expect("at-cap parse should succeed");
+    assert_eq!(parsed.tracked_shards.len(), MAX_TRACKED_SHARDS_PER_PEER);
+
+    // len == cap + 1: must fail with TooManyTrackedShards, before any per-shard allocation.
+    let mut too_many_proto = base;
+    too_many_proto.tracked_shards = (0..=MAX_TRACKED_SHARDS_PER_PEER as u64).collect();
+    match PeerChainInfoV2::try_from(&too_many_proto) {
+        Err(ParsePeerChainInfoV2Error::TooManyTrackedShards { count, max }) => {
+            assert_eq!(count, MAX_TRACKED_SHARDS_PER_PEER + 1);
+            assert_eq!(max, MAX_TRACKED_SHARDS_PER_PEER);
+        }
+        other => panic!("expected TooManyTrackedShards, got: {other:?}"),
+    }
+}
+
+#[test]
 fn serialize_deserialize_protobuf_only() {
     let mut rng = make_rng(39521947542);
     let mut clock = time::FakeClock::default();


### PR DESCRIPTION
Fixes two closely-related pre-authentication OOM issues in the P2P message decode path. Both are unbounded `repeated uint64` shard-id lists that a peer can inflate on the first frame of a raw TCP connection, before authentication or rate-limiting runs, forcing multi-GB allocations from a single message.

- `Handshake.tracked_shards`: decoded into a `Vec<ShardId>` with no length cap. Adds `MAX_TRACKED_SHARDS_PER_PEER = 128` and rejects oversized handshakes before allocation.
- `SnapshotHostInfo.shards` (in `SyncSnapshotHosts`): the same pattern. The existing `MAX_SHARDS_PER_SNAPSHOT_HOST_INFO = 512` cap was only enforced in `verify()`, which runs after decoding and so did not prevent the allocation. Adds the cap to the `TryFrom` parser so oversized messages are rejected before the `Vec<ShardId>` allocation.

Both are receive-side caps, safe to tighten unilaterally (honest peers never exceed the network's shard count) and need no protocol version gate. Each fix has a regression test.
