### PR TITLE
refactor(universal-accounts): drop StateInit canonicity check and RawStateInit borsh

### DIFF
--- a/core/primitives-core/src/universal_state_init.rs
+++ b/core/primitives-core/src/universal_state_init.rs
@@ -1,34 +1,25 @@
 //! Opaque wire form of a universal-account StateInit.
 //!
-//! [`RawStateInit`] carries the canonical borsh of a `UniversalStateInit` (the
-//! typed form lives in `near-primitives`, which decodes and validates it). It sits
-//! in this crypto-free core crate because the host-function ABI in `near-vm-runner`
-//! will name it while forwarding the bytes verbatim; decoding into the typed form
-//! is a host-side concern.
+//! [`RawStateInit`] carries the borsh of a `UniversalStateInit` (the typed form
+//! lives in `near-primitives`, which decodes it). It sits in this crypto-free core
+//! crate because the host-function ABI in `near-vm-runner` will name it while
+//! forwarding the bytes verbatim; decoding into the typed form is a host-side concern.
 
-use borsh::{BorshDeserialize, BorshSerialize};
-use near_schema_checker_lib::ProtocolSchema;
 use serde_with::base64::Base64;
 use serde_with::serde_as;
 
-/// Canonical borsh serialization of a universal-account StateInit, forwarded opaquely.
+/// Borsh serialization of a universal-account StateInit, forwarded opaquely.
 ///
 /// It lets an immutable contract pass through a StateInit version it predates: the
 /// bytes travel verbatim, so a version added after the contract was compiled still
-/// works. Because the account id hashes these exact bytes, they must be canonical
-/// borsh; `near_primitives` decodes them with that check.
+/// works. The account id hashes these exact bytes.
+///
+/// Deliberately not `BorshSerialize`/`BorshDeserialize`: the payload is already
+/// borsh, and borsh-serializing this newtype would prepend a 4-byte `Vec` length,
+/// so hashing the wrapper instead of the inner bytes would derive a wrong id. The
+/// bytes cross the host-function ABI verbatim and serialize as base64 over serde.
 #[serde_as]
-#[derive(
-    BorshSerialize,
-    BorshDeserialize,
-    PartialEq,
-    Eq,
-    Debug,
-    Clone,
-    serde::Serialize,
-    serde::Deserialize,
-    ProtocolSchema,
-)]
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RawStateInit(
     #[serde_as(as = "Base64")]

--- a/core/primitives/src/universal_state_init.rs
+++ b/core/primitives/src/universal_state_init.rs
@@ -46,6 +46,7 @@ use std::io;
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[borsh(use_discriminant = true)]
+#[serde(rename_all = "snake_case")]
 #[repr(u8)]
 pub enum UniversalStateInit {
     V1(UniversalStateInitV1) = 0,
@@ -66,12 +67,15 @@ pub enum UniversalStateInit {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct UniversalStateInitV1 {
     /// Contract code, or `None` for a key-only (EOA) account.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code: Option<GlobalContractIdentifier>,
     /// Initial storage; empty unless seeded. Sorted keys give a canonical encoding.
     #[serde_as(as = "BTreeMap<Base64, Base64>")]
     #[cfg_attr(feature = "schemars", schemars(with = "BTreeMap<String, String>"))]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub data: BTreeMap<Vec<u8>, Vec<u8>>,
     /// Full-access keys as compact on-trie handles. Sorted for a canonical encoding.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub access_keys: BTreeSet<PublicKeyHandle>,
 }
 
@@ -184,6 +188,24 @@ mod tests {
         let raw_json = serde_json::to_string(&raw).unwrap();
         assert!(raw_json.starts_with('"') && raw_json.ends_with('"'));
         assert_eq!(serde_json::from_str::<RawStateInit>(&raw_json).unwrap(), raw);
+    }
+
+    #[test]
+    fn serde_json_shape() {
+        // Externally tagged with a lowercase tag, and empty fields are omitted.
+        let empty = UniversalStateInit::V1(UniversalStateInitV1 {
+            code: None,
+            data: BTreeMap::new(),
+            access_keys: BTreeSet::new(),
+        });
+        assert_eq!(serde_json::to_string(&empty).unwrap(), r#"{"v1":{}}"#);
+        assert_eq!(serde_json::from_str::<UniversalStateInit>(r#"{"v1":{}}"#).unwrap(), empty);
+
+        // Populated fields still round-trip through the omit-on-default wiring.
+        let si = key_only_init();
+        let json = serde_json::to_string(&si).unwrap();
+        assert!(json.starts_with(r#"{"v1":{"access_keys":"#), "unexpected shape: {json}");
+        assert_eq!(serde_json::from_str::<UniversalStateInit>(&json).unwrap(), si);
     }
 
     #[test]

--- a/core/primitives/src/universal_state_init.rs
+++ b/core/primitives/src/universal_state_init.rs
@@ -2,15 +2,21 @@
 //!
 //! [`UniversalStateInit`] fully describes a universal account: contract code,
 //! initial storage, and access keys. Its account id is the `0u` encoding of
-//! SHA3-256 over the canonical borsh of this value (see
+//! SHA3-256 over the borsh of this value (see
 //! [`crate::utils::derive_universal_account_id`]).
 //!
 //! The type is a flat, versioned struct rather than one variant per account
 //! "kind": which fields are populated decides the kind (a key-only account has no
-//! `code`; a contract account has `code`). Because the id hashes the exact bytes,
-//! the encoding must be canonical: sorted containers and one struct per version
-//! give exactly one byte string per end-state, so the id <-> bytes mapping is
-//! bijective and cross-contract verification is unambiguous.
+//! `code`; a contract account has `code`).
+//!
+//! The id commits to the exact bytes hashed. The typed API always produces the
+//! canonical borsh (sorted `BTree*` containers, one struct per version), so ids
+//! minted through it are stable. Decoding, however, does not reject a
+//! non-canonical encoding of the same logical value: such an encoding simply
+//! hashes to a different id, and canonicalization cannot be enforced end to end
+//! anyway (contracts re-serialize their own nested `BTree*` state inside opaque
+//! storage values, out of the protocol's view). Producers are responsible for
+//! serializing consistently.
 //!
 //! This is host-only (it embeds `near-crypto` key handles). The crypto-free wire
 //! form [`RawStateInit`] lives in `near-primitives-core` and is re-exported here.
@@ -69,18 +75,6 @@ pub struct UniversalStateInitV1 {
     pub access_keys: BTreeSet<PublicKeyHandle>,
 }
 
-/// Reason a [`RawStateInit`]'s bytes are not an acceptable [`UniversalStateInit`].
-#[derive(thiserror::Error, Debug)]
-pub enum ParseRawStateInitError {
-    /// Bytes are not valid borsh for a `UniversalStateInit`, or have trailing data.
-    #[error("invalid borsh: {0}")]
-    Borsh(#[from] io::Error),
-    /// Bytes decode but are not the unique canonical encoding (e.g. unsorted
-    /// containers), which would break the id <-> bytes bijection.
-    #[error("non-canonical state init encoding")]
-    NonCanonical,
-}
-
 impl UniversalStateInit {
     /// Contract code, or `None` for a key-only account.
     pub fn code(&self) -> Option<&GlobalContractIdentifier> {
@@ -112,17 +106,13 @@ impl UniversalStateInit {
         RawStateInit(borsh::to_vec(self).expect("borsh must not fail"))
     }
 
-    /// Decode `raw`, rejecting any non-canonical encoding so that the same account
-    /// id always maps back to the same bytes. `try_from_slice` rejects trailing
-    /// bytes; re-serializing and comparing rejects anything else that decodes but
-    /// isn't the canonical form (e.g. unsorted map keys), independently of how
-    /// strict the borsh reader happens to be.
-    pub fn from_raw(raw: &RawStateInit) -> Result<Self, ParseRawStateInitError> {
-        let value = Self::try_from_slice(&raw.0)?;
-        if borsh::to_vec(&value).expect("borsh must not fail") != raw.0 {
-            return Err(ParseRawStateInitError::NonCanonical);
-        }
-        Ok(value)
+    /// Decode `raw` into a typed value. Accepts any well-formed borsh encoding,
+    /// rejecting only trailing or malformed bytes; a non-canonical encoding of
+    /// the same logical value is accepted (it hashes to a different id). Callers
+    /// that need a stable id should mint it through the typed `to_raw` / `derive`
+    /// path, which always serializes canonically.
+    pub fn from_raw(raw: &RawStateInit) -> Result<Self, io::Error> {
+        Self::try_from_slice(&raw.0)
     }
 }
 
@@ -200,23 +190,24 @@ mod tests {
     fn from_raw_rejects_trailing_bytes() {
         let mut bytes = contract_init().to_raw().0;
         bytes.push(0);
-        let err = UniversalStateInit::from_raw(&RawStateInit(bytes)).unwrap_err();
-        assert!(matches!(err, ParseRawStateInitError::Borsh(_)), "got {err:?}");
+        assert!(UniversalStateInit::from_raw(&RawStateInit(bytes)).is_err());
     }
 
     #[test]
     fn from_raw_rejects_malformed() {
         // Empty input and a truncated body (discriminant only) fail borsh decoding.
         for bytes in [vec![], vec![0u8]] {
-            let err = UniversalStateInit::from_raw(&RawStateInit(bytes)).unwrap_err();
-            assert!(matches!(err, ParseRawStateInitError::Borsh(_)), "got {err:?}");
+            assert!(UniversalStateInit::from_raw(&RawStateInit(bytes)).is_err());
         }
     }
 
     #[test]
-    fn from_raw_rejects_non_canonical_order() {
+    fn from_raw_accepts_non_canonical_order() {
         // Hand-build V1{code: None, data: {"b","a"} out of order, access_keys: {}}.
-        // borsh writes map keys sorted, so the canonical form is "a" then "b".
+        // borsh writes map keys sorted, so this is a non-canonical encoding. It is
+        // now accepted: borsh silently re-sorts on read (`de_strict_order` is off)
+        // and we no longer reject non-canonical encodings. Re-serializing yields
+        // the canonical bytes, which differ, so this input hashes to a different id.
         let mut bytes = vec![0u8]; // V1 discriminant
         bytes.push(0u8); // code: None
         bytes.extend_from_slice(&2u32.to_le_bytes()); // data: 2 entries
@@ -227,27 +218,18 @@ mod tests {
         }
         bytes.extend_from_slice(&0u32.to_le_bytes()); // access_keys: empty
 
-        // borsh's `de_strict_order` is off in this workspace, so the reader silently
-        // re-sorts the keys; the re-serialize check in `from_raw` is what rejects this.
-        let err = UniversalStateInit::from_raw(&RawStateInit(bytes)).unwrap_err();
-        assert!(matches!(err, ParseRawStateInitError::NonCanonical), "got {err:?}");
-
-        // The canonical ordering of the same map decodes cleanly.
-        let mut ok = vec![0u8, 0u8];
-        ok.extend_from_slice(&2u32.to_le_bytes());
-        for key in [b'a', b'b'] {
-            ok.extend_from_slice(&1u32.to_le_bytes());
-            ok.push(key);
-            ok.extend_from_slice(&0u32.to_le_bytes());
-        }
-        ok.extend_from_slice(&0u32.to_le_bytes());
-        assert!(UniversalStateInit::from_raw(&RawStateInit(ok)).is_ok());
+        let decoded = UniversalStateInit::from_raw(&RawStateInit(bytes.clone())).unwrap();
+        assert_eq!(
+            decoded.data().keys().cloned().collect::<Vec<_>>(),
+            vec![b"a".to_vec(), b"b".to_vec()],
+        );
+        assert_ne!(decoded.to_raw().0, bytes, "canonical re-encoding must differ from the input");
     }
 
     #[test]
-    fn from_raw_rejects_unsorted_access_keys() {
-        // Two access keys serialized in reverse `Ord` order. borsh re-sorts the set
-        // on read, so only the re-serialize check catches it.
+    fn from_raw_accepts_unsorted_access_keys() {
+        // Two access keys serialized in reverse `Ord` order; borsh re-sorts the set
+        // on read. Accepted, no longer rejected.
         let lo = borsh::to_vec(&ed_handle(1)).unwrap();
         let hi = borsh::to_vec(&ed_handle(2)).unwrap();
         let mut bytes = vec![0u8, 0u8]; // V1, code: None
@@ -255,13 +237,14 @@ mod tests {
         bytes.extend_from_slice(&2u32.to_le_bytes()); // access_keys: 2 entries
         bytes.extend_from_slice(&hi); // reversed: handle(2) before handle(1)
         bytes.extend_from_slice(&lo);
-        let err = UniversalStateInit::from_raw(&RawStateInit(bytes)).unwrap_err();
-        assert!(matches!(err, ParseRawStateInitError::NonCanonical), "got {err:?}");
+        let decoded = UniversalStateInit::from_raw(&RawStateInit(bytes)).unwrap();
+        assert_eq!(decoded.access_keys().len(), 2);
     }
 
     #[test]
-    fn from_raw_rejects_duplicate_keys() {
-        // A data map that declares 2 entries but repeats one key; borsh deduplicates on read.
+    fn from_raw_accepts_duplicate_keys() {
+        // A data map that declares 2 entries but repeats one key; borsh deduplicates
+        // on read. Accepted; the decoded map has a single entry.
         let mut bytes = vec![0u8, 0u8]; // V1, code: None
         bytes.extend_from_slice(&2u32.to_le_bytes()); // data: 2 entries
         for _ in 0..2 {
@@ -270,7 +253,7 @@ mod tests {
             bytes.extend_from_slice(&0u32.to_le_bytes());
         }
         bytes.extend_from_slice(&0u32.to_le_bytes()); // access_keys: empty
-        let err = UniversalStateInit::from_raw(&RawStateInit(bytes)).unwrap_err();
-        assert!(matches!(err, ParseRawStateInitError::NonCanonical), "got {err:?}");
+        let decoded = UniversalStateInit::from_raw(&RawStateInit(bytes)).unwrap();
+        assert_eq!(decoded.data().len(), 1);
     }
 }

--- a/tools/protocol-schema-check/res/protocol_schema.toml
+++ b/tools/protocol-schema-check/res/protocol_schema.toml
@@ -244,7 +244,6 @@ PublicKey = 3910595699
 PublicKeyHandle = 668833534
 RawStateChange = 3620499887
 RawStateChangesWithTrieKey = 3407627494
-RawStateInit = 4017803110
 RawTrieNode = 1893029771
 RawTrieNodeWithSize = 2270541653
 Receipt = 1532724933


### PR DESCRIPTION
Two post-merge review follow-ups to #16092, both on the StateInit wire form:

- Drop canonical-encoding enforcement: `UniversalStateInit::from_raw` no longer re-serializes and compares to reject non-canonical borsh, and `ParseRawStateInitError::NonCanonical` is removed (https://github.com/near/nearcore/pull/16092#discussion_r3638029379)
- Drop `BorshSerialize`/`BorshDeserialize` (and `ProtocolSchema`) from `RawStateInit` (https://github.com/near/nearcore/pull/16092#discussion_r3637954372)
