### PR TITLE
revert(runtime): panic again on vm nondeterministic and unknown errors

### DIFF
--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -24,6 +24,9 @@ pub enum VMRunnerError {
     /// Type erased error from `External` trait implementation.
     #[error("external error")]
     ExternalError(AnyError),
+    /// Non-deterministic error.
+    #[error("non-deterministic error during contract execution: {0}")]
+    Nondeterministic(String),
     #[error("unknown error during contract execution: {debug_message}")]
     WasmUnknownError { debug_message: String },
     #[error("account has no associated contract code")]
@@ -56,12 +59,6 @@ pub enum FunctionCallError {
     LoadingError {
         msg: String,
     },
-    /// The VM runner reported an unrecoverable internal failure (e.g. an
-    /// unhandled wasmtime trap). Surfaced instead of panicking so a single bad
-    /// node does not crash the network; the message is for diagnostics only.
-    WasmUnknownError {
-        msg: String,
-    },
 }
 
 impl FunctionCallError {
@@ -69,9 +66,9 @@ impl FunctionCallError {
         const BASE_SIZE: usize = 4; // to roughly accommodate for static parts of the enum
         match self {
             FunctionCallError::CompilationError(e) => e.size_bytes_approximate(),
-            FunctionCallError::LinkError { msg }
-            | FunctionCallError::LoadingError { msg }
-            | FunctionCallError::WasmUnknownError { msg } => BASE_SIZE + msg.len(),
+            FunctionCallError::LinkError { msg } | FunctionCallError::LoadingError { msg } => {
+                BASE_SIZE + msg.len()
+            }
             FunctionCallError::MethodResolveError(_)
             | FunctionCallError::WasmTrap(_)
             | FunctionCallError::HostError(_) => BASE_SIZE,
@@ -473,9 +470,6 @@ impl fmt::Display for FunctionCallError {
             FunctionCallError::HostError(e) => e.fmt(f),
             FunctionCallError::LinkError { msg } => write!(f, "{}", msg),
             FunctionCallError::LoadingError { msg } => write!(f, "Loading error: {}", msg),
-            FunctionCallError::WasmUnknownError { msg } => {
-                write!(f, "Unknown error during contract execution: {}", msg)
-            }
             FunctionCallError::WasmTrap(trap) => write!(f, "WebAssembly trap: {}", trap),
         }
     }

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -411,9 +411,7 @@ impl IntoVMError for wasmtime::Error {
                     }
                 }));
             };
-            return Err(VMRunnerError::WasmUnknownError {
-                debug_message: format!("nondeterministic trap: {}", nondeterministic_message),
-            });
+            return Err(VMRunnerError::Nondeterministic(nondeterministic_message.into()));
         }
         let description = if cause.is::<wasmtime::UnknownImportError>() {
             "unknown or invalid import".to_string()

--- a/runtime/runtime/src/conversions.rs
+++ b/runtime/runtime/src/conversions.rs
@@ -84,7 +84,6 @@ mod function_call_error {
                 From::LoadingError { msg } => {
                     Self::ExecutionError(format!("Loading Error: {}", msg))
                 }
-                From::WasmUnknownError { msg } => Self::ExecutionError(msg),
                 From::WasmTrap(ref _e) => Self::ExecutionError(outer_err.to_string()),
             }
         }

--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -130,9 +130,6 @@ pub(crate) fn action_function_call(
                     .with_label_values::<&str>(&[inner_err.into()])
                     .inc();
             }
-            FunctionCallError::WasmUnknownError { .. } => {
-                metrics::FUNCTION_CALL_PROCESSED_WASM_UNKNOWN_ERRORS.inc();
-            }
         }
         // Update action result with the abort error converted to the
         // transaction runtime's format of errors.
@@ -284,11 +281,12 @@ pub(crate) fn execute_function_call(
     let result = near_vm_runner::run(contract, runtime_ext, &context, Arc::clone(&config.fees));
     near_vm_runner::report_metrics(apply_state.shard_id, &apply_state.apply_reason.to_string());
 
-    // Most VM runner errors translate to a `RuntimeError` and are propagated
-    // up. `WasmUnknownError` is soft-failed into the function-call outcome
-    // instead of panicking: a consensus failure on one chunk is preferable to
-    // crashing all nodes if a VM bug surfaces post-deploy. User-code errors
-    // are reported via `outcome.aborted` and never reach these arms.
+    // There are many specific errors that the runtime can encounter.
+    // Some can be translated to the more general `RuntimeError`, which allows to pass
+    // the error up to the caller. For all other cases, panicking here is better
+    // than leaking the exact details further up.
+    // Note that this does not include errors caused by user code / input, those are
+    // stored in outcome.aborted.
     let mut outcome = match result {
         Err(VMRunnerError::ContractCodeNotPresent) => {
             if runtime_ext.account().contract().is_some() {
@@ -333,12 +331,11 @@ pub(crate) fn execute_function_call(
         Err(VMRunnerError::LoadingError(msg)) => {
             return Ok(VMOutcome::nop_outcome(FunctionCallError::LoadingError { msg }));
         }
+        Err(VMRunnerError::Nondeterministic(msg)) => {
+            panic!("Contract runner returned non-deterministic error '{}', aborting", msg)
+        }
         Err(VMRunnerError::WasmUnknownError { debug_message }) => {
-            tracing::error!(target: "runtime", "wasm unknown error: {}", debug_message);
-            debug_assert!(false, "wasm unknown error: {}", debug_message);
-            return Ok(VMOutcome::nop_outcome(FunctionCallError::WasmUnknownError {
-                msg: debug_message,
-            }));
+            panic!("Wasmer returned unknown message: {}", debug_message)
         }
         Ok(r) => r,
     };

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -280,15 +280,6 @@ pub static FUNCTION_CALL_PROCESSED_LOADING_ERRORS: LazyLock<IntCounter> = LazyLo
     )
     .unwrap()
 });
-pub static FUNCTION_CALL_PROCESSED_WASM_UNKNOWN_ERRORS: LazyLock<IntCounter> = LazyLock::new(
-    || {
-        try_create_int_counter(
-        "near_function_call_processed_wasm_unknown_errors",
-        "The number of function calls soft-failed due to an unknown VM runner error, since starting this node",
-    )
-    .unwrap()
-    },
-);
 pub static FUNCTION_CALL_PROCESSED_CACHE_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     try_create_int_counter_vec(
         "near_function_call_processed_cache_errors",


### PR DESCRIPTION
Reverts #15782, restoring the panic on `VMRunnerError::Nondeterministic` and `VMRunnerError::WasmUnknownError`.

That PR turned both into a `FunctionCallError` written into the function-call outcome. On the soft-fail path the receipt gets a `Failure` outcome with `gas_burnt: 0` (`VMOutcome::nop_outcome`), and that lands in the state root and the outcome root.

After discussions, we agreed that committing the non-deterministic outcome as error is worse than a crash.

I don't think we need to gate it by a protocol version, we didn't for the change to it and also it should be an unreachable condition anyway.