### PR TITLE
feat(forknet): add forknet image creation metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,6 +4300,7 @@ name = "near-fork-network"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "clap",
  "hex",
@@ -4308,6 +4309,7 @@ dependencies = [
  "near-chain-configs",
  "near-crypto",
  "near-epoch-manager",
+ "near-jsonrpc",
  "near-mirror",
  "near-o11y",
  "near-parameters",

--- a/cspell.json
+++ b/cspell.json
@@ -211,6 +211,7 @@
         "keygen",
         "keypair",
         "keypairs",
+        "keyspace",
         "Kgas",
         "kickout",
         "Kickouts",

--- a/tools/fork-network/Cargo.toml
+++ b/tools/fork-network/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+axum.workspace = true
 chrono.workspace = true
 clap.workspace = true
 hex.workspace = true
@@ -21,7 +22,10 @@ rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
-tokio.workspace = true
+# `time` is required by `enable_all()` and by axum's accept-error backoff, which sleeps.
+# It is enabled transitively today via nearcore, but this crate depends on it directly and
+# the profiles set panic = 'abort', so losing it would abort a running fork rather than warn.
+tokio = { workspace = true, features = ["net", "rt", "time"] }
 tracing.workspace = true
 
 near-async.workspace = true
@@ -29,6 +33,7 @@ near-chain-configs.workspace = true
 near-chain.workspace = true
 near-crypto.workspace = true
 near-epoch-manager.workspace = true
+near-jsonrpc.workspace = true
 near-mirror.workspace = true
 near-o11y.workspace = true
 near-parameters.workspace = true
@@ -41,6 +46,7 @@ nightly = [
     "near-chain-configs/nightly",
     "near-chain/nightly",
     "near-epoch-manager/nightly",
+    "near-jsonrpc/nightly",
     "near-mirror/nightly",
     "near-o11y/nightly",
     "near-parameters/nightly",

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -645,7 +645,6 @@ impl ForkNetworkCommand {
             update_state.clone(),
             target_shard_layout.clone(),
         )?;
-        metrics::set_phase(Phase::AddValidatorAccounts);
         let new_validator_accounts = self.add_validator_accounts(
             validators,
             runtime_config,
@@ -654,7 +653,6 @@ impl ForkNetworkCommand {
             storage_mutator,
         )?;
         let new_state_roots = update_state.into_iter().map(|u| u.state_root()).collect::<Vec<_>>();
-        metrics::set_phase(Phase::WriteGenesis);
         tracing::info!("creating a new genesis");
         backup_genesis_file(home_dir, &near_config)?;
 
@@ -796,7 +794,6 @@ impl ForkNetworkCommand {
 
         // 3. Add benchmark accounts to the state and override new state
         // roots in state and genesis.
-        metrics::set_phase(Phase::AddUserAccounts);
         let state_roots = self.add_user_accounts(
             runtime.as_ref(),
             genesis_protocol_version,
@@ -818,7 +815,6 @@ impl ForkNetworkCommand {
             state_roots.clone(),
             validators,
         )?;
-        metrics::set_phase(Phase::WriteGenesis);
         Self::set_genesis_block(
             epoch_manager.as_ref(),
             runtime.as_ref(),
@@ -831,7 +827,6 @@ impl ForkNetworkCommand {
     /// Deletes DB columns that are not needed in the new chain.
     fn finalize(&self, near_config: &NearConfig, home_dir: &Path) -> anyhow::Result<()> {
         tracing::info!("delete unneeded columns in the original DB");
-        metrics::set_phase(Phase::ClearColumns);
         let mut unwanted_cols = Vec::new();
         for col in DBCol::iter() {
             if !COLUMNS_TO_KEEP.contains(&col) {
@@ -1486,9 +1481,6 @@ impl ForkNetworkCommand {
         let liquid_balance = Balance::from_near(100_000_000);
         let storage_bytes = runtime_config.fees.storage_usage_config.num_bytes_account;
         let account_prefixes = Self::shard_account_prefixes(shard_layout);
-        // Unlike the flat-state scans, this total is known up front, so it yields a real
-        // percentage rather than an estimate.
-        metrics::set_user_accounts_expected(num_accounts_per_shard * account_prefixes.len() as u64);
         for (account_prefix_idx, account_prefix) in account_prefixes.into_iter().enumerate() {
             tracing::info!(
                 %account_prefix_idx,
@@ -1543,7 +1535,6 @@ impl ForkNetworkCommand {
                         storage_bytes,
                     ),
                 )?;
-                metrics::user_account_created();
 
                 // Create multiple access keys for this account (one per CP)
                 for cp_idx in 0..cps_per_shard {

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -1,4 +1,5 @@
 use crate::delayed_receipts::DelayedReceiptTracker;
+use crate::metrics::{self, Phase, SCAN_PROGRESS_INTERVAL, ShardMetrics, ShardPhase};
 use crate::storage_mutator::{ShardUpdateState, StorageMutator};
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -53,6 +54,13 @@ use strum::IntoEnumIterator;
 ///
 /// If something goes wrong, use the sub-command reset and start over.
 pub struct ForkNetworkCommand {
+    /// `host:port` to serve fork-network Prometheus metrics on. `/metrics` is the only route.
+    /// Defaults to the port `neard run` serves metrics on, which existing scrapers already
+    /// target, so a forked-state build needs no scraper change. Pass an empty string to
+    /// disable. Failing to bind is logged and does not fail the command.
+    #[arg(long, global = true, default_value = "0.0.0.0:3030")]
+    prometheus_addr: String,
+
     #[clap(subcommand)]
     command: SubCommand,
 }
@@ -251,6 +259,11 @@ impl ForkNetworkCommand {
         .await
         .global();
 
+        // Start serving metrics before doing any work: the whole point is watching a run that
+        // may get stuck, and an endpoint that appears after the stage that hangs is useless.
+        metrics::init();
+        crate::metrics_server::spawn(&self.prometheus_addr);
+
         match &self.command {
             SubCommand::Init(InitCmd { shard_layout_file, shard_layout_protocol_version }) => {
                 let shard_layout_override = {
@@ -297,6 +310,7 @@ impl ForkNetworkCommand {
                 self.reset(near_config, home_dir)?;
             }
         };
+        metrics::set_phase(Phase::Done);
         Ok(())
     }
 
@@ -317,6 +331,7 @@ impl ForkNetworkCommand {
             Ok(false)
         } else {
             tracing::info!(destination = ?fork_snapshot_path, "creating snapshot of original DB");
+            metrics::set_phase(Phase::Snapshot);
             // checkpointing only hot storage, because cold storage will not be changed
             checkpoint_hot_storage_and_cleanup_columns(&store, &fork_snapshot_path, None)?;
             Ok(true)
@@ -336,6 +351,7 @@ impl ForkNetworkCommand {
         let storage = open_storage(&home_dir, near_config).unwrap();
         let store = storage.get_hot_store();
         assert!(self.snapshot_db(store.clone(), near_config, home_dir)?);
+        metrics::set_phase(Phase::WriteForkInfo);
 
         let epoch_manager = EpochManager::new_arc_handle(
             store.clone(),
@@ -432,6 +448,7 @@ impl ForkNetworkCommand {
                 unwanted_cols.push(col);
             }
         }
+        metrics::set_phase(Phase::ClearColumns);
         near_store::clear_columns(
             home_dir,
             &near_config.config.store,
@@ -480,6 +497,7 @@ impl ForkNetworkCommand {
             StateSnapshotConfig::Disabled,
         )
         .context("could not create the transaction runtime")?;
+        metrics::set_phase(Phase::LoadMemtries);
         runtime.get_tries().load_memtries_for_enabled_shards(&all_shard_uids, None, true)?;
 
         let shard_tries = runtime.get_tries();
@@ -627,6 +645,7 @@ impl ForkNetworkCommand {
             update_state.clone(),
             target_shard_layout.clone(),
         )?;
+        metrics::set_phase(Phase::AddValidatorAccounts);
         let new_validator_accounts = self.add_validator_accounts(
             validators,
             runtime_config,
@@ -635,6 +654,7 @@ impl ForkNetworkCommand {
             storage_mutator,
         )?;
         let new_state_roots = update_state.into_iter().map(|u| u.state_root()).collect::<Vec<_>>();
+        metrics::set_phase(Phase::WriteGenesis);
         tracing::info!("creating a new genesis");
         backup_genesis_file(home_dir, &near_config)?;
 
@@ -776,6 +796,7 @@ impl ForkNetworkCommand {
 
         // 3. Add benchmark accounts to the state and override new state
         // roots in state and genesis.
+        metrics::set_phase(Phase::AddUserAccounts);
         let state_roots = self.add_user_accounts(
             runtime.as_ref(),
             genesis_protocol_version,
@@ -797,6 +818,7 @@ impl ForkNetworkCommand {
             state_roots.clone(),
             validators,
         )?;
+        metrics::set_phase(Phase::WriteGenesis);
         Self::set_genesis_block(
             epoch_manager.as_ref(),
             runtime.as_ref(),
@@ -809,6 +831,7 @@ impl ForkNetworkCommand {
     /// Deletes DB columns that are not needed in the new chain.
     fn finalize(&self, near_config: &NearConfig, home_dir: &Path) -> anyhow::Result<()> {
         tracing::info!("delete unneeded columns in the original DB");
+        metrics::set_phase(Phase::ClearColumns);
         let mut unwanted_cols = Vec::new();
         for col in DBCol::iter() {
             if !COLUMNS_TO_KEEP.contains(&col) {
@@ -907,6 +930,7 @@ impl ForkNetworkCommand {
         if !Path::new(&fork_snapshot_path).exists() {
             panic!("Fork snapshot does not exist");
         }
+        metrics::set_phase(Phase::Reset);
         tracing::info!("removing all current data");
         for entry in std::fs::read_dir(&store_path)? {
             let entry = entry?;
@@ -998,15 +1022,38 @@ impl ForkNetworkCommand {
         let mut receipts_tracker =
             DelayedReceiptTracker::new(shard_uid, target_shard_layout.shard_ids().count());
 
+        let shard_metrics = ShardMetrics::new(shard_uid);
+        shard_metrics.set_phase(ShardPhase::Pass1);
+        let scan = shard_metrics.pass1();
+
         // Iterate over the whole flat storage and do the necessary changes to have access to all accounts.
         let mut ref_keys_retrieved = 0;
         let mut records_not_parsed = 0;
         let mut records_parsed = 0;
+        let mut keys_scanned: u64 = 0;
 
         for (key, flat_value) in store.flat_store().iter(shard_uid) {
+            keys_scanned += 1;
+            scan.key_scanned();
+            if keys_scanned.is_multiple_of(SCAN_PROGRESS_INTERVAL) {
+                let position = scan.report_position(keys_scanned, &key);
+                tracing::info!(
+                    ?shard_uid,
+                    keys_scanned,
+                    position,
+                    // Which trie column the scan is in. `position` alone is misleading here:
+                    // ContractData dwarfs every other column, so pass 1 sits around 0.4 for
+                    // hours and reads as stuck. The column moving is the honest progress.
+                    column = key.first().copied().unwrap_or_default(),
+                    ref_keys_retrieved,
+                    records_parsed,
+                    "pass 1 scanning"
+                );
+            }
             let (key, value) = match flat_value {
                 FlatStateValue::Ref(ref_value) => {
                     ref_keys_retrieved += 1;
+                    shard_metrics.ref_value_retrieved();
                     (key, trie_storage.retrieve_raw_bytes(&ref_value.hash)?.to_vec())
                 }
                 FlatStateValue::Inlined(value) => (key, value),
@@ -1109,8 +1156,10 @@ impl ForkNetworkCommand {
                     }
                 }
                 records_parsed += 1;
+                shard_metrics.record_parsed();
             } else {
                 records_not_parsed += 1;
+                shard_metrics.record_not_parsed();
             }
             if storage_mutator.should_commit(batch_size) {
                 tracing::info!(?shard_uid, ref_keys_retrieved, records_parsed,);
@@ -1126,8 +1175,10 @@ impl ForkNetworkCommand {
             storage_mutator = make_storage_mutator(update_state.clone())?;
         }
 
+        scan.report_complete();
         tracing::info!(
             ?shard_uid,
+            keys_scanned,
             ref_keys_retrieved,
             records_parsed,
             records_not_parsed,
@@ -1139,9 +1190,28 @@ impl ForkNetworkCommand {
         // Remember that we kept track of accounts with full access keys in `has_full_key`.
         // Iterating over the whole flat state is very fast compared to writing all the updates.
         // TODO: Just remember what accounts we saw in the above iteration
+        // Pass 1 rewrote flat state as it went, so its key count is close to, but not exactly,
+        // what pass 2 will scan. It is still a far better denominator than a keyspace estimate.
+        shard_metrics.set_keys_expected(keys_scanned);
+        shard_metrics.set_phase(ShardPhase::Pass2);
+        let scan = shard_metrics.pass2(keys_scanned);
         let mut num_added = 0;
         let mut num_accounts = 0;
+        let mut keys_scanned: u64 = 0;
         for (key, _) in store.flat_store().iter(shard_uid) {
+            keys_scanned += 1;
+            scan.key_scanned();
+            if keys_scanned.is_multiple_of(SCAN_PROGRESS_INTERVAL) {
+                let position = scan.report_position(keys_scanned, &key);
+                tracing::info!(
+                    ?shard_uid,
+                    keys_scanned,
+                    position,
+                    num_accounts,
+                    num_added,
+                    "pass 2 scanning"
+                );
+            }
             if key[0] == col::ACCOUNT {
                 num_accounts += 1;
                 let account_id = match parse_account_id_from_account_key(&key) {
@@ -1177,14 +1247,24 @@ impl ForkNetworkCommand {
                     AccessKey::full_access(),
                 )?;
                 num_added += 1;
+                shard_metrics.access_key_added();
                 if storage_mutator.should_commit(batch_size) {
+                    tracing::info!(
+                        ?shard_uid,
+                        keys_scanned,
+                        num_accounts,
+                        num_added,
+                        "pass 2 commit"
+                    );
                     storage_mutator.commit()?;
                     storage_mutator = make_storage_mutator(update_state.clone())?;
                 }
             }
         }
-        tracing::info!(?shard_uid, num_accounts, num_added, "pass 2 done");
+        scan.report_complete();
+        tracing::info!(?shard_uid, keys_scanned, num_accounts, num_added, "pass 2 done");
         storage_mutator.commit()?;
+        shard_metrics.set_phase(ShardPhase::Done);
         Ok(receipts_tracker)
     }
 
@@ -1227,6 +1307,8 @@ impl ForkNetworkCommand {
             &source_state_roots,
         )?;
 
+        metrics::init_shards(&shard_uids);
+        metrics::set_phase(Phase::PrepareState);
         // the try_fold().try_reduce() will give a Vec<> of the return values and return early if one fails
         let receipt_trackers = shard_uids
             .into_par_iter()
@@ -1260,6 +1342,7 @@ impl ForkNetworkCommand {
             &update_state,
         );
         let shard_tries = runtime.get_tries();
+        metrics::set_phase(Phase::BandwidthScheduler);
         crate::storage_mutator::write_bandwidth_scheduler_state(
             &shard_tries,
             &source_shard_layout,
@@ -1274,6 +1357,7 @@ impl ForkNetworkCommand {
             &target_shard_layout,
             &update_state,
         );
+        metrics::set_phase(Phase::DelayedReceipts);
         crate::delayed_receipts::write_delayed_receipts(
             &shard_tries,
             &update_state,
@@ -1282,6 +1366,7 @@ impl ForkNetworkCommand {
             &target_shard_layout,
             &default_key,
         )?;
+        metrics::set_phase(Phase::FinalizeState);
         crate::storage_mutator::finalize_state(
             &shard_tries,
             &source_shard_layout,
@@ -1401,6 +1486,9 @@ impl ForkNetworkCommand {
         let liquid_balance = Balance::from_near(100_000_000);
         let storage_bytes = runtime_config.fees.storage_usage_config.num_bytes_account;
         let account_prefixes = Self::shard_account_prefixes(shard_layout);
+        // Unlike the flat-state scans, this total is known up front, so it yields a real
+        // percentage rather than an estimate.
+        metrics::set_user_accounts_expected(num_accounts_per_shard * account_prefixes.len() as u64);
         for (account_prefix_idx, account_prefix) in account_prefixes.into_iter().enumerate() {
             tracing::info!(
                 %account_prefix_idx,
@@ -1455,6 +1543,7 @@ impl ForkNetworkCommand {
                         storage_bytes,
                     ),
                 )?;
+                metrics::user_account_created();
 
                 // Create multiple access keys for this account (one per CP)
                 for cp_idx in 0..cps_per_shard {

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -1212,7 +1212,7 @@ impl ForkNetworkCommand {
                     "pass 2 scanning"
                 );
             }
-            if key[0] == col::ACCOUNT {
+            if key.first() == Some(&col::ACCOUNT) {
                 num_accounts += 1;
                 let account_id = match parse_account_id_from_account_key(&key) {
                     Ok(account_id) => account_id,

--- a/tools/fork-network/src/lib.rs
+++ b/tools/fork-network/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod cli;
 mod delayed_receipts;
+mod metrics;
+mod metrics_server;
 mod storage_mutator;

--- a/tools/fork-network/src/metrics.rs
+++ b/tools/fork-network/src/metrics.rs
@@ -1,0 +1,486 @@
+//! Progress metrics for `neard fork-network`.
+//!
+//! `amend-access-keys` is a single command that runs for hours (~3h50m on the Jul 24 mainnet
+//! fork) with no progress signal other than one log line per commit batch, so operators cannot
+//! tell a slow run from a wedged one. These metrics make the run legible: which phase it is in,
+//! how far each shard's flat-state scan has got, and how long each commit stage takes.
+//!
+//! Everything here is read through the `/metrics` endpoint started by [`crate::metrics_server`].
+
+use near_o11y::metrics::{
+    Gauge, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    exponential_buckets, try_create_gauge, try_create_gauge_vec, try_create_histogram_vec,
+    try_create_int_counter, try_create_int_counter_vec, try_create_int_gauge,
+    try_create_int_gauge_vec,
+};
+use near_primitives::shard_layout::ShardUId;
+use near_primitives::trie_key::col;
+use std::sync::LazyLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// One past the largest column byte, used to normalise a flat-state key into a 0..1 keyspace
+/// position. Keys start with the column byte, so without this the position would top out at
+/// around 23/256 and a finished scan would read as 9% done.
+///
+/// Derived from [`col::ALL_COLUMNS_WITH_NAMES`] rather than written down: the column ids are
+/// not contiguous (21 is reserved for the `TrieKey::GasKeyNonce` discriminant), so the count
+/// and the maximum differ, and a new column must not silently make this too small.
+const NUM_TRIE_KEY_COLUMNS: u64 = max_trie_key_column() as u64 + 1;
+
+const fn max_trie_key_column() -> u8 {
+    let columns = col::ALL_COLUMNS_WITH_NAMES;
+    let mut max = 0;
+    let mut i = 0;
+    while i < columns.len() {
+        if columns[i].0 > max {
+            max = columns[i].0;
+        }
+        i += 1;
+    }
+    max
+}
+
+/// How many keys to scan between progress reports. Reporting is deliberately coarse: the
+/// counters below are incremented per key, but the position gauge and the progress log line
+/// are only updated this often.
+///
+/// The log line matters as much as the gauge — layer 1 of the image-creation progress signal
+/// is a `mtime` poll on the neard log file, so a pass that scans silently for an hour reads as
+/// wedged. Kept small enough that even a slow shard keeps the log ticking every few minutes;
+/// a whole mainnet fork emits a few thousand of these lines, which is nothing.
+pub(crate) const SCAN_PROGRESS_INTERVAL: u64 = 250_000;
+
+/// Values of the `near_fork_network_phase` gauge. Process-wide; each subcommand only visits a
+/// subset of these.
+#[derive(Clone, Copy)]
+#[repr(i64)]
+pub(crate) enum Phase {
+    Idle = 0,
+    /// Checkpointing the hot store into `data/fork-snapshot`.
+    Snapshot = 1,
+    /// Advancing flat heads to a common block and persisting the fork parameters.
+    WriteForkInfo = 2,
+    /// Dropping DB columns the forked chain doesn't need.
+    ClearColumns = 3,
+    LoadMemtries = 4,
+    /// Rewriting every shard's state; see `near_fork_network_shard_phase` for per-shard detail.
+    PrepareState = 5,
+    BandwidthScheduler = 6,
+    DelayedReceipts = 7,
+    FinalizeState = 8,
+    AddValidatorAccounts = 9,
+    AddUserAccounts = 10,
+    WriteGenesis = 11,
+    Reset = 12,
+    Done = 13,
+}
+
+static PHASE: LazyLock<IntGauge> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "near_fork_network_phase",
+        "Current phase of the running fork-network subcommand, enum-encoded: 0 - idle, \
+         1 - snapshot, 2 - write fork info, 3 - clear columns, 4 - load memtries, \
+         5 - prepare state, 6 - bandwidth scheduler, 7 - delayed receipts, 8 - finalize state, \
+         9 - add validator accounts, 10 - add user accounts, 11 - write genesis, 12 - reset, \
+         13 - done",
+    )
+    .unwrap()
+});
+
+static PHASE_STARTED: LazyLock<Gauge> = LazyLock::new(|| {
+    try_create_gauge(
+        "near_fork_network_phase_started_seconds",
+        "Unix time at which the current phase started. Together with the phase gauge this \
+         gives the time in phase without needing to hold history.",
+    )
+    .unwrap()
+});
+
+/// Sets the process-wide phase and stamps its start time.
+pub(crate) fn set_phase(phase: Phase) {
+    PHASE_STARTED.set(unix_time_seconds());
+    PHASE.set(phase as i64);
+}
+
+/// Registers the phase gauges at their initial values, so the series exist from the moment the
+/// process starts serving `/metrics` rather than appearing partway through a multi-hour run.
+pub(crate) fn init() {
+    set_phase(Phase::Idle);
+    USER_ACCOUNTS_CREATED.reset();
+    USER_ACCOUNTS_EXPECTED.set(0);
+}
+
+fn unix_time_seconds() -> f64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs_f64()).unwrap_or_default()
+}
+
+/// Values of the `near_fork_network_shard_phase` gauge.
+#[derive(Clone, Copy)]
+#[repr(i64)]
+pub(crate) enum ShardPhase {
+    Idle = 0,
+    /// Full flat-state scan rewriting accounts, access keys, receipts and contract data.
+    Pass1 = 1,
+    /// Second full flat-state scan, adding a full access key to accounts that lack one.
+    Pass2 = 2,
+    Done = 3,
+}
+
+static SHARD_PHASE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    try_create_int_gauge_vec(
+        "near_fork_network_shard_phase",
+        "Per-shard phase of prepare_shard_state, enum-encoded: 0 - idle, 1 - pass 1 \
+         (rewrite state), 2 - pass 2 (add missing full access keys), 3 - done. Shards run in \
+         parallel, so they do not advance together.",
+        &["shard_uid"],
+    )
+    .unwrap()
+});
+
+static KEYS_SCANNED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_fork_network_keys_scanned_total",
+        "Flat-state keys read so far, by shard and scan pass",
+        &["shard_uid", "pass"],
+    )
+    .unwrap()
+});
+
+static KEYS_EXPECTED: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    try_create_int_gauge_vec(
+        "near_fork_network_keys_expected",
+        "Number of flat-state keys a shard holds, as counted by pass 1. Zero until pass 1 \
+         finishes. Pass 1 also writes to flat state, so this is close to but not exactly the \
+         number pass 2 will scan.",
+        &["shard_uid"],
+    )
+    .unwrap()
+});
+
+static POSITION_ESTIMATE: LazyLock<GaugeVec> = LazyLock::new(|| {
+    try_create_gauge_vec(
+        "near_fork_network_position_estimate",
+        "Estimated fraction of a shard's flat-state scan completed, 0..1. Pass 2 divides by \
+         the key count pass 1 measured and can read slightly above 1. Pass 1 has no known \
+         total and instead uses the current key's position in the ordered keyspace, which is \
+         monotone but not proportional to time: keys are far denser in some trie columns than \
+         others.",
+        &["shard_uid", "pass"],
+    )
+    .unwrap()
+});
+
+static RECORDS_PARSED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_fork_network_records_parsed_total",
+        "Flat-state entries pass 1 decoded into a StateRecord and rewrote",
+        &["shard_uid"],
+    )
+    .unwrap()
+});
+
+static RECORDS_NOT_PARSED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_fork_network_records_not_parsed_total",
+        "Flat-state entries pass 1 could not decode into a StateRecord and skipped",
+        &["shard_uid"],
+    )
+    .unwrap()
+});
+
+static REF_VALUES_RETRIEVED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_fork_network_ref_values_retrieved_total",
+        "Values pass 1 had to fetch from the State column because flat state only held a ref. \
+         These are random reads and dominate the cost of the scan.",
+        &["shard_uid"],
+    )
+    .unwrap()
+});
+
+static ACCESS_KEYS_ADDED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_fork_network_access_keys_added_total",
+        "Full access keys pass 2 added to accounts that had none",
+        &["shard_uid"],
+    )
+    .unwrap()
+});
+
+static KEYS_WRITTEN: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_fork_network_keys_written_total",
+        "Trie keys written or removed by committed batches, by shard",
+        &["shard_uid"],
+    )
+    .unwrap()
+});
+
+static BATCHES_COMMITTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "near_fork_network_batches_committed_total",
+        "Non-empty state update batches committed, by shard",
+        &["shard_uid"],
+    )
+    .unwrap()
+});
+
+static COMMIT_STAGE_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec(
+        "near_fork_network_commit_stage_duration_seconds",
+        "Time spent in each stage of committing one batch of state updates for a shard. \
+         `store_commit` is the RocksDB write and is the stage that stalls under compaction \
+         pressure.",
+        &["shard_uid", "stage"],
+        // 10ms .. ~5.5 minutes: batch commits are normally seconds, and the point of the
+        // metric is to catch the pathological tail.
+        Some(exponential_buckets(0.01, 2.0, 16).unwrap()),
+    )
+    .unwrap()
+});
+
+static USER_ACCOUNTS_CREATED: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_fork_network_user_accounts_created_total",
+        "Benchmark user accounts written to state by set-validators",
+    )
+    .unwrap()
+});
+
+static USER_ACCOUNTS_EXPECTED: LazyLock<IntGauge> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "near_fork_network_user_accounts_expected",
+        "Benchmark user accounts set-validators will write in total. Unlike the flat-state \
+         scans this total is known up front, so the ratio is a true percentage.",
+    )
+    .unwrap()
+});
+
+/// Handles for one shard's scan of flat state. Every label lookup happens here, at
+/// construction, and never in the scan loop — these loops run for billions of iterations.
+pub(crate) struct ScanMetrics {
+    keys_scanned: IntCounter,
+    position: Gauge,
+    /// Number of keys the scan expects to read, when known. Pass 2 knows it from pass 1;
+    /// pass 1 does not, and falls back to a keyspace position estimate.
+    total: Option<u64>,
+}
+
+impl ScanMetrics {
+    /// Records one key read. Called per iteration, so it must stay a single atomic add.
+    pub(crate) fn key_scanned(&self) {
+        self.keys_scanned.inc();
+    }
+
+    /// Publishes how far the scan has got and returns it, so the caller can log the same number
+    /// the gauge carries — the log is the only progress signal available over SSH. `key` is the
+    /// key just read and `scanned` the number of keys read so far. Called every
+    /// [`SCAN_PROGRESS_INTERVAL`] keys, not per key.
+    pub(crate) fn report_position(&self, scanned: u64, key: &[u8]) -> f64 {
+        let position = match self.total {
+            Some(total) if total > 0 => scanned as f64 / total as f64,
+            _ => keyspace_position(key),
+        };
+        self.position.set(position);
+        position
+    }
+
+    /// Marks the scan as finished, so a pass that stops just short of the last key does not
+    /// leave the gauge at 0.97 forever.
+    pub(crate) fn report_complete(&self) {
+        self.position.set(1.0);
+    }
+}
+
+/// Monotone 0..1 position of `key` in a shard's ordered flat-state keyspace.
+///
+/// Flat-state keys within a shard are `column_byte || trie_key` and are iterated in byte
+/// order, so the leading bytes locate the scan in the keyspace without knowing the total. It
+/// is monotone but not proportional to time — `CONTRACT_DATA` holds far more keys than the
+/// columns before it — so it is a progress bar, not an ETA.
+fn keyspace_position(key: &[u8]) -> f64 {
+    let mut prefix = [0u8; 8];
+    let len = key.len().min(prefix.len());
+    prefix[..len].copy_from_slice(&key[..len]);
+    // Normalise by the prefix value a key one past the last column would have, so a full scan
+    // spans roughly the whole 0..1 range instead of the bottom tenth of it.
+    let max = NUM_TRIE_KEY_COLUMNS as f64 * (1u64 << 56) as f64;
+    (u64::from_be_bytes(prefix) as f64 / max).min(1.0)
+}
+
+/// All of one shard's `prepare_shard_state` metrics, with label values pre-bound.
+pub(crate) struct ShardMetrics {
+    phase: IntGauge,
+    keys_expected: IntGauge,
+    pass1: ScanMetrics,
+    pass2: ScanMetrics,
+    records_parsed: IntCounter,
+    records_not_parsed: IntCounter,
+    ref_values_retrieved: IntCounter,
+    access_keys_added: IntCounter,
+}
+
+impl ShardMetrics {
+    pub(crate) fn new(shard_uid: ShardUId) -> Self {
+        let shard = shard_uid.to_string();
+        let scan = |pass: &str| ScanMetrics {
+            keys_scanned: KEYS_SCANNED.with_label_values(&[shard.as_str(), pass]),
+            position: POSITION_ESTIMATE.with_label_values(&[shard.as_str(), pass]),
+            total: None,
+        };
+        let metrics = Self {
+            phase: SHARD_PHASE.with_label_values(&[&shard]),
+            keys_expected: KEYS_EXPECTED.with_label_values(&[&shard]),
+            pass1: scan("1"),
+            pass2: scan("2"),
+            records_parsed: RECORDS_PARSED.with_label_values(&[&shard]),
+            records_not_parsed: RECORDS_NOT_PARSED.with_label_values(&[&shard]),
+            ref_values_retrieved: REF_VALUES_RETRIEVED.with_label_values(&[&shard]),
+            access_keys_added: ACCESS_KEYS_ADDED.with_label_values(&[&shard]),
+        };
+        // Zero-initialise so every series exists before the shard starts rewriting state.
+        metrics.set_phase(ShardPhase::Idle);
+        metrics.keys_expected.set(0);
+        metrics.pass1.position.set(0.0);
+        metrics.pass2.position.set(0.0);
+        // These two are incremented from the commit path rather than held here; touching them
+        // creates the series at zero so a rate() covers the very first commit.
+        KEYS_WRITTEN.with_label_values(&[shard.as_str()]);
+        BATCHES_COMMITTED.with_label_values(&[shard.as_str()]);
+        metrics
+    }
+
+    pub(crate) fn set_phase(&self, phase: ShardPhase) {
+        self.phase.set(phase as i64);
+    }
+
+    pub(crate) fn pass1(&self) -> &ScanMetrics {
+        &self.pass1
+    }
+
+    /// Pass 2's scan handles, using the key count pass 1 measured as the denominator.
+    pub(crate) fn pass2(&self, keys_expected: u64) -> ScanMetrics {
+        ScanMetrics {
+            keys_scanned: self.pass2.keys_scanned.clone(),
+            position: self.pass2.position.clone(),
+            total: Some(keys_expected),
+        }
+    }
+
+    /// Records the number of keys pass 1 found in this shard.
+    pub(crate) fn set_keys_expected(&self, keys_expected: u64) {
+        self.keys_expected.set(keys_expected as i64);
+    }
+
+    pub(crate) fn record_parsed(&self) {
+        self.records_parsed.inc();
+    }
+
+    pub(crate) fn record_not_parsed(&self) {
+        self.records_not_parsed.inc();
+    }
+
+    pub(crate) fn ref_value_retrieved(&self) {
+        self.ref_values_retrieved.inc();
+    }
+
+    pub(crate) fn access_key_added(&self) {
+        self.access_keys_added.inc();
+    }
+}
+
+/// Creates every per-shard series at zero before the shards start work, so a dashboard shows
+/// all shards from t=0 instead of one appearing as each gets scheduled.
+pub(crate) fn init_shards(shard_uids: &[ShardUId]) {
+    for shard_uid in shard_uids {
+        ShardMetrics::new(*shard_uid);
+    }
+}
+
+/// Timers for the stages of one shard's batch commit. These are the four writes most likely to
+/// stall on RocksDB, and none of them was timed before.
+pub(crate) struct CommitStages {
+    /// Time spent waiting for the shard's update-state lock, which every shard's rayon thread
+    /// can contend for. Counted inside `total`.
+    pub(crate) lock_wait: Histogram,
+    pub(crate) apply_to_flat_state: Histogram,
+    pub(crate) trie_update: Histogram,
+    pub(crate) apply_all: Histogram,
+    pub(crate) apply_memtrie_changes: Histogram,
+    pub(crate) store_commit: Histogram,
+    pub(crate) total: Histogram,
+}
+
+impl CommitStages {
+    pub(crate) fn new(shard_uid: ShardUId) -> Self {
+        let shard = shard_uid.to_string();
+        let stage = |stage: &str| COMMIT_STAGE_DURATION.with_label_values(&[shard.as_str(), stage]);
+        Self {
+            lock_wait: stage("lock_wait"),
+            apply_to_flat_state: stage("apply_to_flat_state"),
+            trie_update: stage("trie_update"),
+            apply_all: stage("apply_all"),
+            apply_memtrie_changes: stage("apply_memtrie_changes"),
+            store_commit: stage("store_commit"),
+            total: stage("total"),
+        }
+    }
+}
+
+/// Records a committed batch of `num_updates` trie keys for `shard_uid`.
+pub(crate) fn batch_committed(shard_uid: ShardUId, num_updates: usize) {
+    let shard = shard_uid.to_string();
+    KEYS_WRITTEN.with_label_values(&[&shard]).inc_by(num_updates as u64);
+    BATCHES_COMMITTED.with_label_values(&[&shard]).inc();
+}
+
+pub(crate) fn set_user_accounts_expected(total: u64) {
+    USER_ACCOUNTS_EXPECTED.set(total as i64);
+}
+
+pub(crate) fn user_account_created() {
+    USER_ACCOUNTS_CREATED.inc();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NUM_TRIE_KEY_COLUMNS, keyspace_position, max_trie_key_column};
+    use near_primitives::trie_key::col;
+
+    /// Guards the normalisation constant against a new trie key column being added. Getting
+    /// this too small makes a scan of the last column report 100% while it is still running.
+    #[test]
+    fn normalisation_covers_every_column() {
+        for (column, name) in col::ALL_COLUMNS_WITH_NAMES {
+            assert!(
+                (column as u64) < NUM_TRIE_KEY_COLUMNS,
+                "column {name} ({column}) is not below NUM_TRIE_KEY_COLUMNS \
+                 ({NUM_TRIE_KEY_COLUMNS})",
+            );
+        }
+    }
+
+    #[test]
+    fn keyspace_position_is_monotone_and_spans_the_range() {
+        let account_start = keyspace_position(&[col::ACCOUNT]);
+        let account_mid = keyspace_position(&[col::ACCOUNT, b'm', b'i', b'd']);
+        let data = keyspace_position(&[col::CONTRACT_DATA, b'a']);
+        let last = keyspace_position(&[max_trie_key_column(), 0xff, 0xff, 0xff]);
+
+        assert_eq!(account_start, 0.0);
+        assert!(account_start < account_mid, "{account_start} < {account_mid}");
+        assert!(account_mid < data, "{account_mid} < {data}");
+        assert!(data < last, "{data} < {last}");
+        // The last column should read as nearly complete rather than a few percent — but
+        // strictly below 1.0, or a scan still in its final column reports as finished. This
+        // has to stay strict: `keyspace_position` clamps, so `<= 1.0` would always hold.
+        assert!(last > 0.9, "{last} > 0.9");
+        assert!(last < 1.0, "{last} < 1.0");
+    }
+
+    #[test]
+    fn keyspace_position_handles_short_keys() {
+        assert_eq!(keyspace_position(&[]), 0.0);
+        assert!(keyspace_position(&[col::CONTRACT_DATA]) > 0.0);
+    }
+}

--- a/tools/fork-network/src/metrics.rs
+++ b/tools/fork-network/src/metrics.rs
@@ -1,17 +1,16 @@
 //! Progress metrics for `neard fork-network`.
 //!
-//! `amend-access-keys` is a single command that runs for hours (~3h50m on the Jul 24 mainnet
-//! fork) with no progress signal other than one log line per commit batch, so operators cannot
-//! tell a slow run from a wedged one. These metrics make the run legible: which phase it is in,
-//! how far each shard's flat-state scan has got, and how long each commit stage takes.
+//! `amend-access-keys` is a single command that runs for hours with no progress signal other
+//! than one log line per commit batch, so operators cannot tell a slow run from a wedged one.
+//! These metrics make the run legible: which phase it is in, how far each shard's flat-state
+//! scan has got, and how long each commit stage takes.
 //!
 //! Everything here is read through the `/metrics` endpoint started by [`crate::metrics_server`].
 
 use near_o11y::metrics::{
     Gauge, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
     exponential_buckets, try_create_gauge, try_create_gauge_vec, try_create_histogram_vec,
-    try_create_int_counter, try_create_int_counter_vec, try_create_int_gauge,
-    try_create_int_gauge_vec,
+    try_create_int_counter_vec, try_create_int_gauge, try_create_int_gauge_vec,
 };
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::trie_key::col;
@@ -50,8 +49,11 @@ const fn max_trie_key_column() -> u8 {
 /// a whole mainnet fork emits a few thousand of these lines, which is nothing.
 pub(crate) const SCAN_PROGRESS_INTERVAL: u64 = 250_000;
 
-/// Values of the `near_fork_network_phase` gauge. Process-wide; each subcommand only visits a
-/// subset of these.
+/// Values of the `near_fork_network_phase` gauge.
+///
+/// Only the phases of `init` and `amend-access-keys`, the two subcommands image creation runs.
+/// `set-validators` and `finalize` run later, on the forknet hosts booted from the finished
+/// image, and are deliberately not tracked here.
 #[derive(Clone, Copy)]
 #[repr(i64)]
 pub(crate) enum Phase {
@@ -68,11 +70,8 @@ pub(crate) enum Phase {
     BandwidthScheduler = 6,
     DelayedReceipts = 7,
     FinalizeState = 8,
-    AddValidatorAccounts = 9,
-    AddUserAccounts = 10,
-    WriteGenesis = 11,
-    Reset = 12,
-    Done = 13,
+    Reset = 9,
+    Done = 10,
 }
 
 static PHASE: LazyLock<IntGauge> = LazyLock::new(|| {
@@ -81,8 +80,7 @@ static PHASE: LazyLock<IntGauge> = LazyLock::new(|| {
         "Current phase of the running fork-network subcommand, enum-encoded: 0 - idle, \
          1 - snapshot, 2 - write fork info, 3 - clear columns, 4 - load memtries, \
          5 - prepare state, 6 - bandwidth scheduler, 7 - delayed receipts, 8 - finalize state, \
-         9 - add validator accounts, 10 - add user accounts, 11 - write genesis, 12 - reset, \
-         13 - done",
+         9 - reset, 10 - done",
     )
     .unwrap()
 });
@@ -106,8 +104,6 @@ pub(crate) fn set_phase(phase: Phase) {
 /// process starts serving `/metrics` rather than appearing partway through a multi-hour run.
 pub(crate) fn init() {
     set_phase(Phase::Idle);
-    USER_ACCOUNTS_CREATED.reset();
-    USER_ACCOUNTS_EXPECTED.set(0);
 }
 
 fn unix_time_seconds() -> f64 {
@@ -235,23 +231,6 @@ static COMMIT_STAGE_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
         // 10ms .. ~5.5 minutes: batch commits are normally seconds, and the point of the
         // metric is to catch the pathological tail.
         Some(exponential_buckets(0.01, 2.0, 16).unwrap()),
-    )
-    .unwrap()
-});
-
-static USER_ACCOUNTS_CREATED: LazyLock<IntCounter> = LazyLock::new(|| {
-    try_create_int_counter(
-        "near_fork_network_user_accounts_created_total",
-        "Benchmark user accounts written to state by set-validators",
-    )
-    .unwrap()
-});
-
-static USER_ACCOUNTS_EXPECTED: LazyLock<IntGauge> = LazyLock::new(|| {
-    try_create_int_gauge(
-        "near_fork_network_user_accounts_expected",
-        "Benchmark user accounts set-validators will write in total. Unlike the flat-state \
-         scans this total is known up front, so the ratio is a true percentage.",
     )
     .unwrap()
 });
@@ -397,13 +376,14 @@ pub(crate) fn init_shards(shard_uids: &[ShardUId]) {
         // Registers the commit-stage histogram series too, so an early scrape shows them at
         // zero rather than omitting them, and a dashboard can tell "no commits yet" apart
         // from "this build has no commit instrumentation".
-        CommitStages::new(*shard_uid);
+        CommitStagesMetrics::new(*shard_uid);
     }
 }
 
-/// Timers for the stages of one shard's batch commit. These are the four writes most likely to
-/// stall on RocksDB, and none of them was timed before.
-pub(crate) struct CommitStages {
+/// Timers for the stages of one shard's batch commit. These are the writes most likely to stall
+/// on RocksDB, timed one by one so a stall can be attributed to a stage rather than to the
+/// commit as a whole.
+pub(crate) struct CommitStagesMetrics {
     /// Time spent waiting for the shard's update-state lock, which every shard's rayon thread
     /// can contend for. Counted inside `total`.
     pub(crate) lock_wait: Histogram,
@@ -415,7 +395,7 @@ pub(crate) struct CommitStages {
     pub(crate) total: Histogram,
 }
 
-impl CommitStages {
+impl CommitStagesMetrics {
     pub(crate) fn new(shard_uid: ShardUId) -> Self {
         let shard = shard_uid.to_string();
         let stage = |stage: &str| COMMIT_STAGE_DURATION.with_label_values(&[shard.as_str(), stage]);
@@ -436,14 +416,6 @@ pub(crate) fn batch_committed(shard_uid: ShardUId, num_updates: usize) {
     let shard = shard_uid.to_string();
     KEYS_WRITTEN.with_label_values(&[&shard]).inc_by(num_updates as u64);
     BATCHES_COMMITTED.with_label_values(&[&shard]).inc();
-}
-
-pub(crate) fn set_user_accounts_expected(total: u64) {
-    USER_ACCOUNTS_EXPECTED.set(total as i64);
-}
-
-pub(crate) fn user_account_created() {
-    USER_ACCOUNTS_CREATED.inc();
 }
 
 #[cfg(test)]

--- a/tools/fork-network/src/metrics.rs
+++ b/tools/fork-network/src/metrics.rs
@@ -18,7 +18,7 @@ use near_primitives::trie_key::col;
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// One past the largest column byte, used to normalise a flat-state key into a 0..1 keyspace
+/// One past the largest column byte, used to normalize a flat-state key into a 0..1 keyspace
 /// position. Keys start with the column byte, so without this the position would top out at
 /// around 23/256 and a finished scan would read as 9% done.
 ///
@@ -302,7 +302,7 @@ fn keyspace_position(key: &[u8]) -> f64 {
     let mut prefix = [0u8; 8];
     let len = key.len().min(prefix.len());
     prefix[..len].copy_from_slice(&key[..len]);
-    // Normalise by the prefix value a key one past the last column would have, so a full scan
+    // Normalize by the prefix value a key one past the last column would have, so a full scan
     // spans roughly the whole 0..1 range instead of the bottom tenth of it.
     let max = NUM_TRIE_KEY_COLUMNS as f64 * (1u64 << 56) as f64;
     (u64::from_be_bytes(prefix) as f64 / max).min(1.0)
@@ -338,7 +338,7 @@ impl ShardMetrics {
             ref_values_retrieved: REF_VALUES_RETRIEVED.with_label_values(&[&shard]),
             access_keys_added: ACCESS_KEYS_ADDED.with_label_values(&[&shard]),
         };
-        // Zero-initialise so every series exists before the shard starts rewriting state.
+        // Zero-initialize so every series exists before the shard starts rewriting state.
         metrics.set_phase(ShardPhase::Idle);
         metrics.keys_expected.set(0);
         metrics.pass1.position.set(0.0);
@@ -394,6 +394,10 @@ impl ShardMetrics {
 pub(crate) fn init_shards(shard_uids: &[ShardUId]) {
     for shard_uid in shard_uids {
         ShardMetrics::new(*shard_uid);
+        // Registers the commit-stage histogram series too, so an early scrape shows them at
+        // zero rather than omitting them, and a dashboard can tell "no commits yet" apart
+        // from "this build has no commit instrumentation".
+        CommitStages::new(*shard_uid);
     }
 }
 
@@ -447,10 +451,10 @@ mod tests {
     use super::{NUM_TRIE_KEY_COLUMNS, keyspace_position, max_trie_key_column};
     use near_primitives::trie_key::col;
 
-    /// Guards the normalisation constant against a new trie key column being added. Getting
+    /// Guards the normalization constant against a new trie key column being added. Getting
     /// this too small makes a scan of the last column report 100% while it is still running.
     #[test]
-    fn normalisation_covers_every_column() {
+    fn normalization_covers_every_column() {
         for (column, name) in col::ALL_COLUMNS_WITH_NAMES {
             assert!(
                 (column as u64) < NUM_TRIE_KEY_COLUMNS,

--- a/tools/fork-network/src/metrics_server.rs
+++ b/tools/fork-network/src/metrics_server.rs
@@ -1,0 +1,137 @@
+//! A `/metrics` endpoint for `neard fork-network`.
+//!
+//! Tools in this repo get metrics served one of two ways. Long-running ones that host a node
+//! — `tools/mirror` via `nearcore::start_with_config` — get `/metrics` for free, because
+//! starting a node starts `near_jsonrpc::start_http`. Standalone ones that never build a node
+//! have to serve it themselves; `tools/ping` is the precedent.
+//!
+//! `fork-network` is the second kind. It binds no socket at all today, so the metrics its
+//! phases already register — memtrie arena memory, RocksDB op latency, flat storage — are
+//! mutated for hours and are unreadable. This serves them, reusing the same handler
+//! `near_jsonrpc` exposes for `neard run` rather than re-encoding the registry by hand.
+
+use axum::Router;
+use axum::routing::get;
+use std::net::SocketAddr;
+use std::thread::Builder;
+use tokio::net::TcpListener;
+use tokio::runtime;
+
+/// Starts a `/metrics` server on `addr` and detaches it. An empty `addr` disables the server.
+///
+/// The server gets its own OS thread with its own runtime, and deliberately does not use the
+/// runtime `ForkNetworkCommand::run()` builds. That one is `new_current_thread()` and its only
+/// task spends hours inside synchronous state rewriting, so a `tokio::spawn`ed server would
+/// never be polled: it would answer in a unit test and time out in production for exactly the
+/// hours we need it. This is the one place `tools/ping` should not be copied — it spawns onto
+/// the main runtime, but only because it builds a multi-thread one.
+///
+/// Failures to bind or serve are logged and otherwise ignored. Observability must not become a
+/// new way for image creation to fail.
+pub(crate) fn spawn(addr: &str) {
+    if addr.is_empty() {
+        tracing::info!("metrics server disabled");
+        return;
+    }
+    let addr = addr.to_owned();
+    let thread = Builder::new().name("fork-network-metrics".to_owned()).spawn(move || serve(&addr));
+    if let Err(err) = thread {
+        tracing::error!(?err, "failed spawning metrics server thread");
+    }
+}
+
+fn serve(addr: &str) {
+    let socket_addr = match addr.parse::<SocketAddr>() {
+        Ok(socket_addr) => socket_addr,
+        Err(err) => {
+            tracing::error!(%addr, ?err, "not a valid metrics address");
+            return;
+        }
+    };
+    let runtime = match runtime::Builder::new_current_thread().enable_all().build() {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            tracing::error!(?err, "failed building metrics runtime");
+            return;
+        }
+    };
+    runtime.block_on(async move {
+        let listener = match TcpListener::bind(socket_addr).await {
+            Ok(listener) => listener,
+            Err(err) => {
+                tracing::error!(
+                    %socket_addr,
+                    ?err,
+                    "failed binding metrics address, continuing without /metrics"
+                );
+                return;
+            }
+        };
+        tracing::info!(%socket_addr, "serving /metrics");
+        let app = Router::new().route("/metrics", get(near_jsonrpc::prometheus_handler));
+        if let Err(err) = axum::serve(listener, app).await {
+            tracing::error!(?err, "metrics server stopped");
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
+    // Imported as a module, not by item: a bare `spawn` would shadow this module's own.
+    use std::thread;
+    use std::time::{Duration, Instant};
+    use tokio::runtime;
+
+    fn scrape(addr: SocketAddr) -> String {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            assert!(Instant::now() < deadline, "metrics server never answered on {addr}");
+            thread::sleep(Duration::from_millis(50));
+            let Ok(mut stream) = TcpStream::connect(addr) else { continue };
+            stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+            let request =
+                format!("GET /metrics HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+            if stream.write_all(request.as_bytes()).is_err() {
+                continue;
+            }
+            let mut response = String::new();
+            if stream.read_to_string(&mut response).is_ok() && !response.is_empty() {
+                return response;
+            }
+        }
+    }
+
+    /// Reproduces the situation every fork-network phase is in: a `new_current_thread` runtime
+    /// whose single task is blocked in synchronous work, exactly as `ForkNetworkCommand::run`
+    /// builds it. Scraping happens from a second OS thread, since the one running the runtime
+    /// is by construction unavailable.
+    ///
+    /// This is the regression guard for the starvation trap. Change `spawn` to put the server
+    /// on the caller's runtime with `tokio::spawn` and the server never gets polled, the scrape
+    /// never completes, and this test fails on the deadline rather than passing by luck.
+    #[test]
+    fn serves_metrics_while_the_callers_runtime_is_blocked() {
+        // Take a port from the OS, then release it so the server can bind it.
+        let addr = TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap();
+        crate::metrics::init();
+
+        let scraper = thread::spawn(move || scrape(addr));
+
+        let blocking_runtime = runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        blocking_runtime.block_on(async move {
+            super::spawn(&addr.to_string());
+            // Synchronous work inside `block_on`, never yielding to the runtime — a fork phase
+            // does this for hours.
+            let until = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < until {
+                thread::sleep(Duration::from_millis(20));
+            }
+        });
+
+        let response = scraper.join().expect("scraper thread panicked");
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+        assert!(response.contains("near_fork_network_phase"), "{response}");
+    }
+}

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -412,8 +412,9 @@ fn commit_to_existing_state(
     shard_uid: ShardUId,
     root: &mut InProgressRoot,
     updates: Vec<(TrieKey, Option<Vec<u8>>)>,
-    // Owned by the caller so `total` can cover the lock wait too.
-    stages: &CommitStages,
+    // Owned by the caller so `total` can cover the lock wait too. None for empty batches,
+    // which are deliberately not timed.
+    stages: Option<&CommitStages>,
 ) -> anyhow::Result<()> {
     let updates =
         updates.into_iter().map(|(trie_key, value)| (trie_key.to_vec(), value)).collect::<Vec<_>>();
@@ -426,12 +427,12 @@ fn commit_to_existing_state(
     let flat_state_changes = FlatStateChanges::from_raw_key_value(&updates);
     let mut update = shard_tries.store_update();
     {
-        let _timer = stages.apply_to_flat_state.start_timer();
+        let _timer = stages.map(|s| s.apply_to_flat_state.start_timer());
         flat_state_changes.apply_to_flat_state(&mut update.flat_store_update(), shard_uid);
     }
 
     let trie_changes = {
-        let _timer = stages.trie_update.start_timer();
+        let _timer = stages.map(|s| s.trie_update.start_timer());
         shard_tries
             .get_trie_for_shard(shard_uid, root.state_root)
             .update(updates, AccessOptions::DEFAULT)
@@ -443,11 +444,11 @@ fn commit_to_existing_state(
         num_trie_node_deletions = trie_changes.deletions().len()
     );
     let state_root = {
-        let _timer = stages.apply_all.start_timer();
+        let _timer = stages.map(|s| s.apply_all.start_timer());
         shard_tries.apply_all(&trie_changes, shard_uid, &mut update)
     };
     {
-        let _timer = stages.apply_memtrie_changes.start_timer();
+        let _timer = stages.map(|s| s.apply_memtrie_changes.start_timer());
         shard_tries.apply_memtrie_changes(&trie_changes, shard_uid, root.update_height);
         // We may not have loaded memtries (some commands don't need to), so check.
         if let Some(memtries) = shard_tries.get_memtries(shard_uid) {
@@ -462,7 +463,7 @@ fn commit_to_existing_state(
     update.store_update().set_ser(DBCol::Misc, &key, &state_root);
 
     {
-        let _timer = stages.store_commit.start_timer();
+        let _timer = stages.map(|s| s.store_commit.start_timer());
         update.commit();
     }
     tracing::info!(?shard_uid, ?state_root, "commit is done");
@@ -473,6 +474,7 @@ fn commit_to_new_state(
     shard_tries: &ShardTries,
     shard_uid: ShardUId,
     updates: Vec<(TrieKey, Option<Vec<u8>>)>,
+    stages: Option<&CommitStages>,
 ) -> anyhow::Result<StateRoot> {
     let num_updates = updates.len();
     tracing::info!(?shard_uid, num_updates, "commit new");
@@ -485,18 +487,31 @@ fn commit_to_new_state(
         }
     }
     trie_update.commit(StateChangeCause::InitialState);
-    let TrieUpdateResult { trie_changes, state_changes, .. } =
+    // Instrumented with the same stage labels as commit_to_existing_state, so a commit to a
+    // new shard is not silently missing from the per-stage histogram.
+    let TrieUpdateResult { trie_changes, state_changes, .. } = {
+        let _timer = stages.map(|s| s.trie_update.start_timer());
         trie_update.finalize().with_context(|| {
             format!("Initial trie update finalization failed for shard {}", shard_uid)
-        })?;
+        })?
+    };
     let mut store_update = shard_tries.store_update();
-    let state_root = shard_tries.apply_all(&trie_changes, shard_uid, &mut store_update);
-    FlatStateChanges::from_state_changes(&state_changes)
-        .apply_to_flat_state(&mut store_update.flat_store_update(), shard_uid);
+    let state_root = {
+        let _timer = stages.map(|s| s.apply_all.start_timer());
+        shard_tries.apply_all(&trie_changes, shard_uid, &mut store_update)
+    };
+    {
+        let _timer = stages.map(|s| s.apply_to_flat_state.start_timer());
+        FlatStateChanges::from_state_changes(&state_changes)
+            .apply_to_flat_state(&mut store_update.flat_store_update(), shard_uid);
+    }
     let key = crate::cli::make_state_roots_key(shard_uid);
     store_update.store_update().set_ser(DBCol::Misc, &key, &state_root);
     tracing::info!(?shard_uid, "committing initial state to new shard");
-    store_update.commit();
+    {
+        let _timer = stages.map(|s| s.store_commit.start_timer());
+        store_update.commit();
+    }
 
     Ok(state_root)
 }
@@ -508,35 +523,44 @@ pub(crate) fn commit_shard(
     update_state: &ShardUpdateState,
     updates: Vec<(TrieKey, Option<Vec<u8>>)>,
 ) -> anyhow::Result<StateRoot> {
-    // Timed from here, before the lock, so `total` covers waiting for it. Every shard's rayon
-    // thread can write to another shard's update state, so contention on this mutex is real and
-    // is exactly the "why was that batch slow" answer an operator is looking for. It also has
-    // to wrap both branches below, or commits to a new shard would be missing from the
-    // histogram entirely.
-    let stages = CommitStages::new(shard_uid);
-    let _total_timer = stages.total.start_timer();
-    let lock_timer = stages.lock_wait.start_timer();
-    let mut root = update_state.root.lock();
-    lock_timer.observe_duration();
+    // `StorageMutator::commit()` calls this once per target shard, including every shard that
+    // got no updates in this batch. Those still do a little work — they take the lock and
+    // write a state root — but they are a different population from a 500k-update commit, and
+    // timing both into one histogram makes its mean meaningless: on a mainnet fork 69% of the
+    // observations were empty batches, reporting a mean of 6.9s for commits that actually
+    // cost 38.8s. So only real commits are timed, which keeps the histogram's count equal to
+    // `near_fork_network_batches_committed_total`.
+    let num_updates = updates.len();
+    let stages = (num_updates > 0).then(|| CommitStages::new(shard_uid));
 
-    // `StorageMutator::commit()` calls this once per target shard, including shards that got no
-    // updates in this batch, so only count the batches that actually wrote something.
-    if !updates.is_empty() {
-        metrics::batch_committed(shard_uid, updates.len());
+    // Timed from before the lock, so `total` covers waiting for it. Every shard's rayon thread
+    // can write to another shard's update state, so contention on this mutex is real and is
+    // exactly the "why was that batch slow" answer an operator is looking for.
+    let _total_timer = stages.as_ref().map(|s| s.total.start_timer());
+    let lock_timer = stages.as_ref().map(|s| s.lock_wait.start_timer());
+    let mut root = update_state.root.lock();
+    if let Some(lock_timer) = lock_timer {
+        lock_timer.observe_duration();
     }
+
     let new_root = match root.as_mut() {
         Some(root) => {
-            commit_to_existing_state(shard_tries, shard_uid, root, updates, &stages)?;
+            commit_to_existing_state(shard_tries, shard_uid, root, updates, stages.as_ref())?;
             root.state_root
         }
         None => {
-            let state_root = commit_to_new_state(shard_tries, shard_uid, updates)?;
+            let state_root = commit_to_new_state(shard_tries, shard_uid, updates, stages.as_ref())?;
             // TODO: load memtrie
             *root = Some(InProgressRoot { state_root, update_height: 1 });
             state_root
         }
     };
 
+    // Counted only once the write has actually landed, so a batch that fails on the way to
+    // disk is not reported as committed.
+    if num_updates > 0 {
+        metrics::batch_committed(shard_uid, num_updates);
+    }
     Ok(new_root)
 }
 

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -1,4 +1,4 @@
-use crate::metrics::{self, CommitStages};
+use crate::metrics::{self, CommitStagesMetrics};
 use anyhow::Context;
 use near_crypto::PublicKey;
 use near_mirror::key_mapping::map_account;
@@ -414,16 +414,15 @@ fn commit_to_existing_state(
     updates: Vec<(TrieKey, Option<Vec<u8>>)>,
     // Owned by the caller so `total` can cover the lock wait too. None for empty batches,
     // which are deliberately not timed.
-    stages: Option<&CommitStages>,
+    stages: Option<&CommitStagesMetrics>,
 ) -> anyhow::Result<()> {
     let updates =
         updates.into_iter().map(|(trie_key, value)| (trie_key.to_vec(), value)).collect::<Vec<_>>();
 
     let num_updates = updates.len();
     tracing::info!(?shard_uid, num_updates, "commit");
-    // None of these stages was timed before, and they are the ones that stall when RocksDB
-    // falls behind on compaction — the suspected reason for the batch-size tuning advice in
-    // the image-creation script.
+    // These stages are the ones that stall when RocksDB falls behind on compaction, so they
+    // are timed individually rather than as one commit duration.
     let flat_state_changes = FlatStateChanges::from_raw_key_value(&updates);
     let mut update = shard_tries.store_update();
     {
@@ -474,7 +473,7 @@ fn commit_to_new_state(
     shard_tries: &ShardTries,
     shard_uid: ShardUId,
     updates: Vec<(TrieKey, Option<Vec<u8>>)>,
-    stages: Option<&CommitStages>,
+    stages: Option<&CommitStagesMetrics>,
 ) -> anyhow::Result<StateRoot> {
     let num_updates = updates.len();
     tracing::info!(?shard_uid, num_updates, "commit new");
@@ -531,7 +530,7 @@ pub(crate) fn commit_shard(
     // cost 38.8s. So only real commits are timed, which keeps the histogram's count equal to
     // `near_fork_network_batches_committed_total`.
     let num_updates = updates.len();
-    let stages = (num_updates > 0).then(|| CommitStages::new(shard_uid));
+    let stages = (num_updates > 0).then(|| CommitStagesMetrics::new(shard_uid));
 
     // Timed from before the lock, so `total` covers waiting for it. Every shard's rayon thread
     // can write to another shard's update state, so contention on this mutex is real and is

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -1,3 +1,4 @@
+use crate::metrics::{self, CommitStages};
 use anyhow::Context;
 use near_crypto::PublicKey;
 use near_mirror::key_mapping::map_account;
@@ -411,30 +412,47 @@ fn commit_to_existing_state(
     shard_uid: ShardUId,
     root: &mut InProgressRoot,
     updates: Vec<(TrieKey, Option<Vec<u8>>)>,
+    // Owned by the caller so `total` can cover the lock wait too.
+    stages: &CommitStages,
 ) -> anyhow::Result<()> {
     let updates =
         updates.into_iter().map(|(trie_key, value)| (trie_key.to_vec(), value)).collect::<Vec<_>>();
 
     let num_updates = updates.len();
     tracing::info!(?shard_uid, num_updates, "commit");
+    // None of these stages was timed before, and they are the ones that stall when RocksDB
+    // falls behind on compaction — the suspected reason for the batch-size tuning advice in
+    // the image-creation script.
     let flat_state_changes = FlatStateChanges::from_raw_key_value(&updates);
     let mut update = shard_tries.store_update();
-    flat_state_changes.apply_to_flat_state(&mut update.flat_store_update(), shard_uid);
+    {
+        let _timer = stages.apply_to_flat_state.start_timer();
+        flat_state_changes.apply_to_flat_state(&mut update.flat_store_update(), shard_uid);
+    }
 
-    let trie_changes = shard_tries
-        .get_trie_for_shard(shard_uid, root.state_root)
-        .update(updates, AccessOptions::DEFAULT)
-        .with_context(|| format!("failed updating trie for shard {}", shard_uid))?;
+    let trie_changes = {
+        let _timer = stages.trie_update.start_timer();
+        shard_tries
+            .get_trie_for_shard(shard_uid, root.state_root)
+            .update(updates, AccessOptions::DEFAULT)
+            .with_context(|| format!("failed updating trie for shard {}", shard_uid))?
+    };
     tracing::info!(
         ?shard_uid,
         num_trie_node_insertions = trie_changes.insertions().len(),
         num_trie_node_deletions = trie_changes.deletions().len()
     );
-    let state_root = shard_tries.apply_all(&trie_changes, shard_uid, &mut update);
-    shard_tries.apply_memtrie_changes(&trie_changes, shard_uid, root.update_height);
-    // We may not have loaded memtries (some commands don't need to), so check.
-    if let Some(memtries) = shard_tries.get_memtries(shard_uid) {
-        memtries.write().delete_until_height(root.update_height);
+    let state_root = {
+        let _timer = stages.apply_all.start_timer();
+        shard_tries.apply_all(&trie_changes, shard_uid, &mut update)
+    };
+    {
+        let _timer = stages.apply_memtrie_changes.start_timer();
+        shard_tries.apply_memtrie_changes(&trie_changes, shard_uid, root.update_height);
+        // We may not have loaded memtries (some commands don't need to), so check.
+        if let Some(memtries) = shard_tries.get_memtries(shard_uid) {
+            memtries.write().delete_until_height(root.update_height);
+        }
     }
     root.update_height += 1;
     root.state_root = state_root;
@@ -443,7 +461,10 @@ fn commit_to_existing_state(
     let key = crate::cli::make_state_roots_key(shard_uid);
     update.store_update().set_ser(DBCol::Misc, &key, &state_root);
 
-    update.commit();
+    {
+        let _timer = stages.store_commit.start_timer();
+        update.commit();
+    }
     tracing::info!(?shard_uid, ?state_root, "commit is done");
     Ok(())
 }
@@ -487,11 +508,25 @@ pub(crate) fn commit_shard(
     update_state: &ShardUpdateState,
     updates: Vec<(TrieKey, Option<Vec<u8>>)>,
 ) -> anyhow::Result<StateRoot> {
+    // Timed from here, before the lock, so `total` covers waiting for it. Every shard's rayon
+    // thread can write to another shard's update state, so contention on this mutex is real and
+    // is exactly the "why was that batch slow" answer an operator is looking for. It also has
+    // to wrap both branches below, or commits to a new shard would be missing from the
+    // histogram entirely.
+    let stages = CommitStages::new(shard_uid);
+    let _total_timer = stages.total.start_timer();
+    let lock_timer = stages.lock_wait.start_timer();
     let mut root = update_state.root.lock();
+    lock_timer.observe_duration();
 
+    // `StorageMutator::commit()` calls this once per target shard, including shards that got no
+    // updates in this batch, so only count the batches that actually wrote something.
+    if !updates.is_empty() {
+        metrics::batch_committed(shard_uid, updates.len());
+    }
     let new_root = match root.as_mut() {
         Some(root) => {
-            commit_to_existing_state(shard_tries, shard_uid, root, updates)?;
+            commit_to_existing_state(shard_tries, shard_uid, root, updates, &stages)?;
             root.state_root
         }
         None => {


### PR DESCRIPTION
neard fork-network had no metrics, spans or timing anywhere. amend-access-keys runs for ~4 hours on a mainnet fork emitting one log line per commit batch, so an operator cannot tell a slow run from a wedged one.

- Serve /metrics. fork-network binds no socket, so the metrics its phases already register, memtrie arena memory, RocksDB op latency, flat storage;  are mutated for hours and unreadable. Adds --prometheus-addr (global, default 0.0.0.0:3030, empty disables) routing to the shared near_jsonrpc::prometheus_handler, following tools/ping. Failure to bind is logged, never fatal.

- It runs on a dedicated OS thread with its own runtime: the command's runtime is new_current_thread() and its only task blocks for hours in synchronous state rewriting, so a tokio::spawned server would never be polled. Prevents it from passing a unit test and time out in production. Covered by a test that scrapes while the calling thread is blocked.
- New near_fork_network_* metrics (metrics.rs): process phase and per-shard pass as enum gauges, per-shard keys scanned / records parsed / State-column ref lookups / keys written / batches committed / access keys added, and a scan position estimate. Label values are pre-bound outside the scan loops, which run for billions of iterations.
- Commit-stage timers (storage_mutator.rs) for apply_to_flat_state, trie_update, apply_all, apply_memtrie_changes and store_commit. None was timed before, and they are what stalls when RocksDB falls behind on compaction.
- Pass 2 had no in-loop progress at all. A second full flat-state scan in silence. Both passes now log every 250k keys with the position estimate, which also keeps the log growing so an external liveness check on its mtime works.

Position estimates are honest about their limits: pass 2 divides by the key count pass 1 measured, pass 1 has no knowable total and reports a lexicographic keyspace position, monotone, but not proportional to time.