### PR TITLE
fix(network): adjust network limits, make configurable

### DIFF
--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -10,6 +10,7 @@ use crate::stun;
 use crate::tcp;
 use crate::types::ROUTED_MESSAGE_TTL;
 use anyhow::Context;
+use bytesize::{GIB, MIB};
 use near_async::time;
 use near_chain_configs::MutableConfigValue;
 use near_chain_configs::MutableValidatorSigner;
@@ -36,6 +37,11 @@ pub const DEFAULT_ROUTING_GRAPH_MAX_EDGES: usize = 1_000_000;
 /// Maximum number of AnnounceAccount entries allowed in a single SyncRoutingTable message.
 /// Sized at ~10x the realistic validator count to leave headroom.
 pub const DEFAULT_ROUTING_GRAPH_MAX_ACCOUNTS_PER_MESSAGE: usize = 10_000;
+
+/// Default size of the semaphore which limits the total size of the outgoing messages.
+pub const DEFAULT_OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES: usize = 3 * GIB as usize;
+/// Default maximum capacity of the write buffer of a single connection.
+pub const DEFAULT_MAX_WRITE_BUFFER_CAPACITY_BYTES: usize = 700 * MIB as usize;
 
 /// Maximum number of PeerAddrs in the ValidatorConfig::endpoints field.
 pub const MAX_PEER_ADDRS: usize = 10;
@@ -234,6 +240,10 @@ pub struct NetworkConfig {
     pub routing_graph_max_edges: usize,
     /// Maximum number of AnnounceAccount entries allowed in a single SyncRoutingTable message.
     pub routing_graph_max_accounts_per_message: usize,
+    /// Size of the semaphore which limits the total size of the outgoing messages.
+    pub outgoing_queue_limiter_capacity_bytes: usize,
+    /// Maximum capacity of the write buffer of a single connection.
+    pub max_write_buffer_capacity_bytes: usize,
 
     #[cfg(test)]
     pub(crate) event_sink:
@@ -451,6 +461,12 @@ impl NetworkConfig {
             routing_graph_max_peers: DEFAULT_ROUTING_GRAPH_MAX_PEERS,
             routing_graph_max_edges: DEFAULT_ROUTING_GRAPH_MAX_EDGES,
             routing_graph_max_accounts_per_message: DEFAULT_ROUTING_GRAPH_MAX_ACCOUNTS_PER_MESSAGE,
+            outgoing_queue_limiter_capacity_bytes: cfg
+                .outgoing_queue_limiter_capacity_bytes
+                .unwrap_or(DEFAULT_OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES),
+            max_write_buffer_capacity_bytes: cfg
+                .max_write_buffer_capacity_bytes
+                .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_CAPACITY_BYTES),
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),
@@ -536,6 +552,8 @@ impl NetworkConfig {
             routing_graph_max_peers: DEFAULT_ROUTING_GRAPH_MAX_PEERS,
             routing_graph_max_edges: DEFAULT_ROUTING_GRAPH_MAX_EDGES,
             routing_graph_max_accounts_per_message: DEFAULT_ROUTING_GRAPH_MAX_ACCOUNTS_PER_MESSAGE,
+            outgoing_queue_limiter_capacity_bytes: DEFAULT_OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES,
+            max_write_buffer_capacity_bytes: DEFAULT_MAX_WRITE_BUFFER_CAPACITY_BYTES,
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),

--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -211,6 +211,16 @@ pub struct Config {
     #[serde(default = "default_trusted_stun_servers")]
     pub trusted_stun_servers: Vec<stun::ServerAddr>,
 
+    /// Size of the semaphore which limits the total size of the messages queued for sending
+    /// across all the connections. Once exhausted, new outgoing messages are dropped.
+    /// If unset, defaults to `DEFAULT_OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outgoing_queue_limiter_capacity_bytes: Option<usize>,
+    /// Maximum capacity of the write buffer of a single connection. Exceeding it closes the
+    /// connection. If unset, defaults to `DEFAULT_MAX_WRITE_BUFFER_CAPACITY_BYTES`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_write_buffer_capacity_bytes: Option<usize>,
+
     /// Configuration for Tier1 network.
     /// Tier1 network is a special network between validator nodes that provides faster
     /// consensus-related message delivery.
@@ -370,6 +380,8 @@ impl Default for Config {
             public_addrs: vec![],
             allow_private_ip_in_public_addrs: false,
             trusted_stun_servers: default_trusted_stun_servers(),
+            outgoing_queue_limiter_capacity_bytes: None,
+            max_write_buffer_capacity_bytes: None,
             tier1: Tier1Config::default(),
             experimental: ExperimentalConfig::default(),
         }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -349,6 +349,7 @@ impl PeerActor {
             stream,
             stats.clone(),
             network_state.incoming_message_semaphore.clone(),
+            network_state.config.max_write_buffer_capacity_bytes,
         );
         let actor = Self {
             closing_reason: None,

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -448,7 +448,7 @@ impl PeerActor {
                 None => {
                     metrics::MessageDropped::OutgoingQueueLimitExceeded
                         .inc_msg_type(msg.msg_variant());
-                    tracing::debug!(
+                    tracing::warn!(
                         target: "network",
                         msg_type = msg.msg_variant(),
                         bytes_len,

--- a/chain/network/src/peer/stream.rs
+++ b/chain/network/src/peer/stream.rs
@@ -3,7 +3,7 @@ use crate::peer_manager::connection;
 use crate::recv_permit::RecvMessagePermit;
 use crate::stats::metrics;
 use crate::tcp;
-use bytesize::{GIB, MIB};
+use bytesize::MIB;
 use itertools::Itertools;
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{AsyncSender, Sender};
@@ -18,8 +18,6 @@ use tokio::sync::Semaphore;
 /// Maximum size of network message in encoded format.
 /// We encode length as `u32`, and therefore maximum size can't be larger than `u32::MAX`.
 const NETWORK_MESSAGE_MAX_SIZE_BYTES: usize = 512 * MIB as usize;
-/// Maximum capacity of write buffer in bytes.
-const MAX_WRITE_BUFFER_CAPACITY_BYTES: usize = GIB as usize;
 
 /// Timeout for individual write operations (write + flush) to detect if the connection is
 /// stuck due to a half-open TCP connection where the peer stopped ACKing writes.
@@ -116,6 +114,8 @@ pub(crate) struct FramedStream {
     send_buf_size_metric: Arc<metrics::IntGaugeGuard>,
     /// Sender to send the error to the PeerActor.
     error_sender: Sender<Error>,
+    /// Maximum capacity of the write buffer in bytes.
+    max_write_buffer_capacity_bytes: usize,
 }
 
 impl FramedStream {
@@ -126,6 +126,7 @@ impl FramedStream {
         stream: tcp::Stream,
         stats: Arc<connection::Stats>,
         incoming_message_semaphore: Arc<Semaphore>,
+        max_write_buffer_capacity_bytes: usize,
     ) -> Self {
         let (tcp_recv, tcp_send) = tokio::io::split(stream.stream);
         let (queue_send, queue_recv) = tokio::sync::mpsc::unbounded_channel();
@@ -163,7 +164,13 @@ impl FramedStream {
                 }
             }
         });
-        Self { queue_send, stats, send_buf_size_metric, error_sender }
+        Self {
+            queue_send,
+            stats,
+            send_buf_size_metric,
+            error_sender,
+            max_write_buffer_capacity_bytes,
+        }
     }
 
     /// Pushes `msg` to the send queue.
@@ -180,11 +187,11 @@ impl FramedStream {
         // Exceeding buffer capacity is a critical error and Actor should call ctx.stop()
         // when receiving one. It is not like we do any extra allocations, so we can afford
         // pushing the message to the queue anyway.
-        if buf_size > MAX_WRITE_BUFFER_CAPACITY_BYTES {
+        if buf_size > self.max_write_buffer_capacity_bytes {
             metrics::MessageDropped::MaxCapacityExceeded.inc_unknown_msg();
             self.error_sender.send(Error::Send(SendError::QueueOverflow {
                 got_bytes: buf_size,
-                want_max_bytes: MAX_WRITE_BUFFER_CAPACITY_BYTES,
+                want_max_bytes: self.max_write_buffer_capacity_bytes,
             }));
         }
         let _ = self.queue_send.send(frame);

--- a/chain/network/src/peer/tests/stream.rs
+++ b/chain/network/src/peer/tests/stream.rs
@@ -1,4 +1,5 @@
 use crate::auto_stop::AutoStopActor;
+use crate::config::DEFAULT_MAX_WRITE_BUFFER_CAPACITY_BYTES;
 use crate::network_protocol::testonly as data;
 use crate::peer::stream::{self, IncomingFrame};
 use crate::peer_manager::network_state::INCOMING_SEMAPHORE_PERMITS;
@@ -57,6 +58,7 @@ impl Actor {
             s,
             Arc::default(),
             Arc::new(Semaphore::new(INCOMING_SEMAPHORE_PERMITS)),
+            DEFAULT_MAX_WRITE_BUFFER_CAPACITY_BYTES,
         );
         let actor = Actor { handle: handle.clone(), stream: framed_stream, queue_send };
         builder.spawn_tokio_actor(actor);

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -91,9 +91,6 @@ pub(crate) const PENDING_TIER3_REQUEST_TIMEOUT: time::Duration = time::Duration:
 /// 1GB of incoming messages at the same time.
 pub(crate) const INCOMING_SEMAPHORE_PERMITS: usize = 1_000_000_000;
 
-/// Size of the semaphore which limits outgoing messages.
-pub(crate) const OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES: usize = 1024 * 1024 * 1024;
-
 /// Number of bytes reserved for the epoch sync response
 pub(crate) const EPOCH_SYNC_RESPONSE_BYTES: usize = 300 * 1024 * 1024;
 
@@ -349,7 +346,7 @@ impl NetworkState {
             txns_since_last_block: AtomicUsize::new(0),
             pending_tier3_requests: DashMap::new(),
             outgoing_queue_limiter: OutgoingQueueLimiter::new(
-                OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES,
+                config.outgoing_queue_limiter_capacity_bytes,
             ),
             whitelist_nodes,
             set_chain_info_mutex: Mutex::new(()),

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1273,7 +1273,7 @@ impl NetworkState {
                 } else {
                     metrics::MessageDropped::OutgoingQueueLimitExceeded
                         .inc_msg_type("EpochSyncResponse");
-                    tracing::debug!(
+                    tracing::warn!(
                         target: "network",
                         %peer_id,
                         "outgoing queue saturated; dropping epoch sync request",

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1577,7 +1577,7 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                 let (tier2_ack, maybe_tier3_response) = match request.body {
                     Tier3RequestBody::StateHeader(StateHeaderRequestBody { shard_id, sync_hash }) => {
                         let (ack, response) = if response_permit.is_none() {
-                            tracing::debug!(target: "network", ?request, "outgoing queue saturated; dropping state header response");
+                            tracing::warn!(target: "network", ?request, "outgoing queue saturated; dropping state header response");
                             metrics::MessageDropped::OutgoingQueueLimitExceeded
                                 .inc_msg_type("VersionedStateResponse");
                             (StateRequestAckBody::Busy, None)
@@ -1609,7 +1609,7 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                     }
                     Tier3RequestBody::StatePart(StatePartRequestBody { shard_id, sync_hash, part_id }) => {
                         let (ack, response) = if response_permit.is_none() {
-                            tracing::debug!(target: "network", ?request, "outgoing queue saturated; dropping state part response");
+                            tracing::warn!(target: "network", ?request, "outgoing queue saturated; dropping state part response");
                             metrics::MessageDropped::OutgoingQueueLimitExceeded
                                 .inc_msg_type("VersionedStateResponse");
                             (StateRequestAckBody::Busy, None)


### PR DESCRIPTION
Adjust network limits:

* size of a single outgoing buffer: 700 MiB (once reached, drops connection)
* total size of all outgoing buffers: 3 GiB (once reached, waits for the messages to be sent)

Improves network stability.

Refs: https://near.zulipchat.com/#narrow/channel/469556-community-support/topic/peer.20drops/with/613379991