### PR TITLE
ci: bind workflow_dispatch release-type via env before shell

### DIFF
--- a/.github/workflows/neard_custom_binary.yml
+++ b/.github/workflows/neard_custom_binary.yml
@@ -50,4 +50,5 @@ jobs:
       - name: Neard binary build and upload to S3
         env:
           WITH_DEBUG_INFO: ${{ inputs.with-debug-info && '1' || '' }}
-        run: ./scripts/binary_release.sh ${{ github.event.inputs.release-type }}
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+        run: ./scripts/binary_release.sh "$RELEASE_TYPE"


### PR DESCRIPTION
## Summary
- Bind `github.event.inputs.release-type` through `env: RELEASE_TYPE` before invoking `./scripts/binary_release.sh`.
- Same class as GitHub’s documented script-injection guidance for interpolating `workflow_dispatch` inputs into `run:` scripts.

## Test plan
- [ ] Manual dispatch with a release-type still builds/uploads as before


Made with [Cursor](https://cursor.com)