### PR TITLE
fix(test-loop): deflake cross_shard_tx with validator rotation

### DIFF
--- a/test-loop-tests/src/tests/cross_shard_tx.rs
+++ b/test-loop-tests/src/tests/cross_shard_tx.rs
@@ -10,7 +10,7 @@ use near_async::messaging::{CanSend as _, Handler as _};
 use near_async::test_loop::data::TestLoopData;
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
-use near_client::{ProcessTxRequest, Query};
+use near_client::{ProcessTxRequest, Query, QueryError};
 use near_network::types::NetworkRequests;
 use near_network::types::NetworkResponses;
 use near_o11y::testonly::init_test_logger;
@@ -148,7 +148,8 @@ fn test_cross_shard_tx_common(Params { num_transfers, rotate_validators, drop_ch
     let mut nonce = 1;
     let mut unsuccessful_queries = 0;
 
-    let observed_balances = get_balances(&mut env.test_loop.data, &env.node_datas, &test_accounts);
+    let observed_balances =
+        get_balances(&mut env.test_loop.data, &env.node_datas, &test_accounts).unwrap();
     assert_eq!(balances, observed_balances);
 
     let node_datas = env.node_datas.clone();
@@ -157,7 +158,10 @@ fn test_cross_shard_tx_common(Params { num_transfers, rotate_validators, drop_ch
     runner.run_until(
         &mut env,
         |test_loop_data| {
-            let observed_balances = get_balances(test_loop_data, &node_datas, &test_accounts);
+            let Some(observed_balances) = get_balances(test_loop_data, &node_datas, &test_accounts)
+            else {
+                return false;
+            };
             if balances != observed_balances {
                 unsuccessful_queries += 1;
                 if unsuccessful_queries % 100 == 0 {
@@ -208,7 +212,7 @@ fn test_cross_shard_tx_common(Params { num_transfers, rotate_validators, drop_ch
 
             false
         },
-        Duration::seconds(num_transfers as i64 * 4),
+        Duration::seconds(num_transfers as i64 * 8),
     );
 }
 
@@ -233,11 +237,14 @@ impl Runner {
     }
 }
 
+/// Each producer is picked from the first node's head epoch but answers at its own
+/// head. Returns `None` when it is already in a later epoch and no longer tracks
+/// the shard; the next call picks the producer of that later epoch.
 fn get_balances(
     test_loop_data: &mut TestLoopData,
     node_datas: &Vec<NodeExecutionData>,
     test_accounts: &Vec<AccountId>,
-) -> Vec<Balance> {
+) -> Option<Vec<Balance>> {
     let client_handle = node_datas[0].client_sender.actor_handle();
     let client = &test_loop_data.get(&client_handle).client;
     let epoch_manager = client.chain.epoch_manager.clone();
@@ -262,14 +269,18 @@ fn get_balances(
                 QueryRequest::ViewAccount { account_id: account.clone() },
             ));
 
-            let query_response = query_response.unwrap();
+            let query_response = match query_response {
+                Ok(query_response) => query_response,
+                Err(QueryError::UnavailableShard { .. }) => return None,
+                Err(err) => panic!("unexpected query error: {err:?}"),
+            };
 
             let QueryResponseKind::ViewAccount(view_account_result) = query_response.kind else {
                 panic!();
             };
-            view_account_result.amount
+            Some(view_account_result.amount)
         })
-        .collect_vec()
+        .collect()
 }
 
 #[test]


### PR DESCRIPTION
`ultra_slow_test_cross_shard_tx_with_validator_rotation_drop_chunks` needed a nayduck retry in 8 of the last 41 runs, and in run 5210 it used all 4 retries. This is not a recent regression; the retries are spread evenly over the last two weeks.

Two causes are fixed here.

**Stale shard assignment.** `get_balances` picked the chunk producer of an account's shard from node 0's head epoch, then queried that node at its own head. Genesis validators run with `TrackedShardsConfig::NoShards`, so they only hold the shard assigned to them in the current epoch. When the producer had already moved into the next epoch it no longer held the shard, `get_chunk_extra` missed, and `ViewAccount` returned `UnavailableShard`. Observed with instrumentation: node 0 at height 41 in epoch `AQFvj1uA`, while `test1.2` was at height 42 in the next epoch where shard 2 belongs to `test2.2` and `test2.7`. `get_balances` now returns `None` in that case, and the existing wait loop retries. This matches the pattern already used in `test-loop-tests/src/utils/transactions.rs`.

**Deadline sized at the tail.** The runner budget was `num_transfers * 4`, or 96 virtual seconds. Measured over 47 passing runs, the test used 75.1 to 95.2 virtual seconds, so the budget sat inside the normal spread. The multiplier is now 8.

Local dev-release runs of the rotation plus drop_chunks variant: 6 of 48 failed before (4 `UnavailableShard`, 2 deadline), 3 of 96 after. The other three variants passed 6 of 6 each.

The remaining 3% is a separate problem left for later: the test sends each transfer once and never resends, so a dropped transaction stalls the loop until the deadline. `test-loop-tests/src/utils/transactions.rs` already carries a TODO for resending transactions dropped because of missing chunks.