### PR TITLE
test(early-kickout): reshard + abandoned-fork blacklist coverage

### DIFF
--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -2000,12 +2000,15 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     // and the excluding sampler under {1} only (lost inherited 0) and {0} only (lost
     // branch-local 1).
     let full_blacklist = HashSet::from([0, 1]);
+    let only_branch_local = HashSet::from([1]);
+    let only_inherited = HashSet::from([0]);
     let expected_bl = HashMap::from([(shard_id, full_blacklist.clone())]);
     let (mut tip, mut height) = (sibling_tip, sibling_height);
     let mut saw_no_blacklist = false;
     let mut saw_missing_inherited = false;
     let mut saw_missing_branch_local = false;
-    for _ in 0..128 {
+    const SCAN_CAP: u64 = 128;
+    for attempt in 0..SCAN_CAP {
         assert_eq!(
             handle.get_chunk_producer_blacklist(&tip).unwrap(),
             expected_bl,
@@ -2027,7 +2030,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
                 &layout,
                 shard_id,
                 witness.chunk_height,
-                &HashSet::from([1]),
+                &only_branch_local,
             )
             .unwrap();
         let without_branch_local = epoch_info
@@ -2035,7 +2038,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
                 &layout,
                 shard_id,
                 witness.chunk_height,
-                &HashSet::from([0]),
+                &only_inherited,
             )
             .unwrap();
         saw_no_blacklist |= witness.plain != 2;
@@ -2044,8 +2047,12 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
         if saw_no_blacklist && saw_missing_inherited && saw_missing_branch_local {
             return;
         }
-        height += 1;
-        tip = fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, tip, 2, height, 1);
+        // Do not step past the last inspected tip: the panic below reports `tip`, which must
+        // be a tip whose row was actually scanned.
+        if attempt + 1 < SCAN_CAP {
+            height += 1;
+            tip = fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, tip, 2, height, 1);
+        }
     }
     let (basis, basis_height, cache, watermark) = {
         let read = handle.read();
@@ -2058,8 +2065,8 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
         )
     };
     panic!(
-        "no discriminating rows within 128 blocks: tip {tip} at height {height}, basis {basis} \
-         (height {basis_height}), cache {cache}, watermark {watermark}; witnesses \
+        "no discriminating rows within {SCAN_CAP} blocks: tip {tip} at height {height}, basis \
+         {basis} (height {basis_height}), cache {cache}, watermark {watermark}; witnesses \
          no_blacklist={saw_no_blacklist} missing_inherited={saw_missing_inherited} \
          missing_branch_local={saw_missing_branch_local}",
     );

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -43,6 +43,8 @@ use near_store::DBCol;
 #[cfg(feature = "nightly")]
 use near_store::adapter::StoreAdapter;
 use std::collections::{HashMap, HashSet};
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+use std::sync::Arc;
 
 const STAKE: Balance = Balance::from_yoctonear(1_000_000);
 
@@ -534,13 +536,54 @@ fn get_chunk_producer_blacklist_blacklists_miss_heavy_producer() {
     assert_eq!(bl, HashMap::from([(shard_id, HashSet::from([0]))]));
 }
 
-/// Drives `count` blocks in epoch 0 simulating `down` as a non-producing node, using
-/// **blacklist-aware** assignment (mirrors the write path): at each height the chunk is
-/// assigned to `sample_chunk_producer_excluding(current_blacklist)`. If that producer is
-/// `down` the chunk is missed (mask=false); otherwise it is produced (mask=true). So once
-/// `down` is blacklisted its slots reassign to a live producer that actually produces —
-/// exactly what happens in production, with no phantom misses for the replacement.
-/// Returns the recorded block hashes (index = height).
+/// The single-shard epoch-0 context every blacklist-aware driver below records against.
+#[cfg(feature = "nightly")]
+struct ChainCtx<'a> {
+    handle: &'a EpochManagerHandle,
+    epoch_info: &'a EpochInfo,
+    layout: &'a ShardLayout,
+    shard_id: ShardId,
+}
+
+#[cfg(feature = "nightly")]
+impl ChainCtx<'_> {
+    /// Records `cur` on top of `prev` using **blacklist-aware** assignment (mirrors the
+    /// write path): the height's chunk goes to
+    /// `sample_chunk_producer_excluding(blacklist at prev)`, and is missed (mask=false)
+    /// exactly when that producer is `target`. So once `target` is blacklisted its slots
+    /// reassign to a live producer that actually produces — what happens in production,
+    /// with no phantom misses for the replacement.
+    ///
+    /// The blacklist read here is anchored at `prev`, while the row consensus reads is
+    /// anchored one block earlier, so at the single height per blacklist flip the two can
+    /// disagree and credit `target` one spurious `produced`. Harmless at these thresholds:
+    /// a flip needs a full run of fresh misses and `target` never recovers.
+    fn step(
+        &self,
+        prev: CryptoHash,
+        cur: CryptoHash,
+        height: u64,
+        target: ValidatorId,
+    ) -> CryptoHash {
+        let empty = HashSet::new();
+        let blacklist = self.handle.get_chunk_producer_blacklist(&prev).unwrap();
+        let assigned = self
+            .epoch_info
+            .sample_chunk_producer_excluding(
+                self.layout,
+                self.shard_id,
+                height,
+                blacklist.get(&self.shard_id).unwrap_or(&empty),
+            )
+            .unwrap();
+        let produced = assigned != target;
+        record_block_with_mask(&mut self.handle.write(), prev, cur, height, vec![produced]);
+        cur
+    }
+}
+
+/// Drives `count` blocks in epoch 0 simulating `down` as a non-producing node, one
+/// [`ChainCtx::step`] per height. Returns the recorded block hashes (index = height).
 #[cfg(feature = "nightly")]
 fn drive_down_node(handle: &EpochManagerHandle, count: u64, down: ValidatorId) -> Vec<CryptoHash> {
     let h: Vec<CryptoHash> = (0..=count).map(|i| hash(&i.to_le_bytes())).collect();
@@ -549,27 +592,10 @@ fn drive_down_node(handle: &EpochManagerHandle, count: u64, down: ValidatorId) -
     let layout = handle.get_shard_layout(&epoch_id).unwrap();
     let shard_id = layout.shard_ids().next().unwrap();
     let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
-    let empty = HashSet::new();
+    let ctx = ChainCtx { handle, epoch_info: epoch_info.as_ref(), layout: &layout, shard_id };
     let mut prev = h[0];
     for height in 1..=count {
-        let blacklist = handle.get_chunk_producer_blacklist(&prev).unwrap();
-        let assigned = epoch_info
-            .sample_chunk_producer_excluding(
-                &layout,
-                shard_id,
-                height,
-                blacklist.get(&shard_id).unwrap_or(&empty),
-            )
-            .unwrap();
-        let produced = assigned != down;
-        record_block_with_mask(
-            &mut handle.write(),
-            prev,
-            h[height as usize],
-            height,
-            vec![produced],
-        );
-        prev = h[height as usize];
+        prev = ctx.step(prev, h[height as usize], height, down);
     }
     h
 }
@@ -1728,94 +1754,124 @@ fn fork_block_hash(branch: u8, height: u64) -> CryptoHash {
     hash(&[&[branch][..], &height.to_le_bytes()[..]].concat())
 }
 
-/// Records one block on `branch` at `height`, extending `prev`, using the same
-/// blacklist-aware assignment as `drive_down_node`: the chunk is missed when the test's
-/// model schedules `target`, sampling with the accessor blacklist at `prev`. The stored
-/// row consensus reads anchors one block earlier, so at the single height per blacklist
-/// flip the two can disagree and credit `target` one spurious `produced` — harmless at
-/// these thresholds (a flip needs 10 fresh misses and `target` never recovers). Returns
-/// the new tip. Shared by the two fork tests below.
+/// Shared context for the two fork tests: the epoch-0 single-shard chain they both build
+/// on, plus the genesis block they both fork from.
 #[cfg(all(feature = "nightly", feature = "test_features"))]
-fn fork_step(
-    handle: &EpochManagerHandle,
-    epoch_info: &EpochInfo,
-    layout: &ShardLayout,
+struct ForkFixture {
+    handle: EpochManagerHandle,
+    epoch_info: Arc<EpochInfo>,
+    layout: ShardLayout,
     shard_id: ShardId,
-    prev: CryptoHash,
-    branch: u8,
-    height: u64,
-    target: ValidatorId,
-) -> CryptoHash {
-    let cur = fork_block_hash(branch, height);
-    let empty = HashSet::new();
-    let blacklist = handle.get_chunk_producer_blacklist(&prev).unwrap();
-    let assigned = epoch_info
-        .sample_chunk_producer_excluding(
-            layout,
-            shard_id,
-            height,
-            blacklist.get(&shard_id).unwrap_or(&empty),
-        )
-        .unwrap();
-    let produced = assigned != target;
-    record_block_with_mask(&mut handle.write(), prev, cur, height, vec![produced]);
-    cur
+    epoch_id: EpochId,
+    genesis: CryptoHash,
 }
 
-/// Drives one branch forward via `fork_step` until `done(tip)` holds, starting from
-/// `(prev, height)`. Every phase of the fork tests is driven by an observable condition
-/// rather than a fixed block count, because the sampler and the two-block finality lag
-/// decide when a condition becomes true. Panics with the full fork state if `cap` steps
-/// pass first. Returns the tip and its height.
 #[cfg(all(feature = "nightly", feature = "test_features"))]
-fn drive_until(
-    handle: &EpochManagerHandle,
-    epoch_info: &EpochInfo,
-    layout: &ShardLayout,
-    shard_id: ShardId,
-    mut prev: CryptoHash,
-    mut height: u64,
-    branch: u8,
-    target: ValidatorId,
-    cap: u64,
-    phase: &str,
-    mut done: impl FnMut(&EpochManagerHandle, CryptoHash) -> bool,
-) -> (CryptoHash, u64) {
-    for _ in 0..cap {
-        if done(handle, prev) {
+impl ForkFixture {
+    /// 3 validators so blacklisting two producers on one branch does not trip the keep-one
+    /// valve; the contamination a leak would cause then shows up in the blacklist itself.
+    /// The epoch is long enough that everything stays inside epoch 0 (no boundary reset).
+    fn new() -> Self {
+        let validators = vec![
+            ("test0".parse().unwrap(), STAKE),
+            ("test1".parse().unwrap(), STAKE),
+            ("test2".parse().unwrap(), STAKE),
+        ];
+        let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+        let epoch_id = EpochId::default();
+        let layout = handle.get_shard_layout(&epoch_id).unwrap();
+        let shard_id = layout.shard_ids().next().unwrap();
+        let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
+
+        // Premise of both tests: producers are exactly {0, 1, 2}.
+        let shard_index = layout.get_shard_index(shard_id).unwrap();
+        assert_eq!(
+            epoch_info.chunk_producers_settlement()[shard_index]
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>(),
+            HashSet::from([0, 1, 2]),
+            "fork test needs chunk producers exactly {{0, 1, 2}}",
+        );
+
+        let genesis = fork_block_hash(0, 0);
+        record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
+        Self { handle, epoch_info, layout, shard_id, epoch_id, genesis }
+    }
+
+    fn ctx(&self) -> ChainCtx<'_> {
+        ChainCtx {
+            handle: &self.handle,
+            epoch_info: self.epoch_info.as_ref(),
+            layout: &self.layout,
+            shard_id: self.shard_id,
+        }
+    }
+
+    /// One [`ChainCtx::step`] at the hash `branch` reserves for `height`. Returns the tip.
+    fn fork_step(
+        &self,
+        prev: CryptoHash,
+        branch: u8,
+        height: u64,
+        target: ValidatorId,
+    ) -> CryptoHash {
+        self.ctx().step(prev, fork_block_hash(branch, height), height, target)
+    }
+
+    /// Drives one branch forward via [`Self::fork_step`] until `done(tip)` holds, starting
+    /// from `(prev, height)`. Every phase of the fork tests is driven by an observable
+    /// condition rather than a fixed block count, because the sampler and the two-block
+    /// finality lag decide when a condition becomes true. Panics with the full fork state
+    /// if `cap` steps pass first. Returns the tip and its height.
+    fn drive_until(
+        &self,
+        mut prev: CryptoHash,
+        mut height: u64,
+        branch: u8,
+        target: ValidatorId,
+        cap: u64,
+        phase: &str,
+        mut done: impl FnMut(&EpochManagerHandle, CryptoHash) -> bool,
+    ) -> (CryptoHash, u64) {
+        for _ in 0..cap {
+            if done(&self.handle, prev) {
+                return (prev, height);
+            }
+            height += 1;
+            prev = self.fork_step(prev, branch, height, target);
+        }
+        if done(&self.handle, prev) {
             return (prev, height);
         }
-        height += 1;
-        prev = fork_step(handle, epoch_info, layout, shard_id, prev, branch, height, target);
+        let (basis, watermark, cache) = {
+            let read = self.handle.read();
+            let info = read.get_block_info(&prev).unwrap();
+            (
+                *info.last_final_block_hash(),
+                read.largest_final_height,
+                read.epoch_info_aggregator.last_block_hash,
+            )
+        };
+        let shard_id = self.shard_id;
+        let target_stats = self
+            .handle
+            .read()
+            .get_epoch_info_aggregator_upto_last(&basis)
+            .ok()
+            .and_then(|agg| agg.shard_tracker.get(&shard_id).and_then(|m| m.get(&target).cloned()))
+            .map(|s| (s.produced(), s.expected()))
+            .unwrap_or((0, 0));
+        let blacklist = self.handle.get_chunk_producer_blacklist(&prev).unwrap();
+        panic!(
+            "phase {phase:?}: cap {cap} exceeded on branch {branch} at height {height}; anchor \
+             {prev} basis {basis} cache {cache} watermark {watermark}; target {target} produced \
+             {} expected {} missed {}; blacklist {blacklist:?}",
+            target_stats.0,
+            target_stats.1,
+            target_stats.1.saturating_sub(target_stats.0),
+        );
     }
-    if done(handle, prev) {
-        return (prev, height);
-    }
-    let (basis, watermark, cache) = {
-        let read = handle.read();
-        let info = read.get_block_info(&prev).unwrap();
-        (
-            *info.last_final_block_hash(),
-            read.largest_final_height,
-            read.epoch_info_aggregator.last_block_hash,
-        )
-    };
-    let target_stats = handle
-        .read()
-        .get_epoch_info_aggregator_upto_last(&basis)
-        .ok()
-        .and_then(|agg| agg.shard_tracker.get(&shard_id).and_then(|m| m.get(&target).cloned()))
-        .map(|s| (s.produced(), s.expected()))
-        .unwrap_or((0, 0));
-    let blacklist = handle.get_chunk_producer_blacklist(&prev).unwrap();
-    panic!(
-        "phase {phase:?}: cap {cap} exceeded on branch {branch} at height {height}; anchor {prev} \
-         basis {basis} cache {cache} watermark {watermark}; target {target} produced {} expected {} \
-         missed {}; blacklist {blacklist:?}",
-        target_stats.0,
-        target_stats.1,
-        target_stats.1.saturating_sub(target_stats.0),
-    );
 }
 
 // v152+ protocol: two sibling forks off a shared prefix starve different producers, and the
@@ -1824,71 +1880,32 @@ fn drive_until(
 // inferring it from blacklist equality. Also pins the strict `>` watermark gate at a
 // final-height tie and the persisted rows under the inherited {0, 1} blacklist.
 //
-// Lowered test-only thresholds (10 misses past a 20-block grace) keep it cheap. The prior
-// fixture forked an equal-depth sibling at height 1; that ancient fork point pinned the cached
-// aggregator to genesis, so every per-block seed walk ran to genesis and recording cost was
-// quadratic in the sibling depth. Forking at the shared-prefix tip (at or above the cached
-// last-final block) makes the sibling grow linearly, so real thresholds would also work here at
-// ~1500 blocks — the lowered thresholds are for speed, not correctness. Real thresholds stay
+// Thresholds are lowered (10 misses past a 20-block grace) for speed; real thresholds stay
 // covered by the canonical tests.
 #[cfg(all(feature = "nightly", feature = "test_features"))]
 #[test]
 fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     let _guard = set_early_kickout_thresholds_for_testing(Some(10), Some(20));
-    // 3 validators so blacklisting two producers on the sibling does not trip the keep-one
-    // valve; the contamination a leak would cause then shows up in the blacklist itself.
-    let validators = vec![
-        ("test0".parse().unwrap(), STAKE),
-        ("test1".parse().unwrap(), STAKE),
-        ("test2".parse().unwrap(), STAKE),
-    ];
-    // Epoch length large enough that everything stays inside epoch 0 (no boundary reset).
-    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
-    let epoch_id = EpochId::default();
-    let layout = handle.get_shard_layout(&epoch_id).unwrap();
-    let shard_id = layout.shard_ids().next().unwrap();
-    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
-    // Premise: producers are exactly {0, 1, 2}. The sibling blacklists 0 (inherited from the
-    // prefix) and 1 (branch-local), so 2 is the unique remaining eligible producer and the
-    // keep-one valve stays quiet.
-    let shard_index = layout.get_shard_index(shard_id).unwrap();
-    assert_eq!(
-        epoch_info.chunk_producers_settlement()[shard_index]
-            .iter()
-            .copied()
-            .collect::<HashSet<_>>(),
-        HashSet::from([0, 1, 2]),
-        "fork test needs chunk producers exactly {{0, 1, 2}}",
-    );
-
-    let genesis = fork_block_hash(0, 0);
-    record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
+    let fx = ForkFixture::new();
+    // The sibling blacklists 0 (inherited from the prefix) and 1 (branch-local), so 2 is the
+    // unique remaining eligible producer and the keep-one valve stays quiet.
+    let (handle, epoch_info, layout, shard_id) =
+        (&fx.handle, &fx.epoch_info, &fx.layout, fx.shard_id);
 
     // Phase 1: shared prefix on branch 0, starving producer 0, until the accessor is
     // exactly {0}. The fork point is this prefix tip — at or above the cached last-final
     // block, so both forks descend from the cached position (linear seed walks).
     let only_0 = HashMap::from([(shard_id, HashSet::from([0]))]);
-    let (fork_point, fork_point_height) = drive_until(
-        &handle,
-        epoch_info.as_ref(),
-        &layout,
-        shard_id,
-        genesis,
-        0,
-        0,
-        0,
-        256,
-        "shared prefix -> {0}",
-        |h, tip| h.get_chunk_producer_blacklist(&tip).unwrap() == only_0,
-    );
+    let (fork_point, fork_point_height) =
+        fx.drive_until(fx.genesis, 0, 0, 0, 256, "shared prefix -> {0}", |h, tip| {
+            h.get_chunk_producer_blacklist(&tip).unwrap() == only_0
+        });
 
     // Phase 2: branch a canonical child (keeps starving 0) and a sibling child (starves 1)
     // off the shared fork point.
     let first_height = fork_point_height + 1;
-    let canonical_first =
-        fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, fork_point, 1, first_height, 0);
-    let sibling_first =
-        fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, fork_point, 2, first_height, 1);
+    let canonical_first = fx.fork_step(fork_point, 1, first_height, 0);
+    let sibling_first = fx.fork_step(fork_point, 2, first_height, 1);
     assert_ne!(canonical_first, sibling_first, "sibling branches must have distinct hashes");
 
     // Phase 3: aggregating to the first sibling block (not the accessor's basis for that
@@ -1923,11 +1940,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     // Phase 4: extend the canonical branch until its anchor's last-final block is
     // canonical-only (past the shared prefix), then snapshot the finality watermark and the
     // cache position (the canonical anchor's last-final block).
-    let (canonical_tip, _) = drive_until(
-        &handle,
-        epoch_info.as_ref(),
-        &layout,
-        shard_id,
+    let (canonical_tip, _) = fx.drive_until(
         canonical_first,
         first_height,
         1,
@@ -1952,11 +1965,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     // sibling must not move the watermark or the cached aggregator (a `>=` would flap the
     // cache by arrival order). Rows are still seeded for these blocks; only the cache state
     // must stay put.
-    let (sibling_tie, tie_height) = drive_until(
-        &handle,
-        epoch_info.as_ref(),
-        &layout,
-        shard_id,
+    let (sibling_tie, tie_height) = fx.drive_until(
         sibling_first,
         first_height,
         2,
@@ -1987,11 +1996,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     // sibling's own last-final block), and its blacklist is exactly {0, 1}. The monotone
     // `largest_final_height` gate is what keeps the sibling from mutating the cache until it
     // genuinely overtakes; passing it replaces the cache with a fresh walk onto the sibling.
-    let (sibling_tip, sibling_height) = drive_until(
-        &handle,
-        epoch_info.as_ref(),
-        &layout,
-        shard_id,
+    let (sibling_tip, sibling_height) = fx.drive_until(
         sibling_tie,
         tie_height,
         2,
@@ -2070,15 +2075,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
             expected_bl,
             "sibling blacklist drifted from {{0, 1}} while scanning rows",
         );
-        let witness = assert_seeded_row_matches_blacklist(
-            &handle,
-            epoch_info.as_ref(),
-            &layout,
-            shard_id,
-            &epoch_id,
-            tip,
-            &full_blacklist,
-        );
+        let witness = fx.assert_seeded_row(tip, &full_blacklist);
         assert_eq!(witness.expected, 2, "excluding {{0, 1}} from {{0, 1, 2}} must leave 2");
         assert_eq!(witness.stored, 2, "stored row must be the sole non-blacklisted producer");
         let without_inherited = epoch_info
@@ -2107,7 +2104,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
         // be a tip whose row was actually scanned.
         if attempt + 1 < SCAN_CAP {
             height += 1;
-            tip = fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, tip, 2, height, 1);
+            tip = fx.fork_step(tip, 2, height, 1);
         }
     }
     let (basis, basis_height, cache, watermark) = {
@@ -2141,107 +2138,95 @@ struct SeededRowWitness {
     stored: ValidatorId,
 }
 
-/// Reads the persisted `DBCol::ChunkProducers` row for `tip` and asserts it is the
-/// blacklist-aware sample and not blacklisted. The anchor height comes from `tip`'s own
-/// `BlockInfo`, so the row read and the expected sample cannot diverge. Note the two samplers
-/// draw from different distributions, so they can differ even at heights where the plain pick
-/// is not blacklisted.
 #[cfg(all(feature = "nightly", feature = "test_features"))]
-fn assert_seeded_row_matches_blacklist(
-    handle: &EpochManagerHandle,
-    epoch_info: &EpochInfo,
-    layout: &ShardLayout,
-    shard_id: ShardId,
-    epoch_id: &EpochId,
-    tip: CryptoHash,
-    shard_blacklist: &HashSet<ValidatorId>,
-) -> SeededRowWitness {
-    let anchor_height = handle.read().get_block_info(&tip).unwrap().height();
-    let chunk_height = anchor_height + CHUNK_GRANDPARENT_ANCHOR_HEIGHT_OFFSET;
-    let plain = epoch_info.sample_chunk_producer(layout, shard_id, chunk_height).unwrap();
-    let expected = epoch_info
-        .sample_chunk_producer_excluding(layout, shard_id, chunk_height, shard_blacklist)
-        .unwrap();
-    let stored_stake = handle
-        .get_chunk_producer_info_anchored(Some(&tip), epoch_id, chunk_height, shard_id)
-        .unwrap();
-    let stored = epoch_info.get_validator_id(stored_stake.account_id()).copied().unwrap();
-    assert_eq!(stored, expected, "seeded row must be the blacklist-aware sample");
-    assert!(!shard_blacklist.contains(&stored), "seeded row must not be a blacklisted producer");
-    SeededRowWitness { chunk_height, plain, expected, stored }
-}
-
-/// Drives `branch` off the shared `fork_point`, starving `target`, until it blacklists
-/// exactly `{target}`, then manufactures a non-vacuous anchor and asserts the seeded
-/// `DBCol::ChunkProducers` row (the row consensus actually reads) reflects that branch's
-/// blacklist: it excludes `target` at a height where the plain sampler would have picked it.
-#[cfg(all(feature = "nightly", feature = "test_features"))]
-fn assert_branch_seeds_own_blacklist(
-    handle: &EpochManagerHandle,
-    epoch_info: &EpochInfo,
-    layout: &ShardLayout,
-    shard_id: ShardId,
-    epoch_id: &EpochId,
-    fork_point: CryptoHash,
-    fork_point_height: u64,
-    branch: u8,
-    target: ValidatorId,
-) {
-    let only_target = HashMap::from([(shard_id, HashSet::from([target]))]);
-    let (mut tip, mut height) = drive_until(
-        handle,
-        epoch_info,
-        layout,
-        shard_id,
-        fork_point,
-        fork_point_height,
-        branch,
-        target,
-        256,
-        "reach single-producer blacklist",
-        |h, t| h.get_chunk_producer_blacklist(&t).unwrap() == only_target,
-    );
-
-    // Extend (target stays down, so the blacklist stays {target}) until the PLAIN sampler
-    // at the anchor offset picks the blacklisted producer — only such an anchor proves the
-    // seeder rerouted away from a blacklisted canonical pick. With one blacklisted producer
-    // of three, the anchors the drive happened to leave need not contain one.
-    const PLAIN_PICK_CAP: u64 = 128;
-    for attempt in 0..PLAIN_PICK_CAP {
-        let blacklist = handle.get_chunk_producer_blacklist(&tip).unwrap();
-        let shard_blacklist = blacklist.get(&shard_id).cloned().unwrap_or_default();
-        assert_eq!(
-            shard_blacklist,
-            HashSet::from([target]),
-            "branch {branch} blacklist drifted from {{{target}}}",
+impl ForkFixture {
+    /// Reads the persisted `DBCol::ChunkProducers` row for `tip` and asserts it is the
+    /// blacklist-aware sample and not blacklisted. The anchor height comes from `tip`'s own
+    /// `BlockInfo`, so the row read and the expected sample cannot diverge. Note the two
+    /// samplers draw from different distributions, so they can differ even at heights where
+    /// the plain pick is not blacklisted.
+    fn assert_seeded_row(
+        &self,
+        tip: CryptoHash,
+        shard_blacklist: &HashSet<ValidatorId>,
+    ) -> SeededRowWitness {
+        let (epoch_info, layout, shard_id) =
+            (self.epoch_info.as_ref(), &self.layout, self.shard_id);
+        let anchor_height = self.handle.read().get_block_info(&tip).unwrap().height();
+        let chunk_height = anchor_height + CHUNK_GRANDPARENT_ANCHOR_HEIGHT_OFFSET;
+        let plain = epoch_info.sample_chunk_producer(layout, shard_id, chunk_height).unwrap();
+        let expected = epoch_info
+            .sample_chunk_producer_excluding(layout, shard_id, chunk_height, shard_blacklist)
+            .unwrap();
+        let stored_stake = self
+            .handle
+            .get_chunk_producer_info_anchored(Some(&tip), &self.epoch_id, chunk_height, shard_id)
+            .unwrap();
+        let stored = epoch_info.get_validator_id(stored_stake.account_id()).copied().unwrap();
+        assert_eq!(stored, expected, "seeded row must be the blacklist-aware sample");
+        assert!(
+            !shard_blacklist.contains(&stored),
+            "seeded row must not be a blacklisted producer"
         );
-        let witness = assert_seeded_row_matches_blacklist(
-            handle,
-            epoch_info,
-            layout,
-            shard_id,
-            epoch_id,
-            tip,
-            &shard_blacklist,
-        );
-        if shard_blacklist.contains(&witness.plain) {
-            assert_ne!(
-                witness.stored, witness.plain,
-                "branch {branch}: seeder must reassign away from the blacklisted plain pick",
-            );
-            return;
-        }
-        // Do not step past the last inspected tip: the panic below reports `tip`, which must
-        // be a tip whose row was actually scanned.
-        if attempt + 1 < PLAIN_PICK_CAP {
-            height += 1;
-            tip = fork_step(handle, epoch_info, layout, shard_id, tip, branch, height, target);
-        }
+        SeededRowWitness { chunk_height, plain, expected, stored }
     }
-    panic!(
-        "branch {branch}: no anchor whose plain pick is the blacklisted producer within \
-         {PLAIN_PICK_CAP} blocks: tip {tip} at height {height}"
-    );
+
+    /// Drives `branch` off the shared `fork_point`, starving `target`, until it blacklists
+    /// exactly `{target}`, then manufactures a non-vacuous anchor and asserts the seeded
+    /// `DBCol::ChunkProducers` row (the row consensus actually reads) reflects that branch's
+    /// blacklist: it excludes `target` at a height where the plain sampler would have picked
+    /// it.
+    fn assert_branch_seeds_own_blacklist(
+        &self,
+        fork_point: CryptoHash,
+        fork_point_height: u64,
+        branch: u8,
+        target: ValidatorId,
+    ) {
+        let only_target = HashMap::from([(self.shard_id, HashSet::from([target]))]);
+        let (mut tip, mut height) = self.drive_until(
+            fork_point,
+            fork_point_height,
+            branch,
+            target,
+            256,
+            "reach single-producer blacklist",
+            |h, t| h.get_chunk_producer_blacklist(&t).unwrap() == only_target,
+        );
+
+        // Extend (target stays down, so the blacklist stays {target}) until the PLAIN sampler
+        // at the anchor offset picks the blacklisted producer — only such an anchor proves the
+        // seeder rerouted away from a blacklisted canonical pick. With one blacklisted
+        // producer of three, the anchors the drive happened to leave need not contain one.
+        const PLAIN_PICK_CAP: u64 = 128;
+        for attempt in 0..PLAIN_PICK_CAP {
+            let blacklist = self.handle.get_chunk_producer_blacklist(&tip).unwrap();
+            let shard_blacklist = blacklist.get(&self.shard_id).cloned().unwrap_or_default();
+            assert_eq!(
+                shard_blacklist,
+                HashSet::from([target]),
+                "branch {branch} blacklist drifted from {{{target}}}",
+            );
+            let witness = self.assert_seeded_row(tip, &shard_blacklist);
+            if shard_blacklist.contains(&witness.plain) {
+                assert_ne!(
+                    witness.stored, witness.plain,
+                    "branch {branch}: seeder must reassign away from the blacklisted plain pick",
+                );
+                return;
+            }
+            // Do not step past the last inspected tip: the panic below reports `tip`, which
+            // must be a tip whose row was actually scanned.
+            if attempt + 1 < PLAIN_PICK_CAP {
+                height += 1;
+                tip = self.fork_step(tip, branch, height, target);
+            }
+        }
+        panic!(
+            "branch {branch}: no anchor whose plain pick is the blacklisted producer within \
+             {PLAIN_PICK_CAP} blocks: tip {tip} at height {height}"
+        );
+    }
 }
 
 // v152+ protocol, seeded-row companion to the fork isolation test: consensus reads the
@@ -2253,43 +2238,11 @@ fn assert_branch_seeds_own_blacklist(
 #[test]
 fn fork_seeded_rows_reflect_each_branch_blacklist() {
     let _guard = set_early_kickout_thresholds_for_testing(Some(10), Some(20));
-    let validators = vec![
-        ("test0".parse().unwrap(), STAKE),
-        ("test1".parse().unwrap(), STAKE),
-        ("test2".parse().unwrap(), STAKE),
-    ];
-    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
-    let epoch_id = EpochId::default();
-    let layout = handle.get_shard_layout(&epoch_id).unwrap();
-    let shard_id = layout.shard_ids().next().unwrap();
-    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
-
-    let genesis = fork_block_hash(0, 0);
-    record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
+    let fx = ForkFixture::new();
 
     // Two forks off genesis, each starving its own producer. Each branch's blacklist is
     // self-contained: a non-ancestor branch aggregates afresh from the epoch boundary, so the
     // assertions hold regardless of which branch the aggregator cache currently sits on.
-    assert_branch_seeds_own_blacklist(
-        &handle,
-        epoch_info.as_ref(),
-        &layout,
-        shard_id,
-        &epoch_id,
-        genesis,
-        0,
-        1,
-        0,
-    );
-    assert_branch_seeds_own_blacklist(
-        &handle,
-        epoch_info.as_ref(),
-        &layout,
-        shard_id,
-        &epoch_id,
-        genesis,
-        0,
-        2,
-        1,
-    );
+    fx.assert_branch_seeds_own_blacklist(fx.genesis, 0, 1, 0);
+    fx.assert_branch_seeds_own_blacklist(fx.genesis, 0, 2, 1);
 }

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -381,7 +381,11 @@ fn blacklist_dedups_duplicate_settlement_entries() {
 // from candidacy, but not this all-bad-shard interaction.
 #[test]
 fn blacklist_valve_ignores_endorsement_only_entry() {
-    let (epoch_info, layout, shard_id) = single_shard_epoch(2);
+    // Three real epoch validators, but only 0 and 1 settled as producers: id 2 is a genuine
+    // validator that is endorsement-only on this shard, not an unknown tracker entry.
+    let layout = ShardLayout::single_shard();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let epoch_info = epoch_info_for_layout(&layout, vec![vec![0, 1]], 3);
     let mut inner = HashMap::new();
     inner.insert(0, ChunkStats::new_with_production(0, 100));
     inner.insert(1, ChunkStats::new_with_production(0, 100));
@@ -395,9 +399,11 @@ fn blacklist_valve_ignores_endorsement_only_entry() {
     // Deterministic: the two all-bad candidates tie on every level down to lower-id, which
     // keeps 0 — strictly stronger than only asserting the endorsement-only id is not kept.
     assert_eq!(stats.kept, Some(0), "equal all-bad candidates must resolve to the lower id");
-    let bl = &res.blacklist[&shard_id];
-    assert_eq!(bl.len(), 1, "keep-one must leave exactly one survivor");
-    assert!(!bl.contains(&2), "endorsement-only id must never be blacklisted");
+    assert_eq!(
+        res.blacklist[&shard_id],
+        HashSet::from([1]),
+        "exactly the non-kept all-bad producer is blacklisted; endorsement-only id stays out",
+    );
 }
 
 // u128 keeps both the ratio comparison and the safety-valve cross-multiply overflow-proof.

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -410,32 +410,6 @@ fn blacklist_u128_arithmetic_no_overflow() {
     );
 }
 
-// A settlement shorter than the layout's shard count: the shard whose index exceeds the
-// settlement is skipped (`settlement.get(shard_index) -> None`), so it is absent from both
-// the blacklist and the stats even under an all-bad tracker. `EpochInfo::new` does not
-// validate settlement length against the layout, so this inconsistent pairing is
-// constructible; the drop branch is otherwise hard to reach.
-#[test]
-fn blacklist_skips_shard_absent_from_settlement() {
-    let layout = ShardLayout::multi_shard(3, 0);
-    let shard_ids: Vec<ShardId> = layout.shard_ids().collect();
-    let settlement: Vec<ValidatorId> = vec![0, 1, 2];
-    let accounts: Vec<_> = (0..3).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
-    // Two settlements for a three-shard layout: the third shard (index 2) has no entry.
-    let epoch_info = epoch_info(
-        0,
-        accounts,
-        settlement.clone(),
-        vec![settlement.clone(), settlement],
-        PROTOCOL_VERSION,
-        layout.clone(),
-    );
-    let st = tracker(shard_ids[2], &[(0, 0, 100), (1, 0, 100), (2, 0, 100)]);
-    let res = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
-    assert!(res.blacklist.is_empty(), "a shard with no settlement entry must not be blacklisted");
-    assert!(res.shard_stats.is_empty(), "a skipped shard must not appear in the stats");
-}
-
 // --- Accessor tests (end-to-end through EpochManagerHandle) ---
 
 /// Records a block at `cur` with an explicit per-shard `chunk_mask` (true =
@@ -1542,33 +1516,19 @@ fn accessor_propagates_missing_block_info_on_same_epoch_basis() {
     );
 }
 
-// 13. Defense-in-depth unit coverage for resolving mixed parent/child shard ids
-//     against the layout the blacklist is computed for. One `shard_tracker` carrying
-//     ids from both layouts is fed to each: every valid shard keeps its own-settlement
-//     candidate, and ids with no shard index in that layout are dropped. This does not
-//     drive an epoch-boundary resharding transition (see the out-of-scope note below).
-//
-//     Distinct per-shard settlements make it discriminating: with the identical
-//     `0..n` settlement on every shard, resolving a valid shard to a wrong-but-in-range
-//     index would still produce the same blacklist. Production reads the settlement at
-//     the resolved index and filters candidates against it, so a wrong valid index only
-//     surfaces when the settlements differ.
-//
-//     Run over both the V2 and V3 derivations: production dynamic resharding derives
-//     V3, and the two operations under test (`get_shard_index` + settlement lookup)
-//     behave identically in both, so this tracks the fixture to production.
-//
-//     Out of scope: an end-to-end boundary transition. The layout-mismatch drop branch
-//     looks unreachable in production today — `chunk_producer_blacklist_at_anchor`
-//     checks `aggregator.epoch_id` first, and the layout is fixed within an epoch.
+// 13. Resolving mixed parent/child shard ids against the layout the blacklist is computed
+//     for. One `shard_tracker` carrying ids from both layouts is fed to each layout: every
+//     valid shard keeps its own-settlement candidate, ids with no shard index there are
+//     dropped. Distinct per-shard settlements make it discriminating — an identical `0..n`
+//     settlement everywhere would hide a valid shard resolved to a wrong-but-in-range index.
+//     Run over both V2 and V3, since production resharding derives V3 and `get_shard_index` +
+//     settlement lookup behave the same in both. Unit coverage only: no epoch boundary is
+//     driven and no split is finalized.
 #[test]
 fn blacklist_resharding_maps_to_current_layout_shard_ids() {
-    // Explicit non-identity layout so `shard_id != shard_index` holds by construction
-    // for every shard (no dependency on `multi_shard`'s seeded shuffle). Parent covers
-    // accounts split at "mmm" with ids [1, 0]; splitting at "aaa" (sorts first) retires
-    // shard 1 into children [2, 3] and leaves shard 0. Both the V2 and V3 derivations
-    // splice `[max_shard_id + 1, max_shard_id + 2]` at the new boundary's insert index,
-    // so both yield [2, 3, 0]; pin all three vectors before deriving generically.
+    // Explicit non-identity layout so `shard_id != shard_index` by construction. Parent
+    // splits at "mmm" with ids [1, 0]; adding boundary "aaa" (sorts first) retires shard 1
+    // into [2, 3] and keeps shard 0. V2 and V3 derive the same ids; pin them first.
     let split_boundary: AccountId = "aaa".parse().unwrap();
     let parent =
         ShardLayout::v2(vec!["mmm".parse().unwrap()], vec![ShardId::new(1), ShardId::new(0)], None);
@@ -1630,10 +1590,10 @@ fn reshard_case(parent: &ShardLayout, child: &ShardLayout) {
         children[0],
     );
 
-    // Five producers: one bad producer per shard plus a shared healthy producer (id 4).
-    // Distinct settlements built in declared shard-index order, never via `get_shard_index`
-    // (the mechanism under test must not be its own oracle). Each valid shard's bad
-    // producer sits in that shard's own settlement.
+    // One bad producer per shard plus a shared healthy producer (id 4). The settlement Vec
+    // is indexed by ShardIndex, so build it through `shard_infos()` (the API's index-order
+    // contract) rather than `shard_ids()`, and never through `get_shard_index` (the mechanism
+    // under test). Each valid shard's bad producer sits in that shard's own settlement.
     const HEALTHY: ValidatorId = 4;
     let num_producers = 5u64;
     let bad_producer = |shard: ShardId| -> ValidatorId {
@@ -1652,7 +1612,7 @@ fn reshard_case(parent: &ShardLayout, child: &ShardLayout) {
     let settlement_for =
         |shard: ShardId| -> Vec<ValidatorId> { vec![bad_producer(shard), HEALTHY] };
     let settlements = |layout: &ShardLayout| -> Vec<Vec<ValidatorId>> {
-        layout.shard_ids().map(settlement_for).collect()
+        layout.shard_infos().map(|info| settlement_for(info.shard_id())).collect()
     };
     let parent_ei = epoch_info_for_layout(parent, settlements(parent), num_producers);
     let child_ei = epoch_info_for_layout(child, settlements(child), num_producers);
@@ -1802,19 +1762,18 @@ fn drive_until(
     );
 }
 
-// v152+ protocol: two sibling forks off a shared prefix starve different producers, and
-// the accessor (keyed on the anchor hash) resolves each fork to its own blacklist. This
-// one test interleaves the deep-sibling overtake, the late-prefix inheritance and the
-// cached-prefix path, asserting the aggregator exit directly via `aggregate_epoch_info_upto`'s
-// `full_info` flag rather than inferring it from blacklist equality.
+// v152+ protocol: two sibling forks off a shared prefix starve different producers, and the
+// accessor (keyed on the anchor hash) resolves each fork to its own blacklist. Asserts the
+// aggregator exit directly via `aggregate_epoch_info_upto`'s `full_info` flag rather than
+// inferring it from blacklist equality.
 //
 // Lowered test-only thresholds (10 misses past a 20-block grace) keep it cheap. The prior
-// fixture used an equal-depth sibling forked at height 1: that ancient fork point kept the
-// cached aggregator pinned to genesis, so every per-block seed walk ran to genesis and the
-// recording cost was quadratic in the sibling depth. Forking at the cached last-final block
-// (the real production shape) makes the sibling grow linearly, so the real 100-miss /
-// 1000-block thresholds would also work here at ~1500 blocks; the lowered thresholds are for
-// speed and legibility, not correctness. Real thresholds stay covered by the canonical tests.
+// fixture forked an equal-depth sibling at height 1; that ancient fork point pinned the cached
+// aggregator to genesis, so every per-block seed walk ran to genesis and recording cost was
+// quadratic in the sibling depth. Forking at the shared-prefix tip (at or above the cached
+// last-final block) makes the sibling grow linearly, so real thresholds would also work here at
+// ~1500 blocks — the lowered thresholds are for speed, not correctness. Real thresholds stay
+// covered by the canonical tests.
 #[cfg(all(feature = "nightly", feature = "test_features"))]
 #[test]
 fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
@@ -1832,6 +1791,14 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     let layout = handle.get_shard_layout(&epoch_id).unwrap();
     let shard_id = layout.shard_ids().next().unwrap();
     let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
+    // Premise for the {0,1} blacklist below: three distinct producers, so blacklisting two
+    // leaves a survivor and the keep-one valve stays quiet.
+    let shard_index = layout.get_shard_index(shard_id).unwrap();
+    assert_eq!(
+        epoch_info.chunk_producers_settlement()[shard_index].iter().collect::<HashSet<_>>().len(),
+        3,
+        "fork test needs a shard with exactly three distinct chunk producers",
+    );
 
     let genesis = fork_block_hash(0, 0);
     record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
@@ -1863,23 +1830,33 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
         fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, fork_point, 2, first_height, 1);
     assert_ne!(canonical_first, sibling_first, "sibling branches must have distinct hashes");
 
-    // Phase 3: white-box coverage of the aggregator helper. Aggregating to the first sibling
-    // block itself (NOT the blacklist basis for that anchor — the accessor aggregates to the
-    // anchor's last-final block) reaches the same-epoch cached-prefix sync point, so
-    // `full_info` is false and the caller merges the cached prefix. `merge_prefix` is the
-    // intended behaviour there, not contamination: the merged aggregator carries producer 0's
-    // common-prefix stats.
-    let (_, full_info) = handle
+    // Phase 3: aggregating to the first sibling block (not the accessor's basis for that
+    // anchor, which is its last-final block) reaches the same-epoch cached-prefix sync point,
+    // so `full_info` is false and the caller merges the cached prefix. Pin that the merge
+    // actually ran: the merged producer-0 stats must equal cached-prefix + suffix exactly, and
+    // the cached prefix must carry a real contribution (`expected > 0`). Asserting only that
+    // the merged stats are nonzero would pass even without the merge, since the suffix can
+    // itself contain producer-0 stats.
+    let stats = |agg: &EpochInfoAggregator, id: ValidatorId| -> (u64, u64) {
+        agg.shard_tracker
+            .get(&shard_id)
+            .and_then(|m| m.get(&id))
+            .map_or((0, 0), |s| (s.produced(), s.expected()))
+    };
+    let prefix = handle.read().epoch_info_aggregator.clone();
+    let (suffix, full_info) = handle
         .read()
         .aggregate_epoch_info_upto(&sibling_first)
         .unwrap()
         .expect("first sibling block differs from the cache position");
     assert!(!full_info, "first sibling block must hit the same-epoch cached-prefix exit");
     let merged = handle.read().get_epoch_info_aggregator_upto_last(&sibling_first).unwrap();
-    let producer_0 = merged.shard_tracker.get(&shard_id).and_then(|m| m.get(&0));
-    assert!(
-        producer_0.is_some_and(|s| s.expected() > 0),
-        "merged aggregator must carry producer 0's common-prefix stats, got {producer_0:?}",
+    let (prefix_0, suffix_0, merged_0) = (stats(&prefix, 0), stats(&suffix, 0), stats(&merged, 0));
+    assert!(prefix_0.1 > 0, "cached prefix must carry producer 0's common-prefix stats");
+    assert_eq!(
+        merged_0,
+        (prefix_0.0 + suffix_0.0, prefix_0.1 + suffix_0.1),
+        "merged stats must be cached-prefix + suffix (proves merge_prefix ran)",
     );
 
     // Phase 4: extend the canonical branch until its anchor's last-final block is
@@ -1903,7 +1880,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     // watermark, the aggregator cache has moved onto the sibling (its `last_block_hash` is the
     // sibling's own last-final block), and its blacklist is exactly {0, 1}. The monotone
     // `largest_final_height` gate is what keeps the sibling from mutating the cache until it
-    // genuinely overtakes; passing it triggers the full-rewalk replace onto the sibling.
+    // genuinely overtakes; passing it replaces the cache with a fresh walk onto the sibling.
     let (sibling_tip, _) = drive_until(
         &handle,
         epoch_info.as_ref(),
@@ -1936,8 +1913,8 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
 
     // Phase 6: the abandoned canonical anchor is unchanged. Its blacklist is still exactly
     // {0}, and aggregating to its own last-final basis now returns `full_info == true`: the
-    // cache sits on the sibling, so the walk cannot reach the cached sync point and rewalks
-    // the canonical chain to the epoch start.
+    // cache sits on the sibling, so the walk cannot reach the cached sync point and instead
+    // walks the canonical chain from the epoch start.
     let canonical_bl = handle.get_chunk_producer_blacklist(&canonical_tip).unwrap();
     assert_eq!(
         canonical_bl,
@@ -1953,7 +1930,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
         .expect("canonical basis differs from the sibling cache position");
     assert!(
         canonical_full_info,
-        "after the sibling takeover the canonical basis must trigger a full rewalk",
+        "after the sibling takeover the canonical basis must walk from the epoch start",
     );
 
     // Phase 7: the sibling resolves to its own {0, 1}; the valve did not fire (3 producers,
@@ -2065,8 +2042,9 @@ fn fork_seeded_rows_reflect_each_branch_blacklist() {
     let genesis = fork_block_hash(0, 0);
     record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
 
-    // Two forks off genesis, each starving its own producer. Each call drives and asserts to
-    // completion before the next, so at assertion time the aggregator cache is on that branch.
+    // Two forks off genesis, each starving its own producer. Each branch's blacklist is
+    // self-contained: a non-ancestor branch aggregates afresh from the epoch boundary, so the
+    // assertions hold regardless of which branch the aggregator cache currently sits on.
     assert_branch_seeds_own_blacklist(
         &handle,
         epoch_info.as_ref(),

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -324,6 +324,118 @@ fn keep_one_leaves_sampler_nonempty() {
     }
 }
 
+// --- blacklist-math hardening (pure math) ---
+
+// The safety valve's least-bad tiebreak resolves at the FEWER-EXPECTED level, not only
+// on ratio and lower-id. Two all-bad producers with equal ratio (800/2000 == 400/1000):
+// fewer-expected keeps id 1 (expected 1000 < 2000), while a lower-id-only tiebreak would
+// keep id 0. Pins comparator level 2, which `blacklist_safety_valve_all_producers` (equal
+// on every level) cannot.
+#[test]
+fn keep_one_fewer_expected_tiebreak() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(2);
+    let st = tracker(shard_id, &[(0, 800, 2000), (1, 400, 1000)]);
+    assert_eq!(kept_survivor(&st, &epoch_info, &layout, shard_id, &[0, 1]), 1);
+    assert_eq!(
+        blacklist(&st, &epoch_info, &layout),
+        HashMap::from([(shard_id, HashSet::from([0]))]),
+    );
+}
+
+// Duplicate settlement entries do not inflate the safety-valve denominator: `producers` is
+// a set, so a `[0, 0, 1]` settlement has two distinct producers, and two all-bad candidates
+// trip the valve. Were the duplicate counted, the denominator would be 3, the valve would
+// not fire, and both would be blacklisted. `EpochInfo::new` neither rejects nor dedups the
+// duplicate.
+#[test]
+fn blacklist_dedups_duplicate_settlement_entries() {
+    let layout = ShardLayout::single_shard();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let epoch_info = epoch_info_for_layout(&layout, vec![vec![0, 0, 1]], 2);
+    let st = tracker(shard_id, &[(0, 0, 100), (1, 0, 100)]);
+    let res = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    let stats = &res.shard_stats[&shard_id];
+    assert_eq!(stats.raw_candidate_count, 2, "duplicate id must not inflate the candidate count");
+    assert!(stats.safety_valve_fired(), "two distinct all-bad producers must trip the valve");
+    assert_eq!(res.blacklist[&shard_id].len(), 1, "keep-one must leave exactly one survivor");
+}
+
+// Endorsement-only entries stay out of BOTH the safety-valve denominator and the kept set.
+// Two all-bad producers trip the valve; an endorsement-only validator (id 2, not in the
+// settlement) is neither counted nor kept. Existing test 7 covers endorsement-only exclusion
+// from candidacy, but not this all-bad-shard interaction.
+#[test]
+fn blacklist_valve_ignores_endorsement_only_entry() {
+    let (epoch_info, layout, shard_id) = single_shard_epoch(2);
+    let mut inner = HashMap::new();
+    inner.insert(0, ChunkStats::new_with_production(0, 100));
+    inner.insert(1, ChunkStats::new_with_production(0, 100));
+    // Endorsement-only, not in the settlement: high endorsement, zero production.
+    inner.insert(2, ChunkStats::new(0, 0, 1000, 1000));
+    let st = HashMap::from([(shard_id, inner)]);
+    let res = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    let stats = &res.shard_stats[&shard_id];
+    assert_eq!(stats.raw_candidate_count, 2, "endorsement-only id must not be a candidate");
+    assert!(stats.safety_valve_fired());
+    assert_ne!(stats.kept, Some(2), "endorsement-only id must never be the kept producer");
+    let bl = &res.blacklist[&shard_id];
+    assert_eq!(bl.len(), 1, "keep-one must leave exactly one survivor");
+    assert!(!bl.contains(&2), "endorsement-only id must never be blacklisted");
+}
+
+// u128 keeps both the ratio comparison and the safety-valve cross-multiply overflow-proof.
+// A u64 cross-multiply of these operands would panic under `overflow-checks`, which is on in
+// the `dev-release` profile CI builds. `produced == expected == u64::MAX` is avoided on
+// purpose: missed would be 0, so it would not be a candidate.
+#[test]
+fn blacklist_u128_arithmetic_no_overflow() {
+    let big = u64::MAX;
+    // Ratio check: id 0 misses ~2^63 with produced*100 (~9.2e20) < expected*80 (~1.5e21), so
+    // it is a candidate; ids 1, 2 are healthy so the valve does not fire.
+    let (epoch_info, layout, shard_id) = single_shard_epoch(3);
+    let st = tracker(shard_id, &[(0, big / 2, big), (1, 100, 100), (2, 100, 100)]);
+    assert_eq!(
+        blacklist(&st, &epoch_info, &layout),
+        HashMap::from([(shard_id, HashSet::from([0]))]),
+    );
+
+    // Safety-valve comparator cross-multiply (pa*eb vs pb*ea) with operands near 2^127
+    // (still under 2^128). id 0's ratio ~1/2 beats id 1's ~1/4, so the valve keeps id 0.
+    let (epoch_info2, layout2, shard2) = single_shard_epoch(2);
+    let st2 = tracker(shard2, &[(0, big / 2, big), (1, big / 4, big)]);
+    assert_eq!(kept_survivor(&st2, &epoch_info2, &layout2, shard2, &[0, 1]), 0);
+    assert_eq!(
+        blacklist(&st2, &epoch_info2, &layout2),
+        HashMap::from([(shard2, HashSet::from([1]))]),
+    );
+}
+
+// A settlement shorter than the layout's shard count: the shard whose index exceeds the
+// settlement is skipped (`settlement.get(shard_index) -> None`), so it is absent from both
+// the blacklist and the stats even under an all-bad tracker. `EpochInfo::new` does not
+// validate settlement length against the layout, so this inconsistent pairing is
+// constructible; the drop branch is otherwise hard to reach.
+#[test]
+fn blacklist_skips_shard_absent_from_settlement() {
+    let layout = ShardLayout::multi_shard(3, 0);
+    let shard_ids: Vec<ShardId> = layout.shard_ids().collect();
+    let settlement: Vec<ValidatorId> = vec![0, 1, 2];
+    let accounts: Vec<_> = (0..3).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
+    // Two settlements for a three-shard layout: the third shard (index 2) has no entry.
+    let epoch_info = epoch_info(
+        0,
+        accounts,
+        settlement.clone(),
+        vec![settlement.clone(), settlement],
+        PROTOCOL_VERSION,
+        layout.clone(),
+    );
+    let st = tracker(shard_ids[2], &[(0, 0, 100), (1, 0, 100), (2, 0, 100)]);
+    let res = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
+    assert!(res.blacklist.is_empty(), "a shard with no settlement entry must not be blacklisted");
+    assert!(res.shard_stats.is_empty(), "a skipped shard must not appear in the stats");
+}
+
 // --- Accessor tests (end-to-end through EpochManagerHandle) ---
 
 /// Records a block at `cur` with an explicit per-shard `chunk_mask` (true =

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -1765,7 +1765,8 @@ fn drive_until(
 // v152+ protocol: two sibling forks off a shared prefix starve different producers, and the
 // accessor (keyed on the anchor hash) resolves each fork to its own blacklist. Asserts the
 // aggregator exit directly via `aggregate_epoch_info_upto`'s `full_info` flag rather than
-// inferring it from blacklist equality.
+// inferring it from blacklist equality. Also pins the strict `>` watermark gate at a
+// final-height tie and the persisted rows under the inherited {0, 1} blacklist.
 //
 // Lowered test-only thresholds (10 misses past a 20-block grace) keep it cheap. The prior
 // fixture forked an equal-depth sibling at height 1; that ancient fork point pinned the cached
@@ -1791,13 +1792,17 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     let layout = handle.get_shard_layout(&epoch_id).unwrap();
     let shard_id = layout.shard_ids().next().unwrap();
     let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
-    // Premise for the {0,1} blacklist below: three distinct producers, so blacklisting two
-    // leaves a survivor and the keep-one valve stays quiet.
+    // Premise: producers are exactly {0, 1, 2}. The sibling blacklists 0 (inherited from the
+    // prefix) and 1 (branch-local), so 2 is the unique remaining eligible producer and the
+    // keep-one valve stays quiet.
     let shard_index = layout.get_shard_index(shard_id).unwrap();
     assert_eq!(
-        epoch_info.chunk_producers_settlement()[shard_index].iter().collect::<HashSet<_>>().len(),
-        3,
-        "fork test needs a shard with exactly three distinct chunk producers",
+        epoch_info.chunk_producers_settlement()[shard_index]
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>(),
+        HashSet::from([0, 1, 2]),
+        "fork test needs chunk producers exactly {{0, 1, 2}}",
     );
 
     let genesis = fork_block_hash(0, 0);
@@ -1860,7 +1865,8 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     );
 
     // Phase 4: extend the canonical branch until its anchor's last-final block is
-    // canonical-only (past the shared prefix), then snapshot the canonical finality watermark.
+    // canonical-only (past the shared prefix), then snapshot the finality watermark and the
+    // cache position (the canonical anchor's last-final block).
     let (canonical_tip, _) = drive_until(
         &handle,
         epoch_info.as_ref(),
@@ -1874,20 +1880,64 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
         "canonical last-final becomes canonical-only",
         |h, tip| h.read().get_block_info(&tip).unwrap().last_finalized_height() > fork_point_height,
     );
-    let canonical_watermark = handle.read().largest_final_height;
+    let (canonical_watermark, canonical_cache) = {
+        let read = handle.read();
+        let canonical_final = *read.get_block_info(&canonical_tip).unwrap().last_final_block_hash();
+        let cache = read.epoch_info_aggregator.last_block_hash;
+        assert_eq!(
+            cache, canonical_final,
+            "the cache must sit on the canonical anchor's last-final block",
+        );
+        (read.largest_final_height, cache)
+    };
 
-    // Phase 5: extend the sibling, starving producer 1, until it overtakes the canonical
-    // watermark, the aggregator cache has moved onto the sibling (its `last_block_hash` is the
-    // sibling's own last-final block), and its blacklist is exactly {0, 1}. The monotone
-    // `largest_final_height` gate is what keeps the sibling from mutating the cache until it
-    // genuinely overtakes; passing it replaces the cache with a fresh walk onto the sibling.
-    let (sibling_tip, _) = drive_until(
+    // Phase 5: drive the sibling to exact final-height equality with the canonical watermark.
+    // The cache-replacement gate on `largest_final_height` is a strict `>`: at a tie the
+    // sibling must not move the watermark or the cached aggregator (a `>=` would flap the
+    // cache by arrival order). Rows are still seeded for these blocks; only the cache state
+    // must stay put.
+    let (sibling_tie, tie_height) = drive_until(
         &handle,
         epoch_info.as_ref(),
         &layout,
         shard_id,
         sibling_first,
         first_height,
+        2,
+        1,
+        256,
+        "sibling final height ties the canonical watermark",
+        |h, tip| {
+            h.read().get_block_info(&tip).unwrap().last_finalized_height() == canonical_watermark
+        },
+    );
+    let (tie_final_hash, watermark_at_tie, cache_at_tie) = {
+        let read = handle.read();
+        (
+            *read.get_block_info(&sibling_tie).unwrap().last_final_block_hash(),
+            read.largest_final_height,
+            read.epoch_info_aggregator.last_block_hash,
+        )
+    };
+    assert_ne!(
+        tie_final_hash, canonical_cache,
+        "the tie must be a genuinely different sibling final block",
+    );
+    assert_eq!(watermark_at_tie, canonical_watermark, "a tie must not move the watermark");
+    assert_eq!(cache_at_tie, canonical_cache, "a tie must not replace the cached aggregator");
+
+    // Phase 6: extend the sibling, starving producer 1, until it overtakes the canonical
+    // watermark, the aggregator cache has moved onto the sibling (its `last_block_hash` is the
+    // sibling's own last-final block), and its blacklist is exactly {0, 1}. The monotone
+    // `largest_final_height` gate is what keeps the sibling from mutating the cache until it
+    // genuinely overtakes; passing it replaces the cache with a fresh walk onto the sibling.
+    let (sibling_tip, sibling_height) = drive_until(
+        &handle,
+        epoch_info.as_ref(),
+        &layout,
+        shard_id,
+        sibling_tie,
+        tie_height,
         2,
         1,
         256,
@@ -1911,7 +1961,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     );
     assert_ne!(canonical_tip, sibling_tip, "forks must have distinct anchor hashes");
 
-    // Phase 6: the abandoned canonical anchor is unchanged. Its blacklist is still exactly
+    // Phase 7: the abandoned canonical anchor is unchanged. Its blacklist is still exactly
     // {0}, and aggregating to its own last-final basis now returns `full_info == true`: the
     // cache sits on the sibling, so the walk cannot reach the cached sync point and instead
     // walks the canonical chain from the epoch start.
@@ -1933,7 +1983,7 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
         "after the sibling takeover the canonical basis must walk from the epoch start",
     );
 
-    // Phase 7: the sibling resolves to its own {0, 1}; the valve did not fire (3 producers,
+    // Phase 8: the sibling resolves to its own {0, 1}; the valve did not fire (3 producers,
     // one survivor left).
     let sibling_bl = handle.get_chunk_producer_blacklist(&sibling_tip).unwrap();
     assert_eq!(
@@ -1941,6 +1991,121 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
         HashMap::from([(shard_id, HashSet::from([0, 1]))]),
         "sibling must resolve to its own blacklist, isolated from the canonical branch",
     );
+
+    // Phase 9: the persisted rows carry the full {0, 1} blacklist. `stored == 2` alone cannot
+    // prove that: the blacklist-aware sampler redistributes rather than retrying the plain
+    // pick, so a seeder that lost one entry could still store 2 at many heights. So assert
+    // `stored == 2` at every scanned anchor, and keep scanning until heights were seen where
+    // each broken variant would have stored something else — the plain sampler (no blacklist),
+    // and the excluding sampler under {1} only (lost inherited 0) and {0} only (lost
+    // branch-local 1).
+    let full_blacklist = HashSet::from([0, 1]);
+    let expected_bl = HashMap::from([(shard_id, full_blacklist.clone())]);
+    let (mut tip, mut height) = (sibling_tip, sibling_height);
+    let mut saw_no_blacklist = false;
+    let mut saw_missing_inherited = false;
+    let mut saw_missing_branch_local = false;
+    for _ in 0..128 {
+        assert_eq!(
+            handle.get_chunk_producer_blacklist(&tip).unwrap(),
+            expected_bl,
+            "sibling blacklist drifted from {{0, 1}} while scanning rows",
+        );
+        let witness = assert_seeded_row_matches_blacklist(
+            &handle,
+            epoch_info.as_ref(),
+            &layout,
+            shard_id,
+            &epoch_id,
+            tip,
+            &full_blacklist,
+        );
+        assert_eq!(witness.expected, 2, "excluding {{0, 1}} from {{0, 1, 2}} must leave 2");
+        assert_eq!(witness.stored, 2, "stored row must be the sole non-blacklisted producer");
+        let without_inherited = epoch_info
+            .sample_chunk_producer_excluding(
+                &layout,
+                shard_id,
+                witness.chunk_height,
+                &HashSet::from([1]),
+            )
+            .unwrap();
+        let without_branch_local = epoch_info
+            .sample_chunk_producer_excluding(
+                &layout,
+                shard_id,
+                witness.chunk_height,
+                &HashSet::from([0]),
+            )
+            .unwrap();
+        saw_no_blacklist |= witness.plain != 2;
+        saw_missing_inherited |= without_inherited != 2;
+        saw_missing_branch_local |= without_branch_local != 2;
+        if saw_no_blacklist && saw_missing_inherited && saw_missing_branch_local {
+            return;
+        }
+        height += 1;
+        tip = fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, tip, 2, height, 1);
+    }
+    let (basis, basis_height, cache, watermark) = {
+        let read = handle.read();
+        let info = read.get_block_info(&tip).unwrap();
+        (
+            *info.last_final_block_hash(),
+            info.last_finalized_height(),
+            read.epoch_info_aggregator.last_block_hash,
+            read.largest_final_height,
+        )
+    };
+    panic!(
+        "no discriminating rows within 128 blocks: tip {tip} at height {height}, basis {basis} \
+         (height {basis_height}), cache {cache}, watermark {watermark}; witnesses \
+         no_blacklist={saw_no_blacklist} missing_inherited={saw_missing_inherited} \
+         missing_branch_local={saw_missing_branch_local}",
+    );
+}
+
+/// The persisted `DBCol::ChunkProducers` row for one anchor, alongside the samples a caller
+/// needs to judge whether the anchor discriminates a broken blacklist.
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+struct SeededRowWitness {
+    chunk_height: u64,
+    /// Plain height sample (what the seeder would store with no blacklist).
+    plain: ValidatorId,
+    /// Blacklist-aware sample (what the seeder must store).
+    expected: ValidatorId,
+    /// What the seeder actually stored.
+    stored: ValidatorId,
+}
+
+/// Reads the persisted `DBCol::ChunkProducers` row for `tip` and asserts it is the
+/// blacklist-aware sample and not blacklisted. The anchor height comes from `tip`'s own
+/// `BlockInfo`, so the row read and the expected sample cannot diverge. Note the two samplers
+/// draw from different distributions, so they can differ even at heights where the plain pick
+/// is not blacklisted.
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+fn assert_seeded_row_matches_blacklist(
+    handle: &EpochManagerHandle,
+    epoch_info: &EpochInfo,
+    layout: &ShardLayout,
+    shard_id: ShardId,
+    epoch_id: &EpochId,
+    tip: CryptoHash,
+    shard_blacklist: &HashSet<ValidatorId>,
+) -> SeededRowWitness {
+    let anchor_height = handle.read().get_block_info(&tip).unwrap().height();
+    let chunk_height = anchor_height + CHUNK_GRANDPARENT_ANCHOR_HEIGHT_OFFSET;
+    let plain = epoch_info.sample_chunk_producer(layout, shard_id, chunk_height).unwrap();
+    let expected = epoch_info
+        .sample_chunk_producer_excluding(layout, shard_id, chunk_height, shard_blacklist)
+        .unwrap();
+    let stored_stake = handle
+        .get_chunk_producer_info_anchored(Some(&tip), epoch_id, chunk_height, shard_id)
+        .unwrap();
+    let stored = epoch_info.get_validator_id(stored_stake.account_id()).copied().unwrap();
+    assert_eq!(stored, expected, "seeded row must be the blacklist-aware sample");
+    assert!(!shard_blacklist.contains(&stored), "seeded row must not be a blacklisted producer");
+    SeededRowWitness { chunk_height, plain, expected, stored }
 }
 
 /// Drives `branch` off the shared `fork_point`, starving `target`, until it blacklists
@@ -1975,13 +2140,10 @@ fn assert_branch_seeds_own_blacklist(
     );
 
     // Extend (target stays down, so the blacklist stays {target}) until the PLAIN sampler
-    // at the anchor offset would pick the blacklisted producer. Only then does the seeder's
-    // reassignment change the stored row, so scanning only the anchors the drive happened to
-    // leave is not enough — with one blacklisted producer of three a short window need not
-    // contain a plain sample of it.
+    // at the anchor offset picks the blacklisted producer — only such an anchor proves the
+    // seeder rerouted away from a blacklisted canonical pick. With one blacklisted producer
+    // of three, the anchors the drive happened to leave need not contain one.
     for _ in 0..128 {
-        let chunk_height = height + CHUNK_GRANDPARENT_ANCHOR_HEIGHT_OFFSET;
-        let plain = epoch_info.sample_chunk_producer(layout, shard_id, chunk_height).unwrap();
         let blacklist = handle.get_chunk_producer_blacklist(&tip).unwrap();
         let shard_blacklist = blacklist.get(&shard_id).cloned().unwrap_or_default();
         assert_eq!(
@@ -1989,25 +2151,19 @@ fn assert_branch_seeds_own_blacklist(
             HashSet::from([target]),
             "branch {branch} blacklist drifted from {{{target}}}",
         );
-        if shard_blacklist.contains(&plain) {
-            let expected = epoch_info
-                .sample_chunk_producer_excluding(layout, shard_id, chunk_height, &shard_blacklist)
-                .unwrap();
-            let stored_stake = handle
-                .get_chunk_producer_info_anchored(Some(&tip), epoch_id, chunk_height, shard_id)
-                .unwrap();
-            let stored = epoch_info.get_validator_id(stored_stake.account_id()).copied().unwrap();
-            assert_eq!(
-                stored, expected,
-                "branch {branch}: seeded row must be the blacklist-aware sample",
-            );
+        let witness = assert_seeded_row_matches_blacklist(
+            handle,
+            epoch_info,
+            layout,
+            shard_id,
+            epoch_id,
+            tip,
+            &shard_blacklist,
+        );
+        if shard_blacklist.contains(&witness.plain) {
             assert_ne!(
-                stored, plain,
+                witness.stored, witness.plain,
                 "branch {branch}: seeder must reassign away from the blacklisted plain pick",
-            );
-            assert!(
-                !shard_blacklist.contains(&stored),
-                "branch {branch}: seeded row must not be a blacklisted producer",
             );
             return;
         }

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -9,12 +9,15 @@ use crate::EARLY_KICKOUT_EPOCH_GRACE_BLOCKS;
 #[cfg(feature = "nightly")]
 use crate::epoch_info_aggregator::EpochInfoAggregator;
 use crate::reward_calculator::NUM_NS_IN_SECOND;
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+use crate::set_early_kickout_thresholds_for_testing;
 use crate::test_utils::DEFAULT_TOTAL_SUPPLY;
 use crate::test_utils::{
-    record_block, record_block_with_final_and_mask, setup_default_epoch_manager,
+    epoch_info, record_block, record_block_with_final_and_mask, setup_default_epoch_manager,
 };
 use crate::{
-    EpochManager, EpochManagerAdapter, EpochManagerHandle, compute_chunk_producer_blacklist,
+    ChunkProducerBlacklist, EpochManager, EpochManagerAdapter, EpochManagerHandle,
+    compute_chunk_producer_blacklist,
 };
 #[cfg(feature = "nightly")]
 use crate::{SampleEpoch, SeedAnchor};
@@ -31,7 +34,7 @@ use near_primitives::stateless_validation::chunk_endorsements_bitmap::ChunkEndor
 use near_primitives::types::EpochId;
 #[cfg(feature = "nightly")]
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{Balance, ChunkStats, ShardId, ValidatorId};
+use near_primitives::types::{AccountId, Balance, ChunkStats, ShardId, ValidatorId};
 #[cfg(feature = "nightly")]
 use near_primitives::utils::get_block_shard_id;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -43,40 +46,48 @@ use std::collections::{HashMap, HashSet};
 
 const STAKE: Balance = Balance::from_yoctonear(1_000_000);
 
+/// Builds an `EpochInfo` over `layout` with `num_producers` accounts (ids
+/// `0..num_producers`) and one explicit chunk-producer `settlement` per shard, in
+/// shard-index order (`layout.shard_infos()`). `num_producers` is passed explicitly
+/// rather than inferred: it sets the account count that `stake_weights` indexes, and
+/// per-shard settlements no longer determine it.
+fn epoch_info_for_layout(
+    layout: &ShardLayout,
+    settlements: Vec<Vec<ValidatorId>>,
+    num_producers: u64,
+) -> EpochInfo {
+    assert_eq!(
+        settlements.len(),
+        layout.num_shards() as usize,
+        "one chunk-producer settlement per shard",
+    );
+    let accounts: Vec<_> =
+        (0..num_producers).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
+    let block_producers: Vec<ValidatorId> = (0..num_producers).collect();
+    epoch_info(0, accounts, block_producers, settlements, PROTOCOL_VERSION, layout.clone())
+}
+
 /// Builds a single-shard `EpochInfo` with `num_producers` chunk producers (ids
 /// `0..num_producers`) and returns it alongside the layout and the shard id.
 fn single_shard_epoch(num_producers: u64) -> (EpochInfo, ShardLayout, ShardId) {
-    let accounts: Vec<_> =
-        (0..num_producers).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
-    let settlement: Vec<ValidatorId> = (0..num_producers).collect();
     let shard_layout = ShardLayout::single_shard();
     let shard_id = shard_layout.shard_ids().next().unwrap();
-    let epoch_info = crate::test_utils::epoch_info(
-        0,
-        accounts,
-        settlement.clone(),
-        vec![settlement],
-        PROTOCOL_VERSION,
-        shard_layout.clone(),
-    );
+    let settlement: Vec<ValidatorId> = (0..num_producers).collect();
+    let epoch_info = epoch_info_for_layout(&shard_layout, vec![settlement], num_producers);
     (epoch_info, shard_layout, shard_id)
 }
 
-/// Like `single_shard_epoch`, but for an arbitrary `layout`: the same
-/// `0..num_producers` settlement on every shard.
-fn epoch_info_for_layout(layout: &ShardLayout, num_producers: u64) -> EpochInfo {
-    let accounts: Vec<_> =
-        (0..num_producers).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
-    let settlement: Vec<ValidatorId> = (0..num_producers).collect();
-    let num_shards = layout.num_shards() as usize;
-    crate::test_utils::epoch_info(
-        0,
-        accounts,
-        settlement.clone(),
-        vec![settlement; num_shards],
-        PROTOCOL_VERSION,
-        layout.clone(),
-    )
+/// Projects a `ChunkProducerBlacklist`'s per-shard `shard_stats` into a comparable
+/// map (`raw_candidate_count`, `kept`). `BlacklistShardStats` has no `PartialEq`, so
+/// tests read it field by field rather than adding a derive to the production struct.
+fn shard_stats_projection(
+    result: &ChunkProducerBlacklist,
+) -> HashMap<ShardId, (usize, Option<ValidatorId>)> {
+    result
+        .shard_stats
+        .iter()
+        .map(|(shard_id, stats)| (*shard_id, (stats.raw_candidate_count, stats.kept)))
+        .collect()
 }
 
 /// Convenience: builds a `shard_tracker` with a single shard from `(validator_id,
@@ -221,7 +232,7 @@ fn blacklist_multi_shard_independent() {
     let settlement: Vec<ValidatorId> = (0..num_producers).collect();
     let shard_layout = ShardLayout::multi_shard(2, 0);
     let shard_ids: Vec<ShardId> = shard_layout.shard_ids().collect();
-    let epoch_info = crate::test_utils::epoch_info(
+    let epoch_info = epoch_info(
         0,
         accounts,
         settlement.clone(),
@@ -1419,30 +1430,73 @@ fn accessor_propagates_missing_block_info_on_same_epoch_basis() {
     );
 }
 
-// 13. Stats are resolved against the layout the blacklist is computed for. One
-//     `shard_tracker` carrying both a retired parent shard id and a child shard id is
-//     fed to both layouts: each drops the id that has no shard index there, and the
-//     shard that survived the split resolves in both.
+// 13. Defense-in-depth unit coverage for resolving mixed parent/child shard ids
+//     against the layout the blacklist is computed for. One `shard_tracker` carrying
+//     ids from both layouts is fed to each: every valid shard keeps its own-settlement
+//     candidate, and ids with no shard index in that layout are dropped. This does not
+//     drive an epoch-boundary resharding transition (see the out-of-scope note below).
+//
+//     Distinct per-shard settlements make it discriminating: with the identical
+//     `0..n` settlement on every shard, resolving a valid shard to a wrong-but-in-range
+//     index would still produce the same blacklist. Production reads the settlement at
+//     the resolved index and filters candidates against it, so a wrong valid index only
+//     surfaces when the settlements differ.
+//
+//     Run over both the V2 and V3 derivations: production dynamic resharding derives
+//     V3, and the two operations under test (`get_shard_index` + settlement lookup)
+//     behave identically in both, so this tracks the fixture to production.
+//
+//     Out of scope: an end-to-end boundary transition. The layout-mismatch drop branch
+//     looks unreachable in production today — `chunk_producer_blacklist_at_anchor`
+//     checks `aggregator.epoch_id` first, and the layout is fixed within an epoch.
 #[test]
 fn blacklist_resharding_maps_to_current_layout_shard_ids() {
-    let num_producers = 4u64;
-    let parent = ShardLayout::multi_shard(2, 0);
+    // Explicit non-identity layout so `shard_id != shard_index` holds by construction
+    // for every shard (no dependency on `multi_shard`'s seeded shuffle). Parent covers
+    // accounts split at "mmm" with ids [1, 0]; splitting at "aaa" (sorts first) retires
+    // shard 1 into children [2, 3] and leaves shard 0. Both the V2 and V3 derivations
+    // splice `[max_shard_id + 1, max_shard_id + 2]` at the new boundary's insert index,
+    // so both yield [2, 3, 0]; pin all three vectors before deriving generically.
+    let split_boundary: AccountId = "aaa".parse().unwrap();
+    let parent =
+        ShardLayout::v2(vec!["mmm".parse().unwrap()], vec![ShardId::new(1), ShardId::new(0)], None);
+    assert_eq!(
+        parent.shard_ids().collect::<Vec<_>>(),
+        vec![ShardId::new(1), ShardId::new(0)],
+        "parent shard ids",
+    );
+    let v2_child = ShardLayout::derive_shard_layout(&parent, split_boundary.clone());
+    let v3_child = parent.derive_v3(split_boundary, || vec![]).unwrap();
+    for child in [&v2_child, &v3_child] {
+        assert_eq!(
+            child.shard_ids().collect::<Vec<_>>(),
+            vec![ShardId::new(2), ShardId::new(3), ShardId::new(0)],
+            "child shard ids",
+        );
+    }
+
+    reshard_case(&parent, &v2_child);
+    reshard_case(&parent, &v3_child);
+}
+
+/// One reshard mapping check for a `parent`/`child` layout pair (the caller pins the
+/// concrete shard ids first). Derives the retired parent, survivor and children by set
+/// difference, feeds one shared `shard_tracker` to both layouts, and asserts that each
+/// keeps its valid shards' candidates and drops the ids foreign to it.
+fn reshard_case(parent: &ShardLayout, child: &ShardLayout) {
     let parent_ids: Vec<ShardId> = parent.shard_ids().collect();
-    let child = ShardLayout::derive_shard_layout(&parent, "aaa".parse().unwrap());
     let child_ids: Vec<ShardId> = child.shard_ids().collect();
-    assert_eq!(child.num_shards(), 3, "split must add exactly one shard");
 
-    let split_parent = *parent_ids
-        .iter()
-        .find(|id| !child_ids.contains(id))
-        .expect("exactly one parent shard is split/retired");
-    let surviving = *parent_ids
-        .iter()
-        .find(|id| child_ids.contains(id))
-        .expect("exactly one parent shard survives the split");
+    let retired: Vec<ShardId> =
+        parent_ids.iter().copied().filter(|id| !child_ids.contains(id)).collect();
+    let survivors: Vec<ShardId> =
+        parent_ids.iter().copied().filter(|id| child_ids.contains(id)).collect();
+    assert_eq!(retired.len(), 1, "exactly one parent shard is split/retired, got {retired:?}");
+    assert_eq!(survivors.len(), 1, "exactly one parent shard survives, got {survivors:?}");
+    let split_parent = retired[0];
+    let surviving = survivors[0];
     let children = child.get_children_shards_ids(split_parent).expect("split parent has children");
-    assert_eq!(children.len(), 2, "a split yields two children");
-
+    assert_eq!(children.len(), 2, "a split yields two children, got {children:?}");
     for c in &children {
         assert!(!parent_ids.contains(c), "child id {c} must not reuse a parent shard id");
         assert_eq!(
@@ -1452,131 +1506,475 @@ fn blacklist_resharding_maps_to_current_layout_shard_ids() {
         );
     }
 
-    let parent_ei = epoch_info_for_layout(&parent, num_producers);
-    let child_ei = epoch_info_for_layout(&child, num_producers);
+    // The drop is a layout-level `get_shard_index` miss: a retired parent lives only in
+    // the split map, a child does not exist in the parent, so neither resolves.
+    assert!(
+        child.get_shard_index(split_parent).is_err(),
+        "retired parent {split_parent} must have no shard index in the child layout",
+    );
+    assert!(
+        parent.get_shard_index(children[0]).is_err(),
+        "child {} must have no shard index in the parent layout",
+        children[0],
+    );
 
-    // 0/100 clears both gates (100 misses, 0% ratio). Exactly one bad producer per
-    // shard, so the keep-one valve never fires and the expected maps stay exact.
-    let one_bad = |bad_id: ValidatorId| -> HashMap<ValidatorId, ChunkStats> {
-        (0..num_producers)
-            .map(|id| {
-                let stats = if id == bad_id {
-                    ChunkStats::new_with_production(0, 100)
-                } else {
-                    ChunkStats::new_with_production(100, 100)
-                };
-                (id, stats)
-            })
-            .collect()
+    // Five producers: one bad producer per shard plus a shared healthy producer (id 4).
+    // Distinct settlements built in declared shard-index order, never via `get_shard_index`
+    // (the mechanism under test must not be its own oracle). Each valid shard's bad
+    // producer sits in that shard's own settlement.
+    const HEALTHY: ValidatorId = 4;
+    let num_producers = 5u64;
+    let bad_producer = |shard: ShardId| -> ValidatorId {
+        if shard == ShardId::new(1) {
+            0
+        } else if shard == ShardId::new(0) {
+            1
+        } else if shard == ShardId::new(2) {
+            2
+        } else if shard == ShardId::new(3) {
+            3
+        } else {
+            panic!("unexpected shard id {shard}")
+        }
     };
-    let st: HashMap<ShardId, HashMap<ValidatorId, ChunkStats>> = HashMap::from([
-        (surviving, one_bad(0)),
-        (split_parent, one_bad(1)),
-        (children[0], one_bad(2)),
-    ]);
+    let settlement_for =
+        |shard: ShardId| -> Vec<ValidatorId> { vec![bad_producer(shard), HEALTHY] };
+    let settlements = |layout: &ShardLayout| -> Vec<Vec<ValidatorId>> {
+        layout.shard_ids().map(settlement_for).collect()
+    };
+    let parent_ei = epoch_info_for_layout(parent, settlements(parent), num_producers);
+    let child_ei = epoch_info_for_layout(child, settlements(child), num_producers);
 
-    let bl_parent = blacklist(&st, &parent_ei, &parent);
-    assert_eq!(
-        bl_parent,
-        HashMap::from([(surviving, HashSet::from([0])), (split_parent, HashSet::from([1]))]),
-    );
-    assert!(!bl_parent.contains_key(&children[0]), "child id must not resolve on parent layout");
-    assert!(!bl_parent.contains_key(&children[1]), "child id must not resolve on parent layout");
+    // One tracker carrying every shard id from both layouts. 0/100 clears both gates
+    // (100 missed, 0% ratio); the healthy id is 100/100. One candidate per shard, so the
+    // keep-one valve never fires (`kept == None`).
+    let candidate_shard = |shard: ShardId| -> HashMap<ValidatorId, ChunkStats> {
+        HashMap::from([
+            (bad_producer(shard), ChunkStats::new_with_production(0, 100)),
+            (HEALTHY, ChunkStats::new_with_production(100, 100)),
+        ])
+    };
+    let all_shards: HashSet<ShardId> = parent_ids.iter().chain(child_ids.iter()).copied().collect();
+    let st: HashMap<ShardId, HashMap<ValidatorId, ChunkStats>> =
+        all_shards.iter().map(|&shard| (shard, candidate_shard(shard))).collect();
 
-    let bl_child = blacklist(&st, &child_ei, &child);
+    // Parent layout: shards 1 and 0 resolve, the two child ids are foreign and dropped.
+    let parent_result = compute_chunk_producer_blacklist(&st, &parent_ei, parent);
     assert_eq!(
-        bl_child,
-        HashMap::from([(surviving, HashSet::from([0])), (children[0], HashSet::from([2]))]),
+        parent_result.blacklist,
+        HashMap::from([
+            (split_parent, HashSet::from([bad_producer(split_parent)])),
+            (surviving, HashSet::from([bad_producer(surviving)])),
+        ]),
+        "parent layout must blacklist each valid shard's own-settlement candidate",
     );
-    assert!(
-        !bl_child.contains_key(&split_parent),
-        "retired parent id must not resolve on child layout",
+    assert_eq!(
+        shard_stats_projection(&parent_result),
+        HashMap::from([(split_parent, (1, None)), (surviving, (1, None))]),
+        "parent layout stats: one candidate per valid shard, valve not fired",
     );
-    assert!(
-        !bl_child.contains_key(&children[1]),
-        "child shard with no stats must be absent from the blacklist",
+
+    // Child layout: children and the survivor resolve, the retired parent id is dropped.
+    let child_result = compute_chunk_producer_blacklist(&st, &child_ei, child);
+    assert_eq!(
+        child_result.blacklist,
+        HashMap::from([
+            (children[0], HashSet::from([bad_producer(children[0])])),
+            (children[1], HashSet::from([bad_producer(children[1])])),
+            (surviving, HashSet::from([bad_producer(surviving)])),
+        ]),
+        "child layout must blacklist each valid shard's own-settlement candidate",
+    );
+    assert_eq!(
+        shard_stats_projection(&child_result),
+        HashMap::from(
+            [(children[0], (1, None)), (children[1], (1, None)), (surviving, (1, None)),]
+        ),
+        "child layout stats: one candidate per valid shard, valve not fired",
     );
 }
 
-/// `drive_down_node` starting from an arbitrary `fork_point`: blacklist-aware
-/// assignment, chunk missed only when the sampler picks `target`. `salt` keeps sibling
-/// forks' block hashes distinct. Returns the tip.
-#[cfg(feature = "nightly")]
-fn drive_fork(
+/// A block hash on `branch` at `height`. The branch byte is a domain separator, so
+/// sibling branches (and the shared prefix's branch 0) never collide, whatever heights
+/// they reuse across the fork.
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+fn fork_block_hash(branch: u8, height: u64) -> CryptoHash {
+    hash(&[&[branch][..], &height.to_le_bytes()[..]].concat())
+}
+
+/// Records one block on `branch` at `height`, extending `prev`, using the same
+/// blacklist-aware assignment as `drive_down_node`: the chunk is missed exactly when
+/// `target` is the scheduled producer, so `target` accrues misses while its slots
+/// reassign to producers that actually produce. Returns the new tip. Shared by the two
+/// fork tests below (their only genuine overlap).
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+fn fork_step(
     handle: &EpochManagerHandle,
-    fork_point: CryptoHash,
-    fork_point_height: u64,
-    count: u64,
+    epoch_info: &EpochInfo,
+    layout: &ShardLayout,
+    shard_id: ShardId,
+    prev: CryptoHash,
+    branch: u8,
+    height: u64,
     target: ValidatorId,
-    salt: u64,
 ) -> CryptoHash {
-    let fork_hash = |height: u64| hash(&[salt.to_le_bytes(), height.to_le_bytes()].concat());
-    let epoch_id = handle.get_epoch_id(&fork_point).unwrap();
+    let cur = fork_block_hash(branch, height);
+    let empty = HashSet::new();
+    let blacklist = handle.get_chunk_producer_blacklist(&prev).unwrap();
+    let assigned = epoch_info
+        .sample_chunk_producer_excluding(
+            layout,
+            shard_id,
+            height,
+            blacklist.get(&shard_id).unwrap_or(&empty),
+        )
+        .unwrap();
+    let produced = assigned != target;
+    record_block_with_mask(&mut handle.write(), prev, cur, height, vec![produced]);
+    cur
+}
+
+/// Drives one branch forward via `fork_step` until `done(tip)` holds, starting from
+/// `(prev, height)`. Every phase of the fork tests is driven by an observable condition
+/// rather than a fixed block count, because the sampler and the two-block finality lag
+/// decide when a condition becomes true. Panics with the full fork state if `cap` steps
+/// pass first. Returns the tip and its height.
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+fn drive_until(
+    handle: &EpochManagerHandle,
+    epoch_info: &EpochInfo,
+    layout: &ShardLayout,
+    shard_id: ShardId,
+    mut prev: CryptoHash,
+    mut height: u64,
+    branch: u8,
+    target: ValidatorId,
+    cap: u64,
+    phase: &str,
+    mut done: impl FnMut(&EpochManagerHandle, CryptoHash) -> bool,
+) -> (CryptoHash, u64) {
+    for _ in 0..cap {
+        if done(handle, prev) {
+            return (prev, height);
+        }
+        height += 1;
+        prev = fork_step(handle, epoch_info, layout, shard_id, prev, branch, height, target);
+    }
+    if done(handle, prev) {
+        return (prev, height);
+    }
+    let (basis, watermark, cache) = {
+        let read = handle.read();
+        let info = read.get_block_info(&prev).unwrap();
+        (
+            *info.last_final_block_hash(),
+            read.largest_final_height,
+            read.epoch_info_aggregator.last_block_hash,
+        )
+    };
+    let target_stats = handle
+        .read()
+        .get_epoch_info_aggregator_upto_last(&basis)
+        .ok()
+        .and_then(|agg| agg.shard_tracker.get(&shard_id).and_then(|m| m.get(&target).cloned()))
+        .map(|s| (s.produced(), s.expected()))
+        .unwrap_or((0, 0));
+    let blacklist = handle.get_chunk_producer_blacklist(&prev).unwrap();
+    panic!(
+        "phase {phase:?}: cap {cap} exceeded on branch {branch} at height {height}; anchor {prev} \
+         basis {basis} cache {cache} watermark {watermark}; target {target} produced {} expected {} \
+         missed {}; blacklist {blacklist:?}",
+        target_stats.0,
+        target_stats.1,
+        target_stats.1.saturating_sub(target_stats.0),
+    );
+}
+
+// v152+ protocol: two sibling forks off a shared prefix starve different producers, and
+// the accessor (keyed on the anchor hash) resolves each fork to its own blacklist. This
+// one test interleaves the deep-sibling overtake, the late-prefix inheritance and the
+// cached-prefix path, asserting the aggregator exit directly via `aggregate_epoch_info_upto`'s
+// `full_info` flag rather than inferring it from blacklist equality.
+//
+// Lowered test-only thresholds (10 misses past a 20-block grace) keep it cheap. The prior
+// fixture used an equal-depth sibling forked at height 1: that ancient fork point kept the
+// cached aggregator pinned to genesis, so every per-block seed walk ran to genesis and the
+// recording cost was quadratic in the sibling depth. Forking at the cached last-final block
+// (the real production shape) makes the sibling grow linearly, so the real 100-miss /
+// 1000-block thresholds would also work here at ~1500 blocks; the lowered thresholds are for
+// speed and legibility, not correctness. Real thresholds stay covered by the canonical tests.
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+#[test]
+fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
+    let _guard = set_early_kickout_thresholds_for_testing(Some(10), Some(20));
+    // 3 validators so blacklisting two producers on the sibling does not trip the keep-one
+    // valve; the contamination a leak would cause then shows up in the blacklist itself.
+    let validators = vec![
+        ("test0".parse().unwrap(), STAKE),
+        ("test1".parse().unwrap(), STAKE),
+        ("test2".parse().unwrap(), STAKE),
+    ];
+    // Epoch length large enough that everything stays inside epoch 0 (no boundary reset).
+    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+    let epoch_id = EpochId::default();
     let layout = handle.get_shard_layout(&epoch_id).unwrap();
     let shard_id = layout.shard_ids().next().unwrap();
     let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
-    let empty = HashSet::new();
-    let mut prev = fork_point;
-    for i in 1..=count {
-        let height = fork_point_height + i;
-        let cur = fork_hash(height);
-        let blacklist = handle.get_chunk_producer_blacklist(&prev).unwrap();
-        let assigned = epoch_info
-            .sample_chunk_producer_excluding(
-                &layout,
-                shard_id,
-                height,
-                blacklist.get(&shard_id).unwrap_or(&empty),
-            )
-            .unwrap();
-        let produced = assigned != target;
-        record_block_with_mask(&mut handle.write(), prev, cur, height, vec![produced]);
-        prev = cur;
-    }
-    prev
+
+    let genesis = fork_block_hash(0, 0);
+    record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
+
+    // Phase 1: shared prefix on branch 0, starving producer 0, until the accessor is
+    // exactly {0}. The fork point is this prefix tip — at or above the cached last-final
+    // block, so both forks descend from the cached position (linear seed walks).
+    let only_0 = HashMap::from([(shard_id, HashSet::from([0]))]);
+    let (fork_point, fork_point_height) = drive_until(
+        &handle,
+        epoch_info.as_ref(),
+        &layout,
+        shard_id,
+        genesis,
+        0,
+        0,
+        0,
+        256,
+        "shared prefix -> {0}",
+        |h, tip| h.get_chunk_producer_blacklist(&tip).unwrap() == only_0,
+    );
+
+    // Phase 2: branch a canonical child (keeps starving 0) and a sibling child (starves 1)
+    // off the shared fork point.
+    let first_height = fork_point_height + 1;
+    let canonical_first =
+        fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, fork_point, 1, first_height, 0);
+    let sibling_first =
+        fork_step(&handle, epoch_info.as_ref(), &layout, shard_id, fork_point, 2, first_height, 1);
+    assert_ne!(canonical_first, sibling_first, "sibling branches must have distinct hashes");
+
+    // Phase 3: white-box coverage of the aggregator helper. Aggregating to the first sibling
+    // block itself (NOT the blacklist basis for that anchor — the accessor aggregates to the
+    // anchor's last-final block) reaches the same-epoch cached-prefix sync point, so
+    // `full_info` is false and the caller merges the cached prefix. `merge_prefix` is the
+    // intended behaviour there, not contamination: the merged aggregator carries producer 0's
+    // common-prefix stats.
+    let (_, full_info) = handle
+        .read()
+        .aggregate_epoch_info_upto(&sibling_first)
+        .unwrap()
+        .expect("first sibling block differs from the cache position");
+    assert!(!full_info, "first sibling block must hit the same-epoch cached-prefix exit");
+    let merged = handle.read().get_epoch_info_aggregator_upto_last(&sibling_first).unwrap();
+    let producer_0 = merged.shard_tracker.get(&shard_id).and_then(|m| m.get(&0));
+    assert!(
+        producer_0.is_some_and(|s| s.expected() > 0),
+        "merged aggregator must carry producer 0's common-prefix stats, got {producer_0:?}",
+    );
+
+    // Phase 4: extend the canonical branch until its anchor's last-final block is
+    // canonical-only (past the shared prefix), then snapshot the canonical finality watermark.
+    let (canonical_tip, _) = drive_until(
+        &handle,
+        epoch_info.as_ref(),
+        &layout,
+        shard_id,
+        canonical_first,
+        first_height,
+        1,
+        0,
+        256,
+        "canonical last-final becomes canonical-only",
+        |h, tip| h.read().get_block_info(&tip).unwrap().last_finalized_height() > fork_point_height,
+    );
+    let canonical_watermark = handle.read().largest_final_height;
+
+    // Phase 5: extend the sibling, starving producer 1, until it overtakes the canonical
+    // watermark, the aggregator cache has moved onto the sibling (its `last_block_hash` is the
+    // sibling's own last-final block), and its blacklist is exactly {0, 1}. The monotone
+    // `largest_final_height` gate is what keeps the sibling from mutating the cache until it
+    // genuinely overtakes; passing it triggers the full-rewalk replace onto the sibling.
+    let (sibling_tip, _) = drive_until(
+        &handle,
+        epoch_info.as_ref(),
+        &layout,
+        shard_id,
+        sibling_first,
+        first_height,
+        2,
+        1,
+        256,
+        "sibling overtakes and blacklist becomes {0,1}",
+        |h, tip| {
+            let (final_hash, final_height, cache) = {
+                let read = h.read();
+                let info = read.get_block_info(&tip).unwrap();
+                (
+                    *info.last_final_block_hash(),
+                    info.last_finalized_height(),
+                    read.epoch_info_aggregator.last_block_hash,
+                )
+            };
+            if final_height <= canonical_watermark || cache != final_hash {
+                return false;
+            }
+            h.get_chunk_producer_blacklist(&tip).unwrap().get(&shard_id)
+                == Some(&HashSet::from([0, 1]))
+        },
+    );
+    assert_ne!(canonical_tip, sibling_tip, "forks must have distinct anchor hashes");
+
+    // Phase 6: the abandoned canonical anchor is unchanged. Its blacklist is still exactly
+    // {0}, and aggregating to its own last-final basis now returns `full_info == true`: the
+    // cache sits on the sibling, so the walk cannot reach the cached sync point and rewalks
+    // the canonical chain to the epoch start.
+    let canonical_bl = handle.get_chunk_producer_blacklist(&canonical_tip).unwrap();
+    assert_eq!(
+        canonical_bl,
+        HashMap::from([(shard_id, HashSet::from([0]))]),
+        "canonical blacklist must be unchanged after the sibling took over the cache",
+    );
+    let canonical_basis =
+        *handle.read().get_block_info(&canonical_tip).unwrap().last_final_block_hash();
+    let (_, canonical_full_info) = handle
+        .read()
+        .aggregate_epoch_info_upto(&canonical_basis)
+        .unwrap()
+        .expect("canonical basis differs from the sibling cache position");
+    assert!(
+        canonical_full_info,
+        "after the sibling takeover the canonical basis must trigger a full rewalk",
+    );
+
+    // Phase 7: the sibling resolves to its own {0, 1}; the valve did not fire (3 producers,
+    // one survivor left).
+    let sibling_bl = handle.get_chunk_producer_blacklist(&sibling_tip).unwrap();
+    assert_eq!(
+        sibling_bl,
+        HashMap::from([(shard_id, HashSet::from([0, 1]))]),
+        "sibling must resolve to its own blacklist, isolated from the canonical branch",
+    );
 }
 
-// 14. v152+ protocol: two sibling forks off a shared prefix starve different producers.
-//     The accessor is keyed on the anchor hash and aggregates only along that anchor's
-//     own chain, so each fork resolves to its own blacklist. `record_block_info` takes
-//     arbitrary prev/cur, so these are real forks, not a harness approximation.
-#[cfg(feature = "nightly")]
+/// Drives `branch` off the shared `fork_point`, starving `target`, until it blacklists
+/// exactly `{target}`, then manufactures a non-vacuous anchor and asserts the seeded
+/// `DBCol::ChunkProducers` row (the row consensus actually reads) reflects that branch's
+/// blacklist: it excludes `target` at a height where the plain sampler would have picked it.
+#[cfg(all(feature = "nightly", feature = "test_features"))]
+fn assert_branch_seeds_own_blacklist(
+    handle: &EpochManagerHandle,
+    epoch_info: &EpochInfo,
+    layout: &ShardLayout,
+    shard_id: ShardId,
+    epoch_id: &EpochId,
+    fork_point: CryptoHash,
+    fork_point_height: u64,
+    branch: u8,
+    target: ValidatorId,
+) {
+    let only_target = HashMap::from([(shard_id, HashSet::from([target]))]);
+    let (mut tip, mut height) = drive_until(
+        handle,
+        epoch_info,
+        layout,
+        shard_id,
+        fork_point,
+        fork_point_height,
+        branch,
+        target,
+        256,
+        "reach single-producer blacklist",
+        |h, t| h.get_chunk_producer_blacklist(&t).unwrap() == only_target,
+    );
+
+    // Extend (target stays down, so the blacklist stays {target}) until the PLAIN sampler
+    // at the anchor offset would pick the blacklisted producer. Only then does the seeder's
+    // reassignment change the stored row, so scanning only the anchors the drive happened to
+    // leave is not enough — with one blacklisted producer of three a short window need not
+    // contain a plain sample of it.
+    for _ in 0..128 {
+        let chunk_height = height + CHUNK_GRANDPARENT_ANCHOR_HEIGHT_OFFSET;
+        let plain = epoch_info.sample_chunk_producer(layout, shard_id, chunk_height).unwrap();
+        let blacklist = handle.get_chunk_producer_blacklist(&tip).unwrap();
+        let shard_blacklist = blacklist.get(&shard_id).cloned().unwrap_or_default();
+        assert_eq!(
+            shard_blacklist,
+            HashSet::from([target]),
+            "branch {branch} blacklist drifted from {{{target}}}",
+        );
+        if shard_blacklist.contains(&plain) {
+            let expected = epoch_info
+                .sample_chunk_producer_excluding(layout, shard_id, chunk_height, &shard_blacklist)
+                .unwrap();
+            let stored_stake = handle
+                .get_chunk_producer_info_anchored(Some(&tip), epoch_id, chunk_height, shard_id)
+                .unwrap();
+            let stored = epoch_info.get_validator_id(stored_stake.account_id()).copied().unwrap();
+            assert_eq!(
+                stored, expected,
+                "branch {branch}: seeded row must be the blacklist-aware sample",
+            );
+            assert_ne!(
+                stored, plain,
+                "branch {branch}: seeder must reassign away from the blacklisted plain pick",
+            );
+            assert!(
+                !shard_blacklist.contains(&stored),
+                "branch {branch}: seeded row must not be a blacklisted producer",
+            );
+            return;
+        }
+        height += 1;
+        tip = fork_step(handle, epoch_info, layout, shard_id, tip, branch, height, target);
+    }
+    panic!(
+        "branch {branch}: no anchor whose plain pick is the blacklisted producer within 128 blocks"
+    );
+}
+
+// v152+ protocol, seeded-row companion to the fork isolation test: consensus reads the
+// stored `DBCol::ChunkProducers` row, not the live recompute, so pin that the stored row on
+// each fork reflects that fork's own blacklist. Two branches fork at genesis and starve
+// different producers; each ends with its own single-producer blacklist, and its seeded row
+// excludes that producer at a height where the plain sampler would have picked it.
+#[cfg(all(feature = "nightly", feature = "test_features"))]
 #[test]
-fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
-    let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
-    // Epoch length large enough that both forks stay inside epoch 0 (no boundary reset).
+fn fork_seeded_rows_reflect_each_branch_blacklist() {
+    let _guard = set_early_kickout_thresholds_for_testing(Some(10), Some(20));
+    let validators = vec![
+        ("test0".parse().unwrap(), STAKE),
+        ("test1".parse().unwrap(), STAKE),
+        ("test2".parse().unwrap(), STAKE),
+    ];
     let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+    let epoch_id = EpochId::default();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
 
-    let genesis = hash(&0u64.to_le_bytes());
-    let common = hash(&1u64.to_le_bytes());
+    let genesis = fork_block_hash(0, 0);
     record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
-    record_block_with_mask(&mut handle.write(), genesis, common, 1, vec![true]);
 
-    // Past the 1000-block start-of-epoch grace, so each tip has a non-empty blacklist.
-    let depth = 1200;
-    let canonical_tip = drive_fork(&handle, common, 1, depth, 0, 1);
-    // Isolation holds by construction (the aggregator walks only the anchor's own chain,
-    // and its monotone `largest_final_height` watermark rejects sibling mutation), so
-    // this snapshot pins that construction. Worth pinning because a leak would not show
-    // up in the blacklists below: the keep-one valve would drop the extra candidate.
-    let canonical_stats_before =
-        handle.read().get_epoch_info_aggregator_upto_last(&canonical_tip).unwrap().shard_tracker;
-    let fork_tip = drive_fork(&handle, common, 1, depth, 1, 2);
-    assert_ne!(canonical_tip, fork_tip, "forks must have distinct anchor hashes");
-
-    let epoch_id = handle.get_epoch_id_from_prev_block(&canonical_tip).unwrap();
-    let shard_id = handle.get_shard_layout(&epoch_id).unwrap().shard_ids().next().unwrap();
-
-    let canonical_bl = handle.get_chunk_producer_blacklist(&canonical_tip).unwrap();
-    let fork_bl = handle.get_chunk_producer_blacklist(&fork_tip).unwrap();
-
-    assert_eq!(canonical_bl, HashMap::from([(shard_id, HashSet::from([0]))]));
-    assert_eq!(fork_bl, HashMap::from([(shard_id, HashSet::from([1]))]));
-
-    let canonical_stats_after =
-        handle.read().get_epoch_info_aggregator_upto_last(&canonical_tip).unwrap().shard_tracker;
-    assert_eq!(
-        canonical_stats_before, canonical_stats_after,
-        "driving the abandoned fork must not alter the canonical anchor's aggregated stats",
+    // Two forks off genesis, each starving its own producer. Each call drives and asserts to
+    // completion before the next, so at assertion time the aggregator cache is on that branch.
+    assert_branch_seeds_own_blacklist(
+        &handle,
+        epoch_info.as_ref(),
+        &layout,
+        shard_id,
+        &epoch_id,
+        genesis,
+        0,
+        1,
+        0,
+    );
+    assert_branch_seeds_own_blacklist(
+        &handle,
+        epoch_info.as_ref(),
+        &layout,
+        shard_id,
+        &epoch_id,
+        genesis,
+        0,
+        2,
+        1,
     );
 }

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -62,6 +62,24 @@ fn single_shard_epoch(num_producers: u64) -> (EpochInfo, ShardLayout, ShardId) {
     (epoch_info, shard_layout, shard_id)
 }
 
+/// Builds an `EpochInfo` matching `layout`: `num_producers` chunk producers (ids
+/// `0..num_producers`) settled identically on EVERY shard. Used by the resharding
+/// test, where parent and child layouts need distinct shard counts.
+fn epoch_info_for_layout(layout: &ShardLayout, num_producers: u64) -> EpochInfo {
+    let accounts: Vec<_> =
+        (0..num_producers).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
+    let settlement: Vec<ValidatorId> = (0..num_producers).collect();
+    let num_shards = layout.num_shards() as usize;
+    crate::test_utils::epoch_info(
+        0,
+        accounts,
+        settlement.clone(),
+        vec![settlement; num_shards],
+        PROTOCOL_VERSION,
+        layout.clone(),
+    )
+}
+
 /// Convenience: builds a `shard_tracker` with a single shard from `(validator_id,
 /// produced, expected)` triples.
 fn tracker(
@@ -1399,5 +1417,194 @@ fn accessor_propagates_missing_block_info_on_same_epoch_basis() {
         err,
         EpochError::MissingBlock(fx.third_last),
         "expected the missing basis block to propagate verbatim, got {err:?}",
+    );
+}
+
+// 13. The blacklist is keyed by `ShardId` and resolved against the layout it is
+//     computed for. Split one shard of a 2-shard parent into two children, then feed
+//     a single `shard_tracker` that carries BOTH the retired parent shard id and a
+//     child shard id. Against the parent layout the child id is dropped; against the
+//     child layout the retired parent id is dropped. The unchanged (surviving) shard
+//     resolves in both. This proves per-shard stats map to the correct parent/child
+//     `ShardId` and never leak across the split.
+#[test]
+fn blacklist_resharding_maps_to_current_layout_shard_ids() {
+    let num_producers = 4u64;
+    // Parent layout with two (non-contiguous) shard ids.
+    let parent = ShardLayout::multi_shard(2, 0);
+    let parent_ids: Vec<ShardId> = parent.shard_ids().collect();
+    // Split one shard on a fresh boundary account -> three shards.
+    let child = ShardLayout::derive_shard_layout(&parent, "aaa".parse().unwrap());
+    let child_ids: Vec<ShardId> = child.shard_ids().collect();
+    assert_eq!(child.num_shards(), 3, "split must add exactly one shard");
+
+    // Classify the parent shards: exactly one is retired (split), one survives.
+    let split_parent = *parent_ids
+        .iter()
+        .find(|id| !child_ids.contains(id))
+        .expect("exactly one parent shard is split/retired");
+    let surviving = *parent_ids
+        .iter()
+        .find(|id| child_ids.contains(id))
+        .expect("exactly one parent shard survives the split");
+    let children = child.get_children_shards_ids(split_parent).expect("split parent has children");
+    assert_eq!(children.len(), 2, "a split yields two children");
+
+    // Child ids are brand new (not reused from the parent layout), and each maps back
+    // to the retired parent.
+    for c in &children {
+        assert!(!parent_ids.contains(c), "child id {c} must not reuse a parent shard id");
+        assert_eq!(
+            child.get_parent_shard_id(*c).unwrap(),
+            split_parent,
+            "child {c} must map to the retired parent {split_parent}",
+        );
+    }
+
+    let parent_ei = epoch_info_for_layout(&parent, num_producers);
+    let child_ei = epoch_info_for_layout(&child, num_producers);
+
+    // One failing producer per shard; the rest healthy (single candidate -> no valve).
+    // 0/100 clears both gates: missed 100 >= EARLY_KICKOUT_MIN_MISSES and ratio 0 < 80%.
+    let one_bad = |bad_id: ValidatorId| -> HashMap<ValidatorId, ChunkStats> {
+        (0..num_producers)
+            .map(|id| {
+                let stats = if id == bad_id {
+                    ChunkStats::new_with_production(0, 100)
+                } else {
+                    ChunkStats::new_with_production(100, 100)
+                };
+                (id, stats)
+            })
+            .collect()
+    };
+    // Distinct bad producer per shard so results are unambiguous.
+    let st: HashMap<ShardId, HashMap<ValidatorId, ChunkStats>> = HashMap::from([
+        (surviving, one_bad(0)),
+        (split_parent, one_bad(1)),
+        (children[0], one_bad(2)),
+    ]);
+
+    // Against the PARENT layout: the child id has no shard index and is dropped; the
+    // surviving and retired-parent ids resolve.
+    let bl_parent = blacklist(&st, &parent_ei, &parent);
+    assert_eq!(
+        bl_parent,
+        HashMap::from([(surviving, HashSet::from([0])), (split_parent, HashSet::from([1]))]),
+    );
+    assert!(!bl_parent.contains_key(&children[0]), "child id must not resolve on parent layout");
+    assert!(!bl_parent.contains_key(&children[1]), "child id must not resolve on parent layout");
+
+    // Against the CHILD layout: the retired parent id has no shard index and is
+    // dropped; the surviving and child ids resolve.
+    let bl_child = blacklist(&st, &child_ei, &child);
+    assert_eq!(
+        bl_child,
+        HashMap::from([(surviving, HashSet::from([0])), (children[0], HashSet::from([2]))]),
+    );
+    assert!(
+        !bl_child.contains_key(&split_parent),
+        "retired parent id must not resolve on child layout",
+    );
+    assert!(
+        !bl_child.contains_key(&children[1]),
+        "child shard with no stats must be absent from the blacklist",
+    );
+}
+
+/// Drives `count` blocks descending from `fork_point` (at height `fork_point_height`)
+/// with **blacklist-aware** assignment, exactly like `drive_down_node`: at each height
+/// the chunk goes to `sample_chunk_producer_excluding(current_blacklist)` and is missed
+/// only when that producer is `target`. `salt` disambiguates block hashes so sibling
+/// forks never collide. Returns the tip.
+#[cfg(feature = "nightly")]
+fn drive_fork(
+    handle: &EpochManagerHandle,
+    fork_point: CryptoHash,
+    fork_point_height: u64,
+    count: u64,
+    target: ValidatorId,
+    salt: u64,
+) -> CryptoHash {
+    let fork_hash = |height: u64| hash(&[salt.to_le_bytes(), height.to_le_bytes()].concat());
+    let epoch_id = handle.get_epoch_id(&fork_point).unwrap();
+    let layout = handle.get_shard_layout(&epoch_id).unwrap();
+    let shard_id = layout.shard_ids().next().unwrap();
+    let epoch_info = handle.get_epoch_info(&epoch_id).unwrap();
+    let empty = HashSet::new();
+    let mut prev = fork_point;
+    for i in 1..=count {
+        let height = fork_point_height + i;
+        let cur = fork_hash(height);
+        let blacklist = handle.get_chunk_producer_blacklist(&prev).unwrap();
+        let assigned = epoch_info
+            .sample_chunk_producer_excluding(
+                &layout,
+                shard_id,
+                height,
+                blacklist.get(&shard_id).unwrap_or(&empty),
+            )
+            .unwrap();
+        let produced = assigned != target;
+        record_block_with_mask(&mut handle.write(), prev, cur, height, vec![produced]);
+        prev = cur;
+    }
+    prev
+}
+
+// 14. v152+ protocol: two forks share a common prefix, then diverge with different
+//     miss stats (canonical starves producer 0, abandoned fork starves producer 1).
+//     The accessor is keyed on the anchor block hash and aggregates only along that
+//     anchor's own chain, so each anchor resolves to ITS OWN chain's blacklist. The
+//     abandoned fork's blacklisted producer never appears on the canonical anchor and
+//     vice versa. The epoch-manager harness DOES support real forks (arbitrary
+//     prev/cur in `record_block_info`), so this exercises the real production path.
+#[cfg(feature = "nightly")]
+#[test]
+fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
+    let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
+    // Large epoch length so both forks stay inside epoch 0 (no boundary reset).
+    let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
+
+    // Common prefix: genesis + a single shared epoch-0 first block to fork from.
+    let genesis = hash(&0u64.to_le_bytes());
+    let common = hash(&1u64.to_le_bytes());
+    record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
+    record_block_with_mask(&mut handle.write(), genesis, common, 1, vec![true]);
+
+    // Each fork must run past the 1000-block start-of-epoch grace for its blacklist to
+    // become non-empty at the tip.
+    let depth = 1200;
+    // Two sibling chains fork from `common`. Build the canonical one first; each block
+    // finalizes only its own parent, so the chains' aggregations stay independent.
+    let canonical_tip = drive_fork(&handle, common, 1, depth, 0, 1);
+    // Snapshot the canonical anchor's aggregated stats before the sibling fork exists.
+    // Isolation holds by construction (the aggregator walks only the anchor's own chain,
+    // and its monotone `largest_final_height` watermark rejects sibling mutation), so
+    // this pins that construction rather than detecting a live leak. Worth pinning
+    // because a leak would be invisible in the post-valve blacklist below: the keep-one
+    // valve would simply drop the least-bad extra candidate.
+    let canonical_stats_before =
+        handle.read().get_epoch_info_aggregator_upto_last(&canonical_tip).unwrap().shard_tracker;
+    let fork_tip = drive_fork(&handle, common, 1, depth, 1, 2);
+    assert_ne!(canonical_tip, fork_tip, "forks must have distinct anchor hashes");
+
+    let epoch_id = handle.get_epoch_id_from_prev_block(&canonical_tip).unwrap();
+    let shard_id = handle.get_shard_layout(&epoch_id).unwrap().shard_ids().next().unwrap();
+
+    let canonical_bl = handle.get_chunk_producer_blacklist(&canonical_tip).unwrap();
+    let fork_bl = handle.get_chunk_producer_blacklist(&fork_tip).unwrap();
+
+    // Each anchor resolves to its own chain's starved producer.
+    assert_eq!(canonical_bl, HashMap::from([(shard_id, HashSet::from([0]))]));
+    assert_eq!(fork_bl, HashMap::from([(shard_id, HashSet::from([1]))]));
+
+    // The pinned half of the snapshot above: the canonical anchor's aggregated stats
+    // must be untouched by the abandoned fork.
+    let canonical_stats_after =
+        handle.read().get_epoch_info_aggregator_upto_last(&canonical_tip).unwrap().shard_tracker;
+    assert_eq!(
+        canonical_stats_before, canonical_stats_after,
+        "driving the abandoned fork must not alter the canonical anchor's aggregated stats",
     );
 }

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -61,6 +61,14 @@ fn epoch_info_for_layout(
         layout.num_shards() as usize,
         "one chunk-producer settlement per shard",
     );
+    for settlement in &settlements {
+        for id in settlement {
+            assert!(
+                *id < num_producers,
+                "settlement id {id} out of range for {num_producers} producers"
+            );
+        }
+    }
     let accounts: Vec<_> =
         (0..num_producers).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
     let block_producers: Vec<ValidatorId> = (0..num_producers).collect();
@@ -346,12 +354,19 @@ fn keep_one_fewer_expected_tiebreak() {
 // a set, so a `[0, 0, 1]` settlement has two distinct producers, and two all-bad candidates
 // trip the valve. Were the duplicate counted, the denominator would be 3, the valve would
 // not fire, and both would be blacklisted. `EpochInfo::new` neither rejects nor dedups the
-// duplicate.
+// duplicate — pinned below, so a future constructor normalization fails this test loudly
+// instead of silently draining it of the duplicate it exists to exercise.
 #[test]
 fn blacklist_dedups_duplicate_settlement_entries() {
     let layout = ShardLayout::single_shard();
     let shard_id = layout.shard_ids().next().unwrap();
     let epoch_info = epoch_info_for_layout(&layout, vec![vec![0, 0, 1]], 2);
+    let shard_index = layout.get_shard_index(shard_id).unwrap();
+    assert_eq!(
+        epoch_info.chunk_producers_settlement()[shard_index],
+        vec![0, 0, 1],
+        "fixture must reach the math with the duplicate intact",
+    );
     let st = tracker(shard_id, &[(0, 0, 100), (1, 0, 100)]);
     let res = compute_chunk_producer_blacklist(&st, &epoch_info, &layout);
     let stats = &res.shard_stats[&shard_id];
@@ -377,7 +392,9 @@ fn blacklist_valve_ignores_endorsement_only_entry() {
     let stats = &res.shard_stats[&shard_id];
     assert_eq!(stats.raw_candidate_count, 2, "endorsement-only id must not be a candidate");
     assert!(stats.safety_valve_fired());
-    assert_ne!(stats.kept, Some(2), "endorsement-only id must never be the kept producer");
+    // Deterministic: the two all-bad candidates tie on every level down to lower-id, which
+    // keeps 0 — strictly stronger than only asserting the endorsement-only id is not kept.
+    assert_eq!(stats.kept, Some(0), "equal all-bad candidates must resolve to the lower id");
     let bl = &res.blacklist[&shard_id];
     assert_eq!(bl.len(), 1, "keep-one must leave exactly one survivor");
     assert!(!bl.contains(&2), "endorsement-only id must never be blacklisted");
@@ -391,12 +408,25 @@ fn blacklist_valve_ignores_endorsement_only_entry() {
 fn blacklist_u128_arithmetic_no_overflow() {
     let big = u64::MAX;
     // Ratio check: id 0 misses ~2^63 with produced*100 (~9.2e20) < expected*80 (~1.5e21), so
-    // it is a candidate; ids 1, 2 are healthy so the valve does not fire.
+    // it is a candidate; ids 1, 2 are healthy so the valve does not fire. This case is
+    // protected by the `overflow-checks` panic alone: its wrapped-u64 comparison happens to
+    // reach the same verdict.
     let (epoch_info, layout, shard_id) = single_shard_epoch(3);
     let st = tracker(shard_id, &[(0, big / 2, big), (1, 100, 100), (2, 100, 100)]);
     assert_eq!(
         blacklist(&st, &epoch_info, &layout),
         HashMap::from([(shard_id, HashSet::from([0]))]),
+    );
+
+    // Value-level wrap guard for the ratio comparison: wrapped u64 `expected * 80`
+    // (80 * 2^62 = 5 * 2^66) is 0 mod 2^64 while `produced * 100` (100 * 2^57) does not
+    // wrap, so a u64 regression drops id 0's candidacy and fails this assert in any build
+    // profile, with or without `overflow-checks`.
+    let (epoch_info3, layout3, shard3) = single_shard_epoch(3);
+    let st3 = tracker(shard3, &[(0, 1 << 57, 1 << 62), (1, 100, 100), (2, 100, 100)]);
+    assert_eq!(
+        blacklist(&st3, &epoch_info3, &layout3),
+        HashMap::from([(shard3, HashSet::from([0]))]),
     );
 
     // Safety-valve comparator cross-multiply (pa*eb vs pb*ea) with operands near 2^127
@@ -1584,16 +1614,21 @@ fn reshard_case(parent: &ShardLayout, child: &ShardLayout) {
         child.get_shard_index(split_parent).is_err(),
         "retired parent {split_parent} must have no shard index in the child layout",
     );
-    assert!(
-        parent.get_shard_index(children[0]).is_err(),
-        "child {} must have no shard index in the parent layout",
-        children[0],
-    );
+    for c in &children {
+        assert!(
+            parent.get_shard_index(*c).is_err(),
+            "child {c} must have no shard index in the parent layout",
+        );
+    }
 
     // One bad producer per shard plus a shared healthy producer (id 4). The settlement Vec
     // is indexed by ShardIndex, so build it through `shard_infos()` (the API's index-order
     // contract) rather than `shard_ids()`, and never through `get_shard_index` (the mechanism
-    // under test). Each valid shard's bad producer sits in that shard's own settlement.
+    // under test). Each valid shard's bad producer sits in that shard's own settlement, and
+    // every settlement also carries the bad producers of the shards foreign to that layout:
+    // their stats live only under foreign tracker keys, so valid-shard results are unchanged,
+    // but a foreign id wrongly resolved to any in-range index then surfaces as a foreign
+    // blacklist entry instead of dropping out for want of a settlement match.
     const HEALTHY: ValidatorId = 4;
     let num_producers = 5u64;
     let bad_producer = |shard: ShardId| -> ValidatorId {
@@ -1609,10 +1644,24 @@ fn reshard_case(parent: &ShardLayout, child: &ShardLayout) {
             panic!("unexpected shard id {shard}")
         }
     };
-    let settlement_for =
-        |shard: ShardId| -> Vec<ValidatorId> { vec![bad_producer(shard), HEALTHY] };
+    let all_shards: HashSet<ShardId> = parent_ids.iter().chain(child_ids.iter()).copied().collect();
     let settlements = |layout: &ShardLayout| -> Vec<Vec<ValidatorId>> {
-        layout.shard_infos().map(|info| settlement_for(info.shard_id())).collect()
+        let own_ids: Vec<ShardId> = layout.shard_ids().collect();
+        let mut foreign_bad: Vec<ValidatorId> = all_shards
+            .iter()
+            .filter(|id| !own_ids.contains(id))
+            .map(|&id| bad_producer(id))
+            .collect();
+        foreign_bad.sort_unstable();
+        layout
+            .shard_infos()
+            .map(|info| {
+                let mut settlement = vec![bad_producer(info.shard_id())];
+                settlement.extend(foreign_bad.iter().copied());
+                settlement.push(HEALTHY);
+                settlement
+            })
+            .collect()
     };
     let parent_ei = epoch_info_for_layout(parent, settlements(parent), num_producers);
     let child_ei = epoch_info_for_layout(child, settlements(child), num_producers);
@@ -1626,7 +1675,6 @@ fn reshard_case(parent: &ShardLayout, child: &ShardLayout) {
             (HEALTHY, ChunkStats::new_with_production(100, 100)),
         ])
     };
-    let all_shards: HashSet<ShardId> = parent_ids.iter().chain(child_ids.iter()).copied().collect();
     let st: HashMap<ShardId, HashMap<ValidatorId, ChunkStats>> =
         all_shards.iter().map(|&shard| (shard, candidate_shard(shard))).collect();
 
@@ -1675,10 +1723,12 @@ fn fork_block_hash(branch: u8, height: u64) -> CryptoHash {
 }
 
 /// Records one block on `branch` at `height`, extending `prev`, using the same
-/// blacklist-aware assignment as `drive_down_node`: the chunk is missed exactly when
-/// `target` is the scheduled producer, so `target` accrues misses while its slots
-/// reassign to producers that actually produce. Returns the new tip. Shared by the two
-/// fork tests below (their only genuine overlap).
+/// blacklist-aware assignment as `drive_down_node`: the chunk is missed when the test's
+/// model schedules `target`, sampling with the accessor blacklist at `prev`. The stored
+/// row consensus reads anchors one block earlier, so at the single height per blacklist
+/// flip the two can disagree and credit `target` one spurious `produced` — harmless at
+/// these thresholds (a flip needs 10 fresh misses and `target` never recovers). Returns
+/// the new tip. Shared by the two fork tests below.
 #[cfg(all(feature = "nightly", feature = "test_features"))]
 fn fork_step(
     handle: &EpochManagerHandle,
@@ -2150,7 +2200,8 @@ fn assert_branch_seeds_own_blacklist(
     // at the anchor offset picks the blacklisted producer — only such an anchor proves the
     // seeder rerouted away from a blacklisted canonical pick. With one blacklisted producer
     // of three, the anchors the drive happened to leave need not contain one.
-    for _ in 0..128 {
+    const PLAIN_PICK_CAP: u64 = 128;
+    for attempt in 0..PLAIN_PICK_CAP {
         let blacklist = handle.get_chunk_producer_blacklist(&tip).unwrap();
         let shard_blacklist = blacklist.get(&shard_id).cloned().unwrap_or_default();
         assert_eq!(
@@ -2174,11 +2225,16 @@ fn assert_branch_seeds_own_blacklist(
             );
             return;
         }
-        height += 1;
-        tip = fork_step(handle, epoch_info, layout, shard_id, tip, branch, height, target);
+        // Do not step past the last inspected tip: the panic below reports `tip`, which must
+        // be a tip whose row was actually scanned.
+        if attempt + 1 < PLAIN_PICK_CAP {
+            height += 1;
+            tip = fork_step(handle, epoch_info, layout, shard_id, tip, branch, height, target);
+        }
     }
     panic!(
-        "branch {branch}: no anchor whose plain pick is the blacklisted producer within 128 blocks"
+        "branch {branch}: no anchor whose plain pick is the blacklisted producer within \
+         {PLAIN_PICK_CAP} blocks: tip {tip} at height {height}"
     );
 }
 

--- a/chain/epoch-manager/src/tests/early_kickout.rs
+++ b/chain/epoch-manager/src/tests/early_kickout.rs
@@ -62,9 +62,8 @@ fn single_shard_epoch(num_producers: u64) -> (EpochInfo, ShardLayout, ShardId) {
     (epoch_info, shard_layout, shard_id)
 }
 
-/// Builds an `EpochInfo` matching `layout`: `num_producers` chunk producers (ids
-/// `0..num_producers`) settled identically on EVERY shard. Used by the resharding
-/// test, where parent and child layouts need distinct shard counts.
+/// Like `single_shard_epoch`, but for an arbitrary `layout`: the same
+/// `0..num_producers` settlement on every shard.
 fn epoch_info_for_layout(layout: &ShardLayout, num_producers: u64) -> EpochInfo {
     let accounts: Vec<_> =
         (0..num_producers).map(|i| (format!("test{i}").parse().unwrap(), STAKE)).collect();
@@ -1420,25 +1419,19 @@ fn accessor_propagates_missing_block_info_on_same_epoch_basis() {
     );
 }
 
-// 13. The blacklist is keyed by `ShardId` and resolved against the layout it is
-//     computed for. Split one shard of a 2-shard parent into two children, then feed
-//     a single `shard_tracker` that carries BOTH the retired parent shard id and a
-//     child shard id. Against the parent layout the child id is dropped; against the
-//     child layout the retired parent id is dropped. The unchanged (surviving) shard
-//     resolves in both. This proves per-shard stats map to the correct parent/child
-//     `ShardId` and never leak across the split.
+// 13. Stats are resolved against the layout the blacklist is computed for. One
+//     `shard_tracker` carrying both a retired parent shard id and a child shard id is
+//     fed to both layouts: each drops the id that has no shard index there, and the
+//     shard that survived the split resolves in both.
 #[test]
 fn blacklist_resharding_maps_to_current_layout_shard_ids() {
     let num_producers = 4u64;
-    // Parent layout with two (non-contiguous) shard ids.
     let parent = ShardLayout::multi_shard(2, 0);
     let parent_ids: Vec<ShardId> = parent.shard_ids().collect();
-    // Split one shard on a fresh boundary account -> three shards.
     let child = ShardLayout::derive_shard_layout(&parent, "aaa".parse().unwrap());
     let child_ids: Vec<ShardId> = child.shard_ids().collect();
     assert_eq!(child.num_shards(), 3, "split must add exactly one shard");
 
-    // Classify the parent shards: exactly one is retired (split), one survives.
     let split_parent = *parent_ids
         .iter()
         .find(|id| !child_ids.contains(id))
@@ -1450,8 +1443,6 @@ fn blacklist_resharding_maps_to_current_layout_shard_ids() {
     let children = child.get_children_shards_ids(split_parent).expect("split parent has children");
     assert_eq!(children.len(), 2, "a split yields two children");
 
-    // Child ids are brand new (not reused from the parent layout), and each maps back
-    // to the retired parent.
     for c in &children {
         assert!(!parent_ids.contains(c), "child id {c} must not reuse a parent shard id");
         assert_eq!(
@@ -1464,8 +1455,8 @@ fn blacklist_resharding_maps_to_current_layout_shard_ids() {
     let parent_ei = epoch_info_for_layout(&parent, num_producers);
     let child_ei = epoch_info_for_layout(&child, num_producers);
 
-    // One failing producer per shard; the rest healthy (single candidate -> no valve).
-    // 0/100 clears both gates: missed 100 >= EARLY_KICKOUT_MIN_MISSES and ratio 0 < 80%.
+    // 0/100 clears both gates (100 misses, 0% ratio). Exactly one bad producer per
+    // shard, so the keep-one valve never fires and the expected maps stay exact.
     let one_bad = |bad_id: ValidatorId| -> HashMap<ValidatorId, ChunkStats> {
         (0..num_producers)
             .map(|id| {
@@ -1478,15 +1469,12 @@ fn blacklist_resharding_maps_to_current_layout_shard_ids() {
             })
             .collect()
     };
-    // Distinct bad producer per shard so results are unambiguous.
     let st: HashMap<ShardId, HashMap<ValidatorId, ChunkStats>> = HashMap::from([
         (surviving, one_bad(0)),
         (split_parent, one_bad(1)),
         (children[0], one_bad(2)),
     ]);
 
-    // Against the PARENT layout: the child id has no shard index and is dropped; the
-    // surviving and retired-parent ids resolve.
     let bl_parent = blacklist(&st, &parent_ei, &parent);
     assert_eq!(
         bl_parent,
@@ -1495,8 +1483,6 @@ fn blacklist_resharding_maps_to_current_layout_shard_ids() {
     assert!(!bl_parent.contains_key(&children[0]), "child id must not resolve on parent layout");
     assert!(!bl_parent.contains_key(&children[1]), "child id must not resolve on parent layout");
 
-    // Against the CHILD layout: the retired parent id has no shard index and is
-    // dropped; the surviving and child ids resolve.
     let bl_child = blacklist(&st, &child_ei, &child);
     assert_eq!(
         bl_child,
@@ -1512,11 +1498,9 @@ fn blacklist_resharding_maps_to_current_layout_shard_ids() {
     );
 }
 
-/// Drives `count` blocks descending from `fork_point` (at height `fork_point_height`)
-/// with **blacklist-aware** assignment, exactly like `drive_down_node`: at each height
-/// the chunk goes to `sample_chunk_producer_excluding(current_blacklist)` and is missed
-/// only when that producer is `target`. `salt` disambiguates block hashes so sibling
-/// forks never collide. Returns the tip.
+/// `drive_down_node` starting from an arbitrary `fork_point`: blacklist-aware
+/// assignment, chunk missed only when the sampler picks `target`. `salt` keeps sibling
+/// forks' block hashes distinct. Returns the tip.
 #[cfg(feature = "nightly")]
 fn drive_fork(
     handle: &EpochManagerHandle,
@@ -1552,38 +1536,29 @@ fn drive_fork(
     prev
 }
 
-// 14. v152+ protocol: two forks share a common prefix, then diverge with different
-//     miss stats (canonical starves producer 0, abandoned fork starves producer 1).
-//     The accessor is keyed on the anchor block hash and aggregates only along that
-//     anchor's own chain, so each anchor resolves to ITS OWN chain's blacklist. The
-//     abandoned fork's blacklisted producer never appears on the canonical anchor and
-//     vice versa. The epoch-manager harness DOES support real forks (arbitrary
-//     prev/cur in `record_block_info`), so this exercises the real production path.
+// 14. v152+ protocol: two sibling forks off a shared prefix starve different producers.
+//     The accessor is keyed on the anchor hash and aggregates only along that anchor's
+//     own chain, so each fork resolves to its own blacklist. `record_block_info` takes
+//     arbitrary prev/cur, so these are real forks, not a harness approximation.
 #[cfg(feature = "nightly")]
 #[test]
 fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     let validators = vec![("test0".parse().unwrap(), STAKE), ("test1".parse().unwrap(), STAKE)];
-    // Large epoch length so both forks stay inside epoch 0 (no boundary reset).
+    // Epoch length large enough that both forks stay inside epoch 0 (no boundary reset).
     let handle = setup_default_epoch_manager(validators, 10_000, 1, 3, 90, 60).into_handle();
 
-    // Common prefix: genesis + a single shared epoch-0 first block to fork from.
     let genesis = hash(&0u64.to_le_bytes());
     let common = hash(&1u64.to_le_bytes());
     record_block(&mut handle.write(), CryptoHash::default(), genesis, 0, vec![]);
     record_block_with_mask(&mut handle.write(), genesis, common, 1, vec![true]);
 
-    // Each fork must run past the 1000-block start-of-epoch grace for its blacklist to
-    // become non-empty at the tip.
+    // Past the 1000-block start-of-epoch grace, so each tip has a non-empty blacklist.
     let depth = 1200;
-    // Two sibling chains fork from `common`. Build the canonical one first; each block
-    // finalizes only its own parent, so the chains' aggregations stay independent.
     let canonical_tip = drive_fork(&handle, common, 1, depth, 0, 1);
-    // Snapshot the canonical anchor's aggregated stats before the sibling fork exists.
     // Isolation holds by construction (the aggregator walks only the anchor's own chain,
     // and its monotone `largest_final_height` watermark rejects sibling mutation), so
-    // this pins that construction rather than detecting a live leak. Worth pinning
-    // because a leak would be invisible in the post-valve blacklist below: the keep-one
-    // valve would simply drop the least-bad extra candidate.
+    // this snapshot pins that construction. Worth pinning because a leak would not show
+    // up in the blacklists below: the keep-one valve would drop the extra candidate.
     let canonical_stats_before =
         handle.read().get_epoch_info_aggregator_upto_last(&canonical_tip).unwrap().shard_tracker;
     let fork_tip = drive_fork(&handle, common, 1, depth, 1, 2);
@@ -1595,12 +1570,9 @@ fn get_chunk_producer_blacklist_isolates_abandoned_fork() {
     let canonical_bl = handle.get_chunk_producer_blacklist(&canonical_tip).unwrap();
     let fork_bl = handle.get_chunk_producer_blacklist(&fork_tip).unwrap();
 
-    // Each anchor resolves to its own chain's starved producer.
     assert_eq!(canonical_bl, HashMap::from([(shard_id, HashSet::from([0]))]));
     assert_eq!(fork_bl, HashMap::from([(shard_id, HashSet::from([1]))]));
 
-    // The pinned half of the snapshot above: the canonical anchor's aggregated stats
-    // must be untouched by the abandoned fork.
     let canonical_stats_after =
         handle.read().get_epoch_info_aggregator_upto_last(&canonical_tip).unwrap().shard_tracker;
     assert_eq!(


### PR DESCRIPTION
Tightens the two early-kickout blacklist tests this PR adds. No production code changes.

## Reshard test (`blacklist_resharding_maps_to_current_layout_shard_ids`)

Defense-in-depth unit coverage for resolving mixed parent/child shard ids against the supplied layout. It does not drive the epoch manager through a boundary, finalize a split, or install a layout in a later epoch.

- Uses an explicit non-identity layout (`shard_id != shard_index` by construction) instead of `multi_shard`'s seeded shuffle, and distinct per-shard settlements, so a valid shard resolved to a wrong-but-in-range index is caught. Identical settlements hid that.
- Runs the same case over both the V2 and V3 derivations, since production dynamic resharding derives V3 and the two operations under test behave identically in both.
- Asserts the per-shard `shard_stats` through a local projection, so no production struct gains a test-only derive.

## Abandoned-fork test (`get_chunk_producer_blacklist_isolates_abandoned_fork`)

Now uses lowered test-only thresholds to avoid an equal-depth sibling fixture with quadratic aggregation work. The prior fixture forked at height 1; that ancient fork point kept the cached aggregator pinned to genesis, so every per-block seed walk ran to genesis, quadratic in the sibling depth. Forking at the shared-prefix tip, at or above the cached last-final block and the real production fork shape, makes the sibling grow linearly.

The rewrite is condition-driven (each phase waits on an observable condition, capped), asserts the aggregator exit directly via `aggregate_epoch_info_upto`'s `full_info` flag rather than inferring it from blacklist equality, and folds three separately planned cases (deep-sibling overtake, late-prefix inheritance, cached-prefix path) into one chain. A companion `fork_seeded_rows_reflect_each_branch_blacklist` pins the stored `DBCol::ChunkProducers` row (what consensus reads) per fork. Two later phases pin the strict greater-than watermark gate at an exact final-height tie (a `>=` regression would flap the cache by arrival order) and the persisted rows under the inherited two-entry blacklist, using counterfactual sampler witnesses so a seeder that silently lost either blacklist entry fails; both were validated by mutation.

Real production thresholds (100 misses past a 1000-block grace) stay covered by the existing canonical tests, which are linear and stay on the real thresholds.

The old test passed optimized CI under the 25-second per-test termination limit; its individual optimized runtime is not exposed by the public job page and must be measured locally. Its debug runtime reproduced on this branch was 105.52s (`cargo test -p near-epoch-manager --features nightly,test_features --lib -- tests::early_kickout::get_chunk_producer_blacklist_isolates_abandoned_fork --exact`, debug, commit d523552ab, Apple Silicon). The rewritten fork tests run at 0.025s / 0.023s each under `--cargo-profile dev-release` (commit 8848e3222, Apple Silicon, all phases included).

## Math hardening

A separate commit adds blacklist-math hardening unit tests: fewer-expected safety-valve tiebreak, duplicate-settlement dedup, endorsement-only entry on an all-bad shard, and u128 no-overflow with near-`u64::MAX` operands. All sub-millisecond pure math.



