### PR TITLE
fix(stateless-validation): derive chunk endorsement signed bytes from chunk_hash

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -220,3 +220,78 @@ pub fn validate_chunk_endorsements_in_header(
     }
     Ok(())
 }
+
+// Needs `near-primitives/test_features` for `ChunkEndorsement::new_with_differentiator`. Under
+// spice `TestBlockBuilder` produces a block with no legacy chunk endorsements, so the test would
+// stop at the chunks/endorsements count check above instead of at signature verification.
+#[cfg(all(test, feature = "test_features", not(feature = "protocol_feature_spice")))]
+mod tests {
+    use super::*;
+    use crate::test_utils::setup;
+    use near_async::time::Clock;
+    use near_crypto::Signature;
+    use near_primitives::sharding::ShardChunkHeader;
+    use near_primitives::test_utils::TestBlockBuilder;
+    use near_primitives::types::ShardId;
+    use near_primitives::validator_signer::ValidatorSigner;
+    use std::sync::Arc;
+
+    /// Builds a single-shard block at the next height carrying `chunk` and a single endorsement
+    /// signature for the only chunk validator.
+    fn build_block(
+        clock: Clock,
+        prev_block: &Block,
+        chunk: &ShardChunkHeader,
+        signature: Signature,
+        signer: Arc<ValidatorSigner>,
+    ) -> Block {
+        TestBlockBuilder::from_prev_block(clock, prev_block, signer)
+            .chunks([chunk.clone()])
+            .chunk_endorsements(vec![vec![Some(Box::new(signature))]])
+            .build_owned()
+    }
+
+    /// Documents the impact of an endorsement with a non-canonical `signature_differentiator`: the
+    /// signature does not match the bytes block validation derives from `chunk_hash`, so the whole
+    /// block is rejected. This passes both before and after the `verify` fix, since block
+    /// validation already reconstructed the canonical bytes; it is not a regression guard.
+    #[test]
+    fn poisoned_endorsement_rejects_whole_block() {
+        let clock = Clock::real();
+        let (chain, epoch_manager, _runtime, signer) = setup(clock.clone());
+        let genesis = chain.genesis_block();
+        let height = genesis.header().height() + 1;
+
+        // `new_dummy` leaves `height_included` at zero, and a chunk that is not new in this block
+        // skips endorsement checks entirely.
+        let mut chunk = ShardChunkHeader::new_dummy(height, ShardId::new(0), *genesis.hash());
+        *chunk.height_included_mut() = height;
+
+        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(genesis.hash()).unwrap();
+
+        let poisoned = ChunkEndorsement::new_with_differentiator(
+            epoch_id,
+            &chunk,
+            signer.as_ref(),
+            "POISONED".to_owned(),
+        )
+        .signature();
+        let block = build_block(clock.clone(), &genesis, &chunk, poisoned, signer.clone());
+        assert!(
+            matches!(
+                validate_chunk_endorsements_in_block(epoch_manager.as_ref(), &block),
+                Err(Error::InvalidChunkEndorsement)
+            ),
+            "poisoned endorsement must make validate_chunk_endorsements_in_block reject the block"
+        );
+
+        // Control: the same block with a canonical signature is accepted, so the rejection above
+        // is caused by the differentiator and nothing else.
+        let honest = ChunkEndorsement::new(epoch_id, &chunk, signer.as_ref()).signature();
+        let block = build_block(clock, &genesis, &chunk, honest, signer);
+        assert!(
+            validate_chunk_endorsements_in_block(epoch_manager.as_ref(), &block).is_ok(),
+            "canonical endorsement must be accepted"
+        );
+    }
+}

--- a/core/primitives/src/stateless_validation/chunk_endorsement.rs
+++ b/core/primitives/src/stateless_validation/chunk_endorsement.rs
@@ -229,4 +229,15 @@ mod tests {
             &signer.public_key(),
         ));
     }
+
+    /// Pins the exact bytes every endorsement signature is taken over. Changing them silently
+    /// would invalidate signatures across a version boundary, so this must fail loudly.
+    #[test]
+    fn signed_bytes_are_stable() {
+        assert_eq!(
+            hex::encode(endorsement_signed_bytes(&ChunkHash(CryptoHash::default()))),
+            "0000000000000000000000000000000000000000000000000000000000000000\
+             100000004368756e6b456e646f7273656d656e74",
+        );
+    }
 }

--- a/core/primitives/src/stateless_validation/chunk_endorsement.rs
+++ b/core/primitives/src/stateless_validation/chunk_endorsement.rs
@@ -25,14 +25,31 @@ impl ChunkEndorsement {
         chunk_header: &ShardChunkHeader,
         signer: &ValidatorSigner,
     ) -> ChunkEndorsement {
-        let metadata = ChunkEndorsementMetadata {
-            account_id: signer.validator_id().clone(),
-            shard_id: chunk_header.shard_id(),
-            epoch_id,
-            height_created: chunk_header.height_created(),
-        };
-        let metadata_signature = signer.sign_bytes(&borsh::to_vec(&metadata).unwrap());
+        let (metadata, metadata_signature) = signed_metadata(epoch_id, chunk_header, signer);
         let inner = ChunkEndorsementInnerV1::new(chunk_header.chunk_hash().clone());
+        let signature = signer.sign_bytes(&endorsement_signed_bytes(&inner.chunk_hash));
+        let endorsement = ChunkEndorsementV2 { inner, signature, metadata, metadata_signature };
+        ChunkEndorsement::V2(endorsement)
+    }
+
+    /// Test-only constructor that puts a caller-chosen `signature_differentiator` on the wire and
+    /// signs the resulting inner verbatim.
+    ///
+    /// It must not sign through `endorsement_signed_bytes`: that would produce a canonical
+    /// signature for a non-canonical inner, and the regression tests built on this constructor
+    /// would pass even with the fix reverted.
+    #[cfg(any(test, feature = "test_features"))]
+    pub fn new_with_differentiator(
+        epoch_id: EpochId,
+        chunk_header: &ShardChunkHeader,
+        signer: &ValidatorSigner,
+        signature_differentiator: SignatureDifferentiator,
+    ) -> ChunkEndorsement {
+        let (metadata, metadata_signature) = signed_metadata(epoch_id, chunk_header, signer);
+        let inner = ChunkEndorsementInnerV1 {
+            chunk_hash: chunk_header.chunk_hash().clone(),
+            signature_differentiator,
+        };
         let signature = signer.sign_bytes(&borsh::to_vec(&inner).unwrap());
         let endorsement = ChunkEndorsementV2 { inner, signature, metadata, metadata_signature };
         ChunkEndorsement::V2(endorsement)
@@ -77,9 +94,7 @@ impl ChunkEndorsement {
         signature: &Signature,
         public_key: &PublicKey,
     ) -> bool {
-        let inner = ChunkEndorsementInnerV1::new(chunk_hash);
-        let data = borsh::to_vec(&inner).unwrap();
-        signature.verify(&data, public_key)
+        signature.verify(&endorsement_signed_bytes(&chunk_hash), public_key)
     }
 
     /// Returns the account ID of the chunk validator that generated this endorsement.
@@ -110,11 +125,40 @@ pub struct ChunkEndorsementV2 {
 
 impl ChunkEndorsementV2 {
     fn verify(&self, public_key: &PublicKey) -> bool {
-        let inner = borsh::to_vec(&self.inner).unwrap();
+        // Verify against bytes reconstructed from `chunk_hash`, never against the wire-supplied
+        // `inner`. Serializing `self.inner` here would let a peer pick the signed bytes through
+        // `signature_differentiator`, which the consensus path never reads, so an endorsement
+        // could pass this check and fail `validate_signature` later.
         let metadata = borsh::to_vec(&self.metadata).unwrap();
-        self.signature.verify(&inner, public_key)
+        self.signature.verify(&endorsement_signed_bytes(&self.inner.chunk_hash), public_key)
             && self.metadata_signature.verify(&metadata, public_key)
     }
+}
+
+/// The bytes a chunk endorsement signature is taken over, derived from `chunk_hash` alone.
+///
+/// Single source of truth for both the receive path ([`ChunkEndorsementV2::verify`]) and the
+/// consensus path ([`ChunkEndorsement::validate_signature`]), so the two can never disagree on
+/// what was signed.
+fn endorsement_signed_bytes(chunk_hash: &ChunkHash) -> Vec<u8> {
+    borsh::to_vec(&ChunkEndorsementInnerV1::new(chunk_hash.clone())).unwrap()
+}
+
+/// Builds the endorsement metadata and its signature. Shared by the production and test-only
+/// constructors, which deliberately do not share the `inner` signing step.
+fn signed_metadata(
+    epoch_id: EpochId,
+    chunk_header: &ShardChunkHeader,
+    signer: &ValidatorSigner,
+) -> (ChunkEndorsementMetadata, Signature) {
+    let metadata = ChunkEndorsementMetadata {
+        account_id: signer.validator_id().clone(),
+        shard_id: chunk_header.shard_id(),
+        epoch_id,
+        height_created: chunk_header.height_created(),
+    };
+    let metadata_signature = signer.sign_bytes(&borsh::to_vec(&metadata).unwrap());
+    (metadata, metadata_signature)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
@@ -129,11 +173,60 @@ pub struct ChunkEndorsementMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
 struct ChunkEndorsementInnerV1 {
     chunk_hash: ChunkHash,
+    /// Kept on the wire for borsh compatibility, but never read back from it: every signature
+    /// check reconstructs the canonical value through `endorsement_signed_bytes`.
     signature_differentiator: SignatureDifferentiator,
 }
 
 impl ChunkEndorsementInnerV1 {
     fn new(chunk_hash: ChunkHash) -> Self {
         Self { chunk_hash, signature_differentiator: "ChunkEndorsement".to_owned() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::CryptoHash;
+    use crate::test_utils::create_test_signer;
+    use near_primitives_core::types::ShardId;
+
+    /// An endorsement carrying a non-canonical `signature_differentiator` must be rejected by both
+    /// the receive path (`verify`) and the consensus path (`validate_signature`). `verify` used to
+    /// sign-check the wire `inner`, so it accepted such an endorsement while `validate_signature`,
+    /// which rebuilds the inner from `chunk_hash`, rejected it.
+    #[test]
+    fn poisoned_differentiator_is_rejected_by_verify() {
+        let signer = create_test_signer("test0");
+        let chunk_header = ShardChunkHeader::new_dummy(42, ShardId::new(0), CryptoHash::default());
+
+        let endorsement = ChunkEndorsement::new_with_differentiator(
+            EpochId::default(),
+            &chunk_header,
+            &signer,
+            "POISONED".to_owned(),
+        );
+
+        assert!(
+            !endorsement.verify(&signer.public_key()),
+            "verify() must reject a non-canonical signature_differentiator"
+        );
+        assert!(
+            !ChunkEndorsement::validate_signature(
+                chunk_header.chunk_hash().clone(),
+                &endorsement.signature(),
+                &signer.public_key(),
+            ),
+            "validate_signature() must reject a non-canonical signature_differentiator"
+        );
+
+        // Control: a canonical endorsement passes both paths.
+        let honest = ChunkEndorsement::new(EpochId::default(), &chunk_header, &signer);
+        assert!(honest.verify(&signer.public_key()));
+        assert!(ChunkEndorsement::validate_signature(
+            chunk_header.chunk_hash().clone(),
+            &honest.signature(),
+            &signer.public_key(),
+        ));
     }
 }


### PR DESCRIPTION
The two chunk endorsement signature checks disagreed on what was signed. `ChunkEndorsementV2::verify` serialized the wire `inner`, while `ChunkEndorsement::validate_signature` rebuilt it from `chunk_hash`. A non-canonical `signature_differentiator` passed one and failed the other.

Both now derive the signed bytes from `chunk_hash` through a single `endorsement_signed_bytes` helper, and `ChunkEndorsement::new` signs the same bytes.

`signature_differentiator` stays on the wire for borsh compatibility, so there is no wire or protocol change.

Tests:
- `poisoned_differentiator_is_rejected_by_verify` checks a non-canonical differentiator is rejected by both paths, with a canonical endorsement as the control.
- `poisoned_endorsement_rejects_whole_block` checks a block carrying such an endorsement is rejected by `validate_chunk_endorsements_in_block`. It passes with or without the change, so it documents behaviour rather than guarding it.

The test-only `new_with_differentiator` signs its inner directly and does not share a signing line with `new`. Sharing one would give it a canonical signature.