### PR TITLE
fix(forknet): use mainnet eth wallet by default

### DIFF
--- a/chain/jsonrpc/jsonrpc-tests/tests/http_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/http_query.rs
@@ -1,5 +1,6 @@
 use near_jsonrpc::client::new_http_client;
 use near_jsonrpc_tests::{NodeType, create_test_setup_with_node_type};
+use near_primitives::chains;
 
 #[tokio::test]
 async fn test_status() {
@@ -9,6 +10,6 @@ async fn test_status() {
     let client = new_http_client(&setup.server_addr);
     let status_response = client.status().await.expect("Failed to get status");
 
-    assert_eq!(status_response.chain_id, "unittest");
+    assert_eq!(status_response.chain_id, chains::TEST_CHAIN);
     assert_eq!(status_response.sync_info.syncing, false);
 }

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -16,6 +16,7 @@ use near_network::test_utils::wait_or_timeout;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::action::GlobalContractDeployMode;
+use near_primitives::chains;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
@@ -442,7 +443,7 @@ async fn test_status() {
     let client = new_client(&setup.server_addr);
 
     let status = client.status().await.unwrap();
-    assert_eq!(status.chain_id, "unittest");
+    assert_eq!(status.chain_id, chains::TEST_CHAIN);
     // Height may vary depending on block production, so we just check that we get a valid response
     assert!(status.sync_info.latest_block_height < 100); // Should be reasonable for test
     assert_eq!(status.sync_info.syncing, false);

--- a/core/chain-configs/src/test_genesis.rs
+++ b/core/chain-configs/src/test_genesis.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use near_crypto::PublicKey;
 use near_primitives::account::{AccessKey, Account, AccountContract};
+use near_primitives::chains;
 use near_primitives::epoch_manager::{EpochConfig, EpochConfigBuilder, EpochConfigStore};
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::state_record::StateRecord;
@@ -277,7 +278,7 @@ impl Default for TestGenesisBuilder {
     // modify the defaults.
     fn default() -> Self {
         Self {
-            chain_id: "test".to_string(),
+            chain_id: chains::TEST_CHAIN.to_string(),
             protocol_version: PROTOCOL_VERSION,
             epoch_length: 100,
             shard_layout: ShardLayout::single_shard(),

--- a/core/chain-configs/src/test_utils.rs
+++ b/core/chain-configs/src/test_utils.rs
@@ -11,6 +11,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use near_crypto::{InMemorySigner, PublicKey};
 use near_primitives::account::{AccessKey, Account, AccountContract};
+use near_primitives::chains;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::state_record::StateRecord;
@@ -220,7 +221,7 @@ pub fn add_account_with_key(
 }
 
 pub fn random_chain_id() -> String {
-    format!("test-chain-{}", generate_random_string(5))
+    format!("{}-{}", chains::TEST_CHAIN, generate_random_string(5))
 }
 
 pub fn get_initial_supply(records: &[StateRecord]) -> Balance {
@@ -258,7 +259,7 @@ impl ClientConfig {
 
         ClientConfig {
             version: Default::default(),
-            chain_id: "unittest".to_string(),
+            chain_id: chains::TEST_CHAIN.to_string(),
             rpc_addr: Some("0.0.0.0:3030".to_string()),
             expected_shutdown: MutableConfigValue::new(None, "expected_shutdown"),
             block_production_tracking_delay: MutableConfigValue::new(

--- a/core/primitives-core/src/chains.rs
+++ b/core/primitives-core/src/chains.rs
@@ -9,8 +9,21 @@ pub const TESTNET: &str = "testnet";
 /// Pre-release testing environment.
 pub const MOCKNET: &str = "mocknet";
 
+/// Local development environment.
+pub const LOCALNET: &str = "localnet";
+
 /// Used by ft-benchmark.  http://go/crt-benchmark
 pub const BENCHMARKNET: &str = "benchmarknet";
 
+/// Chain id of the networks the test setups spin up. Some setups append a
+/// suffix, e.g. `random_chain_id` appends a random one.
+pub const TEST_CHAIN: &str = "test-chain";
+
 /// Used by congestion control tests in nayduck.
-pub const CONGESTION_CONTROL_TEST: &str = "congestion_control_test";
+pub const CONGESTION_CONTROL_TEST: &str = "test-chain-congestion-control";
+
+/// Whether the chain id belongs to a network created locally, i.e. a localnet or
+/// one of the test networks.
+pub fn is_local(chain_id: &str) -> bool {
+    chain_id == LOCALNET || chain_id.starts_with(TEST_CHAIN)
+}

--- a/integration-tests/src/env/setup.rs
+++ b/integration-tests/src/env/setup.rs
@@ -43,6 +43,7 @@ use near_network::state_witness::PartialWitnessSenderForNetwork;
 use near_network::types::{NetworkRequests, NetworkResponses, PeerManagerAdapter};
 use near_network::types::{PeerManagerMessageRequest, PeerManagerMessageResponse};
 use near_o11y::span_wrapped_msg::SpanWrapped;
+use near_primitives::chains;
 use near_primitives::epoch_info::RngSeed;
 use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
@@ -131,7 +132,7 @@ fn setup(
         transaction_validity_period,
         epoch_length,
         protocol_version: PROTOCOL_VERSION,
-        chain_id: "integration_test".to_string(),
+        chain_id: chains::TEST_CHAIN.to_string(),
     };
 
     let signer = MutableConfigValue::new(

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -12,6 +12,7 @@ use near_client::sync::external::{StateFileType, external_storage_location};
 use near_crypto::InMemorySigner;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Tip;
+use near_primitives::chains;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::FlatStateValue;
 use near_primitives::state_part::{PartId, StatePart};
@@ -96,7 +97,7 @@ fn slow_test_state_dump() {
             let num_parts = 1;
             for part_id in 0..num_parts {
                 let path = root_dir.path().join(external_storage_location(
-                    "unittest",
+                    chains::TEST_CHAIN,
                     &epoch_id,
                     epoch_height,
                     shard_id,

--- a/pytest/tests/sanity/congestion_control.py
+++ b/pytest/tests/sanity/congestion_control.py
@@ -273,7 +273,7 @@ class CongestionControlTest(unittest.TestCase):
             # runtime parameters to their original values. This is needed so
             # that the test doesn't need to be updated every time the parameters
             # are changed.
-            ("chain_id", "congestion_control_test"),
+            ("chain_id", "test-chain-congestion-control"),
         ]
         client_config_changes = {
             0: {

--- a/runtime/near-wallet-contract/src/lib.rs
+++ b/runtime/near-wallet-contract/src/lib.rs
@@ -73,9 +73,9 @@ pub fn wallet_contract(code_hash: CryptoHash) -> Option<Arc<ContractCode>> {
 /// near[wallet contract hash]
 pub fn wallet_contract_magic_bytes(chain_id: &str) -> Arc<ContractCode> {
     match chain_id {
-        chains::MAINNET => MAINNET.magic_bytes(),
         chains::TESTNET => TESTNET.magic_bytes(),
-        _ => LOCALNET.magic_bytes(),
+        _ if chains::is_local(chain_id) => LOCALNET.magic_bytes(),
+        _ => MAINNET.magic_bytes(),
     }
 }
 
@@ -83,24 +83,25 @@ pub fn wallet_contract_magic_bytes(chain_id: &str) -> Arc<ContractCode> {
 /// This is the hash of the deployed global contract that ETH implicit accounts
 /// should use when the EthImplicitGlobalContract protocol feature is enabled.
 ///
-/// For other chains (localnet, test chains): Uses the hash of the embedded
-/// wallet contract WASM, allowing tests to deploy the same contract as a
-/// global contract.
+/// Mainnet and testnet use the hash of the contract already deployed there.
+/// Local networks (see [`chains::is_local`]) use the hash of the embedded localnet
+/// WASM, which they are expected to deploy as a global contract themselves.
+/// Every other chain id defaults to mainnet, see [`wallet_contract_magic_bytes`].
 pub fn eth_wallet_global_contract_hash(chain_id: &str) -> CryptoHash {
     match chain_id {
-        // 2zodJZK2e4nnv5AqwCRnenNSmkikXhEd7PPY6BmfTmW4
-        chains::MAINNET | chains::MOCKNET => CryptoHash([
-            0x1d, 0xaa, 0x83, 0x5c, 0x46, 0x37, 0xf7, 0xae, 0x3d, 0x92, 0x40, 0x95, 0xba, 0x3f,
-            0x0b, 0xf2, 0x82, 0x9b, 0xcf, 0xa1, 0x7b, 0x10, 0x68, 0xcd, 0x58, 0xbd, 0x85, 0x3d,
-            0xca, 0xd7, 0xce, 0xb5,
-        ]),
         // 3PpYvRxBfC5BkZxTw8ZFG3D52w1ZRhvDDWirKoxphMDn
         chains::TESTNET => CryptoHash([
             0x23, 0x8f, 0xea, 0xc1, 0xf8, 0x6c, 0xc9, 0xf9, 0xf4, 0x00, 0x3e, 0x3f, 0x6d, 0x5a,
             0xeb, 0xc0, 0x4e, 0xae, 0xa9, 0xc3, 0x94, 0x03, 0x2b, 0xd2, 0x94, 0x70, 0xe9, 0x60,
             0x9b, 0x67, 0xf6, 0xc5,
         ]),
-        _ => *LOCALNET.read_contract().hash(),
+        _ if chains::is_local(chain_id) => *LOCALNET.read_contract().hash(),
+        // 2zodJZK2e4nnv5AqwCRnenNSmkikXhEd7PPY6BmfTmW4
+        _ => CryptoHash([
+            0x1d, 0xaa, 0x83, 0x5c, 0x46, 0x37, 0xf7, 0xae, 0x3d, 0x92, 0x40, 0x95, 0xba, 0x3f,
+            0x0b, 0xf2, 0x82, 0x9b, 0xcf, 0xa1, 0x7b, 0x10, 0x68, 0xcd, 0x58, 0xbd, 0x85, 0x3d,
+            0xca, 0xd7, 0xce, 0xb5,
+        ]),
     }
 }
 

--- a/test-loop-tests/src/tests/chain_id.rs
+++ b/test-loop-tests/src/tests/chain_id.rs
@@ -2,6 +2,7 @@ use crate::setup::builder::TestLoopBuilder;
 use crate::utils::account::create_account_id;
 use near_async::time::Duration;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::chains;
 use near_primitives::gas::Gas;
 use near_primitives::types::Balance;
 use near_primitives::views::FinalExecutionStatus;
@@ -33,7 +34,7 @@ fn test_chain_id_returns_chain_id() {
     let outcome = env.rpc_runner().execute_tx(call_tx, Duration::seconds(5)).unwrap();
     match &outcome.status {
         FinalExecutionStatus::SuccessValue(bytes) => {
-            assert_eq!(bytes, b"test", "expected the genesis chain id");
+            assert_eq!(bytes, chains::TEST_CHAIN.as_bytes(), "expected the genesis chain id");
         }
         other => panic!("expected SuccessValue, got {other:?}"),
     }


### PR DESCRIPTION
Let's use the mainnet eth wallet contract as the default option for unknown chain ids. This will help in forknet, which uses a random chain id, but the state contains only the mainnet eth wallet contract.

Previous logic:
```rust
pub fn wallet_contract_magic_bytes(chain_id: &str) -> Arc<ContractCode> {
    match chain_id {
        chains::MAINNET => MAINNET.magic_bytes(),
        chains::TESTNET => TESTNET.magic_bytes(),
        _ => LOCALNET.magic_bytes(),
    }
}
```

New logic:
```rust
pub fn wallet_contract_magic_bytes(chain_id: &str) -> Arc<ContractCode> {
    match chain_id {
        chains::TESTNET => TESTNET.magic_bytes(),
        _ if chains::is_local(chain_id) => LOCALNET.magic_bytes(),
        _ => MAINNET.magic_bytes(),
    }
}

pub fn is_local(chain_id: &str) -> bool {
    chain_id == "localnet" || chain_id.starts_with("test-chain")
}
```

I also unified all the tests to use a chain id that starts with `"test-chain".