### PR TITLE
feat(dynamic-resharding): allow dynamic shard layout in genesis

### DIFF
--- a/chain/epoch-manager/src/genesis.rs
+++ b/chain/epoch-manager/src/genesis.rs
@@ -61,12 +61,6 @@ impl EpochManager {
             }
             Ok(genesis_epoch_info)
         } else {
-            let shard_layout = genesis_epoch_config.static_shard_layout().ok_or_else(|| {
-                EpochError::ShardingError(format!(
-                    "static shard layout expected for genesis. genesis_protocol_version={}",
-                    genesis_protocol_version
-                ))
-            })?;
             proposals_to_epoch_info(
                 &genesis_epoch_config,
                 [0; 32],
@@ -76,7 +70,7 @@ impl EpochManager {
                 validator_reward,
                 Balance::ZERO,
                 genesis_protocol_version,
-                shard_layout,
+                self.config.genesis_shard_layout(),
                 &AssignmentStrategy::Fresh,
                 None,
             )

--- a/chain/epoch-manager/src/genesis.rs
+++ b/chain/epoch-manager/src/genesis.rs
@@ -10,7 +10,7 @@ use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{AccountId, Balance, EpochId, NumSeats, ValidatorId};
-use near_primitives::version::PROD_GENESIS_PROTOCOL_VERSION;
+use near_primitives::version::{PROD_GENESIS_PROTOCOL_VERSION, ProtocolFeature};
 use rand::{RngCore, SeedableRng};
 use rand_hc::Hc128Rng;
 use std::collections::HashMap;
@@ -61,6 +61,18 @@ impl EpochManager {
             }
             Ok(genesis_epoch_info)
         } else {
+            // `proposals_to_epoch_info` only records the shard layout once dynamic resharding is
+            // enabled; before that it drops the layout it is handed and the epoch config stays
+            // authoritative. Falling back to the genesis-declared layout would therefore be
+            // silently ignored, so require the epoch config to carry one.
+            if !ProtocolFeature::DynamicResharding.enabled(genesis_protocol_version)
+                && genesis_epoch_config.static_shard_layout().is_none()
+            {
+                return Err(EpochError::ShardingError(format!(
+                    "static shard layout expected for genesis when dynamic resharding is \
+                     disabled. genesis_protocol_version={genesis_protocol_version}"
+                )));
+            }
             proposals_to_epoch_info(
                 &genesis_epoch_config,
                 [0; 32],

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -557,6 +557,7 @@ impl EpochManager {
             epoch_length,
             epoch_config_store,
             genesis_config.protocol_version,
+            genesis_config.shard_layout.clone(),
         );
         Arc::new(
             Self::new(store, all_epoch_config, reward_calculator, genesis_config.validators())

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -370,6 +370,7 @@ impl EpochManager {
             epoch_length,
             epoch_config_store,
             genesis_config.protocol_version,
+            genesis_config.shard_layout.clone(),
         );
         Arc::new(
             Self::new(store, all_epoch_config, reward_calculator, genesis_config.validators())

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -141,6 +141,7 @@ pub fn epoch_config(
     chunk_validator_only_kickout_threshold: u8,
     max_inflation_rate: Rational32,
 ) -> AllEpochConfig {
+    let shard_layout = ShardLayout::multi_shard(num_shards, 0);
     let epoch_config = EpochConfigBuilder::default()
         .epoch_length(epoch_length)
         .num_block_producer_seats(num_block_producer_seats)
@@ -159,7 +160,7 @@ pub fn epoch_config(
         .minimum_stake_ratio(Ratio::new(160i32, 1_000_000i32))
         .chunk_producer_assignment_changes_limit(5)
         .shuffle_shard_assignment_for_chunk_producers(false)
-        .shard_layout(ShardLayout::multi_shard(num_shards, 0))
+        .shard_layout(shard_layout.clone())
         .validator_max_kickout_stake_perc(100)
         .max_inflation_rate(max_inflation_rate)
         .build()
@@ -170,6 +171,7 @@ pub fn epoch_config(
         epoch_length,
         config_store,
         PROTOCOL_VERSION,
+        shard_layout,
     )
 }
 

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -165,6 +165,7 @@ pub fn epoch_config_at_version(
     max_inflation_rate: Rational32,
     protocol_version: ProtocolVersion,
 ) -> AllEpochConfig {
+    let shard_layout = ShardLayout::multi_shard(num_shards, 0);
     let epoch_config = EpochConfigBuilder::default()
         .epoch_length(epoch_length)
         .num_block_producer_seats(num_block_producer_seats)
@@ -183,7 +184,7 @@ pub fn epoch_config_at_version(
         .minimum_stake_ratio(Ratio::new(160i32, 1_000_000i32))
         .chunk_producer_assignment_changes_limit(5)
         .shuffle_shard_assignment_for_chunk_producers(false)
-        .shard_layout(ShardLayout::multi_shard(num_shards, 0))
+        .shard_layout(shard_layout.clone())
         .validator_max_kickout_stake_perc(100)
         .max_inflation_rate(max_inflation_rate)
         .build()
@@ -194,6 +195,7 @@ pub fn epoch_config_at_version(
         epoch_length,
         config_store,
         protocol_version,
+        shard_layout,
     )
 }
 

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2190,6 +2190,7 @@ fn test_protocol_version_switch() {
     let epoch_config = epoch_config(2, 1, 2, 100, 90, 60, 0, Rational32::new(1, 40))
         .for_protocol_version(PROTOCOL_VERSION);
     let genesis_protocol_version = 0;
+    let genesis_shard_layout = epoch_config.static_shard_layout().unwrap();
     let config_store = EpochConfigStore::test(BTreeMap::from_iter(vec![
         (genesis_protocol_version, Arc::new(epoch_config.clone())),
         (PROTOCOL_VERSION, Arc::new(epoch_config)),
@@ -2199,6 +2200,7 @@ fn test_protocol_version_switch() {
         2,
         config_store,
         genesis_protocol_version,
+        genesis_shard_layout,
     );
 
     let amount_staked = Balance::from_yoctonear(1_000_000);
@@ -2232,6 +2234,7 @@ fn test_protocol_version_switch_with_shard_layout_change() {
     let new_epoch_config = epoch_config(2, 4, 2, 100, 90, 60, 0, Rational32::new(1, 40))
         .for_protocol_version(PROTOCOL_VERSION);
     let genesis_protocol_version = PROTOCOL_VERSION - 1;
+    let genesis_shard_layout = old_epoch_config.static_shard_layout().unwrap();
     let config_store = EpochConfigStore::test(BTreeMap::from_iter(vec![
         (genesis_protocol_version, Arc::new(old_epoch_config)),
         (PROTOCOL_VERSION, Arc::new(new_epoch_config)),
@@ -2241,6 +2244,7 @@ fn test_protocol_version_switch_with_shard_layout_change() {
         2,
         config_store,
         genesis_protocol_version,
+        genesis_shard_layout,
     );
 
     let amount_staked = Balance::from_yoctonear(1_000_000);
@@ -2289,12 +2293,16 @@ fn test_protocol_version_switch_with_many_seats() {
         stake("test2".parse().unwrap(), amount_staked.checked_div(5).unwrap()),
     ];
 
-    let config_store = EpochConfigStore::test_single_version(
+    let epoch_config = TestEpochConfigBuilder::new().epoch_length(10).build();
+    let genesis_shard_layout = epoch_config.static_shard_layout().unwrap();
+    let config_store = EpochConfigStore::test_single_version(PROTOCOL_VERSION, epoch_config);
+    let config = AllEpochConfig::from_epoch_config_store(
+        "test-chain",
+        10,
+        config_store,
         PROTOCOL_VERSION,
-        TestEpochConfigBuilder::new().epoch_length(10).build(),
+        genesis_shard_layout,
     );
-    let config =
-        AllEpochConfig::from_epoch_config_store("test-chain", 10, config_store, PROTOCOL_VERSION);
 
     let mut epoch_manager =
         EpochManager::new(store, config, default_reward_calculator(), validators).unwrap();
@@ -2322,12 +2330,18 @@ fn test_version_switch_kickout_old_version() {
     let epoch_length = 2;
     let epoch_config = epoch_config(epoch_length, 1, 2, 100, 90, 60, 0, Rational32::new(0, 1))
         .for_protocol_version(version);
+    let genesis_shard_layout = epoch_config.static_shard_layout().unwrap();
     let config_store = EpochConfigStore::test(BTreeMap::from_iter(vec![
         (version, Arc::new(epoch_config.clone())),
         (new_version, Arc::new(epoch_config)),
     ]));
-    let config =
-        AllEpochConfig::from_epoch_config_store("test-chain", 2, config_store, PROTOCOL_VERSION);
+    let config = AllEpochConfig::from_epoch_config_store(
+        "test-chain",
+        2,
+        config_store,
+        PROTOCOL_VERSION,
+        genesis_shard_layout,
+    );
 
     let (large_stake, small_stake) = (Balance::from_yoctonear(1_000), Balance::from_yoctonear(100));
     let validators = vec![

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2189,6 +2189,7 @@ fn test_protocol_version_switch() {
     let epoch_config = epoch_config(2, 1, 2, 100, 90, 60, 0, Rational32::new(1, 40))
         .for_protocol_version(PROTOCOL_VERSION);
     let genesis_protocol_version = 0;
+    let genesis_shard_layout = epoch_config.static_shard_layout().unwrap();
     let config_store = EpochConfigStore::test(BTreeMap::from_iter(vec![
         (genesis_protocol_version, Arc::new(epoch_config.clone())),
         (PROTOCOL_VERSION, Arc::new(epoch_config)),
@@ -2198,6 +2199,7 @@ fn test_protocol_version_switch() {
         2,
         config_store,
         genesis_protocol_version,
+        genesis_shard_layout,
     );
 
     let amount_staked = Balance::from_yoctonear(1_000_000);
@@ -2231,6 +2233,7 @@ fn test_protocol_version_switch_with_shard_layout_change() {
     let new_epoch_config = epoch_config(2, 4, 2, 100, 90, 60, 0, Rational32::new(1, 40))
         .for_protocol_version(PROTOCOL_VERSION);
     let genesis_protocol_version = PROTOCOL_VERSION - 1;
+    let genesis_shard_layout = old_epoch_config.static_shard_layout().unwrap();
     let config_store = EpochConfigStore::test(BTreeMap::from_iter(vec![
         (genesis_protocol_version, Arc::new(old_epoch_config)),
         (PROTOCOL_VERSION, Arc::new(new_epoch_config)),
@@ -2240,6 +2243,7 @@ fn test_protocol_version_switch_with_shard_layout_change() {
         2,
         config_store,
         genesis_protocol_version,
+        genesis_shard_layout,
     );
 
     let amount_staked = Balance::from_yoctonear(1_000_000);
@@ -2288,12 +2292,16 @@ fn test_protocol_version_switch_with_many_seats() {
         stake("test2".parse().unwrap(), amount_staked.checked_div(5).unwrap()),
     ];
 
-    let config_store = EpochConfigStore::test_single_version(
+    let epoch_config = TestEpochConfigBuilder::new().epoch_length(10).build();
+    let genesis_shard_layout = epoch_config.static_shard_layout().unwrap();
+    let config_store = EpochConfigStore::test_single_version(PROTOCOL_VERSION, epoch_config);
+    let config = AllEpochConfig::from_epoch_config_store(
+        "test-chain",
+        10,
+        config_store,
         PROTOCOL_VERSION,
-        TestEpochConfigBuilder::new().epoch_length(10).build(),
+        genesis_shard_layout,
     );
-    let config =
-        AllEpochConfig::from_epoch_config_store("test-chain", 10, config_store, PROTOCOL_VERSION);
 
     let mut epoch_manager =
         EpochManager::new(store, config, default_reward_calculator(), validators).unwrap();
@@ -2321,12 +2329,18 @@ fn test_version_switch_kickout_old_version() {
     let epoch_length = 2;
     let epoch_config = epoch_config(epoch_length, 1, 2, 100, 90, 60, 0, Rational32::new(0, 1))
         .for_protocol_version(version);
+    let genesis_shard_layout = epoch_config.static_shard_layout().unwrap();
     let config_store = EpochConfigStore::test(BTreeMap::from_iter(vec![
         (version, Arc::new(epoch_config.clone())),
         (new_version, Arc::new(epoch_config)),
     ]));
-    let config =
-        AllEpochConfig::from_epoch_config_store("test-chain", 2, config_store, PROTOCOL_VERSION);
+    let config = AllEpochConfig::from_epoch_config_store(
+        "test-chain",
+        2,
+        config_store,
+        PROTOCOL_VERSION,
+        genesis_shard_layout,
+    );
 
     let (large_stake, small_stake) = (Balance::from_yoctonear(1_000), Balance::from_yoctonear(100));
     let validators = vec![

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -318,6 +318,8 @@ pub struct AllEpochConfig {
     chain_id: String,
     epoch_length: BlockHeightDelta,
     genesis_protocol_version: ProtocolVersion,
+    /// Shard layout of the genesis epoch, as declared in the genesis config.
+    genesis_shard_layout: ShardLayout,
 }
 
 impl AllEpochConfig {
@@ -326,12 +328,14 @@ impl AllEpochConfig {
         epoch_length: BlockHeightDelta,
         config_store: EpochConfigStore,
         genesis_protocol_version: ProtocolVersion,
+        genesis_shard_layout: ShardLayout,
     ) -> Self {
         Self {
             config_store,
             chain_id: chain_id.to_string(),
             epoch_length,
             genesis_protocol_version,
+            genesis_shard_layout,
         }
     }
 
@@ -350,6 +354,18 @@ impl AllEpochConfig {
 
     pub fn genesis_protocol_version(&self) -> ProtocolVersion {
         self.genesis_protocol_version
+    }
+
+    /// Shard layout of the genesis epoch.
+    ///
+    /// For a genesis protocol version with a static shard layout the layout from the epoch config
+    /// is authoritative. Once dynamic resharding is enabled the epoch config no longer defines a
+    /// layout, so the layout declared in the genesis config is used instead.
+    pub fn genesis_shard_layout(&self) -> ShardLayout {
+        self.config_store
+            .get_config(self.genesis_protocol_version)
+            .static_shard_layout()
+            .unwrap_or_else(|| self.genesis_shard_layout.clone())
     }
 }
 

--- a/core/store/src/genesis/initialization.rs
+++ b/core/store/src/genesis/initialization.rs
@@ -34,7 +34,7 @@ pub fn initialize_sharded_genesis_state(
 ) {
     let shard_layout = genesis_epoch_config
         .static_shard_layout()
-        .expect("genesis config must have static shard layout");
+        .unwrap_or_else(|| genesis.config.shard_layout.clone());
     let state_roots = if let Some(state_roots) = get_genesis_state_roots(&store) {
         // TODO: with 2.6 release, remove storing genesis height
         let mut store_update: crate::StoreUpdate = store.store_update();

--- a/core/store/src/genesis/initialization.rs
+++ b/core/store/src/genesis/initialization.rs
@@ -29,13 +29,14 @@ const GENESIS_ROOTS_FILE: &str = "genesis_roots";
 pub fn initialize_sharded_genesis_state(
     store: Store,
     genesis: &Genesis,
-    genesis_epoch_config: &EpochConfig,
+    // The layout genesis state is built under. Callers that have an EpochManager must pass the
+    // layout recorded in the genesis EpochInfo, so the two cannot disagree; `initialize_genesis_state`
+    // resolves it the same way the EpochManager would.
+    shard_layout: &ShardLayout,
     home_dir: Option<&Path>,
 ) {
-    let shard_layout = genesis_epoch_config
-        .static_shard_layout()
-        .unwrap_or_else(|| genesis.config.shard_layout.clone());
     let state_roots = if let Some(state_roots) = get_genesis_state_roots(&store) {
+        check_state_roots_match_layout(&state_roots, shard_layout, "already stored");
         // TODO: with 2.6 release, remove storing genesis height
         let mut store_update: crate::StoreUpdate = store.store_update();
         set_genesis_height(&mut store_update, &genesis.config.genesis_height);
@@ -50,14 +51,18 @@ pub fn initialize_sharded_genesis_state(
         state_roots
     } else {
         let has_dump = home_dir.is_some_and(|dir| dir.join(STATE_DUMP_FILE).exists());
-        let state_roots = if has_dump {
+        let (state_roots, source) = if has_dump {
             if let GenesisContents::Records { .. } = &genesis.contents {
                 tracing::warn!(target: "store", "found both records in genesis config and the state dump file, will ignore the records");
             }
-            genesis_state_from_dump(store.clone(), home_dir.unwrap())
+            (genesis_state_from_dump(store.clone(), home_dir.unwrap()), "from the state dump")
         } else {
-            genesis_state_from_genesis(store.clone(), genesis, &shard_layout)
+            (genesis_state_from_genesis(store.clone(), genesis, shard_layout), "in genesis")
         };
+        // Before committing, not after: the genesis EpochInfo has already been written by the
+        // EpochManager by the time we get here, so failing after `set_genesis_state_roots` would
+        // leave a half-initialized DB that is never re-derived on restart and can only be wiped.
+        check_state_roots_match_layout(&state_roots, shard_layout, source);
         let mut store_update = store.store_update();
         set_genesis_state_roots(&mut store_update, &state_roots);
         set_genesis_height(&mut store_update, &genesis.config.genesis_height);
@@ -75,8 +80,37 @@ pub fn initialize_sharded_genesis_state(
     }
 }
 
+/// The shard layout and the genesis state roots have to agree on how many shards there are.
+///
+/// This is a real cross-check only where the roots do not come from the layout: state roots given
+/// directly in genesis, or loaded from a state dump. When they are computed from records they are
+/// derived per shard uid and the counts agree by construction.
+///
+/// It is worth checking on every path regardless, because `genesis_chunks` silently replicates a
+/// single root across every shard when the counts disagree, which yields a chain that starts and
+/// is wrong rather than one that refuses to start.
+fn check_state_roots_match_layout(
+    state_roots: &[StateRoot],
+    shard_layout: &ShardLayout,
+    source: &str,
+) {
+    assert_eq!(
+        state_roots.len(),
+        shard_layout.num_shards() as usize,
+        "genesis state has {} state roots ({source}) but the genesis shard layout has {} shards. \
+         If the epoch config for the genesis protocol version declares no static shard layout, \
+         genesis.config.shard_layout must describe the state - note it defaults to a single shard \
+         when the field is omitted.",
+        state_roots.len(),
+        shard_layout.num_shards(),
+    );
+}
+
 pub fn initialize_genesis_state(store: Store, genesis: &Genesis, home_dir: Option<&Path>) {
-    initialize_sharded_genesis_state(store, genesis, &EpochConfig::from(&genesis.config), home_dir);
+    let epoch_config = EpochConfig::from(&genesis.config);
+    let shard_layout =
+        epoch_config.static_shard_layout().unwrap_or_else(|| genesis.config.shard_layout.clone());
+    initialize_sharded_genesis_state(store, genesis, &shard_layout, home_dir);
 }
 
 fn genesis_state_from_dump(store: Store, home_dir: &Path) -> Vec<StateRoot> {
@@ -180,4 +214,86 @@ fn genesis_state_from_genesis(
             )
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::initialize_sharded_genesis_state;
+    use crate::genesis::initialization::get_genesis_state_roots;
+    use crate::test_utils::create_test_store;
+    use near_chain_configs::{Genesis, GenesisConfig, GenesisContents};
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::shard_layout::ShardLayout;
+
+    /// Genesis whose state roots are given directly, so they are independent of the shard layout
+    /// and the two can actually disagree. This is the shape a forknet image uses.
+    fn genesis_with_state_roots(num_roots: usize) -> Genesis {
+        let mut config = GenesisConfig::default();
+        config.chain_id = "test-dynamic-genesis".to_string();
+        config.genesis_height = 1;
+        Genesis {
+            config,
+            contents: GenesisContents::StateRoots {
+                state_roots: (0..num_roots).map(|i| CryptoHash::hash_bytes(&[i as u8])).collect(),
+            },
+        }
+    }
+
+    /// A layout the epoch config does not declare - it can only have come from genesis - is
+    /// accepted when it describes the state that is actually there.
+    #[test]
+    fn genesis_shard_layout_matching_state_roots_is_accepted() {
+        let shard_layout = ShardLayout::multi_shard(4, 3);
+        let genesis = genesis_with_state_roots(shard_layout.num_shards() as usize);
+        let store = create_test_store();
+
+        initialize_sharded_genesis_state(store.clone(), &genesis, &shard_layout, None);
+
+        let roots = get_genesis_state_roots(&store).unwrap();
+        assert_eq!(roots.len(), shard_layout.num_shards() as usize);
+    }
+
+    /// The case the check exists for: `genesis.config.shard_layout` is `#[serde(default)]`, so a
+    /// genesis file that omits it silently claims a single shard. Against real multi-shard state
+    /// that must fail loudly rather than start a wrong chain.
+    #[test]
+    #[should_panic(expected = "state roots")]
+    fn defaulted_single_shard_layout_against_multi_shard_state_is_rejected() {
+        let genesis = genesis_with_state_roots(4);
+        let store = create_test_store();
+
+        initialize_sharded_genesis_state(store, &genesis, &ShardLayout::single_shard(), None);
+    }
+
+    /// Nothing is written when validation fails, so a corrected config works on the next attempt
+    /// instead of needing the DB wiped.
+    #[test]
+    fn nothing_is_committed_when_validation_fails() {
+        let genesis = genesis_with_state_roots(4);
+        let store = create_test_store();
+
+        // AssertUnwindSafe: the store is only read after the unwind, to check nothing landed.
+        let bad = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            initialize_sharded_genesis_state(
+                store.clone(),
+                &genesis,
+                &ShardLayout::single_shard(),
+                None,
+            )
+        }));
+        assert!(bad.is_err(), "mismatched layout should have been rejected");
+        assert!(
+            get_genesis_state_roots(&store).is_none(),
+            "genesis state roots must not be committed when the layout does not match"
+        );
+
+        // Same store, corrected layout: succeeds without any manual cleanup.
+        initialize_sharded_genesis_state(
+            store.clone(),
+            &genesis,
+            &ShardLayout::multi_shard(4, 3),
+            None,
+        );
+        assert_eq!(get_genesis_state_roots(&store).unwrap().len(), 4);
+    }
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -413,14 +413,17 @@ pub async fn start_with_config_and_synchronization_impl(
     );
 
     let epoch_id = EpochId::default();
-    let genesis_epoch_config = epoch_manager.get_epoch_config(&epoch_id)?;
+    // Take the layout from the genesis EpochInfo the EpochManager just wrote rather than
+    // re-deriving it, so genesis state can never be built under a different layout than the
+    // one the epoch manager recorded.
+    let genesis_shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
     // Initialize genesis_state in store either from genesis config or dump before other components.
     // We only initialize if the genesis state is not already initialized in store.
     // This sets up genesis_state_roots and genesis_hash in store.
     initialize_sharded_genesis_state(
         storage.get_hot_store(),
         &config.genesis,
-        &genesis_epoch_config,
+        &genesis_shard_layout,
         Some(home_dir),
     );
 

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -706,6 +706,7 @@ impl ForkNetworkCommand {
             original_genesis_config,
             genesis_file,
             epoch_config,
+            target_shard_layout,
             new_state_roots,
             new_validator_accounts,
         )
@@ -788,7 +789,12 @@ impl ForkNetworkCommand {
         let genesis_protocol_version = genesis.config.protocol_version;
         genesis.config.epoch_length = epoch_length;
         genesis.config.chain_id.clone_from(chain_id);
-        initialize_sharded_genesis_state(store.clone(), &genesis, &epoch_config, Some(home_dir));
+        initialize_sharded_genesis_state(
+            store.clone(),
+            &genesis,
+            target_shard_layout,
+            Some(home_dir),
+        );
         genesis.to_file(home_dir.join(&near_config.config.genesis_file));
         near_config.genesis = genesis.clone();
 
@@ -849,6 +855,7 @@ impl ForkNetworkCommand {
             genesis.config,
             near_config.config.genesis_file.clone(),
             epoch_config,
+            target_shard_layout.clone(),
             state_roots.clone(),
             validators,
         )?;
@@ -1010,11 +1017,20 @@ impl ForkNetworkCommand {
                 config.num_chunk_validator_seats = *num_seats;
             }
             if let Some(shard_layout) = shard_layout_override {
-                // fork-network writes a static-layout genesis, so apply the requested shard
-                // layout whether the base (mainnet) config is static or dynamic. The base is
-                // dynamic since resharding stabilized; otherwise make_and_write_genesis fails.
-                config.shard_layout_config =
-                    ShardLayoutConfig::Static { shard_layout: shard_layout.clone() };
+                // Only pin versions that already had a static layout. Once dynamic resharding is
+                // enabled the layout comes from EpochInfo, and forcing it static here would
+                // disable resharding on the fork -- which is one of the things a fork exists to
+                // exercise.
+                if config.shard_layout_config.static_shard_layout().is_some() {
+                    config.shard_layout_config =
+                        ShardLayoutConfig::Static { shard_layout: shard_layout.clone() };
+                } else {
+                    tracing::warn!(
+                        target: "near", version,
+                        "shard layout override ignored: this protocol version uses dynamic \
+                         resharding, so the layout is determined per-epoch rather than by config"
+                    );
+                }
             }
             new_epoch_configs.insert(version, Arc::new(config));
         }
@@ -1707,12 +1723,12 @@ impl ForkNetworkCommand {
         original_config: GenesisConfig,
         genesis_file: String,
         epoch_config: EpochConfig,
+        // The layout the fork was built with. Passed in rather than read back out of
+        // `epoch_config`, which has no static layout once dynamic resharding is enabled.
+        shard_layout: ShardLayout,
         new_state_roots: Vec<StateRoot>,
         new_validator_accounts: Vec<AccountInfo>,
     ) -> anyhow::Result<()> {
-        let shard_layout = epoch_config
-            .static_shard_layout()
-            .context("dynamic resharding epoch config is not supported")?;
         let new_config = GenesisConfig {
             chain_id: original_config.chain_id,
             genesis_height: original_config.genesis_height,


### PR DESCRIPTION
Currently the code expects genesis to have a static shard layout. This causes trouble on forknets which start from the latest mainnet state, which has a dynamic shard layout. Let's allow having a genesis with dynamic shard layout.