### PR TITLE
feat(spice): push the witness when the all-stake fallback opens

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -23,7 +23,7 @@ use near_chain::Block;
 use near_chain::spice::activation::{
     SpiceMessageGate, SpiceMessageKind, spice_enabled_at_head_on_startup, spice_enabled_for_block,
 };
-use near_chain::spice::all_stake_fallback::fallback_eligible;
+use near_chain::spice::all_stake_fallback::{fallback_eligible, fallback_endorsers};
 use near_chain::spice::core::SpiceCoreReader;
 use near_chain::spice::core_writer_actor::ProcessedBlock;
 use near_chain::stateless_validation::metrics::PROCESS_CONTRACT_CODE_REQUEST_TIME;
@@ -63,6 +63,7 @@ use near_primitives::stateless_validation::contract_distribution::{
     SpiceContractCodeRequest, SpiceContractCodeResponse,
 };
 use near_primitives::types::AccountId;
+use near_primitives::types::BlockHeight;
 use near_primitives::types::EpochId;
 use near_primitives::types::ShardId;
 use near_primitives::types::SpiceChunkId;
@@ -154,6 +155,16 @@ impl ReceiveDataError {
     }
 }
 
+/// Blocks between the all-stake fallback opening for a chunk and a non-designated validator
+/// starting to request its witness. The producers push the witness when the fallback opens, so the
+/// request only covers a push that did not arrive.
+pub(crate) const FALLBACK_WITNESS_PULL_GRACE: BlockHeight = 2;
+
+/// A producer pushes the moment it sees the fallback open for a chunk. A receiver whose head is a
+/// few blocks behind does not see it open yet, so it accepts a push for a chunk that becomes
+/// fallback eligible within this many blocks. Only decides whether to buffer the parts.
+pub(crate) const FALLBACK_WITNESS_PUSH_LOOKAHEAD: BlockHeight = 2;
+
 /// Bundles channels for all SPICE-related messages that the network layer dispatches to.
 /// Acts as a demux: handles messages it owns (partial data, etc) directly, and forwards the other
 /// message types (contract-{accesses,response}) to validator via injected senders.
@@ -178,7 +189,7 @@ pub struct SpiceDataDistributorActor {
     pending_partial_data: LruCache<CryptoHash, Vec<SpiceVerifiedPartialData>>,
 
     // TODO(spice): Populate data we are waiting on during actor start.
-    waiting_on_data: HashMap<SpiceDataIdentifier, HashMap<SpiceDataCommitment, DataPartsEntry>>,
+    waiting_on_data: HashMap<SpiceDataIdentifier, WaitingOnDataEntry>,
     // Purpose of this cache is to help make sure we don't decode the same data over and over.
     // TODO(spice): Once we remove data from waiting_on_data when it's saved (either relevant
     // endorsement or receipts are validated and saved), we should get rid of this cache and rely
@@ -190,6 +201,12 @@ pub struct SpiceDataDistributorActor {
     processed_contract_code_requests: LruCache<(SpiceChunkId, AccountId), ()>,
 
     spice_gate: SpiceMessageGate,
+
+    /// Chunks whose witness we already pushed for the all-stake fallback. A chunk stays eligible
+    /// for many blocks, so we push each once and leave a lost push to the recipients' request.
+    /// Only the oldest uncertified block's chunks are ever eligible, and entries go away once the
+    /// chunk certifies, so this holds at most one block's worth of chunks.
+    pushed_fallback_witnesses: HashSet<SpiceChunkId>,
 
     /// Rounds of [`Self::request_waiting_on_data`], so each retry moves to another producer.
     request_round: u64,
@@ -224,6 +241,24 @@ pub struct SpiceDataDistributorAdapter {
 
 struct DataPartsEntry {
     tracker: ReedSolomonPartsTracker<SpiceData>,
+}
+
+/// Data we still miss: the parts received so far, and when we may start requesting it.
+struct WaitingOnDataEntry {
+    parts_by_commitment: HashMap<SpiceDataCommitment, DataPartsEntry>,
+    /// Head height from which we send requests for this data. Designated recipients are allowed to
+    /// request right away; fallback recipients hold back so the producers' push can arrive first.
+    request_from_height: BlockHeight,
+}
+
+impl WaitingOnDataEntry {
+    fn request_immediately() -> Self {
+        Self { parts_by_commitment: HashMap::new(), request_from_height: 0 }
+    }
+
+    fn request_from_height(request_from_height: BlockHeight) -> Self {
+        Self { parts_by_commitment: HashMap::new(), request_from_height }
+    }
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -386,6 +421,9 @@ impl Handler<ProcessedBlock> for SpiceDataDistributorActor {
                 return;
             }
         }
+        if let Err(err) = self.push_fallback_witnesses(&block_hash) {
+            tracing::error!(target: "spice_data_distribution", ?err, "failed pushing fallback witnesses");
+        }
         if let Err(err) = self.contribute_fallback_endorsements(&block_hash) {
             tracing::error!(target: "spice_data_distribution", ?err, "failed contributing fallback endorsements");
         }
@@ -437,6 +475,7 @@ impl SpiceDataDistributorActor {
                 PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE,
             ),
             spice_gate: SpiceMessageGate::default(),
+            pushed_fallback_witnesses: HashSet::new(),
             request_round: 0,
         }
     }
@@ -635,15 +674,18 @@ impl SpiceDataDistributorActor {
         // It's possible that waiting_on_data wasn't populated yet if we received data after block
         // became available but before we processed it.
         self.start_waiting_on_data(block.hash())?;
+        if !self.waiting_on_data.contains_key(&id) {
+            self.start_waiting_on_pushed_fallback_witness(&id, block)?;
+        }
 
-        let Some(data_parts) = self.waiting_on_data.get_mut(&id) else {
+        let Some(waiting) = self.waiting_on_data.get_mut(&id) else {
             return Err(Error::DataIsIrrelevant(id));
         };
 
         // TODO(spice): Check that encoded_length isn't too large.
         let encoded_length = commitment.encoded_length;
         let total_parts = producers.len();
-        let entry = data_parts.entry(commitment.clone()).or_insert_with(|| {
+        let entry = waiting.parts_by_commitment.entry(commitment.clone()).or_insert_with(|| {
             let encoder = self.rs_encoders.entry(total_parts);
             DataPartsEntry {
                 tracker: ReedSolomonPartsTracker::new(encoder, encoded_length as usize),
@@ -954,8 +996,101 @@ impl SpiceDataDistributorActor {
             // A tracker that hasn't applied the chunk yet has no result to endorse; it records and
             // broadcasts after it applies. A non-tracker pulls the witness so it can produce one.
             if !tracks_shard {
-                self.start_waiting_on_fallback_witness(chunk_id, &chunk_block, me)?;
+                self.start_waiting_on_fallback_witness(
+                    chunk_id,
+                    &chunk_block,
+                    me,
+                    block.header().height() + FALLBACK_WITNESS_PULL_GRACE,
+                )?;
             }
+        }
+        Ok(())
+    }
+
+    /// As a chunk producer, push an overdue chunk's witness to the epoch validators that did not
+    /// receive it in the initial distribution, so they can endorse it via the all-stake fallback.
+    /// Every producer of the shard holds the witness and sees the same eligibility, so each sends
+    /// its own part to the wider set exactly as it did in the initial distribution.
+    fn push_fallback_witnesses(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
+        let Some(signer) = self.validator_signer.get() else {
+            return Ok(());
+        };
+        let me = signer.validator_id();
+        let block = self.chain_store.get_block(block_hash)?;
+        let carrying_height = block.header().height() + 1;
+
+        let uncertified_chunks = self.core_reader.get_uncertified_chunks(block_hash)?;
+        let still_uncertified: HashSet<&SpiceChunkId> =
+            uncertified_chunks.iter().map(|chunk_info| &chunk_info.chunk_id).collect();
+        self.pushed_fallback_witnesses.retain(|chunk_id| still_uncertified.contains(chunk_id));
+
+        for chunk_info in &uncertified_chunks {
+            let chunk_id = &chunk_info.chunk_id;
+            if !fallback_eligible(carrying_height, chunk_info) {
+                continue;
+            }
+            if self.pushed_fallback_witnesses.contains(chunk_id) {
+                continue;
+            }
+            let data_id = SpiceDataIdentifier::Witness {
+                block_hash: chunk_id.block_hash,
+                shard_id: chunk_id.shard_id,
+            };
+            let chunk_block = self.chain_store.get_block(&chunk_id.block_hash)?;
+            // The designated recipients of the initial distribution are not needed here:
+            // fallback_endorsers already excludes every designated validator.
+            let (_, producers) = self.recipients_and_producers(&data_id, &chunk_block)?;
+            let Some(my_producer_index) = producers.iter().position(|producer| producer == me)
+            else {
+                continue;
+            };
+            let recipients: HashSet<AccountId> = fallback_endorsers(
+                self.epoch_manager.as_ref(),
+                chunk_block.header().epoch_id(),
+                chunk_id.shard_id,
+                chunk_block.header().height(),
+            )?
+            .into_iter()
+            .filter(|account_id| !producers.contains(account_id))
+            .collect();
+            debug_assert!(!recipients.contains(me));
+            if recipients.is_empty() {
+                continue;
+            }
+            let Some(mut distribution_data) = self.get_distribution_data(&data_id, producers.len())
+            else {
+                tracing::warn!(target: "spice_data_distribution", ?data_id, "no witness to push for the all-stake fallback");
+                continue;
+            };
+            let my_part = distribution_data.parts.swap_remove(my_producer_index);
+
+            // Sent before the witness for the same reason as in the initial distribution: the
+            // recipient can check its compiled contract cache while the parts arrive.
+            let accesses = get_contract_accesses(
+                self.chain_store.store_ref(),
+                &chunk_id.block_hash,
+                chunk_id.shard_id,
+            )
+            .expect("contract accesses should have been written atomically with witness");
+            let accesses_msg = SpiceChunkContractAccesses::new(chunk_id.clone(), accesses, &signer);
+            self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                NetworkRequests::SpiceChunkContractAccesses(
+                    recipients.iter().cloned().collect(),
+                    accesses_msg,
+                ),
+            ));
+            self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                NetworkRequests::SpicePartialData {
+                    partial_data: SpicePartialData::new(
+                        data_id,
+                        distribution_data.commitment,
+                        vec![my_part],
+                        &signer,
+                    ),
+                    recipients,
+                },
+            ));
+            self.pushed_fallback_witnesses.insert(chunk_id.clone());
         }
         Ok(())
     }
@@ -1003,6 +1138,7 @@ impl SpiceDataDistributorActor {
         chunk_id: &SpiceChunkId,
         chunk_block: &Block,
         me: &AccountId,
+        request_from_height: BlockHeight,
     ) -> Result<(), Error> {
         let id = SpiceDataIdentifier::Witness {
             block_hash: chunk_id.block_hash,
@@ -1016,8 +1152,60 @@ impl SpiceDataDistributorActor {
         {
             return Ok(());
         }
-        self.waiting_on_data.insert(id, HashMap::new());
+        self.waiting_on_data
+            .insert(id, WaitingOnDataEntry::request_from_height(request_from_height));
         Ok(())
+    }
+
+    /// A producer pushes an overdue chunk's witness as soon as the fallback opens, which can be
+    /// before we processed the block that opened it. Start waiting on the witness now, so the
+    /// pushed parts have somewhere to go, if we are a validator the fallback expects to endorse it.
+    fn start_waiting_on_pushed_fallback_witness(
+        &mut self,
+        id: &SpiceDataIdentifier,
+        chunk_block: &Block,
+    ) -> Result<(), Error> {
+        let SpiceDataIdentifier::Witness { block_hash, shard_id } = id else {
+            return Ok(());
+        };
+        let Some(signer) = self.validator_signer.get() else {
+            return Ok(());
+        };
+        let me = signer.validator_id();
+        let epoch_id = chunk_block.header().epoch_id();
+        if self.epoch_manager.get_validator_by_account_id(epoch_id, me).is_err() {
+            return Ok(());
+        }
+        let assignments = self.epoch_manager.get_chunk_validator_assignments(
+            epoch_id,
+            *shard_id,
+            chunk_block.header().height(),
+        )?;
+        if assignments.contains(me) {
+            return Ok(());
+        }
+        if self.shard_tracker.should_apply_chunk(
+            ApplyChunksMode::IsCaughtUp,
+            chunk_block.header().prev_hash(),
+            *shard_id,
+        ) {
+            return Ok(());
+        }
+        let chunk_id = SpiceChunkId { block_hash: *block_hash, shard_id: *shard_id };
+        let head = self.chain_store.head()?;
+        if !self.core_reader.fallback_eligible_in_carrying_block(
+            head.height + 1 + FALLBACK_WITNESS_PUSH_LOOKAHEAD,
+            &head.last_block_hash,
+            &chunk_id,
+        )? {
+            return Ok(());
+        }
+        self.start_waiting_on_fallback_witness(
+            &chunk_id,
+            chunk_block,
+            me,
+            head.height + FALLBACK_WITNESS_PULL_GRACE,
+        )
     }
 
     fn start_waiting_on_data(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
@@ -1104,7 +1292,7 @@ impl SpiceDataDistributorActor {
                 tracing::debug!(target: "spice_data_distribution", ?id, "data is known; will not start waiting on it");
                 continue;
             }
-            self.waiting_on_data.insert(id, HashMap::new());
+            self.waiting_on_data.insert(id, WaitingOnDataEntry::request_immediately());
         }
         Ok(())
     }
@@ -1130,9 +1318,19 @@ impl SpiceDataDistributorActor {
             return;
         };
         let me = signer.validator_id();
+        let head_height = match self.chain_store.head() {
+            Ok(head) => head.height,
+            Err(err) => {
+                tracing::error!(target: "spice_data_distribution", ?err, "no head to request data at");
+                return;
+            }
+        };
         // TODO(spice): Stop waiting on witnesses past final certification head.
 
-        for (id, _data_parts) in &self.waiting_on_data {
+        for (id, waiting) in &self.waiting_on_data {
+            if head_height < waiting.request_from_height {
+                continue;
+            }
             let block = self
                 .chain_store
                 .get_block(id.block_hash())

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -3,8 +3,8 @@ use crate::spice::chunk_executor_actor::{
 };
 use crate::spice::chunk_validator_actor::SpiceChunkStateWitnessMessage;
 use crate::spice::data_distributor_actor::{
-    Error, ReceiveDataError, SpiceDataDistributorActor, SpiceDistributorOutgoingReceipts,
-    SpiceDistributorStateWitness,
+    Error, FALLBACK_WITNESS_PULL_GRACE, FALLBACK_WITNESS_PUSH_LOOKAHEAD, ReceiveDataError,
+    SpiceDataDistributorActor, SpiceDistributorOutgoingReceipts, SpiceDistributorStateWitness,
 };
 use assert_matches::assert_matches;
 use itertools::Itertools as _;
@@ -2577,9 +2577,18 @@ fn test_contract_code_request_happy_path() {
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
 }
 
-/// Grows the chain until the all-stake fallback is open for a chunk of `shard_id`, and returns it.
-/// Takes the shard's first uncertified chunk, the oldest one, since every block appends its own.
 fn grow_chain_until_fallback_opens(chain: &mut Chain, shard_id: ShardId) -> SpiceChunkId {
+    grow_chain_toward_fallback_opening(chain, shard_id, 0)
+}
+
+/// Grows the chain until the all-stake fallback is `blocks_short` blocks away from opening for a
+/// chunk of `shard_id`, and returns it. Takes the shard's first uncertified chunk, the oldest one,
+/// since every block appends its own.
+fn grow_chain_toward_fallback_opening(
+    chain: &mut Chain,
+    shard_id: ShardId,
+    blocks_short: BlockHeight,
+) -> SpiceChunkId {
     let head = chain.chain_store.head().unwrap();
     let chunk_info = chain
         .spice_core_reader
@@ -2591,7 +2600,7 @@ fn grow_chain_until_fallback_opens(chain: &mut Chain, shard_id: ShardId) -> Spic
     let certifiable_since =
         chunk_info.certifiable_since_height.expect("the oldest chunk is not certifiable yet");
 
-    while chain.chain_store.head().unwrap().height + 1
+    while chain.chain_store.head().unwrap().height + 1 + blocks_short
         < certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY
     {
         produce_block(chain, &latest_block(chain));
@@ -2688,4 +2697,220 @@ fn test_fallback_endorsement_is_broadcast_on_every_block_until_it_is_on_chain() 
         produce_block_carrying_endorsement(&mut chain, &block, &chunk_id, &validator);
     actor.handle(ProcessedBlock { block_hash: *carrying_block.hash() });
     assert!(!broadcast_endorsement_chunk_ids(&mut outgoing_rc).contains(&chunk_id));
+}
+
+fn save_test_witness_for_chunk(chain: &Chain, chunk_id: &SpiceChunkId) -> SpiceChunkStateWitness {
+    let block = chain.chain_store.get_block(&chunk_id.block_hash).unwrap();
+    let chunks = block.chunks();
+    let chunk_header =
+        chunks.iter_raw().find(|chunk| chunk.shard_id() == chunk_id.shard_id).unwrap();
+    let witness = new_test_witness_for_chunk(&block, chunk_header);
+    save_witness_and_contract_accesses(
+        &chain.chain_store,
+        block.hash(),
+        chunk_id.shard_id,
+        &witness,
+        &HashSet::new(),
+    );
+    witness
+}
+
+/// What the push targets: the fallback endorsers of `chunk_id`, less its producers, who already
+/// hold the witness.
+fn fallback_witness_recipients(chain: &Chain, chunk_id: &SpiceChunkId) -> HashSet<AccountId> {
+    let block = chain.chain_store.get_block(&chunk_id.block_hash).unwrap();
+    let epoch_id = block.header().epoch_id();
+    let producers: HashSet<AccountId> = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(epoch_id, chunk_id.shard_id)
+        .unwrap()
+        .into_iter()
+        .collect();
+    fallback_endorsers(
+        chain.epoch_manager.as_ref(),
+        epoch_id,
+        chunk_id.shard_id,
+        block.header().height(),
+    )
+    .unwrap()
+    .into_iter()
+    .filter(|account_id| !producers.contains(account_id))
+    .collect()
+}
+
+fn requested_witness_chunk_ids(
+    outgoing_rc: &mut UnboundedReceiver<OutgoingMessage>,
+) -> HashSet<SpiceChunkId> {
+    drain_outgoing_data_requests(outgoing_rc)
+        .into_iter()
+        .filter_map(|request| match request.data_id {
+            SpiceDataIdentifier::Witness { block_hash, shard_id } => {
+                Some(SpiceChunkId { block_hash, shard_id })
+            }
+            SpiceDataIdentifier::ReceiptProof { .. } => None,
+        })
+        .collect()
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_witness_is_pushed_when_fallback_opens() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (_genesis, mut chain) = setup(2, 100);
+    let shard_id = witness_shard_id(&latest_block(&chain));
+    let chunk_id = grow_chain_until_fallback_opens(&mut chain, shard_id);
+    let witness = save_test_witness_for_chunk(&chain, &chunk_id);
+
+    let head_block = latest_block(&chain);
+    let producer = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(head_block.header().epoch_id(), shard_id)
+        .unwrap()
+        .swap_remove(0);
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
+    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+
+    let mut pushes = drain_outgoing_partial_data(&mut outgoing_rc);
+    assert_eq!(pushes.len(), 1);
+    let (partial_data, recipients) = pushes.swap_remove(0);
+    assert_eq!(partial_data.block_hash(), &witness.chunk_id().block_hash);
+    assert_eq!(recipients, fallback_witness_recipients(&chain, &chunk_id));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_witness_is_pushed_only_once() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (_genesis, mut chain) = setup(2, 100);
+    let shard_id = witness_shard_id(&latest_block(&chain));
+    let chunk_id = grow_chain_until_fallback_opens(&mut chain, shard_id);
+    save_test_witness_for_chunk(&chain, &chunk_id);
+
+    let head_block = latest_block(&chain);
+    let producer = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(head_block.header().epoch_id(), shard_id)
+        .unwrap()
+        .swap_remove(0);
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
+    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+    assert_eq!(drain_outgoing_partial_data(&mut outgoing_rc).len(), 1);
+
+    let next_block = produce_block(&mut chain, &head_block);
+    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_fallback_witness_is_requested_only_after_the_pull_grace() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (_genesis, mut chain) = setup(2, 100);
+    let shard_id = witness_shard_id(&latest_block(&chain));
+    let chunk_id = grow_chain_until_fallback_opens(&mut chain, shard_id);
+
+    let head_block = latest_block(&chain);
+    save_final_execution_head(&chain, &head_block);
+    let validator =
+        fallback_witness_recipients(&chain, &chunk_id).into_iter().sorted().next().unwrap();
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);
+    let mut fake_runner = FakeDelayedActionRunner::default();
+    actor.start_actor(&mut fake_runner);
+    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+
+    fake_runner.run_queued_actions(&mut actor);
+    assert!(!requested_witness_chunk_ids(&mut outgoing_rc).contains(&chunk_id));
+
+    let mut block = head_block;
+    for _ in 0..FALLBACK_WITNESS_PULL_GRACE {
+        block = produce_block(&mut chain, &block);
+    }
+    fake_runner.run_queued_actions(&mut actor);
+    assert!(requested_witness_chunk_ids(&mut outgoing_rc).contains(&chunk_id));
+}
+
+/// A producer's own part of `chunk_id`'s witness, the same content a fallback push carries.
+fn pushed_witness_data(chain: &Chain, chunk_id: &SpiceChunkId) -> SpicePartialData {
+    let block = chain.chain_store.get_block(&chunk_id.block_hash).unwrap();
+    let chunks = block.chunks();
+    let chunk_header =
+        chunks.iter_raw().find(|chunk| chunk.shard_id() == chunk_id.shard_id).unwrap();
+    let state_witness = new_test_witness_for_chunk(&block, chunk_header);
+    let producer = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(block.header().epoch_id(), chunk_id.shard_id)
+        .unwrap()
+        .swap_remove(0);
+    let (incoming, _) = get_incoming_data(
+        &producer,
+        chain,
+        SpiceDistributorStateWitness { contract_accesses: HashSet::new(), state_witness },
+    );
+    incoming.data
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_pushed_fallback_witness_is_kept_when_head_is_within_the_lookahead() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (_genesis, mut chain) = setup(2, 100);
+    let shard_id = witness_shard_id(&latest_block(&chain));
+    // The producer pushes as soon as it sees the fallback open. This receiver is still short of
+    // that height, so it has no entry waiting for the witness.
+    let chunk_id =
+        grow_chain_toward_fallback_opening(&mut chain, shard_id, FALLBACK_WITNESS_PUSH_LOOKAHEAD);
+    let data = pushed_witness_data(&chain, &chunk_id);
+    let validator = fallback_witness_recipients(&chain, &chunk_id)
+        .into_iter()
+        .sorted()
+        .next()
+        .expect("no non-designated validator; increase the validator count");
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);
+    actor.handle(SpiceIncomingPartialData { data, recv_permit: RecvMessagePermit::none() });
+
+    let message = outgoing_rc.try_recv().unwrap();
+    let OutgoingMessage::ChunkStateWitnessMessage(SpiceChunkStateWitnessMessage {
+        witness, ..
+    }) = message
+    else {
+        panic!("expected the pushed witness to be reassembled");
+    };
+    assert_eq!(witness.chunk_id(), &chunk_id);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_pushed_fallback_witness_is_dropped_when_head_is_beyond_the_lookahead() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (_genesis, mut chain) = setup(2, 100);
+    let shard_id = witness_shard_id(&latest_block(&chain));
+    let chunk_id = grow_chain_toward_fallback_opening(
+        &mut chain,
+        shard_id,
+        FALLBACK_WITNESS_PUSH_LOOKAHEAD + 1,
+    );
+    let data = pushed_witness_data(&chain, &chunk_id);
+    let validator = fallback_witness_recipients(&chain, &chunk_id)
+        .into_iter()
+        .sorted()
+        .next()
+        .expect("no non-designated validator; increase the validator count");
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);
+    let result = actor.receive_data(data);
+
+    assert_matches!(
+        result,
+        Err(ReceiveDataError::ReceivingDataWithBlock(Error::DataIsIrrelevant(_)))
+    );
+    assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
 }

--- a/test-loop-tests/src/setup/drop_condition.rs
+++ b/test-loop-tests/src/setup/drop_condition.rs
@@ -2,7 +2,7 @@ use super::peer_manager_actor::NetworkRequestHandler;
 use super::state::NodeExecutionData;
 use crate::utils::network::{
     block_dropper_by_height, chunk_endorsement_dropper, chunk_endorsement_dropper_by_hash,
-    spice_designated_endorsement_dropper,
+    spice_designated_endorsement_dropper, spice_partial_data_request_dropper,
 };
 use near_async::messaging::{CanSend, LateBoundSender};
 use near_async::test_loop::data::TestLoopData;
@@ -47,6 +47,9 @@ pub enum DropCondition {
     /// disabling the designated certification path so chunks can certify only via the all-stake
     /// fallback.
     DesignatedSpiceEndorsements,
+    /// Drops every request for spice partial data, so a node can only get data that was pushed to
+    /// it.
+    SpicePartialDataRequests,
 }
 
 /// Stores all chunks ever observed on chain. Determines if a chunk can be
@@ -149,6 +152,12 @@ impl NodeExecutionData {
             }
             DropCondition::DesignatedSpiceEndorsements => {
                 self.register_drop_designated_spice_endorsements(test_loop_data);
+            }
+            DropCondition::SpicePartialDataRequests => {
+                self.register_override_handler(
+                    test_loop_data,
+                    spice_partial_data_request_dropper(),
+                );
             }
         }
     }

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -164,6 +164,32 @@ fn slow_test_spice_all_stake_fallback_certifies_without_designated_endorsements(
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_all_stake_fallback_certifies_without_witness_requests() {
+    init_test_logger();
+
+    let (accounts, genesis, epoch_config_store) = FallbackSetup::new().build();
+    // Every request for partial data is dropped, so a non-designated validator can endorse only if
+    // the producers pushed the witness to it when the fallback opened.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .build()
+        .drop(DropCondition::DesignatedSpiceEndorsements)
+        .drop(DropCondition::SpicePartialDataRequests);
+    assert_fallback_has_enough_stake(&env.node(0));
+
+    let target = env.node(0).last_certified_block_header().height() + 4;
+    env.node_runner(0).run_until(
+        |node| node.last_certified_block_header().height() >= target,
+        Duration::seconds(300),
+    );
+    let frontier = env.node(0).last_certified_block_header();
+    assert_certified_via_fallback(&env.node(0), frontier.as_ref());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn slow_test_spice_all_stake_fallback_certifies_across_epoch_boundary() {
     init_test_logger();
 

--- a/test-loop-tests/src/utils/network.rs
+++ b/test-loop-tests/src/utils/network.rs
@@ -84,6 +84,16 @@ pub fn spice_designated_endorsement_dropper(
     })
 }
 
+/// Handler to drop every request for spice partial data, leaving only pushed data to arrive.
+pub fn spice_partial_data_request_dropper() -> Box<dyn Fn(NetworkRequests) -> HandlerResult> {
+    Box::new(move |request| match &request {
+        NetworkRequests::SpicePartialDataRequest { .. } => {
+            HandlerResult::Handled(NetworkResponses::NoResponse)
+        }
+        _ => HandlerResult::Unhandled(request),
+    })
+}
+
 /// Handler to drop all network messages containing chunk endorsements sent
 /// from a given chunk-validator account.
 pub fn chunk_endorsement_dropper(


### PR DESCRIPTION
When a chunk goes overdue the all-stake fallback lets any epoch validator endorse it, but a non-designated validator could only get the witness by requesting it, one request per second per node, after noticing the chunk was overdue itself.

Every chunk producer of the shard already holds the witness and computes the same eligibility from on-chain data, so each now sends its own erasure part, together with the contract accesses, to the fallback endorsers that are not producers of the chunk. This reuses the erasure spread of the initial distribution: no new message type and no new encoding.

The request stays as the recovery path for a push that did not arrive. It is held back two blocks so it does not duplicate the push, and a receiver whose head lags accepts a push for a chunk that becomes eligible within two blocks, so an early push is not discarded.

`DropCondition::SpicePartialDataRequests` drops every partial data request, so the new test-loop test certifies only if the push carries the witness on its own.

Third of three, stacked on #16211, which it needs: without it an endorsement produced from an early push is dropped once and never sent again.