### PR TITLE
fix(network): admission control hardening for SyncRoutingTable

### DIFF
--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -33,6 +33,9 @@ pub const DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_MESSAGE: usize = 50_000;
 pub const DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_SOURCE: usize = 50_000;
 pub const DEFAULT_ROUTING_GRAPH_MAX_PEERS: usize = 100_000;
 pub const DEFAULT_ROUTING_GRAPH_MAX_EDGES: usize = 1_000_000;
+/// Maximum number of AnnounceAccount entries allowed in a single SyncRoutingTable message.
+/// Sized at ~10x the realistic validator count to leave headroom.
+pub const DEFAULT_ROUTING_GRAPH_MAX_ACCOUNTS_PER_MESSAGE: usize = 10_000;
 
 /// Maximum number of PeerAddrs in the ValidatorConfig::endpoints field.
 pub const MAX_PEER_ADDRS: usize = 10;
@@ -229,6 +232,8 @@ pub struct NetworkConfig {
     pub routing_graph_max_peers: usize,
     /// Maximum total number of edges stored in the routing graph.
     pub routing_graph_max_edges: usize,
+    /// Maximum number of AnnounceAccount entries allowed in a single SyncRoutingTable message.
+    pub routing_graph_max_accounts_per_message: usize,
 
     #[cfg(test)]
     pub(crate) event_sink:
@@ -289,6 +294,9 @@ impl NetworkConfig {
         }
         if let Some(v) = overrides.routing_graph_max_edges {
             self.routing_graph_max_edges = v;
+        }
+        if let Some(v) = overrides.routing_graph_max_accounts_per_message {
+            self.routing_graph_max_accounts_per_message = v;
         }
     }
 
@@ -442,6 +450,7 @@ impl NetworkConfig {
             routing_graph_max_edges_per_source: DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_SOURCE,
             routing_graph_max_peers: DEFAULT_ROUTING_GRAPH_MAX_PEERS,
             routing_graph_max_edges: DEFAULT_ROUTING_GRAPH_MAX_EDGES,
+            routing_graph_max_accounts_per_message: DEFAULT_ROUTING_GRAPH_MAX_ACCOUNTS_PER_MESSAGE,
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),
@@ -526,6 +535,7 @@ impl NetworkConfig {
             routing_graph_max_edges_per_source: DEFAULT_ROUTING_GRAPH_MAX_EDGES_PER_SOURCE,
             routing_graph_max_peers: DEFAULT_ROUTING_GRAPH_MAX_PEERS,
             routing_graph_max_edges: DEFAULT_ROUTING_GRAPH_MAX_EDGES,
+            routing_graph_max_accounts_per_message: DEFAULT_ROUTING_GRAPH_MAX_ACCOUNTS_PER_MESSAGE,
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),
@@ -598,6 +608,10 @@ impl NetworkConfig {
         anyhow::ensure!(
             self.routing_graph_max_edges_per_source <= self.routing_graph_max_edges,
             "routing_graph_max_edges_per_source must be <= routing_graph_max_edges"
+        );
+        anyhow::ensure!(
+            self.routing_graph_max_accounts_per_message > 0,
+            "routing_graph_max_accounts_per_message must be > 0"
         );
 
         Ok(VerifiedConfig { node_id: self.node_id(), inner: self })
@@ -750,6 +764,11 @@ mod test {
                 &after.routing_graph_max_edges,
                 &overrides.routing_graph_max_edges
             ));
+            assert!(check_override_field(
+                &before.routing_graph_max_accounts_per_message,
+                &after.routing_graph_max_accounts_per_message,
+                &overrides.routing_graph_max_accounts_per_message
+            ));
         };
         let no_overrides = NetworkConfigOverrides::default();
         let mut overrides = NetworkConfigOverrides::default();
@@ -762,6 +781,7 @@ mod test {
         overrides.routing_graph_max_edges_per_source = Some(20_000);
         overrides.routing_graph_max_peers = Some(30_000);
         overrides.routing_graph_max_edges = Some(40_000);
+        overrides.routing_graph_max_accounts_per_message = Some(5_000);
 
         let nc_before =
             config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
@@ -830,6 +850,11 @@ mod test {
         let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
         nc.routing_graph_max_edges_per_source = 100;
         nc.routing_graph_max_edges = 50;
+        assert!(nc.verify().is_err());
+
+        // max_accounts_per_message = 0 should fail.
+        let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
+        nc.routing_graph_max_accounts_per_message = 0;
         assert!(nc.verify().is_err());
 
         // Valid config should pass.

--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -338,6 +338,8 @@ pub struct NetworkConfigOverrides {
     pub routing_graph_max_peers: Option<usize>,
     /// Maximum total number of edges stored in the routing graph.
     pub routing_graph_max_edges: Option<usize>,
+    /// Maximum number of AnnounceAccount entries allowed in a single SyncRoutingTable message.
+    pub routing_graph_max_accounts_per_message: Option<usize>,
 }
 
 impl Default for Config {

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1401,6 +1401,21 @@ impl PeerActor {
             conn.stop(Some(ban_reason));
         }
 
+        // Ingress cap for AnnounceAccount entries: each one is signature-verified downstream,
+        // so an unbounded `accounts` field is a parallel DoS vector to the edges field above.
+        let max_accounts = network_state.config.routing_graph_max_accounts_per_message;
+        if rtu.accounts.len() > max_accounts {
+            tracing::warn!(
+                target: "network",
+                peer_id = %conn.peer_info.id,
+                accounts_count = rtu.accounts.len(),
+                limit = max_accounts,
+                "too many AnnounceAccount entries in SyncRoutingTable message, dropping accounts"
+            );
+            metrics::ACCOUNT_ANNOUNCEMENT_DROPPED.inc_by(rtu.accounts.len() as u64);
+            return;
+        }
+
         // For every announce we received, we fetch the last announce with the same account_id
         // that we already broadcasted. Client actor will both verify signatures of the received announces
         // as well as filter out those which are older than the fetched ones (to avoid overriding

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -118,6 +118,14 @@ impl Config {
             RateLimitedPeerMessageKey::EpochSyncResponse,
             SingleMessageConfig::new(1, 1.0 / 30.0, None),
         );
+        // SyncRoutingTable carries forged-edge OOM potential. The sender side already throttles
+        // via routing_table_update_rate_limit (qps=1, burst=1) per peer, so 1 msg/s sustained
+        // with burst 10 accommodates legitimate sync (including reconnection bursts) while
+        // blocking sustained floods.
+        config.rate_limits.insert(
+            RateLimitedPeerMessageKey::SyncRoutingTable,
+            SingleMessageConfig::new(10, 1.0, None),
+        );
         config
     }
 
@@ -284,7 +292,7 @@ fn get_key_and_token_cost(message: &PeerMessage) -> Option<(RateLimitedPeerMessa
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::network_protocol::{Disconnect, PeerMessage};
+    use crate::network_protocol::{Disconnect, PeerMessage, RoutingTableUpdate};
     use near_async::time::{Duration, FakeClock};
     use near_primitives::hash::CryptoHash;
 
@@ -584,5 +592,22 @@ mod tests {
             get_key_and_token_cost(&versioned_forward),
             "forward legacy/versioned wire must share the same rate-limit bucket",
         );
+    }
+
+    #[test]
+    fn test_sync_routing_table_rate_limit() {
+        let config = Config::standard_preset();
+        let clock = FakeClock::default();
+        let mut rate_limits = RateLimits::from_config(&config, clock.now());
+        let msg = PeerMessage::SyncRoutingTable(RoutingTableUpdate::default());
+        // Burst of 10 allowed, then refusal until next refill.
+        for _ in 0..10 {
+            assert!(rate_limits.is_allowed(&msg, clock.now()));
+        }
+        assert!(!rate_limits.is_allowed(&msg, clock.now()));
+        // After 1 second one token is refilled.
+        clock.advance(Duration::seconds(1));
+        assert!(rate_limits.is_allowed(&msg, clock.now()));
+        assert!(!rate_limits.is_allowed(&msg, clock.now()));
     }
 }

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -21,6 +21,13 @@ type EdgeKey = (PeerId, PeerId);
 /// Clock-skew tolerance for accepting edges with nonces in the future. Edges with nonces
 /// further ahead than this are rejected to prevent attackers from setting far-future
 /// timestamps to bypass the past-only `PRUNE_EDGES_AFTER` window.
+///
+/// This is distinct from, and stricter than, `EDGE_NONCE_MAX_TIME_DELTA` (20 min): that
+/// constant guards the nonce of the *local* node's own partial edges during handshake
+/// (`routing::edge::verify_nonce`) and is a symmetric past/future bound. This one applies
+/// to *all* propagated edges in the graph, where the past direction is already covered by
+/// the `PRUNE_EDGES_AFTER` window, so only the future direction needs bounding — and we
+/// keep that bound tight, just enough to absorb realistic clock skew between peers.
 const EDGE_NONCE_FUTURE_TOLERANCE: time::Duration = time::Duration::minutes(5);
 pub type NextHopTable = HashMap<PeerId, Vec<PeerId>>;
 pub type DistanceTable = HashMap<PeerId, u32>;
@@ -223,9 +230,13 @@ impl Inner {
             }
 
             // Reject edges with nonces too far in the future. Otherwise an attacker can set
-            // nonces years ahead to bypass the past-only prune window above.
-            if let Ok(nonce_time) = Edge::nonce_to_utc(e.nonce()) {
-                if nonce_time > now + EDGE_NONCE_FUTURE_TOLERANCE {
+            // nonces years ahead to bypass the past-only prune window above. A nonce that
+            // doesn't map to a valid timestamp is rejected as well: `is_edge_older_than`
+            // treats such an edge as not-old, so it would never be pruned, granting the
+            // attacker the very immunity this check is meant to deny.
+            match Edge::nonce_to_utc(e.nonce()) {
+                Ok(nonce_time) if nonce_time <= now + EDGE_NONCE_FUTURE_TOLERANCE => {}
+                _ => {
                     metrics::EDGE_DROPPED.inc();
                     return false;
                 }

--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -17,6 +17,11 @@ mod tests;
 
 // TODO: make it opaque, so that the key.0 < key.1 invariant is protected.
 type EdgeKey = (PeerId, PeerId);
+
+/// Clock-skew tolerance for accepting edges with nonces in the future. Edges with nonces
+/// further ahead than this are rejected to prevent attackers from setting far-future
+/// timestamps to bypass the past-only `PRUNE_EDGES_AFTER` window.
+const EDGE_NONCE_FUTURE_TOLERANCE: time::Duration = time::Duration::minutes(5);
 pub type NextHopTable = HashMap<PeerId, Vec<PeerId>>;
 pub type DistanceTable = HashMap<PeerId, u32>;
 
@@ -213,6 +218,15 @@ impl Inner {
             if let Some(prune_edges_after) = self.config.prune_edges_after {
                 // Don't add edges that are older than the limit.
                 if e.is_edge_older_than(now - prune_edges_after) {
+                    return false;
+                }
+            }
+
+            // Reject edges with nonces too far in the future. Otherwise an attacker can set
+            // nonces years ahead to bypass the past-only prune window above.
+            if let Ok(nonce_time) = Edge::nonce_to_utc(e.nonce()) {
+                if nonce_time > now + EDGE_NONCE_FUTURE_TOLERANCE {
+                    metrics::EDGE_DROPPED.inc();
                     return false;
                 }
             }

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -176,6 +176,32 @@ async fn expired_edges() {
     g.check(&[]);
 }
 
+#[tokio::test]
+async fn future_nonce_edges_are_rejected() {
+    init_test_logger();
+    let clock = time::FakeClock::default();
+    clock.set_utc(time::Utc::UNIX_EPOCH + time::Duration::days(2));
+    let mut rng = make_rng(87927346);
+    let rng = &mut rng;
+    let node_key = data::make_secret_key(rng);
+    let g = Arc::new(Graph::new(clock.clock(), test_graph_config(peer_id(&node_key))));
+
+    let p1 = data::make_secret_key(rng);
+    let p2 = data::make_secret_key(rng);
+    let p3 = data::make_secret_key(rng);
+
+    let now = clock.now_utc();
+    // Within tolerance (1 minute ahead) — accepted.
+    let near_future = data::make_edge(&node_key, &p1, to_active_nonce(now + 60 * SEC));
+    // Far in the future (1 hour ahead) — rejected.
+    let far_future = data::make_edge(&node_key, &p2, to_active_nonce(now + 3600 * SEC));
+    // Present nonce — accepted as a control.
+    let present = data::make_edge(&node_key, &p3, to_active_nonce(now));
+
+    g.simple_update(vec![near_future.clone(), far_future.clone(), present.clone()]).await;
+    g.check(&[near_future, present]);
+}
+
 // ======================== Routing graph limit tests ========================
 //
 // All limit tests create edges adjacent to `node_key` so the introduced peers

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -189,6 +189,7 @@ async fn future_nonce_edges_are_rejected() {
     let p1 = data::make_secret_key(rng);
     let p2 = data::make_secret_key(rng);
     let p3 = data::make_secret_key(rng);
+    let p4 = data::make_secret_key(rng);
 
     let now = clock.now_utc();
     // Within tolerance (1 minute ahead) — accepted.
@@ -197,8 +198,12 @@ async fn future_nonce_edges_are_rejected() {
     let far_future = data::make_edge(&node_key, &p2, to_active_nonce(now + 3600 * SEC));
     // Present nonce — accepted as a control.
     let present = data::make_edge(&node_key, &p3, to_active_nonce(now));
+    // Nonce that doesn't map to a valid timestamp (> i64::MAX) — rejected, so it can't
+    // slip past the future-tolerance check and become un-prunable. u64::MAX is odd, so
+    // the edge is Active.
+    let invalid_nonce = data::make_edge(&node_key, &p4, u64::MAX);
 
-    g.simple_update(vec![near_future.clone(), far_future.clone(), present.clone()]).await;
+    g.simple_update(vec![near_future.clone(), far_future, present.clone(), invalid_nonce]);
     g.check(&[near_future, present]);
 }
 

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -263,6 +263,14 @@ pub(crate) static EDGE_DROPPED: LazyLock<IntCounter> = LazyLock::new(|| {
     .unwrap()
 });
 
+pub(crate) static ACCOUNT_ANNOUNCEMENT_DROPPED: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_account_announcement_dropped",
+        "Number of AnnounceAccount entries rejected due to per-message limits",
+    )
+    .unwrap()
+});
+
 pub(crate) static EDGE_TOMBSTONE_SENDING_SKIPPED: LazyLock<IntCounter> = LazyLock::new(|| {
     try_create_int_counter(
         "near_edge_tombstone_sending_skip",

--- a/nearcore/src/config_duration_test.rs
+++ b/nearcore/src/config_duration_test.rs
@@ -70,6 +70,7 @@ fn test_config_duration_all_std() {
                     routing_graph_max_edges_per_source: Some(50_000),
                     routing_graph_max_peers: Some(100_000),
                     routing_graph_max_edges: Some(1_000_000),
+                    routing_graph_max_accounts_per_message: Some(10_000),
                 },
                 ..Default::default()
             },


### PR DESCRIPTION
Closes three residual gaps that the existing per-message and per-source edge caps don't cover:

- Rate-limit SyncRoutingTable in standard_preset (burst 10, 1/s). The sender side already throttles at qps=1/burst=1 per peer, so this accommodates legitimate sync (including reconnection bursts) while blocking sustained floods.

- Reject edges with nonces more than 5 minutes in the future. Without this an attacker can use far-future timestamps to bypass the past-only PRUNE_EDGES_AFTER window.

- Cap rtu.accounts.len() per message at 10_000 (configurable via routing_graph_max_accounts_per_message). Each AnnounceAccount is signature-verified downstream, so an unbounded accounts field was a parallel DoS vector to the edges field.
