### PR TITLE
chore(spice): spread data requests over producers and rotate retries

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -1388,9 +1388,9 @@ impl SpiceDataDistributorActor {
     }
 }
 
-/// Requesters start at different indices, so requests for the same data spread over the producers
-/// instead of all landing on one. Each round moves along, so an unresponsive producer is not asked
-/// forever.
+/// The starting producer index is derived from a hash of (data_id, requester), so requests for the
+/// same data are spread across producers instead of all landing on one. Adding `round` advances the
+/// index each tick, so retries move along rather than repeatedly targeting an unresponsive producer.
 fn producer_index_to_request_from(
     num_producers: usize,
     data_id: &SpiceDataIdentifier,

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -72,6 +72,8 @@ use near_store::{TrieDBStorage, TrieStorage};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash as _, Hasher as _};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -187,6 +189,9 @@ pub struct SpiceDataDistributorActor {
     /// at most once.
     /// TODO(spice): re-broadcast until the endorsement appears on chain rather than once.
     broadcast_own_fallback_endorsements: LruCache<SpiceChunkId, ()>,
+
+    /// Rounds of [`Self::request_waiting_on_data`], so each retry moves to another producer.
+    request_round: u64,
 }
 
 struct DistributionData {
@@ -399,6 +404,7 @@ impl SpiceDataDistributorActor {
             broadcast_own_fallback_endorsements: LruCache::new(
                 BROADCAST_FALLBACK_ENDORSEMENTS_CACHE_SIZE,
             ),
+            request_round: 0,
         }
     }
 
@@ -1062,8 +1068,9 @@ impl SpiceDataDistributorActor {
         Ok(())
     }
 
-    fn schedule_data_fetching(&self, ctx: &mut dyn DelayedActionRunner<Self>) {
+    fn schedule_data_fetching(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
         self.request_waiting_on_data();
+        self.request_round = self.request_round.wrapping_add(1);
 
         ctx.run_later(
             "SpiceDataDistributorActor request waiting on data",
@@ -1099,10 +1106,12 @@ impl SpiceDataDistributorActor {
             // producers.
             // TODO(spice): Request data only we know may be available. (For example based on
             // execution and certification heads.)
+            let producer_index =
+                producer_index_to_request_from(producers.len(), id, me, self.request_round);
             self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::SpicePartialDataRequest {
                     request: SpicePartialDataRequest { data_id: id.clone(), requester: me.clone() },
-                    producer: producers.swap_remove(0),
+                    producer: producers.swap_remove(producer_index),
                 },
             ));
         }
@@ -1377,4 +1386,19 @@ impl SpiceDataDistributorActor {
         }
         Ok(())
     }
+}
+
+/// Requesters start at different indices, so requests for the same data spread over the producers
+/// instead of all landing on one. Each round moves along, so an unresponsive producer is not asked
+/// forever.
+fn producer_index_to_request_from(
+    num_producers: usize,
+    data_id: &SpiceDataIdentifier,
+    requester: &AccountId,
+    round: u64,
+) -> usize {
+    let mut hasher = DefaultHasher::new();
+    data_id.hash(&mut hasher);
+    requester.hash(&mut hasher);
+    (hasher.finish().wrapping_add(round) % num_producers as u64) as usize
 }

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -786,6 +786,50 @@ fn drain_outgoing_data_requests(
     requests
 }
 
+fn drain_outgoing_witness_request_producers(
+    outgoing_rc: &mut UnboundedReceiver<OutgoingMessage>,
+    block_hash: &CryptoHash,
+) -> Vec<AccountId> {
+    let mut asked_producers = Vec::new();
+    while let Ok(message) = outgoing_rc.try_recv() {
+        let OutgoingMessage::NetworkRequests {
+            request: NetworkRequests::SpicePartialDataRequest { request, producer },
+        } = message
+        else {
+            continue;
+        };
+        let SpiceDataIdentifier::Witness { block_hash: requested_block_hash, .. } = request.data_id
+        else {
+            continue;
+        };
+        if &requested_block_hash == block_hash {
+            asked_producers.push(producer);
+        }
+    }
+    asked_producers
+}
+
+/// Uses the same assignment lookup as `start_waiting_on_data`, so the sets match.
+fn witness_requesters(chain: &Chain, block: &Block, shard_id: ShardId) -> Vec<AccountId> {
+    let epoch_id = block.header().epoch_id();
+    let producers: HashSet<AccountId> = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(&epoch_id, shard_id)
+        .unwrap()
+        .into_iter()
+        .collect();
+    chain
+        .epoch_manager
+        .get_chunk_validator_assignments(&epoch_id, shard_id, block.header().height())
+        .unwrap()
+        .assignments()
+        .iter()
+        .map(|(account_id, _)| account_id)
+        .filter(|account_id| !producers.contains(*account_id))
+        .cloned()
+        .collect()
+}
+
 fn get_incoming_data<T>(
     producer: &AccountId,
     chain: &Chain,
@@ -1450,6 +1494,77 @@ fn test_incoming_data_is_processed_with_block_arriving_late() {
     actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
     assert_eq!(actor.pending_partial_data_size(), 0);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_witness_requests_from_different_validators_reach_different_producers() {
+    let num_chunk_producers = 4;
+    let (_genesis, mut chain) =
+        setup_with_shard_layout(num_chunk_producers, 8, ShardLayout::single_shard());
+    let block = latest_block(&chain);
+    let next_block = produce_block(&mut chain, &block);
+    save_final_execution_head(&chain, &block);
+
+    let shard_id = witness_shard_id(&next_block);
+    let requesters = witness_requesters(&chain, &next_block, shard_id);
+    assert!(requesters.len() > 1);
+
+    let asked_producers: HashSet<_> = requesters
+        .iter()
+        .map(|requester| {
+            let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+            let mut actor = new_actor_for_account(outgoing_sc, &chain, requester);
+            let mut fake_runner = FakeDelayedActionRunner::default();
+            actor.start_actor(&mut fake_runner);
+
+            let asked =
+                drain_outgoing_witness_request_producers(&mut outgoing_rc, next_block.hash());
+            assert_eq!(asked.len(), 1);
+            asked.into_iter().next().unwrap()
+        })
+        .collect();
+
+    assert!(
+        asked_producers.len() > 1,
+        "{} requesters all asked {asked_producers:?}",
+        requesters.len()
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_witness_request_retries_cycle_through_all_producers() {
+    let num_chunk_producers = 4;
+    let (_genesis, mut chain) =
+        setup_with_shard_layout(num_chunk_producers, 8, ShardLayout::single_shard());
+    let block = latest_block(&chain);
+    let next_block = produce_block(&mut chain, &block);
+    save_final_execution_head(&chain, &block);
+
+    let shard_id = witness_shard_id(&next_block);
+    let requester = witness_requesters(&chain, &next_block, shard_id).into_iter().next().unwrap();
+    let producers: HashSet<AccountId> = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(&next_block.header().epoch_id(), shard_id)
+        .unwrap()
+        .into_iter()
+        .collect();
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &requester);
+    let mut fake_runner = FakeDelayedActionRunner::default();
+    actor.start_actor(&mut fake_runner);
+
+    let mut asked_producers =
+        drain_outgoing_witness_request_producers(&mut outgoing_rc, next_block.hash());
+    for _ in 1..producers.len() {
+        fake_runner.run_queued_actions(&mut actor);
+        asked_producers
+            .extend(drain_outgoing_witness_request_producers(&mut outgoing_rc, next_block.hash()));
+    }
+
+    assert_eq!(asked_producers.into_iter().collect::<HashSet<_>>(), producers);
 }
 
 #[test]


### PR DESCRIPTION
Every node waiting on spice data asked `producers.swap_remove(0)`, so all requesters for the same data hit the same producer, and a retry asked that same producer again however many times it had already failed to answer.

The producer to ask is now derived from a hash of the data id and the requester, offset by a request round that advances on each `request_waiting_on_data` tick. Requesters start at different indices, so requests for one piece of data spread across its producers, and successive retries move along instead of hammering an unresponsive one.

This is just a simple band-aid so all requests don't go to the first producer, while the proper solution is being developed in the data-distribution redesign.