### PR TITLE
feat(debug-ui): change landing page

### DIFF
--- a/tools/debug-ui/src/index.tsx
+++ b/tools/debug-ui/src/index.tsx
@@ -34,7 +34,7 @@ const router = createBrowserRouter([
         children: [
             {
                 index: true,
-                element: <Navigate to="cluster" />,
+                element: <Navigate to="epoch_info" />,
             },
             {
                 path: '*',


### PR DESCRIPTION
Currently the default page for debug ui is `/cluster`. This is a heavy page - it opens connections to tens/hundreds of nodes to get their status. This could cause some issues with debug-ui, when I was looking into the source of instability, Claude said that this could be a problem.

Let's change the landing page to something more lightweight, like recent epoch page. This does one quick request to get recent epoch ids.

This will limit the number of connections, potentially improving performance. Debug-ui api-proxy is hosted on Google CloudFront, which might have rate limits etc. The less connections going through it the better.