### PR TITLE
fix(runtime): propagate storage error when reading promise yield indices

### DIFF
--- a/runtime/runtime/src/function_call.rs
+++ b/runtime/runtime/src/function_call.rs
@@ -153,7 +153,7 @@ pub(crate) fn action_function_call(
     result.profile.merge(&outcome.profile);
     if execution_succeeded {
         // Fetch metadata for PromiseYield timeout queue
-        let mut promise_yield_indices = get_promise_yield_indices(state_update).unwrap_or_default();
+        let mut promise_yield_indices = get_promise_yield_indices(state_update)?;
         let initial_promise_yield_indices = promise_yield_indices.clone();
 
         let mut new_receipts: Vec<_> = receipt_manager

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -1875,6 +1875,8 @@ fn test_promise_yield_indices_missing_trie_value_not_swallowed() {
             Default::default(),
         )
         .unwrap();
+    // This call writes the `{0, 1}` indices the rest of the test depends on.
+    assert_matches!(apply_result.outcomes[0].outcome.status, ExecutionStatus::SuccessValue(_));
     let mut store_update = tries.store_update();
     let root = tries.apply_all(&apply_result.trie_changes, shard_uid, &mut store_update);
     store_update.commit();
@@ -1892,6 +1894,8 @@ fn test_promise_yield_indices_missing_trie_value_not_swallowed() {
             Default::default(),
         )
         .unwrap();
+    // The read under test only runs on the success path, so a failed call would exercise nothing.
+    assert_matches!(apply_result.outcomes[0].outcome.status, ExecutionStatus::SuccessValue(_));
     let partial_storage = apply_result.proof.unwrap();
     let PartialState::TrieValues(mut nodes) = partial_storage.nodes;
 

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -30,7 +30,9 @@ use near_primitives::errors::{
     InvalidTxError, MissingTrieValue, RuntimeError, TxExecutionError,
 };
 use near_primitives::hash::{CryptoHash, hash};
-use near_primitives::receipt::{ActionReceipt, DataReceipt, Receipt, ReceiptEnum, ReceiptV0};
+use near_primitives::receipt::{
+    ActionReceipt, DataReceipt, PromiseYieldIndices, Receipt, ReceiptEnum, ReceiptV0,
+};
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::state::PartialState;
 use near_primitives::stateless_validation::contract_distribution::CodeHash;
@@ -51,11 +53,13 @@ use near_store::test_utils::TestTriesBuilder;
 use near_store::trie::AccessOptions;
 use near_store::trie::receipts_column_helper::ShardsOutgoingReceiptBuffer;
 use near_store::{
-    MissingTrieValueContext, ShardTries, StorageError, Trie, get_access_key, get_account,
-    get_gas_key_nonce, get_postponed_receipt, get_received_data, set_access_key, set_account,
+    MissingTrieValueContext, PartialStorage, ShardTries, StorageError, Trie, get_access_key,
+    get_account, get_gas_key_nonce, get_postponed_receipt, get_received_data, set_access_key,
+    set_account,
 };
 use near_vm_runner::{ContractCode, FilesystemContractRuntimeCache};
 use std::collections::HashSet;
+use std::slice::from_ref;
 use std::sync::Arc;
 use testlib::runtime_utils::{alice_account, bob_account};
 
@@ -1780,6 +1784,214 @@ fn test_validation_rejects_missing_contract_code() {
 #[should_panic(expected = "contract code is missing from the trie")]
 fn test_tracked_shard_apply_asserts_on_missing_contract_code() {
     let _ = apply_call_to_contract_missing_from_witness(ApplyChunkReason::UpdateTrackedShard);
+}
+
+/// Deploys the test contract to alice and returns the resulting state root.
+fn deploy_rs_contract(
+    runtime: &Runtime,
+    tries: &ShardTries,
+    root: CryptoHash,
+    apply_state: &ApplyState,
+    signer: Arc<Signer>,
+    epoch_info_provider: &dyn EpochInfoProvider,
+) -> CryptoHash {
+    let deploy_receipt = create_receipt_with_actions(
+        alice_account(),
+        signer,
+        vec![Action::DeployContract(DeployContractAction {
+            code: near_test_contracts::rs_contract().to_vec(),
+        })],
+    );
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            &None,
+            apply_state,
+            &[deploy_receipt],
+            SignedValidPeriodTransactions::empty(),
+            epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+    let mut store_update = tries.store_update();
+    let root =
+        tries.apply_all(&apply_result.trie_changes, ShardUId::single_shard(), &mut store_update);
+    store_update.commit();
+    root
+}
+
+/// A witness whose recorded state omits the `PromiseYieldIndices` value makes the read in
+/// `action_function_call` return `Err(MissingTrieValue)`. The error must propagate; swallowing it
+/// with `.unwrap_or_default()` resets the indices to `{0, 0}` and lets `apply` return `Ok`, so a
+/// chunk producer could hand out a witness that validates against state it never proved.
+///
+/// The receipt must create a yield. A call that creates none writes nothing back, and the later
+/// `resolve_promise_yield_timeouts` read propagates the same error either way, which would make
+/// the two cases indistinguishable.
+#[test]
+fn test_promise_yield_indices_missing_trie_value_not_swallowed() {
+    let (runtime, tries, root, mut apply_state, signers, epoch_info_provider) = setup_runtime(
+        vec![alice_account()],
+        Balance::from_near(1_000_000),
+        Balance::from_near(500_000),
+        Gas::from_teragas(1000),
+    );
+    // The helper installs `RuntimeConfig::test()`; run the deploy and the yield calls without gas
+    // accounting noise instead.
+    apply_state.config = Arc::new(RuntimeConfig::free());
+
+    let shard_uid = ShardUId::single_shard();
+    let root = deploy_rs_contract(
+        &runtime,
+        &tries,
+        root,
+        &apply_state,
+        signers[0].clone(),
+        &epoch_info_provider,
+    );
+
+    let yield_receipt = || {
+        create_receipt_with_actions(
+            alice_account(),
+            signers[0].clone(),
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "call_yield_create_return_data_id".to_string(),
+                args: vec![6u8; 16],
+                gas: Gas::from_teragas(300),
+                deposit: Balance::ZERO,
+            }))],
+        )
+    };
+
+    // First yield call. State now holds indices `{0, 1}` and one timeout entry.
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(shard_uid, root),
+            &None,
+            &apply_state,
+            &[yield_receipt()],
+            SignedValidPeriodTransactions::empty(),
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+    let mut store_update = tries.store_update();
+    let root = tries.apply_all(&apply_result.trie_changes, shard_uid, &mut store_update);
+    store_update.commit();
+
+    // Replay the same call with recording on, so the proof captures the indices value.
+    let second_yield = yield_receipt();
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(shard_uid, root).recording_reads_new_recorder(),
+            &None,
+            &apply_state,
+            from_ref(&second_yield),
+            SignedValidPeriodTransactions::empty(),
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+    let partial_storage = apply_result.proof.unwrap();
+    let PartialState::TrieValues(mut nodes) = partial_storage.nodes;
+
+    // Drop exactly the `PromiseYieldIndices` value blob from the recorded proof.
+    let target = hash(
+        &borsh::to_vec(&PromiseYieldIndices { first_index: 0, next_available_index: 1 }).unwrap(),
+    );
+    let before = nodes.len();
+    nodes.retain(|value| hash(&value[..]) != target);
+    assert_eq!(nodes.len(), before - 1, "expected to remove exactly the indices value blob");
+
+    // Contract code bypasses the trie recorder, so re-add it. The indices blob is now the only
+    // node missing from the proof.
+    nodes.push(near_test_contracts::rs_contract().to_vec().into());
+
+    let trie = Trie::from_recorded_storage(
+        PartialStorage { nodes: PartialState::TrieValues(nodes) },
+        root,
+        false,
+    );
+    let result = runtime.apply(
+        trie,
+        &None,
+        &apply_state,
+        from_ref(&second_yield),
+        SignedValidPeriodTransactions::empty(),
+        &epoch_info_provider,
+        Default::default(),
+    );
+
+    // Bind the missing hash and compare it, so an unrelated omitted blob cannot make this pass.
+    let missing_hash = assert_matches!(
+        result,
+        Err(RuntimeError::StorageError(StorageError::MissingTrieValue(MissingTrieValue {
+            context: MissingTrieValueContext::TrieMemoryPartialStorage,
+            hash,
+        }))) => hash
+    );
+    assert_eq!(missing_hash, target, "expected the missing value to be the trimmed indices blob");
+}
+
+/// The honest path the `?` above could plausibly break: when the `PromiseYieldIndices` key has
+/// never been written, the read must still yield the default and the call must succeed.
+///
+/// This needs a fresh harness. Reusing the state left by the test above would make the assertion
+/// vacuous, since the key is already present there.
+#[test]
+fn test_promise_yield_indices_absent_key_still_applies() {
+    let (runtime, tries, root, mut apply_state, signers, epoch_info_provider) = setup_runtime(
+        vec![alice_account()],
+        Balance::from_near(1_000_000),
+        Balance::from_near(500_000),
+        Gas::from_teragas(1000),
+    );
+    apply_state.config = Arc::new(RuntimeConfig::free());
+
+    let shard_uid = ShardUId::single_shard();
+    let root = deploy_rs_contract(
+        &runtime,
+        &tries,
+        root,
+        &apply_state,
+        signers[0].clone(),
+        &epoch_info_provider,
+    );
+
+    // `setup_runtime_for_shard` writes accounts and access keys only, and the deploy above does
+    // not touch the queue, so the key is genuinely absent.
+    assert_eq!(
+        tries
+            .get_trie_for_shard(shard_uid, root)
+            .get(&TrieKey::PromiseYieldIndices.to_vec(), AccessOptions::DEFAULT)
+            .unwrap(),
+        None,
+        "the promise yield indices key must be absent for this control to mean anything"
+    );
+
+    // A call that creates no yield leaves the indices untouched, so nothing is written back.
+    let call_receipt = create_receipt_with_actions(
+        alice_account(),
+        signers[0].clone(),
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
+            method_name: "log_something".to_string(),
+            args: Vec::new(),
+            gas: Gas::from_teragas(300),
+            deposit: Balance::ZERO,
+        }))],
+    );
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(shard_uid, root),
+            &None,
+            &apply_state,
+            &[call_receipt],
+            SignedValidPeriodTransactions::empty(),
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+    assert_matches!(apply_result.outcomes[0].outcome.status, ExecutionStatus::SuccessValue(_));
 }
 
 // Tests excluding contract code from state witness and recording of contract deployments and function calls.


### PR DESCRIPTION
`action_function_call` read the promise yield indices with `.unwrap_or_default()`, which swallows any `StorageError`, not just a missing key. The helper already returns the default for a genuinely absent key, so the read now propagates with `?`.

No change on the absent-key path, and no protocol change.

Tests:
- `test_promise_yield_indices_missing_trie_value_not_swallowed` replays a call over a proof with the indices value removed, and asserts the error reaches the caller.
- `test_promise_yield_indices_absent_key_still_applies` checks a non-yield call still succeeds when the key was never written.