### PR TITLE
fix(near-vm-runner): bound view-call gas by max_gas_burnt_view

### DIFF
--- a/runtime/cspell.json
+++ b/runtime/cspell.json
@@ -174,6 +174,7 @@
     "typesafe",
     "unalign",
     "underflowed",
+    "underflows",
     "unistd",
     "unlinkable",
     "unrkyv",

--- a/runtime/near-vm-runner/src/logic/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/gas_counter.rs
@@ -90,8 +90,15 @@ impl GasCounter {
         is_view: bool,
     ) -> Self {
         use std::cmp::min;
-        // Ignore prepaid gas limit when in view.
-        let prepaid_gas = if is_view { Gas::MAX } else { prepaid_gas };
+        // In view mode there is no real prepaid gas; the per-call budget is
+        // `max_gas_burnt` (i.e. `max_gas_burnt_view`). Bound `prepaid_gas` by it
+        // rather than widening it to `Gas::MAX`: `remaining_gas()` seeds the
+        // in-Wasm gas global on the Wasmtime backend, and seeding it from
+        // `Gas::MAX` let a pure-Wasm loop with no host imports run until it
+        // drained ~u64::MAX of guest gas before the cap was ever checked.
+        // Promises are prohibited in view mode, so `used_gas` never exceeds
+        // `burnt_gas` and this does not change any view-call result.
+        let prepaid_gas = if is_view { max_gas_burnt } else { prepaid_gas };
         Self {
             ext_costs_config,
             fast_counter: FastGasCounter {

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -9,6 +9,7 @@ mod rs_contract;
 mod runtime_errors;
 pub(crate) mod test_builder;
 mod ts_contract;
+mod view_call_gas_limit;
 mod wasm_validation;
 
 use crate::logic::VMContext;

--- a/runtime/near-vm-runner/src/tests/view_call_gas_limit.rs
+++ b/runtime/near-vm-runner/src/tests/view_call_gas_limit.rs
@@ -1,0 +1,101 @@
+//! Regression test: view calls are bounded by `max_gas_burnt_view`.
+//!
+//! In view mode `GasCounter::new` used to widen `prepaid_gas` to `Gas::MAX`.
+//! The Wasmtime backend seeds the in-Wasm gas global from `remaining_gas()`
+//! (`prepaid_gas - used_gas`), and the finite-wasm instrumentation only calls
+//! back into the host (where `max_gas_burnt_view` is enforced) when that global
+//! underflows a per-block constant. Seeding from `Gas::MAX` therefore let a
+//! pure-Wasm loop with no host imports run for ~`u64::MAX / per_block_cost`
+//! iterations (minutes-to-hours of CPU) before the cap was ever checked, so a
+//! single anonymous `call_function` view query could pin an RPC worker thread.
+//!
+//! The fix bounds `prepaid_gas` by `max_gas_burnt` in view mode, so the guest
+//! gas global reflects the cap and an unbounded loop aborts promptly.
+
+use crate::logic::VMContext;
+use crate::logic::VMOutcome;
+use crate::logic::errors::{FunctionCallError, HostError};
+use crate::logic::mocks::mock_external::MockedExternal;
+use crate::runner::VMKindExt;
+use near_parameters::vm::VMKind;
+use near_parameters::{RuntimeConfigStore, RuntimeFeesConfig};
+use near_primitives_core::code::ContractCode;
+use near_primitives_core::config::ViewConfig;
+use near_primitives_core::types::{Balance, Gas};
+use near_primitives_core::version::PROTOCOL_VERSION;
+use std::sync::Arc;
+use std::sync::mpsc;
+use std::time::Duration;
+
+fn run_view_call(cap: Gas, code: &[u8]) -> VMOutcome {
+    let store = RuntimeConfigStore::new(None);
+    let mut config =
+        near_parameters::vm::Config::clone(&store.get_config(PROTOCOL_VERSION).wasm_config);
+    config.vm_kind = VMKind::Wasmtime;
+    let config = Arc::new(config);
+
+    let context = VMContext {
+        current_account_id: "alice".parse().unwrap(),
+        signer_account_id: "bob".parse().unwrap(),
+        signer_account_pk: vec![0, 1, 2],
+        predecessor_account_id: "carol".parse().unwrap(),
+        refund_to_account_id: "david".parse().unwrap(),
+        input: std::rc::Rc::from(Vec::new()),
+        promise_results: Vec::new().into(),
+        block_height: 10,
+        block_timestamp: 42,
+        epoch_height: 1,
+        account_balance: Balance::from_yoctonear(2),
+        account_locked_balance: Balance::ZERO,
+        storage_usage: 12,
+        account_contract: near_primitives_core::account::AccountContract::None,
+        attached_deposit: Balance::from_yoctonear(2),
+        prepaid_gas: Gas::from_teragas(100),
+        random_seed: vec![0, 1, 2],
+        view_config: Some(ViewConfig { max_gas_burnt: cap }),
+        output_data_receivers: vec![],
+    };
+
+    let gas_counter = context.make_gas_counter(&config);
+    let mut ext = MockedExternal::with_code(ContractCode::new(code.to_vec(), None));
+    let fees = Arc::new(RuntimeFeesConfig::test());
+    let runtime = VMKind::Wasmtime.runtime(Arc::clone(&config)).expect("wasmtime not compiled in");
+    runtime
+        .prepare(&ext, None, gas_counter, "burn")
+        .run(&mut ext, &context, fees)
+        .expect("execution failed")
+}
+
+#[test]
+fn view_call_gas_is_bounded_for_pure_wasm_loop() {
+    // Infinite in-Wasm loop, no host imports.
+    let code = wat::parse_str(r#"(module (func (export "burn") (loop $l br $l)))"#).unwrap();
+    // 1 Tgas ≈ ~1.2M wasm ops at regular_op_cost, i.e. a fraction of a second.
+    let cap = Gas::from_teragas(1);
+
+    // Execute on a watchdog thread: if the cap is not enforced the loop never
+    // returns, and we want that to fail the test (recv_timeout) rather than
+    // hang the test binary forever.
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(run_view_call(cap, &code));
+    });
+    let outcome = rx
+        .recv_timeout(Duration::from_secs(60))
+        .expect("view call did not return within 60s: max_gas_burnt_view is not enforced in-Wasm");
+
+    let err = outcome.aborted.expect("expected the infinite loop to hit the gas limit");
+    assert!(
+        matches!(
+            err,
+            FunctionCallError::HostError(HostError::GasLimitExceeded | HostError::GasExceeded)
+        ),
+        "expected a gas-limit error, got {err:?}"
+    );
+    assert!(
+        outcome.burnt_gas <= cap,
+        "view call burnt {} gas, exceeding the cap {}",
+        outcome.burnt_gas.as_gas(),
+        cap.as_gas()
+    );
+}


### PR DESCRIPTION
## Summary

In view mode `GasCounter::new` widened `prepaid_gas` to `Gas::MAX`. On the Wasmtime backend the in-Wasm gas global is seeded from `remaining_gas()` (`prepaid_gas - used_gas`), and the finite-wasm gas instrumentation only calls back into the host (where `max_gas_burnt_view` is enforced) when that global underflows a per-block constant. Seeding it from `Gas::MAX` let a pure-Wasm loop with no host imports run for roughly `u64::MAX / per_block_cost` iterations before the cap was ever checked, so a single anonymous `call_function` / `query{CallFunction}` view request could pin a `ViewClientActor` worker thread for minutes to hours. With the default pool of 4 view-client threads, a handful of concurrent requests starve the node's entire query RPC.

## Fix

Bound `prepaid_gas` by `max_gas_burnt` in view mode so `remaining_gas()`, and therefore the guest gas global, reflects the cap. Promises are prohibited in view mode, so `used_gas` never exceeds `burnt_gas` and this does not change any view-call result. View execution is not part of consensus, so no protocol-version gate is needed.

## Testing

- New regression test runs an infinite pure-Wasm loop as a view call and asserts it aborts within the cap. Verified it hangs/fails without the fix and passes with it.
- Full `near-vm-runner` test suite green (427 passed).
- `cargo fmt` and `RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets` are clean.
- End-to-end on a local node: the malicious view call now returns a gas-limit error in ~0.26s (was: no response in 20s), and four concurrent loops no longer starve normal queries (node CPU ~6% vs ~408%, a normal `view_account` query ~10ms vs timing out).
