### PR TITLE
fix(spice): re-broadcast a fallback endorsement until it is on chain

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -189,11 +189,6 @@ pub struct SpiceDataDistributorActor {
     /// to avoid redundant storage lookups and network responses for repeated requests.
     processed_contract_code_requests: LruCache<(SpiceChunkId, AccountId), ()>,
 
-    /// Fallback endorsements we already broadcast from a locally recorded result, so we send each
-    /// at most once.
-    /// TODO(spice): re-broadcast until the endorsement appears on chain rather than once.
-    broadcast_own_fallback_endorsements: LruCache<SpiceChunkId, ()>,
-
     spice_gate: SpiceMessageGate,
 
     /// Rounds of [`Self::request_waiting_on_data`], so each retry moves to another producer.
@@ -421,8 +416,6 @@ impl SpiceDataDistributorActor {
         const PENDING_PARTIAL_DATA_CAP: NonZeroUsize = NonZeroUsize::new(10).unwrap();
         const PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE: NonZeroUsize =
             NonZeroUsize::new(30).unwrap();
-        const BROADCAST_FALLBACK_ENDORSEMENTS_CACHE_SIZE: NonZeroUsize =
-            NonZeroUsize::new(100).unwrap();
         Self {
             // TODO(spice): Evaluate whether the same data parts ratio makes sense for all data
             // distributed.
@@ -442,9 +435,6 @@ impl SpiceDataDistributorActor {
             recently_decoded_data: LruCache::new(RECENTLY_DECODED_DATA_CACHE_SIZE),
             processed_contract_code_requests: LruCache::new(
                 PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE,
-            ),
-            broadcast_own_fallback_endorsements: LruCache::new(
-                BROADCAST_FALLBACK_ENDORSEMENTS_CACHE_SIZE,
             ),
             spice_gate: SpiceMessageGate::default(),
             request_round: 0,
@@ -944,22 +934,25 @@ impl SpiceDataDistributorActor {
             if assignments.contains(me) {
                 continue;
             }
+            if self.core_reader.endorsement_exists(&chunk_id.block_hash, chunk_id.shard_id, me) {
+                // Recorded at apply time by a tracker, or on witness validation by a non-tracker.
+                // Broadcast once per block until it is on chain: a first broadcast can reach
+                // producers before they see the fallback open for the chunk, and is dropped there
+                // as irrelevant.
+                let on_chain =
+                    chunk_info.all_present_endorsements().any(|(account_id, _)| account_id == me);
+                if !on_chain {
+                    self.broadcast_own_fallback_endorsement(chunk_id, &signer);
+                }
+                continue;
+            }
             let tracks_shard = self.shard_tracker.should_apply_chunk(
                 ApplyChunksMode::IsCaughtUp,
                 chunk_block.header().prev_hash(),
                 chunk_id.shard_id,
             );
-
-            if self.core_reader.endorsement_exists(&chunk_id.block_hash, chunk_id.shard_id, me) {
-                // Trackers recorded their endorsement at apply time without broadcasting (not yet
-                // eligible); broadcast now. Non-trackers already broadcast via the witness path.
-                if tracks_shard {
-                    self.broadcast_own_fallback_endorsement(chunk_id, &signer);
-                }
-                continue;
-            }
             // A tracker that hasn't applied the chunk yet has no result to endorse; it records and
-            // broadcasts once applied. A non-tracker pulls the witness so it can produce one.
+            // broadcasts after it applies. A non-tracker pulls the witness so it can produce one.
             if !tracks_shard {
                 self.start_waiting_on_fallback_witness(chunk_id, &chunk_block, me)?;
             }
@@ -967,27 +960,27 @@ impl SpiceDataDistributorActor {
         Ok(())
     }
 
-    /// Rebuild the wire endorsement from our recorded result and broadcast it once, so producers
-    /// can include it in the all-stake fallback tally. The result was persisted when we recorded
-    /// the endorsement at apply time.
+    /// Rebuild the wire endorsement from our recorded result and broadcast it, so producers can
+    /// include it in the all-stake fallback tally. The result was persisted when we recorded the
+    /// endorsement at apply time.
     fn broadcast_own_fallback_endorsement(
-        &mut self,
+        &self,
         chunk_id: &SpiceChunkId,
         signer: &ValidatorSigner,
     ) {
-        if self.broadcast_own_fallback_endorsements.contains(chunk_id) {
-            return;
-        }
         let Some(stored) = self.core_reader.get_endorsement(
             &chunk_id.block_hash,
             chunk_id.shard_id,
             signer.validator_id(),
         ) else {
+            // The caller just checked that it exists.
+            debug_assert!(false, "no recorded endorsement to broadcast for {chunk_id:?}");
             return;
         };
         let Some(execution_result) =
             self.core_reader.get_uncertified_execution_result(&stored.execution_result_hash)
         else {
+            tracing::debug!(target: "spice_data_distribution", ?chunk_id, result_hash = ?stored.execution_result_hash, "no execution result for the recorded endorsement");
             return;
         };
         let endorsement = SpiceChunkEndorsement::new(
@@ -1001,7 +994,6 @@ impl SpiceDataDistributorActor {
             &self.network_adapter.clone().into_sender(),
             signer,
         );
-        self.broadcast_own_fallback_endorsements.put(chunk_id.clone(), ());
     }
 
     /// Pull a chunk's witness (not received by non-designated validators in the initial

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -14,6 +14,9 @@ use near_async::test_utils::FakeDelayedActionRunner;
 use near_async::time::Clock;
 use near_chain::Block;
 use near_chain::ChainStoreAccess;
+use near_chain::spice::all_stake_fallback::{
+    SPICE_FALLBACK_CERTIFICATION_DELAY, fallback_endorsers,
+};
 use near_chain::spice::core::SpiceCoreReader;
 use near_chain::spice::core_writer_actor::{ProcessedBlock, SpiceCoreWriterActor};
 use near_chain::test_utils::{
@@ -37,6 +40,7 @@ use near_network::types::{
 };
 use near_o11y::span_wrapped_msg::SpanWrapped;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::block_body::SpiceCoreStatement;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
 use near_primitives::hash::hash;
@@ -45,7 +49,9 @@ use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ReceiptProof;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::sharding::ShardProof;
-use near_primitives::spice::chunk_endorsement::SpiceChunkEndorsement;
+use near_primitives::spice::chunk_endorsement::{
+    SpiceChunkEndorsement, SpiceEndorsementSignedData, testonly_create_endorsement_core_statement,
+};
 use near_primitives::spice::partial_data::{
     SpiceDataCommitment, SpiceDataIdentifier, SpiceDataPart, SpicePartialData,
     SpiceVerifiedPartialData, testonly_create_spice_partial_data,
@@ -73,13 +79,21 @@ use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 fn build_block(epoch_manager: &dyn EpochManagerAdapter, prev_block: &Block) -> Arc<Block> {
+    build_block_with_core_statements(epoch_manager, prev_block, vec![])
+}
+
+fn build_block_with_core_statements(
+    epoch_manager: &dyn EpochManagerAdapter,
+    prev_block: &Block,
+    spice_core_statements: Vec<SpiceCoreStatement>,
+) -> Arc<Block> {
     let block_producer = epoch_manager
         .get_block_producer_info(prev_block.header().epoch_id(), prev_block.header().height() + 1)
         .unwrap();
     let signer = Arc::new(create_test_signer(block_producer.account_id().as_str()));
     TestBlockBuilder::from_prev_block(Clock::real(), prev_block, signer)
         .chunks(get_fake_next_block_chunk_headers(&prev_block, epoch_manager))
-        .spice_core_statements(vec![])
+        .spice_core_statements(spice_core_statements)
         .build()
 }
 
@@ -2561,4 +2575,117 @@ fn test_contract_code_request_happy_path() {
     assert_eq!(decoded_contracts.len(), 1);
     assert_eq!(&*decoded_contracts[0].0, contract_bytes.as_slice());
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
+}
+
+/// Grows the chain until the all-stake fallback is open for a chunk of `shard_id`, and returns it.
+/// Takes the shard's first uncertified chunk, the oldest one, since every block appends its own.
+fn grow_chain_until_fallback_opens(chain: &mut Chain, shard_id: ShardId) -> SpiceChunkId {
+    let head = chain.chain_store.head().unwrap();
+    let chunk_info = chain
+        .spice_core_reader
+        .get_uncertified_chunks(&head.last_block_hash)
+        .unwrap()
+        .into_iter()
+        .find(|chunk_info| chunk_info.chunk_id.shard_id == shard_id)
+        .expect("no uncertified chunk for the shard");
+    let certifiable_since =
+        chunk_info.certifiable_since_height.expect("the oldest chunk is not certifiable yet");
+
+    while chain.chain_store.head().unwrap().height + 1
+        < certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY
+    {
+        produce_block(chain, &latest_block(chain));
+    }
+    chunk_info.chunk_id
+}
+
+fn broadcast_endorsement_chunk_ids(
+    outgoing_rc: &mut UnboundedReceiver<OutgoingMessage>,
+) -> HashSet<SpiceChunkId> {
+    let mut chunk_ids = HashSet::new();
+    while let Ok(message) = outgoing_rc.try_recv() {
+        let OutgoingMessage::NetworkRequests {
+            request: NetworkRequests::SpiceChunkEndorsement(_target, endorsement),
+        } = message
+        else {
+            continue;
+        };
+        chunk_ids.insert(SpiceChunkId {
+            block_hash: *endorsement.block_hash(),
+            shard_id: endorsement.shard_id(),
+        });
+    }
+    chunk_ids
+}
+
+/// Produces a block whose core statements carry `validator`'s stored endorsement of `chunk_id`.
+fn produce_block_carrying_endorsement(
+    chain: &mut Chain,
+    prev_block: &Block,
+    chunk_id: &SpiceChunkId,
+    validator: &AccountId,
+) -> Arc<Block> {
+    let stored = chain
+        .spice_core_reader
+        .get_endorsement(&chunk_id.block_hash, chunk_id.shard_id, validator)
+        .unwrap();
+    let core_statement =
+        SpiceCoreStatement::Endorsement(testonly_create_endorsement_core_statement(
+            validator.clone(),
+            stored.signature.clone(),
+            SpiceEndorsementSignedData {
+                execution_result_hash: stored.execution_result_hash,
+                chunk_id: chunk_id.clone(),
+            },
+        ));
+    let block = build_block_with_core_statements(
+        chain.epoch_manager.as_ref(),
+        prev_block,
+        vec![core_statement],
+    );
+    process_block_sync(
+        chain,
+        block.clone().into(),
+        Provenance::PRODUCED,
+        &mut BlockProcessingArtifact::default(),
+    )
+    .unwrap();
+    block
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_fallback_endorsement_is_broadcast_on_every_block_until_it_is_on_chain() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (_genesis, mut chain) = setup(2, 100);
+    let shard_id = witness_shard_id(&latest_block(&chain));
+    let chunk_id = grow_chain_until_fallback_opens(&mut chain, shard_id);
+
+    let chunk_block = chain.chain_store.get_block(&chunk_id.block_hash).unwrap();
+    let validator = fallback_endorsers(
+        chain.epoch_manager.as_ref(),
+        chunk_block.header().epoch_id(),
+        chunk_id.shard_id,
+        chunk_block.header().height(),
+    )
+    .unwrap()
+    .into_iter()
+    .next()
+    .expect("no non-designated validator; increase the validator count");
+    record_endorsement(&chain, chunk_id.clone(), &validator);
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);
+
+    let mut block = latest_block(&chain);
+    for _ in 0..3 {
+        actor.handle(ProcessedBlock { block_hash: *block.hash() });
+        assert!(broadcast_endorsement_chunk_ids(&mut outgoing_rc).contains(&chunk_id));
+        block = produce_block(&mut chain, &block);
+    }
+
+    let carrying_block =
+        produce_block_carrying_endorsement(&mut chain, &block, &chunk_id, &validator);
+    actor.handle(ProcessedBlock { block_hash: *carrying_block.hash() });
+    assert!(!broadcast_endorsement_chunk_ids(&mut outgoing_rc).contains(&chunk_id));
 }


### PR DESCRIPTION
A validator that endorses a chunk through the all-stake fallback broadcast that endorsement exactly once. A non-designated validator sent it from the witness validation path, and a tracker re-sent it once from an LRU cache. A producer that has not yet seen the fallback open for the chunk rejects the endorsement as irrelevant, and nothing ever sent it again, so that validator's stake left the fallback tally for good.

Broadcast once per block while the endorsement is not on chain instead. `SpiceUncertifiedChunkInfo` already records which endorsements landed, so the stop condition comes from chain state, and the broadcast-once cache and its TODO are gone.

The new test fails on master and passes with the change.

Second of three, stacked on #16213. #16212 pushes the witness when the fallback opens, which is what makes this race common rather than rare.