### PR TITLE
fix: chunk cache hardening

### DIFF
--- a/chain/chunks-primitives/src/error.rs
+++ b/chain/chunks-primitives/src/error.rs
@@ -5,6 +5,8 @@ use std::fmt;
 pub enum Error {
     InvalidPartMessage,
     InvalidChunkPartId,
+    InvalidChunkPartSize,
+    TooManyChunkParts,
     InvalidChunkShardId,
     InvalidMerkleProof,
     InvalidChunkSignature,

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -25,10 +25,6 @@ use time::ext::InstantExt;
 //    will only include chunks in the block for which it has received the part it owns.
 //    Users of the data structure are responsible for adding chunk to this map at the right time.
 
-/// Default height horizon for chunk cache. A chunk is out of rear horizon if its
-/// height + DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON < largest_seen_height.
-pub const DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON: BlockHeightDelta = 128;
-
 /// A chunk is out of front horizon if its height > largest_seen_height + MAX_HEIGHTS_AHEAD
 const MAX_HEIGHTS_AHEAD: BlockHeightDelta = 5;
 
@@ -369,9 +365,10 @@ impl EncodedChunksCache {
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON, MAX_HEIGHTS_AHEAD};
+    use super::MAX_HEIGHTS_AHEAD;
     use crate::chunk_cache::EncodedChunksCache;
     use crate::shards_manager_actor::ChunkRequestInfo;
+    use near_chain_configs::default_chunks_cache_height_horizon;
     use near_crypto::KeyType;
     use near_primitives::hash::CryptoHash;
     use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV2};
@@ -403,7 +400,7 @@ mod tests {
 
     #[test]
     fn test_incomplete_chunks() {
-        let mut cache = EncodedChunksCache::new(DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON);
+        let mut cache = EncodedChunksCache::new(default_chunks_cache_height_horizon());
         let header0 = create_chunk_header(1, ShardId::new(0));
         let header1 = create_chunk_header(1, ShardId::new(1));
         cache.get_or_insert_from_header(&header0);
@@ -427,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_height_within_horizon_no_overflow() {
-        let horizon = DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON;
+        let horizon = default_chunks_cache_height_horizon();
         let mut cache = EncodedChunksCache::new(horizon);
 
         // Normal range: largest_seen_height well above the rear horizon.
@@ -460,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_cache_removal() {
-        let mut cache = EncodedChunksCache::new(DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON);
+        let mut cache = EncodedChunksCache::new(default_chunks_cache_height_horizon());
         let header = create_chunk_header(1, ShardId::new(0));
         cache.merge_in_partial_encoded_chunk(
             &header,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -5,5 +5,3 @@ pub mod logic;
 pub mod metrics;
 pub mod shards_manager_actor;
 pub mod test_utils;
-
-pub use chunk_cache::DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON;

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -115,7 +115,9 @@ use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, verify_path_with_index};
 use near_primitives::receipt::Receipt;
-use near_primitives::reed_solomon::{reed_solomon_decode, reed_solomon_encode};
+use near_primitives::reed_solomon::{
+    reed_solomon_decode, reed_solomon_encode, reed_solomon_part_length,
+};
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunk, EncodedShardChunkBody, PartialEncodedChunk,
     PartialEncodedChunkPart, PartialEncodedChunkV2, ShardChunk, ShardChunkHeader,
@@ -142,9 +144,17 @@ pub const CHUNK_REQUEST_RETRY: time::Duration = time::Duration::milliseconds(100
 pub const CHUNK_REQUEST_SWITCH_TO_OTHERS: time::Duration = time::Duration::milliseconds(400);
 pub const CHUNK_REQUEST_SWITCH_TO_FULL_FETCH: time::Duration = time::Duration::seconds(3);
 const CHUNK_REQUEST_RETRY_MAX: time::Duration = time::Duration::seconds(1000);
-const CHUNK_FORWARD_CACHE_SIZE: usize = 1000;
+/// Maximum number of chunks held in `chunk_forwards_cache` at once. Sized
+/// roughly to the mainnet shard count so one height's worth of legitimate
+/// forwards fits, while keeping the cache's worst-case memory footprint limited.
+const CHUNK_FORWARD_CACHE_SIZE: usize = 10;
 // Only request chunks from peers whose latest height >= chunk_height - CHUNK_REQUEST_PEER_HORIZON
 const CHUNK_REQUEST_PEER_HORIZON: BlockHeightDelta = 5;
+
+/// Maximum size of a partial encoded chunk (serialized).
+/// 20MB should be plenty to fit 4MB of transactions and 4.5MB of outgoing receipts, with some extra
+/// safety margin.
+const MAX_CHUNK_SIZE_BYTES: usize = 20 * 1024 * 1024;
 
 /// Result of attempting to decode and validate a complete encoded chunk.
 #[allow(clippy::large_enum_variant)]
@@ -1264,27 +1274,35 @@ impl ShardsManagerActor {
         merkle_root: MerkleHash,
         part: &PartialEncodedChunkPart,
         num_total_parts: usize,
+        num_data_parts: usize,
     ) -> Result<(), Error> {
-        if (part.part_ord as usize) < num_total_parts {
-            if !verify_path_with_index(
-                merkle_root,
-                &part.merkle_proof,
-                &part.part,
-                part.part_ord,
-                num_total_parts as u64,
-            ) {
-                return Err(Error::InvalidMerkleProof);
-            }
-
-            Ok(())
-        } else {
-            Err(Error::InvalidChunkPartId)
+        if (part.part_ord as usize) >= num_total_parts {
+            return Err(Error::InvalidChunkPartId);
         }
+
+        let max_part_length = reed_solomon_part_length(MAX_CHUNK_SIZE_BYTES, num_data_parts);
+        if part.part.len() > max_part_length {
+            return Err(Error::InvalidChunkPartSize);
+        }
+
+        if !verify_path_with_index(
+            merkle_root,
+            &part.merkle_proof,
+            &part.part,
+            part.part_ord,
+            num_total_parts as u64,
+        ) {
+            return Err(Error::InvalidMerkleProof);
+        }
+
+        Ok(())
     }
 
     fn validate_partial_encoded_chunk_forward(
         &self,
         forward: &PartialEncodedChunkForwardMsg,
+        num_total_parts: usize,
+        num_data_parts: usize,
     ) -> Result<(), Error> {
         let valid_hash = forward.is_valid_hash(); // check hash
 
@@ -1293,9 +1311,11 @@ impl ShardsManagerActor {
         }
 
         // check part merkle proofs
-        let num_total_parts = self.epoch_manager.num_total_parts();
+        if forward.parts.len() > self.epoch_manager.num_total_parts() {
+            return Err(Error::TooManyChunkParts);
+        }
         for part_info in &forward.parts {
-            self.validate_part(forward.merkle_root, part_info, num_total_parts)?;
+            self.validate_part(forward.merkle_root, part_info, num_total_parts, num_data_parts)?;
         }
 
         // check signature
@@ -1372,8 +1392,17 @@ impl ShardsManagerActor {
         forward: PartialEncodedChunkForwardMsg,
         me: Option<&AccountId>,
     ) -> Result<(), Error> {
+        let chunk_requested =
+            self.requested_partial_encoded_chunks.contains_key(&forward.chunk_hash);
+        if !chunk_requested && !self.encoded_chunks.height_within_horizon(forward.height_created) {
+            metrics::PARTIAL_ENCODED_CHUNK_OUTSIDE_HORIZON.inc();
+            return Ok(());
+        }
+
+        let num_total_parts = self.epoch_manager.num_total_parts();
+        let num_data_parts = self.epoch_manager.num_data_parts();
         let maybe_header = self
-            .validate_partial_encoded_chunk_forward(&forward)
+            .validate_partial_encoded_chunk_forward(&forward, num_total_parts, num_data_parts)
             .and_then(|_| self.get_partial_encoded_chunk_header(&forward.chunk_hash));
 
         let header = match maybe_header {
@@ -1600,6 +1629,7 @@ impl ShardsManagerActor {
             "process partial encoded chunk");
         // Verify the partial encoded chunk is valid and worth processing
         // 1.a Leave if we received known chunk
+        let num_data_parts = self.epoch_manager.num_data_parts();
         if let Some(entry) = self.encoded_chunks.get(&chunk_hash) {
             if entry.complete {
                 return Ok(ProcessPartialEncodedChunkResult::Known);
@@ -1607,9 +1637,9 @@ impl ShardsManagerActor {
             if entry.decode_failed {
                 return Ok(ProcessPartialEncodedChunkResult::DecodeFailed);
             }
-            tracing::debug!(target: "chunks", num_parts_in_cache = entry.parts.len(), total_needed = self.epoch_manager.num_data_parts(), tag_chunk_distribution = true);
+            tracing::debug!(target: "chunks", num_parts_in_cache = entry.parts.len(), total_needed = num_data_parts, tag_chunk_distribution = true);
         } else {
-            tracing::debug!(target: "chunks", num_parts_in_cache = 0, total_needed = self.epoch_manager.num_data_parts(), tag_chunk_distribution = true);
+            tracing::debug!(target: "chunks", num_parts_in_cache = 0, total_needed = num_data_parts, tag_chunk_distribution = true);
         }
 
         // 1.b Checking chunk height
@@ -1672,10 +1702,18 @@ impl ShardsManagerActor {
 
         // 1.d Checking part_ords' validity
         let num_total_parts = self.epoch_manager.num_total_parts();
+        if parts.len() > num_total_parts {
+            return Err(Error::TooManyChunkParts);
+        }
         for part_info in &parts {
             // TODO: only validate parts we care about
             // https://github.com/near/nearcore/issues/5885
-            self.validate_part(*header.encoded_merkle_root(), part_info, num_total_parts)?;
+            self.validate_part(
+                *header.encoded_merkle_root(),
+                part_info,
+                num_total_parts,
+                num_data_parts,
+            )?;
         }
 
         // 1.e Checking receipts validity
@@ -2434,13 +2472,13 @@ impl PartialEncodedChunkResponseSource {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON;
     use crate::logic::{make_outgoing_receipts_proofs, persist_chunk};
     use crate::test_utils::*;
     use assert_matches::assert_matches;
     use near_async::messaging::IntoSender;
     use near_async::time::FakeClock;
     use near_chain_configs::MutableConfigValue;
+    use near_chain_configs::default_chunks_cache_height_horizon;
     use near_network::types::NetworkRequests;
     use near_primitives::hash::CryptoHash;
     use near_primitives::types::EpochId;
@@ -2485,7 +2523,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
 
         let added = clock.now().into();
@@ -2547,7 +2585,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         // process chunk part 0
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&[0]);
@@ -2629,7 +2667,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
 
         // part id > num parts
@@ -2662,7 +2700,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         let count_num_forward_msgs = |fixture: &ChunkTestFixture| {
             fixture
@@ -2745,7 +2783,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         shards_manager.insert_header_if_not_exists_and_process_cached_chunk_forwards(
             &fixture.mock_chunk_header,
@@ -2837,7 +2875,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         let (most_parts, other_parts) = {
             let mut most_parts = fixture.mock_chunk_parts.clone();
@@ -2918,7 +2956,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         let forward = PartialEncodedChunkForwardMsg::from_header_and_parts(
             &fixture.mock_chunk_header,
@@ -2991,7 +3029,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
 
         shards_manager
@@ -3029,7 +3067,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
 
         shards_manager
@@ -3064,7 +3102,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
 
         persist_chunk(
@@ -3099,7 +3137,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
 
         let mut update = fixture.chain_store.store_update();
@@ -3132,7 +3170,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         // Split the part ords into two groups.
         assert!(fixture.all_part_ords.len() >= 2);
@@ -3177,7 +3215,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         // Only add half of the parts to the cache.
         assert!(fixture.all_part_ords.len() >= 2);
@@ -3223,7 +3261,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         // Split the part ords into three groups; put one in cache, the second in partial
         // and the third is missing. We should return the first two groups.
@@ -3270,7 +3308,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         let (source, response) =
             shards_manager.prepare_partial_encoded_chunk_response(PartialEncodedChunkRequestMsg {
@@ -3297,7 +3335,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         let (source, response) =
             shards_manager.prepare_partial_encoded_chunk_response(PartialEncodedChunkRequestMsg {
@@ -3324,7 +3362,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         let mut update = fixture.chain_store.store_update();
         let shard_chunk = fixture.mock_encoded_chunk.decode_chunk().unwrap();
@@ -3358,7 +3396,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         let mut update = fixture.chain_store.store_update();
         let shard_chunk = fixture.mock_encoded_chunk.decode_chunk().unwrap();
@@ -3390,7 +3428,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
         let part = fixture.make_partial_encoded_chunk(&fixture.mock_part_ords);
         shards_manager
@@ -3436,7 +3474,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         )
     }
 
@@ -3460,7 +3498,7 @@ mod test {
             fixture.mock_chain_head.clone(),
             fixture.mock_chain_head.clone(),
             Duration::hours(1),
-            DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+            default_chunks_cache_height_horizon(),
         );
 
         // Orphan fixture: prev_block_hash is unknown, ancestor_hash is known (genesis).

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -213,7 +213,7 @@ impl ChunkTestFixture {
             mock_chunk_header: encoded_chunk.cloned_header(),
             mock_chunk_parts: encoded_chunk.parts().to_vec(),
             mock_chain_head: Tip {
-                height: 0,
+                height: mock_height,
                 last_block_hash: CryptoHash::default(),
                 prev_block_hash: CryptoHash::default(),
                 epoch_id: EpochId::default(),

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -13380,7 +13380,7 @@
             "description": "Multiplier for the wait time for all chunks to be received."
           },
           "chunks_cache_height_horizon": {
-            "description": "Height horizon for the chunk cache. A chunk is removed from the cache\nif its height + chunks_cache_height_horizon < largest_seen_height.\nThe default value is DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON.",
+            "description": "Height horizon for the chunk cache. A chunk is removed from the cache\nif its height + chunks_cache_height_horizon < largest_seen_height.\nThe default value is given by default_chunks_cache_height_horizon().",
             "format": "uint64",
             "minimum": 0,
             "type": "integer"

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -8255,7 +8255,7 @@
             "description": "Multiplier for the wait time for all chunks to be received."
           },
           "chunks_cache_height_horizon": {
-            "description": "Height horizon for the chunk cache. A chunk is removed from the cache\nif its height + chunks_cache_height_horizon < largest_seen_height.\nThe default value is DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON.",
+            "description": "Height horizon for the chunk cache. A chunk is removed from the cache\nif its height + chunks_cache_height_horizon < largest_seen_height.\nThe default value is given by default_chunks_cache_height_horizon().",
             "format": "uint64",
             "minimum": 0,
             "type": "integer"

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -593,7 +593,7 @@ pub fn default_enable_early_prepare_transactions() -> bool {
 /// Returns the default value for `chunks_cache_height_horizon`.
 /// A chunk is out of rear horizon if its height + chunks_cache_height_horizon < largest_seen_height.
 pub fn default_chunks_cache_height_horizon() -> BlockHeightDelta {
-    128
+    2
 }
 
 /// Config for the Chunk Distribution Network feature.
@@ -840,7 +840,7 @@ pub struct ClientConfig {
     pub enable_early_prepare_transactions: bool,
     /// Height horizon for the chunk cache. A chunk is removed from the cache
     /// if its height + chunks_cache_height_horizon < largest_seen_height.
-    /// The default value is DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON.
+    /// The default value is given by default_chunks_cache_height_horizon().
     pub chunks_cache_height_horizon: BlockHeightDelta,
     /// If true, SPICE nodes track uncertified transactions in a pending
     /// transaction queue to enforce P_MAX, nonce, gas-key, and deploy

--- a/integration-tests/src/env/setup.rs
+++ b/integration-tests/src/env/setup.rs
@@ -14,13 +14,13 @@ use near_chain::resharding::types::ReshardingSender;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::types::{ChainConfig, RuntimeAdapter};
 use near_chain::{Chain, ChainGenesis, DoomslugThresholdMode};
+use near_chain_configs::default_chunks_cache_height_horizon;
 use near_chain_configs::test_utils::TestClientConfigParams;
 use near_chain_configs::{
     ChunkDistributionNetworkConfig, ClientConfig, Genesis, MutableConfigValue,
     MutableValidatorSigner, ProtocolVersionCheckConfig, ReshardingConfig, ReshardingHandle,
     TrackedShardsConfig,
 };
-use near_chunks::DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON;
 use near_chunks::adapter::ShardsManagerRequestFromClient;
 use near_chunks::client::ShardsManagerResponse;
 use near_chunks::shards_manager_actor::{ShardsManagerActor, start_shards_manager};
@@ -594,7 +594,7 @@ pub fn setup_synchronous_shards_manager(
         <_>::clone(&chain_head),
         <_>::clone(&chain_header_head),
         Duration::hours(1),
-        DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON,
+        default_chunks_cache_height_horizon(),
     );
     SynchronousShardsManagerAdapter::new(shards_manager)
 }

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -449,7 +449,7 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Height horizon for the chunk cache. A chunk is removed from the cache
     /// if its height + chunks_cache_height_horizon < largest_seen_height.
-    /// The default value is DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON.
+    /// The default value is given by default_chunks_cache_height_horizon().
     pub chunks_cache_height_horizon: Option<BlockHeightDelta>,
     /// If true, SPICE nodes track uncertified transactions in a pending
     /// transaction queue to enforce P_MAX, nonce, gas-key, and deploy

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -11,8 +11,10 @@ two stages:
    the test kills the validator node so that no new blocks are generated.
 
    At this stage, the test verifies that Fred can sync correctly and that the
-   boot node serves all partial chunks requests from its in-memory cache (which
-   is determined by looking at Prometheus metrics).
+   boot node serves partial chunk requests from its in-memory cache for chunks
+   within the cache's height horizon (which is determined by looking at
+   Prometheus metrics).  Older chunks, outside the horizon, are served from
+   hot storage.
 
 2. The test then restarts Fred so that its in-memory cache is cleared.  It
    finally starts a new observer (let’s call it Barney) and points it at Fred as
@@ -173,9 +175,13 @@ def run_test(cluster: Cluster) -> None:
     metrics = get_metrics('boot', boot)
     boot.kill()
 
-    # We didn’t generate enough blocks to fill boot’s in-memory cache which
-    # means all Fred’s requests should be served from it.
-    assert_metrics(metrics, ('cache/ok',))
+    # With the default (production) chunks_cache_height_horizon value, boot's
+    # in-memory cache only covers the most recent heights.  Chunks requested by
+    # Fred that are within that horizon are served from the cache, while older
+    # ones are served from hot storage.  So we expect both 'cache/ok' and
+    # 'partial/ok' to be non-zero; nothing should come from cold storage yet
+    # since the chain is still short and nothing has been GC'ed.
+    assert_metrics(metrics, ('cache/ok', 'partial/ok'))
 
     # Restart Fred so that its cache is cleared.  Then start the second
     # observer, Barney, and wait for it to sync up.


### PR DESCRIPTION
cherry-pick 7053212d1dcf15f59e102fdfb1a6cfd18cd02137 to master

Add more limits in the chunk cache

* Remove `DEFAULT_CHUNKS_CACHE_HEIGHT_HORIZON` as it's not used in production code, replace with `default_chunks_cache_height_horizon()`
* Reduce `default_chunks_cache_height_horizon()` from 128 heights to 2 heights
* Limit max chunk size to 20MB (`MAX_CHUNK_SIZE_BYTES`) and apply the size limits to parts
* Limit number of chunk parts in a message
* Reduce size of unverified chunks cache from 1000 elements to 10 elements (about 1 per shard)