### PR TITLE
feat(network): outgoing memory semaphore 

### DIFF
--- a/chain/client/src/spice/tests/chunk_executor_actor.rs
+++ b/chain/client/src/spice/tests/chunk_executor_actor.rs
@@ -157,6 +157,15 @@ impl TestActor {
                     outgoing_sc.unbounded_send(OutgoingMessage::NetworkRequests(request)).unwrap();
                 }
             }),
+            request_with_permit_sender: Sender::from_fn({
+                let outgoing_sc = outgoing_sc.clone();
+                move |message: near_network::types::NetworkRequestWithPermit| {
+                    // ignore the permit in tests
+                    outgoing_sc
+                        .unbounded_send(OutgoingMessage::NetworkRequests(message.request))
+                        .unwrap();
+                }
+            }),
         };
         let data_distributor_adapter = SpiceDataDistributorAdapter {
             receipts: Sender::from_fn({

--- a/chain/client/src/spice/tests/chunk_validator_actor.rs
+++ b/chain/client/src/spice/tests/chunk_validator_actor.rs
@@ -25,7 +25,9 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::recv_permit::RecvMessagePermit;
 use near_network::spice::data_distribution::SpiceChunkContractAccessesMessage;
-use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
+use near_network::types::{
+    NetworkRequestWithPermit, NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest,
+};
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt as _;
 use near_o11y::testonly::init_test_logger;
 use near_parameters::{ActionCosts, RuntimeConfigStore};
@@ -350,8 +352,15 @@ fn setup_with_genesis(genesis: Genesis, signer: Arc<ValidatorSigner>) -> TestAct
         set_chain_info_sender: noop().into_sender(),
         state_sync_event_sender: noop().into_sender(),
         request_sender: Sender::from_fn({
+            let network_sc = network_sc.clone();
             move |event: PeerManagerMessageRequest| {
                 network_sc.send(event).unwrap();
+            }
+        }),
+        request_with_permit_sender: Sender::from_fn({
+            move |event: NetworkRequestWithPermit| {
+                // ignore the permit in tests
+                network_sc.send(PeerManagerMessageRequest::NetworkRequests(event.request)).unwrap();
             }
         }),
     };

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -32,7 +32,9 @@ use near_network::spice::data_distribution::{
     SpiceContractCodeRequestMessage, SpiceIncomingPartialData, SpicePartialDataRequest,
     SpicePartialDataRequestMessage,
 };
-use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
+use near_network::types::{
+    NetworkRequestWithPermit, NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest,
+};
 use near_o11y::span_wrapped_msg::SpanWrapped;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::gas::Gas;
@@ -256,6 +258,15 @@ impl ActorBuilder {
                         unreachable!()
                     };
                     outgoing_sc.send(OutgoingMessage::NetworkRequests { request }).unwrap();
+                }
+            }),
+            request_with_permit_sender: Sender::from_fn({
+                let outgoing_sc = outgoing_sc.clone();
+                move |message: NetworkRequestWithPermit| {
+                    // ignore the permit in tests
+                    outgoing_sc
+                        .send(OutgoingMessage::NetworkRequests { request: message.request })
+                        .unwrap();
                 }
             }),
         };

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor_tests.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor_tests.rs
@@ -181,6 +181,7 @@ fn build_test_actor(
     let network_adapter = PeerManagerAdapter {
         async_request_sender: noop().into_async_sender(),
         request_sender: noop().into_sender(),
+        request_with_permit_sender: noop().into_sender(),
         set_chain_info_sender: noop().into_sender(),
         state_sync_event_sender: noop().into_sender(),
     };

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -14,7 +14,8 @@ use near_epoch_manager::epoch_sync::{
 };
 use near_network::client::{EpochSyncRequestMessage, EpochSyncResponseMessage};
 use near_network::types::{
-    HighestHeightPeerInfo, NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest,
+    HighestHeightPeerInfo, NetworkRequestWithPermit, NetworkRequests, PeerManagerAdapter,
+    PeerManagerMessageRequest,
 };
 use near_primitives::block::{Approval, ApprovalInner, compute_bp_hash_from_validator_stakes};
 use near_primitives::epoch_block_info::BlockInfo;
@@ -573,6 +574,7 @@ impl EpochSync {
 
 impl Handler<EpochSyncRequestMessage> for ClientActor {
     fn handle(&mut self, msg: EpochSyncRequestMessage) {
+        let response_permit = msg.response_permit;
         if ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) {
             // When ContinuousEpochSync is enabled, we simply return the stored compressed proof.
             // The proof is automatically updated at the beginning of each epoch via the epoch manager.
@@ -585,9 +587,10 @@ impl Handler<EpochSyncRequestMessage> for ClientActor {
                 tracing::warn!(target: "sync", ?head, ?genesis_height, "no epoch sync proof is stored");
                 return;
             };
-            self.client.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
-                NetworkRequests::EpochSyncResponse { peer_id: msg.from_peer, proof },
-            ));
+            self.client.network_adapter.send(NetworkRequestWithPermit {
+                request: NetworkRequests::EpochSyncResponse { peer_id: msg.from_peer, proof },
+                permit: response_permit,
+            });
         } else {
             let store = self.client.chain.chain_store.store();
             let network_adapter = self.client.network_adapter.clone();
@@ -608,9 +611,13 @@ impl Handler<EpochSyncRequestMessage> for ClientActor {
                             return;
                         }
                     };
-                    network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
-                        NetworkRequests::EpochSyncResponse { peer_id: requester_peer_id, proof },
-                    ));
+                    network_adapter.send(NetworkRequestWithPermit {
+                        request: NetworkRequests::EpochSyncResponse {
+                            peer_id: requester_peer_id,
+                            proof,
+                        },
+                        permit: response_permit,
+                    });
                 },
             )
         }

--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -1,3 +1,4 @@
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::network_protocol::StateResponseInfo;
 use crate::recv_permit::RecvMessagePermit;
 use crate::types::{NetworkInfo, ReasonForBan};
@@ -154,6 +155,10 @@ pub struct SpiceChunkEndorsementMessage(pub SpiceChunkEndorsement, pub RecvMessa
 pub struct EpochSyncRequestMessage {
     pub from_peer: PeerId,
     pub recv_permit: RecvMessagePermit,
+    /// Outgoing-queue reservation for the response message. Acquired in
+    /// the network layer when this request arrived. The client holds it
+    /// through proof derivation and uses it when sending the response.
+    pub response_permit: OutgoingPermit,
 }
 
 #[derive(Debug)]

--- a/chain/network/src/concurrency/mod.rs
+++ b/chain/network/src/concurrency/mod.rs
@@ -1,6 +1,7 @@
 pub mod arc_mutex;
 pub mod atomic_cell;
 pub mod demux;
+pub mod outgoing_queue_limiter;
 pub mod rate;
 pub mod rayon;
 

--- a/chain/network/src/concurrency/outgoing_queue_limiter.rs
+++ b/chain/network/src/concurrency/outgoing_queue_limiter.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
+
+/// Semaphore used to limit total size of network messages in the outgoing queues.
+/// A message must acquire permits before being enqueued, if there are not enough permits the message is dropped.
+pub(crate) struct OutgoingQueueLimiter {
+    semaphore: Arc<Semaphore>,
+}
+
+impl OutgoingQueueLimiter {
+    pub fn new(capacity_bytes: usize) -> Self {
+        Self { semaphore: Arc::new(Semaphore::new(capacity_bytes)) }
+    }
+
+    /// Try to reserve `bytes` worth of permits. Returns `None` if not enough
+    /// permits are currently available - the caller should drop the message.
+    pub fn try_acquire(&self, bytes: usize) -> Option<OutgoingPermit> {
+        // tokio's semaphore caps a single acquisition at u32::MAX; the byte
+        // counts we care about (hundreds of MB) are well within range.
+        let n = u32::try_from(bytes).ok()?;
+        match self.semaphore.clone().try_acquire_many_owned(n) {
+            Ok(permit) => Some(OutgoingPermit { permit }),
+            Err(TryAcquireError::NoPermits | TryAcquireError::Closed) => None,
+        }
+    }
+}
+
+/// Memory permit taken from the outgoing messages semaphore.
+pub struct OutgoingPermit {
+    permit: OwnedSemaphorePermit,
+}
+
+impl std::fmt::Debug for OutgoingPermit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OutgoingPermit").field("bytes", &self.bytes()).finish()
+    }
+}
+
+impl OutgoingPermit {
+    pub fn bytes(&self) -> usize {
+        self.permit.num_permits() as usize
+    }
+
+    /// Reduce this reservation down to `new_bytes`, releasing the surplus
+    /// back to the limiter. No-op if `new_bytes >= self.bytes()`. Used
+    /// when a message turns out to be smaller than the upper bound we
+    /// reserved.
+    pub fn shrink_to(&mut self, new_bytes: usize) {
+        let cur = self.bytes();
+        if new_bytes >= cur {
+            return;
+        }
+        let to_release = cur - new_bytes;
+        // `split` peels `to_release` permits off into a fresh OwnedSemaphorePermit.
+        // Dropping that returns the bytes to the semaphore.
+        if let Some(released) = self.permit.split(to_release) {
+            drop(released);
+        }
+    }
+
+    /// Test-only constructor.
+    pub fn fake_for_test() -> Self {
+        let sem = Arc::new(Semaphore::new(1));
+        let permit = sem.try_acquire_owned().expect("fresh semaphore has capacity");
+        Self { permit }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_acquire_succeeds_under_capacity() {
+        let limiter = OutgoingQueueLimiter::new(1000);
+        let p = limiter.try_acquire(400).unwrap();
+        assert_eq!(p.bytes(), 400);
+    }
+
+    #[test]
+    fn try_acquire_fails_over_capacity() {
+        let limiter = OutgoingQueueLimiter::new(1000);
+        let _p = limiter.try_acquire(800).unwrap();
+        assert!(limiter.try_acquire(300).is_none());
+    }
+
+    #[test]
+    fn permit_release_on_drop() {
+        let limiter = OutgoingQueueLimiter::new(1000);
+        {
+            let _p = limiter.try_acquire(800).unwrap();
+            assert!(limiter.try_acquire(300).is_none());
+        }
+        assert!(limiter.try_acquire(300).is_some());
+    }
+
+    #[test]
+    fn shrink_releases_surplus() {
+        let limiter = OutgoingQueueLimiter::new(1000);
+        let mut p = limiter.try_acquire(800).unwrap();
+        assert!(limiter.try_acquire(300).is_none());
+        p.shrink_to(100);
+        assert_eq!(p.bytes(), 100);
+        // 1000 - 100 = 900 available now
+        let _q = limiter.try_acquire(800).unwrap();
+    }
+
+    #[test]
+    fn shrink_to_larger_is_noop() {
+        let limiter = OutgoingQueueLimiter::new(1000);
+        let mut p = limiter.try_acquire(500).unwrap();
+        p.shrink_to(800);
+        assert_eq!(p.bytes(), 500);
+    }
+
+    #[test]
+    fn fake_for_test_does_not_touch_real_limiter() {
+        let limiter = OutgoingQueueLimiter::new(100);
+        let _exhaust = limiter.try_acquire(100).unwrap();
+        // Production limiter is fully reserved, but the fake permit comes
+        // from its own semaphore so construction still succeeds.
+        let _fake = OutgoingPermit::fake_for_test();
+    }
+}

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -396,6 +396,14 @@ impl PeerActor {
     }
 
     fn send_message(&self, msg: &PeerMessage) {
+        self.send_message_inner(msg, None);
+    }
+
+    fn send_message_inner(
+        &self,
+        msg: &PeerMessage,
+        reserved_permit: Option<crate::concurrency::outgoing_queue_limiter::OutgoingPermit>,
+    ) {
         if let (PeerStatus::Ready(conn), PeerMessage::PeersRequest(_)) = (&self.peer_status, msg) {
             conn.last_time_peer_requested.store(Some(self.clock.now()));
         }
@@ -424,10 +432,35 @@ impl PeerActor {
         };
 
         let bytes = msg.serialize();
-        self.tracker.lock().increment_sent(&self.clock, bytes.len() as u64);
         let bytes_len = bytes.len();
+        // Reserve capacity in the global outgoing-queue limiter. Pre-acquired reservations are
+        // shrunk to the actual serialized size; everything else acquires now and drops the message
+        // if there is no headroom.
+        let permit = match reserved_permit {
+            Some(mut p) => {
+                p.shrink_to(bytes_len);
+                p
+            }
+            None => match self.network_state.outgoing_queue_limiter.try_acquire(bytes_len) {
+                Some(p) => p,
+                None => {
+                    metrics::MessageDropped::OutgoingQueueLimitExceeded
+                        .inc_msg_type(msg.msg_variant());
+                    tracing::debug!(
+                        target: "network",
+                        msg_type = msg.msg_variant(),
+                        bytes_len,
+                        peer = %self.peer_info,
+                        "dropping outgoing message: global outgoing-queue limit reached",
+                    );
+                    return;
+                }
+            },
+        };
+        self.tracker.lock().increment_sent(&self.clock, bytes_len as u64);
         tracing::trace!(target: "network", msg_len = bytes_len);
-        self.framed.send(stream::Frame(bytes));
+        let frame = stream::Frame::with_permit(bytes, permit);
+        self.framed.send(frame);
         metrics::PEER_DATA_SENT_BYTES.inc_by(bytes_len as u64);
         let msg_type = msg.msg_variant();
         metrics::PEER_MESSAGE_SENT_BY_TYPE_TOTAL.with_label_values(&[msg_type]).inc();
@@ -1691,7 +1724,7 @@ impl messaging::Handler<SpanWrapped<SendMessage>> for PeerActor {
     fn handle(&mut self, msg: SpanWrapped<SendMessage>) {
         self.delay_if_registering(move |this| {
             let msg = msg.span_unwrap();
-            this.send_message(&msg.message);
+            this.send_message_inner(&msg.message, msg.reserved_permit);
         });
     }
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1,6 +1,7 @@
 use crate::accounts_data::AccountDataError;
 use crate::client::AnnounceAccountRequest;
 use crate::concurrency::atomic_cell::AtomicCell;
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::config::PEERS_RESPONSE_MAX_PEERS;
 use crate::network_protocol::{
     Edge, EdgeState, OwnedAccount, PartialEdgeInfo, PeerChainInfoV2, PeerIdOrHash, PeerInfo,
@@ -399,11 +400,7 @@ impl PeerActor {
         self.send_message_inner(msg, None);
     }
 
-    fn send_message_inner(
-        &self,
-        msg: &PeerMessage,
-        reserved_permit: Option<crate::concurrency::outgoing_queue_limiter::OutgoingPermit>,
-    ) {
+    fn send_message_inner(&self, msg: &PeerMessage, reserved_permit: Option<OutgoingPermit>) {
         if let (PeerStatus::Ready(conn), PeerMessage::PeersRequest(_)) = (&self.peer_status, msg) {
             conn.last_time_peer_requested.store(Some(self.clock.now()));
         }

--- a/chain/network/src/peer/stream.rs
+++ b/chain/network/src/peer/stream.rs
@@ -55,10 +55,6 @@ pub(crate) struct Frame {
 }
 
 impl Frame {
-    pub fn new(bytes: Vec<u8>) -> Self {
-        Self { bytes, _permit: None }
-    }
-
     pub fn with_permit(bytes: Vec<u8>, permit: OutgoingPermit) -> Self {
         Self { bytes, _permit: Some(permit) }
     }
@@ -354,7 +350,8 @@ mod tests {
 
         // Enqueue enough large messages to fill the TCP send buffer.
         for _ in 0..64 {
-            let _ = queue_send.send(Frame::new(vec![0u8; 1024 * 1024]));
+            let _ = queue_send
+                .send(Frame::with_permit(vec![0u8; 1024 * 1024], OutgoingPermit::fake_for_test()));
         }
         // Close the sender so run_send_loop will drain the queue and exit.
         drop(queue_send);

--- a/chain/network/src/peer/stream.rs
+++ b/chain/network/src/peer/stream.rs
@@ -1,3 +1,4 @@
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::peer_manager::connection;
 use crate::recv_permit::RecvMessagePermit;
 use crate::stats::metrics;
@@ -48,8 +49,34 @@ pub(crate) enum RecvError {
     IncomingSemaphoreClosed,
 }
 
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub(crate) struct Frame(pub Vec<u8>);
+pub(crate) struct Frame {
+    pub bytes: Vec<u8>,
+    _permit: Option<OutgoingPermit>,
+}
+
+impl Frame {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes, _permit: None }
+    }
+
+    pub fn with_permit(bytes: Vec<u8>, permit: OutgoingPermit) -> Self {
+        Self { bytes, _permit: Some(permit) }
+    }
+}
+
+impl std::fmt::Debug for Frame {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Frame").field("bytes_len", &self.bytes.len()).finish()
+    }
+}
+
+impl PartialEq for Frame {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes == other.bytes
+    }
+}
+
+impl Eq for Frame {}
 
 pub(crate) struct IncomingFrame {
     pub data: Vec<u8>,
@@ -141,12 +168,12 @@ impl FramedStream {
     /// If the message is too large, it will be silently dropped inside run_send_loop.
     /// Emits a critical error to Actor if send queue is full.
     pub fn send(&self, frame: Frame) {
-        let msg = &frame.0;
+        let msg_len = frame.bytes.len();
         let mut buf_size =
-            self.stats.bytes_to_send.fetch_add(msg.len() as u64, Ordering::Acquire) as usize;
-        buf_size += msg.len();
+            self.stats.bytes_to_send.fetch_add(msg_len as u64, Ordering::Acquire) as usize;
+        buf_size += msg_len;
         self.stats.messages_to_send.fetch_add(1, Ordering::Acquire);
-        self.send_buf_size_metric.add(msg.len() as i64);
+        self.send_buf_size_metric.add(msg_len as i64);
         // Exceeding buffer capacity is a critical error and Actor should call ctx.stop()
         // when receiving one. It is not like we do any extra allocations, so we can afford
         // pushing the message to the queue anyway.
@@ -245,17 +272,18 @@ impl FramedStream {
     ) -> io::Result<()> {
         const WRITE_BUFFER_CAPACITY: usize = 8 * 1024;
         let mut writer = tokio::io::BufWriter::with_capacity(WRITE_BUFFER_CAPACITY, tcp_send);
-        while let Some(Frame(mut msg)) = queue_recv.recv().await {
+        while let Some(mut frame) = queue_recv.recv().await {
             // Try writing a batch of messages and flush once at the end.
             loop {
+                let msg_len = frame.bytes.len();
                 // TODO(gprusak): sending a too large message should probably be treated as a bug,
                 // since dropping messages may lead to hard-to-debug high-level issues.
-                if msg.len() > NETWORK_MESSAGE_MAX_SIZE_BYTES {
+                if msg_len > NETWORK_MESSAGE_MAX_SIZE_BYTES {
                     metrics::MessageDropped::InputTooLong.inc_unknown_msg();
                 } else {
                     tokio::time::timeout(write_timeout, async {
-                        writer.write_u32_le(msg.len() as u32).await?;
-                        writer.write_all(&msg[..]).await?;
+                        writer.write_u32_le(msg_len as u32).await?;
+                        writer.write_all(&frame.bytes[..]).await?;
                         io::Result::Ok(())
                     })
                     .await
@@ -268,10 +296,13 @@ impl FramedStream {
                     })??;
                 }
                 stats.messages_to_send.fetch_sub(1, Ordering::Release);
-                stats.bytes_to_send.fetch_sub(msg.len() as u64, Ordering::Release);
-                buf_size_metric.sub(msg.len() as i64);
-                msg = match queue_recv.try_recv() {
-                    Ok(Frame(it)) => it,
+                stats.bytes_to_send.fetch_sub(msg_len as u64, Ordering::Release);
+                buf_size_metric.sub(msg_len as i64);
+                // Drop the previous frame (and its permit) before pulling the
+                // next, so the limiter sees capacity return immediately.
+                drop(frame);
+                frame = match queue_recv.try_recv() {
+                    Ok(f) => f,
                     Err(_) => break,
                 };
             }
@@ -323,7 +354,7 @@ mod tests {
 
         // Enqueue enough large messages to fill the TCP send buffer.
         for _ in 0..64 {
-            let _ = queue_send.send(Frame(vec![0u8; 1024 * 1024]));
+            let _ = queue_send.send(Frame::new(vec![0u8; 1024 * 1024]));
         }
         // Close the sender so run_send_loop will drain the queue and exit.
         drop(queue_send);

--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -45,7 +45,9 @@ pub(crate) struct PeerHandle {
 impl PeerHandle {
     pub async fn send(&self, message: PeerMessage) {
         self.actor
-            .send_async(SendMessage { message: Arc::new(message) }.span_wrap())
+            .send_async(
+                SendMessage { message: Arc::new(message), reserved_permit: None }.span_wrap(),
+            )
             .await
             .unwrap();
     }

--- a/chain/network/src/peer/tests/stream.rs
+++ b/chain/network/src/peer/tests/stream.rs
@@ -20,11 +20,11 @@ struct Actor {
 impl messaging::Actor for Actor {}
 
 #[derive(Debug)]
-struct SendFrame(stream::Frame);
+struct SendFrame(Vec<u8>);
 
 impl messaging::Handler<SendFrame> for Actor {
-    fn handle(&mut self, SendFrame(frame): SendFrame) {
-        self.stream.send(frame);
+    fn handle(&mut self, SendFrame(bytes): SendFrame) {
+        self.stream.send(stream::Frame::new(bytes));
     }
 }
 
@@ -74,12 +74,12 @@ async fn send_recv() {
 
     for _ in 0..5 {
         let n = rng.gen_range(1..10);
-        let msgs: Vec<_> = (0..n)
+        let msgs: Vec<Vec<u8>> = (0..n)
             .map(|_| {
                 let size = rng.gen_range(0..10000);
                 let mut msg = vec![0; size];
                 rng.fill(&mut msg[..]);
-                stream::Frame(msg)
+                msg
             })
             .collect();
         for msg in &msgs {
@@ -87,7 +87,7 @@ async fn send_recv() {
         }
         for want in &msgs {
             let got = a2.queue_recv.recv().await.unwrap();
-            assert_eq!(got.data, want.0);
+            assert_eq!(&got.data, want);
         }
     }
 }

--- a/chain/network/src/peer/tests/stream.rs
+++ b/chain/network/src/peer/tests/stream.rs
@@ -1,4 +1,5 @@
 use crate::auto_stop::AutoStopActor;
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::network_protocol::testonly as data;
 use crate::peer::stream::{self, IncomingFrame};
 use crate::peer_manager::network_state::INCOMING_SEMAPHORE_PERMITS;
@@ -24,7 +25,7 @@ struct SendFrame(Vec<u8>);
 
 impl messaging::Handler<SendFrame> for Actor {
     fn handle(&mut self, SendFrame(bytes): SendFrame) {
-        self.stream.send(stream::Frame::new(bytes));
+        self.stream.send(stream::Frame::with_permit(bytes, OutgoingPermit::fake_for_test()));
     }
 }
 

--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -1,5 +1,6 @@
 use crate::concurrency::arc_mutex::ArcMutex;
 use crate::concurrency::atomic_cell::AtomicCell;
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::network_protocol::{PeerInfo, PeerMessage, SignedOwnedAccount, TieredMessageBody};
 use crate::peer::peer_actor;
 use crate::peer::peer_actor::PeerActor;
@@ -141,9 +142,20 @@ impl Connection {
     // TODO(gprusak): embed Stream directly in Connection,
     // so that we can skip the actor queue when sending messages.
     pub fn send_message(&self, msg: Arc<PeerMessage>) {
+        self.send_message_with_permit(msg, None);
+    }
+
+    /// Like `send_message`, but forwards a pre-acquired reservation
+    /// against the outgoing-queue limiter. Used by callers that reserved
+    /// worst-case capacity before producing the message.
+    pub fn send_message_with_permit(
+        &self,
+        msg: Arc<PeerMessage>,
+        reserved_permit: Option<OutgoingPermit>,
+    ) {
         let msg_kind = msg.msg_variant().to_string();
         tracing::trace!(target: "network", ?msg_kind, "sending message");
-        self.handle.send(SendMessage { message: msg }.span_wrap());
+        self.handle.send(SendMessage { message: msg, reserved_permit }.span_wrap());
     }
 }
 
@@ -371,9 +383,21 @@ impl Pool {
     /// Send message to peer that belongs to our active set
     /// Return whether the message is sent or not.
     pub fn send_message(&self, peer_id: PeerId, msg: Arc<PeerMessage>) -> bool {
+        self.send_message_with_permit(peer_id, msg, None)
+    }
+
+    /// Like `send_message`, but forwards a pre-acquired reservation
+    /// against the outgoing-queue limiter. Returns false (and the permit
+    /// is released) if the peer isn't connected.
+    pub fn send_message_with_permit(
+        &self,
+        peer_id: PeerId,
+        msg: Arc<PeerMessage>,
+        reserved_permit: Option<OutgoingPermit>,
+    ) -> bool {
         let pool = self.load();
         if let Some(peer) = pool.ready.get(&peer_id) {
-            peer.send_message(msg);
+            peer.send_message_with_permit(msg, reserved_permit);
             return true;
         }
         tracing::debug!(target: "network",

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -97,7 +97,7 @@ pub(crate) const OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES: usize = 1024 * 1024 * 10
 /// Number of bytes reserved for the epoch sync response
 pub(crate) const EPOCH_SYNC_RESPONSE_BYTES: usize = 300 * 1024 * 1024;
 
-// Number of bytes reserved for the state sync reponse
+// Number of bytes reserved for the state sync response
 pub(crate) const STATE_SYNC_RESPONSE_BYTES: usize = 30 * 1024 * 1024;
 
 impl WhitelistNode {

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -8,6 +8,7 @@ use crate::client::{
     StateResponseReceived, TxStatusRequest, TxStatusResponse,
 };
 use crate::concurrency::demux;
+use crate::concurrency::outgoing_queue_limiter::OutgoingQueueLimiter;
 use crate::config;
 use crate::network_protocol::{
     Edge, EdgeState, PartialEdgeInfo, PeerIdOrHash, PeerInfo, PeerMessage, RawRoutedMessage,
@@ -89,6 +90,15 @@ pub(crate) const PENDING_TIER3_REQUEST_TIMEOUT: time::Duration = time::Duration:
 /// Number of permits in the incoming semaphore - set to 1GB, meaning that neard will handle at most
 /// 1GB of incoming messages at the same time.
 pub(crate) const INCOMING_SEMAPHORE_PERMITS: usize = 1_000_000_000;
+
+/// Size of the semaphore which limits outgoing messages.
+pub(crate) const OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES: usize = 1024 * 1024 * 1024;
+
+/// Number of bytes reserved for the epoch sync response
+pub(crate) const EPOCH_SYNC_RESPONSE_BYTES: usize = 300 * 1024 * 1024;
+
+// Number of bytes reserved for the state sync reponse
+pub(crate) const STATE_SYNC_RESPONSE_BYTES: usize = 30 * 1024 * 1024;
 
 impl WhitelistNode {
     pub fn from_peer_info(pi: &PeerInfo) -> anyhow::Result<Self> {
@@ -182,6 +192,11 @@ pub(crate) struct NetworkState {
     // Before reading a message into memory, we acquire a number of permits that's equal to the
     // message size. Limits total memory usage.
     pub incoming_message_semaphore: Arc<Semaphore>,
+
+    /// Caps total bytes sitting in outgoing queues across all connections.
+    /// Permits are acquired when frames are enqueued and released as frames
+    /// drain to the socket.
+    pub(crate) outgoing_queue_limiter: OutgoingQueueLimiter,
 
     /// Whitelisted nodes, which are allowed to connect even if the connection limit has been
     /// reached.
@@ -333,6 +348,9 @@ impl NetworkState {
             )),
             txns_since_last_block: AtomicUsize::new(0),
             pending_tier3_requests: DashMap::new(),
+            outgoing_queue_limiter: OutgoingQueueLimiter::new(
+                OUTGOING_QUEUE_LIMITER_CAPACITY_BYTES,
+            ),
             whitelist_nodes,
             set_chain_info_mutex: Mutex::new(()),
             config,
@@ -1245,7 +1263,25 @@ impl NetworkState {
                 None
             }
             PeerMessage::EpochSyncRequest => {
-                self.client.send(EpochSyncRequestMessage { from_peer: peer_id, recv_permit });
+                // Get a memory permit for the response before handling the request.
+                // We use an estimated size, later the permit will be reduced to the actual size.
+                if let Some(response_permit) =
+                    self.outgoing_queue_limiter.try_acquire(EPOCH_SYNC_RESPONSE_BYTES)
+                {
+                    self.client.send(EpochSyncRequestMessage {
+                        from_peer: peer_id,
+                        recv_permit,
+                        response_permit,
+                    });
+                } else {
+                    metrics::MessageDropped::OutgoingQueueLimitExceeded
+                        .inc_msg_type("EpochSyncResponse");
+                    tracing::debug!(
+                        target: "network",
+                        %peer_id,
+                        "outgoing queue saturated; dropping epoch sync request",
+                    );
+                }
                 None
             }
             PeerMessage::EpochSyncResponse(proof) => {

--- a/chain/network/src/peer_manager/network_transport.rs
+++ b/chain/network/src/peer_manager/network_transport.rs
@@ -1,3 +1,4 @@
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::network_protocol::PeerInfo;
 use crate::tcp;
 use crate::types::{PeerMessage, ReasonForBan};
@@ -21,6 +22,24 @@ pub trait NetworkTransport: Send + Sync + 'static {
     /// Deliver a message to a specific peer over the given tier.
     /// Returns true if the message was enqueued; false if not connected.
     fn send_message(&self, tier: tcp::Tier, peer_id: PeerId, msg: Arc<PeerMessage>) -> bool;
+
+    /// Like `send_message`, but the caller has already reserved bytes
+    /// against the global outgoing-queue limiter (e.g. before producing a
+    /// state-sync or epoch-sync response). The permit is shrunk to the
+    /// actual serialized size and released when the frame drains. Returns
+    /// false if the peer isn't connected; the permit is dropped in that case.
+    fn send_message_with_permit(
+        &self,
+        tier: tcp::Tier,
+        peer_id: PeerId,
+        msg: Arc<PeerMessage>,
+        permit: OutgoingPermit,
+    ) -> bool {
+        // Default impl ignores the permit and falls back to plain send_message.
+        // TestLoopTransport overrides this if it needs to track permits.
+        let _ = permit;
+        self.send_message(tier, peer_id, msg)
+    }
 
     /// Broadcast a message to all connected TIER2 peers. T1 and T3 do
     /// not have broadcast semantics. Must be synchronous (enqueue-only)

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -12,7 +12,7 @@ use crate::network_protocol::{
 use crate::network_protocol::{SyncSnapshotHosts, T1MessageBody};
 use crate::peer_manager::connected_peers::ConnectedPeerState;
 use crate::peer_manager::network_state::{
-    NetworkState, PENDING_TIER3_REQUEST_TIMEOUT, WhitelistNode,
+    NetworkState, PENDING_TIER3_REQUEST_TIMEOUT, STATE_SYNC_RESPONSE_BYTES, WhitelistNode,
 };
 use crate::peer_manager::network_transport::{NetworkTransport, PeerTransportStats};
 use crate::peer_manager::peer_store;
@@ -834,7 +834,11 @@ impl PeerManagerActor {
         );
     }
 
-    fn handle_msg_network_requests(&self, msg: NetworkRequests) -> NetworkResponses {
+    fn handle_msg_network_requests(
+        &self,
+        msg: NetworkRequests,
+        permit: Option<crate::concurrency::outgoing_queue_limiter::OutgoingPermit>,
+    ) -> NetworkResponses {
         let msg_type: &str = msg.as_ref();
         let _span =
             tracing::trace_span!(target: "network", "handle_msg_network_requests", msg_type)
@@ -1329,15 +1333,15 @@ impl PeerManagerActor {
                 }
             }
             NetworkRequests::EpochSyncResponse { peer_id, proof } => {
-                if self.transport.send_message(
-                    tcp::Tier::T2,
-                    peer_id,
-                    PeerMessage::EpochSyncResponse(proof).into(),
-                ) {
-                    NetworkResponses::NoResponse
-                } else {
-                    NetworkResponses::RouteNotFound
-                }
+                // Use the pre-acquired permit if the caller supplied one.
+                let msg: Arc<PeerMessage> = PeerMessage::EpochSyncResponse(proof).into();
+                let sent = match permit {
+                    Some(p) => {
+                        self.transport.send_message_with_permit(tcp::Tier::T2, peer_id, msg, p)
+                    }
+                    None => self.transport.send_message(tcp::Tier::T2, peer_id, msg),
+                };
+                if sent { NetworkResponses::NoResponse } else { NetworkResponses::RouteNotFound }
             }
             NetworkRequests::ChunkContractAccesses(validators, accesses) => {
                 for validator in validators {
@@ -1458,7 +1462,9 @@ impl PeerManagerActor {
     ) -> PeerManagerMessageResponse {
         match msg {
             PeerManagerMessageRequest::NetworkRequests(msg) => {
-                PeerManagerMessageResponse::NetworkResponses(self.handle_msg_network_requests(msg))
+                PeerManagerMessageResponse::NetworkResponses(
+                    self.handle_msg_network_requests(msg, None),
+                )
             }
             PeerManagerMessageRequest::AdvertiseTier1Proxies => {
                 let state = self.state.clone();
@@ -1542,6 +1548,13 @@ impl messaging::Handler<StateSyncEvent> for PeerManagerActor {
     }
 }
 
+impl messaging::Handler<crate::types::NetworkRequestWithPermit> for PeerManagerActor {
+    fn handle(&mut self, msg: crate::types::NetworkRequestWithPermit) {
+        let crate::types::NetworkRequestWithPermit { request, permit } = msg;
+        let _ = self.handle_msg_network_requests(request, Some(permit));
+    }
+}
+
 impl messaging::Handler<Tier3Request> for PeerManagerActor {
     fn handle(&mut self, request: Tier3Request) {
         let _timer = metrics::PEER_MANAGER_TIER3_REQUEST_TIME
@@ -1553,22 +1566,34 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
         let transport = self.transport.clone();
         self.handle.spawn("handle tier3 request",
             async move {
+                // Get a memory permit for the response before generating it.
+                let response_permit = state
+                    .outgoing_queue_limiter
+                    .try_acquire(STATE_SYNC_RESPONSE_BYTES);
+
                 // Process the request.
                 // Unconditionally produce an ack to be sent back over tier2.
                 // Optionally produce a response to be sent over tier3.
                 let (tier2_ack, maybe_tier3_response) = match request.body {
                     Tier3RequestBody::StateHeader(StateHeaderRequestBody { shard_id, sync_hash }) => {
-                        let (ack, response) = match state.state_request_adapter.send_async(StateRequestHeader { shard_id, sync_hash }).await {
-                            Ok(Some(client_response)) => {
-                                (StateRequestAckBody::WillRespond, Some(PeerMessage::VersionedStateResponse(*client_response.0)))
-                            }
-                            Ok(None) => {
-                                tracing::debug!(target: "network", ?request, "client declined to respond");
-                                (StateRequestAckBody::Busy, None)
-                            }
-                            Err(err) => {
-                                tracing::error!(target: "network", ?request, ?err, "client failed to respond");
-                                (StateRequestAckBody::Error, None)
+                        let (ack, response) = if response_permit.is_none() {
+                            tracing::debug!(target: "network", ?request, "outgoing queue saturated; dropping state header response");
+                            metrics::MessageDropped::OutgoingQueueLimitExceeded
+                                .inc_msg_type("VersionedStateResponse");
+                            (StateRequestAckBody::Busy, None)
+                        } else {
+                            match state.state_request_adapter.send_async(StateRequestHeader { shard_id, sync_hash }).await {
+                                Ok(Some(client_response)) => {
+                                    (StateRequestAckBody::WillRespond, Some(PeerMessage::VersionedStateResponse(*client_response.0)))
+                                }
+                                Ok(None) => {
+                                    tracing::debug!(target: "network", ?request, "client declined to respond");
+                                    (StateRequestAckBody::Busy, None)
+                                }
+                                Err(err) => {
+                                    tracing::error!(target: "network", ?request, ?err, "client failed to respond");
+                                    (StateRequestAckBody::Error, None)
+                                }
                             }
                         };
 
@@ -1583,17 +1608,24 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                         )
                     }
                     Tier3RequestBody::StatePart(StatePartRequestBody { shard_id, sync_hash, part_id }) => {
-                        let (ack, response) = match state.state_request_adapter.send_async(StateRequestPart { shard_id, sync_hash, part_id }).await {
-                            Ok(Some(client_response)) => {
-                                (StateRequestAckBody::WillRespond, Some(PeerMessage::VersionedStateResponse(*client_response.0)))
-                            }
-                            Ok(None) => {
-                                tracing::debug!(target: "network", ?request, "client declined to respond");
-                                (StateRequestAckBody::Busy, None)
-                            }
-                            Err(err) => {
-                                tracing::error!(target: "network", ?err, ?request, "client failed to respond");
-                                (StateRequestAckBody::Error, None)
+                        let (ack, response) = if response_permit.is_none() {
+                            tracing::debug!(target: "network", ?request, "outgoing queue saturated; dropping state part response");
+                            metrics::MessageDropped::OutgoingQueueLimitExceeded
+                                .inc_msg_type("VersionedStateResponse");
+                            (StateRequestAckBody::Busy, None)
+                        } else {
+                            match state.state_request_adapter.send_async(StateRequestPart { shard_id, sync_hash, part_id }).await {
+                                Ok(Some(client_response)) => {
+                                    (StateRequestAckBody::WillRespond, Some(PeerMessage::VersionedStateResponse(*client_response.0)))
+                                }
+                                Ok(None) => {
+                                    tracing::debug!(target: "network", ?request, "client declined to respond");
+                                    (StateRequestAckBody::Busy, None)
+                                }
+                                Err(err) => {
+                                    tracing::error!(target: "network", ?err, ?request, "client failed to respond");
+                                    (StateRequestAckBody::Error, None)
+                                }
                             }
                         };
 
@@ -1627,6 +1659,9 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                 let Some(tier3_response) = maybe_tier3_response else {
                     return;
                 };
+                // Safe to unwrap: maybe_tier3_response is only Some when we
+                // had a permit (the Busy branch above clears it).
+                let response_permit = response_permit.expect("permit set when response present");
 
                 // Establish a tier3 connection if we don't have one already.
                 let already_connected_t3 =
@@ -1640,7 +1675,12 @@ impl messaging::Handler<Tier3Request> for PeerManagerActor {
                     }
                 }
 
-                transport.send_message(tcp::Tier::T3, sender, Arc::new(tier3_response));
+                transport.send_message_with_permit(
+                    tcp::Tier::T3,
+                    sender,
+                    Arc::new(tier3_response),
+                    response_permit,
+                );
             }
         );
     }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -2,6 +2,7 @@ use crate::client::{
     ClientSenderForNetwork, GetCurrentEpochHeight, SetNetworkInfo, SpiceChunkEndorsementMessage,
     StateRequestHeader, StateRequestPart,
 };
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::config;
 use crate::debug::{DebugStatus, GetDebugStatus};
 use crate::network_protocol::{self, T2MessageBody};
@@ -837,7 +838,7 @@ impl PeerManagerActor {
     fn handle_msg_network_requests(
         &self,
         msg: NetworkRequests,
-        permit: Option<crate::concurrency::outgoing_queue_limiter::OutgoingPermit>,
+        permit: Option<OutgoingPermit>,
     ) -> NetworkResponses {
         let msg_type: &str = msg.as_ref();
         let _span =

--- a/chain/network/src/peer_manager/tcp_transport.rs
+++ b/chain/network/src/peer_manager/tcp_transport.rs
@@ -1,3 +1,4 @@
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::network_protocol::PeerInfo;
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::connection;
@@ -180,6 +181,20 @@ impl NetworkTransport for TcpTransport {
             tcp::Tier::T1 => self.tier1.send_message(peer_id, msg),
             tcp::Tier::T2 => self.tier2.send_message(peer_id, msg),
             tcp::Tier::T3 => self.tier3.send_message(peer_id, msg),
+        }
+    }
+
+    fn send_message_with_permit(
+        &self,
+        tier: tcp::Tier,
+        peer_id: PeerId,
+        msg: Arc<PeerMessage>,
+        permit: OutgoingPermit,
+    ) -> bool {
+        match tier {
+            tcp::Tier::T1 => self.tier1.send_message_with_permit(peer_id, msg, Some(permit)),
+            tcp::Tier::T2 => self.tier2.send_message_with_permit(peer_id, msg, Some(permit)),
+            tcp::Tier::T3 => self.tier3.send_message_with_permit(peer_id, msg, Some(permit)),
         }
     }
 

--- a/chain/network/src/private_messages.rs
+++ b/chain/network/src/private_messages.rs
@@ -1,5 +1,6 @@
 /// This file is contains all types used for communication between `Actors` within this crate.
 /// They are not meant to be used outside.
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use crate::network_protocol::PeerMessage;
 use crate::peer_manager::connection;
 use std::fmt::Debug;
@@ -17,7 +18,12 @@ pub(crate) enum RegisterPeerError {
     UnexpectedTier3Connection,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct SendMessage {
     pub message: Arc<PeerMessage>,
+    /// Optional pre-acquired reservation against the outgoing-queue
+    /// limiter. Set by callers that reserved capacity before producing the
+    /// message (state/epoch sync responses); other callers leave it None
+    /// and acquire on the fly inside PeerActor::send_message.
+    pub reserved_permit: Option<OutgoingPermit>,
 }

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -476,6 +476,7 @@ pub(crate) enum MessageDropped {
     MaxCapacityExceeded,
     TransactionsPerBlockExceeded,
     Duplicate,
+    OutgoingQueueLimitExceeded,
 }
 
 impl MessageDropped {
@@ -487,7 +488,7 @@ impl MessageDropped {
         self.inc_msg_type("unknown")
     }
 
-    fn inc_msg_type(self, msg_type: &str) {
+    pub(crate) fn inc_msg_type(self, msg_type: &str) {
         let reason = self.as_ref();
         DROPPED_MESSAGE_COUNT.with_label_values(&[msg_type, reason]).inc();
     }

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -180,6 +180,12 @@ impl CanSend<Tier3Request> for MockPeerManagerAdapter {
     fn send(&self, _msg: Tier3Request) {}
 }
 
+impl CanSend<crate::types::NetworkRequestWithPermit> for MockPeerManagerAdapter {
+    fn send(&self, _msg: crate::types::NetworkRequestWithPermit) {
+        unimplemented!()
+    }
+}
+
 impl MockPeerManagerAdapter {
     pub fn pop(&self) -> Option<PeerManagerMessageRequest> {
         self.requests.write().pop_front()

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1,4 +1,5 @@
 use crate::client::{StatePartOrHeader, StateRequestHeader, StateRequestPart};
+use crate::concurrency::outgoing_queue_limiter::OutgoingPermit;
 /// Type that belong to the network protocol.
 pub use crate::network_protocol::{
     Disconnect, Handshake, HandshakeFailureReason, PeerMessage, RoutingTableUpdate,
@@ -443,10 +444,19 @@ pub enum NetworkResponses {
     SelectedDestination(PeerId),
 }
 
+/// `NetworkRequests` plus a pre-acquired outgoing-queue permit. Used when the sender has already
+/// reserved bytes in the the `OutgoingQueueLimiter`.
+#[derive(Debug)]
+pub struct NetworkRequestWithPermit {
+    pub request: NetworkRequests,
+    pub permit: OutgoingPermit,
+}
+
 #[derive(Clone, MultiSend, MultiSenderFrom)]
 pub struct PeerManagerAdapter {
     pub async_request_sender: AsyncSender<PeerManagerMessageRequest, PeerManagerMessageResponse>,
     pub request_sender: Sender<PeerManagerMessageRequest>,
+    pub request_with_permit_sender: Sender<NetworkRequestWithPermit>,
     pub set_chain_info_sender: Sender<SetChainInfo>,
     pub state_sync_event_sender: Sender<StateSyncEvent>,
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -445,7 +445,7 @@ pub enum NetworkResponses {
 }
 
 /// `NetworkRequests` plus a pre-acquired outgoing-queue permit. Used when the sender has already
-/// reserved bytes in the the `OutgoingQueueLimiter`.
+/// reserved bytes in the `OutgoingQueueLimiter`.
 #[derive(Debug)]
 pub struct NetworkRequestWithPermit {
     pub request: NetworkRequests,

--- a/integration-tests/src/utils/peer_manager_mock.rs
+++ b/integration-tests/src/utils/peer_manager_mock.rs
@@ -43,3 +43,9 @@ impl messaging::Handler<StateSyncEvent> for PeerManagerMock {
 impl messaging::Handler<Tier3Request> for PeerManagerMock {
     fn handle(&mut self, _msg: Tier3Request) {}
 }
+
+impl messaging::Handler<near_network::types::NetworkRequestWithPermit> for PeerManagerMock {
+    fn handle(&mut self, _msg: near_network::types::NetworkRequestWithPermit) {
+        unimplemented!()
+    }
+}

--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -16,6 +16,7 @@ use near_network::client::{
     ProcessTxResponse, SpiceChunkEndorsementMessage, StateRequestHeader, StateRequestPart,
     StateResponse, StateResponseReceived,
 };
+use near_network::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use near_network::recv_permit::RecvMessagePermit;
 use near_network::shards_manager::ShardsManagerRequestFromNetwork;
 use near_network::spice::data_distribution::{
@@ -558,6 +559,20 @@ impl Handler<Tier3Request> for TestLoopPeerManagerActor {
     fn handle(&mut self, _msg: Tier3Request) {}
 }
 
+impl Handler<near_network::types::NetworkRequestWithPermit> for TestLoopPeerManagerActor {
+    fn handle(&mut self, msg: near_network::types::NetworkRequestWithPermit) {
+        // Test-loop has no real outgoing-queue limiter; the permit is
+        // discarded. Forward the inner request through the existing
+        // PeerManagerMessageRequest dispatch so request-handler hooks
+        // (NetworkRequests) see it.
+        let near_network::types::NetworkRequestWithPermit { request, permit: _ } = msg;
+        Handler::<PeerManagerMessageRequest, PeerManagerMessageResponse>::handle(
+            self,
+            PeerManagerMessageRequest::NetworkRequests(request),
+        );
+    }
+}
+
 impl Handler<PeerManagerMessageRequest> for TestLoopPeerManagerActor {
     fn handle(&mut self, msg: PeerManagerMessageRequest) {
         Handler::<PeerManagerMessageRequest, PeerManagerMessageResponse>::handle(self, msg);
@@ -689,6 +704,7 @@ fn network_message_to_client_handler(
                 EpochSyncRequestMessage {
                     from_peer: my_peer_id,
                     recv_permit: RecvMessagePermit::none(),
+                    response_permit: OutgoingPermit::fake_for_test(),
                 },
             );
             HandlerResult::Handled(NetworkResponses::NoResponse)


### PR DESCRIPTION


cherry-pick 526f116a5caeda301448bd7e80801755873f18ee to master.

The commit cherry-picked cleanly, but I had to change a few lines to make things right. The changes are in the second commit.

Adds an outgoing memory semaphore to limit memory usage of queued outgoing network messages