### PR TITLE
fix(debug): report entity queries for columns not in cold storage

### DIFF
--- a/core/store/src/db/cold_column_checked.rs
+++ b/core/store/src/db/cold_column_checked.rs
@@ -1,0 +1,161 @@
+use crate::db::{DBIterator, DBSlice, DBTransaction, Database, StoreStatistics};
+use crate::{DBCol, Store, deserialized_column};
+use std::sync::{Arc, OnceLock};
+
+/// Reads a cold database for a caller whose column is not known statically, such as the
+/// entity debug endpoint where the column follows from a request field.
+///
+/// Cold storage holds only the columns `DBCol::is_in_colddb` admits, so a read of any other
+/// column can never return data. [`crate::db::ColdDB`] expects its callers to pick such a
+/// column in code and does not serve those reads. This wrapper instead records the column and
+/// reports it absent, leaving the caller to turn [`Self::rejected_column`] into an error.
+pub struct ColumnCheckedColdDB {
+    cold: Store,
+    rejected: OnceLock<DBCol>,
+}
+
+impl ColumnCheckedColdDB {
+    pub fn new(cold: Store) -> Arc<Self> {
+        Arc::new(Self { cold, rejected: OnceLock::new() })
+    }
+
+    /// The first column asked for that cold storage never holds.
+    pub fn rejected_column(&self) -> Option<DBCol> {
+        self.rejected.get().copied()
+    }
+
+    fn is_readable(&self, col: DBCol) -> bool {
+        if col.is_in_colddb() {
+            return true;
+        }
+        self.rejected.get_or_init(|| col);
+        false
+    }
+
+    fn cold(&self) -> &dyn Database {
+        self.cold.database()
+    }
+}
+
+impl Database for ColumnCheckedColdDB {
+    fn get_raw_bytes(&self, col: DBCol, key: &[u8]) -> Option<DBSlice<'_>> {
+        if !self.is_readable(col) {
+            return None;
+        }
+        self.cold().get_raw_bytes(col, key)
+    }
+
+    fn get_with_rc_stripped(&self, col: DBCol, key: &[u8]) -> Option<DBSlice<'_>> {
+        if !self.is_readable(col) {
+            return None;
+        }
+        self.cold().get_with_rc_stripped(col, key)
+    }
+
+    fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+        if !self.is_readable(col) {
+            return Box::new(std::iter::empty());
+        }
+        self.cold().iter(col)
+    }
+
+    fn iter_prefix<'a>(&'a self, col: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a> {
+        if !self.is_readable(col) {
+            return Box::new(std::iter::empty());
+        }
+        self.cold().iter_prefix(col, key_prefix)
+    }
+
+    fn iter_range<'a>(
+        &'a self,
+        col: DBCol,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
+    ) -> DBIterator<'a> {
+        if !self.is_readable(col) {
+            return Box::new(std::iter::empty());
+        }
+        self.cold().iter_range(col, lower_bound, upper_bound)
+    }
+
+    fn iter_raw_bytes<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+        if !self.is_readable(col) {
+            return Box::new(std::iter::empty());
+        }
+        self.cold().iter_raw_bytes(col)
+    }
+
+    fn write(&self, batch: DBTransaction) {
+        self.cold().write(batch)
+    }
+
+    fn flush(&self) {
+        self.cold().flush()
+    }
+
+    fn compact(&self) {
+        self.cold().compact()
+    }
+
+    fn get_store_statistics(&self) -> Option<StoreStatistics> {
+        self.cold().get_store_statistics()
+    }
+
+    fn create_checkpoint(
+        &self,
+        path: &std::path::Path,
+        columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
+        self.cold().create_checkpoint(path, columns_to_keep)
+    }
+
+    fn deserialized_column_cache(&self) -> Arc<deserialized_column::Cache> {
+        self.cold().deserialized_column_cache()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnCheckedColdDB;
+    use crate::DBCol;
+    use crate::Store;
+    use crate::db::metadata::{DB_VERSION, DbKind};
+    use crate::db::{DBTransaction, Database, TestDB};
+    use crate::test_utils::create_test_node_storage_with_cold;
+    use std::sync::Arc;
+
+    fn cold_store_and_db() -> (Store, Arc<TestDB>) {
+        let (storage, _hot, cold) = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
+        (storage.get_cold_store().unwrap(), cold)
+    }
+
+    #[test]
+    fn test_column_absent_from_cold_storage_is_reported() {
+        let checked = ColumnCheckedColdDB::new(cold_store_and_db().0);
+        let store = Store::new(checked.clone());
+
+        assert!(!DBCol::BlockHeight.is_in_colddb());
+        assert_eq!(store.get(DBCol::BlockHeight, &[0]), None);
+        assert_eq!(store.iter(DBCol::BlockHeight).count(), 0);
+        assert_eq!(checked.rejected_column(), Some(DBCol::BlockHeight));
+    }
+
+    #[test]
+    fn test_columns_present_in_cold_storage_are_served() {
+        let (cold, cold_db) = cold_store_and_db();
+        let checked = ColumnCheckedColdDB::new(cold);
+        let store = Store::new(checked.clone());
+
+        // `Block` is copied into cold storage; `BlockMisc` is not copied but holds cold
+        // storage's own head bookkeeping, so both must be readable.
+        assert!(DBCol::Block.is_in_colddb() && DBCol::BlockMisc.is_in_colddb());
+        let mut transaction = DBTransaction::new();
+        transaction.set(DBCol::Block, vec![1], b"block".to_vec());
+        transaction.set(DBCol::BlockMisc, vec![2], b"misc".to_vec());
+        cold_db.write(transaction);
+
+        assert_eq!(store.get(DBCol::Block, &[1]).as_deref(), Some(b"block".as_slice()));
+        assert_eq!(store.get(DBCol::BlockMisc, &[2]).as_deref(), Some(b"misc".as_slice()));
+        assert_eq!(checked.rejected_column(), None);
+    }
+}

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -4,6 +4,7 @@ use near_primitives::types::ShardId;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+mod cold_column_checked;
 mod colddb;
 mod database_tests;
 pub mod metadata;
@@ -15,6 +16,7 @@ mod slice;
 mod splitdb;
 mod testdb;
 
+pub use self::cold_column_checked::ColumnCheckedColdDB;
 pub use self::colddb::ColdDB;
 pub use self::mixeddb::{MixedDB, ReadOrder};
 pub use self::recoverydb::RecoveryDB;

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -36,7 +36,7 @@ use near_primitives::views::{
 };
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::flat_store::encode_flat_state_db_key;
-use near_store::db::GENESIS_CONGESTION_INFO_KEY;
+use near_store::db::{ColumnCheckedColdDB, GENESIS_CONGESTION_INFO_KEY};
 use near_store::flat::delta::KeyForFlatStateDelta;
 use near_store::flat::{FlatStateChanges, FlatStateDeltaMetadata, FlatStorageStatus};
 use near_store::trie::AccessOptions;
@@ -617,15 +617,69 @@ fn serialize_raw_trie_node(node: RawTrieNodeWithSize) -> EntityDataValue {
 
 impl EntityDebugHandler for EntityDebugHandlerImpl {
     fn query(&self, query: EntityQueryWithParams) -> Result<EntityDataValue, RpcError> {
-        let store = if query.use_cold_storage {
-            self.cold_store.clone().ok_or_else(|| {
-                RpcError::new_internal_error(None, "Cold storage is not available".to_string())
-            })?
-        } else {
-            self.hot_store.clone()
+        if !query.use_cold_storage {
+            return self
+                .query_impl(self.hot_store.clone(), query.query)
+                .map_err(|err| RpcError::new_internal_error(None, format!("{:?}", err)));
+        }
+        let cold_store = self.cold_store.clone().ok_or_else(|| {
+            RpcError::new_internal_error(None, "Cold storage is not available".to_string())
+        })?;
+        let checked_cold_db = ColumnCheckedColdDB::new(cold_store);
+        let result = self.query_impl(Store::new(checked_cold_db.clone()), query.query);
+        if let Some(column) = checked_cold_db.rejected_column() {
+            return Err(RpcError::new_internal_error(
+                None,
+                format!("{column} is not stored in cold storage"),
+            ));
+        }
+        result.map_err(|err| RpcError::new_internal_error(None, format!("{:?}", err)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EntityDebugHandlerImpl;
+    use near_chain::runtime::NightshadeRuntime;
+    use near_chain_configs::test_genesis::{TestGenesisBuilder, ValidatorsSpec};
+    use near_epoch_manager::EpochManager;
+    use near_jsonrpc_primitives::types::entity_debug::{
+        EntityDebugHandler, EntityQuery, EntityQueryWithParams,
+    };
+    use near_store::db::metadata::{DB_VERSION, DbKind};
+    use near_store::test_utils::create_test_node_storage_with_cold;
+
+    #[test]
+    fn test_cold_storage_query_names_the_column_absent_from_cold_storage() {
+        let genesis = TestGenesisBuilder::new()
+            .validators_spec(ValidatorsSpec::desired_roles(&["test0"], &[]))
+            .build();
+        let (storage, ..) = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
+        let hot_store = storage.get_hot_store();
+        let epoch_manager = EpochManager::new_arc_handle(hot_store.clone(), &genesis.config, None);
+        let home_dir = tempfile::tempdir().unwrap();
+        let handler = EntityDebugHandlerImpl {
+            runtime: NightshadeRuntime::test(
+                home_dir.path(),
+                hot_store.clone(),
+                &genesis.config,
+                epoch_manager.clone(),
+            ),
+            epoch_manager,
+            hot_store,
+            cold_store: storage.get_cold_store(),
         };
-        self.query_impl(store, query.query)
-            .map_err(|err| RpcError::new_internal_error(None, format!("{:?}", err)))
+
+        let error = handler
+            .query(EntityQueryWithParams {
+                query: EntityQuery::BlockHashByHeight { block_height: 0 },
+                use_cold_storage: true,
+            })
+            .unwrap_err();
+        assert!(
+            format!("{error:?}").contains("BlockHeight is not stored in cold storage"),
+            "{error:?}"
+        );
     }
 }
 


### PR DESCRIPTION
`/debug/api/entity` takes the store and the column as independent inputs, so a query whose column is never copied to cold storage still reads the cold store. `ColumnCheckedColdDB` wraps the cold store for that one caller, answers columns outside `DBCol::is_in_colddb` as absent, and `query()` turns the recorded column into `"<column> is not stored in cold storage"`. Tests cover the wrapper in `core/store` and the endpoint error in `nearcore/src/entity_debug.rs`.