### PR TITLE
fix(pytest): de-flake db_migration by using the final block as tx base

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -313,6 +313,15 @@ class BaseNode(object):
         return BlockId(height=sync_info['latest_block_height'],
                        hash=sync_info['latest_block_hash'])
 
+    def get_final_block_id(self) -> BlockId:
+        """
+        Get the hash and height of the latest final block.
+        Prefer this over `.get_latest_block()` as the base block of a
+        transaction: the latest block may not have reached the node that the
+        transaction is forwarded to, which drops it as expired.
+        """
+        return BlockId.from_header(self.get_final_block()['result']['header'])
+
     def get_all_heights(self):
 
         # Helper function to check if the block response is a "block not found" error.

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -313,14 +313,15 @@ class BaseNode(object):
         return BlockId(height=sync_info['latest_block_height'],
                        hash=sync_info['latest_block_hash'])
 
-    def get_final_block_id(self) -> BlockId:
+    def get_final_block_id(self, **kw) -> BlockId:
         """
         Get the hash and height of the latest final block.
         Prefer this over `.get_latest_block()` as the base block of a
         transaction: the latest block may not have reached the node that the
         transaction is forwarded to, which drops it as expired.
         """
-        return BlockId.from_header(self.get_final_block()['result']['header'])
+        return BlockId.from_header(
+            self.get_final_block(**kw)['result']['header'])
 
     def get_all_heights(self):
 
@@ -438,7 +439,7 @@ class BaseNode(object):
         return self.json_rpc('block', {'block_id': block_height}, **kwargs)
 
     def get_final_block(self, **kwargs):
-        return self.get_block_by_finality('final')
+        return self.get_block_by_finality('final', **kwargs)
 
     def get_block_by_finality(self, finality, **kwargs):
         assert finality in ('final', 'optimistic'), \

--- a/pytest/tests/sanity/db_migration.py
+++ b/pytest/tests/sanity/db_migration.py
@@ -25,7 +25,7 @@ node_config = {"tracked_shards_config": "AllShards"}
 
 
 def deploy_contract(node, config):
-    hash_ = node.get_latest_block().hash_bytes
+    hash_ = node.get_final_block_id().hash_bytes
     test_contract = utils.load_test_contract(config=config)
     tx = sign_deploy_contract_tx(node.signer_key, test_contract, 10, hash_)
     node.send_tx_and_wait(tx, timeout=15)
@@ -37,7 +37,7 @@ def send_some_tx(node):
     nonce = node.get_nonce_for_pk(node.signer_key.account_id,
                                   node.signer_key.pk) + 10
     for i in range(10):
-        hash_ = node.get_latest_block().hash_bytes
+        hash_ = node.get_final_block_id().hash_bytes
         keyvalue = bytearray(16)
         keyvalue[0] = (nonce // 10) % 256
         keyvalue[8] = (nonce // 10) % 255
@@ -62,7 +62,7 @@ def unstake_and_stake(node, tx_sender_node):
     nonce = tx_sender_node.get_nonce_for_pk(node.signer_key.account_id,
                                             node.signer_key.pk) + 10
 
-    hash_ = tx_sender_node.get_latest_block().hash_bytes
+    hash_ = tx_sender_node.get_final_block_id().hash_bytes
     tx = sign_staking_tx(node.signer_key, node.validator_key, 0, nonce, hash_)
 
     nonce += 10
@@ -72,7 +72,7 @@ def unstake_and_stake(node, tx_sender_node):
     utils.wait_for_blocks(tx_sender_node, count=EPOCH_LENGTH * 2)
 
     logging.info(f'Restaking {node.signer_key.account_id}...')
-    hash_ = tx_sender_node.get_latest_block().hash_bytes
+    hash_ = tx_sender_node.get_final_block_id().hash_bytes
     tx = sign_staking_tx(node.signer_key, node.validator_key, full_balance // 2,
                          nonce, hash_)
     nonce += 10


### PR DESCRIPTION
`db_migration.py` signs transactions against the head block of the RPC node. The RPC node forwards the transaction to the chunk producer for the shard, which may not have processed that block yet, so it drops the transaction as expired. The sender keeps no copy, so the transaction is lost from every pool.

The RPC then polls. On `UnknownTransaction`, `tx_status_fetch` re-validates the transaction locally on each new block, so once the head passes `base_height + transaction_validity_period` the call returns `Expired`:

    AssertionError: {'TxExecutionError': {'InvalidTxError': 'Expired'}}

Failing run: https://github.com/near/nearcore/actions/runs/31139209776/job/92745302663

In that run node0 produced block 33 at `02:00:52.090` and forwarded the transaction at `02:00:52.094113`. Node1 rejected it 100 µs later at `02:00:52.094216` with `invalid tx: expired or from a different fork`, because it had not processed block 33 yet.

The window is narrow: `cluster.py` sets `transaction_validity_period` to `epoch_length * 2`, which is 10 blocks with `EPOCH_LENGTH = 5`. Widening it is not possible, as `EpochManager::new` asserts `transaction_validity_period <= epoch_length * 2`.

Signing against the final block removes the race. A final block carries approvals from both validators, so the node that receives the forwarded transaction already has it. The final block trails the head by about 2 blocks and inclusion normally takes 2, so the window is still sufficient.

`BaseNode.get_final_block_id()` sits next to `get_latest_block()` and returns the same `BlockId` type. 21 other pytest files use `get_latest_block().hash_bytes` and carry the same race; this PR does not change them.