### PR TITLE
fix(debug): clamp block_status starting_height to the header head

### DIFF
--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -236,9 +236,9 @@ fn find_first_height_to_fetch(
     }
 
     let min_height_to_search = max(
-        height_to_fetch as i64 - DEBUG_MAX_BLOCKS_TO_SEARCH as i64,
-        chain_store.get_genesis_height() as i64,
-    ) as u64;
+        height_to_fetch.saturating_sub(DEBUG_MAX_BLOCKS_TO_SEARCH),
+        chain_store.get_genesis_height(),
+    );
     while height_to_fetch > min_height_to_search {
         let block_hashes = get_block_hashes_to_fetch(chain_store, height_to_fetch, final_height);
         if block_hashes.is_empty() {
@@ -560,13 +560,12 @@ impl ClientActor {
         let initial_gas_price = self.client.chain.genesis_block().header().next_gas_price();
 
         let chain_store = self.client.chain.chain_store();
-        let mut height_to_fetch = starting_height.unwrap_or(header_head.height);
+        let mut height_to_fetch =
+            min(starting_height.unwrap_or(header_head.height), header_head.height);
         height_to_fetch =
             find_first_height_to_fetch(chain_store, height_to_fetch, mode, final_head.height)?;
-        let min_height_to_fetch = max(
-            height_to_fetch as i64 - num_blocks as i64,
-            chain_store.get_genesis_height() as i64,
-        ) as u64;
+        let min_height_to_fetch =
+            max(height_to_fetch.saturating_sub(num_blocks), chain_store.get_genesis_height());
 
         let mut block_hashes_to_force_fetch = HashSet::new();
         while height_to_fetch > min_height_to_fetch || !block_hashes_to_force_fetch.is_empty() {

--- a/test-loop-tests/src/tests/debug_block_status.rs
+++ b/test-loop-tests/src/tests/debug_block_status.rs
@@ -17,7 +17,13 @@ fn test_debug_block_status_clamps_starting_height_to_header_head() {
     let client_actor = env.test_loop.data.get_mut(&handle);
 
     // Boundary values of the u64 range, not just a height one past the head.
-    for starting_height in [header_head + 1, 1 << 63, u64::MAX] {
+    // Genesis height reports nothing, since the range below it is empty.
+    for (starting_height, expected_heights) in [
+        (header_head + 1, vec![header_head]),
+        (1 << 63, vec![header_head]),
+        (u64::MAX, vec![header_head]),
+        (0, vec![]),
+    ] {
         let query = DebugBlockStatusQuery {
             starting_height: Some(starting_height),
             mode: DebugBlocksStartingMode::All,
@@ -34,6 +40,6 @@ fn test_debug_block_status_clamps_starting_height_to_header_head() {
             .map(|block| block.block_height)
             .chain(data.missed_heights.iter().map(|missed| missed.block_height))
             .collect::<Vec<_>>();
-        assert_eq!(heights, vec![header_head], "starting_height {starting_height}");
+        assert_eq!(heights, expected_heights, "starting_height {starting_height}");
     }
 }

--- a/test-loop-tests/src/tests/debug_block_status.rs
+++ b/test-loop-tests/src/tests/debug_block_status.rs
@@ -1,0 +1,39 @@
+use crate::setup::builder::TestLoopBuilder;
+use near_async::messaging::Handler;
+use near_client_primitives::debug::{
+    DebugBlockStatusQuery, DebugBlocksStartingMode, DebugStatus, DebugStatusResponse,
+};
+use near_o11y::testonly::init_test_logger;
+
+#[test]
+fn test_debug_block_status_clamps_starting_height_to_header_head() {
+    init_test_logger();
+
+    let mut env = TestLoopBuilder::new().epoch_length(5).build();
+    env.node_runner(0).run_until_new_epoch();
+    let header_head = env.node(0).client().chain.header_head().unwrap().height;
+
+    let handle = env.node_datas[0].client_sender.actor_handle();
+    let client_actor = env.test_loop.data.get_mut(&handle);
+
+    // Boundary values of the u64 range, not just a height one past the head.
+    for starting_height in [header_head + 1, 1 << 63, u64::MAX] {
+        let query = DebugBlockStatusQuery {
+            starting_height: Some(starting_height),
+            mode: DebugBlocksStartingMode::All,
+            num_blocks: 1,
+        };
+        let DebugStatusResponse::BlockStatus(data) =
+            client_actor.handle(DebugStatus::BlockStatus(query)).unwrap()
+        else {
+            panic!("expected BlockStatus response");
+        };
+        let heights = data
+            .blocks
+            .iter()
+            .map(|block| block.block_height)
+            .chain(data.missed_heights.iter().map(|missed| missed.block_height))
+            .collect::<Vec<_>>();
+        assert_eq!(heights, vec![header_head], "starting_height {starting_height}");
+    }
+}

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -21,6 +21,7 @@ mod contract_distribution_cross_shard;
 mod contract_distribution_simple;
 mod create_delete_account;
 mod cross_shard_tx;
+mod debug_block_status;
 mod debug_epoch_info;
 mod deploy_compute_cost;
 mod deterministic_account_id;


### PR DESCRIPTION
`block_status` uses the caller's `starting_height` as given, so a request above the header head reports missed heights that do not exist. Clamp it to `header_head.height`, and compute the two range floors with `saturating_sub` instead of `i64` casts. Adds `test-loop-tests/src/tests/debug_block_status.rs`.