### PR TITLE
fix(forknet): default chain id to mocknet

### DIFF
--- a/pytest/tests/mocknet/forknet_scenarios/base.py
+++ b/pytest/tests/mocknet/forknet_scenarios/base.py
@@ -81,6 +81,11 @@ class TestSetup:
         self.start_height = args.start_height
         # The unique id of the forknet.
         self.unique_id = args.unique_id
+        # The new chain id for the forknet genesis.
+        # We set the chain id to "mocknet" to trigger neard code paths restricted by the chain id.
+        # You can change this value to any other string but chain id bound features may change the behavior of the test.
+        # "mainnet" checks are too restrictive and will break the test.
+        self.new_chain_id = "mocknet"
         # The genesis protocol version.
         self.genesis_protocol_version = getattr(args,
                                                 'genesis_protocol_version',
@@ -206,7 +211,7 @@ class TestSetup:
         new_test_args.num_validators = self.node_hardware_config.num_chunk_validator_seats
         # Set all seats to the lower value. This will be increased later in epoch config.
         new_test_args.num_seats = self.node_hardware_config.num_chunk_producer_seats
-        new_test_args.new_chain_id = self.unique_id
+        new_test_args.new_chain_id = self.new_chain_id
         new_test_args.yes = True
         new_test_args.gcs_state_sync = self.has_state_dumper
         new_test_args.state_source = 'dump'


### PR DESCRIPTION
Previously, the chain id was set to unique id of the forknet. 
Some of the neard features are gated behind chain id. 
Setting it to `mocknet` allows us to test more features.