### PR TITLE
fix(stateless-validation): fail validation on missing contract code

### DIFF
--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -17,8 +17,8 @@ use near_primitives::trie_key::{SmallKeyVec, TrieKey};
 use near_primitives::types::{AccountId, EpochInfoProvider};
 use near_store::trie::AccessOptions;
 use near_store::{
-    KeyLookupMode, StorageError, TrieUpdate, enqueue_promise_yield_timeout,
-    get_promise_yield_indices, set_promise_yield_indices,
+    KeyLookupMode, MissingTrieValue, MissingTrieValueContext, StorageError, TrieUpdate,
+    enqueue_promise_yield_timeout, get_promise_yield_indices, set_promise_yield_indices,
 };
 use near_vm_runner::PreparedContract;
 use near_vm_runner::logic::errors::{
@@ -75,6 +75,7 @@ pub(crate) fn action_function_call(
     );
     let outcome = execute_function_call(
         contract,
+        contract_id.hash(),
         apply_state,
         &mut runtime_ext,
         receipt.predecessor_id(),
@@ -234,6 +235,7 @@ pub(crate) fn action_function_call(
 /// Runs given function call with given context / apply state.
 pub(crate) fn execute_function_call(
     contract: Box<dyn near_vm_runner::PreparedContract>,
+    contract_code_hash: CryptoHash,
     apply_state: &ApplyState,
     runtime_ext: &mut RuntimeExt,
     predecessor_id: &AccountId,
@@ -289,6 +291,18 @@ pub(crate) fn execute_function_call(
     // are reported via `outcome.aborted` and never reach these arms.
     let mut outcome = match result {
         Err(VMRunnerError::ContractCodeNotPresent) => {
+            // A missing body for an account that commits to a code hash is
+            // witness incompleteness, not an execution result. Fail like any
+            // other missing witness value rather than treating it as no-op.
+            if apply_state.apply_reason == ApplyChunkReason::ValidateChunkStateWitness
+                && runtime_ext.account().contract().is_some()
+            {
+                return Err(StorageError::MissingTrieValue(MissingTrieValue {
+                    context: MissingTrieValueContext::TrieMemoryPartialStorage,
+                    hash: contract_code_hash,
+                })
+                .into());
+            }
             let error = FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist {
                 account_id: account_id.as_str().into(),
             });

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -291,17 +291,22 @@ pub(crate) fn execute_function_call(
     // are reported via `outcome.aborted` and never reach these arms.
     let mut outcome = match result {
         Err(VMRunnerError::ContractCodeNotPresent) => {
-            // A missing body for an account that commits to a code hash is
-            // witness incompleteness, not an execution result. Fail like any
-            // other missing witness value rather than treating it as no-op.
-            if apply_state.apply_reason == ApplyChunkReason::ValidateChunkStateWitness
-                && runtime_ext.account().contract().is_some()
-            {
-                return Err(StorageError::MissingTrieValue(MissingTrieValue {
-                    context: MissingTrieValueContext::TrieMemoryPartialStorage,
-                    hash: contract_code_hash,
-                })
-                .into());
+            if runtime_ext.account().contract().is_some() {
+                debug_assert!(
+                    apply_state.apply_reason != ApplyChunkReason::UpdateTrackedShard,
+                    "inconsistent state: contract code is missing from the trie, but the account has a non-empty contract"
+                );
+
+                // A missing body for an account that commits to a code hash is
+                // witness incompleteness, not an execution result. Fail like any
+                // other missing witness value rather than treating it as no-op.
+                if apply_state.apply_reason == ApplyChunkReason::ValidateChunkStateWitness {
+                    return Err(StorageError::MissingTrieValue(MissingTrieValue {
+                        context: MissingTrieValueContext::TrieMemoryPartialStorage,
+                        hash: contract_code_hash,
+                    })
+                    .into());
+                }
             }
             let error = FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist {
                 account_id: account_id.as_str().into(),

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -487,6 +487,7 @@ impl TrieViewer {
             &epoch_info_provider.chain_id(),
             AccessOptions::DEFAULT,
         )?;
+        let contract_code_hash = contract_id_resolved.hash();
         let contract =
             pipeline.get_contract(&receipt, contract_id_resolved, 0, view_config.clone());
 
@@ -506,6 +507,7 @@ impl TrieViewer {
         );
         let outcome = execute_function_call(
             contract,
+            contract_code_hash,
             &apply_state,
             &mut runtime_ext,
             originator_id,

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -1765,8 +1765,8 @@ fn test_validation_rejects_missing_contract_code() {
         apply_with_missing_code(&apply_state),
         Err(RuntimeError::StorageError(StorageError::MissingTrieValue(MissingTrieValue {
             context: MissingTrieValueContext::TrieMemoryPartialStorage,
-            hash: _,
-        })))
+            hash,
+        }))) if hash == *contract_code.hash()
     );
 
     // Block production resolves the body from its own trie, so the guard must

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -1687,8 +1687,11 @@ fn test_per_receipt_storage_proof_size_limit() {
     assert!(error_message.contains("storage proof"), "unexpected error message: {error_message}");
 }
 
-#[test]
-fn test_validation_rejects_missing_contract_code() {
+/// Deploys a contract, records a witness for a call to it (which excludes the
+/// contract body), then applies that call over the recorded storage.
+fn apply_call_to_contract_missing_from_witness(
+    apply_reason: ApplyChunkReason,
+) -> Result<ApplyResult, RuntimeError> {
     let (runtime, tries, root, mut apply_state, signers, epoch_info_provider) = setup_runtime(
         vec![alice_account()],
         Balance::from_near(1_000_000),
@@ -1748,43 +1751,35 @@ fn test_validation_rejects_missing_contract_code() {
     // A validator with an empty compiled-contract cache has no source for the
     // body other than the witness, which excludes it.
     apply_state.cache = Some(Box::new(FilesystemContractRuntimeCache::test().unwrap()));
-    let apply_with_missing_code = |apply_state: &ApplyState| {
-        runtime.apply(
-            Trie::from_recorded_storage(partial_storage.clone(), root, false),
-            &None,
-            apply_state,
-            std::slice::from_ref(&call_receipt),
-            SignedValidPeriodTransactions::empty(),
-            &epoch_info_provider,
-            Default::default(),
-        )
-    };
+    apply_state.apply_reason = apply_reason;
+    runtime.apply(
+        Trie::from_recorded_storage(partial_storage, root, false),
+        &None,
+        &apply_state,
+        std::slice::from_ref(&call_receipt),
+        SignedValidPeriodTransactions::empty(),
+        &epoch_info_provider,
+        Default::default(),
+    )
+}
 
-    apply_state.apply_reason = ApplyChunkReason::ValidateChunkStateWitness;
+#[test]
+fn test_validation_rejects_missing_contract_code() {
+    let contract_code = ContractCode::new(near_test_contracts::rs_contract().to_vec(), None);
     assert_matches!(
-        apply_with_missing_code(&apply_state),
+        apply_call_to_contract_missing_from_witness(ApplyChunkReason::ValidateChunkStateWitness),
         Err(RuntimeError::StorageError(StorageError::MissingTrieValue(MissingTrieValue {
             context: MissingTrieValueContext::TrieMemoryPartialStorage,
             hash,
         }))) if hash == *contract_code.hash()
     );
+}
 
-    // Block production resolves the body from its own trie, so the guard must
-    // not change the outcome outside witness validation.
-    apply_state.apply_reason = ApplyChunkReason::UpdateTrackedShard;
-    let apply_result = apply_with_missing_code(&apply_state).unwrap();
-    let [ExecutionOutcomeWithId { outcome, .. }] = &apply_result.outcomes[..] else {
-        panic!("expected a single outcome, got {:?}", apply_result.outcomes);
-    };
-    assert_matches!(
-        &outcome.status,
-        ExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
-            kind: ActionErrorKind::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::CodeDoesNotExist { .. }
-            )),
-            ..
-        }))
-    );
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "contract code is missing from the trie")]
+fn test_tracked_shard_apply_asserts_on_missing_contract_code() {
+    let _ = apply_call_to_contract_missing_from_witness(ApplyChunkReason::UpdateTrackedShard);
 }
 
 // Tests excluding contract code from state witness and recording of contract deployments and function calls.

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -27,7 +27,7 @@ use near_primitives::congestion_info::{
 };
 use near_primitives::errors::{
     ActionError, ActionErrorKind, CompilationError, DepositCostFailureReason, FunctionCallError,
-    InvalidTxError, MissingTrieValue, TxExecutionError,
+    InvalidTxError, MissingTrieValue, RuntimeError, TxExecutionError,
 };
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV0};
@@ -1685,6 +1685,106 @@ fn test_per_receipt_storage_proof_size_limit() {
         ActionErrorKind::FunctionCallError(FunctionCallError::ExecutionError(msg)) => msg
     );
     assert!(error_message.contains("storage proof"), "unexpected error message: {error_message}");
+}
+
+#[test]
+fn test_validation_rejects_missing_contract_code() {
+    let (runtime, tries, root, mut apply_state, signers, epoch_info_provider) = setup_runtime(
+        vec![alice_account()],
+        Balance::from_near(1_000_000),
+        Balance::from_near(500_000),
+        Gas::from_teragas(1000),
+    );
+
+    let contract_code = ContractCode::new(near_test_contracts::rs_contract().to_vec(), None);
+    let deploy_receipt = create_receipt_with_actions(
+        alice_account(),
+        signers[0].clone(),
+        vec![Action::DeployContract(DeployContractAction { code: contract_code.code().to_vec() })],
+    );
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            &None,
+            &apply_state,
+            &[deploy_receipt],
+            SignedValidPeriodTransactions::empty(),
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+    let mut store_update = tries.store_update();
+    let root =
+        tries.apply_all(&apply_result.trie_changes, ShardUId::single_shard(), &mut store_update);
+    store_update.commit();
+
+    let call_receipt = create_receipt_with_actions(
+        alice_account(),
+        signers[0].clone(),
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
+            method_name: "log_something".to_string(),
+            args: Vec::new(),
+            gas: Gas::from_teragas(300),
+            deposit: Balance::ZERO,
+        }))],
+    );
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(ShardUId::single_shard(), root).recording_reads_new_recorder(),
+            &None,
+            &apply_state,
+            std::slice::from_ref(&call_receipt),
+            SignedValidPeriodTransactions::empty(),
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+    assert_eq!(
+        apply_result.contract_updates.contract_accesses,
+        HashSet::from([CodeHash(*contract_code.hash())])
+    );
+    let partial_storage = apply_result.proof.unwrap();
+
+    // A validator with an empty compiled-contract cache has no source for the
+    // body other than the witness, which excludes it.
+    apply_state.cache = Some(Box::new(FilesystemContractRuntimeCache::test().unwrap()));
+    let apply_with_missing_code = |apply_state: &ApplyState| {
+        runtime.apply(
+            Trie::from_recorded_storage(partial_storage.clone(), root, false),
+            &None,
+            apply_state,
+            std::slice::from_ref(&call_receipt),
+            SignedValidPeriodTransactions::empty(),
+            &epoch_info_provider,
+            Default::default(),
+        )
+    };
+
+    apply_state.apply_reason = ApplyChunkReason::ValidateChunkStateWitness;
+    assert_matches!(
+        apply_with_missing_code(&apply_state),
+        Err(RuntimeError::StorageError(StorageError::MissingTrieValue(MissingTrieValue {
+            context: MissingTrieValueContext::TrieMemoryPartialStorage,
+            hash: _,
+        })))
+    );
+
+    // Block production resolves the body from its own trie, so the guard must
+    // not change the outcome outside witness validation.
+    apply_state.apply_reason = ApplyChunkReason::UpdateTrackedShard;
+    let apply_result = apply_with_missing_code(&apply_state).unwrap();
+    let [ExecutionOutcomeWithId { outcome, .. }] = &apply_result.outcomes[..] else {
+        panic!("expected a single outcome, got {:?}", apply_result.outcomes);
+    };
+    assert_matches!(
+        &outcome.status,
+        ExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+            kind: ActionErrorKind::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::CodeDoesNotExist { .. }
+            )),
+            ..
+        }))
+    );
 }
 
 // Tests excluding contract code from state witness and recording of contract deployments and function calls.


### PR DESCRIPTION
During witness validation, a function call to an account that commits to a code hash whose body is unavailable from every source (in-chunk deploy record, recorded partial state, and the compiled-contract cache) hit `ContractCodeNotPresent` and was mapped to a `CodeDoesNotExist` no-op outcome, the same as calling an account with no contract. A chunk validator would recompute and endorse that no-op transition.

`execute_function_call` now treats this as witness incompleteness: when applying in the `ValidateChunkStateWitness` role and the account commits to a code hash, a missing body fails with `MissingTrieValue`, like any other missing witness value. Block production (`UpdateTrackedShard`) is unchanged, since a full node always resolves the body from its own trie.

Adds a regression test that records a witness for a call to a deployed contract, then replays it with an empty compiled-contract cache so the body has no source. Validation must fail with `MissingTrieValue`; the same replay outside the validation role still produces the `CodeDoesNotExist` outcome.