### PR TITLE
feat(spice): light-client chunk-execution proof

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -5,7 +5,7 @@ use near_primitives::network::PeerId;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, BlockReference, EpochId, EpochReference,
-    MaybeBlockId, ShardId, TransactionOrReceiptId,
+    MaybeBlockId, ShardId, SpiceChunkId, TransactionOrReceiptId,
 };
 use near_primitives::views::{
     EpochSyncStatusView, ExecutionOutcomeWithIdView, LightClientBlockLiteView, QueryRequest,
@@ -912,6 +912,48 @@ impl From<near_chain_primitives::error::Error> for GetBlockProofError {
                 Self::InternalError { error_message }
             }
             err => Self::Unreachable { error_message: err.to_string() },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GetLightClientChunkExecutionProof {
+    pub chunk_id: SpiceChunkId,
+    pub light_client_head: CryptoHash,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetLightClientProofError {
+    #[error("Chunk {chunk_id:?} is not yet certified")]
+    ChunkNotCertified { chunk_id: SpiceChunkId },
+    #[error(
+        "Light client head height {head_height} must be greater than height \
+         {certifying_block_height} of the block certifying chunk {chunk_id:?}"
+    )]
+    LightClientHeadTooOld {
+        chunk_id: SpiceChunkId,
+        certifying_block_height: BlockHeight,
+        head_height: BlockHeight,
+    },
+    #[error(
+        "Block either has never been observed on the node or has been garbage collected: \
+         {error_message}"
+    )]
+    UnknownBlock { error_message: String },
+    #[error("Internal error: {error_message}")]
+    InternalError { error_message: String },
+}
+
+impl From<near_chain_primitives::error::Error> for GetLightClientProofError {
+    fn from(error: near_chain_primitives::error::Error) -> Self {
+        match error {
+            near_chain_primitives::error::Error::DBNotFoundErr(error_message) => {
+                Self::UnknownBlock { error_message }
+            }
+            near_chain_primitives::error::Error::IOErr(error) => {
+                Self::InternalError { error_message: error.to_string() }
+            }
+            err => Self::InternalError { error_message: err.to_string() },
         }
     }
 }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -21,12 +21,13 @@ pub use near_client_primitives::debug::DebugStatus;
 pub use near_client_primitives::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
     GetChunkExtraExists, GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
-    GetExecutionOutcomesForBlock, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
-    GetNextLightClientBlock, GetProcessedReceiptIds, GetProtocolConfig, GetReceipt, GetReceiptToTx,
-    GetReceiptToTxResponse, GetShardChunk, GetSplitStorageInfo, GetStateChanges,
-    GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
-    GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
-    QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError, TxStatusOutcome,
+    GetExecutionOutcomesForBlock, GetGasPrice, GetLightClientChunkExecutionProof,
+    GetLightClientProofError, GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock,
+    GetProcessedReceiptIds, GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse,
+    GetShardChunk, GetSplitStorageInfo, GetStateChanges, GetStateChangesInBlock,
+    GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
+    GetValidatorInfo, GetValidatorOrdered, Query, QueryError, Status, StatusResponse, SyncStatus,
+    TxStatus, TxStatusError, TxStatusOutcome,
 };
 pub use near_network::client::{
     BlockApproval, BlockResponse, ProcessTxRequest, ProcessTxResponse, SetNetworkInfo,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -23,9 +23,10 @@ use near_client_primitives::types::{
     Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError, GetBlockProofResponse,
     GetBlockWithMerkleTree, GetChunkError, GetChunkExtraExists, GetExecutionOutcome,
     GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError,
-    GetMaintenanceWindows, GetMaintenanceWindowsError, GetNextLightClientBlockError,
-    GetProcessedReceiptIds, GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError,
-    GetReceipt, GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
+    GetLightClientChunkExecutionProof, GetLightClientProofError, GetMaintenanceWindows,
+    GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProcessedReceiptIds,
+    GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError, GetReceipt,
+    GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
     GetSplitStorageInfo, GetSplitStorageInfoError, GetStateChangesError,
     GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
     GetValidatorInfoError, Query, QueryError, TxStatus, TxStatusError, TxStatusOutcome,
@@ -52,16 +53,17 @@ use near_primitives::sharding::ShardChunk;
 use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockId, BlockReference, EpochHeight, EpochId, EpochReference,
-    Finality, MaybeBlockId, ShardId, SyncCheckpoint, TransactionOrReceiptId,
-    ValidatorInfoIdentifier,
+    Finality, MaybeBlockId, ShardId, SpiceChunkId, SyncCheckpoint, TransactionOrReceiptId,
+    ValidatorInfoIdentifier, sorted_chunk_execution_roots,
 };
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
-    BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView, ExecutionStatusView,
-    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockView,
-    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, SplitStorageInfoView,
-    StateChangesKindsView, StateChangesView, TxExecutionStatus, TxStatusView,
+    BlockView, ChunkExecutionProofView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
+    ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView,
+    LightClientBlockLiteView, LightClientBlockView, MaintenanceWindowsView, QueryRequest,
+    QueryResponse, ReceiptView, SplitStorageInfoView, StateChangesKindsView, StateChangesView,
+    TxExecutionStatus, TxStatusView,
 };
 use near_store::adapter::StoreAdapter as _;
 use near_store::merkle_proof::MerkleProofAccess;
@@ -1617,6 +1619,94 @@ impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> f
             &msg.head_block_hash,
         )?;
         Ok(GetBlockProofResponse { block_header_lite, proof })
+    }
+}
+
+impl ViewClientActor {
+    /// Builds a light-client proof that a chunk's certified execution roots are
+    /// committed by the block certifying them, and that this block is in the
+    /// block merkle tree of a final `light_client_head`.
+    fn build_chunk_execution_proof(
+        &self,
+        chunk_id: &SpiceChunkId,
+        light_client_head: &CryptoHash,
+    ) -> Result<ChunkExecutionProofView, GetLightClientProofError> {
+        let Some(certifying_block_hash) =
+            self.runtime.store().chain_store().get_chunk_certifying_block(chunk_id)
+        else {
+            return Err(GetLightClientProofError::ChunkNotCertified { chunk_id: chunk_id.clone() });
+        };
+
+        let head_header = self.chain.get_block_header(light_client_head)?;
+        self.chain.check_blocks_final_and_canonical(&[BlockHeader::clone(&head_header)]).map_err(
+            |error| GetLightClientProofError::InternalError {
+                error_message: format!("light client head is not final and canonical: {error}"),
+            },
+        )?;
+
+        let certifying_block = self.chain.get_block(&certifying_block_hash)?;
+        let certifying_height = certifying_block.header().height();
+        let head_height = head_header.height();
+        // The head must be strictly after the certifying block: the block merkle
+        // proof recomputes the head's block_merkle_root from the certifying block,
+        // and that root commits only to blocks before the head.
+        if head_height <= certifying_height {
+            return Err(GetLightClientProofError::LightClientHeadTooOld {
+                chunk_id: chunk_id.clone(),
+                certifying_block_height: certifying_height,
+                head_height,
+            });
+        }
+
+        let leaves = sorted_chunk_execution_roots(
+            certifying_block.spice_core_statements().iter_execution_results(),
+        );
+        let Some(index) = leaves.iter().position(|leaf| leaf.chunk_id() == chunk_id) else {
+            return Err(GetLightClientProofError::ChunkNotCertified { chunk_id: chunk_id.clone() });
+        };
+        let (root, paths) = merklize(&leaves);
+        if Some(root) != certifying_block.header().chunk_execution_root() {
+            return Err(GetLightClientProofError::InternalError {
+                error_message:
+                    "recomputed chunk_execution_root disagrees with the certifying block's committed root"
+                        .to_string(),
+            });
+        }
+        let roots = leaves[index].clone();
+        let roots_proof = paths[index].clone();
+
+        let certifying_block_header_lite =
+            LightClientBlockLiteView::from(BlockHeader::clone(certifying_block.header()));
+        let certifying_block_proof =
+            self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
+                &certifying_block_hash,
+                light_client_head,
+            )?;
+
+        Ok(ChunkExecutionProofView {
+            roots,
+            roots_proof,
+            certifying_block_header_lite,
+            certifying_block_proof,
+        })
+    }
+}
+
+impl
+    Handler<
+        GetLightClientChunkExecutionProof,
+        Result<ChunkExecutionProofView, GetLightClientProofError>,
+    > for ViewClientActor
+{
+    fn handle(
+        &mut self,
+        msg: GetLightClientChunkExecutionProof,
+    ) -> Result<ChunkExecutionProofView, GetLightClientProofError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetLightClientChunkExecutionProof"])
+            .start_timer();
+        self.build_chunk_execution_proof(&msg.chunk_id, &msg.light_client_head)
     }
 }
 

--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -45,6 +45,19 @@ pub struct RpcLightClientBlockProofResponse {
     pub block_proof: near_primitives::merkle::MerklePath,
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientChunkExecutionProofRequest {
+    pub chunk_id: near_primitives::types::SpiceChunkId,
+    pub light_client_head: near_primitives::hash::CryptoHash,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientChunkExecutionProofResponse {
+    pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
+}
+
 #[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
@@ -72,6 +85,17 @@ pub enum RpcLightClientProofError {
     UnavailableShard {
         transaction_or_receipt_id: near_primitives::hash::CryptoHash,
         shard_id: near_primitives::types::ShardId,
+    },
+    #[error("Chunk {chunk_id:?} is not yet certified")]
+    ChunkNotCertified { chunk_id: near_primitives::types::SpiceChunkId },
+    #[error(
+        "Light client head height {head_height} must be greater than height \
+         {certifying_block_height} of the block certifying chunk {chunk_id:?}"
+    )]
+    LightClientHeadTooOld {
+        chunk_id: near_primitives::types::SpiceChunkId,
+        certifying_block_height: near_primitives::types::BlockHeight,
+        head_height: near_primitives::types::BlockHeight,
     },
     #[error("Internal error: {error_message}")]
     InternalError { error_message: String },

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "NEAR Protocol JSON RPC API",
-    "version": "1.3.15"
+    "version": "1.3.16"
   },
   "paths": {
     "/EXPERIMENTAL_call_function": {
@@ -166,6 +166,34 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/JsonRpcResponse_for_RpcLightClientBlockProofResponse_and_RpcLightClientProofError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/EXPERIMENTAL_light_client_chunk_execution_proof": {
+      "post": {
+        "description": "Returns a proof that a chunk's certified execution roots are committed by the chain, verifiable against a trusted light client head.",
+        "operationId": "EXPERIMENTAL_light_client_chunk_execution_proof",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_light_client_chunk_execution_proof"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonRpcResponse_for_RpcLightClientChunkExecutionProofResponse_and_RpcLightClientProofError"
                 }
               }
             }
@@ -3892,6 +3920,76 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "ChunkExecutionProofView": {
+        "description": "Proof that a chunk's certified execution roots are committed by a spice block\nthat a light client can trust via its `light_client_head`.\n\n`roots_proof` recomputes the certifying block's `chunk_execution_root` from the leaf;\n`certifying_block_proof` places the certifying block into the head's block merkle tree.",
+        "properties": {
+          "certifying_block_header_lite": {
+            "$ref": "#/components/schemas/LightClientBlockLiteView"
+          },
+          "certifying_block_proof": {
+            "items": {
+              "$ref": "#/components/schemas/MerklePathItem"
+            },
+            "type": "array"
+          },
+          "roots": {
+            "$ref": "#/components/schemas/ChunkExecutionRoots"
+          },
+          "roots_proof": {
+            "items": {
+              "$ref": "#/components/schemas/MerklePathItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "roots",
+          "roots_proof",
+          "certifying_block_header_lite",
+          "certifying_block_proof"
+        ],
+        "type": "object"
+      },
+      "ChunkExecutionRoots": {
+        "description": "Merkle leaf committing to a single chunk's certified execution roots.\nThe `chunk_execution_root` in a spice block header is the merkle root over\nthese leaves, sorted by `chunk_id`.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "V1": {
+                "$ref": "#/components/schemas/ChunkExecutionRootsV1"
+              }
+            },
+            "required": [
+              "V1"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ChunkExecutionRootsV1": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "outcome_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "outgoing_receipts_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "state_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "state_root",
+          "outcome_root",
+          "outgoing_receipts_root"
+        ],
         "type": "object"
       },
       "ChunkHash": {
@@ -9371,6 +9469,33 @@
         "title": "JsonRpcRequest_for_EXPERIMENTAL_light_client_block_proof",
         "type": "object"
       },
+      "JsonRpcRequest_for_EXPERIMENTAL_light_client_chunk_execution_proof": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          },
+          "method": {
+            "enum": [
+              "EXPERIMENTAL_light_client_chunk_execution_proof"
+            ],
+            "type": "string"
+          },
+          "params": {
+            "$ref": "#/components/schemas/RpcLightClientChunkExecutionProofRequest"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id",
+          "params",
+          "method"
+        ],
+        "title": "JsonRpcRequest_for_EXPERIMENTAL_light_client_chunk_execution_proof",
+        "type": "object"
+      },
       "JsonRpcRequest_for_EXPERIMENTAL_light_client_proof": {
         "properties": {
           "id": {
@@ -10729,6 +10854,46 @@
           "id"
         ],
         "title": "JsonRpcResponse_for_RpcLightClientBlockProofResponse_and_RpcLightClientProofError",
+        "type": "object"
+      },
+      "JsonRpcResponse_for_RpcLightClientChunkExecutionProofResponse_and_RpcLightClientProofError": {
+        "oneOf": [
+          {
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/RpcLightClientChunkExecutionProofResponse"
+              }
+            },
+            "required": [
+              "result"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "error": {
+                "$ref": "#/components/schemas/ErrorWrapper_for_RpcLightClientProofError"
+              }
+            },
+            "required": [
+              "error"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id"
+        ],
+        "title": "JsonRpcResponse_for_RpcLightClientChunkExecutionProofResponse_and_RpcLightClientProofError",
         "type": "object"
       },
       "JsonRpcResponse_for_RpcLightClientExecutionProofResponse_and_RpcLightClientProofError": {
@@ -14105,6 +14270,33 @@
         ],
         "type": "object"
       },
+      "RpcLightClientChunkExecutionProofRequest": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "light_client_head": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "light_client_head"
+        ],
+        "title": "RpcLightClientChunkExecutionProofRequest",
+        "type": "object"
+      },
+      "RpcLightClientChunkExecutionProofResponse": {
+        "properties": {
+          "chunk_execution_proof": {
+            "$ref": "#/components/schemas/ChunkExecutionProofView"
+          }
+        },
+        "required": [
+          "chunk_execution_proof"
+        ],
+        "type": "object"
+      },
       "RpcLightClientExecutionProofRequest": {
         "oneOf": [
           {
@@ -14448,6 +14640,70 @@
               "name": {
                 "enum": [
                   "UNAVAILABLE_SHARD"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "info"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "info": {
+                "properties": {
+                  "chunk_id": {
+                    "$ref": "#/components/schemas/SpiceChunkId"
+                  }
+                },
+                "required": [
+                  "chunk_id"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "enum": [
+                  "CHUNK_NOT_CERTIFIED"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "info"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "info": {
+                "properties": {
+                  "certifying_block_height": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "chunk_id": {
+                    "$ref": "#/components/schemas/SpiceChunkId"
+                  },
+                  "head_height": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "chunk_id",
+                  "certifying_block_height",
+                  "head_height"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "enum": [
+                  "LIGHT_CLIENT_HEAD_TOO_OLD"
                 ],
                 "type": "string"
               }
@@ -20240,6 +20496,22 @@
         "required": [
           "produced",
           "expected"
+        ],
+        "type": "object"
+      },
+      "SpiceChunkId": {
+        "description": "In spice missing chunks and equivalent to empty chunks so block hash and shard id always\nuniquely identifies chunks.",
+        "properties": {
+          "block_hash": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "shard_id": {
+            "$ref": "#/components/schemas/ShardId"
+          }
+        },
+        "required": [
+          "block_hash",
+          "shard_id"
         ],
         "type": "object"
       },

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "NEAR Protocol JSON RPC API",
-    "version": "1.2.14"
+    "version": "1.2.15"
   },
   "paths": {
     "/EXPERIMENTAL_call_function": {
@@ -166,6 +166,34 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/JsonRpcResponse_for_RpcLightClientBlockProofResponse_and_RpcLightClientProofError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/EXPERIMENTAL_light_client_chunk_execution_proof": {
+      "post": {
+        "description": "Returns a proof that a chunk's certified execution roots are committed by the chain, verifiable against a trusted light client head.",
+        "operationId": "EXPERIMENTAL_light_client_chunk_execution_proof",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_light_client_chunk_execution_proof"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonRpcResponse_for_RpcLightClientChunkExecutionProofResponse_and_RpcLightClientProofError"
                 }
               }
             }
@@ -3869,6 +3897,76 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "ChunkExecutionProofView": {
+        "description": "Proof that a chunk's certified execution roots are committed by a spice block\nthat a light client can trust via its `light_client_head`.\n\n`roots_proof` recomputes the certifying block's `chunk_execution_root` from the leaf;\n`certifying_block_proof` places the certifying block into the head's block merkle tree.",
+        "properties": {
+          "certifying_block_header_lite": {
+            "$ref": "#/components/schemas/LightClientBlockLiteView"
+          },
+          "certifying_block_proof": {
+            "items": {
+              "$ref": "#/components/schemas/MerklePathItem"
+            },
+            "type": "array"
+          },
+          "roots": {
+            "$ref": "#/components/schemas/ChunkExecutionRoots"
+          },
+          "roots_proof": {
+            "items": {
+              "$ref": "#/components/schemas/MerklePathItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "roots",
+          "roots_proof",
+          "certifying_block_header_lite",
+          "certifying_block_proof"
+        ],
+        "type": "object"
+      },
+      "ChunkExecutionRoots": {
+        "description": "Merkle leaf committing to a single chunk's certified execution roots.\nThe `chunk_execution_root` in a spice block header is the merkle root over\nthese leaves, sorted by `chunk_id`.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "V1": {
+                "$ref": "#/components/schemas/ChunkExecutionRootsV1"
+              }
+            },
+            "required": [
+              "V1"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ChunkExecutionRootsV1": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "outcome_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "outgoing_receipts_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "state_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "state_root",
+          "outcome_root",
+          "outgoing_receipts_root"
+        ],
         "type": "object"
       },
       "ChunkHash": {
@@ -9336,6 +9434,33 @@
         "title": "JsonRpcRequest_for_EXPERIMENTAL_light_client_block_proof",
         "type": "object"
       },
+      "JsonRpcRequest_for_EXPERIMENTAL_light_client_chunk_execution_proof": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          },
+          "method": {
+            "enum": [
+              "EXPERIMENTAL_light_client_chunk_execution_proof"
+            ],
+            "type": "string"
+          },
+          "params": {
+            "$ref": "#/components/schemas/RpcLightClientChunkExecutionProofRequest"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id",
+          "params",
+          "method"
+        ],
+        "title": "JsonRpcRequest_for_EXPERIMENTAL_light_client_chunk_execution_proof",
+        "type": "object"
+      },
       "JsonRpcRequest_for_EXPERIMENTAL_light_client_proof": {
         "properties": {
           "id": {
@@ -10694,6 +10819,46 @@
           "id"
         ],
         "title": "JsonRpcResponse_for_RpcLightClientBlockProofResponse_and_RpcLightClientProofError",
+        "type": "object"
+      },
+      "JsonRpcResponse_for_RpcLightClientChunkExecutionProofResponse_and_RpcLightClientProofError": {
+        "oneOf": [
+          {
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/RpcLightClientChunkExecutionProofResponse"
+              }
+            },
+            "required": [
+              "result"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "error": {
+                "$ref": "#/components/schemas/ErrorWrapper_for_RpcLightClientProofError"
+              }
+            },
+            "required": [
+              "error"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id"
+        ],
+        "title": "JsonRpcResponse_for_RpcLightClientChunkExecutionProofResponse_and_RpcLightClientProofError",
         "type": "object"
       },
       "JsonRpcResponse_for_RpcLightClientExecutionProofResponse_and_RpcLightClientProofError": {
@@ -14070,6 +14235,33 @@
         ],
         "type": "object"
       },
+      "RpcLightClientChunkExecutionProofRequest": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "light_client_head": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "light_client_head"
+        ],
+        "title": "RpcLightClientChunkExecutionProofRequest",
+        "type": "object"
+      },
+      "RpcLightClientChunkExecutionProofResponse": {
+        "properties": {
+          "chunk_execution_proof": {
+            "$ref": "#/components/schemas/ChunkExecutionProofView"
+          }
+        },
+        "required": [
+          "chunk_execution_proof"
+        ],
+        "type": "object"
+      },
       "RpcLightClientExecutionProofRequest": {
         "oneOf": [
           {
@@ -14413,6 +14605,70 @@
               "name": {
                 "enum": [
                   "UNAVAILABLE_SHARD"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "info"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "info": {
+                "properties": {
+                  "chunk_id": {
+                    "$ref": "#/components/schemas/SpiceChunkId"
+                  }
+                },
+                "required": [
+                  "chunk_id"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "enum": [
+                  "CHUNK_NOT_CERTIFIED"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "info"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "info": {
+                "properties": {
+                  "certifying_block_height": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "chunk_id": {
+                    "$ref": "#/components/schemas/SpiceChunkId"
+                  },
+                  "head_height": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "chunk_id",
+                  "certifying_block_height",
+                  "head_height"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "enum": [
+                  "LIGHT_CLIENT_HEAD_TOO_OLD"
                 ],
                 "type": "string"
               }
@@ -20205,6 +20461,22 @@
         "required": [
           "produced",
           "expected"
+        ],
+        "type": "object"
+      },
+      "SpiceChunkId": {
+        "description": "In spice missing chunks and equivalent to empty chunks so block hash and shard id always\nuniquely identifies chunks.",
+        "properties": {
+          "block_hash": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "shard_id": {
+            "$ref": "#/components/schemas/ShardId"
+          }
+        },
+        "required": [
+          "block_hash",
+          "shard_id"
         ],
         "type": "object"
       },

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -2784,6 +2784,80 @@
         "title": "ChunkDistributionUris",
         "type": "object"
       },
+      "ChunkExecutionProofView": {
+        "description": "Proof that a chunk's certified execution roots are committed by a spice block\nthat a light client can trust via its `light_client_head`.\n\n`roots_proof` recomputes the certifying block's `chunk_execution_root` from the leaf;\n`certifying_block_proof` places the certifying block into the head's block merkle tree.",
+        "properties": {
+          "certifying_block_header_lite": {
+            "$ref": "#/components/schemas/LightClientBlockLiteView"
+          },
+          "certifying_block_proof": {
+            "items": {
+              "$ref": "#/components/schemas/MerklePathItem"
+            },
+            "type": "array"
+          },
+          "roots": {
+            "$ref": "#/components/schemas/ChunkExecutionRoots"
+          },
+          "roots_proof": {
+            "items": {
+              "$ref": "#/components/schemas/MerklePathItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "roots",
+          "roots_proof",
+          "certifying_block_header_lite",
+          "certifying_block_proof"
+        ],
+        "title": "ChunkExecutionProofView",
+        "type": "object"
+      },
+      "ChunkExecutionRoots": {
+        "description": "Merkle leaf committing to a single chunk's certified execution roots.\nThe `chunk_execution_root` in a spice block header is the merkle root over\nthese leaves, sorted by `chunk_id`.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "V1": {
+                "$ref": "#/components/schemas/ChunkExecutionRootsV1"
+              }
+            },
+            "required": [
+              "V1"
+            ],
+            "title": "V1",
+            "type": "object"
+          }
+        ],
+        "title": "ChunkExecutionRoots"
+      },
+      "ChunkExecutionRootsV1": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "outcome_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "outgoing_receipts_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "state_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "state_root",
+          "outcome_root",
+          "outgoing_receipts_root"
+        ],
+        "title": "ChunkExecutionRootsV1",
+        "type": "object"
+      },
       "ChunkHeaderView": {
         "description": "Contains main info about the chunk.",
         "properties": {
@@ -8927,6 +9001,34 @@
         "title": "RpcLightClientBlockProofResponse",
         "type": "object"
       },
+      "RpcLightClientChunkExecutionProofRequest": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "light_client_head": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "light_client_head"
+        ],
+        "title": "RpcLightClientChunkExecutionProofRequest",
+        "type": "object"
+      },
+      "RpcLightClientChunkExecutionProofResponse": {
+        "properties": {
+          "chunk_execution_proof": {
+            "$ref": "#/components/schemas/ChunkExecutionProofView"
+          }
+        },
+        "required": [
+          "chunk_execution_proof"
+        ],
+        "title": "RpcLightClientChunkExecutionProofResponse",
+        "type": "object"
+      },
       "RpcLightClientExecutionProofRequest": {
         "oneOf": [
           {
@@ -11272,6 +11374,23 @@
           "expected"
         ],
         "title": "SpiceChunkEndorsementStats",
+        "type": "object"
+      },
+      "SpiceChunkId": {
+        "description": "In spice missing chunks and equivalent to empty chunks so block hash and shard id always\nuniquely identifies chunks.",
+        "properties": {
+          "block_hash": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "shard_id": {
+            "$ref": "#/components/schemas/ShardId"
+          }
+        },
+        "required": [
+          "block_hash",
+          "shard_id"
+        ],
+        "title": "SpiceChunkId",
         "type": "object"
       },
       "StakeAction": {
@@ -14162,6 +14281,41 @@
         }
       },
       "summary": "Returns block proof for light clients",
+      "tags": [
+        {
+          "name": "light_client"
+        },
+        {
+          "name": "experimental"
+        }
+      ]
+    },
+    {
+      "name": "EXPERIMENTAL_light_client_chunk_execution_proof",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "chunk_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          }
+        },
+        {
+          "name": "light_client_head",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$ref": "#/components/schemas/RpcLightClientChunkExecutionProofResponse"
+        }
+      },
+      "summary": "Returns a proof of a chunk's certified execution roots for light clients",
       "tags": [
         {
           "name": "light_client"

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -2760,6 +2760,80 @@
         "title": "ChunkDistributionUris",
         "type": "object"
       },
+      "ChunkExecutionProofView": {
+        "description": "Proof that a chunk's certified execution roots are committed by a spice block\nthat a light client can trust via its `light_client_head`.\n\n`roots_proof` recomputes the certifying block's `chunk_execution_root` from the leaf;\n`certifying_block_proof` places the certifying block into the head's block merkle tree.",
+        "properties": {
+          "certifying_block_header_lite": {
+            "$ref": "#/components/schemas/LightClientBlockLiteView"
+          },
+          "certifying_block_proof": {
+            "items": {
+              "$ref": "#/components/schemas/MerklePathItem"
+            },
+            "type": "array"
+          },
+          "roots": {
+            "$ref": "#/components/schemas/ChunkExecutionRoots"
+          },
+          "roots_proof": {
+            "items": {
+              "$ref": "#/components/schemas/MerklePathItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "roots",
+          "roots_proof",
+          "certifying_block_header_lite",
+          "certifying_block_proof"
+        ],
+        "title": "ChunkExecutionProofView",
+        "type": "object"
+      },
+      "ChunkExecutionRoots": {
+        "description": "Merkle leaf committing to a single chunk's certified execution roots.\nThe `chunk_execution_root` in a spice block header is the merkle root over\nthese leaves, sorted by `chunk_id`.",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "V1": {
+                "$ref": "#/components/schemas/ChunkExecutionRootsV1"
+              }
+            },
+            "required": [
+              "V1"
+            ],
+            "title": "V1",
+            "type": "object"
+          }
+        ],
+        "title": "ChunkExecutionRoots"
+      },
+      "ChunkExecutionRootsV1": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "outcome_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "outgoing_receipts_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "state_root": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "state_root",
+          "outcome_root",
+          "outgoing_receipts_root"
+        ],
+        "title": "ChunkExecutionRootsV1",
+        "type": "object"
+      },
       "ChunkHeaderView": {
         "description": "Contains main info about the chunk.",
         "properties": {
@@ -8891,6 +8965,34 @@
         "title": "RpcLightClientBlockProofResponse",
         "type": "object"
       },
+      "RpcLightClientChunkExecutionProofRequest": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "light_client_head": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "light_client_head"
+        ],
+        "title": "RpcLightClientChunkExecutionProofRequest",
+        "type": "object"
+      },
+      "RpcLightClientChunkExecutionProofResponse": {
+        "properties": {
+          "chunk_execution_proof": {
+            "$ref": "#/components/schemas/ChunkExecutionProofView"
+          }
+        },
+        "required": [
+          "chunk_execution_proof"
+        ],
+        "title": "RpcLightClientChunkExecutionProofResponse",
+        "type": "object"
+      },
       "RpcLightClientExecutionProofRequest": {
         "oneOf": [
           {
@@ -11236,6 +11338,23 @@
           "expected"
         ],
         "title": "SpiceChunkEndorsementStats",
+        "type": "object"
+      },
+      "SpiceChunkId": {
+        "description": "In spice missing chunks and equivalent to empty chunks so block hash and shard id always\nuniquely identifies chunks.",
+        "properties": {
+          "block_hash": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "shard_id": {
+            "$ref": "#/components/schemas/ShardId"
+          }
+        },
+        "required": [
+          "block_hash",
+          "shard_id"
+        ],
+        "title": "SpiceChunkId",
         "type": "object"
       },
       "StakeAction": {
@@ -14126,6 +14245,41 @@
         }
       },
       "summary": "Returns block proof for light clients",
+      "tags": [
+        {
+          "name": "light_client"
+        },
+        {
+          "name": "experimental"
+        }
+      ]
+    },
+    {
+      "name": "EXPERIMENTAL_light_client_chunk_execution_proof",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "chunk_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          }
+        },
+        {
+          "name": "light_client_head",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$ref": "#/components/schemas/RpcLightClientChunkExecutionProofResponse"
+        }
+      },
+      "summary": "Returns a proof of a chunk's certified execution roots for light clients",
       "tags": [
         {
           "name": "light_client"

--- a/chain/jsonrpc/openapi/src/main.rs
+++ b/chain/jsonrpc/openapi/src/main.rs
@@ -23,6 +23,7 @@ use near_jsonrpc_primitives::types::{
     gas_price::{RpcGasPriceError, RpcGasPriceRequest, RpcGasPriceResponse},
     light_client::{
         RpcLightClientBlockProofRequest, RpcLightClientBlockProofResponse,
+        RpcLightClientChunkExecutionProofRequest, RpcLightClientChunkExecutionProofResponse,
         RpcLightClientExecutionProofResponse, RpcLightClientNextBlockError,
         RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse, RpcLightClientProofError,
     },
@@ -700,7 +701,7 @@ fn whole_spec(all_schemas: SchemasMap, all_paths: PathsMap) -> OpenApi {
         openapi: "3.0.0".to_string(),
         info: okapi::openapi3::Info {
             title: "NEAR Protocol JSON RPC API".to_string(),
-            version: "1.3.15".to_string(),
+            version: "1.3.16".to_string(),
             ..Default::default()
         },
         paths: all_paths,
@@ -894,6 +895,16 @@ fn main() {
         &mut all_paths,
         "EXPERIMENTAL_light_client_block_proof".to_string(),
         "Returns the proofs for a transaction execution.".to_string(),
+    );
+    add_spec_for_path::<
+        RpcLightClientChunkExecutionProofRequest,
+        RpcLightClientChunkExecutionProofResponse,
+        RpcLightClientProofError,
+    >(
+        &mut all_schemas,
+        &mut all_paths,
+        "EXPERIMENTAL_light_client_chunk_execution_proof".to_string(),
+        "Returns a proof that a chunk's certified execution roots are committed by the chain, verifiable against a trusted light client head.".to_string(),
     );
     add_spec_for_path::<RpcProtocolConfigRequest, RpcProtocolConfigResponse, RpcProtocolConfigError>(
         &mut all_schemas,

--- a/chain/jsonrpc/openapi/src/main.rs
+++ b/chain/jsonrpc/openapi/src/main.rs
@@ -23,6 +23,7 @@ use near_jsonrpc_primitives::types::{
     gas_price::{RpcGasPriceError, RpcGasPriceRequest, RpcGasPriceResponse},
     light_client::{
         RpcLightClientBlockProofRequest, RpcLightClientBlockProofResponse,
+        RpcLightClientChunkExecutionProofRequest, RpcLightClientChunkExecutionProofResponse,
         RpcLightClientExecutionProofResponse, RpcLightClientNextBlockError,
         RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse, RpcLightClientProofError,
     },
@@ -700,7 +701,7 @@ fn whole_spec(all_schemas: SchemasMap, all_paths: PathsMap) -> OpenApi {
         openapi: "3.0.0".to_string(),
         info: okapi::openapi3::Info {
             title: "NEAR Protocol JSON RPC API".to_string(),
-            version: "1.2.14".to_string(),
+            version: "1.2.15".to_string(),
             ..Default::default()
         },
         paths: all_paths,
@@ -894,6 +895,16 @@ fn main() {
         &mut all_paths,
         "EXPERIMENTAL_light_client_block_proof".to_string(),
         "Returns the proofs for a transaction execution.".to_string(),
+    );
+    add_spec_for_path::<
+        RpcLightClientChunkExecutionProofRequest,
+        RpcLightClientChunkExecutionProofResponse,
+        RpcLightClientProofError,
+    >(
+        &mut all_schemas,
+        &mut all_paths,
+        "EXPERIMENTAL_light_client_chunk_execution_proof".to_string(),
+        "Returns a proof that a chunk's certified execution roots are committed by the chain, verifiable against a trusted light client head.".to_string(),
     );
     add_spec_for_path::<RpcProtocolConfigRequest, RpcProtocolConfigResponse, RpcProtocolConfigError>(
         &mut all_schemas,

--- a/chain/jsonrpc/openapi/src/openrpc.rs
+++ b/chain/jsonrpc/openapi/src/openrpc.rs
@@ -27,6 +27,7 @@ use near_jsonrpc_primitives::types::congestion::{
 use near_jsonrpc_primitives::types::gas_price::{RpcGasPriceRequest, RpcGasPriceResponse};
 use near_jsonrpc_primitives::types::light_client::{
     RpcLightClientBlockProofRequest, RpcLightClientBlockProofResponse,
+    RpcLightClientChunkExecutionProofRequest, RpcLightClientChunkExecutionProofResponse,
     RpcLightClientExecutionProofRequest, RpcLightClientExecutionProofResponse,
     RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse,
 };
@@ -1220,6 +1221,14 @@ pub fn generate_openrpc() -> serde_json::Value {
         &mut all_schemas,
         "EXPERIMENTAL_light_client_block_proof",
         "Returns block proof for light clients",
+        false,
+        &["light_client", "experimental"],
+    );
+    add_method::<RpcLightClientChunkExecutionProofRequest, RpcLightClientChunkExecutionProofResponse>(
+        &mut methods,
+        &mut all_schemas,
+        "EXPERIMENTAL_light_client_chunk_execution_proof",
+        "Returns a proof of a chunk's certified execution roots for light clients",
         false,
         &["light_client", "experimental"],
     );

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -1,13 +1,14 @@
 use super::{Params, RpcFrom, RpcRequest};
 use near_async::messaging::AsyncSendError;
 use near_client_primitives::types::{
-    GetBlockProofError, GetExecutionOutcomeError, GetNextLightClientBlockError,
+    GetBlockProofError, GetExecutionOutcomeError, GetLightClientProofError,
+    GetNextLightClientBlockError,
 };
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::light_client::{
-    RpcLightClientBlockProofRequest, RpcLightClientExecutionProofRequest,
-    RpcLightClientNextBlockError, RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse,
-    RpcLightClientProofError,
+    RpcLightClientBlockProofRequest, RpcLightClientChunkExecutionProofRequest,
+    RpcLightClientExecutionProofRequest, RpcLightClientNextBlockError,
+    RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse, RpcLightClientProofError,
 };
 use near_primitives::views::LightClientBlockView;
 use serde_json::Value;
@@ -30,6 +31,33 @@ impl RpcRequest for RpcLightClientNextBlockRequest {
 impl RpcRequest for RpcLightClientBlockProofRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
         Params::parse(value)
+    }
+}
+
+impl RpcRequest for RpcLightClientChunkExecutionProofRequest {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
+        Params::parse(value)
+    }
+}
+
+impl RpcFrom<GetLightClientProofError> for RpcLightClientProofError {
+    fn rpc_from(error: GetLightClientProofError) -> Self {
+        match error {
+            GetLightClientProofError::ChunkNotCertified { chunk_id } => {
+                Self::ChunkNotCertified { chunk_id }
+            }
+            GetLightClientProofError::LightClientHeadTooOld {
+                chunk_id,
+                certifying_block_height,
+                head_height,
+            } => Self::LightClientHeadTooOld { chunk_id, certifying_block_height, head_height },
+            GetLightClientProofError::UnknownBlock { error_message } => {
+                Self::UnknownBlock { error_message }
+            }
+            GetLightClientProofError::InternalError { error_message } => {
+                Self::InternalError { error_message }
+            }
+        }
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -16,11 +16,11 @@ use near_chain_configs::{ClientConfig, GenesisConfig, ProtocolConfigView};
 use near_client::{
     DebugStatus, GetBlock, GetBlockProof, GetBlockProofResponse, GetChunk, GetChunkExtraExists,
     GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice,
-    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
-    GetReceiptToTx, GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock,
-    GetValidatorInfo, GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse,
-    Query as ClientQuery, QueryError, Status, StatusResponse, TxStatus, TxStatusError,
-    TxStatusOutcome,
+    GetLightClientChunkExecutionProof, GetLightClientProofError, GetMaintenanceWindows,
+    GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetReceiptToTx,
+    GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo,
+    GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse, Query as ClientQuery, QueryError,
+    Status, StatusResponse, TxStatus, TxStatusError, TxStatusOutcome,
 };
 use near_client_primitives::debug::{
     DebugBlockStatusQuery, DebugBlocksStartingMode, DebugStatusResponse,
@@ -93,10 +93,10 @@ use near_primitives::types::{
 };
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
-    BlockView, ChunkView, EpochValidatorInfo, GasPriceView, LightClientBlockView,
-    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, SplitStorageInfoView,
-    StateChangeKindView, StateChangesKindsView, StateChangesRequestView, StateChangesView,
-    TxExecutionStatus,
+    BlockView, ChunkExecutionProofView, ChunkView, EpochValidatorInfo, GasPriceView,
+    LightClientBlockView, MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView,
+    SplitStorageInfoView, StateChangeKindView, StateChangesKindsView, StateChangesRequestView,
+    StateChangesView, TxExecutionStatus,
 };
 use parking_lot::RwLock;
 use serde_json::{Value, json};
@@ -457,6 +457,10 @@ pub struct ViewClientSenderForRpc(
     AsyncSender<GetBlock, Result<BlockView, GetBlockError>>,
     AsyncSender<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>>,
     AsyncSender<GetChunk, Result<ChunkView, GetChunkError>>,
+    AsyncSender<
+        GetLightClientChunkExecutionProof,
+        Result<ChunkExecutionProofView, GetLightClientProofError>,
+    >,
     AsyncSender<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>,
     AsyncSender<GetGasPrice, Result<GasPriceView, GetGasPriceError>>,
     AsyncSender<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanceWindowsError>>,
@@ -763,6 +767,12 @@ impl JsonRpcHandler {
             }
             "EXPERIMENTAL_light_client_block_proof" => {
                 process_method_call(request, |params| self.light_client_block_proof(params)).await
+            }
+            "EXPERIMENTAL_light_client_chunk_execution_proof" => {
+                process_method_call(request, |params| {
+                    self.light_client_chunk_execution_proof(params)
+                })
+                .await
             }
             "EXPERIMENTAL_protocol_config" => {
                 process_method_call(request, |params| self.protocol_config(params)).await
@@ -2476,6 +2486,25 @@ impl JsonRpcHandler {
         Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientBlockProofResponse {
             block_header_lite: block_proof.block_header_lite,
             block_proof: block_proof.proof,
+        })
+    }
+
+    async fn light_client_chunk_execution_proof(
+        &self,
+        request: near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofRequest,
+    ) -> Result<
+        near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofResponse,
+        near_jsonrpc_primitives::types::light_client::RpcLightClientProofError,
+    > {
+        let near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofRequest {
+            chunk_id,
+            light_client_head,
+        } = request;
+        let chunk_execution_proof: ChunkExecutionProofView = self
+            .view_client_send(GetLightClientChunkExecutionProof { chunk_id, light_client_head })
+            .await?;
+        Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofResponse {
+            chunk_execution_proof,
         })
     }
 

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1340,8 +1340,11 @@ pub struct StateChangesForShard {
     Ord,
     BorshSerialize,
     BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
     ProtocolSchema,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SpiceChunkId {
     pub block_hash: CryptoHash,
     pub shard_id: ShardId,
@@ -1357,12 +1360,34 @@ pub struct ChunkExecutionResult {
 /// Merkle leaf committing to a single chunk's certified execution roots.
 /// The `chunk_execution_root` in a spice block header is the merkle root over
 /// these leaves, sorted by `chunk_id`.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    ProtocolSchema,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ChunkExecutionRoots {
     V1(ChunkExecutionRootsV1),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    ProtocolSchema,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ChunkExecutionRootsV1 {
     pub chunk_id: SpiceChunkId,
     pub state_root: CryptoHash,
@@ -1390,16 +1415,24 @@ impl ChunkExecutionRoots {
     }
 }
 
-/// Merkle root over the block's certified chunk execution results, sorted by `chunk_id`.
-pub fn compute_chunk_execution_root<'a>(
+/// Leaves for the block's certified chunk execution results, sorted by `chunk_id`.
+pub fn sorted_chunk_execution_roots<'a>(
     execution_results: impl Iterator<Item = (&'a SpiceChunkId, &'a ChunkExecutionResult)>,
-) -> CryptoHash {
+) -> Vec<ChunkExecutionRoots> {
     let mut leaves: Vec<ChunkExecutionRoots> = execution_results
         .map(|(chunk_id, execution_result)| {
             ChunkExecutionRoots::from_execution_result(chunk_id, execution_result)
         })
         .collect();
     leaves.sort_by(|a, b| a.chunk_id().cmp(b.chunk_id()));
+    leaves
+}
+
+/// Merkle root over the block's certified chunk execution results, sorted by `chunk_id`.
+pub fn compute_chunk_execution_root<'a>(
+    execution_results: impl Iterator<Item = (&'a SpiceChunkId, &'a ChunkExecutionResult)>,
+) -> CryptoHash {
+    let leaves = sorted_chunk_execution_roots(execution_results);
     merklize(&leaves).0
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -42,10 +42,10 @@ use crate::transaction::{
 };
 use crate::trie_split::TrieSplit;
 use crate::types::{
-    AccountId, AccountWithPublicKey, Balance, BlockHeight, EpochHeight, EpochId, FunctionArgs, Gas,
-    Nonce, NumBlocks, ShardId, SpiceChunkEndorsementStats, StateChangeCause, StateChangeKind,
-    StateChangeValue, StateChangeWithCause, StateChangesRequest, StateRoot, StorageUsage, StoreKey,
-    StoreValue, ValidatorKickoutReason,
+    AccountId, AccountWithPublicKey, Balance, BlockHeight, ChunkExecutionRoots, EpochHeight,
+    EpochId, FunctionArgs, Gas, Nonce, NumBlocks, ShardId, SpiceChunkEndorsementStats,
+    StateChangeCause, StateChangeKind, StateChangeValue, StateChangeWithCause, StateChangesRequest,
+    StateRoot, StorageUsage, StoreKey, StoreValue, ValidatorKickoutReason,
 };
 use crate::version::{ProtocolVersion, Version};
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -2767,6 +2767,20 @@ impl LightClientBlockLiteView {
             &self.prev_block_hash,
         )
     }
+}
+
+/// Proof that a chunk's certified execution roots are committed by a spice block
+/// that a light client can trust via its `light_client_head`.
+///
+/// `roots_proof` recomputes the certifying block's `chunk_execution_root` from the leaf;
+/// `certifying_block_proof` places the certifying block into the head's block merkle tree.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct ChunkExecutionProofView {
+    pub roots: ChunkExecutionRoots,
+    pub roots_proof: MerklePath,
+    pub certifying_block_header_lite: LightClientBlockLiteView,
+    pub certifying_block_proof: MerklePath,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -36,6 +36,7 @@ pub mod genesis;
 pub mod merkle_proof;
 pub mod metrics;
 mod node_storage;
+pub mod spice_proof_verifier;
 mod store;
 pub mod trie;
 mod utils;

--- a/core/store/src/spice_proof_verifier.rs
+++ b/core/store/src/spice_proof_verifier.rs
@@ -1,0 +1,57 @@
+//! Verification for SPICE light-client chunk-execution proofs.
+//!
+//! A light client trusts a final head and its block merkle root. These functions
+//! recompute that root from a served proof without trusting the serving node.
+
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::{compute_root_from_path, compute_root_from_path_and_item};
+use near_primitives::types::SpiceChunkId;
+use near_primitives::views::ChunkExecutionProofView;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SpiceProofVerificationError {
+    #[error("proof is for chunk {found:?}, not the requested chunk {expected:?}")]
+    UnexpectedChunkId { expected: SpiceChunkId, found: SpiceChunkId },
+    #[error("certifying block header does not commit a chunk_execution_root")]
+    MissingChunkExecutionRoot,
+    #[error("roots proof does not recompute the certifying block's chunk_execution_root")]
+    InvalidRootsProof,
+    #[error("certifying block is not committed in the light client head's block merkle root")]
+    InvalidBlockProof,
+}
+
+/// Checks that `expected_chunk_id`'s execution roots are committed by a block that
+/// the trusted `light_client_head_block_merkle_root` includes. The chunk id is
+/// checked so a server cannot answer with a valid proof for a different chunk.
+pub fn verify_chunk_execution_proof(
+    proof: &ChunkExecutionProofView,
+    expected_chunk_id: &SpiceChunkId,
+    light_client_head_block_merkle_root: &CryptoHash,
+) -> Result<(), SpiceProofVerificationError> {
+    if proof.roots.chunk_id() != expected_chunk_id {
+        return Err(SpiceProofVerificationError::UnexpectedChunkId {
+            expected: expected_chunk_id.clone(),
+            found: proof.roots.chunk_id().clone(),
+        });
+    }
+
+    let committed_chunk_execution_root = proof
+        .certifying_block_header_lite
+        .inner_lite
+        .chunk_execution_root
+        .ok_or(SpiceProofVerificationError::MissingChunkExecutionRoot)?;
+
+    let computed_chunk_execution_root =
+        compute_root_from_path_and_item(&proof.roots_proof, &proof.roots);
+    if computed_chunk_execution_root != committed_chunk_execution_root {
+        return Err(SpiceProofVerificationError::InvalidRootsProof);
+    }
+
+    let certifying_block_hash = proof.certifying_block_header_lite.hash();
+    let computed_head_root =
+        compute_root_from_path(&proof.certifying_block_proof, certifying_block_hash);
+    if &computed_head_root != light_client_head_block_merkle_root {
+        return Err(SpiceProofVerificationError::InvalidBlockProof);
+    }
+    Ok(())
+}

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -1,0 +1,123 @@
+use crate::setup::builder::TestLoopBuilder;
+use assert_matches::assert_matches;
+use near_async::messaging::Handler as _;
+use near_chain::ChainStoreAccess as _;
+use near_client::GetLightClientChunkExecutionProof;
+use near_client_primitives::types::GetLightClientProofError;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::block::BlockHeader;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{ChunkExecutionRoots, ChunkExecutionRootsV1, SpiceChunkId};
+use near_primitives::views::{ChunkExecutionProofView, LightClientBlockLiteView};
+use near_store::spice_proof_verifier::{SpiceProofVerificationError, verify_chunk_execution_proof};
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_chunk_execution_proof() {
+    init_test_logger();
+
+    let mut env = TestLoopBuilder::new().validators(1, 0).build();
+
+    // Certify the chain through the current tip, then let finality advance strictly
+    // past it. The handler serves from the certifying-block index (written at
+    // finality), and the head must be strictly after a chunk's certifying block for
+    // the block merkle proof to recompute the head's block_merkle_root from it.
+    let tip_height = env.validator().head().height;
+    env.validator_runner().run_until_certified(tip_height);
+    let certified_head_height = env.validator().head().height;
+    env.validator_runner().run_until_final_head_height(certified_head_height + 1);
+
+    let light_client_head = env.validator().final_head().last_block_hash;
+    let head_header = env.validator().client().chain.get_block_header(&light_client_head).unwrap();
+    let trusted_block_merkle_root = *head_header.block_merkle_root();
+
+    // Any chunk certified by a block strictly below the head is servable. Walk back
+    // from the head to the first block that carries execution results.
+    let chain_store = &env.validator().client().chain.chain_store;
+    let mut hash = *head_header.prev_hash();
+    let (chunk_id, certifying_block_hash) = loop {
+        let block = chain_store.get_block(&hash).unwrap();
+        if let Some((chunk_id, _)) = block.spice_core_statements().iter_execution_results().next() {
+            break (chunk_id.clone(), hash);
+        }
+        hash = *block.header().prev_hash();
+        assert_ne!(hash, CryptoHash::default(), "no certified chunk below the light client head");
+    };
+
+    let chunk_proof: ChunkExecutionProofView = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientChunkExecutionProof { chunk_id: chunk_id.clone(), light_client_head })
+        .unwrap();
+    verify_chunk_execution_proof(&chunk_proof, &chunk_id, &trusted_block_merkle_root).unwrap();
+
+    // Every merkle path in this proof is genuine, so only the chunk id check stops a
+    // server from serving it as the answer for a chunk in another block.
+    let chunk_id_in_another_block =
+        SpiceChunkId { block_hash: light_client_head, shard_id: chunk_id.shard_id };
+    assert_matches!(
+        verify_chunk_execution_proof(
+            &chunk_proof,
+            &chunk_id_in_another_block,
+            &trusted_block_merkle_root
+        ),
+        Err(SpiceProofVerificationError::UnexpectedChunkId { .. })
+    );
+
+    // Tampering a committed root no longer recomputes the chunk_execution_root.
+    let ChunkExecutionRoots::V1(good_roots) = &chunk_proof.roots;
+    let mut tampered_proof = chunk_proof.clone();
+    tampered_proof.roots = ChunkExecutionRoots::V1(ChunkExecutionRootsV1 {
+        state_root: CryptoHash::hash_bytes(b"tampered state root"),
+        ..good_roots.clone()
+    });
+    assert_matches!(
+        verify_chunk_execution_proof(&tampered_proof, &chunk_id, &trusted_block_merkle_root),
+        Err(SpiceProofVerificationError::InvalidRootsProof)
+    );
+
+    // A correct proof must not verify against a wrong trusted root.
+    let wrong_root = CryptoHash::hash_bytes(b"not the head block merkle root");
+    assert_matches!(
+        verify_chunk_execution_proof(&chunk_proof, &chunk_id, &wrong_root),
+        Err(SpiceProofVerificationError::InvalidBlockProof)
+    );
+
+    // The certifying block's own block merkle root does not commit to itself, so a head
+    // at exactly that height is rejected.
+    let result =
+        env.validator_mut().view_client_actor().handle(GetLightClientChunkExecutionProof {
+            chunk_id: chunk_id.clone(),
+            light_client_head: certifying_block_hash,
+        });
+    assert_matches!(result, Err(GetLightClientProofError::LightClientHeadTooOld { .. }));
+
+    // A not-yet-certified chunk (in the non-final head block) is not served.
+    let head_block = env.validator().head_block();
+    let uncertified_chunk_id =
+        SpiceChunkId { block_hash: *head_block.hash(), shard_id: chunk_id.shard_id };
+    let result =
+        env.validator_mut().view_client_actor().handle(GetLightClientChunkExecutionProof {
+            chunk_id: uncertified_chunk_id,
+            light_client_head,
+        });
+    assert_matches!(result, Err(GetLightClientProofError::ChunkNotCertified { .. }));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_block_lite_view_hash() {
+    init_test_logger();
+
+    // `build()` warms up, so the chain already has produced a block.
+    let env = TestLoopBuilder::new().validators(1, 0).build();
+
+    // The verifier derives the certifying block's hash by calling
+    // LightClientBlockLiteView::hash(), so that reconstruction (rebuilding the spice
+    // header's inner-lite, including chunk_execution_root) must equal the real hash.
+    let block = env.validator().head_block();
+    assert_eq!(
+        LightClientBlockLiteView::from(BlockHeader::clone(block.header())).hash(),
+        *block.header().hash(),
+    );
+}

--- a/test-loop-tests/src/tests/spice/mod.rs
+++ b/test-loop-tests/src/tests/spice/mod.rs
@@ -3,6 +3,7 @@ mod basic;
 mod congestion;
 mod core_statement_limit;
 mod garbage_collection;
+mod light_client;
 mod malicious_chunk_producer;
 mod pre_activation;
 mod resharding;

--- a/test-loop-tests/src/tests/spice/mod.rs
+++ b/test-loop-tests/src/tests/spice/mod.rs
@@ -2,6 +2,7 @@ mod basic;
 mod congestion;
 mod core_statement_limit;
 mod garbage_collection;
+mod light_client;
 mod malicious_chunk_producer;
 mod resharding;
 mod utils;


### PR DESCRIPTION
A light client that trusts a final head can now prove what a chunk executed to, without trusting the node that serves the proof.

`EXPERIMENTAL_light_client_chunk_execution_proof` returns a chunk's certified execution roots (`state_root`, `outcome_root`, `outgoing_receipts_root`) with the merkle path tying them to the block that certified the chunk, and the path tying that block into the trusted head's block merkle root.

The matching verifier is a public module in `near-store`, `core/store/src/spice_proof_verifier.rs`, so a client can check a served proof against a head it already trusts. Only the test-loop test calls it so far.

A proof is served only for a certified chunk, and only against a final head that is strictly newer than the certifying block. (A block's `block_merkle_root` is the merkle root over all blocks preceding it)

Execution-outcome proofs and state proofs reuse the same view and follow in later PRs.

The second commit is the regenerated OpenAPI and OpenRPC spec; almost all of it is generated JSON.