### PR TITLE
fix(network): prevent OOM from inflated delegate actions

### DIFF
--- a/chain/network/src/network_protocol/proto_conv/peer_message.rs
+++ b/chain/network/src/network_protocol/proto_conv/peer_message.rs
@@ -27,6 +27,12 @@ use std::sync::Arc;
 /// and far below the 512 MiB peer-frame cap.
 const MAX_TRANSACTION_SIZE_BYTES: usize = 16 * MIB as usize;
 
+/// Upper bound on the Borsh-encoded size of a peer-supplied routed-message body,
+/// enforced before it is deserialized so a maliciously inflated payload (e.g. a
+/// `ForwardTx` carrying an oversized delegate action) cannot exhaust node memory
+/// at decode time.
+const MAX_ROUTED_MESSAGE_SIZE_BYTES: usize = 64 * MIB as usize;
+
 #[derive(thiserror::Error, Debug)]
 pub enum ParseRoutingTableUpdateError {
     #[error("edges {0}")]
@@ -459,7 +465,10 @@ impl TryFrom<&proto::PeerMessage> for PeerMessage {
                     .map_err(Self::Error::Transaction)?,
             ),
             ProtoMT::Routed(r) => {
-                let msg = RoutedMessageV1::try_from_slice(&r.borsh).map_err(Self::Error::Routed)?;
+                // Bound the decode-time allocation: see `MAX_ROUTED_MESSAGE_SIZE_BYTES`.
+                let msg: RoutedMessageV1 =
+                    try_from_slice_with_limit(&r.borsh, MAX_ROUTED_MESSAGE_SIZE_BYTES)
+                        .map_err(Self::Error::Routed)?;
                 let body = TieredMessageBody::from_routed(msg.body);
                 PeerMessage::Routed(Box::new(
                     RoutedMessageV3 {
@@ -567,7 +576,9 @@ impl TryFrom<&proto::RoutedMessageV3> for RoutedMessageV3 {
             target: try_from_required(&x.target).map_err(Self::Error::Target)?,
             author: try_from_required(&x.author).map_err(Self::Error::Author)?,
             ttl: x.ttl as u8,
-            body: TieredMessageBody::try_from_slice(&x.borsh_body).map_err(Self::Error::Body)?,
+            // Bound the decode-time allocation: see `MAX_ROUTED_MESSAGE_SIZE_BYTES`.
+            body: try_from_slice_with_limit(&x.borsh_body, MAX_ROUTED_MESSAGE_SIZE_BYTES)
+                .map_err(Self::Error::Body)?,
             signature: try_from_optional(&x.signature)
                 .map_err(|e| Self::Error::Signature(ParseRequiredError::Other(e)))?,
             created_at: x.created_at,
@@ -585,7 +596,7 @@ mod tests {
     /// A normally-sized transaction passes the network size gate and round-trips
     /// through the proto conversion; an oversized body is rejected before it is
     /// Borsh-decoded, so the inflated nested-action `Vec` is never materialized
-    /// at decode time (NEAP-621).
+    /// at decode time.
     #[test]
     fn transaction_size_gate() {
         let mut rng = make_rng(89028037453);
@@ -604,6 +615,37 @@ mod tests {
             PeerMessage::try_from(&proto).expect_err("oversized transaction must be rejected");
         assert!(
             matches!(err, ParsePeerMessageError::Transaction(_)),
+            "unexpected error variant: {err:?}"
+        );
+        assert!(err.to_string().contains("exceeds"), "unexpected error: {err}");
+    }
+
+    /// A normally-sized routed message decodes, while an oversized borsh body is
+    /// rejected before it is Borsh-decoded, so a `ForwardTx` (or any routed
+    /// payload) carrying an inflated delegate action is never materialized at
+    /// decode time.
+    #[test]
+    fn routed_message_size_gate() {
+        use crate::network_protocol::T2MessageBody;
+
+        let mut rng = make_rng(89028037453);
+        let tx = data::make_signed_transaction(&mut rng);
+        let body = TieredMessageBody::T2(Box::new(T2MessageBody::ForwardTx(tx)));
+        let msg = PeerMessage::Routed(Box::new(data::make_routed_message(&mut rng, body)));
+        let proto: proto::PeerMessage = (&msg).into();
+        PeerMessage::try_from(&proto).expect("normally-sized routed message must decode");
+
+        let proto = proto::PeerMessage {
+            message_type: Some(ProtoMT::Routed(proto::RoutedMessage {
+                borsh: vec![0u8; MAX_ROUTED_MESSAGE_SIZE_BYTES + 1],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let err =
+            PeerMessage::try_from(&proto).expect_err("oversized routed message must be rejected");
+        assert!(
+            matches!(err, ParsePeerMessageError::Routed(_)),
             "unexpected error variant: {err:?}"
         );
         assert!(err.to_string().contains("exceeds"), "unexpected error: {err}");

--- a/chain/network/src/network_protocol/proto_conv/peer_message.rs
+++ b/chain/network/src/network_protocol/proto_conv/peer_message.rs
@@ -10,15 +10,22 @@ use crate::network_protocol::{
 use crate::network_protocol::{PeerIdOrHash, RoutedMessageV1};
 use crate::types::StateResponseInfo;
 use borsh::BorshDeserialize as _;
+use bytesize::MIB;
 use near_async::time::error::ComponentRange;
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::challenge::Challenge;
 use near_primitives::optimistic_block::{OptimisticBlock, OptimisticBlockInner};
-use near_primitives::transaction::SignedTransaction;
 use near_primitives::utils::compression::CompressedData;
 use proto::peer_id_or_hash::Target_type::*;
 use protobuf::MessageField as MF;
 use std::sync::Arc;
+
+/// Upper bound on the Borsh-encoded size of a peer-supplied transaction body,
+/// enforced before the body is deserialized to mitigate maliciously inflated
+/// transactions exhausting node memory at decode time. Set comfortably above
+/// the largest valid transaction (`max_transaction_size`, historically 4 MiB)
+/// and far below the 512 MiB peer-frame cap.
+const MAX_TRANSACTION_SIZE_BYTES: usize = 16 * MIB as usize;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ParseRoutingTableUpdateError {
@@ -447,7 +454,9 @@ impl TryFrom<&proto::PeerMessage> for PeerMessage {
                 PeerMessage::OptimisticBlock(ob.try_into().map_err(Self::Error::OptimisticBlock)?)
             }
             ProtoMT::Transaction(t) => PeerMessage::Transaction(
-                SignedTransaction::try_from_slice(&t.borsh).map_err(Self::Error::Transaction)?,
+                // Bound the decode-time allocation: see `MAX_TRANSACTION_SIZE_BYTES`.
+                try_from_slice_with_limit(&t.borsh, MAX_TRANSACTION_SIZE_BYTES)
+                    .map_err(Self::Error::Transaction)?,
             ),
             ProtoMT::Routed(r) => {
                 let msg = RoutedMessageV1::try_from_slice(&r.borsh).map_err(Self::Error::Routed)?;
@@ -564,5 +573,39 @@ impl TryFrom<&proto::RoutedMessageV3> for RoutedMessageV3 {
             created_at: x.created_at,
             num_hops: x.num_hops,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network_protocol::testonly as data;
+    use crate::testonly::make_rng;
+
+    /// A normally-sized transaction passes the network size gate and round-trips
+    /// through the proto conversion; an oversized body is rejected before it is
+    /// Borsh-decoded, so the inflated nested-action `Vec` is never materialized
+    /// at decode time (NEAP-621).
+    #[test]
+    fn transaction_size_gate() {
+        let mut rng = make_rng(89028037453);
+        let msg = PeerMessage::Transaction(data::make_signed_transaction(&mut rng));
+        let proto: proto::PeerMessage = (&msg).into();
+        assert_eq!(PeerMessage::try_from(&proto).unwrap(), msg);
+
+        let proto = proto::PeerMessage {
+            message_type: Some(ProtoMT::Transaction(proto::SignedTransaction {
+                borsh: vec![0u8; MAX_TRANSACTION_SIZE_BYTES + 1],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let err =
+            PeerMessage::try_from(&proto).expect_err("oversized transaction must be rejected");
+        assert!(
+            matches!(err, ParsePeerMessageError::Transaction(_)),
+            "unexpected error variant: {err:?}"
+        );
+        assert!(err.to_string().contains("exceeds"), "unexpected error: {err}");
     }
 }

--- a/chain/network/src/network_protocol/proto_conv/util.rs
+++ b/chain/network/src/network_protocol/proto_conv/util.rs
@@ -1,5 +1,7 @@
 /// Proto conversion utilities.
+use borsh::BorshDeserialize;
 use protobuf::MessageField as MF;
+use std::io;
 
 #[derive(thiserror::Error, Debug)]
 #[error("[{idx}]: {source}")]
@@ -7,6 +9,22 @@ pub struct ParseVecError<E> {
     idx: usize,
     #[source]
     source: E,
+}
+
+/// Borsh-deserializes `T` from `bytes`, rejecting inputs larger than `limit`
+/// before decoding so a maliciously inflated peer payload cannot force a large
+/// allocation at decode time. Use this for any peer-supplied borsh blob whose
+/// decoded form can be much larger than its wire size; `limit` must sit above
+/// the largest legitimate encoding of `T` and well below the peer-frame cap.
+/// Returns `io::Error` so it composes with the borsh-based proto decode sites.
+pub fn try_from_slice_with_limit<T: BorshDeserialize>(bytes: &[u8], limit: usize) -> io::Result<T> {
+    if bytes.len() > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("encoded size {} exceeds the limit of {limit} bytes", bytes.len()),
+        ));
+    }
+    T::try_from_slice(bytes)
 }
 
 pub fn try_from_slice<'a, X, Y: TryFrom<&'a X>>(

--- a/runtime/runtime/src/action_validation.rs
+++ b/runtime/runtime/src/action_validation.rs
@@ -186,6 +186,17 @@ fn validate_delegate_action(
     current_protocol_version: ProtocolVersion,
     mode: ValidateReceiptMode,
 ) -> Result<(), ActionsValidationError> {
+    // Check the count before `get_actions()` clones the list, so a huge
+    // nested-action list can't force the allocation before being rejected.
+    // Consensus-neutral: same `TotalNumberOfActionsExceeded` as the check in
+    // `validate_actions_with_mode` below.
+    let num_actions = delegate_action.actions().len() as u64;
+    if num_actions > limit_config.max_actions_per_receipt {
+        return Err(ActionsValidationError::TotalNumberOfActionsExceeded {
+            total_number_of_actions: num_actions,
+            limit: limit_config.max_actions_per_receipt,
+        });
+    }
     let actions = delegate_action.get_actions();
     let inner_receiver =
         if ProtocolFeature::FixDelegatedDeterministicStateInit.enabled(current_protocol_version) {
@@ -1093,6 +1104,44 @@ mod tests {
                 PROTOCOL_VERSION,
             ),
             Ok(()),
+        );
+    }
+
+    /// A `Delegate` action whose nested-action count exceeds the limit is
+    /// rejected with `TotalNumberOfActionsExceeded` before the inner actions are
+    /// materialized via `get_actions()`.
+    #[test]
+    fn test_validate_delegate_action_too_many_nested_actions() {
+        let mut limit_config = test_limit_config();
+        limit_config.max_actions_per_receipt = 3;
+        let receiver = "alice.near".parse().unwrap();
+        let signed_delegate_action = SignedDelegateAction {
+            delegate_action: DelegateAction {
+                sender_id: "bob.test.near".parse().unwrap(),
+                receiver_id: "token.test.near".parse().unwrap(),
+                actions: (0..4)
+                    .map(|_| {
+                        NonDelegateAction::try_from(Action::CreateAccount(CreateAccountAction {}))
+                            .unwrap()
+                    })
+                    .collect(),
+                nonce: 19000001,
+                max_block_height: 57,
+                public_key: PublicKey::empty(KeyType::ED25519),
+            },
+            signature: Signature::default(),
+        };
+        assert_eq!(
+            validate_action(
+                &limit_config,
+                &Action::Delegate(Box::new(signed_delegate_action)),
+                &receiver,
+                PROTOCOL_VERSION,
+            ),
+            Err(ActionsValidationError::TotalNumberOfActionsExceeded {
+                total_number_of_actions: 4,
+                limit: 3,
+            }),
         );
     }
 


### PR DESCRIPTION
An unauthenticated T2 peer could send a sub-frame `PeerMessage::Transaction` whose lone `Delegate` action carries a huge nested-action list. The body was Borsh-decoded and the list cloned during validation before the action-count check rejected it, amplifying ~1 wire byte into ~96 bytes of retained heap and exhausting node memory.

Two complementary changes:
- **runtime**: `validate_delegate_action` checks the nested-action count against `max_actions_per_receipt` before `get_actions()` clones the list. Consensus-neutral (same `TotalNumberOfActionsExceeded` error for the same inputs). This is the load-bearing fix and covers both the direct `Transaction` and routed `ForwardTx` ingress paths.
- **network**: caps the transaction wire size before decoding, via a reusable `try_from_slice_with_limit` helper that can be applied to other peer-message decode sites.

Complements the broader incoming-message memory bounding work, which limits aggregate wire bytes but not per-message decode amplification.
