### PR TITLE
refactor(spice): extract the fallback_endorsers function

### DIFF
--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -4,7 +4,7 @@
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::errors::EpochError;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
-use near_primitives::types::{BlockHeight, EpochId, SpiceUncertifiedChunkInfo};
+use near_primitives::types::{AccountId, BlockHeight, EpochId, ShardId, SpiceUncertifiedChunkInfo};
 
 /// Blocks a chunk must stay certifiable-but-uncertified before the all-stake fallback opens for it.
 /// Well below epoch length (to rescue liveness before the one-epoch lag guard stalls consensus).
@@ -34,4 +34,25 @@ pub fn all_stake_fallback_assignment(
     let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
     let assignments = epoch_info.validators_iter().map(|validator| validator.account_and_stake());
     Ok(ChunkValidatorAssignments::new(assignments.collect()))
+}
+
+/// Epoch validators that may endorse the chunk only through the all-stake fallback: every validator
+/// of the epoch that is not designated for it. Ordered by the epoch's validator order, so callers
+/// building block content stay deterministic.
+pub fn fallback_endorsers(
+    epoch_manager: &dyn EpochManagerAdapter,
+    epoch_id: &EpochId,
+    shard_id: ShardId,
+    chunk_height_created: BlockHeight,
+) -> Result<Vec<AccountId>, EpochError> {
+    let designated =
+        epoch_manager.get_chunk_validator_assignments(epoch_id, shard_id, chunk_height_created)?;
+    let all_validators = all_stake_fallback_assignment(epoch_manager, epoch_id)?;
+    Ok(all_validators
+        .assignments()
+        .iter()
+        .map(|(account_id, _)| account_id)
+        .filter(|account_id| !designated.contains(account_id))
+        .cloned()
+        .collect())
 }

--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -37,8 +37,8 @@ pub fn all_stake_fallback_assignment(
 }
 
 /// Epoch validators that may endorse the chunk only through the all-stake fallback: every validator
-/// of the epoch that is not designated for it. Ordered by the epoch's validator order, so callers
-/// building block content stay deterministic.
+/// of the epoch that is not designated for it. Keeps the epoch's validator order, the same order
+/// [`all_stake_fallback_assignment`] has, so callers building block content stay deterministic.
 pub fn fallback_endorsers(
     epoch_manager: &dyn EpochManagerAdapter,
     epoch_id: &EpochId,
@@ -47,12 +47,10 @@ pub fn fallback_endorsers(
 ) -> Result<Vec<AccountId>, EpochError> {
     let designated =
         epoch_manager.get_chunk_validator_assignments(epoch_id, shard_id, chunk_height_created)?;
-    let all_validators = all_stake_fallback_assignment(epoch_manager, epoch_id)?;
-    Ok(all_validators
-        .assignments()
-        .iter()
-        .map(|(account_id, _)| account_id)
+    let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
+    Ok(epoch_info
+        .validators_iter()
+        .map(|validator| validator.take_account_id())
         .filter(|account_id| !designated.contains(account_id))
-        .cloned()
         .collect())
 }

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,5 +1,7 @@
 use crate::metrics;
-use crate::spice::all_stake_fallback::{all_stake_fallback_assignment, fallback_eligible};
+use crate::spice::all_stake_fallback::{
+    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers,
+};
 use crate::spice::ancestry_endorsements::AncestryEndorsements;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
 use near_chain_primitives::Error;
@@ -380,21 +382,19 @@ impl SpiceCoreReader {
         let chunk_id = &chunk_info.chunk_id;
         let chunk_block_header = self.chain_store.get_block_header(&chunk_id.block_hash)?;
         let epoch_id = chunk_block_header.epoch_id();
-        let designated = self.epoch_manager.get_chunk_validator_assignments(
+        let endorsers = fallback_endorsers(
+            self.epoch_manager.as_ref(),
             epoch_id,
             chunk_id.shard_id,
             chunk_block_header.height(),
         )?;
-        let all_validators = all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?;
         let on_chain: HashSet<&AccountId> = chunk_info
             .present_fallback_endorsements
             .iter()
             .map(|(account_id, _)| account_id)
             .collect();
         let fallback_accounts =
-            all_validators.assignments().iter().map(|(account_id, _)| account_id).filter(
-                |account_id| !designated.contains(account_id) && !on_chain.contains(*account_id),
-            );
+            endorsers.iter().filter(|account_id| !on_chain.contains(account_id));
         Ok(self.stored_endorsements(chunk_id, fallback_accounts).collect())
     }
 


### PR DESCRIPTION
`core.rs::fallback_endorsements` computed "every epoch validator that is not designated for this chunk" inline, and two follow-ups need the same rule. Give it one definition next to the rest of the fallback, as `fallback_endorsers`.

No behavior change. The result keeps the epoch's validator order rather than becoming a set, so the core statements a block carries are byte-for-byte what they were.

First of three: #16211 fixes a fallback endorsement that is broadcast once and lost, and #16212 pushes the witness when the fallback opens. Both call this function.