### PR TITLE
perf(sync): offload peer height approval verification

### DIFF
--- a/chain/chain/src/approval_verification.rs
+++ b/chain/chain/src/approval_verification.rs
@@ -1,12 +1,62 @@
+use crate::{Doomslug, DoomslugThresholdMode};
 use near_chain_primitives::error::Error;
 use near_crypto::Signature;
 use near_primitives::{
+    block::BlockHeader,
     block_header::{Approval, ApprovalInner},
     epoch_info::EpochInfo,
     hash::CryptoHash,
-    types::{AccountId, ApprovalStake, Balance, BlockHeight},
+    types::{AccountId, ApprovalStake, Balance, BlockHeight, validator_stake::ValidatorStake},
 };
 use std::{collections::HashSet, sync::Arc};
+
+/// All immutable inputs needed for the CPU-intensive portion of block header approval
+/// verification. Epoch-manager lookups happen while preparing this value, so `verify` can safely
+/// run on a computation worker without accessing `Chain`.
+pub struct BlockHeaderApprovalVerification {
+    header: BlockHeader,
+    block_producer: ValidatorStake,
+    epoch_info: Arc<EpochInfo>,
+    doomslug_threshold_mode: DoomslugThresholdMode,
+}
+
+impl BlockHeaderApprovalVerification {
+    pub(crate) fn new(
+        header: BlockHeader,
+        block_producer: ValidatorStake,
+        epoch_info: Arc<EpochInfo>,
+        doomslug_threshold_mode: DoomslugThresholdMode,
+    ) -> Self {
+        Self { header, block_producer, epoch_info, doomslug_threshold_mode }
+    }
+
+    pub fn verify(self) -> Result<(), Error> {
+        if !self
+            .header
+            .signature()
+            .verify(self.header.hash().as_ref(), self.block_producer.public_key())
+        {
+            return Err(Error::InvalidSignature);
+        }
+        let Some(prev_height) = self.header.prev_height() else {
+            return Err(Error::Other("header too old to verify approvals without ancestry".into()));
+        };
+        verify_approvals_and_threshold_orphan(
+            &|approvals, stakes| {
+                Doomslug::can_approved_block_be_produced(
+                    self.doomslug_threshold_mode,
+                    approvals,
+                    stakes,
+                )
+            },
+            self.header.prev_hash(),
+            prev_height,
+            self.header.height(),
+            self.header.approvals(),
+            self.epoch_info,
+        )
+    }
+}
 
 pub fn verify_approval_with_approvers_info(
     prev_block_hash: &CryptoHash,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1,5 +1,5 @@
 use crate::approval_verification::{
-    verify_approval_with_approvers_info, verify_approvals_and_threshold_orphan,
+    BlockHeaderApprovalVerification, verify_approval_with_approvers_info,
 };
 use crate::block_processing_utils::{
     ApplyChunksDoneWaiter, ApplyChunksStillApplying, BlockPreprocessInfo, BlockProcessingArtifact,
@@ -4058,42 +4058,30 @@ impl Chain {
         self.invalid_blocks.contains(hash)
     }
 
-    /// Verifies that a header carries approvals from >2/3 of the stake of a
-    /// validator set we already know (current or next epoch). Errors if the
-    /// header's epoch is unknown (too far ahead to validate), the approvals fall
-    /// short, or the header is too old to carry a `prev_height` (V1/V2).
+    /// Collects the immutable inputs needed to verify a header's producer signature and approvals.
+    /// The returned verification performs only CPU work and can run outside the client actor.
+    pub fn prepare_header_approval_verification(
+        &self,
+        header: &BlockHeader,
+    ) -> Result<BlockHeaderApprovalVerification, Error> {
+        let epoch_info = self.epoch_manager.get_epoch_info(header.epoch_id())?;
+        let block_producer =
+            epoch_info.get_validator(epoch_info.sample_block_producer(header.height()));
+        Ok(BlockHeaderApprovalVerification::new(
+            header.clone(),
+            block_producer,
+            epoch_info,
+            self.doomslug_threshold_mode,
+        ))
+    }
+
+    /// Verifies a block producer signature and approvals synchronously. Callers on latency-sensitive
+    /// threads should prepare the immutable inputs above and run `verify` on a computation worker.
     pub fn verify_header_approvals_without_ancestry(
         &self,
         header: &BlockHeader,
     ) -> Result<(), Error> {
-        // Producer signature first: the header hash covers the approvals, so a
-        // header with any tampered approval dies after one signature check
-        // instead of a full pass over ~100 approval signatures.
-        if !self.partial_verify_orphan_header_signature(header)? {
-            return Err(Error::InvalidSignature);
-        }
-        let prev_hash = header.prev_hash();
-        let Some(prev_height) = header.prev_height() else {
-            return Err(Error::Other("header too old to verify approvals without ancestry".into()));
-        };
-        let height = header.height();
-        let epoch_id = header.epoch_id();
-        let approvals = header.approvals();
-        let epoch_info = self.epoch_manager.get_epoch_info(epoch_id)?;
-        verify_approvals_and_threshold_orphan(
-            &|approvals, stakes| {
-                Doomslug::can_approved_block_be_produced(
-                    self.doomslug_threshold_mode,
-                    approvals,
-                    stakes,
-                )
-            },
-            prev_hash,
-            prev_height,
-            height,
-            approvals,
-            epoch_info,
-        )
+        self.prepare_header_approval_verification(header)?.verify()
     }
 
     /// Check that sync_hash matches the one we expect for the epoch containing that block.

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -1,3 +1,4 @@
+pub use approval_verification::BlockHeaderApprovalVerification;
 pub use block_processing_utils::BlockProcessingArtifact;
 pub use chain::{Chain, MemtrieLoadingSpawner, collect_receipts};
 pub use chain_update::ChainUpdate;

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1242,12 +1242,8 @@ impl Client {
             return;
         };
         let job = BlockApprovalVerificationJob { header_hash, verification };
-        match self.block_approval_verification_scheduler.enqueue(job) {
-            Ok(Some(job)) => self.spawn_block_approval_verification(job),
-            Ok(None) => {}
-            Err(job) => {
-                self.verified_peer_heights.cancel_verification(&job.header_hash);
-            }
+        if let Some(job) = self.block_approval_verification_scheduler.enqueue(job) {
+            self.spawn_block_approval_verification(job);
         }
     }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -20,7 +20,9 @@ use crate::sync::handler::SyncHandler;
 use crate::sync::header::HeaderSync;
 use crate::sync::state::chain_requests::ChainSenderForStateSync;
 use crate::sync::state::{StateSync, StateSyncShardResult};
-use crate::verified_peer_heights::{BlockApprovalVerificationScheduler, VerifiedPeerHeights};
+use crate::verified_peer_heights::{
+    BlockApprovalVerificationScheduler, VerificationRegistration, VerifiedPeerHeights,
+};
 use crate::{ProduceChunkResult, metrics};
 use itertools::Itertools;
 use near_async::futures::RayonAsyncComputationSpawner;
@@ -199,7 +201,9 @@ pub struct Client {
 }
 
 struct BlockApprovalVerificationJob {
+    peer_id: PeerId,
     header_hash: CryptoHash,
+    height: BlockHeight,
     verification: BlockHeaderApprovalVerification,
 }
 
@@ -1233,17 +1237,69 @@ impl Client {
             return;
         }
         let header_hash = *block.hash();
-        if !self.verified_peer_heights.register_verification(peer_id, &header_hash, height) {
+        let registration =
+            self.verified_peer_heights.register_verification(peer_id, &header_hash, height);
+        if registration == VerificationRegistration::Handled {
+            return;
+        }
+        if registration == VerificationRegistration::Defer
+            && self
+                .block_approval_verification_scheduler
+                .deferred_height(peer_id)
+                .is_some_and(|deferred_height| deferred_height >= height)
+        {
             return;
         }
         let Ok(verification) = self.chain.prepare_header_approval_verification(block.header())
         else {
-            self.verified_peer_heights.cancel_verification(&header_hash);
+            if registration == VerificationRegistration::Enqueue {
+                let released = self.verified_peer_heights.cancel_verification(&header_hash);
+                self.promote_deferred_block_approval_verifications(released);
+            }
             return;
         };
-        let job = BlockApprovalVerificationJob { header_hash, verification };
+        let job = BlockApprovalVerificationJob {
+            peer_id: peer_id.clone(),
+            header_hash,
+            height,
+            verification,
+        };
+        if registration == VerificationRegistration::Defer {
+            self.block_approval_verification_scheduler.defer(peer_id.clone(), height, job);
+            return;
+        }
+        self.enqueue_block_approval_verification(job);
+    }
+
+    fn enqueue_block_approval_verification(&mut self, job: BlockApprovalVerificationJob) {
         if let Some(job) = self.block_approval_verification_scheduler.enqueue(job) {
             self.spawn_block_approval_verification(job);
+        }
+    }
+
+    fn promote_deferred_block_approval_verifications(&mut self, peer_ids: Vec<PeerId>) {
+        for peer_id in peer_ids {
+            let Some(job) = self.block_approval_verification_scheduler.take_deferred(&peer_id)
+            else {
+                continue;
+            };
+            match self.verified_peer_heights.register_verification(
+                &job.peer_id,
+                &job.header_hash,
+                job.height,
+            ) {
+                VerificationRegistration::Enqueue => {
+                    self.enqueue_block_approval_verification(job);
+                }
+                VerificationRegistration::Defer => {
+                    self.block_approval_verification_scheduler.defer(
+                        job.peer_id.clone(),
+                        job.height,
+                        job,
+                    );
+                }
+                VerificationRegistration::Handled => {}
+            }
         }
     }
 
@@ -1261,17 +1317,18 @@ impl Client {
         &mut self,
         result: BlockApprovalVerificationResult,
     ) {
-        match self.chain.head() {
+        let released = match self.chain.head() {
             Ok(head) => self.verified_peer_heights.finish_verification(
                 &result.header_hash,
                 result.is_valid,
                 head.height,
             ),
             Err(_) => self.verified_peer_heights.cancel_verification(&result.header_hash),
-        }
+        };
         if let Some(job) = self.block_approval_verification_scheduler.complete() {
             self.spawn_block_approval_verification(job);
         }
+        self.promote_deferred_block_approval_verifications(released);
     }
 
     /// Processes received block. Ban peer if the block header is invalid or the block is ill-formed.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -20,7 +20,7 @@ use crate::sync::handler::SyncHandler;
 use crate::sync::header::HeaderSync;
 use crate::sync::state::chain_requests::ChainSenderForStateSync;
 use crate::sync::state::{StateSync, StateSyncShardResult};
-use crate::verified_peer_heights::VerifiedPeerHeights;
+use crate::verified_peer_heights::{BlockApprovalVerificationScheduler, VerifiedPeerHeights};
 use crate::{ProduceChunkResult, metrics};
 use itertools::Itertools;
 use near_async::futures::RayonAsyncComputationSpawner;
@@ -39,9 +39,9 @@ use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::test_utils::format_hash;
 use near_chain::types::{ChainConfig, LatestKnown, RuntimeAdapter};
 use near_chain::{
-    ApplyChunksSpawner, BlockProcessingArtifact, BlockStatus, Chain, ChainGenesis,
-    ChainStoreAccess, ChunksReadiness, Doomslug, DoomslugThresholdMode, MemtrieLoadingSpawner,
-    Provenance,
+    ApplyChunksSpawner, BlockHeaderApprovalVerification, BlockProcessingArtifact, BlockStatus,
+    Chain, ChainGenesis, ChainStoreAccess, ChunksReadiness, Doomslug, DoomslugThresholdMode,
+    MemtrieLoadingSpawner, Provenance,
 };
 use near_chain_configs::{
     BLOCK_HORIZON, ClientConfig, MutableValidatorSigner, UpdatableClientConfig,
@@ -194,6 +194,13 @@ pub struct Client {
         tokio::sync::watch::Sender<Option<BlockNotificationMessage>>,
     pub(crate) verified_peer_heights: VerifiedPeerHeights,
     block_approval_verification_spawner: Arc<dyn AsyncComputationSpawner>,
+    block_approval_verification_scheduler:
+        BlockApprovalVerificationScheduler<BlockApprovalVerificationJob>,
+}
+
+struct BlockApprovalVerificationJob {
+    header_hash: CryptoHash,
+    verification: BlockHeaderApprovalVerification,
 }
 
 impl AsRef<Client> for Client {
@@ -518,6 +525,7 @@ impl Client {
             block_notification_watch_sender,
             verified_peer_heights: VerifiedPeerHeights::default(),
             block_approval_verification_spawner: multi_spawner.block_approval_verification,
+            block_approval_verification_scheduler: BlockApprovalVerificationScheduler::default(),
         };
         Ok(client)
     }
@@ -1225,7 +1233,7 @@ impl Client {
             return;
         }
         let header_hash = *block.hash();
-        if !self.verified_peer_heights.start_verification(peer_id, &header_hash, height) {
+        if !self.verified_peer_heights.register_verification(peer_id, &header_hash, height) {
             return;
         }
         let Ok(verification) = self.chain.prepare_header_approval_verification(block.header())
@@ -1233,11 +1241,22 @@ impl Client {
             self.verified_peer_heights.cancel_verification(&header_hash);
             return;
         };
+        let job = BlockApprovalVerificationJob { header_hash, verification };
+        match self.block_approval_verification_scheduler.enqueue(job) {
+            Ok(Some(job)) => self.spawn_block_approval_verification(job),
+            Ok(None) => {}
+            Err(job) => {
+                self.verified_peer_heights.cancel_verification(&job.header_hash);
+            }
+        }
+    }
+
+    fn spawn_block_approval_verification(&self, job: BlockApprovalVerificationJob) {
         let result_sender = self.myself_sender.block_approval_verification_result.clone();
         self.block_approval_verification_spawner.spawn("block_approval_verification", move || {
             result_sender.send(BlockApprovalVerificationResult {
-                header_hash,
-                is_valid: verification.verify().is_ok(),
+                header_hash: job.header_hash,
+                is_valid: job.verification.verify().is_ok(),
             });
         });
     }
@@ -1246,15 +1265,17 @@ impl Client {
         &mut self,
         result: BlockApprovalVerificationResult,
     ) {
-        let Ok(head) = self.chain.head() else {
-            self.verified_peer_heights.cancel_verification(&result.header_hash);
-            return;
-        };
-        self.verified_peer_heights.finish_verification(
-            &result.header_hash,
-            result.is_valid,
-            head.height,
-        );
+        match self.chain.head() {
+            Ok(head) => self.verified_peer_heights.finish_verification(
+                &result.header_hash,
+                result.is_valid,
+                head.height,
+            ),
+            Err(_) => self.verified_peer_heights.cancel_verification(&result.header_hash),
+        }
+        if let Some(job) = self.block_approval_verification_scheduler.complete() {
+            self.spawn_block_approval_verification(job);
+        }
     }
 
     /// Processes received block. Ban peer if the block header is invalid or the block is ill-formed.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -7,7 +7,7 @@ use crate::chunk_inclusion_tracker::ChunkInclusionTracker;
 #[cfg(feature = "test_features")]
 use crate::chunk_producer::AdvProduceChunksMode;
 use crate::chunk_producer::ChunkProducer;
-use crate::client_actor::ClientSenderForClient;
+use crate::client_actor::{BlockApprovalVerificationResult, ClientSenderForClient};
 use crate::debug::BlockProductionTracker;
 use crate::pending_transaction_queue::ShardedPendingTransactionQueue;
 use crate::spice::timer::SpiceTimer;
@@ -24,7 +24,7 @@ use crate::verified_peer_heights::VerifiedPeerHeights;
 use crate::{ProduceChunkResult, metrics};
 use itertools::Itertools;
 use near_async::futures::RayonAsyncComputationSpawner;
-use near_async::futures::{AsyncComputationSpawner, FutureSpawner};
+use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt, FutureSpawner};
 use near_async::messaging::IntoAsyncSender;
 use near_async::messaging::{CanSend, Sender};
 use near_async::time::{Clock, Duration, Instant};
@@ -193,6 +193,7 @@ pub struct Client {
     pub block_notification_watch_sender:
         tokio::sync::watch::Sender<Option<BlockNotificationMessage>>,
     pub(crate) verified_peer_heights: VerifiedPeerHeights,
+    block_approval_verification_spawner: Arc<dyn AsyncComputationSpawner>,
 }
 
 impl AsRef<Client> for Client {
@@ -289,6 +290,8 @@ pub struct AsyncComputationMultiSpawner {
     epoch_sync: Arc<dyn AsyncComputationSpawner>,
     /// Spawner to run 'prepare transactions' tasks (defaults to `RayonAsyncComputationSpawner`)
     prepare_transactions: Arc<dyn AsyncComputationSpawner>,
+    /// Spawner to verify peer block approvals without blocking the client actor.
+    block_approval_verification: Arc<dyn AsyncComputationSpawner>,
     /// Spawner to run background memtrie loading tasks (defaults to `StdThreadAsyncComputationSpawner`)
     pub memtrie_loading: MemtrieLoadingSpawner,
 }
@@ -299,6 +302,7 @@ impl Default for AsyncComputationMultiSpawner {
             apply_chunks: Default::default(),
             epoch_sync: Arc::new(RayonAsyncComputationSpawner),
             prepare_transactions: Arc::new(RayonAsyncComputationSpawner),
+            block_approval_verification: Arc::new(RayonAsyncComputationSpawner),
             memtrie_loading: Default::default(),
         }
     }
@@ -311,6 +315,7 @@ impl AsyncComputationMultiSpawner {
             apply_chunks: ApplyChunksSpawner::Custom(spawner.clone()),
             epoch_sync: spawner.clone(),
             prepare_transactions: spawner.clone(),
+            block_approval_verification: spawner.clone(),
             memtrie_loading: MemtrieLoadingSpawner::Custom(spawner),
         }
     }
@@ -512,6 +517,7 @@ impl Client {
             last_validator_key_check_epoch: None,
             block_notification_watch_sender,
             verified_peer_heights: VerifiedPeerHeights::default(),
+            block_approval_verification_spawner: multi_spawner.block_approval_verification,
         };
         Ok(client)
     }
@@ -1206,19 +1212,49 @@ impl Client {
         Ok(Some(block))
     }
 
-    /// Record `peer_id`'s verified height if the relayed block is ahead of us
-    /// and its approvals verify as >2/3 of a known epoch's stake; far-ahead
-    /// blocks (unknown epoch) fail that check and are ignored.
+    /// Schedule approval verification for a relayed block that is ahead of us. Duplicate relays
+    /// share one bounded background job, and far-ahead blocks with unknown epochs are ignored.
     pub(crate) fn note_verified_peer_height(&mut self, block: &Block, peer_id: &PeerId) {
-        let head_height = self.chain.head().map(|tip| tip.height).unwrap_or(0);
+        let Ok(head) = self.chain.head() else {
+            return;
+        };
+        let head_height = head.height;
         self.verified_peer_heights.prune_at_or_below(head_height);
         let height = block.header().height();
         if height <= head_height {
             return;
         }
-        self.verified_peer_heights.record_if_verified(peer_id, block.hash(), height, || {
-            self.chain.verify_header_approvals_without_ancestry(block.header()).is_ok()
+        let header_hash = *block.hash();
+        if !self.verified_peer_heights.start_verification(peer_id, &header_hash, height) {
+            return;
+        }
+        let Ok(verification) = self.chain.prepare_header_approval_verification(block.header())
+        else {
+            self.verified_peer_heights.cancel_verification(&header_hash);
+            return;
+        };
+        let result_sender = self.myself_sender.block_approval_verification_result.clone();
+        self.block_approval_verification_spawner.spawn("block_approval_verification", move || {
+            result_sender.send(BlockApprovalVerificationResult {
+                header_hash,
+                is_valid: verification.verify().is_ok(),
+            });
         });
+    }
+
+    pub(crate) fn finish_block_approval_verification(
+        &mut self,
+        result: BlockApprovalVerificationResult,
+    ) {
+        let Ok(head) = self.chain.head() else {
+            self.verified_peer_heights.cancel_verification(&result.header_hash);
+            return;
+        };
+        self.verified_peer_heights.finish_verification(
+            &result.header_hash,
+            result.is_valid,
+            head.height,
+        );
     }
 
     /// Processes received block. Ban peer if the block header is invalid or the block is ill-formed.

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -291,6 +291,13 @@ pub fn start_client(
 pub struct ClientSenderForClient {
     pub apply_chunks_done: Sender<SpanWrapped<ApplyChunksDoneMessage>>,
     pub on_post_state_ready: Sender<SpanWrapped<PostStateReadyMessage>>,
+    pub block_approval_verification_result: Sender<BlockApprovalVerificationResult>,
+}
+
+#[derive(Debug)]
+pub struct BlockApprovalVerificationResult {
+    pub(crate) header_hash: CryptoHash,
+    pub(crate) is_valid: bool,
 }
 
 #[derive(Clone, MultiSend, MultiSenderFrom)]
@@ -652,6 +659,12 @@ impl Handler<SpanWrapped<BlockResponse>> for ClientActor {
                 _ => {}
             }
         }
+    }
+}
+
+impl Handler<BlockApprovalVerificationResult> for ClientActor {
+    fn handle(&mut self, msg: BlockApprovalVerificationResult) {
+        self.client.finish_block_approval_verification(msg);
     }
 }
 

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -2,49 +2,100 @@ use lru::LruCache;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::BlockHeight;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
+
+const HEADER_VERIFICATION_CACHE_SIZE: usize = 32;
+const MAX_PENDING_HEADER_VERIFICATIONS: usize = 4;
+
+struct PendingHeaderVerification {
+    height: BlockHeight,
+    peers: HashSet<PeerId>,
+}
 
 /// Highest block height each peer is *verified* to have reached, via a relayed
 /// block whose approvals we checked against a known epoch's validators (>2/3
 /// stake).
 pub struct VerifiedPeerHeights {
     by_peer: HashMap<PeerId, BlockHeight>,
-    /// Headers whose approvals already verified; bounds the signature checks
-    /// to one pass per distinct header, however many peers relay or replay it.
-    verified_header_hashes: LruCache<CryptoHash, ()>,
+    /// Positive and negative results, so repeated invalid headers cannot consume worker time.
+    header_verification_results: LruCache<CryptoHash, bool>,
+    /// Peers waiting on each in-flight header verification. The map has a strict cap so an input
+    /// burst cannot create an unbounded computation queue.
+    pending_header_verifications: HashMap<CryptoHash, PendingHeaderVerification>,
 }
 
 impl Default for VerifiedPeerHeights {
     fn default() -> Self {
         Self {
             by_peer: HashMap::new(),
-            verified_header_hashes: LruCache::new(NonZeroUsize::new(32).unwrap()),
+            header_verification_results: LruCache::new(
+                NonZeroUsize::new(HEADER_VERIFICATION_CACHE_SIZE).unwrap(),
+            ),
+            pending_header_verifications: HashMap::new(),
         }
     }
 }
 
 impl VerifiedPeerHeights {
-    /// Record `height` for `peer_id` if the header is verified: by an earlier
-    /// call, or established now by `verify_approvals` (invoked at most once
-    /// per distinct header). Keeps the highest height per peer.
-    pub fn record_if_verified(
+    /// Registers interest in a header and returns whether the caller should start verification.
+    /// Repeated relays share one in-flight job. Cached valid results update the peer immediately,
+    /// while cached invalid results are ignored.
+    pub fn start_verification(
         &mut self,
         peer_id: &PeerId,
         header_hash: &CryptoHash,
         height: BlockHeight,
-        verify_approvals: impl FnOnce() -> bool,
-    ) {
+    ) -> bool {
         if self.get(peer_id).is_some_and(|verified| verified >= height) {
+            return false;
+        }
+        if let Some(is_valid) = self.header_verification_results.get(header_hash).copied() {
+            if is_valid {
+                self.record_height(peer_id.clone(), height);
+            }
+            return false;
+        }
+        if let Some(pending) = self.pending_header_verifications.get_mut(header_hash) {
+            debug_assert_eq!(pending.height, height);
+            pending.peers.insert(peer_id.clone());
+            return false;
+        }
+        if self.pending_header_verifications.len() >= MAX_PENDING_HEADER_VERIFICATIONS {
+            return false;
+        }
+        self.pending_header_verifications.insert(
+            *header_hash,
+            PendingHeaderVerification { height, peers: HashSet::from([peer_id.clone()]) },
+        );
+        true
+    }
+
+    /// Completes a pending verification. A result at or below the current head is discarded
+    /// because it can no longer prove that a peer is ahead of us.
+    pub fn finish_verification(
+        &mut self,
+        header_hash: &CryptoHash,
+        is_valid: bool,
+        head_height: BlockHeight,
+    ) {
+        let Some(pending) = self.pending_header_verifications.remove(header_hash) else {
+            return;
+        };
+        self.header_verification_results.put(*header_hash, is_valid);
+        if !is_valid || pending.height <= head_height {
             return;
         }
-        if !self.verified_header_hashes.contains(header_hash) {
-            if !verify_approvals() {
-                return;
-            }
-            self.verified_header_hashes.put(*header_hash, ());
+        for peer_id in pending.peers {
+            self.record_height(peer_id, pending.height);
         }
-        self.by_peer.insert(peer_id.clone(), height);
+    }
+
+    /// Drops an in-flight entry when the immutable verification inputs are not currently
+    /// available. Unlike a failed cryptographic check, this is not cached because epoch data can
+    /// become available later.
+    pub fn cancel_verification(&mut self, header_hash: &CryptoHash) {
+        self.pending_header_verifications.remove(header_hash);
     }
 
     pub fn get(&self, peer_id: &PeerId) -> Option<BlockHeight> {
@@ -55,6 +106,13 @@ impl VerifiedPeerHeights {
     /// them bounds the map as the head advances and peers churn.
     pub fn prune_at_or_below(&mut self, height: BlockHeight) {
         self.by_peer.retain(|_, recorded| *recorded > height);
+    }
+
+    fn record_height(&mut self, peer_id: PeerId, height: BlockHeight) {
+        self.by_peer
+            .entry(peer_id)
+            .and_modify(|recorded| *recorded = (*recorded).max(height))
+            .or_insert(height);
     }
 }
 
@@ -75,8 +133,11 @@ mod tests {
     fn record_keeps_max_height_per_peer() {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
-        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || true);
-        heights.record_if_verified(&p, &header_hash(b"h5"), 5, || true);
+        let h10 = header_hash(b"h10");
+        assert!(heights.start_verification(&p, &h10, 10));
+        heights.finish_verification(&h10, true, 0);
+        let h5 = header_hash(b"h5");
+        assert!(!heights.start_verification(&p, &h5, 5));
         assert_eq!(heights.get(&p), Some(10));
     }
 
@@ -84,8 +145,23 @@ mod tests {
     fn failed_verification_records_nothing() {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
-        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || false);
+        let hash = header_hash(b"h10");
+        assert!(heights.start_verification(&p, &hash, 10));
+        heights.finish_verification(&hash, false, 0);
         assert_eq!(heights.get(&p), None);
+        assert!(!heights.start_verification(&p, &hash, 10));
+    }
+
+    #[test]
+    fn relays_share_one_verification() {
+        let mut heights = VerifiedPeerHeights::default();
+        let (p1, p2) = (peer("a"), peer("b"));
+        let hash = header_hash(b"h10");
+        assert!(heights.start_verification(&p1, &hash, 10));
+        assert!(!heights.start_verification(&p2, &hash, 10));
+        heights.finish_verification(&hash, true, 0);
+        assert_eq!(heights.get(&p1), Some(10));
+        assert_eq!(heights.get(&p2), Some(10));
     }
 
     #[test]
@@ -93,30 +169,70 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
         let hash = header_hash(b"h10");
-        heights.record_if_verified(&p1, &hash, 10, || true);
-        heights.record_if_verified(&p2, &hash, 10, || panic!("must not re-verify"));
+        assert!(heights.start_verification(&p1, &hash, 10));
+        heights.finish_verification(&hash, true, 0);
+        assert!(!heights.start_verification(&p2, &hash, 10));
         assert_eq!(heights.get(&p2), Some(10));
     }
 
     #[test]
-    fn already_verified_height_skips_verification() {
+    fn result_at_current_head_is_discarded() {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
-        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || true);
-        heights.record_if_verified(&p, &header_hash(b"other"), 10, || {
-            panic!("must not verify below already verified height")
-        });
-        assert_eq!(heights.get(&p), Some(10));
+        let hash = header_hash(b"h10");
+        assert!(heights.start_verification(&p, &hash, 10));
+        heights.finish_verification(&hash, true, 10);
+        assert_eq!(heights.get(&p), None);
+    }
+
+    #[test]
+    fn out_of_order_results_keep_highest_height() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        let h10 = header_hash(b"h10");
+        let h20 = header_hash(b"h20");
+        assert!(heights.start_verification(&p, &h10, 10));
+        assert!(heights.start_verification(&p, &h20, 20));
+        heights.finish_verification(&h20, true, 0);
+        heights.finish_verification(&h10, true, 0);
+        assert_eq!(heights.get(&p), Some(20));
+    }
+
+    #[test]
+    fn cancelled_verification_can_be_retried() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        let hash = header_hash(b"h10");
+        assert!(heights.start_verification(&p, &hash, 10));
+        heights.cancel_verification(&hash);
+        assert!(heights.start_verification(&p, &hash, 10));
     }
 
     #[test]
     fn prune_at_or_below_drops_caught_up_entries() {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
-        heights.record_if_verified(&p1, &header_hash(b"h10"), 10, || true);
-        heights.record_if_verified(&p2, &header_hash(b"h20"), 20, || true);
+        let h10 = header_hash(b"h10");
+        assert!(heights.start_verification(&p1, &h10, 10));
+        heights.finish_verification(&h10, true, 0);
+        let h20 = header_hash(b"h20");
+        assert!(heights.start_verification(&p2, &h20, 20));
+        heights.finish_verification(&h20, true, 0);
         heights.prune_at_or_below(10);
         assert_eq!(heights.get(&p1), None);
         assert_eq!(heights.get(&p2), Some(20));
+    }
+
+    #[test]
+    fn pending_verifications_are_bounded() {
+        let mut heights = VerifiedPeerHeights::default();
+        for i in 0..MAX_PENDING_HEADER_VERIFICATIONS {
+            assert!(heights.start_verification(
+                &peer(&i.to_string()),
+                &header_hash(&[i as u8]),
+                10
+            ));
+        }
+        assert!(!heights.start_verification(&peer("overflow"), &header_hash(b"overflow"), 10));
     }
 }

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -2,11 +2,52 @@ use lru::LruCache;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::BlockHeight;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
 
 const HEADER_VERIFICATION_CACHE_SIZE: usize = 32;
-const MAX_PENDING_HEADER_VERIFICATIONS: usize = 4;
+const MAX_TRACKED_HEADER_VERIFICATIONS: usize = HEADER_VERIFICATION_CACHE_SIZE;
+const MAX_ACTIVE_HEADER_VERIFICATIONS: usize = 4;
+const MAX_QUEUED_HEADER_VERIFICATIONS: usize =
+    MAX_TRACKED_HEADER_VERIFICATIONS - MAX_ACTIVE_HEADER_VERIFICATIONS;
+
+/// Limits CPU concurrency while retaining accepted work until a worker becomes available.
+pub(crate) struct BlockApprovalVerificationScheduler<T> {
+    active: usize,
+    queued: VecDeque<T>,
+}
+
+impl<T> Default for BlockApprovalVerificationScheduler<T> {
+    fn default() -> Self {
+        Self { active: 0, queued: VecDeque::new() }
+    }
+}
+
+impl<T> BlockApprovalVerificationScheduler<T> {
+    /// Returns the job when it should run immediately, or queues it when all worker slots are busy.
+    /// An error means the total active and queued work budget has been reached.
+    pub(crate) fn enqueue(&mut self, job: T) -> Result<Option<T>, T> {
+        if self.active < MAX_ACTIVE_HEADER_VERIFICATIONS {
+            self.active += 1;
+            return Ok(Some(job));
+        }
+        if self.queued.len() >= MAX_QUEUED_HEADER_VERIFICATIONS {
+            return Err(job);
+        }
+        self.queued.push_back(job);
+        Ok(None)
+    }
+
+    /// Releases a completed worker slot and returns the oldest queued job to take its place.
+    pub(crate) fn complete(&mut self) -> Option<T> {
+        debug_assert!(self.active > 0);
+        if let Some(job) = self.queued.pop_front() {
+            return Some(job);
+        }
+        self.active = self.active.saturating_sub(1);
+        None
+    }
+}
 
 struct PendingHeaderVerification {
     height: BlockHeight,
@@ -20,8 +61,8 @@ pub struct VerifiedPeerHeights {
     by_peer: HashMap<PeerId, BlockHeight>,
     /// Positive and negative results, so repeated invalid headers cannot consume worker time.
     header_verification_results: LruCache<CryptoHash, bool>,
-    /// Peers waiting on each in-flight header verification. The map has a strict cap so an input
-    /// burst cannot create an unbounded computation queue.
+    /// Peers waiting on each active or queued header verification. The map has a strict cap so an
+    /// input burst cannot create an unbounded computation queue.
     pending_header_verifications: HashMap<CryptoHash, PendingHeaderVerification>,
 }
 
@@ -38,10 +79,10 @@ impl Default for VerifiedPeerHeights {
 }
 
 impl VerifiedPeerHeights {
-    /// Registers interest in a header and returns whether the caller should start verification.
-    /// Repeated relays share one in-flight job. Cached valid results update the peer immediately,
+    /// Registers interest in a header and returns whether the caller should enqueue verification.
+    /// Repeated relays share one pending job. Cached valid results update the peer immediately,
     /// while cached invalid results are ignored.
-    pub fn start_verification(
+    pub fn register_verification(
         &mut self,
         peer_id: &PeerId,
         header_hash: &CryptoHash,
@@ -61,7 +102,7 @@ impl VerifiedPeerHeights {
             pending.peers.insert(peer_id.clone());
             return false;
         }
-        if self.pending_header_verifications.len() >= MAX_PENDING_HEADER_VERIFICATIONS {
+        if self.pending_header_verifications.len() >= MAX_TRACKED_HEADER_VERIFICATIONS {
             return false;
         }
         self.pending_header_verifications.insert(
@@ -134,10 +175,10 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let h10 = header_hash(b"h10");
-        assert!(heights.start_verification(&p, &h10, 10));
+        assert!(heights.register_verification(&p, &h10, 10));
         heights.finish_verification(&h10, true, 0);
         let h5 = header_hash(b"h5");
-        assert!(!heights.start_verification(&p, &h5, 5));
+        assert!(!heights.register_verification(&p, &h5, 5));
         assert_eq!(heights.get(&p), Some(10));
     }
 
@@ -146,10 +187,10 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let hash = header_hash(b"h10");
-        assert!(heights.start_verification(&p, &hash, 10));
+        assert!(heights.register_verification(&p, &hash, 10));
         heights.finish_verification(&hash, false, 0);
         assert_eq!(heights.get(&p), None);
-        assert!(!heights.start_verification(&p, &hash, 10));
+        assert!(!heights.register_verification(&p, &hash, 10));
     }
 
     #[test]
@@ -157,8 +198,8 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
         let hash = header_hash(b"h10");
-        assert!(heights.start_verification(&p1, &hash, 10));
-        assert!(!heights.start_verification(&p2, &hash, 10));
+        assert!(heights.register_verification(&p1, &hash, 10));
+        assert!(!heights.register_verification(&p2, &hash, 10));
         heights.finish_verification(&hash, true, 0);
         assert_eq!(heights.get(&p1), Some(10));
         assert_eq!(heights.get(&p2), Some(10));
@@ -169,9 +210,9 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
         let hash = header_hash(b"h10");
-        assert!(heights.start_verification(&p1, &hash, 10));
+        assert!(heights.register_verification(&p1, &hash, 10));
         heights.finish_verification(&hash, true, 0);
-        assert!(!heights.start_verification(&p2, &hash, 10));
+        assert!(!heights.register_verification(&p2, &hash, 10));
         assert_eq!(heights.get(&p2), Some(10));
     }
 
@@ -180,7 +221,7 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let hash = header_hash(b"h10");
-        assert!(heights.start_verification(&p, &hash, 10));
+        assert!(heights.register_verification(&p, &hash, 10));
         heights.finish_verification(&hash, true, 10);
         assert_eq!(heights.get(&p), None);
     }
@@ -191,8 +232,8 @@ mod tests {
         let p = peer("a");
         let h10 = header_hash(b"h10");
         let h20 = header_hash(b"h20");
-        assert!(heights.start_verification(&p, &h10, 10));
-        assert!(heights.start_verification(&p, &h20, 20));
+        assert!(heights.register_verification(&p, &h10, 10));
+        assert!(heights.register_verification(&p, &h20, 20));
         heights.finish_verification(&h20, true, 0);
         heights.finish_verification(&h10, true, 0);
         assert_eq!(heights.get(&p), Some(20));
@@ -203,9 +244,9 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let hash = header_hash(b"h10");
-        assert!(heights.start_verification(&p, &hash, 10));
+        assert!(heights.register_verification(&p, &hash, 10));
         heights.cancel_verification(&hash);
-        assert!(heights.start_verification(&p, &hash, 10));
+        assert!(heights.register_verification(&p, &hash, 10));
     }
 
     #[test]
@@ -213,10 +254,10 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
         let h10 = header_hash(b"h10");
-        assert!(heights.start_verification(&p1, &h10, 10));
+        assert!(heights.register_verification(&p1, &h10, 10));
         heights.finish_verification(&h10, true, 0);
         let h20 = header_hash(b"h20");
-        assert!(heights.start_verification(&p2, &h20, 20));
+        assert!(heights.register_verification(&p2, &h20, 20));
         heights.finish_verification(&h20, true, 0);
         heights.prune_at_or_below(10);
         assert_eq!(heights.get(&p1), None);
@@ -226,13 +267,42 @@ mod tests {
     #[test]
     fn pending_verifications_are_bounded() {
         let mut heights = VerifiedPeerHeights::default();
-        for i in 0..MAX_PENDING_HEADER_VERIFICATIONS {
-            assert!(heights.start_verification(
+        for i in 0..MAX_TRACKED_HEADER_VERIFICATIONS {
+            assert!(heights.register_verification(
                 &peer(&i.to_string()),
                 &header_hash(&[i as u8]),
                 10
             ));
         }
-        assert!(!heights.start_verification(&peer("overflow"), &header_hash(b"overflow"), 10));
+        assert!(!heights.register_verification(&peer("overflow"), &header_hash(b"overflow"), 10));
+    }
+
+    #[test]
+    fn fifth_verification_waits_for_a_worker_slot() {
+        let mut scheduler = BlockApprovalVerificationScheduler::default();
+        for job in 0..MAX_ACTIVE_HEADER_VERIFICATIONS {
+            assert_eq!(scheduler.enqueue(job), Ok(Some(job)));
+        }
+
+        assert_eq!(scheduler.enqueue(MAX_ACTIVE_HEADER_VERIFICATIONS), Ok(None));
+        assert_eq!(scheduler.complete(), Some(MAX_ACTIVE_HEADER_VERIFICATIONS));
+    }
+
+    #[test]
+    fn verification_scheduler_preserves_total_work_bound() {
+        let mut scheduler = BlockApprovalVerificationScheduler::default();
+        for job in 0..MAX_TRACKED_HEADER_VERIFICATIONS {
+            let scheduled = scheduler.enqueue(job);
+            if job < MAX_ACTIVE_HEADER_VERIFICATIONS {
+                assert_eq!(scheduled, Ok(Some(job)));
+            } else {
+                assert_eq!(scheduled, Ok(None));
+            }
+        }
+
+        assert_eq!(
+            scheduler.enqueue(MAX_TRACKED_HEADER_VERIFICATIONS),
+            Err(MAX_TRACKED_HEADER_VERIFICATIONS)
+        );
     }
 }

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -6,12 +6,11 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
 
 const HEADER_VERIFICATION_CACHE_SIZE: usize = 32;
-const MAX_TRACKED_HEADER_VERIFICATIONS: usize = HEADER_VERIFICATION_CACHE_SIZE;
 const MAX_ACTIVE_HEADER_VERIFICATIONS: usize = 4;
-const MAX_QUEUED_HEADER_VERIFICATIONS: usize =
-    MAX_TRACKED_HEADER_VERIFICATIONS - MAX_ACTIVE_HEADER_VERIFICATIONS;
 
-/// Limits CPU concurrency while retaining accepted work until a worker becomes available.
+/// Limits CPU concurrency while retaining admitted work until a worker becomes available.
+/// [`VerifiedPeerHeights`] admits at most one pending job per relaying peer, so the queue is bounded
+/// by the network peer set rather than by an arbitrary burst size.
 pub(crate) struct BlockApprovalVerificationScheduler<T> {
     active: usize,
     queued: VecDeque<T>,
@@ -25,17 +24,13 @@ impl<T> Default for BlockApprovalVerificationScheduler<T> {
 
 impl<T> BlockApprovalVerificationScheduler<T> {
     /// Returns the job when it should run immediately, or queues it when all worker slots are busy.
-    /// An error means the total active and queued work budget has been reached.
-    pub(crate) fn enqueue(&mut self, job: T) -> Result<Option<T>, T> {
+    pub(crate) fn enqueue(&mut self, job: T) -> Option<T> {
         if self.active < MAX_ACTIVE_HEADER_VERIFICATIONS {
             self.active += 1;
-            return Ok(Some(job));
-        }
-        if self.queued.len() >= MAX_QUEUED_HEADER_VERIFICATIONS {
-            return Err(job);
+            return Some(job);
         }
         self.queued.push_back(job);
-        Ok(None)
+        None
     }
 
     /// Releases a completed worker slot and returns the oldest queued job to take its place.
@@ -61,9 +56,12 @@ pub struct VerifiedPeerHeights {
     by_peer: HashMap<PeerId, BlockHeight>,
     /// Positive and negative results, so repeated invalid headers cannot consume worker time.
     header_verification_results: LruCache<CryptoHash, bool>,
-    /// Peers waiting on each active or queued header verification. The map has a strict cap so an
-    /// input burst cannot create an unbounded computation queue.
+    /// Peers waiting on each active or queued header verification.
     pending_header_verifications: HashMap<CryptoHash, PendingHeaderVerification>,
+    /// The pending header assigned to each peer. A peer can consume at most one verification slot,
+    /// which bounds admitted work by the network peer set without dropping distinct peers merely
+    /// because a short block burst exceeds the result cache size.
+    pending_header_by_peer: HashMap<PeerId, CryptoHash>,
 }
 
 impl Default for VerifiedPeerHeights {
@@ -74,6 +72,7 @@ impl Default for VerifiedPeerHeights {
                 NonZeroUsize::new(HEADER_VERIFICATION_CACHE_SIZE).unwrap(),
             ),
             pending_header_verifications: HashMap::new(),
+            pending_header_by_peer: HashMap::new(),
         }
     }
 }
@@ -97,18 +96,20 @@ impl VerifiedPeerHeights {
             }
             return false;
         }
+        if self.pending_header_by_peer.contains_key(peer_id) {
+            return false;
+        }
         if let Some(pending) = self.pending_header_verifications.get_mut(header_hash) {
             debug_assert_eq!(pending.height, height);
             pending.peers.insert(peer_id.clone());
-            return false;
-        }
-        if self.pending_header_verifications.len() >= MAX_TRACKED_HEADER_VERIFICATIONS {
+            self.pending_header_by_peer.insert(peer_id.clone(), *header_hash);
             return false;
         }
         self.pending_header_verifications.insert(
             *header_hash,
             PendingHeaderVerification { height, peers: HashSet::from([peer_id.clone()]) },
         );
+        self.pending_header_by_peer.insert(peer_id.clone(), *header_hash);
         true
     }
 
@@ -120,7 +121,7 @@ impl VerifiedPeerHeights {
         is_valid: bool,
         head_height: BlockHeight,
     ) {
-        let Some(pending) = self.pending_header_verifications.remove(header_hash) else {
+        let Some(pending) = self.take_pending_verification(header_hash) else {
             return;
         };
         self.header_verification_results.put(*header_hash, is_valid);
@@ -136,7 +137,7 @@ impl VerifiedPeerHeights {
     /// available. Unlike a failed cryptographic check, this is not cached because epoch data can
     /// become available later.
     pub fn cancel_verification(&mut self, header_hash: &CryptoHash) {
-        self.pending_header_verifications.remove(header_hash);
+        self.take_pending_verification(header_hash);
     }
 
     pub fn get(&self, peer_id: &PeerId) -> Option<BlockHeight> {
@@ -154,6 +155,17 @@ impl VerifiedPeerHeights {
             .entry(peer_id)
             .and_modify(|recorded| *recorded = (*recorded).max(height))
             .or_insert(height);
+    }
+
+    fn take_pending_verification(
+        &mut self,
+        header_hash: &CryptoHash,
+    ) -> Option<PendingHeaderVerification> {
+        let pending = self.pending_header_verifications.remove(header_hash)?;
+        for peer_id in &pending.peers {
+            self.pending_header_by_peer.remove(peer_id);
+        }
+        Some(pending)
     }
 }
 
@@ -265,44 +277,60 @@ mod tests {
     }
 
     #[test]
-    fn pending_verifications_are_bounded() {
+    fn pending_verifications_are_bounded_per_peer() {
         let mut heights = VerifiedPeerHeights::default();
-        for i in 0..MAX_TRACKED_HEADER_VERIFICATIONS {
+        let p = peer("a");
+        let first = header_hash(b"first");
+        assert!(heights.register_verification(&p, &first, 10));
+        assert!(!heights.register_verification(&p, &header_hash(b"second"), 11));
+        assert_eq!(heights.pending_header_verifications.len(), 1);
+
+        heights.finish_verification(&first, false, 0);
+        assert!(heights.register_verification(&p, &header_hash(b"third"), 12));
+    }
+
+    #[test]
+    fn distinct_peers_are_retained_beyond_the_result_cache_size() {
+        let mut heights = VerifiedPeerHeights::default();
+        for i in 0..=HEADER_VERIFICATION_CACHE_SIZE {
             assert!(heights.register_verification(
                 &peer(&i.to_string()),
                 &header_hash(&[i as u8]),
                 10
             ));
         }
-        assert!(!heights.register_verification(&peer("overflow"), &header_hash(b"overflow"), 10));
+
+        let overflow_peer = peer(&HEADER_VERIFICATION_CACHE_SIZE.to_string());
+        let overflow_hash = header_hash(&[HEADER_VERIFICATION_CACHE_SIZE as u8]);
+        heights.finish_verification(&overflow_hash, true, 0);
+        assert_eq!(heights.get(&overflow_peer), Some(10));
     }
 
     #[test]
     fn fifth_verification_waits_for_a_worker_slot() {
         let mut scheduler = BlockApprovalVerificationScheduler::default();
         for job in 0..MAX_ACTIVE_HEADER_VERIFICATIONS {
-            assert_eq!(scheduler.enqueue(job), Ok(Some(job)));
+            assert_eq!(scheduler.enqueue(job), Some(job));
         }
 
-        assert_eq!(scheduler.enqueue(MAX_ACTIVE_HEADER_VERIFICATIONS), Ok(None));
+        assert_eq!(scheduler.enqueue(MAX_ACTIVE_HEADER_VERIFICATIONS), None);
         assert_eq!(scheduler.complete(), Some(MAX_ACTIVE_HEADER_VERIFICATIONS));
     }
 
     #[test]
-    fn verification_scheduler_preserves_total_work_bound() {
+    fn verification_scheduler_retains_a_burst_beyond_the_result_cache_size() {
         let mut scheduler = BlockApprovalVerificationScheduler::default();
-        for job in 0..MAX_TRACKED_HEADER_VERIFICATIONS {
+        for job in 0..=HEADER_VERIFICATION_CACHE_SIZE {
             let scheduled = scheduler.enqueue(job);
             if job < MAX_ACTIVE_HEADER_VERIFICATIONS {
-                assert_eq!(scheduled, Ok(Some(job)));
+                assert_eq!(scheduled, Some(job));
             } else {
-                assert_eq!(scheduled, Ok(None));
+                assert_eq!(scheduled, None);
             }
         }
 
-        assert_eq!(
-            scheduler.enqueue(MAX_TRACKED_HEADER_VERIFICATIONS),
-            Err(MAX_TRACKED_HEADER_VERIFICATIONS)
-        );
+        for job in MAX_ACTIVE_HEADER_VERIFICATIONS..=HEADER_VERIFICATION_CACHE_SIZE {
+            assert_eq!(scheduler.complete(), Some(job));
+        }
     }
 }

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -2,6 +2,7 @@ use lru::LruCache;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::BlockHeight;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
 
@@ -14,11 +15,12 @@ const MAX_ACTIVE_HEADER_VERIFICATIONS: usize = 4;
 pub(crate) struct BlockApprovalVerificationScheduler<T> {
     active: usize,
     queued: VecDeque<T>,
+    deferred_by_peer: HashMap<PeerId, (BlockHeight, T)>,
 }
 
 impl<T> Default for BlockApprovalVerificationScheduler<T> {
     fn default() -> Self {
-        Self { active: 0, queued: VecDeque::new() }
+        Self { active: 0, queued: VecDeque::new(), deferred_by_peer: HashMap::new() }
     }
 }
 
@@ -42,6 +44,37 @@ impl<T> BlockApprovalVerificationScheduler<T> {
         self.active = self.active.saturating_sub(1);
         None
     }
+
+    /// Retains only the newest verification received while a peer already has admitted work.
+    pub(crate) fn defer(&mut self, peer_id: PeerId, height: BlockHeight, job: T) {
+        match self.deferred_by_peer.entry(peer_id) {
+            Entry::Occupied(mut entry) if entry.get().0 < height => {
+                entry.insert((height, job));
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((height, job));
+            }
+            Entry::Occupied(_) => {}
+        }
+    }
+
+    pub(crate) fn deferred_height(&self, peer_id: &PeerId) -> Option<BlockHeight> {
+        self.deferred_by_peer.get(peer_id).map(|(height, _)| *height)
+    }
+
+    pub(crate) fn take_deferred(&mut self, peer_id: &PeerId) -> Option<T> {
+        self.deferred_by_peer.remove(peer_id).map(|(_, job)| job)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum VerificationRegistration {
+    /// The caller must prepare and enqueue a new verification job.
+    Enqueue,
+    /// The peer already has admitted work, so the caller must retain this newer header for later.
+    Defer,
+    /// The relay was satisfied by verified, cached, or shared pending state.
+    Handled,
 }
 
 struct PendingHeaderVerification {
@@ -78,39 +111,48 @@ impl Default for VerifiedPeerHeights {
 }
 
 impl VerifiedPeerHeights {
-    /// Registers interest in a header and returns whether the caller should enqueue verification.
+    /// Registers interest in a header and tells the caller whether to enqueue, defer, or drop it.
     /// Repeated relays share one pending job. Cached valid results update the peer immediately,
-    /// while cached invalid results are ignored.
+    /// while cached invalid results are ignored. A strictly newer header is deferred when this
+    /// peer already has admitted work.
     pub fn register_verification(
         &mut self,
         peer_id: &PeerId,
         header_hash: &CryptoHash,
         height: BlockHeight,
-    ) -> bool {
+    ) -> VerificationRegistration {
         if self.get(peer_id).is_some_and(|verified| verified >= height) {
-            return false;
+            return VerificationRegistration::Handled;
         }
         if let Some(is_valid) = self.header_verification_results.get(header_hash).copied() {
             if is_valid {
                 self.record_height(peer_id.clone(), height);
             }
-            return false;
+            return VerificationRegistration::Handled;
         }
-        if self.pending_header_by_peer.contains_key(peer_id) {
-            return false;
+        if let Some(pending_hash) = self.pending_header_by_peer.get(peer_id) {
+            let pending = self
+                .pending_header_verifications
+                .get(pending_hash)
+                .expect("pending header by peer must reference pending verification");
+            return if height > pending.height {
+                VerificationRegistration::Defer
+            } else {
+                VerificationRegistration::Handled
+            };
         }
         if let Some(pending) = self.pending_header_verifications.get_mut(header_hash) {
             debug_assert_eq!(pending.height, height);
             pending.peers.insert(peer_id.clone());
             self.pending_header_by_peer.insert(peer_id.clone(), *header_hash);
-            return false;
+            return VerificationRegistration::Handled;
         }
         self.pending_header_verifications.insert(
             *header_hash,
             PendingHeaderVerification { height, peers: HashSet::from([peer_id.clone()]) },
         );
         self.pending_header_by_peer.insert(peer_id.clone(), *header_hash);
-        true
+        VerificationRegistration::Enqueue
     }
 
     /// Completes a pending verification. A result at or below the current head is discarded
@@ -120,24 +162,28 @@ impl VerifiedPeerHeights {
         header_hash: &CryptoHash,
         is_valid: bool,
         head_height: BlockHeight,
-    ) {
+    ) -> Vec<PeerId> {
         let Some(pending) = self.take_pending_verification(header_hash) else {
-            return;
+            return Vec::new();
         };
+        let peer_ids = pending.peers.into_iter().collect::<Vec<_>>();
         self.header_verification_results.put(*header_hash, is_valid);
         if !is_valid || pending.height <= head_height {
-            return;
+            return peer_ids;
         }
-        for peer_id in pending.peers {
-            self.record_height(peer_id, pending.height);
+        for peer_id in &peer_ids {
+            self.record_height(peer_id.clone(), pending.height);
         }
+        peer_ids
     }
 
     /// Drops an in-flight entry when the immutable verification inputs are not currently
     /// available. Unlike a failed cryptographic check, this is not cached because epoch data can
     /// become available later.
-    pub fn cancel_verification(&mut self, header_hash: &CryptoHash) {
-        self.take_pending_verification(header_hash);
+    pub fn cancel_verification(&mut self, header_hash: &CryptoHash) -> Vec<PeerId> {
+        self.take_pending_verification(header_hash)
+            .map(|pending| pending.peers.into_iter().collect())
+            .unwrap_or_default()
     }
 
     pub fn get(&self, peer_id: &PeerId) -> Option<BlockHeight> {
@@ -187,10 +233,10 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let h10 = header_hash(b"h10");
-        assert!(heights.register_verification(&p, &h10, 10));
+        assert_eq!(heights.register_verification(&p, &h10, 10), VerificationRegistration::Enqueue);
         heights.finish_verification(&h10, true, 0);
         let h5 = header_hash(b"h5");
-        assert!(!heights.register_verification(&p, &h5, 5));
+        assert_eq!(heights.register_verification(&p, &h5, 5), VerificationRegistration::Handled);
         assert_eq!(heights.get(&p), Some(10));
     }
 
@@ -199,10 +245,10 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let hash = header_hash(b"h10");
-        assert!(heights.register_verification(&p, &hash, 10));
+        assert_eq!(heights.register_verification(&p, &hash, 10), VerificationRegistration::Enqueue);
         heights.finish_verification(&hash, false, 0);
         assert_eq!(heights.get(&p), None);
-        assert!(!heights.register_verification(&p, &hash, 10));
+        assert_eq!(heights.register_verification(&p, &hash, 10), VerificationRegistration::Handled);
     }
 
     #[test]
@@ -210,8 +256,14 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
         let hash = header_hash(b"h10");
-        assert!(heights.register_verification(&p1, &hash, 10));
-        assert!(!heights.register_verification(&p2, &hash, 10));
+        assert_eq!(
+            heights.register_verification(&p1, &hash, 10),
+            VerificationRegistration::Enqueue
+        );
+        assert_eq!(
+            heights.register_verification(&p2, &hash, 10),
+            VerificationRegistration::Handled
+        );
         heights.finish_verification(&hash, true, 0);
         assert_eq!(heights.get(&p1), Some(10));
         assert_eq!(heights.get(&p2), Some(10));
@@ -222,9 +274,15 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
         let hash = header_hash(b"h10");
-        assert!(heights.register_verification(&p1, &hash, 10));
+        assert_eq!(
+            heights.register_verification(&p1, &hash, 10),
+            VerificationRegistration::Enqueue
+        );
         heights.finish_verification(&hash, true, 0);
-        assert!(!heights.register_verification(&p2, &hash, 10));
+        assert_eq!(
+            heights.register_verification(&p2, &hash, 10),
+            VerificationRegistration::Handled
+        );
         assert_eq!(heights.get(&p2), Some(10));
     }
 
@@ -233,21 +291,22 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let hash = header_hash(b"h10");
-        assert!(heights.register_verification(&p, &hash, 10));
+        assert_eq!(heights.register_verification(&p, &hash, 10), VerificationRegistration::Enqueue);
         heights.finish_verification(&hash, true, 10);
         assert_eq!(heights.get(&p), None);
     }
 
     #[test]
-    fn out_of_order_results_keep_highest_height() {
+    fn newer_height_is_deferred_until_the_current_verification_finishes() {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let h10 = header_hash(b"h10");
         let h20 = header_hash(b"h20");
-        assert!(heights.register_verification(&p, &h10, 10));
-        assert!(heights.register_verification(&p, &h20, 20));
+        assert_eq!(heights.register_verification(&p, &h10, 10), VerificationRegistration::Enqueue);
+        assert_eq!(heights.register_verification(&p, &h20, 20), VerificationRegistration::Defer);
+        assert_eq!(heights.finish_verification(&h10, false, 0), vec![p.clone()]);
+        assert_eq!(heights.register_verification(&p, &h20, 20), VerificationRegistration::Enqueue);
         heights.finish_verification(&h20, true, 0);
-        heights.finish_verification(&h10, true, 0);
         assert_eq!(heights.get(&p), Some(20));
     }
 
@@ -256,9 +315,9 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let hash = header_hash(b"h10");
-        assert!(heights.register_verification(&p, &hash, 10));
+        assert_eq!(heights.register_verification(&p, &hash, 10), VerificationRegistration::Enqueue);
         heights.cancel_verification(&hash);
-        assert!(heights.register_verification(&p, &hash, 10));
+        assert_eq!(heights.register_verification(&p, &hash, 10), VerificationRegistration::Enqueue);
     }
 
     #[test]
@@ -266,10 +325,10 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
         let h10 = header_hash(b"h10");
-        assert!(heights.register_verification(&p1, &h10, 10));
+        assert_eq!(heights.register_verification(&p1, &h10, 10), VerificationRegistration::Enqueue);
         heights.finish_verification(&h10, true, 0);
         let h20 = header_hash(b"h20");
-        assert!(heights.register_verification(&p2, &h20, 20));
+        assert_eq!(heights.register_verification(&p2, &h20, 20), VerificationRegistration::Enqueue);
         heights.finish_verification(&h20, true, 0);
         heights.prune_at_or_below(10);
         assert_eq!(heights.get(&p1), None);
@@ -281,23 +340,31 @@ mod tests {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
         let first = header_hash(b"first");
-        assert!(heights.register_verification(&p, &first, 10));
-        assert!(!heights.register_verification(&p, &header_hash(b"second"), 11));
+        assert_eq!(
+            heights.register_verification(&p, &first, 10),
+            VerificationRegistration::Enqueue
+        );
+        assert_eq!(
+            heights.register_verification(&p, &header_hash(b"second"), 11),
+            VerificationRegistration::Defer
+        );
         assert_eq!(heights.pending_header_verifications.len(), 1);
 
         heights.finish_verification(&first, false, 0);
-        assert!(heights.register_verification(&p, &header_hash(b"third"), 12));
+        assert_eq!(
+            heights.register_verification(&p, &header_hash(b"third"), 12),
+            VerificationRegistration::Enqueue
+        );
     }
 
     #[test]
     fn distinct_peers_are_retained_beyond_the_result_cache_size() {
         let mut heights = VerifiedPeerHeights::default();
         for i in 0..=HEADER_VERIFICATION_CACHE_SIZE {
-            assert!(heights.register_verification(
-                &peer(&i.to_string()),
-                &header_hash(&[i as u8]),
-                10
-            ));
+            assert_eq!(
+                heights.register_verification(&peer(&i.to_string()), &header_hash(&[i as u8]), 10),
+                VerificationRegistration::Enqueue
+            );
         }
 
         let overflow_peer = peer(&HEADER_VERIFICATION_CACHE_SIZE.to_string());
@@ -315,6 +382,20 @@ mod tests {
 
         assert_eq!(scheduler.enqueue(MAX_ACTIVE_HEADER_VERIFICATIONS), None);
         assert_eq!(scheduler.complete(), Some(MAX_ACTIVE_HEADER_VERIFICATIONS));
+    }
+
+    #[test]
+    fn scheduler_retains_only_the_newest_deferred_height_per_peer() {
+        let mut scheduler = BlockApprovalVerificationScheduler::default();
+        let p = peer("a");
+
+        scheduler.defer(p.clone(), 11, "h11");
+        scheduler.defer(p.clone(), 13, "h13");
+        scheduler.defer(p.clone(), 12, "h12");
+
+        assert_eq!(scheduler.deferred_height(&p), Some(13));
+        assert_eq!(scheduler.take_deferred(&p), Some("h13"));
+        assert_eq!(scheduler.take_deferred(&p), None);
     }
 
     #[test]

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -25,11 +25,12 @@ periodically in the client actor — if the node is behind by more than
 
 While the local head is fresh, peer heights are accepted as sync targets only after the peer has
 relayed a block whose producer signature and approvals verify against a known epoch. Signature
-verification runs with four active background computation slots and a bounded FIFO waiting queue so
-relayed blocks cannot stall the client actor or disappear during a short input burst. Relays of the
-same header share one verification, and the result is applied only if the block is still ahead of
-the local head when the worker completes. Once the local head is stale, the node falls back to
-advertised peer heights so a node outside its known epochs can bootstrap.
+verification runs with four active background computation slots and a FIFO waiting queue. Each peer
+can occupy at most one pending verification, so one peer cannot monopolize the queue while distinct
+peers' sync signals survive bursts larger than the result cache. Relays of the same header share one
+verification, and the result is applied only if the block is still ahead of the local head when the
+worker completes. Once the local head is stale, the node falls back to advertised peer heights so a
+node outside its known epochs can bootstrap.
 
 The sync handler classifies the node into one of two categories based on how
 far behind it is, and routes it through the appropriate path.

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -23,6 +23,13 @@ If your node is behind the head, it starts the sync process. This runs
 periodically in the client actor — if the node is behind by more than
 `sync_height_threshold` (default 1) blocks, sync is enabled.
 
+While the local head is fresh, peer heights are accepted as sync targets only after the peer has
+relayed a block whose producer signature and approvals verify against a known epoch. Signature
+verification runs on a bounded background computation queue so relayed blocks cannot stall the
+client actor. Relays of the same header share one verification, and the result is applied only if
+the block is still ahead of the local head when the worker completes. Once the local head is stale,
+the node falls back to advertised peer heights so a node outside its known epochs can bootstrap.
+
 The sync handler classifies the node into one of two categories based on how
 far behind it is, and routes it through the appropriate path.
 

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -26,8 +26,10 @@ periodically in the client actor — if the node is behind by more than
 While the local head is fresh, peer heights are accepted as sync targets only after the peer has
 relayed a block whose producer signature and approvals verify against a known epoch. Signature
 verification runs with four active background computation slots and a FIFO waiting queue. Each peer
-can occupy at most one pending verification, so one peer cannot monopolize the queue while distinct
-peers' sync signals survive bursts larger than the result cache. Relays of the same header share one
+can occupy at most one pending verification. If that peer relays newer headers before its pending
+verification completes, only its newest header is retained and promoted next. This prevents one
+peer from monopolizing the queue while preserving its latest sync signal and distinct peers' sync
+signals during bursts larger than the result cache. Relays of the same header share one
 verification, and the result is applied only if the block is still ahead of the local head when the
 worker completes. Once the local head is stale, the node falls back to advertised peer heights so a
 node outside its known epochs can bootstrap.

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -25,10 +25,11 @@ periodically in the client actor — if the node is behind by more than
 
 While the local head is fresh, peer heights are accepted as sync targets only after the peer has
 relayed a block whose producer signature and approvals verify against a known epoch. Signature
-verification runs on a bounded background computation queue so relayed blocks cannot stall the
-client actor. Relays of the same header share one verification, and the result is applied only if
-the block is still ahead of the local head when the worker completes. Once the local head is stale,
-the node falls back to advertised peer heights so a node outside its known epochs can bootstrap.
+verification runs with four active background computation slots and a bounded FIFO waiting queue so
+relayed blocks cannot stall the client actor or disappear during a short input burst. Relays of the
+same header share one verification, and the result is applied only if the block is still ahead of
+the local head when the worker completes. Once the local head is stale, the node falls back to
+advertised peer heights so a node outside its known epochs can bootstrap.
 
 The sync handler classifies the node into one of two categories based on how
 far behind it is, and routes it through the appropriate path.


### PR DESCRIPTION
## Summary

- move block producer and approval signature verification out of `ClientActor`
- deduplicate concurrent relays of the same header and bound verification concurrency
- retain accepted overflow work in a bounded FIFO queue until a worker is available
- cache stable positive and negative verification results
- reject stale worker results once the local head reaches the verified height
- preserve retry behavior when epoch data is not yet available
- document the asynchronous verified-peer-height path

## Root cause

PR #16133 made sync target selection depend on approval-verified peer heights. `BlockResponse` handling called the verification synchronously, so a relayed block could make the client actor verify the producer signature and the full approval set before processing the rest of its mailbox. On mainnet this can involve roughly 100 Ed25519 signature checks for each distinct header.

## Solution

The client actor now performs only the epoch lookup and snapshots the immutable verification inputs. It sends the signature-heavy work to the existing asynchronous computation spawner and receives the result as an internal actor message.

`VerifiedPeerHeights` tracks active and queued work by header hash. Relays of the same header share one job, stable valid or invalid outcomes are cached, and accepted jobs are retained when all workers are occupied. Four jobs can run concurrently and up to 28 additional jobs wait in FIFO order, preserving a strict total budget of 32 tracked headers. A missing epoch is treated as transient and is not cached. When a worker result returns, the actor checks the current chain head, records only heights that are still ahead, and immediately dispatches the oldest queued job. Per-peer heights use maximum updates, so out-of-order completion cannot move a peer backward.

The synchronous `Chain::verify_header_approvals_without_ancestry` API remains available as a compatibility wrapper.

## Safety and resource bounds

- only a cryptographically valid approval result can advance a verified peer height
- at most four verification jobs run concurrently
- active and queued work has a strict 32-header total cap
- a short burst cannot discard the fifth header solely because every worker is occupied
- repeated relays share existing work instead of adding computation
- invalid headers are cached so they cannot repeatedly consume worker time
- transient epoch lookup failures remain retryable
- late results cannot restore heights that the local chain has already reached

## Validation

- `cargo test --package near-client --features test_features --lib`
- `cargo test --package test-loop-tests --features test_features -- tests::sync::adversarial_height::test_synced_node_ignores_unverified_far_ahead_height --exact --show-output`
- `cargo clippy --package near-client --features test_features --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The focused state-machine suite includes regression coverage proving that a fifth distinct header waits for a worker slot, is dispatched when a running job completes, and does not weaken the total work bound. The repository-wide all-feature, all-target Clippy run was started and produced no findings, but its generated artifacts exhausted the available temporary workspace budget before completion.

Closes #16134
