### PR TITLE
chore(deps): remove unmaintained smartstring dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4605,7 +4605,6 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "smartstring",
  "strum",
  "thiserror 2.0.18",
  "tracing",
@@ -7390,17 +7389,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "static_assertions",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,7 +331,6 @@ sha2 = "0.10"
 sha3 = "0.10"
 smallvec = "1.6"
 smart-default = "0.7"
-smartstring = "1.0.1"
 strum = { version = "0.24", features = ["derive"] }
 stun = "0.7"
 subtle = "2.2"

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -35,7 +35,6 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 bencher.workspace = true
 itoa.workspace = true
-smartstring.workspace = true
 
 [features]
 nightly = [

--- a/core/o11y/benches/metrics.rs
+++ b/core/o11y/benches/metrics.rs
@@ -26,18 +26,6 @@ fn inc_counter_vec_with_label_values_itoa(bench: &mut Bencher) {
     });
 }
 
-// cspell:words smartstring
-fn inc_counter_vec_with_label_values_smartstring(bench: &mut Bencher) {
-    use std::fmt::Write;
-    bench.iter(|| {
-        for shard_id in 0..NUM_SHARDS {
-            let mut label = smartstring::alias::String::new();
-            write!(label, "{shard_id}").unwrap();
-            COUNTERS.with_label_values(&[&label]).inc();
-        }
-    });
-}
-
 fn inc_counter_vec_with_label_values_stack(bench: &mut Bencher) {
     use std::io::Write;
     bench.iter(|| {
@@ -98,7 +86,6 @@ benchmark_group!(
     benches,
     inc_counter_vec_with_label_values,
     inc_counter_vec_with_label_values_itoa,
-    inc_counter_vec_with_label_values_smartstring,
     inc_counter_vec_with_label_values_stack,
     inc_counter_vec_with_label_values_stack_no_format,
     inc_counter_vec_cached_str,


### PR DESCRIPTION
`smartstring` 1.0.1 was flagged unmaintained today as RUSTSEC-2026-0249, which fails `cargo audit -D warnings` in CI.

It was a dev-dependency of `near-o11y` used by exactly one arm of the metric-label micro-benchmark in `core/o11y/benches/metrics.rs`. Dropping that arm removes the dependency, so no audit ignore is needed. The bench keeps its other six label-building variants.

This by itself does not resolve the other advisories.