### PR TITLE
fix(cloud-archive): hardening found by running the fleet

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -50,7 +50,7 @@ use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::db::CLOUD_PREV_EPOCH_END_KEY;
 use near_store::db::metadata::DbKind;
 use near_store::flat::FlatStorageManager;
-use near_store::trie::{FindSplitError, find_trie_split, total_mem_usage};
+use near_store::trie::{FindSplitError, SnapshotError, find_trie_split, total_mem_usage};
 use near_store::{
     ApplyStatePartResult, COLD_HEAD_KEY, DBCol, ShardTries, StateSnapshotConfig, Store, Trie,
     TrieConfig, TrieUpdate, WrappedTrieChanges, get_access_key, get_gas_key_nonce,
@@ -523,6 +523,11 @@ impl NightshadeRuntime {
         );
         let partial_state = match trie_nodes {
             Ok(partial_state) => partial_state,
+            // Expected while a snapshot is being created; the caller retries.
+            Err(err) if err == SnapshotError::LockWouldBlock.into() => {
+                tracing::debug!(target: "runtime", %shard_id, part_id.idx, part_id.total, %prev_hash, %state_root, "state snapshot is locked, will retry");
+                return Err(err.into());
+            }
             Err(err) => {
                 tracing::error!(target: "runtime", ?err, part_id.idx, part_id.total, %prev_hash, %state_root, %shard_id, "can't get trie nodes for state part");
                 return Err(err.into());

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -524,13 +524,13 @@ impl NightshadeRuntime {
         let partial_state = match trie_nodes {
             Ok(partial_state) => partial_state,
             // Expected while a snapshot is being created; the caller retries.
-            Err(err) if err == SnapshotError::LockWouldBlock.into() => {
+            Err(err @ SnapshotError::LockWouldBlock) => {
                 tracing::debug!(target: "runtime", %shard_id, part_id.idx, part_id.total, %prev_hash, %state_root, "state snapshot is locked, will retry");
-                return Err(err.into());
+                return Err(StorageError::from(err).into());
             }
             Err(err) => {
                 tracing::error!(target: "runtime", ?err, part_id.idx, part_id.total, %prev_hash, %state_root, %shard_id, "can't get trie nodes for state part");
-                return Err(err.into());
+                return Err(StorageError::from(err).into());
             }
         };
         let state_part =

--- a/chain/client/src/archive/cloud_archival_reader.rs
+++ b/chain/client/src/archive/cloud_archival_reader.rs
@@ -4,7 +4,7 @@ use near_primitives::utils::{get_block_shard_id, index_to_bytes};
 use near_store::archive::cloud_storage::{
     BlockData, CloudRetrievalError, CloudStorage, EpochData, ShardData,
 };
-use near_store::{DBCol, Store, StoreUpdate};
+use near_store::{DBCol, Store, StoreUpdate, set_cloud_reader_store};
 use std::collections::HashSet;
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
@@ -93,6 +93,11 @@ pub fn bootstrap_range(
     start_height: BlockHeight,
     end_height: BlockHeight,
 ) -> anyhow::Result<()> {
+    // Before the first write, so an interrupted bootstrap leaves the store marked too.
+    let mut update = store.store_update();
+    set_cloud_reader_store(&mut update);
+    update.commit();
+
     let mut saved_epochs = HashSet::<EpochId>::new();
 
     // Backfill blocks from the first epoch's start up to `start_height` so the

--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -61,6 +61,9 @@ impl StateSyncConnection {
         Self { connection }
     }
 
+    // TODO(cloud_archival): state parts come through here, and `get_file` below reads with no
+    // credentials, which a private bucket refuses. Give them a `CloudStorageFileID` and
+    // retrieve them like every other archive object.
     pub fn from_cloud_storage(cloud_storage: &CloudStorage) -> Self {
         Self { connection: cloud_storage.connection().clone() }
     }

--- a/core/external-storage/src/lib.rs
+++ b/core/external-storage/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use futures::TryStreamExt;
 use near_chain_configs::ExternalStorageLocation;
+use object_store::path::Path as ObjectStorePath;
 use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -16,9 +17,9 @@ pub enum ExternalConnection {
     S3 { bucket: Arc<s3::Bucket> },
     /// Local filesystem root directory.
     Filesystem { root_dir: PathBuf },
-    /// GCS client (upload/list via SDK, anonymous downloads via HTTP).
+    /// GCS client (SDK for signed calls, plain HTTP for anonymous downloads).
     GCS {
-        // May be used for uploading and listing state parts. Requires valid credentials
+        // Uploads, listing, and signed downloads. Requires valid credentials
         // to be specified through env variable.
         gcs_client: Arc<object_store::gcp::GoogleCloudStorage>,
         // May be used for anonymously downloading state parts.
@@ -104,7 +105,8 @@ impl ExternalConnection {
         }
     }
 
-    /// Download an object at `path` as bytes.
+    /// Download an object at `path` as bytes. GCS reads go out with no credentials,
+    /// so a GCS bucket must grant anonymous read for this to succeed.
     pub async fn get(&self, path: &str) -> Result<Vec<u8>, anyhow::Error> {
         match self {
             ExternalConnection::S3 { bucket } => {
@@ -123,8 +125,7 @@ impl ExternalConnection {
                 Ok(data)
             }
             ExternalConnection::GCS { reqwest_client, bucket, .. } => {
-                // Download should be handled anonymously, therefore we are not using cloud-storage crate.
-                // TODO(cloud_archival) Consider the case of cloud archival
+                // A bare HTTP client, so the request goes out with no credentials.
                 let url = format!(
                     "https://storage.googleapis.com/storage/v1/b/{}/o/{}?alt=media",
                     percent_encoding::percent_encode(bucket.as_bytes(), GCS_ENCODE_SET),
@@ -141,6 +142,23 @@ impl ExternalConnection {
                 }
             }
         }
+    }
+
+    /// Download an object at `path` as bytes, signing GCS reads with the connection's
+    /// credentials. A bucket with `public_access_prevention` enforced requires them.
+    ///
+    /// S3 and filesystem reads already carry whatever access the connection was built with,
+    /// so they take the same path as [`Self::get`].
+    pub async fn get_authenticated(&self, path: &str) -> Result<Vec<u8>, anyhow::Error> {
+        let ExternalConnection::GCS { gcs_client, .. } = self else {
+            return self.get(path).await;
+        };
+        let parsed_path = ObjectStorePath::parse(path)
+            .with_context(|| format!("{path} isn't a valid path for GCP"))?;
+        tracing::debug!(target: "external", ?parsed_path, "reading from GCS with credentials");
+        let response = gcs_client.get(&parsed_path).await?;
+        let bytes = response.bytes().await?.to_vec();
+        Ok(bytes)
     }
 
     /// Upload/overwrite an object at `path` with `value`.

--- a/core/store/src/archive/cloud_storage/retrieve.rs
+++ b/core/store/src/archive/cloud_storage/retrieve.rs
@@ -144,7 +144,7 @@ impl CloudStorage {
     async fn download(&self, file_id: &CloudStorageFileID) -> Result<Vec<u8>, CloudRetrievalError> {
         let path = self.file_path(file_id);
         self.external
-            .get(&path)
+            .get_authenticated(&path)
             .await
             .map_err(|error| CloudRetrievalError::GetError { file_id: file_id.clone(), error })
     }

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -53,6 +53,9 @@ pub const CLOUD_MIN_HEAD_KEY: &[u8] = b"CLOUD_MIN_HEAD";
 pub const CLOUD_PREV_EPOCH_END_KEY: &[u8] = b"CLOUD_PREV_EPOCH_END";
 /// Set once a cloud-archive reader has written into this store. A running node refuses
 /// such a store; only the cloud-archive tool may use it.
+// TODO(cloud_archival): consider supporting a normal node on a store that was a recent
+// reader's. It is missing at least the epoch info for the epoch after the head; what else
+// it needs is unknown.
 pub const CLOUD_READER_STORE_KEY: &[u8] = b"CLOUD_READER_STORE";
 
 pub fn cloud_shard_head_key(shard_id: ShardId) -> Vec<u8> {

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -51,6 +51,9 @@ pub const CLOUD_MIN_HEAD_KEY: &[u8] = b"CLOUD_MIN_HEAD";
 /// Hash of the last block of the latest epoch this writer archived its assigned
 /// components for. GC stops at the start of that epoch.
 pub const CLOUD_PREV_EPOCH_END_KEY: &[u8] = b"CLOUD_PREV_EPOCH_END";
+/// Set once a cloud-archive reader has written into this store. A running node refuses
+/// such a store; only the cloud-archive tool may use it.
+pub const CLOUD_READER_STORE_KEY: &[u8] = b"CLOUD_READER_STORE";
 
 pub fn cloud_shard_head_key(shard_id: ShardId) -> Vec<u8> {
     let mut key = CLOUD_SHARD_HEAD_PREFIX.to_vec();

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -30,6 +30,8 @@ pub enum SnapshotError {
     // Lock for snapshot acquired by another process.
     // Most likely the StateSnapshotActor is creating a snapshot or doing compaction.
     LockWouldBlock,
+    // Error while reading from the snapshot.
+    Storage(StorageError),
     // Any other unexpected error
     Other(String),
 }
@@ -48,6 +50,7 @@ impl std::fmt::Display for SnapshotError {
             SnapshotError::LockWouldBlock => {
                 write!(f, "Accessing state snapshot would block. Retry in a few seconds.")
             }
+            SnapshotError::Storage(err) => write!(f, "{}", err),
             SnapshotError::Other(err_msg) => write!(f, "{}", err_msg),
         }
     }
@@ -57,7 +60,10 @@ impl Error for SnapshotError {}
 
 impl From<SnapshotError> for StorageError {
     fn from(err: SnapshotError) -> Self {
-        StorageError::StorageInconsistentState(err.to_string())
+        match err {
+            SnapshotError::Storage(err) => err,
+            err => StorageError::StorageInconsistentState(err.to_string()),
+        }
     }
 }
 
@@ -197,15 +203,14 @@ impl ShardTries {
         block_hash: &CryptoHash,
         part_id: PartId,
         state_trie: Trie,
-    ) -> Result<PartialState, StorageError> {
+    ) -> Result<PartialState, SnapshotError> {
         let guard = self.state_snapshot().try_read().ok_or(SnapshotError::LockWouldBlock)?;
         let data = guard.as_ref().ok_or(SnapshotError::SnapshotNotFound(*block_hash))?;
         if &data.prev_block_hash != block_hash {
             return Err(SnapshotError::IncorrectSnapshotRequested(
                 *block_hash,
                 data.prev_block_hash,
-            )
-            .into());
+            ));
         };
         let cache = self
             .get_trie_cache_for(shard_uid, true)
@@ -215,7 +220,9 @@ impl ShardTries {
         let flat_storage_chunk_view = data.flat_storage_manager.chunk_view(shard_uid, *block_hash);
 
         let snapshot_trie = Trie::new(storage, *state_root, flat_storage_chunk_view);
-        snapshot_trie.get_trie_nodes_for_part_with_flat_storage(part_id, &state_trie)
+        snapshot_trie
+            .get_trie_nodes_for_part_with_flat_storage(part_id, &state_trie)
+            .map_err(SnapshotError::Storage)
     }
 
     /// Makes a snapshot of the current state of the DB, if one is not already available.

--- a/core/store/src/utils/mod.rs
+++ b/core/store/src/utils/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod sync_utils;
 pub mod test_utils;
 
-use crate::db::{GENESIS_CONGESTION_INFO_KEY, GENESIS_HEIGHT_KEY};
+use crate::db::{CLOUD_READER_STORE_KEY, GENESIS_CONGESTION_INFO_KEY, GENESIS_HEIGHT_KEY};
 use crate::trie::AccessOptions;
 use crate::{
     DBCol, GENESIS_STATE_ROOTS_KEY, KeyLookupMode, Store, StoreUpdate, TrieAccess, TrieUpdate,
@@ -576,6 +576,14 @@ pub fn remove_account(
 
 pub fn get_genesis_state_roots(store: &Store) -> Option<Vec<StateRoot>> {
     store.get_ser::<Vec<StateRoot>>(DBCol::BlockMisc, GENESIS_STATE_ROOTS_KEY)
+}
+
+pub fn is_cloud_reader_store(store: &Store) -> bool {
+    store.get_ser::<bool>(DBCol::BlockMisc, CLOUD_READER_STORE_KEY).unwrap_or(false)
+}
+
+pub fn set_cloud_reader_store(store_update: &mut StoreUpdate) {
+    store_update.set_ser(DBCol::BlockMisc, CLOUD_READER_STORE_KEY, &true);
 }
 
 pub fn get_genesis_congestion_infos(store: &Store) -> Option<Vec<CongestionInfo>> {

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -290,12 +290,6 @@ impl<'a> ConfigValidator<'a> {
             let error_message = "`archive` is false, but `cloud_archival` is enabled.".to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
-        if self.config.cloud_archival_writer.is_none() && self.config.cold_store.is_none() {
-            let error_message =
-                "Cloud archival is enabled in reader mode, but `cold_store` is missing."
-                    .to_string();
-            self.validation_errors.push_config_semantics_error(error_message);
-        }
 
         let Some(writer_config) = &self.config.cloud_archival_writer else {
             return;
@@ -606,12 +600,20 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "\\nconfig.json semantic issue: Cloud archival is enabled in reader mode, but `cold_store` is missing."
-    )]
     fn test_cloud_archival_reader_without_cold_store() {
         let mut config = Config::default();
+        config.archive = true;
         config.cloud_archival = Some(test_cloud_archival_config(""));
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn test_cloud_archival_reader_with_cold_store() {
+        let mut config = Config::default();
+        config.archive = true;
+        config.cloud_archival = Some(test_cloud_archival_config(""));
+        config.cold_store = Some(config.store.clone());
+        config.save_trie_changes = Some(true);
         validate_config(&config).unwrap();
     }
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -50,7 +50,7 @@ use near_store::adapter::StoreAdapter as _;
 use near_store::db::metadata::DbKind;
 use near_store::genesis::initialize_sharded_genesis_state;
 use near_store::metrics::spawn_db_metrics_loop;
-use near_store::{NodeStorage, Store, StoreOpenerError};
+use near_store::{NodeStorage, Store, StoreOpenerError, is_cloud_reader_store};
 use near_telemetry::TelemetryActor;
 use parking_lot::RwLock;
 use std::path::{Path, PathBuf};
@@ -394,6 +394,13 @@ pub async fn start_with_config_and_synchronization_impl(
     config_updater: Option<ConfigUpdater>,
 ) -> anyhow::Result<NearNode> {
     let storage = open_storage(home_dir, &config)?;
+    // Before any actor is spawned, so the GC actor never starts on this store.
+    if is_cloud_reader_store(&storage.get_hot_store()) {
+        anyhow::bail!(
+            "this store was written by a cloud-archive reader and cannot be used by a running \
+             node; point the cloud-archive tool at it instead"
+        );
+    }
     if config.client_config.enable_statistics_export {
         let period = config.client_config.log_summary_period;
         spawn_db_metrics_loop(actor_system.clone(), &storage, period);

--- a/tools/cloud-archive/src/bootstrap_reader.rs
+++ b/tools/cloud-archive/src/bootstrap_reader.rs
@@ -4,6 +4,7 @@ use near_client::archive::cloud_archival_reader::bootstrap_range;
 use near_primitives::types::BlockHeight;
 use near_store::{Mode, NodeStorage};
 use std::path::Path;
+use tokio::runtime::Runtime;
 
 #[derive(clap::Parser)]
 pub(crate) struct BootstrapReaderCmd {
@@ -46,12 +47,10 @@ impl BootstrapReaderCmd {
             .cloud_storage_context()
             .context("cloud_archival not configured in config.json")?;
 
-        // Constructing the GCS client and every retrieval below run on tokio, and this
-        // command is not itself async, so hold a runtime for the rest of the function.
-        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Failed to create Tokio runtime");
+        // Opening cloud storage and every retrieval below run on tokio, and this command
+        // is not async. Multi-threaded on purpose: the retrievals are polled by a foreign
+        // executor, so tokio's driver needs worker threads of its own to make progress.
+        let tokio_runtime = Runtime::new().expect("failed to create the tokio runtime");
         let _runtime_guard = tokio_runtime.enter();
 
         let storage = NodeStorage::opener(

--- a/tools/cloud-archive/src/bootstrap_reader.rs
+++ b/tools/cloud-archive/src/bootstrap_reader.rs
@@ -46,6 +46,14 @@ impl BootstrapReaderCmd {
             .cloud_storage_context()
             .context("cloud_archival not configured in config.json")?;
 
+        // Constructing the GCS client and every retrieval below run on tokio, and this
+        // command is not itself async, so hold a runtime for the rest of the function.
+        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create Tokio runtime");
+        let _runtime_guard = tokio_runtime.enter();
+
         let storage = NodeStorage::opener(
             home_dir,
             &near_config.config.store,


### PR DESCRIPTION
Five fixes found by running the cloud archival fleet.

**Credentialed GCS reads.** `ExternalConnection::get` sends GCS reads unsigned. Cloud archival buckets set `public_access_prevention`, so no reader can read one. `get_authenticated` signs the read through the `object_store` client the connection already uses for uploads. The unsigned arm stays. Nothing needs it since https://github.com/near/nearcore/pull/16009, but collapsing it changes an announced state sync tool, so that belongs in its own PR.

**A tokio runtime in `bootstrap-reader`.** Without one, constructing the GCS client panics with "there is no reactor running". It must be multi-threaded: the retrievals are polled by a foreign executor, so a current-thread runtime never drives its reactor and the download hangs.

**Cold storage and cloud archival become independent.** Reader mode required a cold store. Every cloud archival role reads and writes the hot store. In practice the requirement was met with a `cold-data` path that stayed empty while 6.8 GB went to the hot store, so the check had no behaviour behind it. It is neither required nor rejected now.

**A running node refuses a reader's database.** This comes with the change above, because that cold store requirement is the only thing keeping GC off a reader's database today. A reader marks the store in `DBCol::BlockMisc`. `start_with_config` refuses a marked store before any actor is spawned. The cloud-archive tool does not go through that path, so it still serves what it wrote.

**One log line demoted.** Dumping state parts reads the trie while a snapshot is being created, so lock contention is expected and the caller retries it after 200ms. Every retried part logged at ERROR. That one case is now debug and every other storage error keeps ERROR.
