### PR TITLE
fix(chain): bound BlocksDelayTracker to blocks near the head

### DIFF
--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -24,8 +24,9 @@ const BLOCK_DELAY_TRACKING_COUNT: u64 = 50;
 pub const BLOCK_HORIZON: BlockHeightDelta = 500;
 
 /// How many deliberately-skipped block hashes to remember, so the `mark_block_*`
-/// helpers can tell an expected missing entry from a bookkeeping bug.
-const SKIPPED_BLOCKS_CACHE_SIZE: usize = 512;
+/// helpers can tell an expected missing entry from a bookkeeping bug. Sized to the
+/// tracking window, which bounds how many blocks can be in flight around the head.
+const SKIPPED_BLOCKS_CACHE_SIZE: usize = (BLOCK_DELAY_TRACKING_COUNT + BLOCK_HORIZON) as usize;
 
 /// A centralized place that records monitoring information about the important timestamps throughout
 /// the lifetime of blocks and chunks. It keeps information of recent blocks and chunks, tracking
@@ -46,7 +47,7 @@ pub struct BlocksDelayTracker {
     chunks: HashMap<ChunkHash, ChunkTrackingStats>,
     // Chunks that we don't know which block it belongs to yet
     floating_chunks: HashMap<ChunkHash, BlockHeight>,
-    // Blocks refused by `is_too_far_ahead`, so a missing entry can be recognised as expected.
+    // Blocks refused by `is_too_far_ahead`, so a missing entry can be recognized as expected.
     skipped_blocks: LruCache<CryptoHash, ()>,
     head_height: BlockHeight,
 }
@@ -360,31 +361,32 @@ impl BlocksDelayTracker {
     }
 
     fn update_head(&mut self, head_height: BlockHeight) {
-        if head_height != self.head_height {
-            let cutoff_height = head_height.saturating_sub(BLOCK_DELAY_TRACKING_COUNT);
-            self.head_height = head_height;
-            let mut blocks_to_remove = self.blocks_height_map.split_off(&cutoff_height);
-            mem::swap(&mut self.blocks_height_map, &mut blocks_to_remove);
-
-            for block_hash in blocks_to_remove.values().flatten() {
-                if let Some(block) = self.blocks.remove(&block_hash) {
-                    for chunk_hash in block.chunks {
-                        if let Some(chunk_hash) = chunk_hash {
-                            self.chunks.remove(&chunk_hash);
-                        }
-                    }
-                } else {
-                    debug_assert!(false);
-                    tracing::error!(target: "block_delay_tracker", ?block_hash, "block in height map but not in blocks");
-                }
-            }
-
-            self.floating_chunks
-                .extract_if(|_, chunk_height| *chunk_height < cutoff_height)
-                .for_each(|(chunk_hash, _)| {
-                    self.chunks.remove(&chunk_hash);
-                });
+        if head_height <= self.head_height {
+            return;
         }
+        let cutoff_height = head_height.saturating_sub(BLOCK_DELAY_TRACKING_COUNT);
+        self.head_height = head_height;
+        let mut blocks_to_remove = self.blocks_height_map.split_off(&cutoff_height);
+        mem::swap(&mut self.blocks_height_map, &mut blocks_to_remove);
+
+        for block_hash in blocks_to_remove.values().flatten() {
+            if let Some(block) = self.blocks.remove(&block_hash) {
+                for chunk_hash in block.chunks {
+                    if let Some(chunk_hash) = chunk_hash {
+                        self.chunks.remove(&chunk_hash);
+                    }
+                }
+            } else {
+                debug_assert!(false);
+                tracing::error!(target: "block_delay_tracker", ?block_hash, "block in height map but not in blocks");
+            }
+        }
+
+        self.floating_chunks.extract_if(|_, chunk_height| *chunk_height < cutoff_height).for_each(
+            |(chunk_hash, _)| {
+                self.chunks.remove(&chunk_hash);
+            },
+        );
     }
 
     pub fn finish_block_processing(
@@ -603,15 +605,25 @@ mod tests {
     use near_async::time::{Clock, Utc};
     use near_primitives::block::Block;
     use near_primitives::genesis::genesis_block;
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::sharding::ShardChunkHeader;
     use near_primitives::test_utils::{TestBlockBuilder, create_test_signer};
-    use near_primitives::types::Balance;
+    use near_primitives::types::{Balance, ShardId};
     use near_primitives::version::PROTOCOL_VERSION;
     use std::sync::Arc;
 
+    /// A chunk the block treats as new, i.e. one included at the block's own height.
+    fn new_chunk_at(height: u64, prev_block_hash: CryptoHash) -> ShardChunkHeader {
+        let mut chunk = ShardChunkHeader::new_dummy(height, ShardId::new(0), prev_block_hash);
+        *chunk.height_included_mut() = height;
+        chunk
+    }
+
+    /// A block carrying one new chunk, so the tracker's chunk bookkeeping is exercised.
     fn block_at(height: u64) -> Arc<Block> {
         let genesis = Arc::new(genesis_block(
             PROTOCOL_VERSION,
-            vec![],
+            vec![ShardChunkHeader::new_dummy(0, ShardId::new(0), CryptoHash::default())],
             Utc::now_utc(),
             0,
             Balance::ZERO,
@@ -624,6 +636,7 @@ mod tests {
             Arc::new(create_test_signer("test")),
         )
         .height(height)
+        .chunks(vec![new_chunk_at(height, *genesis.hash())])
         .build()
     }
 
@@ -646,7 +659,9 @@ mod tests {
         assert_eq!(tracker.blocks.len(), 1);
         assert!(tracker.blocks.contains_key(within.hash()));
         assert_eq!(tracker.blocks_height_map.len(), 1);
-        assert_eq!(tracker.chunks.len(), within.chunks().len());
+        // Only the tracked block's chunk is recorded; the skipped blocks carry
+        // chunks of their own and must not leave anything behind.
+        assert_eq!(tracker.chunks.len(), 1);
 
         // The client still runs its own checks against skipped blocks, so the
         // mark_block_* helpers must treat their missing entries as expected.

--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -605,39 +605,42 @@ mod tests {
     use near_async::time::{Clock, Utc};
     use near_primitives::block::Block;
     use near_primitives::genesis::genesis_block;
-    use near_primitives::hash::CryptoHash;
+    use near_primitives::hash::hash;
     use near_primitives::sharding::ShardChunkHeader;
-    use near_primitives::test_utils::{TestBlockBuilder, create_test_signer};
-    use near_primitives::types::{Balance, ShardId};
+    use near_primitives::test_utils::{TestBlockBuilder, create_test_signer, test_chunk_header};
+    use near_primitives::types::Balance;
+    use near_primitives::validator_signer::ValidatorSigner;
     use near_primitives::version::PROTOCOL_VERSION;
     use std::sync::Arc;
 
     /// A chunk the block treats as new, i.e. one included at the block's own height.
-    fn new_chunk_at(height: u64, prev_block_hash: CryptoHash) -> ShardChunkHeader {
-        let mut chunk = ShardChunkHeader::new_dummy(height, ShardId::new(0), prev_block_hash);
+    ///
+    /// Built via `test_chunk_header` rather than `ShardChunkHeader::new_dummy`: the
+    /// latter picks a Spice transaction-only header inner once that feature is on,
+    /// which carries no `prev_state_root` and panics in `genesis_block`.
+    fn new_chunk_at(height: u64, signer: &ValidatorSigner) -> ShardChunkHeader {
+        // Vary the chunk's prev hash so each block contributes a distinct chunk.
+        let mut chunk = test_chunk_header(hash(&height.to_le_bytes()), signer, PROTOCOL_VERSION);
         *chunk.height_included_mut() = height;
         chunk
     }
 
     /// A block carrying one new chunk, so the tracker's chunk bookkeeping is exercised.
     fn block_at(height: u64) -> Arc<Block> {
+        let signer = Arc::new(create_test_signer("test"));
         let genesis = Arc::new(genesis_block(
             PROTOCOL_VERSION,
-            vec![ShardChunkHeader::new_dummy(0, ShardId::new(0), CryptoHash::default())],
+            vec![new_chunk_at(0, &signer)],
             Utc::now_utc(),
             0,
             Balance::ZERO,
             Balance::ZERO,
             &vec![],
         ));
-        TestBlockBuilder::from_prev_block(
-            Clock::real(),
-            &genesis,
-            Arc::new(create_test_signer("test")),
-        )
-        .height(height)
-        .chunks(vec![new_chunk_at(height, *genesis.hash())])
-        .build()
+        TestBlockBuilder::from_prev_block(Clock::real(), &genesis, signer.clone())
+            .height(height)
+            .chunks(vec![new_chunk_at(height, &signer)])
+            .build()
     }
 
     /// A node far behind the tip keeps receiving blocks gossiped from there. They

--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -6,7 +6,7 @@ use near_primitives::block::{Block, ChunkType, Tip};
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
-use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::types::{BlockHeight, BlockHeightDelta, ShardId};
 use near_primitives::views::{
     BlockProcessingInfo, BlockProcessingStatus, ChainProcessingInfo, ChunkProcessingInfo,
     ChunkProcessingStatus, DroppedReason,
@@ -18,22 +18,19 @@ use time::ext::InstantExt as _;
 
 const BLOCK_DELAY_TRACKING_COUNT: u64 = 50;
 
-/// How far ahead of the head a block may be and still be tracked.
-///
-/// Mirrors `BLOCK_HORIZON` in the client, which is the point past which a block
-/// is dropped without processing. The client records a block in the tracker
-/// *before* applying that check, and `update_head` only reclaims entries below
-/// the head, so without this bound a node that is far behind the tip tracks
-/// every gossiped block at the tip forever.
-const BLOCK_DELAY_TRACKING_AHEAD: u64 = 500;
+/// Blocks at or above `head + BLOCK_HORIZON` are dropped without being processed.
+/// The client applies the same bound when deciding whether to accept an incoming
+/// block, and the tracker applies it when deciding whether to record one.
+pub const BLOCK_HORIZON: BlockHeightDelta = 500;
+
+/// How many deliberately-skipped block hashes to remember, so the `mark_block_*`
+/// helpers can tell an expected missing entry from a bookkeeping bug.
+const SKIPPED_BLOCKS_CACHE_SIZE: usize = 512;
 
 /// A centralized place that records monitoring information about the important timestamps throughout
-/// the lifetime of blocks and chunks. It keeps information of recent blocks and chunks
-/// (blocks with height > head height - BLOCK_DELAY_TRACKING_HORIZON).
-/// A block is added the first time when chain tries to process the block. Note that this means
-/// the block already passes a few checks in ClientActor and in Client before it enters the chain
-/// code. For example, client actor checks that the block must be within head_height + BLOCK_HORIZON (500),
-/// that's why we know tracker at most tracks 550 blocks.
+/// the lifetime of blocks and chunks. It keeps information of recent blocks and chunks, tracking
+/// heights in `[head - BLOCK_DELAY_TRACKING_COUNT, head + BLOCK_HORIZON)` — at most 550 blocks.
+/// A block is added the first time when chain tries to process the block.
 pub struct BlocksDelayTracker {
     clock: Clock,
     // A block is added at the first time it was received, and
@@ -49,6 +46,8 @@ pub struct BlocksDelayTracker {
     chunks: HashMap<ChunkHash, ChunkTrackingStats>,
     // Chunks that we don't know which block it belongs to yet
     floating_chunks: HashMap<ChunkHash, BlockHeight>,
+    // Blocks refused by `is_too_far_ahead`, so a missing entry can be recognised as expected.
+    skipped_blocks: LruCache<CryptoHash, ()>,
     head_height: BlockHeight,
 }
 
@@ -179,7 +178,7 @@ impl ChunkTrackingStats {
 }
 
 impl BlocksDelayTracker {
-    pub fn new(clock: Clock) -> Self {
+    pub fn new(clock: Clock, head_height: BlockHeight) -> Self {
         Self {
             clock,
             blocks: HashMap::new(),
@@ -189,24 +188,20 @@ impl BlocksDelayTracker {
             ),
             chunks: HashMap::new(),
             floating_chunks: HashMap::new(),
-            head_height: 0,
+            skipped_blocks: LruCache::new(NonZeroUsize::new(SKIPPED_BLOCKS_CACHE_SIZE).unwrap()),
+            head_height,
         }
     }
 
     /// Whether a block at this height is far enough ahead of the head that the
-    /// tracker deliberately ignores it.
-    ///
-    /// During catch-up the node keeps receiving blocks gossiped from the tip.
-    /// The client discards them without processing, and `update_head` only
-    /// reclaims entries *below* the head, so tracking them would grow the maps
-    /// without bound. The threshold matches the client's `BLOCK_HORIZON`, which
-    /// also rejects at `>= head + 500`.
-    ///
-    /// `head_height` is zero until the first block finishes processing; until
-    /// then nothing is skipped, and `update_head` drops whatever accumulated.
+    /// client would discard it, in which case the tracker does not record it.
     fn is_too_far_ahead(&self, height: BlockHeight) -> bool {
-        self.head_height != 0
-            && height >= self.head_height.saturating_add(BLOCK_DELAY_TRACKING_AHEAD)
+        height >= self.head_height.saturating_add(BLOCK_HORIZON)
+    }
+
+    /// A missing entry is a bug unless the block was deliberately skipped.
+    fn should_report_missing_entry(&self, block_hash: &CryptoHash) -> bool {
+        !self.skipped_blocks.contains(block_hash)
     }
 
     pub fn mark_block_received(&mut self, block: &Block) {
@@ -214,6 +209,7 @@ impl BlocksDelayTracker {
         let height = block.header().height();
 
         if self.is_too_far_ahead(height) {
+            self.skipped_blocks.put(*block_hash, ());
             return;
         }
 
@@ -259,17 +255,10 @@ impl BlocksDelayTracker {
         entry.observe_metrics();
     }
 
-    pub fn mark_block_dropped(
-        &mut self,
-        block_hash: &CryptoHash,
-        height: BlockHeight,
-        reason: DroppedReason,
-    ) {
+    pub fn mark_block_dropped(&mut self, block_hash: &CryptoHash, reason: DroppedReason) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.dropped = Some(reason);
-        } else if !self.is_too_far_ahead(height) {
-            // Blocks past the tracking window are never marked received, so a
-            // missing entry is expected for them rather than an inconsistency.
+        } else if self.should_report_missing_entry(block_hash) {
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was dropped but was not marked received");
         }
     }
@@ -277,7 +266,7 @@ impl BlocksDelayTracker {
     pub fn mark_block_errored(&mut self, block_hash: &CryptoHash, err: String) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.error = Some(err);
-        } else {
+        } else if self.should_report_missing_entry(block_hash) {
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was errored but was not marked received");
         }
     }
@@ -285,7 +274,7 @@ impl BlocksDelayTracker {
     pub fn mark_block_orphaned(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.orphaned_timestamp = Some(self.clock.now());
-        } else {
+        } else if self.should_report_missing_entry(block_hash) {
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was orphaned but was not marked received");
         }
     }
@@ -293,7 +282,7 @@ impl BlocksDelayTracker {
     pub fn mark_block_unorphaned(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_orphan_timestamp = Some(self.clock.now());
-        } else {
+        } else if self.should_report_missing_entry(block_hash) {
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was unorphaned but was not marked received");
         }
     }
@@ -301,7 +290,7 @@ impl BlocksDelayTracker {
     pub fn mark_block_has_missing_chunks(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.missing_chunks_timestamp = Some(self.clock.now());
-        } else {
+        } else if self.should_report_missing_entry(block_hash) {
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as having missing chunks but was not marked received");
         }
     }
@@ -309,7 +298,7 @@ impl BlocksDelayTracker {
     pub fn mark_block_pending_execution(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.pending_execution_timestamp = Some(self.clock.now());
-        } else {
+        } else if self.should_report_missing_entry(block_hash) {
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as pending execution but was not marked received");
         }
     }
@@ -317,7 +306,7 @@ impl BlocksDelayTracker {
     pub fn mark_block_completed_pending_execution(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_pending_timestamp = Some(self.clock.now());
-        } else {
+        } else if self.should_report_missing_entry(block_hash) {
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as completed pending execution but was not marked received");
         }
     }
@@ -325,7 +314,7 @@ impl BlocksDelayTracker {
     pub fn mark_block_completed_missing_chunks(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_missing_chunks_timestamp = Some(self.clock.now());
-        } else {
+        } else if self.should_report_missing_entry(block_hash) {
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was marked as having no missing chunks but was not marked received");
         }
     }
@@ -377,14 +366,7 @@ impl BlocksDelayTracker {
             let mut blocks_to_remove = self.blocks_height_map.split_off(&cutoff_height);
             mem::swap(&mut self.blocks_height_map, &mut blocks_to_remove);
 
-            // Entries above the window are refused by `mark_block_received`, but only
-            // once the head is known; drop whatever accumulated before that.
-            let ahead_cutoff = head_height.saturating_add(BLOCK_DELAY_TRACKING_AHEAD);
-            let blocks_ahead = self.blocks_height_map.split_off(&ahead_cutoff);
-
-            for block_hash in
-                blocks_to_remove.values().flatten().chain(blocks_ahead.values().flatten())
-            {
+            for block_hash in blocks_to_remove.values().flatten() {
                 if let Some(block) = self.blocks.remove(&block_hash) {
                     for chunk_hash in block.chunks {
                         if let Some(chunk_hash) = chunk_hash {
@@ -617,27 +599,59 @@ impl Chain {
 
 #[cfg(test)]
 mod tests {
-    use super::{BLOCK_DELAY_TRACKING_AHEAD, BlocksDelayTracker};
-    use near_async::time::Clock;
+    use super::{BLOCK_HORIZON, BlocksDelayTracker};
+    use near_async::time::{Clock, Utc};
+    use near_primitives::block::Block;
+    use near_primitives::genesis::genesis_block;
+    use near_primitives::test_utils::{TestBlockBuilder, create_test_signer};
+    use near_primitives::types::Balance;
+    use near_primitives::version::PROTOCOL_VERSION;
+    use std::sync::Arc;
 
-    #[test]
-    fn tracking_window_is_bounded_above_the_head() {
-        let mut tracker = BlocksDelayTracker::new(Clock::real());
-        let head = 1_000_000;
-        tracker.update_head(head);
-
-        assert!(!tracker.is_too_far_ahead(head));
-        assert!(!tracker.is_too_far_ahead(head + BLOCK_DELAY_TRACKING_AHEAD - 1));
-        // The client drops at `>= head + BLOCK_HORIZON`; match it exactly so the
-        // tracker never holds a block the client refuses to process.
-        assert!(tracker.is_too_far_ahead(head + BLOCK_DELAY_TRACKING_AHEAD));
-        // A node far behind the tip keeps receiving gossip from there.
-        assert!(tracker.is_too_far_ahead(head + 1_200_000));
+    fn block_at(height: u64) -> Arc<Block> {
+        let genesis = Arc::new(genesis_block(
+            PROTOCOL_VERSION,
+            vec![],
+            Utc::now_utc(),
+            0,
+            Balance::ZERO,
+            Balance::ZERO,
+            &vec![],
+        ));
+        TestBlockBuilder::from_prev_block(
+            Clock::real(),
+            &genesis,
+            Arc::new(create_test_signer("test")),
+        )
+        .height(height)
+        .build()
     }
 
+    /// A node far behind the tip keeps receiving blocks gossiped from there. They
+    /// sit above the head, so `update_head` never reclaims them; the tracker must
+    /// refuse them outright or its maps grow for the lifetime of the process.
     #[test]
-    fn nothing_is_skipped_before_the_head_is_known() {
-        let tracker = BlocksDelayTracker::new(Clock::real());
-        assert!(!tracker.is_too_far_ahead(1_000_000));
+    fn blocks_beyond_the_horizon_are_not_tracked() {
+        let head = 1_000;
+        let mut tracker = BlocksDelayTracker::new(Clock::real(), head);
+
+        let within = block_at(head + BLOCK_HORIZON - 1);
+        let beyond = block_at(head + BLOCK_HORIZON);
+        let from_the_tip = block_at(head + 1_200_000);
+
+        for block in [&within, &beyond, &from_the_tip] {
+            tracker.mark_block_received(block);
+        }
+
+        assert_eq!(tracker.blocks.len(), 1);
+        assert!(tracker.blocks.contains_key(within.hash()));
+        assert_eq!(tracker.blocks_height_map.len(), 1);
+        assert_eq!(tracker.chunks.len(), within.chunks().len());
+
+        // The client still runs its own checks against skipped blocks, so the
+        // mark_block_* helpers must treat their missing entries as expected.
+        assert!(!tracker.should_report_missing_entry(beyond.hash()));
+        assert!(!tracker.should_report_missing_entry(from_the_tip.hash()));
+        assert!(tracker.should_report_missing_entry(within.hash()));
     }
 }

--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -193,18 +193,27 @@ impl BlocksDelayTracker {
         }
     }
 
+    /// Whether a block at this height is far enough ahead of the head that the
+    /// tracker deliberately ignores it.
+    ///
+    /// During catch-up the node keeps receiving blocks gossiped from the tip.
+    /// The client discards them without processing, and `update_head` only
+    /// reclaims entries *below* the head, so tracking them would grow the maps
+    /// without bound. The threshold matches the client's `BLOCK_HORIZON`, which
+    /// also rejects at `>= head + 500`.
+    ///
+    /// `head_height` is zero until the first block finishes processing; until
+    /// then nothing is skipped, and `update_head` drops whatever accumulated.
+    fn is_too_far_ahead(&self, height: BlockHeight) -> bool {
+        self.head_height != 0
+            && height >= self.head_height.saturating_add(BLOCK_DELAY_TRACKING_AHEAD)
+    }
+
     pub fn mark_block_received(&mut self, block: &Block) {
         let block_hash = block.header().hash();
         let height = block.header().height();
 
-        // During catch-up sync the node keeps receiving gossiped blocks from the
-        // tip, which the client drops without processing. They sit above the head
-        // and are therefore never reclaimed by `update_head`, so refuse to track
-        // them at all. `head_height` is zero until the first block finishes
-        // processing; don't apply the bound before we know where the head is.
-        if self.head_height != 0
-            && height > self.head_height.saturating_add(BLOCK_DELAY_TRACKING_AHEAD)
-        {
+        if self.is_too_far_ahead(height) {
             return;
         }
 
@@ -250,10 +259,17 @@ impl BlocksDelayTracker {
         entry.observe_metrics();
     }
 
-    pub fn mark_block_dropped(&mut self, block_hash: &CryptoHash, reason: DroppedReason) {
+    pub fn mark_block_dropped(
+        &mut self,
+        block_hash: &CryptoHash,
+        height: BlockHeight,
+        reason: DroppedReason,
+    ) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.dropped = Some(reason);
-        } else {
+        } else if !self.is_too_far_ahead(height) {
+            // Blocks past the tracking window are never marked received, so a
+            // missing entry is expected for them rather than an inconsistency.
             tracing::error!(target: "blocks_delay_tracker", ?block_hash, "block was dropped but was not marked received");
         }
     }
@@ -361,7 +377,14 @@ impl BlocksDelayTracker {
             let mut blocks_to_remove = self.blocks_height_map.split_off(&cutoff_height);
             mem::swap(&mut self.blocks_height_map, &mut blocks_to_remove);
 
-            for block_hash in blocks_to_remove.values().flatten() {
+            // Entries above the window are refused by `mark_block_received`, but only
+            // once the head is known; drop whatever accumulated before that.
+            let ahead_cutoff = head_height.saturating_add(BLOCK_DELAY_TRACKING_AHEAD);
+            let blocks_ahead = self.blocks_height_map.split_off(&ahead_cutoff);
+
+            for block_hash in
+                blocks_to_remove.values().flatten().chain(blocks_ahead.values().flatten())
+            {
                 if let Some(block) = self.blocks.remove(&block_hash) {
                     for chunk_hash in block.chunks {
                         if let Some(chunk_hash) = chunk_hash {
@@ -589,5 +612,32 @@ impl Chain {
             blocks_info,
             floating_chunks_info,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BLOCK_DELAY_TRACKING_AHEAD, BlocksDelayTracker};
+    use near_async::time::Clock;
+
+    #[test]
+    fn tracking_window_is_bounded_above_the_head() {
+        let mut tracker = BlocksDelayTracker::new(Clock::real());
+        let head = 1_000_000;
+        tracker.update_head(head);
+
+        assert!(!tracker.is_too_far_ahead(head));
+        assert!(!tracker.is_too_far_ahead(head + BLOCK_DELAY_TRACKING_AHEAD - 1));
+        // The client drops at `>= head + BLOCK_HORIZON`; match it exactly so the
+        // tracker never holds a block the client refuses to process.
+        assert!(tracker.is_too_far_ahead(head + BLOCK_DELAY_TRACKING_AHEAD));
+        // A node far behind the tip keeps receiving gossip from there.
+        assert!(tracker.is_too_far_ahead(head + 1_200_000));
+    }
+
+    #[test]
+    fn nothing_is_skipped_before_the_head_is_known() {
+        let tracker = BlocksDelayTracker::new(Clock::real());
+        assert!(!tracker.is_too_far_ahead(1_000_000));
     }
 }

--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -18,6 +18,15 @@ use time::ext::InstantExt as _;
 
 const BLOCK_DELAY_TRACKING_COUNT: u64 = 50;
 
+/// How far ahead of the head a block may be and still be tracked.
+///
+/// Mirrors `BLOCK_HORIZON` in the client, which is the point past which a block
+/// is dropped without processing. The client records a block in the tracker
+/// *before* applying that check, and `update_head` only reclaims entries below
+/// the head, so without this bound a node that is far behind the tip tracks
+/// every gossiped block at the tip forever.
+const BLOCK_DELAY_TRACKING_AHEAD: u64 = 500;
+
 /// A centralized place that records monitoring information about the important timestamps throughout
 /// the lifetime of blocks and chunks. It keeps information of recent blocks and chunks
 /// (blocks with height > head height - BLOCK_DELAY_TRACKING_HORIZON).
@@ -186,12 +195,23 @@ impl BlocksDelayTracker {
 
     pub fn mark_block_received(&mut self, block: &Block) {
         let block_hash = block.header().hash();
+        let height = block.header().height();
+
+        // During catch-up sync the node keeps receiving gossiped blocks from the
+        // tip, which the client drops without processing. They sit above the head
+        // and are therefore never reclaimed by `update_head`, so refuse to track
+        // them at all. `head_height` is zero until the first block finishes
+        // processing; don't apply the bound before we know where the head is.
+        if self.head_height != 0
+            && height > self.head_height.saturating_add(BLOCK_DELAY_TRACKING_AHEAD)
+        {
+            return;
+        }
 
         let Entry::Vacant(entry) = self.blocks.entry(*block_hash) else {
             return;
         };
 
-        let height = block.header().height();
         let chunks = block
             .chunks()
             .iter()

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1245,8 +1245,11 @@ impl Chain {
         );
 
         if matches!(res, Err(Error::TooManyProcessingBlocks)) {
-            self.blocks_delay_tracker
-                .mark_block_dropped(&hash, DroppedReason::TooManyProcessingBlocks);
+            self.blocks_delay_tracker.mark_block_dropped(
+                &hash,
+                block_height,
+                DroppedReason::TooManyProcessingBlocks,
+            );
         }
         // Save the block as processed even if it failed. This is used to filter out the
         // incoming blocks that are not requested but already processed.

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -413,6 +413,7 @@ impl Chain {
             chain_genesis,
             state_roots,
         )?;
+        let head_height = chain_store.head().map_or(0, |tip| tip.height);
         let (sc, rc) = unbounded();
         let resharding_manager = ReshardingManager::new(
             store.clone(),
@@ -442,7 +443,7 @@ impl Chain {
             epoch_length: chain_genesis.epoch_length,
             block_economics_config: BlockEconomicsConfig::from(chain_genesis),
             doomslug_threshold_mode,
-            blocks_delay_tracker: BlocksDelayTracker::new(clock.clone()),
+            blocks_delay_tracker: BlocksDelayTracker::new(clock.clone(), head_height),
             apply_chunks_sender: sc,
             apply_chunks_receiver: rc,
             apply_chunks_spawner: ApplyChunksSpawner::default().into_spawner(thread_limit),
@@ -610,6 +611,7 @@ impl Chain {
             epoch_manager.clone(),
             chain_genesis.gas_limit,
         );
+        let head_height = chain_store.head().map_or(0, |tip| tip.height);
         Ok(Chain {
             clock: clock.clone(),
             chain_store,
@@ -628,7 +630,7 @@ impl Chain {
             epoch_length: chain_genesis.epoch_length,
             block_economics_config: BlockEconomicsConfig::from(chain_genesis),
             doomslug_threshold_mode,
-            blocks_delay_tracker: BlocksDelayTracker::new(clock.clone()),
+            blocks_delay_tracker: BlocksDelayTracker::new(clock.clone(), head_height),
             apply_chunks_sender: sc,
             apply_chunks_receiver: rc,
             apply_chunks_spawner,
@@ -1245,11 +1247,8 @@ impl Chain {
         );
 
         if matches!(res, Err(Error::TooManyProcessingBlocks)) {
-            self.blocks_delay_tracker.mark_block_dropped(
-                &hash,
-                block_height,
-                DroppedReason::TooManyProcessingBlocks,
-            );
+            self.blocks_delay_tracker
+                .mark_block_dropped(&hash, DroppedReason::TooManyProcessingBlocks);
         }
         // Save the block as processed even if it failed. This is used to filter out the
         // incoming blocks that are not requested but already processed.

--- a/chain/client/src/chunk_distribution_network.rs
+++ b/chain/client/src/chunk_distribution_network.rs
@@ -240,7 +240,7 @@ mod tests {
         let (mock_sender, mut message_receiver) = mpsc::unbounded_channel();
         let mut client = MockClient::default();
         let missing_chunk = mock_shard_chunk(0, 0u64.into());
-        let mut blocks_delay_tracker = BlocksDelayTracker::new(Clock::real());
+        let mut blocks_delay_tracker = BlocksDelayTracker::new(Clock::real(), 0);
         let shards_manager = MockSender::new(mock_sender);
         let shards_manager_adapter = shards_manager.into_sender();
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -27,6 +27,7 @@ use near_async::futures::{AsyncComputationSpawner, FutureSpawner};
 use near_async::messaging::IntoAsyncSender;
 use near_async::messaging::{CanSend, Sender};
 use near_async::time::{Clock, Duration, Instant};
+use near_chain::blocks_delay_tracker::BLOCK_HORIZON;
 use near_chain::chain::{
     ApplyChunksDoneSender, BlockCatchUpRequest, BlockMissingChunks, BlocksCatchUpState,
     VerifyBlockHashAndSignatureResult,
@@ -85,9 +86,6 @@ use std::sync::{Arc, OnceLock};
 use tracing::instrument;
 
 const NUM_REBROADCAST_BLOCKS: usize = 30;
-
-/// Drop blocks whose height are beyond head + horizon if it is not in the current epoch.
-const BLOCK_HORIZON: u64 = 500;
 
 /// number of blocks at the epoch start for which we will log more detailed info
 pub const EPOCH_START_INFO_BLOCKS: u64 = 500;
@@ -1273,11 +1271,9 @@ impl Client {
         // To protect ourselves from spamming, we do a pre-check before doing
         // any real processing.
         if !self.should_process_block(&block, was_requested)? {
-            self.chain.blocks_delay_tracker.mark_block_dropped(
-                block.hash(),
-                block.header().height(),
-                DroppedReason::HeightProcessed,
-            );
+            self.chain
+                .blocks_delay_tracker
+                .mark_block_dropped(block.hash(), DroppedReason::HeightProcessed);
             return Ok(());
         }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1273,9 +1273,11 @@ impl Client {
         // To protect ourselves from spamming, we do a pre-check before doing
         // any real processing.
         if !self.should_process_block(&block, was_requested)? {
-            self.chain
-                .blocks_delay_tracker
-                .mark_block_dropped(block.hash(), DroppedReason::HeightProcessed);
+            self.chain.blocks_delay_tracker.mark_block_dropped(
+                block.hash(),
+                block.header().height(),
+                DroppedReason::HeightProcessed,
+            );
             return Ok(());
         }
 


### PR DESCRIPTION
`BlocksDelayTracker` documents that it tracks at most 550 blocks, relying on the
client dropping anything beyond `head + BLOCK_HORIZON`. That bound is not
enforced: `receive_block_impl` records a block via `mark_block_received` before
`should_process_block` runs, and `update_head` only reclaims entries below
`head - BLOCK_DELAY_TRACKING_COUNT`. Blocks above the head are never reclaimed.

For a node at the tip this is harmless, since gossip lands inside the pruning
window. For a node catching up it is not: every block gossiped from the tip sits
far above the head, so `blocks`, `blocks_height_map` and `chunks` grow at network
block rate for the lifetime of the process.

This bounds tracking to `BLOCK_DELAY_TRACKING_AHEAD` (500) blocks above the head,
matching the invariant the type already claims.

Observed on an archival node roughly 1.2M blocks behind the tip:

| | unpatched | patched |
|---|---|---|
| `Dropped` entries in `/debug/api/chain_processing_status` | 33676 after a few hours, still climbing | 11, unchanged over 14h uptime |
| total tracked entries | ~33800 | 164 |

The same node also showed block application throughput decaying from ~10 bps to
~6 bps over six hours before this change, and holding ~10 bps over 14 hours after
it, with no other configuration difference. That correlation is suggestive but
not established; the unbounded growth stands on its own.

Behaviour change: blocks rejected by the `BLOCK_HORIZON` check no longer appear in
the chain processing debug output while a node is far behind the tip. They
describe blocks the node never processes.