### PR TITLE
feat(cloud-archive): throttle catch-up between batches

### DIFF
--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -242,7 +242,7 @@ impl CloudArchivalWriter {
                 }
             } else {
                 match self.try_archive_data().await {
-                    Ok(CloudArchivingOutcome::Old { .. }) => Duration::ZERO,
+                    Ok(CloudArchivingOutcome::Old { .. }) => self.config.catch_up_throttle,
                     _ => self.config.polling_interval,
                 }
             };

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -47,7 +47,7 @@ enum CloudArchivingOutcome {
     Recent { batch_end: BlockHeight },
     /// Archived a batch below the previous final head; more batches are
     /// immediately available.
-    Old { batch_end: BlockHeight, target_height: BlockHeight },
+    Old { batch_end: BlockHeight, target_height: BlockHeight, cloud_head_written: bool },
 }
 
 /// Error surfaced while initializing cloud archive or writer.
@@ -152,12 +152,20 @@ struct ShardBatchToArchive {
     retired_parent: bool,
 }
 
+/// The block head height to advance to. `cloud_head_written` is false when
+/// another writer had already published the batch.
+struct BlockHeadUpdate {
+    head: BlockHeight,
+    cloud_head_written: bool,
+}
+
 /// A shard's head height to reflect in the gauge; `retired` drops the shard's
 /// series instead of setting it.
 struct ShardHeadUpdate {
     shard_id: ShardId,
     head: BlockHeight,
     retired: bool,
+    cloud_head_written: bool,
 }
 
 /// Creates the cloud archival writer if it is configured.
@@ -242,6 +250,11 @@ impl CloudArchivalWriter {
                 }
             } else {
                 match self.try_archive_data().await {
+                    // The delay protects the head objects, so a batch that wrote
+                    // none needs none.
+                    Ok(CloudArchivingOutcome::Old { cloud_head_written: false, .. }) => {
+                        Duration::ZERO
+                    }
                     Ok(CloudArchivingOutcome::Old { .. }) => self.config.catch_up_throttle,
                     _ => self.config.polling_interval,
                 }
@@ -305,11 +318,12 @@ impl CloudArchivalWriter {
                     "recent batch was archived"
                 );
             }
-            CloudArchivingOutcome::Old { batch_end, target_height } => {
+            CloudArchivingOutcome::Old { batch_end, target_height, cloud_head_written } => {
                 tracing::trace!(
                     target: "cloud_archival",
                     batch_end,
                     target_height,
+                    cloud_head_written,
                     "older batch was archived - more archiving needed"
                 );
             }
@@ -332,7 +346,7 @@ impl CloudArchivalWriter {
             return Ok(CloudArchivingOutcome::Idle { cloud_head: min_head });
         }
 
-        self.archive_lagging_components(&batch_range).await?;
+        let cloud_head_written = self.archive_lagging_components(&batch_range).await?;
 
         let next_batch = self.next_batch_after(batch_range.end());
         let outcome = if next_batch.end() >= hot_final_height {
@@ -341,6 +355,7 @@ impl CloudArchivalWriter {
             CloudArchivingOutcome::Old {
                 batch_end: batch_range.end(),
                 target_height: hot_final_height - 1,
+                cloud_head_written,
             }
         };
         tracing::trace!(target: "cloud_archival", ?outcome, "ending");
@@ -355,19 +370,22 @@ impl CloudArchivalWriter {
     }
 
     /// Archives all lagging components for the given batch and advances local heads.
+    /// Returns whether any cloud head was rewritten.
     async fn archive_lagging_components(
         &self,
         batch_range: &BatchRange,
-    ) -> Result<(), CloudArchivingError> {
+    ) -> Result<bool, CloudArchivingError> {
         let epoch_ending_block_hash = self.find_epoch_ending_in_batch(batch_range)?;
 
-        let block_advanced = if self.config.archive_block_data {
+        let block_update = if self.config.archive_block_data {
             self.archive_block_batch_if_lagging(batch_range).await?
         } else {
-            false
+            None
         };
-        let advanced_shards =
+        let shards_update =
             self.archive_shard_batches_if_lagging(batch_range, epoch_ending_block_hash).await?;
+        let cloud_head_written = block_update.as_ref().is_some_and(|u| u.cloud_head_written)
+            || shards_update.iter().any(|shard| shard.cloud_head_written);
         if self.config.archive_block_data {
             if let Some(last_block_hash) = epoch_ending_block_hash {
                 self.archive_ending_epoch_data(last_block_hash).await?;
@@ -375,11 +393,11 @@ impl CloudArchivalWriter {
         }
         self.advance_local_heads(
             batch_range.end(),
-            block_advanced,
-            &advanced_shards,
+            block_update.as_ref(),
+            &shards_update,
             epoch_ending_block_hash,
         )?;
-        Ok(())
+        Ok(cloud_head_written)
     }
 
     /// Whether the batch's end lands in a resharding epoch.
@@ -517,24 +535,27 @@ impl CloudArchivalWriter {
     }
 
     /// Archives the block batch if the local block head is behind `batch_range.end()`.
-    /// Returns true if the block head was advanced.
+    /// Returns the head update, absent when the local head already covers the batch.
     async fn archive_block_batch_if_lagging(
         &self,
         batch_range: &BatchRange,
-    ) -> Result<bool, CloudArchivingError> {
+    ) -> Result<Option<BlockHeadUpdate>, CloudArchivingError> {
         if let Some(head) = self.get_local_block_head()? {
             if head >= batch_range.end() {
-                return Ok(false);
+                return Ok(None);
             }
         }
         // TODO(cloud_archival): Race condition between this check and the upload below.
         // Will be replaced with ifGenerationMatch:0 atomic uploads + hash metadata verification.
         let ext_head = self.cloud_storage.retrieve_cloud_block_head_if_exists().await?;
+        let mut cloud_head_written = false;
         if ext_head.is_none_or(|h| h < batch_range.end()) {
             self.cloud_storage.archive_block_batch(&self.hot_store, batch_range).await?;
             self.cloud_storage.update_cloud_block_head(batch_range.end()).await?;
+            cloud_head_written = true;
         }
-        Ok(true)
+        let update = BlockHeadUpdate { head: batch_range.end(), cloud_head_written };
+        Ok(Some(update))
     }
 
     /// Archives shard batches for tracked shards whose local head is behind
@@ -559,6 +580,7 @@ impl CloudArchivalWriter {
             // TODO(cloud_archival): Race condition between this check and the upload below.
             // Will be replaced with ifGenerationMatch:0 atomic uploads + hash metadata verification.
             let ext_head = self.cloud_storage.retrieve_cloud_shard_head_if_exists(shard_id).await?;
+            let mut cloud_head_written = false;
             if ext_head.is_none_or(|h| h < batch_end) {
                 self.cloud_storage
                     .archive_shard_batch(
@@ -570,11 +592,13 @@ impl CloudArchivalWriter {
                     )
                     .await?;
                 self.cloud_storage.update_cloud_shard_head(shard_id, batch_end).await?;
+                cloud_head_written = true;
             }
             advanced_shards.push(ShardHeadUpdate {
                 shard_id,
                 head: batch_end,
                 retired: shard_batch.retired_parent,
+                cloud_head_written,
             });
         }
         Ok(advanced_shards)
@@ -967,7 +991,12 @@ impl CloudArchivalWriter {
         // No shard retires during initialization.
         let head_updates: Vec<ShardHeadUpdate> = shard_heads
             .iter()
-            .map(|&(shard_id, head)| ShardHeadUpdate { shard_id, head, retired: false })
+            .map(|&(shard_id, head)| ShardHeadUpdate {
+                shard_id,
+                head,
+                retired: false,
+                cloud_head_written: false,
+            })
             .collect();
         Self::report_head_heights(block_head, &head_updates, min_height);
         Ok(())
@@ -1034,16 +1063,17 @@ impl CloudArchivalWriter {
     fn advance_local_heads(
         &self,
         height: BlockHeight,
-        block_advanced: bool,
-        advanced_shards: &[ShardHeadUpdate],
+        block_update: Option<&BlockHeadUpdate>,
+        shards_update: &[ShardHeadUpdate],
         new_prev_epoch_end: Option<CryptoHash>,
     ) -> Result<(), near_chain_primitives::Error> {
         let height_bytes = borsh::to_vec(&height).unwrap();
         let mut transaction = DBTransaction::new();
-        if block_advanced {
-            transaction.set(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY.to_vec(), height_bytes.clone());
+        if let Some(block_update) = block_update {
+            let block_head_bytes = borsh::to_vec(&block_update.head).unwrap();
+            transaction.set(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY.to_vec(), block_head_bytes);
         }
-        for advanced in advanced_shards {
+        for advanced in shards_update {
             let shard_head_bytes = borsh::to_vec(&advanced.head).unwrap();
             transaction.set(
                 DBCol::BlockMisc,
@@ -1060,7 +1090,7 @@ impl CloudArchivalWriter {
             );
         }
         self.hot_store.database().write(transaction);
-        Self::report_head_heights(block_advanced.then_some(height), advanced_shards, height);
+        Self::report_head_heights(block_update.map(|u| u.head), shards_update, height);
         Ok(())
     }
 }

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "NEAR Protocol JSON RPC API",
-    "version": "1.2.14"
+    "version": "1.2.15"
   },
   "paths": {
     "/EXPERIMENTAL_call_function": {
@@ -3964,6 +3964,18 @@
             "default": false,
             "description": "Determines whether block-related data should be written to cloud storage.",
             "type": "boolean"
+          },
+          "catch_up_throttle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DurationAsStdSchemaProvider"
+              }
+            ],
+            "default": {
+              "nanos": 100000000,
+              "secs": 1
+            },
+            "description": "Delay between consecutive batches while the writer is catching up, pacing\nhow fast it uploads to the storage backend."
           },
           "polling_interval": {
             "allOf": [

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -2848,6 +2848,18 @@
             "description": "Determines whether block-related data should be written to cloud storage.",
             "type": "boolean"
           },
+          "catch_up_throttle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DurationAsStdSchemaProvider"
+              }
+            ],
+            "default": {
+              "nanos": 100000000,
+              "secs": 1
+            },
+            "description": "Delay between consecutive batches while the writer is catching up, pacing\nhow fast it uploads to the storage backend."
+          },
           "polling_interval": {
             "allOf": [
               {

--- a/chain/jsonrpc/openapi/src/main.rs
+++ b/chain/jsonrpc/openapi/src/main.rs
@@ -700,7 +700,7 @@ fn whole_spec(all_schemas: SchemasMap, all_paths: PathsMap) -> OpenApi {
         openapi: "3.0.0".to_string(),
         info: okapi::openapi3::Info {
             title: "NEAR Protocol JSON RPC API".to_string(),
-            version: "1.2.14".to_string(),
+            version: "1.2.15".to_string(),
             ..Default::default()
         },
         paths: all_paths,

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -186,6 +186,13 @@ pub fn default_archival_writer_polling_interval() -> Duration {
     Duration::seconds(1)
 }
 
+pub fn default_archival_writer_catch_up_throttle() -> Duration {
+    // GCS allows about one mutation per second on a single object, and the writer
+    // rewrites the cloud heads once per batch.
+    // TODO(cloud_archival): consider a faster catch-up, rewriting the heads less often.
+    Duration::milliseconds(1100)
+}
+
 pub fn default_snapshot_every_n_epochs() -> u64 {
     10
 }
@@ -206,6 +213,13 @@ pub struct CloudArchivalWriterConfig {
     #[serde(default = "default_archival_writer_polling_interval")]
     pub polling_interval: Duration,
 
+    /// Delay between consecutive batches while the writer is catching up, pacing
+    /// how fast it uploads to the storage backend.
+    #[serde(with = "near_time::serde_duration_as_std")]
+    #[cfg_attr(feature = "schemars", schemars(with = "DurationAsStdSchemaProvider"))]
+    #[serde(default = "default_archival_writer_catch_up_throttle")]
+    pub catch_up_throttle: Duration,
+
     /// Cadence of state snapshots, in epochs. Higher values reduce bucket cost at
     /// the expense of potentially longer delta replay during reader bootstrap.
     #[serde(default = "default_snapshot_every_n_epochs")]
@@ -217,6 +231,7 @@ impl Default for CloudArchivalWriterConfig {
         Self {
             archive_block_data: false,
             polling_interval: default_archival_writer_polling_interval(),
+            catch_up_throttle: default_archival_writer_catch_up_throttle(),
             snapshot_every_n_epochs: default_snapshot_every_n_epochs(),
         }
     }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -189,7 +189,8 @@ pub fn default_archival_writer_polling_interval() -> Duration {
 pub fn default_archival_writer_catch_up_throttle() -> Duration {
     // GCS allows about one mutation per second on a single object, and the writer
     // rewrites the cloud heads once per batch.
-    // TODO(cloud_archival): consider a faster catch-up, rewriting the heads less often.
+    // TODO(cloud_archival): consider a faster catch-up, rewriting the heads less
+    // often, or waiting per head object against its own last write.
     Duration::milliseconds(1100)
 }
 

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -43,11 +43,11 @@ pub const STATE_SNAPSHOT_KEY: &[u8; 18] = b"STATE_SNAPSHOT_KEY";
 pub const GC_STOP_HEIGHT_KEY: &[u8; 14] = b"GC_STOP_HEIGHT";
 pub const CLOUD_BLOCK_HEAD_KEY: &[u8] = b"CLOUD_BLOCK_HEAD";
 pub const CLOUD_SHARD_HEAD_PREFIX: &[u8] = b"CLOUD_SHARD_HEAD:";
-/// Highest height up to which the writer knows all components are archived
-/// (by us or another writer). Drives the next batch range to upload.
+/// Highest height every component this writer archives has reached in the
+/// bucket, whoever put it there. Drives the next batch range to upload.
 pub const CLOUD_MIN_HEAD_KEY: &[u8] = b"CLOUD_MIN_HEAD";
-/// Hash of the last block of the latest epoch the writer has fully archived.
-/// GC stops at the start of that epoch.
+/// Hash of the last block of the latest epoch this writer archived its assigned
+/// components for. GC stops at the start of that epoch.
 pub const CLOUD_PREV_EPOCH_END_KEY: &[u8] = b"CLOUD_PREV_EPOCH_END";
 
 pub fn cloud_shard_head_key(shard_id: ShardId) -> Vec<u8> {

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -76,6 +76,9 @@ struct CloudArchiveHarnessBuilder {
     resharding_enabled: bool,
     /// Cloud archival batch size in blocks.
     batch_size: u32,
+    /// Delay between catch-up batches. Zero by default, so a small batch size
+    /// cannot hold catch-up below block production.
+    catch_up_throttle: Duration,
 }
 
 impl CloudArchiveHarnessBuilder {
@@ -138,12 +141,18 @@ impl CloudArchiveHarnessBuilder {
         self
     }
 
+    fn catch_up_throttle(mut self, throttle: Duration) -> Self {
+        self.catch_up_throttle = throttle;
+        self
+    }
+
     fn build(self) -> CloudArchiveHarness {
         let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
         let archival_kind =
             if self.cold_storage { ArchivalKind::ColdAndCloud } else { ArchivalKind::Cloud };
         let archival_id = self.writer.id.clone();
         let snapshot_every_n_epochs = self.writer.snapshot_every_n_epochs;
+        let catch_up_throttle = self.catch_up_throttle;
         let has_drops =
             !self.dropped_block_heights.is_empty() || !self.dropped_chunks_by_shard.is_empty();
         let base_shard_layout = CloudArchiveHarness::default_shard_layout();
@@ -163,6 +172,7 @@ impl CloudArchiveHarnessBuilder {
                     self.writer.archive_block_data,
                     &self.writer.tracked_shards,
                     snapshot_every_n_epochs,
+                    catch_up_throttle,
                 );
             });
         let mut new_shard_layout = None;
@@ -245,6 +255,7 @@ impl CloudArchiveHarness {
             dropped_chunks_by_shard: HashMap::new(),
             resharding_enabled: false,
             batch_size: Self::TEST_BATCH_SIZE,
+            catch_up_throttle: Duration::ZERO,
         }
     }
 
@@ -468,6 +479,42 @@ fn test_cloud_archival_resume() {
     h.run_until_epoch(2 * MIN_GC_NUM_EPOCHS_TO_KEEP + 4);
     h.assert_heads_and_gc_ok();
     h.assert_snapshots_ok();
+    h.shutdown();
+}
+
+/// Verifies that a writer clearing a lag archives one batch per
+/// `catch_up_throttle`, so three seconds of catch-up at a one second delay
+/// archive three batches.
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_catch_up_throttle_limits_batch_rate() {
+    let throttle = Duration::seconds(1);
+    let window = Duration::seconds(3);
+    // The window holds one batch per delay.
+    let expected_batches = 3;
+    let batch_size = u64::from(CloudArchiveHarness::TEST_BATCH_SIZE);
+
+    let mut h = CloudArchiveHarness::builder().catch_up_throttle(throttle).build();
+    let paused_at = h.epoch_length;
+    h.run_until(paused_at);
+
+    // Pause long enough to leave the batches the window clears, plus a buffer.
+    h.pause_writer();
+    let lag_batches = expected_batches + 5;
+    h.run_until(paused_at + lag_batches * batch_size);
+    h.resume_writer();
+
+    // The first batch after initializing is archived immediately, the delay only
+    // separating later ones. Let it land before measuring, half a delay being too
+    // short for the next one.
+    h.env.test_loop.run_for(throttle / 2);
+    let head_before = h.cloud_head();
+    h.env.test_loop.run_for(window);
+
+    let batches = (h.cloud_head() - head_before) / batch_size;
+    assert_eq!(batches, expected_batches);
+
     h.shutdown();
 }
 

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -235,10 +235,12 @@ pub(crate) fn apply_writer_settings(
     archive_block_data: bool,
     tracked_shards: &[ShardUId],
     snapshot_every_n_epochs: u64,
+    catch_up_throttle: Duration,
 ) {
     config.cloud_archival_writer = Some(CloudArchivalWriterConfig {
         archive_block_data,
         snapshot_every_n_epochs,
+        catch_up_throttle,
         ..Default::default()
     });
     config.tracked_shards_config = if tracked_shards.is_empty() {
@@ -279,6 +281,7 @@ pub(crate) fn add_writer_node(env: &mut TestLoopEnv, config: &WriterConfig) {
                 archive_block_data,
                 &tracked_shards,
                 snapshot_every_n_epochs,
+                Duration::ZERO,
             );
         })
         .build();


### PR DESCRIPTION
The cloud archival writer now sleeps `catch_up_throttle` (default 1100 ms) between batches during catch-up, instead of archiving them back to back.

Each batch rewrites the `block_head` and `shard_head/<shard_id>` progress objects, and GCS allows roughly one mutation per second per object. Back-to-back batches exceed that, so the head write fails and the batch is rebuilt and retried after `polling_interval` without progress. The throttle keeps head writes under the limit; rewriting heads less often than once per batch would be faster and is left as a TODO at the default. A batch that rewrote no head, because another writer was already ahead, skips the delay.

Testloop zeroes the delay, since at batch size 1 it would hold catch-up below block production. One test opts back in: three seconds at a one second delay archive exactly three batches.
