### PR TITLE
chore: remove unused `rust-s3` dependency from `near-client` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,7 +4114,6 @@ dependencies = [
  "reed-solomon-erasure",
  "regex",
  "reqwest 0.13.2",
- "rust-s3",
  "serde",
  "serde_json",
  "strum",

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -25,7 +25,6 @@ rayon.workspace = true
 reed-solomon-erasure.workspace = true
 regex.workspace = true
 reqwest.workspace = true
-rust-s3.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 strum.workspace = true
@@ -109,6 +108,3 @@ sandbox = [
     "near-chain/sandbox",
     "near-o11y/sandbox",
 ]
-
-[package.metadata.cargo-machete]
-ignored = ["rust-s3"]

--- a/chain/client/src/stateless_validation/state_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/state_witness_tracker.rs
@@ -4,9 +4,9 @@ use lru::LruCache;
 use near_async::time::Clock;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::stateless_validation::state_witness::ChunkStateWitnessAck;
-use s3::creds::time::ext::InstantExt as _;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
+use time::ext::InstantExt as _;
 
 /// Limit to the number of witnesses tracked.
 ///


### PR DESCRIPTION
`s3::creds::time` is a [reimport](https://github.com/durch/rust-s3/blob/b584ce7d53825705332c13136769546166622ad1/aws-creds/src/lib.rs#L8-L9) of `time`, no need to pull the whole `rust-s3` dependency for that.