### PR TITLE
fix(network): return after banning abusive PeersResponse sender

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1087,10 +1087,12 @@ impl PeerActor {
                 // Check for abusive behavior (sending too many peers)
                 if peers.len() > PEERS_RESPONSE_MAX_PEERS.try_into().unwrap() {
                     self.stop(ClosingReason::Ban(ReasonForBan::Abusive));
+                    return;
                 }
                 // Check for abusive behavior (sending too many direct peers)
                 if direct_peers.len() > MAX_TIER2_PEERS {
                     self.stop(ClosingReason::Ban(ReasonForBan::Abusive));
+                    return;
                 }
 
                 let node_id = self.network_state.config.node_id();

--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -36,6 +36,7 @@ impl PeerConfig {
 
 pub(crate) struct PeerHandle {
     pub cfg: Arc<PeerConfig>,
+    pub network_state: Arc<NetworkState>,
     actor: AutoStopActor<PeerActor>,
     pub events: broadcast::Receiver<Event>,
     pub edge: Option<Edge>,
@@ -113,8 +114,8 @@ impl PeerHandle {
             actor_system.new_future_spawner("peer testonly"),
         );
         let actor = AutoStopActor(
-            PeerActor::spawn(clock, actor_system, stream, network_state, tcp).unwrap().0,
+            PeerActor::spawn(clock, actor_system, stream, network_state.clone(), tcp).unwrap().0,
         );
-        Self { actor, cfg, events: recv, edge: None }
+        Self { actor, cfg, network_state, events: recv, edge: None }
     }
 }

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -1,3 +1,4 @@
+use crate::config::PEERS_RESPONSE_MAX_PEERS;
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::{
     Handshake, HandshakeFailureReason, PartialEdgeInfo, PeerMessage, PeersRequest, PeersResponse,
@@ -201,6 +202,58 @@ async fn test_request_update_nonce_rejects_invalid_nonce() -> anyhow::Result<()>
         })
         .await;
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_oversized_peers_response_bans_without_adding_to_peer_store() -> anyhow::Result<()> {
+    init_test_logger();
+    let mut rng = make_rng(89028037453);
+    let mut clock = time::FakeClock::default();
+
+    let chain = Arc::new(data::Chain::make(&mut clock, &mut rng, 12));
+    let inbound_cfg = PeerConfig { chain: chain.clone(), network: chain.make_config(&mut rng) };
+    let outbound_cfg = PeerConfig { chain: chain.clone(), network: chain.make_config(&mut rng) };
+    let (outbound_stream, inbound_stream) =
+        tcp::Stream::loopback(inbound_cfg.id(), tcp::Tier::T2).await;
+    let actor_system = ActorSystem::new();
+    let mut inbound = PeerHandle::start_endpoint(
+        clock.clock(),
+        actor_system.clone(),
+        inbound_cfg,
+        inbound_stream,
+    );
+    let mut outbound =
+        PeerHandle::start_endpoint(clock.clock(), actor_system, outbound_cfg, outbound_stream);
+
+    outbound.complete_handshake().await;
+    inbound.complete_handshake().await;
+
+    let store_size_before = inbound.network_state.peer_store.len();
+
+    let fake_peers: Vec<_> =
+        (0..PEERS_RESPONSE_MAX_PEERS + 1).map(|_| data::make_peer_info(&mut rng)).collect();
+    let msg = PeerMessage::PeersResponse(PeersResponse { peers: fake_peers, direct_peers: vec![] });
+
+    let mut events = inbound.events.from_now();
+    outbound.send(msg).await;
+
+    events
+        .recv_until(|ev| match ev {
+            Event::ConnectionClosed(ev)
+                if ev.reason == ClosingReason::Ban(ReasonForBan::Abusive) =>
+            {
+                Some(())
+            }
+            _ => None,
+        })
+        .await;
+
+    assert_eq!(
+        inbound.network_state.peer_store.len(),
+        store_size_before,
+        "peer store should not be modified by an oversized PeersResponse"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
`PeerActor` checks the `PeersResponse` message against `PEERS_RESPONSE_MAX_PEERS` and `MAX_TIER2_PEERS`. When a limit is exceeded it calls `self.stop()` with `ReasonForBan::Abusive`, but then falls through and keeps processing the rest of the handler, so the over-limit peer lists still reach the peer store. Return after each ban so the handler stops there.

Adds a test that sends an over-limit `PeersResponse`, waits for the ban, and asserts the peer store size is unchanged. `PeerHandle` now exposes `network_state` so the test can read the store.