### PR TITLE
feat(sync): verify target height block approvals when node is not lagging

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1,4 +1,6 @@
-use crate::approval_verification::verify_approval_with_approvers_info;
+use crate::approval_verification::{
+    verify_approval_with_approvers_info, verify_approvals_and_threshold_orphan,
+};
 use crate::block_processing_utils::{
     ApplyChunksDoneWaiter, ApplyChunksStillApplying, BlockPreprocessInfo, BlockProcessingArtifact,
     BlocksInProcessing, OptimisticBlockInfo,
@@ -1482,7 +1484,6 @@ impl Chain {
             &mut self.chain_store,
             self.epoch_manager.clone(),
             self.runtime_adapter.clone(),
-            self.doomslug_threshold_mode,
         )
     }
 
@@ -2431,7 +2432,7 @@ impl Chain {
             }
             block.check_validity()?;
             // TODO: enable after #3729 and #3863
-            // self.verify_orphan_header_approvals(&header)?;
+            // self.verify_header_approvals_without_ancestry(&header)?;
             return Err(Error::Orphan);
         }
 
@@ -4034,6 +4035,44 @@ impl Chain {
     #[inline]
     pub fn is_block_invalid(&self, hash: &CryptoHash) -> bool {
         self.invalid_blocks.contains(hash)
+    }
+
+    /// Verifies that a header carries approvals from >2/3 of the stake of a
+    /// validator set we already know (current or next epoch). Errors if the
+    /// header's epoch is unknown (too far ahead to validate), the approvals fall
+    /// short, or the header is too old to carry a `prev_height` (V1/V2).
+    pub fn verify_header_approvals_without_ancestry(
+        &self,
+        header: &BlockHeader,
+    ) -> Result<(), Error> {
+        // Producer signature first: the header hash covers the approvals, so a
+        // header with any tampered approval dies after one signature check
+        // instead of a full pass over ~100 approval signatures.
+        if !self.partial_verify_orphan_header_signature(header)? {
+            return Err(Error::InvalidSignature);
+        }
+        let prev_hash = header.prev_hash();
+        let Some(prev_height) = header.prev_height() else {
+            return Err(Error::Other("header too old to verify approvals without ancestry".into()));
+        };
+        let height = header.height();
+        let epoch_id = header.epoch_id();
+        let approvals = header.approvals();
+        let epoch_info = self.epoch_manager.get_epoch_info(epoch_id)?;
+        verify_approvals_and_threshold_orphan(
+            &|approvals, stakes| {
+                Doomslug::can_approved_block_be_produced(
+                    self.doomslug_threshold_mode,
+                    approvals,
+                    stakes,
+                )
+            },
+            prev_hash,
+            prev_height,
+            height,
+            approvals,
+            epoch_info,
+        )
     }
 
     /// Check that sync_hash matches the one we expect for the epoch containing that block.

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -1,6 +1,7 @@
-use crate::approval_verification::verify_approvals_and_threshold_orphan;
+use crate::Chain;
 use crate::block_processing_utils::BlockPreprocessInfo;
 use crate::chain::collect_receipts_from_response;
+use crate::metrics;
 use crate::metrics::{SHARD_LAYOUT_NUM_SHARDS, SHARD_LAYOUT_VERSION};
 use crate::spice::chunk_application::apply_chunk_postprocessing;
 use crate::spice::core::{
@@ -12,8 +13,6 @@ use crate::types::{
     ApplyChunkBlockContext, ApplyChunkShardContext, BlockType, RuntimeAdapter, RuntimeStorageConfig,
 };
 use crate::update_shard::{NewChunkResult, OldChunkResult, ShardUpdateResult};
-use crate::{Chain, Doomslug};
-use crate::{DoomslugThresholdMode, metrics};
 use near_chain_configs::ProtocolVersionCheckConfig;
 use near_chain_primitives::error::Error;
 use near_epoch_manager::EpochManagerAdapter;
@@ -44,7 +43,6 @@ pub struct ChainUpdate<'a> {
     epoch_manager: Arc<dyn EpochManagerAdapter>,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     chain_store_update: ChainStoreUpdate<'a>,
-    doomslug_threshold_mode: DoomslugThresholdMode,
 }
 
 impl<'a> ChainUpdate<'a> {
@@ -52,19 +50,17 @@ impl<'a> ChainUpdate<'a> {
         chain_store: &'a mut ChainStore,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
-        doomslug_threshold_mode: DoomslugThresholdMode,
     ) -> Self {
         let chain_store_update: ChainStoreUpdate<'_> = chain_store.store_update();
-        Self::new_impl(epoch_manager, runtime_adapter, doomslug_threshold_mode, chain_store_update)
+        Self::new_impl(epoch_manager, runtime_adapter, chain_store_update)
     }
 
     fn new_impl(
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
-        doomslug_threshold_mode: DoomslugThresholdMode,
         chain_store_update: ChainStoreUpdate<'a>,
     ) -> Self {
-        ChainUpdate { epoch_manager, runtime_adapter, chain_store_update, doomslug_threshold_mode }
+        ChainUpdate { epoch_manager, runtime_adapter, chain_store_update }
     }
 
     pub fn check_protocol_version(
@@ -352,37 +348,6 @@ impl<'a> ChainUpdate<'a> {
             header,
             self.epoch_manager.as_ref(),
             &mut self.chain_store_update,
-        )
-    }
-
-    #[allow(dead_code)]
-    fn verify_orphan_header_approvals(&self, header: &BlockHeader) -> Result<(), Error> {
-        let prev_hash = header.prev_hash();
-        let prev_height = match header.prev_height() {
-            None => {
-                // this will accept orphans of V1 and V2
-                // TODO: reject header V1 and V2 after a certain height
-                return Ok(());
-            }
-            Some(prev_height) => prev_height,
-        };
-        let height = header.height();
-        let epoch_id = header.epoch_id();
-        let approvals = header.approvals();
-        let epoch_info = self.epoch_manager.get_epoch_info(epoch_id)?;
-        verify_approvals_and_threshold_orphan(
-            &|approvals, stakes| {
-                Doomslug::can_approved_block_be_produced(
-                    self.doomslug_threshold_mode,
-                    approvals,
-                    stakes,
-                )
-            },
-            prev_hash,
-            prev_height,
-            height,
-            approvals,
-            epoch_info,
         )
     }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -20,6 +20,7 @@ use crate::sync::handler::SyncHandler;
 use crate::sync::header::HeaderSync;
 use crate::sync::state::chain_requests::ChainSenderForStateSync;
 use crate::sync::state::{StateSync, StateSyncShardResult};
+use crate::verified_peer_heights::VerifiedPeerHeights;
 use crate::{ProduceChunkResult, metrics};
 use itertools::Itertools;
 use near_async::futures::RayonAsyncComputationSpawner;
@@ -192,6 +193,7 @@ pub struct Client {
     /// watch::Sender used to notify watchers about new postprocessed blocks.
     pub block_notification_watch_sender:
         tokio::sync::watch::Sender<Option<BlockNotificationMessage>>,
+    pub(crate) verified_peer_heights: VerifiedPeerHeights,
 }
 
 impl AsRef<Client> for Client {
@@ -510,6 +512,7 @@ impl Client {
             shadow_validation_reed_solomon: OnceLock::new(),
             last_validator_key_check_epoch: None,
             block_notification_watch_sender,
+            verified_peer_heights: VerifiedPeerHeights::default(),
         };
         Ok(client)
     }
@@ -1202,6 +1205,21 @@ impl Client {
         metrics::BLOCK_PRODUCED_TOTAL.inc();
 
         Ok(Some(block))
+    }
+
+    /// Record `peer_id`'s verified height if the relayed block is ahead of us
+    /// and its approvals verify as >2/3 of a known epoch's stake; far-ahead
+    /// blocks (unknown epoch) fail that check and are ignored.
+    pub(crate) fn note_verified_peer_height(&mut self, block: &Block, peer_id: &PeerId) {
+        let head_height = self.chain.head().map(|tip| tip.height).unwrap_or(0);
+        self.verified_peer_heights.prune_at_or_below(head_height);
+        let height = block.header().height();
+        if height <= head_height {
+            return;
+        }
+        self.verified_peer_heights.record_if_verified(peer_id, block.hash(), height, || {
+            self.chain.verify_header_approvals_without_ancestry(block.header()).is_ok()
+        });
     }
 
     /// Processes received block. Ban peer if the block header is invalid or the block is ill-formed.

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -622,6 +622,8 @@ impl Handler<SpanWrapped<BlockResponse>> for ClientActor {
     fn handle(&mut self, msg: SpanWrapped<BlockResponse>) {
         let BlockResponse { block, peer_id, was_requested } = msg.span_unwrap();
         tracing::debug!(target: "client", block_height = block.header().height(), block_hash = ?block.header().hash(), "received block response");
+        // Feed the verified-height signal before the branching below can drop the block.
+        self.client.note_verified_peer_height(&block, &peer_id);
         let blocks_at_height =
             self.client.chain.chain_store().get_all_block_hashes_by_height(block.header().height());
         if was_requested || blocks_at_height.is_empty() {
@@ -1678,9 +1680,44 @@ impl ClientActor {
         }
 
         let head = self.client.chain.head()?;
+        let head = Tip::clone(&head);
         let is_syncing = self.client.sync_handler.sync_status.is_syncing();
 
-        // Only consider peers whose latest block is not invalid blocks
+        if self.head_is_stale(&head)? {
+            // Head hasn't advanced in ~1 epoch: we really are behind (a peer can't
+            // fake this), so use the unvalidated claimed heights to pick who to sync
+            // from; the proof and downstream checks re-validate the target.
+            self.sync_requirement_from_claimed_peers(head, is_syncing)
+        } else {
+            // Head is recent, so we still know the validator set for nearby heights
+            // and can verify a peer's advertised height before entering sync.
+            self.sync_requirement_from_verified_peers(head, is_syncing)
+        }
+    }
+
+    /// True when our head has not advanced in ~1 epoch of wall-clock time: the
+    /// point where our known validator sets (current + next epoch) stop covering
+    /// the tip. Uses the head's producer-signed timestamp, so a peer can't forge it.
+    fn head_is_stale(&self, head: &Tip) -> Result<bool, near_chain::Error> {
+        let head_header = self.client.chain.get_block_header(&head.last_block_hash)?;
+        let head_time =
+            Utc::from_unix_timestamp_nanos(head_header.raw_timestamp() as i128).unwrap();
+        let now = self.clock.now_utc();
+        if now <= head_time {
+            return Ok(false);
+        }
+        let epoch_length = self.client.chain.epoch_length;
+        let one_epoch = self.client.config.min_block_production_delay.get() * epoch_length as u32;
+        Ok(now - head_time >= one_epoch)
+    }
+
+    /// Sync decision from the unvalidated `highest_height_peers`. Used only once
+    /// our own clock already shows we are behind.
+    fn sync_requirement_from_claimed_peers(
+        &self,
+        head: Tip,
+        is_syncing: bool,
+    ) -> Result<SyncRequirement, near_chain::Error> {
         let eligible_peers: Vec<_> = self
             .network_info
             .highest_height_peers
@@ -1689,29 +1726,74 @@ impl ClientActor {
             .collect();
         metrics::PEERS_WITH_INVALID_HASH
             .set(self.network_info.highest_height_peers.len() as i64 - eligible_peers.len() as i64);
-        let peer_info = if let Some(peer_info) = eligible_peers.choose(&mut thread_rng()) {
-            peer_info
-        } else {
+        let Some(peer_info) = eligible_peers.choose(&mut thread_rng()) else {
             return Ok(SyncRequirement::NoPeers);
         };
-
         let peer_id = peer_info.peer_info.id.clone();
         let shutdown_height = self.client.config.expected_shutdown.get().unwrap_or(u64::MAX);
         let highest_height = peer_info.highest_block_height.min(shutdown_height);
-        let head = Tip::clone(&head);
+        Ok(self.sync_requirement(peer_id, highest_height, head, is_syncing))
+    }
 
-        if is_syncing {
-            if highest_height <= head.height {
-                Ok(SyncRequirement::AlreadyCaughtUp { peer_id, highest_height, head })
-            } else {
-                Ok(SyncRequirement::SyncNeeded { peer_id, highest_height, head })
-            }
+    /// Per peer, uses min(SetNetworkInfo height, verified height): we act only on a
+    /// height confirmed from block approvals, and the slower SetNetworkInfo push
+    /// keeps us from syncing over a block we're about to process ourselves.
+    fn sync_requirement_from_verified_peers(
+        &self,
+        head: Tip,
+        is_syncing: bool,
+    ) -> Result<SyncRequirement, near_chain::Error> {
+        let invalid_peers = self
+            .network_info
+            .connected_peers
+            .iter()
+            .filter(|peer| {
+                peer.full_peer_info
+                    .chain_info
+                    .last_block
+                    .as_ref()
+                    .is_some_and(|block| self.client.chain.is_block_invalid(&block.hash))
+            })
+            .count();
+        metrics::PEERS_WITH_INVALID_HASH.set(invalid_peers as i64);
+        let best_peer = self
+            .network_info
+            .connected_peers
+            .iter()
+            .filter_map(|peer| {
+                let peer_id = &peer.full_peer_info.peer_info.id;
+                let last_block = peer.full_peer_info.chain_info.last_block.as_ref()?;
+                if self.client.chain.is_block_invalid(&last_block.hash) {
+                    return None;
+                }
+                let verified_height = self.client.verified_peer_heights.get(peer_id)?;
+                Some((peer_id.clone(), last_block.height.min(verified_height)))
+            })
+            .max_by_key(|(_, height)| *height);
+        let Some((peer_id, height)) = best_peer else {
+            return Ok(SyncRequirement::NoPeers);
+        };
+        let shutdown_height = self.client.config.expected_shutdown.get().unwrap_or(u64::MAX);
+        let highest_height = height.min(shutdown_height);
+        Ok(self.sync_requirement(peer_id, highest_height, head, is_syncing))
+    }
+
+    fn sync_requirement(
+        &self,
+        peer_id: PeerId,
+        highest_height: BlockHeight,
+        head: Tip,
+        is_syncing: bool,
+    ) -> SyncRequirement {
+        let needed = if is_syncing {
+            highest_height > head.height
         } else {
-            if highest_height > head.height + self.client.config.sync_height_threshold {
-                Ok(SyncRequirement::SyncNeeded { peer_id, highest_height, head })
-            } else {
-                Ok(SyncRequirement::AlreadyCaughtUp { peer_id, highest_height, head })
-            }
+            highest_height > head.height + self.client.config.sync_height_threshold
+        };
+        if needed {
+            SyncRequirement::SyncNeeded { peer_id, highest_height, head }
+        } else {
+            SyncRequirement::AlreadyCaughtUp { peer_id, highest_height, head }
         }
     }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1700,8 +1700,7 @@ impl ClientActor {
     /// the tip. Uses the head's producer-signed timestamp, so a peer can't forge it.
     fn head_is_stale(&self, head: &Tip) -> Result<bool, near_chain::Error> {
         let head_header = self.client.chain.get_block_header(&head.last_block_hash)?;
-        let head_time =
-            Utc::from_unix_timestamp_nanos(head_header.raw_timestamp() as i128).unwrap();
+        let head_time = head_header.timestamp();
         let now = self.clock.now_utc();
         if now <= head_time {
             return Ok(false);
@@ -1771,6 +1770,7 @@ impl ClientActor {
             })
             .max_by_key(|(_, height)| *height);
         let Some((peer_id, height)) = best_peer else {
+            tracing::debug!(target: "sync", connected_peers = self.network_info.connected_peers.len(), "no peer with a verified height");
             return Ok(SyncRequirement::NoPeers);
         };
         let shutdown_height = self.client.config.expected_shutdown.get().unwrap_or(u64::MAX);

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -58,4 +58,5 @@ pub mod stateless_validation;
 pub mod sync;
 pub mod sync_jobs_actor;
 pub mod test_utils;
+mod verified_peer_heights;
 mod view_client_actor;

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -1,0 +1,122 @@
+use lru::LruCache;
+use near_primitives::hash::CryptoHash;
+use near_primitives::network::PeerId;
+use near_primitives::types::BlockHeight;
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+
+/// Highest block height each peer is *verified* to have reached, via a relayed
+/// block whose approvals we checked against a known epoch's validators (>2/3
+/// stake).
+pub struct VerifiedPeerHeights {
+    by_peer: HashMap<PeerId, BlockHeight>,
+    /// Headers whose approvals already verified; bounds the signature checks
+    /// to one pass per distinct header, however many peers relay or replay it.
+    verified_header_hashes: LruCache<CryptoHash, ()>,
+}
+
+impl Default for VerifiedPeerHeights {
+    fn default() -> Self {
+        Self {
+            by_peer: HashMap::new(),
+            verified_header_hashes: LruCache::new(NonZeroUsize::new(32).unwrap()),
+        }
+    }
+}
+
+impl VerifiedPeerHeights {
+    /// Record `height` for `peer_id` if the header is verified: by an earlier
+    /// call, or established now by `verify_approvals` (invoked at most once
+    /// per distinct header). Keeps the highest height per peer.
+    pub fn record_if_verified(
+        &mut self,
+        peer_id: &PeerId,
+        header_hash: &CryptoHash,
+        height: BlockHeight,
+        verify_approvals: impl FnOnce() -> bool,
+    ) {
+        if self.get(peer_id).is_some_and(|verified| verified >= height) {
+            return;
+        }
+        if !self.verified_header_hashes.contains(header_hash) {
+            if !verify_approvals() {
+                return;
+            }
+            self.verified_header_hashes.put(*header_hash, ());
+        }
+        self.by_peer.insert(peer_id.clone(), height);
+    }
+
+    pub fn get(&self, peer_id: &PeerId) -> Option<BlockHeight> {
+        self.by_peer.get(peer_id).copied()
+    }
+
+    /// Entries at or below our head can't indicate a peer ahead of us; pruning
+    /// them bounds the map as the head advances and peers churn.
+    pub fn prune_at_or_below(&mut self, height: BlockHeight) {
+        self.by_peer.retain(|_, recorded| *recorded > height);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use near_crypto::{KeyType, SecretKey};
+
+    fn peer(seed: &str) -> PeerId {
+        PeerId::new(SecretKey::from_seed(KeyType::ED25519, seed).public_key())
+    }
+
+    fn header_hash(seed: &[u8]) -> CryptoHash {
+        CryptoHash::hash_bytes(seed)
+    }
+
+    #[test]
+    fn record_keeps_max_height_per_peer() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || true);
+        heights.record_if_verified(&p, &header_hash(b"h5"), 5, || true);
+        assert_eq!(heights.get(&p), Some(10));
+    }
+
+    #[test]
+    fn failed_verification_records_nothing() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || false);
+        assert_eq!(heights.get(&p), None);
+    }
+
+    #[test]
+    fn known_header_skips_verification() {
+        let mut heights = VerifiedPeerHeights::default();
+        let (p1, p2) = (peer("a"), peer("b"));
+        let hash = header_hash(b"h10");
+        heights.record_if_verified(&p1, &hash, 10, || true);
+        heights.record_if_verified(&p2, &hash, 10, || panic!("must not re-verify"));
+        assert_eq!(heights.get(&p2), Some(10));
+    }
+
+    #[test]
+    fn already_verified_height_skips_verification() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || true);
+        heights.record_if_verified(&p, &header_hash(b"other"), 10, || {
+            panic!("must not verify below already verified height")
+        });
+        assert_eq!(heights.get(&p), Some(10));
+    }
+
+    #[test]
+    fn prune_at_or_below_drops_caught_up_entries() {
+        let mut heights = VerifiedPeerHeights::default();
+        let (p1, p2) = (peer("a"), peer("b"));
+        heights.record_if_verified(&p1, &header_hash(b"h10"), 10, || true);
+        heights.record_if_verified(&p2, &header_hash(b"h20"), 20, || true);
+        heights.prune_at_or_below(10);
+        assert_eq!(heights.get(&p1), None);
+        assert_eq!(heights.get(&p2), Some(20));
+    }
+}

--- a/cspell.json
+++ b/cspell.json
@@ -451,6 +451,7 @@
         "subsec",
         "subservices",
         "subslice",
+        "syncer",
         "syscall",
         "syscalls",
         "sysinfo",

--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -29,9 +29,10 @@ use near_network::state_witness::{
     PartialWitnessSenderForNetwork,
 };
 use near_network::types::{
-    HighestHeightPeerInfo, NetworkInfo, NetworkRequests, NetworkResponses, PeerInfo,
-    PeerManagerMessageRequest, PeerManagerMessageResponse, ReasonForBan, SetChainInfo,
-    SnapshotHostEvent, StateRequestSenderForNetwork, StateSyncEvent, Tier3Request,
+    BlockInfo, ConnectedPeerInfo, FullPeerInfo, HighestHeightPeerInfo, NetworkInfo,
+    NetworkRequests, NetworkResponses, PeerChainInfo, PeerInfo, PeerManagerMessageRequest,
+    PeerManagerMessageResponse, PeerType, ReasonForBan, SetChainInfo, SnapshotHostEvent,
+    StateRequestSenderForNetwork, StateSyncEvent, Tier3Request,
 };
 use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
 use near_primitives::genesis::GenesisId;
@@ -127,6 +128,7 @@ pub type NetworkRequestHandler = Box<dyn Fn(NetworkRequests) -> HandlerResult>;
 pub struct TestLoopPeerManagerActor {
     handlers: Vec<NetworkRequestHandler>,
 
+    clock: Clock,
     client_sender: ClientSenderForTestLoopNetwork,
     shared_state: TestLoopNetworkSharedState,
     genesis_id: GenesisId,
@@ -174,7 +176,11 @@ impl TestLoopPeerManagerActor {
                 future_spawner.clone(),
             ),
             network_message_to_partial_witness_handler(&account_id, shared_state.clone()),
-            network_message_to_shards_manager_handler(clock, &account_id, shared_state.clone()),
+            network_message_to_shards_manager_handler(
+                clock.clone(),
+                &account_id,
+                shared_state.clone(),
+            ),
             network_message_to_state_sync_handler(
                 &account_id,
                 shared_state.clone(),
@@ -184,6 +190,7 @@ impl TestLoopPeerManagerActor {
         ];
         Self {
             handlers,
+            clock,
             client_sender,
             shared_state: shared_state.clone(),
             genesis_id,
@@ -205,6 +212,7 @@ impl TestLoopPeerManagerActor {
     ) {
         // Some tests (especially the ones having to do with sync) need NetworkInfo to be up to
         // date to work properly. That's why we're sending it periodically here.
+        let now = self.clock.now();
         let future = self.client_sender.send_async(
             SetNetworkInfo(NetworkInfo {
                 highest_height_peers: self
@@ -217,6 +225,31 @@ impl TestLoopPeerManagerActor {
                         highest_block_height: header.height(),
                         tracked_shards: vec![],
                         peer_info: peer_info.clone(),
+                    })
+                    .collect(),
+                connected_peers: self
+                    .last_block_headers
+                    .iter()
+                    .map(|(peer_info, header)| ConnectedPeerInfo {
+                        full_peer_info: FullPeerInfo {
+                            peer_info: peer_info.clone(),
+                            chain_info: PeerChainInfo {
+                                genesis_id: self.genesis_id.clone(),
+                                last_block: Some(BlockInfo {
+                                    height: header.height(),
+                                    hash: *header.hash(),
+                                }),
+                                tracked_shards: vec![],
+                                archival: self.shared_state.is_peer_archival(&peer_info.id),
+                            },
+                        },
+                        received_bytes_per_sec: 0,
+                        sent_bytes_per_sec: 0,
+                        last_time_peer_requested: now,
+                        last_time_received_message: now,
+                        connection_established_time: now,
+                        peer_type: PeerType::Outbound,
+                        nonce: 0,
                     })
                     .collect(),
                 ..NetworkInfo::default()

--- a/test-loop-tests/src/tests/sync/adversarial_height.rs
+++ b/test-loop-tests/src/tests/sync/adversarial_height.rs
@@ -1,0 +1,189 @@
+//! Adversarial test for the verified-peer-height gate in `syncing_info`.
+//!
+//! A synced node at the tip (fresh head) is fed a fabricated far-ahead peer
+//! height. The network layer records any peer's advertised block height
+//! unconditionally, so this models an adversary advertising a false position
+//! many epochs ahead. The gate must ignore the unvalidated claim: the node
+//! keeps following the chain, never enters sync, and is never wiped.
+
+use super::util::{TEST_EPOCH_SYNC_HORIZON, run_until_synced, track_sync_status};
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::peer_manager_actor::TestLoopNetworkBlockInfo;
+use crate::tests::sync::util::far_horizon_height;
+use crate::utils::account::create_account_id;
+use crate::utils::transactions::{execute_money_transfers, make_accounts};
+use near_async::messaging::Sender;
+use near_chain_configs::TrackedShardsConfig;
+use near_crypto::{KeyType, SecretKey};
+use near_network::types::PeerInfo;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::network::PeerId;
+use near_primitives::types::Balance;
+
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_synced_node_ignores_unverified_far_ahead_height() {
+    init_test_logger();
+
+    let epoch_length = 10;
+    let accounts = make_accounts(100);
+    let mut env = TestLoopBuilder::new()
+        .validators(4, 0)
+        .num_shards(4)
+        .epoch_length(epoch_length)
+        .add_user_accounts(&accounts, Balance::from_near(1_000_000))
+        .build();
+
+    execute_money_transfers(&mut env.test_loop, &env.node_datas, &accounts).unwrap();
+    env.node_runner(0).run_until_head_height((TEST_EPOCH_SYNC_HORIZON + 3) * epoch_length);
+
+    let victim_account = create_account_id("victim");
+    let node_state = env
+        .node_state_builder()
+        .account_id(&victim_account)
+        .config_modifier(|config| {
+            config.tracked_shards_config = TrackedShardsConfig::AllShards;
+            config.epoch_sync.epoch_sync_horizon_num_epochs = TEST_EPOCH_SYNC_HORIZON;
+        })
+        .build();
+    env.add_node("victim", node_state);
+    let victim_idx = env.node_datas.len() - 1;
+    run_until_synced(&mut env.test_loop, &env.node_datas, victim_idx, 0);
+
+    // A real header with its height bumped past the epoch sync horizon, attributed
+    // to an adversarial peer. `last_block_headers` keeps the max, so the claim
+    // persists in every SetNetworkInfo push.
+    let victim_handle = env.node_datas[victim_idx].client_sender.actor_handle();
+    let head = env.test_loop.data.get(&victim_handle).client.chain.head().unwrap();
+    let head_before = head.height;
+    let head_header = env
+        .test_loop
+        .data
+        .get(&victim_handle)
+        .client
+        .chain
+        .get_block_header(&head.last_block_hash)
+        .unwrap();
+    let mut fake_header = head_header.as_ref().clone();
+    fake_header.set_height(head.height + (TEST_EPOCH_SYNC_HORIZON + 3) * epoch_length);
+    let adversary = PeerInfo {
+        id: PeerId::new(SecretKey::from_seed(KeyType::ED25519, "adversary").public_key()),
+        addr: None,
+        account_id: None,
+    };
+    Sender::<TestLoopNetworkBlockInfo>::from(&env.node_datas[victim_idx])
+        .send(TestLoopNetworkBlockInfo { peer: adversary, block_header: fake_header });
+
+    let sync_history = track_sync_status(&mut env.test_loop, &env.node_datas, victim_idx);
+    env.node_runner(0).run_for_number_of_blocks(2 * epoch_length as usize);
+
+    let victim_client = &env.test_loop.data.get(&victim_handle).client;
+    let victim_head = victim_client.chain.head().unwrap().height;
+    let status = victim_client.sync_handler.sync_status.as_variant_name();
+    assert_eq!(status, "NoSync", "victim should stay NoSync, was {status}");
+    assert!(victim_head > head_before, "victim should keep following the chain");
+    assert!(
+        sync_history.borrow().iter().all(|s| s == "NoSync"),
+        "victim must not enter any sync phase after the adversarial far-ahead claim, saw {:?}",
+        sync_history.borrow(),
+    );
+    assert!(!env.test_loop.is_denylisted("victim"), "victim must not be wiped");
+}
+
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_genesis_node_bootstraps() {
+    init_test_logger();
+
+    let epoch_length = 10;
+    let accounts = make_accounts(100);
+    let mut env = TestLoopBuilder::new()
+        .validators(4, 0)
+        .num_shards(4)
+        .epoch_length(epoch_length)
+        .track_all_shards()
+        .add_user_accounts(&accounts, Balance::from_near(1_000_000))
+        .build();
+
+    execute_money_transfers(&mut env.test_loop, &env.node_datas, &accounts).unwrap();
+    env.node_runner(0).run_until_head_height(far_horizon_height(epoch_length));
+
+    let syncer_account = create_account_id("syncer");
+    let node_state = env
+        .node_state_builder()
+        .account_id(&syncer_account)
+        .config_modifier(|config| {
+            config.tracked_shards_config = TrackedShardsConfig::AllShards;
+            config.epoch_sync.epoch_sync_horizon_num_epochs = TEST_EPOCH_SYNC_HORIZON;
+        })
+        .build();
+    env.add_node("syncer", node_state);
+    let syncer_idx = env.node_datas.len() - 1;
+
+    let sync_history = track_sync_status(&mut env.test_loop, &env.node_datas, syncer_idx);
+    run_until_synced(&mut env.test_loop, &env.node_datas, syncer_idx, 0);
+
+    // The genesis node runs the full far-horizon pipeline and returns to NoSync.
+    let expected =
+        ["AwaitingPeers", "NoSync", "EpochSync", "HeaderSync", "StateSync", "BlockSync", "NoSync"]
+            .map(String::from);
+    assert_eq!(sync_history.borrow().as_slice(), expected.as_slice());
+}
+
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_stale_node_syncs() {
+    init_test_logger();
+
+    let epoch_length = 10;
+    let accounts = make_accounts(100);
+    let mut env = TestLoopBuilder::new()
+        .validators(4, 0)
+        .num_shards(4)
+        .epoch_length(epoch_length)
+        .track_all_shards()
+        .add_user_accounts(&accounts, Balance::from_near(1_000_000))
+        .build();
+
+    execute_money_transfers(&mut env.test_loop, &env.node_datas, &accounts).unwrap();
+    env.node_runner(0).run_until_head_height(far_horizon_height(epoch_length));
+
+    // Sync fully first so the head is past genesis (past the bootstrap exemption).
+    let syncer_account = create_account_id("syncer");
+    let node_state = env
+        .node_state_builder()
+        .account_id(&syncer_account)
+        .config_modifier(|config| {
+            config.tracked_shards_config = TrackedShardsConfig::AllShards;
+            config.epoch_sync.epoch_sync_horizon_num_epochs = TEST_EPOCH_SYNC_HORIZON;
+        })
+        .build();
+    env.add_node("syncer", node_state);
+    let syncer_idx = env.node_datas.len() - 1;
+    run_until_synced(&mut env.test_loop, &env.node_datas, syncer_idx, 0);
+
+    // Advance past the horizon while it is down: the virtual clock moves with block
+    // production, so its head goes stale and the tip lands in epochs it can't resolve.
+    let killed_state = env.kill_node("syncer");
+    env.node_runner(0).run_for_number_of_blocks(far_horizon_height(epoch_length) as usize);
+
+    let restart_id = "syncer_restarted";
+    env.restart_node(restart_id, killed_state);
+    let restarted_idx = env.node_datas.len() - 1;
+
+    let sync_history = track_sync_status(&mut env.test_loop, &env.node_datas, restarted_idx);
+    env.node_runner(0).run_for_number_of_blocks(2 * epoch_length as usize);
+
+    // The staleness gate lets the node enter epoch sync, which then triggers the
+    // epoch-sync data reset (the separately guarded issue), recorded by the test
+    // loop as a denylist.
+    let expected = ["AwaitingPeers", "NoSync", "EpochSync"].map(String::from);
+    assert_eq!(sync_history.borrow().as_slice(), expected.as_slice());
+    assert!(
+        env.test_loop.is_denylisted(restart_id),
+        "stale node should reach epoch sync and trigger the data reset"
+    );
+}

--- a/test-loop-tests/src/tests/sync/mod.rs
+++ b/test-loop-tests/src/tests/sync/mod.rs
@@ -1,3 +1,4 @@
+mod adversarial_height;
 mod continuous_epoch_sync;
 mod epoch_sync;
 mod far_horizon;


### PR DESCRIPTION
Before this change a node picked its sync target from `highest_height_peers`, which carries a height a peer claims but nothing proves. Any peer could claim an arbitrary height and push a caught-up node into sync.

Now the node verifies the claim when it can:

- Moves the unused `verify_orphan_header_approvals` to `Chain::verify_header_approvals_without_ancestry`, and rejects headers too old to carry `prev_height` (V1/V2).
- Checks the block producer signature first. The header hash covers the approvals, so a header with any tampered approval fails after one signature check instead of a full pass over ~100 approval signatures.
- When `ClientActor` handles a `Block` message, records the peer's verified height if the block's epoch ID is known and its approvals reach >2/3 of that epoch's stake. `VerifiedPeerHeights` keeps the highest verified height per peer, caches verified header hashes so a header is only checked once however many peers relay it, and prunes entries at or below our head.
- While the head is fresh, the sync target height per peer is `min(SetNetworkInfo height, verified height)`. Both known validator sets (current and next epoch) still cover the tip, so a claim is checkable.
- Once the head has not advanced for about one epoch of `min_block_production_delay`, the node keeps the prior behavior and uses the unverified claimed heights. A peer cannot forge that condition, since it comes from the producer-signed head timestamp.