### PR TITLE
doc(store): fix ChunkHashesByHeight comment from inclusion to creation height

### DIFF
--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -207,9 +207,10 @@ pub enum DBCol {
     /// - *Rows*: BlockHash
     /// - *Column type*: PartialMerkleTree - MerklePath to the leaf + number of leaves in the whole tree.
     BlockMerkleTree,
-    /// Mapping from height to the set of Chunk Hashes created at that height.
+    /// Mapping from height to the set of Chunk Hashes created at that height. Note: a chunk may be
+    /// included in a block with `height >= chunk.height_created()`.
     /// - *Rows*: height (u64)
-    /// - *Column type*: Vec<ChunkHash (CryptoHash)>
+    /// - *Column type*: HashSet<ChunkHash (CryptoHash)>
     ChunkHashesByHeight,
     /// Mapping from block ordinal number (number of the block in the chain) to the BlockHash.
     /// Note: that it can be different than BlockHeight - if we have skipped some heights when creating the blocks.

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -207,7 +207,7 @@ pub enum DBCol {
     /// - *Rows*: BlockHash
     /// - *Column type*: PartialMerkleTree - MerklePath to the leaf + number of leaves in the whole tree.
     BlockMerkleTree,
-    /// Mapping from height to the set of Chunk Hashes that were included in the block at that height.
+    /// Mapping from height to the set of Chunk Hashes created at that height.
     /// - *Rows*: height (u64)
     /// - *Column type*: Vec<ChunkHash (CryptoHash)>
     ChunkHashesByHeight,


### PR DESCRIPTION
The `DBCol::ChunkHashesByHeight` doc said the column maps a height to the chunk hashes "included in the block at that height". The rows are written from `chunk.height_created()` in `ChainStoreUpdate::finalize`, and the GC loops assert it with `debug_assert_eq!(chunk.height_created(), height)`, so the key is the creation height.

The two heights differ whenever a chunk is created at one height and included later, which makes the old wording misleading for anyone reasoning about what GC deletes at a given height. The comment now also states the relation between them: a chunk may be included in a block with `height >= chunk.height_created()`.

The column type in the same comment said `Vec<ChunkHash>`, but nothing uses that type. The writer builds `HashSet<ChunkHash>` (`chain/chain/src/store/mod.rs:1850`) and the readers deserialize a `HashSet` (`core/store/src/adapter/chunk_store.rs:68`, `chain/chain/src/store_validator.rs:218`, `chain/chain/src/store_validator/validate.rs:273`). Borsh encodes `Vec` and `HashSet` the same way (u32 count + items), so this is a doc fix and no stored data changes.
