### PR TITLE
feat(forknet): support ml-dsa65 tx

### DIFF
--- a/core/crypto/src/lib.rs
+++ b/core/crypto/src/lib.rs
@@ -4,9 +4,9 @@ pub use errors::{ParseKeyError, ParseKeyTypeError, ParseSignatureError};
 pub use key_file::KeyFile;
 pub use signature::{
     ED25519PublicKey, ED25519SecretKey, KeyType, ML_DSA_65_HASH_LENGTH,
-    ML_DSA_65_PUBLIC_KEY_LENGTH, ML_DSA_65_SIGNATURE_LENGTH, MlDsa65PublicKey,
-    MlDsa65PublicKeyHandle, MlDsa65Signature, PublicKey, PublicKeyHandle, Secp256K1PublicKey,
-    Secp256K1Signature, SecretKey, Signature,
+    ML_DSA_65_PUBLIC_KEY_LENGTH, ML_DSA_65_SEED_LENGTH, ML_DSA_65_SIGNATURE_LENGTH,
+    MlDsa65PublicKey, MlDsa65PublicKeyHandle, MlDsa65Signature, PublicKey, PublicKeyHandle,
+    Secp256K1PublicKey, Secp256K1Signature, SecretKey, Signature, ml_dsa_65_from_seed,
 };
 pub use signer::{EmptySigner, InMemorySigner, Signer};
 

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -24,7 +24,6 @@ pub const ML_DSA_65_SECRET_KEY_LENGTH: usize = 4032;
 /// ML-DSA-65 signature length in bytes.
 pub const ML_DSA_65_SIGNATURE_LENGTH: usize = 3309;
 /// FIPS 204 seed length in bytes (used to derive an ML-DSA private key).
-#[cfg(feature = "rand")]
 pub const ML_DSA_65_SEED_LENGTH: usize = 32;
 /// SHA3-256 output length used as the on-trie identifier for an
 /// ML-DSA-65 access key. The same digest is expected to be reused as
@@ -576,25 +575,6 @@ impl PublicKeyHandle {
             Self::MlDsa65(_) => KeyType::MLDSA65,
         }
     }
-
-    /// Returns the underlying full public key, if this handle carries
-    /// one (ed25519 / secp256k1). For ML-DSA-65 entries the trie stores
-    /// only a hash, so the full pubkey is not recoverable - returns
-    /// `None` in that case.
-    ///
-    /// TODO(post-quantum): every current caller treats the `None` case as "skip
-    /// this entry" (fork-network and mirror tools), which means
-    /// ML-DSA-65 access keys are silently dropped during network
-    /// forking and mirroring. Grep for `TODO(post-quantum)` to find the call
-    /// sites that need to be taught to recover the full pubkey (e.g.
-    /// via a side index of pubkey-hash → pubkey, or via RPC lookup).
-    pub fn full_pubkey(&self) -> Option<PublicKey> {
-        match self {
-            Self::ED25519(k) => Some(PublicKey::ED25519(k.clone())),
-            Self::SECP256K1(k) => Some(PublicKey::SECP256K1(k.clone())),
-            Self::MlDsa65(_) => None,
-        }
-    }
 }
 
 impl From<PublicKey> for PublicKeyHandle {
@@ -862,7 +842,6 @@ fn ml_dsa_65_secret_from_keypair(kp: &PqdsaKeyPair) -> MlDsa65SecretKey {
 }
 
 /// Helper: build an `MlDsa65SecretKey` from a 32-byte seed (deterministic).
-#[cfg(feature = "rand")]
 fn ml_dsa_65_secret_from_seed(
     seed: &[u8; ML_DSA_65_SEED_LENGTH],
 ) -> Result<MlDsa65SecretKey, crate::errors::ParseKeyError> {
@@ -881,7 +860,6 @@ fn ml_dsa_65_secret_from_seed(
 /// Build an [`MlDsa65SecretKey`] from a 32-byte seed.
 ///
 /// Wraps `aws_lc_rs::unstable::signature::PqdsaKeyPair::from_seed`.
-#[cfg(feature = "rand")]
 pub fn ml_dsa_65_from_seed(
     seed: &[u8; ML_DSA_65_SEED_LENGTH],
 ) -> Result<SecretKey, crate::errors::ParseKeyError> {

--- a/docs/architecture/how/post_quantum_signatures.md
+++ b/docs/architecture/how/post_quantum_signatures.md
@@ -201,9 +201,6 @@ Gas:
 - **Host functions / on-chain verification primitives**: out of scope for the
   `PostQuantumSignatures` feature itself - `ml_dsa_verify` landed afterwards
   under its own config gate, see §7.
-- **Cross-network mirror** (`tools/mirror/src/key_mapping.rs`) panics on
-  ML-DSA-65 pubkey mapping; deterministic-derivation scheme for PQ keys is a
-  follow-up.
 - **ETH wallet contract** (`integration-tests/src/tests/features/wallet_contract.rs`)
   marks ML-DSA-65 unreachable in the AddKey selector path - wallet contracts
   are explicitly ed25519/secp256k1.
@@ -300,20 +297,11 @@ same deferred bucket.
 
 These do not block stabilization and are tracked as follow-up work:
 
-1. **Mirror / fork-network cross-network support for PQ keys.** Behavior is
-    currently inconsistent across entry points and should be unified before any
-    serious mirroring of a PQ-bearing chain:
-    - `tools/mirror/src/genesis.rs` panics loudly when it encounters an
-      ML-DSA-65 access-key or gas-key-nonce record.
-    - `tools/mirror/src/key_util.rs`, `tools/mirror/src/{offline,online}.rs`,
-      and `tools/fork-network/src/cli.rs` silently `filter_map` / `continue`
-      past hash-form entries with no log or warning, so a real ML-DSA-bearing
-      chain would be silently mirrored with access keys missing.
-    Proper support likely needs a deterministic seed-derived mapping
-    (analogous to ed25519/secp256k1 mapping in `key_mapping.rs`). For now the
-    design accepts that PQ keys cannot be mirrored; at minimum the
-    inconsistency above should be unified to "log + skip" so failures are
-    visible. The `TODO(post-quantum)` markers at these call sites track this.
+1. **Mirror `show-keys from-pubkey` only accepts full pubkeys.**
+    `tools/mirror/src/key_util.rs::map_pub_key` parses a `PublicKey`, so the
+    `ml-dsa-65-hash:` form that `view_access_key_list` returns - and that the
+    other `show-keys` subcommands print - is rejected. Every other mirror and
+    fork-network entry point maps ML-DSA-65 keys via `map_key_handle`.
 
 2. **Wallet/SDK story for the view-RPC change.** Add the
    `near-api-js`/`near-cli-rs` side of the change (external repos), document

--- a/pytest/lib/key.py
+++ b/pytest/lib/key.py
@@ -5,12 +5,15 @@ import typing
 
 from nacl.signing import SigningKey
 
+from messages.crypto import KEY_TYPE_ED25519
+
 
 # cspell:ignore urandom
 class Key:
     account_id: str
     pk: str
     sk: str
+    key_type = KEY_TYPE_ED25519
 
     def __init__(self, account_id: str, pk: str, sk: str) -> None:
         super(Key, self).__init__()

--- a/pytest/lib/messages/crypto.py
+++ b/pytest/lib/messages/crypto.py
@@ -34,8 +34,7 @@ class PublicKey:
     pass
 
 
-def make_public_key(data: bytes,
-                    key_type: str = KEY_TYPE_ED25519) -> PublicKey:
+def make_public_key(data: bytes, key_type: str = KEY_TYPE_ED25519) -> PublicKey:
     """Build a PublicKey from raw key bytes."""
     expected = KEY_TYPE_LENGTHS[key_type]
     assert len(data) == expected, \

--- a/pytest/lib/messages/crypto.py
+++ b/pytest/lib/messages/crypto.py
@@ -2,23 +2,9 @@ import typing
 
 import base58
 
-
-class Signature:
-    _KEY_TYPES = {
-        'ed25519': 0,
-        'secp256k1': 1,
-    }
-
-    def __init__(self, signature: typing.Optional[str] = None) -> None:
-        if signature:
-            keyType, data = signature.split(':')
-            self.keyType = self._KEY_TYPES[keyType]
-            self.data = base58.b58decode(data)
-
-
-# Borsh variant names for PublicKey. A key's position in `PublicKey`'s schema
-# below is its borsh discriminant, and the name doubles as the attribute the
-# serializer reads the key bytes from.
+# Borsh variant names for PublicKey and Signature. A key's position in the
+# `PublicKey` / `Signature` schemas below is its borsh discriminant, and the
+# name doubles as the attribute the serializer reads the bytes from.
 KEY_TYPE_ED25519 = 'ed25519'
 KEY_TYPE_SECP256K1 = 'secp256k1'
 KEY_TYPE_MLDSA65 = 'mldsa65'
@@ -29,20 +15,54 @@ KEY_TYPE_LENGTHS = {
     KEY_TYPE_MLDSA65: 1952,
 }
 
+SIGNATURE_LENGTHS = {
+    KEY_TYPE_ED25519: 64,
+    KEY_TYPE_SECP256K1: 65,
+    KEY_TYPE_MLDSA65: 3309,
+}
+
+# Prefix each key type is displayed with in strings like `ed25519:3s2f...`.
+KEY_TYPE_BY_PREFIX = {
+    'ed25519': KEY_TYPE_ED25519,
+    'secp256k1': KEY_TYPE_SECP256K1,
+    'ml-dsa-65': KEY_TYPE_MLDSA65,
+}
+
 
 class PublicKey:
     pass
 
 
+class Signature:
+
+    def __init__(self, signature: typing.Optional[str] = None) -> None:
+        if signature:
+            prefix, data = signature.split(':')
+            init_key_enum(self, base58.b58decode(data),
+                          KEY_TYPE_BY_PREFIX[prefix], SIGNATURE_LENGTHS,
+                          'signature')
+
+
+def init_key_enum(obj, data: bytes, key_type: str, lengths, what: str):
+    """Set the borsh enum variant and its raw bytes on obj."""
+    expected = lengths[key_type]
+    assert len(data) == expected, \
+        f'{key_type} {what} must be {expected} bytes, got {len(data)}'
+    obj.enum = key_type
+    setattr(obj, key_type, data)
+    return obj
+
+
 def make_public_key(data: bytes, key_type: str = KEY_TYPE_ED25519) -> PublicKey:
     """Build a PublicKey from raw key bytes."""
-    expected = KEY_TYPE_LENGTHS[key_type]
-    assert len(data) == expected, \
-        f'{key_type} public key must be {expected} bytes, got {len(data)}'
-    public_key = PublicKey()
-    public_key.enum = key_type
-    setattr(public_key, key_type, data)
-    return public_key
+    return init_key_enum(PublicKey(), data, key_type, KEY_TYPE_LENGTHS,
+                         'public key')
+
+
+def make_signature(data: bytes, key_type: str = KEY_TYPE_ED25519) -> Signature:
+    """Build a Signature from raw signature bytes."""
+    return init_key_enum(Signature(), data, key_type, SIGNATURE_LENGTHS,
+                         'signature')
 
 
 class AccessKey:
@@ -88,8 +108,15 @@ class ShardProof:
 crypto_schema = [
     [
         Signature, {
-            'kind': 'struct',
-            'fields': [['keyType', 'u8'], ['data', [64]]]
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [
+                [KEY_TYPE_ED25519, [SIGNATURE_LENGTHS[KEY_TYPE_ED25519]]],
+                [KEY_TYPE_SECP256K1, [SIGNATURE_LENGTHS[KEY_TYPE_SECP256K1]]],
+                [KEY_TYPE_MLDSA65, [SIGNATURE_LENGTHS[KEY_TYPE_MLDSA65]]],
+            ]
         }
     ],
     [

--- a/pytest/lib/messages/crypto.py
+++ b/pytest/lib/messages/crypto.py
@@ -16,8 +16,34 @@ class Signature:
             self.data = base58.b58decode(data)
 
 
+# Borsh variant names for PublicKey. A key's position in `PublicKey`'s schema
+# below is its borsh discriminant, and the name doubles as the attribute the
+# serializer reads the key bytes from.
+KEY_TYPE_ED25519 = 'ed25519'
+KEY_TYPE_SECP256K1 = 'secp256k1'
+KEY_TYPE_MLDSA65 = 'mldsa65'
+
+KEY_TYPE_LENGTHS = {
+    KEY_TYPE_ED25519: 32,
+    KEY_TYPE_SECP256K1: 64,
+    KEY_TYPE_MLDSA65: 1952,
+}
+
+
 class PublicKey:
     pass
+
+
+def make_public_key(data: bytes,
+                    key_type: str = KEY_TYPE_ED25519) -> PublicKey:
+    """Build a PublicKey from raw key bytes."""
+    expected = KEY_TYPE_LENGTHS[key_type]
+    assert len(data) == expected, \
+        f'{key_type} public key must be {expected} bytes, got {len(data)}'
+    public_key = PublicKey()
+    public_key.enum = key_type
+    setattr(public_key, key_type, data)
+    return public_key
 
 
 class AccessKey:
@@ -69,8 +95,15 @@ crypto_schema = [
     ],
     [
         PublicKey, {
-            'kind': 'struct',
-            'fields': [['keyType', 'u8'], ['data', [32]]]
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [
+                [KEY_TYPE_ED25519, [KEY_TYPE_LENGTHS[KEY_TYPE_ED25519]]],
+                [KEY_TYPE_SECP256K1, [KEY_TYPE_LENGTHS[KEY_TYPE_SECP256K1]]],
+                [KEY_TYPE_MLDSA65, [KEY_TYPE_LENGTHS[KEY_TYPE_MLDSA65]]],
+            ]
         }
     ],
     [

--- a/pytest/lib/mldsa65.py
+++ b/pytest/lib/mldsa65.py
@@ -1,0 +1,75 @@
+"""ML-DSA-65 (post-quantum) keys, mirroring `SecretKey::MLDSA65` in core/crypto.
+
+Needs cryptography>=48, so only import this from tests that use ML-DSA-65 keys.
+"""
+
+import hashlib
+import typing
+
+import base58
+from cryptography.hazmat.primitives.asymmetric import mldsa
+
+from messages.crypto import KEY_TYPE_MLDSA65
+
+SEED_LENGTH = 32
+# `HashDomainTag::MlDsa65PubkeyV1` in core/crypto.
+HASH_DOMAIN_TAG = b'near:ml-dsa-65-pubkey-hash:v1'
+PUBLIC_KEY_PREFIX = 'ml-dsa-65:'
+HANDLE_PREFIX = 'ml-dsa-65-hash:'
+
+
+def _b58(data: bytes) -> str:
+    return base58.b58encode(data).decode('ascii')
+
+
+class MlDsa65Key:
+    """An ML-DSA-65 signer, shaped like `key.Key`.
+
+    `pk` is the on-trie handle, because that is what the chain indexes access
+    keys by, while `full_pk` is the 1952-byte key that goes on the wire.
+    `decoded_sk()` is the 32-byte seed rather than the expanded private key;
+    it is all that is needed to sign.
+    """
+    key_type = KEY_TYPE_MLDSA65
+
+    def __init__(self, account_id: str, seed: bytes) -> None:
+        self.account_id = account_id
+        self.seed = seed
+        self._private_key = self._load(seed)
+        self.pubkey = self._private_key.public_key().public_bytes_raw()
+        self.pk = HANDLE_PREFIX + _b58(self.handle_digest())
+        self.full_pk = PUBLIC_KEY_PREFIX + _b58(self.pubkey)
+
+    @classmethod
+    def from_seed_testonly(cls, account_id: str, seed: str) -> 'MlDsa65Key':
+        """Derive from a seed string, padded like `SecretKey::from_seed` does."""
+        return cls(account_id,
+                   seed.encode('utf8')[:SEED_LENGTH].ljust(SEED_LENGTH, b' '))
+
+    @classmethod
+    def sign_with_seed(cls, seed: bytes,
+                       data: typing.Union[bytes, bytearray]) -> bytes:
+        """Sign without building a key: the generic `transaction.sign_hash`
+        path only has the raw secret key."""
+        return cls._load(seed).sign(bytes(data))
+
+    @staticmethod
+    def _load(seed: bytes) -> mldsa.MLDSA65PrivateKey:
+        assert len(seed) == SEED_LENGTH, \
+            f'ML-DSA-65 seed must be {SEED_LENGTH} bytes, got {len(seed)}'
+        return mldsa.MLDSA65PrivateKey.from_seed_bytes(seed)
+
+    def handle_digest(self) -> bytes:
+        """SHA3-256 of (domain tag || pubkey), the raw on-trie handle bytes."""
+        digest = hashlib.sha3_256(HASH_DOMAIN_TAG + self.pubkey).digest()
+        assert len(digest) == SEED_LENGTH
+        return digest
+
+    def decoded_pk(self) -> bytes:
+        return self.pubkey
+
+    def decoded_sk(self) -> bytes:
+        return self.seed
+
+    def sign_bytes(self, data: typing.Union[bytes, bytearray]) -> bytes:
+        return self._private_key.sign(bytes(data))

--- a/pytest/lib/transaction.py
+++ b/pytest/lib/transaction.py
@@ -14,9 +14,7 @@ def make_transaction(receiverId, nonce, actions, blockHash, accountId,
                      pk) -> Transaction:
     tx = Transaction()
     tx.signerId = accountId
-    tx.publicKey = PublicKey()
-    tx.publicKey.keyType = 0
-    tx.publicKey.data = pk
+    tx.publicKey = make_public_key(pk)
     tx.nonce = nonce
     tx.receiverId = receiverId
     tx.actions = actions
@@ -65,9 +63,7 @@ def compute_delegated_action_hash(senderId, receiverId, actions, nonce,
     delegateAction.actions = actions
     delegateAction.nonce = nonce
     delegateAction.maxBlockHeight = maxBlockHeight
-    delegateAction.publicKey = PublicKey()
-    delegateAction.publicKey.keyType = 0
-    delegateAction.publicKey.data = publicKey
+    delegateAction.publicKey = make_public_key(publicKey)
     signableMessageDiscriminant = 2**30 + 366
     serializer = BinarySerializer(schema)
     serializer.serialize_num(signableMessageDiscriminant, 4)
@@ -103,16 +99,14 @@ def create_create_account_action():
     return action
 
 
-def create_full_access_key_action(pk):
+def create_full_access_key_action(pk, key_type=KEY_TYPE_ED25519):
     permission = AccessKeyPermission()
     permission.enum = 'fullAccess'
     permission.fullAccess = FullAccessPermission()
     accessKey = AccessKey()
     accessKey.nonce = 0
     accessKey.permission = permission
-    publicKey = PublicKey()
-    publicKey.keyType = 0
-    publicKey.data = pk
+    publicKey = make_public_key(pk, key_type)
     addKey = AddKey()
     addKey.accessKey = accessKey
     addKey.publicKey = publicKey
@@ -123,9 +117,7 @@ def create_full_access_key_action(pk):
 
 
 def create_delete_access_key_action(pk):
-    publicKey = PublicKey()
-    publicKey.keyType = 0
-    publicKey.data = pk
+    publicKey = make_public_key(pk)
     deleteKey = DeleteKey()
     deleteKey.publicKey = publicKey
     action = Action()
@@ -146,9 +138,7 @@ def create_payment_action(amount):
 def create_staking_action(amount, pk):
     stake = Stake()
     stake.stake = amount
-    stake.publicKey = PublicKey()
-    stake.publicKey.keyType = 0
-    stake.publicKey.data = pk
+    stake.publicKey = make_public_key(pk)
     action = Action()
     action.enum = 'stake'
     action.stake = stake
@@ -204,7 +194,9 @@ def create_delete_account_action(beneficiary):
     return action
 
 
-def create_gas_key_full_access_key_action(pk, num_nonces):
+def create_gas_key_full_access_key_action(pk,
+                                          num_nonces,
+                                          key_type=KEY_TYPE_ED25519):
     gasKeyInfo = GasKeyInfo()
     gasKeyInfo.balance = 0
     gasKeyInfo.numNonces = num_nonces
@@ -216,9 +208,7 @@ def create_gas_key_full_access_key_action(pk, num_nonces):
     accessKey = AccessKey()
     accessKey.nonce = 0
     accessKey.permission = permission
-    publicKey = PublicKey()
-    publicKey.keyType = 0
-    publicKey.data = pk
+    publicKey = make_public_key(pk, key_type)
     addKey = AddKey()
     addKey.accessKey = accessKey
     addKey.publicKey = publicKey
@@ -230,9 +220,7 @@ def create_gas_key_full_access_key_action(pk, num_nonces):
 
 def create_transfer_to_gas_key_action(pk, deposit):
     transferToGasKey = TransferToGasKey()
-    transferToGasKey.publicKey = PublicKey()
-    transferToGasKey.publicKey.keyType = 0
-    transferToGasKey.publicKey.data = pk
+    transferToGasKey.publicKey = make_public_key(pk)
     transferToGasKey.deposit = deposit
     action = Action()
     action.enum = 'transferToGasKey'
@@ -242,9 +230,7 @@ def create_transfer_to_gas_key_action(pk, deposit):
 
 def create_withdraw_from_gas_key_action(pk, amount):
     withdrawFromGasKey = WithdrawFromGasKey()
-    withdrawFromGasKey.publicKey = PublicKey()
-    withdrawFromGasKey.publicKey.keyType = 0
-    withdrawFromGasKey.publicKey.data = pk
+    withdrawFromGasKey.publicKey = make_public_key(pk)
     withdrawFromGasKey.amount = amount
     action = Action()
     action.enum = 'withdrawFromGasKey'
@@ -256,9 +242,7 @@ def sign_and_serialize_transaction_v1(receiverId, nonce, nonce_index, actions,
                                       blockHash, accountId, pk, sk):
     tx = TransactionV1()
     tx.signerId = accountId
-    tx.publicKey = PublicKey()
-    tx.publicKey.keyType = 0
-    tx.publicKey.data = pk
+    tx.publicKey = make_public_key(pk)
     txNonce = TransactionNonce()
     txNonce.enum = 'gasKeyNonce'
     nonceData = GasKeyNonceData()

--- a/pytest/lib/transaction.py
+++ b/pytest/lib/transaction.py
@@ -237,9 +237,9 @@ def create_gas_key_full_access_key_action(pk,
     return action
 
 
-def create_transfer_to_gas_key_action(pk, deposit):
+def create_transfer_to_gas_key_action(pk, deposit, key_type=KEY_TYPE_ED25519):
     transferToGasKey = TransferToGasKey()
-    transferToGasKey.publicKey = make_public_key(pk)
+    transferToGasKey.publicKey = make_public_key(pk, key_type)
     transferToGasKey.deposit = deposit
     action = Action()
     action.enum = 'transferToGasKey'
@@ -257,11 +257,18 @@ def create_withdraw_from_gas_key_action(pk, amount):
     return action
 
 
-def sign_and_serialize_transaction_v1(receiverId, nonce, nonce_index, actions,
-                                      blockHash, accountId, pk, sk):
+def sign_and_serialize_transaction_v1(receiverId,
+                                      nonce,
+                                      nonce_index,
+                                      actions,
+                                      blockHash,
+                                      accountId,
+                                      pk,
+                                      sk,
+                                      key_type=KEY_TYPE_ED25519):
     tx = TransactionV1()
     tx.signerId = accountId
-    tx.publicKey = make_public_key(pk)
+    tx.publicKey = make_public_key(pk, key_type)
     txNonce = TransactionNonce()
     txNonce.enum = 'gasKeyNonce'
     nonceData = GasKeyNonceData()
@@ -283,7 +290,8 @@ def sign_and_serialize_transaction_v1(receiverId, nonce, nonce_index, actions,
     tx_bytes = bytes(serializer.array)
 
     hash_bytes = hashlib.sha256(tx_bytes).digest()
-    serializer.serialize_struct(make_signature(sign_hash(hash_bytes, sk)))
+    serializer.serialize_struct(
+        make_signature(sign_hash(hash_bytes, sk, key_type), key_type))
     return bytes(serializer.array)
 
 

--- a/pytest/lib/transaction.py
+++ b/pytest/lib/transaction.py
@@ -10,11 +10,16 @@ from messages.bridge import *
 schema = dict(tx_schema + crypto_schema + bridge_schema)
 
 
-def make_transaction(receiverId, nonce, actions, blockHash, accountId,
-                     pk) -> Transaction:
+def make_transaction(receiverId,
+                     nonce,
+                     actions,
+                     blockHash,
+                     accountId,
+                     pk,
+                     key_type=KEY_TYPE_ED25519) -> Transaction:
     tx = Transaction()
     tx.signerId = accountId
-    tx.publicKey = make_public_key(pk)
+    tx.publicKey = make_public_key(pk, key_type)
     tx.nonce = nonce
     tx.receiverId = receiverId
     tx.actions = actions
@@ -27,19 +32,30 @@ def compute_transaction_hash(tx: Transaction) -> bytes:
     return hashlib.sha256(msg).digest()
 
 
-def sign_transaction(receiverId, nonce, actions, blockHash, accountId, pk,
-                     sk) -> SignedTransaction:
-    tx = make_transaction(receiverId, nonce, actions, blockHash, accountId, pk)
-    hash_bytes = compute_transaction_hash(tx)
+def sign_hash(hash_bytes, sk, key_type=KEY_TYPE_ED25519) -> bytes:
+    if key_type == KEY_TYPE_MLDSA65:
+        # imported here because it needs cryptography>=48
+        from mldsa65 import MlDsa65Key
+        return MlDsa65Key.sign_with_seed(sk, hash_bytes)
+    return SigningKey(sk[:32]).sign(hash_bytes).signature
 
-    signature = Signature()
-    signature.keyType = 0
-    seed = sk[:32]
-    signature.data = SigningKey(seed).sign(hash_bytes).signature
+
+def sign_transaction(receiverId,
+                     nonce,
+                     actions,
+                     blockHash,
+                     accountId,
+                     pk,
+                     sk,
+                     key_type=KEY_TYPE_ED25519) -> SignedTransaction:
+    tx = make_transaction(receiverId, nonce, actions, blockHash, accountId, pk,
+                          key_type)
+    hash_bytes = compute_transaction_hash(tx)
 
     signedTx = SignedTransaction()
     signedTx.transaction = tx
-    signedTx.signature = signature
+    signedTx.signature = make_signature(sign_hash(hash_bytes, sk, key_type),
+                                        key_type)
     signedTx.id = base58.b58encode(hash_bytes).decode('utf8')
     return signedTx
 
@@ -48,11 +64,17 @@ def serialize_transaction(tx: SignedTransaction) -> bytes:
     return BinarySerializer(schema).serialize(tx)
 
 
-def sign_and_serialize_transaction(receiverId, nonce, actions, blockHash,
-                                   accountId, pk, sk):
+def sign_and_serialize_transaction(receiverId,
+                                   nonce,
+                                   actions,
+                                   blockHash,
+                                   accountId,
+                                   pk,
+                                   sk,
+                                   key_type=KEY_TYPE_ED25519):
     return serialize_transaction(
         sign_transaction(receiverId, nonce, actions, blockHash, accountId, pk,
-                         sk))
+                         sk, key_type))
 
 
 def compute_delegated_action_hash(senderId, receiverId, actions, nonce,
@@ -80,10 +102,7 @@ def create_signed_delegated_action(senderId, receiverId, actions, nonce,
     delegated_action, hash_ = compute_delegated_action_hash(
         senderId, receiverId, actions, nonce, maxBlockHeight, publicKey)
 
-    signature = Signature()
-    signature.keyType = 0
-    seed = sk[:32]
-    signature.data = SigningKey(seed).sign(hash_).signature
+    signature = make_signature(sign_hash(hash_, sk))
 
     signedDA = SignedDelegate()
     signedDA.delegateAction = delegated_action
@@ -264,13 +283,7 @@ def sign_and_serialize_transaction_v1(receiverId, nonce, nonce_index, actions,
     tx_bytes = bytes(serializer.array)
 
     hash_bytes = hashlib.sha256(tx_bytes).digest()
-    seed = sk[:32]
-    sig_data = SigningKey(seed).sign(hash_bytes).signature
-
-    sig = Signature()
-    sig.keyType = 0
-    sig.data = sig_data
-    serializer.serialize_struct(sig)
+    serializer.serialize_struct(make_signature(sign_hash(hash_bytes, sk)))
     return bytes(serializer.array)
 
 
@@ -331,13 +344,13 @@ def sign_payment_tx(key, to, amount, nonce, blockHash):
     action = create_payment_action(amount)
     return sign_and_serialize_transaction(to, nonce, [action], blockHash,
                                           key.account_id, key.decoded_pk(),
-                                          key.decoded_sk())
+                                          key.decoded_sk(), key.key_type)
 
 
 def sign_payment_tx_and_get_hash(key, to, amount, nonce, block_hash):
     action = create_payment_action(amount)
     tx = make_transaction(to, nonce, [action], block_hash, key.account_id,
-                          key.decoded_pk())
+                          key.decoded_pk(), key.key_type)
     hash_bytes = compute_transaction_hash(tx)
     signed_tx = sign_payment_tx(key, to, amount, nonce, block_hash)
     return signed_tx, base58.b58encode(hash_bytes).decode('utf8')

--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -1,6 +1,7 @@
 PyGithub
 base58
 cachetools
+cryptography>=48
 cython
 deepdiff
 json-rpc

--- a/pytest/tests/replay/replay.py
+++ b/pytest/tests/replay/replay.py
@@ -4,7 +4,7 @@ from account import Account
 from collections import OrderedDict
 from key import Key
 from messages.tx import *
-from messages.crypto import AccessKey, crypto_schema, PublicKey, Signature
+from messages.crypto import AccessKey, crypto_schema, make_public_key, Signature
 from messages.bridge import bridge_schema
 from serializer import BinarySerializer
 import mocknet_helpers
@@ -89,10 +89,7 @@ def convert_transaction_type_string_to_class(name):
 def convert_json_public_key_to_py_public_key(json_public_key):
     pk_str = json_public_key.split(
         ':')[1] if ':' in json_public_key else json_public_key
-    ans = PublicKey()
-    ans.keyType = 0
-    ans.data = base58.b58decode(pk_str.encode('ascii'))
-    return ans
+    return make_public_key(base58.b58decode(pk_str.encode('ascii')))
 
 
 '''
@@ -161,9 +158,7 @@ def send_resigned_transactions(tx_path, home_dir):
                 ]
             except ValueError:
                 continue
-        tx.publicKey = PublicKey()
-        tx.publicKey.keyType = 0
-        tx.publicKey.data = key_pair.decoded_pk()
+        tx.publicKey = make_public_key(key_pair.decoded_pk())
         msg = BinarySerializer(schema).serialize(tx)
         hash_ = hashlib.sha256(msg).digest()
         signature = Signature()

--- a/pytest/tests/replay/replay.py
+++ b/pytest/tests/replay/replay.py
@@ -4,7 +4,8 @@ from account import Account
 from collections import OrderedDict
 from key import Key
 from messages.tx import *
-from messages.crypto import AccessKey, crypto_schema, make_public_key, Signature
+from messages.crypto import (AccessKey, crypto_schema, make_public_key,
+                             make_signature)
 from messages.bridge import bridge_schema
 from serializer import BinarySerializer
 import mocknet_helpers
@@ -161,9 +162,7 @@ def send_resigned_transactions(tx_path, home_dir):
         tx.publicKey = make_public_key(key_pair.decoded_pk())
         msg = BinarySerializer(schema).serialize(tx)
         hash_ = hashlib.sha256(msg).digest()
-        signature = Signature()
-        signature.keyType = 0
-        signature.data = key_pair.sign_bytes(hash_)
+        signature = make_signature(key_pair.sign_bytes(hash_))
         resigned_tx = SignedTransaction()
         resigned_tx.transaction = tx
         resigned_tx.signature = signature

--- a/pytest/tools/mirror/mirror_utils.py
+++ b/pytest/tools/mirror/mirror_utils.py
@@ -1,7 +1,6 @@
 import sys
 import time
 import atexit
-import hashlib
 import json
 import os
 import pathlib
@@ -12,10 +11,10 @@ import subprocess
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 import base58
-from cryptography.hazmat.primitives.asymmetric import mldsa
 from nacl.signing import SigningKey
 
 from configured_logger import logger
+import mldsa65
 import transaction
 import utils
 import key
@@ -242,16 +241,18 @@ def send_mldsa65_add_key(node, key, action, nonce, block_hash, label):
     logger.info(f'added ML-DSA-65 {label} to {key.account_id}')
 
 
-def send_add_mldsa65_access_key(node, key, mldsa65_pk, nonce, block_hash):
+def send_add_mldsa65_access_key(node, key, mldsa65_key, nonce, block_hash):
     action = transaction.create_full_access_key_action(
-        mldsa65_pk, key_type=transaction.KEY_TYPE_MLDSA65)
+        mldsa65_key.decoded_pk(), key_type=transaction.KEY_TYPE_MLDSA65)
     send_mldsa65_add_key(node, key, action, nonce, block_hash, 'access key')
 
 
-def send_add_mldsa65_gas_key(node, key, mldsa65_pk, num_nonces, nonce,
+def send_add_mldsa65_gas_key(node, key, mldsa65_key, num_nonces, nonce,
                              block_hash):
     action = transaction.create_gas_key_full_access_key_action(
-        mldsa65_pk, num_nonces, key_type=transaction.KEY_TYPE_MLDSA65)
+        mldsa65_key.decoded_pk(),
+        num_nonces,
+        key_type=transaction.KEY_TYPE_MLDSA65)
     send_mldsa65_add_key(node, key, action, nonce, block_hash, 'gas key')
 
 
@@ -529,42 +530,14 @@ def map_key_no_secret(pk_str):
     return 'ed25519:' + base58.b58encode(mapped_pk).decode('ascii')
 
 
-MLDSA65_SEED_LEN = 32
-MLDSA65_HASH_DOMAIN = b'near:ml-dsa-65-pubkey-hash:v1'
+def map_mldsa65_key_no_secret(mldsa65_key):
+    """Map an ML-DSA-65 key through the --no-secret mirror key mapping.
 
-
-def mldsa65_public_key(seed):
-    """Deterministic ML-DSA-65 pubkey bytes from a seed string.
-
-    Pads the seed to 32 bytes with spaces so a given string yields the same
-    key as `SecretKey::from_seed(KeyType::MLDSA65, seed)` does in Rust
+    The account id carries over: the mirror does not map named accounts.
     """
-    seed_bytes = seed.encode('utf8')[:MLDSA65_SEED_LEN]
-    seed_bytes = seed_bytes.ljust(MLDSA65_SEED_LEN, b' ')
-    private_key = mldsa.MLDSA65PrivateKey.from_seed_bytes(seed_bytes)
-    return private_key.public_key().public_bytes_raw()
-
-
-def mldsa65_handle_digest(mldsa65_pk):
-    """SHA3-256 of (domain tag || pubkey), the raw on-trie handle bytes."""
-    digest = hashlib.sha3_256(MLDSA65_HASH_DOMAIN + mldsa65_pk).digest()
-    assert len(digest) == MLDSA65_SEED_LEN
-    return digest
-
-
-def mldsa65_handle(mldsa65_pk):
-    """The on-trie identifier for an ML-DSA-65 pubkey."""
-    digest = mldsa65_handle_digest(mldsa65_pk)
-    return 'ml-dsa-65-hash:' + base58.b58encode(digest).decode('ascii')
-
-
-def map_mldsa65_key_no_secret(mldsa65_pk):
-    """Map an ML-DSA-65 pubkey through the --no-secret mirror key mapping."""
     # --no-secret feeds the handle bytes straight in as the seed.
-    mapped = mldsa.MLDSA65PrivateKey.from_seed_bytes(
-        mldsa65_handle_digest(mldsa65_pk))
-    mapped_pk = mapped.public_key().public_bytes_raw()
-    return mapped_pk, mldsa65_handle(mapped_pk)
+    return mldsa65.MlDsa65Key(mldsa65_key.account_id,
+                              mldsa65_key.handle_digest())
 
 
 def map_account_no_secret(account_id):

--- a/pytest/tools/mirror/mirror_utils.py
+++ b/pytest/tools/mirror/mirror_utils.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import atexit
+import hashlib
 import json
 import os
 import pathlib
@@ -11,6 +12,7 @@ import subprocess
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 import base58
+from cryptography.hazmat.primitives.asymmetric import mldsa
 from nacl.signing import SigningKey
 
 from configured_logger import logger
@@ -225,6 +227,32 @@ def send_add_access_key(node, key, target_key, nonce, block_hash):
     res = node.send_tx(tx)
     logger.info(
         f'sent add key tx for {target_key.account_id} {target_key.pk}: {res}')
+
+
+def send_mldsa65_add_key(node, key, action, nonce, block_hash, label):
+    tx = transaction.sign_and_serialize_transaction(key.account_id, nonce,
+                                                    [action], block_hash,
+                                                    key.account_id,
+                                                    key.decoded_pk(),
+                                                    key.decoded_sk())
+    res = node.send_tx_and_wait(tx, timeout=30)
+    assert 'error' not in res, f'ML-DSA-65 {label} tx failed: {res}'
+    status = res['result']['status']
+    assert 'SuccessValue' in status, f'ML-DSA-65 {label} tx failed: {status}'
+    logger.info(f'added ML-DSA-65 {label} to {key.account_id}')
+
+
+def send_add_mldsa65_access_key(node, key, mldsa65_pk, nonce, block_hash):
+    action = transaction.create_full_access_key_action(
+        mldsa65_pk, key_type=transaction.KEY_TYPE_MLDSA65)
+    send_mldsa65_add_key(node, key, action, nonce, block_hash, 'access key')
+
+
+def send_add_mldsa65_gas_key(node, key, mldsa65_pk, num_nonces, nonce,
+                             block_hash):
+    action = transaction.create_gas_key_full_access_key_action(
+        mldsa65_pk, num_nonces, key_type=transaction.KEY_TYPE_MLDSA65)
+    send_mldsa65_add_key(node, key, action, nonce, block_hash, 'gas key')
 
 
 def create_subaccount(node,
@@ -499,6 +527,44 @@ def map_key_no_secret(pk_str):
     pk_bytes = base58.b58decode(pk_str.split(':')[1].encode('ascii'))
     mapped_pk = bytes(SigningKey(pk_bytes).verify_key)
     return 'ed25519:' + base58.b58encode(mapped_pk).decode('ascii')
+
+
+MLDSA65_SEED_LEN = 32
+MLDSA65_HASH_DOMAIN = b'near:ml-dsa-65-pubkey-hash:v1'
+
+
+def mldsa65_public_key(seed):
+    """Deterministic ML-DSA-65 pubkey bytes from a seed string.
+
+    Pads the seed to 32 bytes with spaces so a given string yields the same
+    key as `SecretKey::from_seed(KeyType::MLDSA65, seed)` does in Rust
+    """
+    seed_bytes = seed.encode('utf8')[:MLDSA65_SEED_LEN]
+    seed_bytes = seed_bytes.ljust(MLDSA65_SEED_LEN, b' ')
+    private_key = mldsa.MLDSA65PrivateKey.from_seed_bytes(seed_bytes)
+    return private_key.public_key().public_bytes_raw()
+
+
+def mldsa65_handle_digest(mldsa65_pk):
+    """SHA3-256 of (domain tag || pubkey), the raw on-trie handle bytes."""
+    digest = hashlib.sha3_256(MLDSA65_HASH_DOMAIN + mldsa65_pk).digest()
+    assert len(digest) == MLDSA65_SEED_LEN
+    return digest
+
+
+def mldsa65_handle(mldsa65_pk):
+    """The on-trie identifier for an ML-DSA-65 pubkey."""
+    digest = mldsa65_handle_digest(mldsa65_pk)
+    return 'ml-dsa-65-hash:' + base58.b58encode(digest).decode('ascii')
+
+
+def map_mldsa65_key_no_secret(mldsa65_pk):
+    """Map an ML-DSA-65 pubkey through the --no-secret mirror key mapping."""
+    # --no-secret feeds the handle bytes straight in as the seed.
+    mapped = mldsa.MLDSA65PrivateKey.from_seed_bytes(
+        mldsa65_handle_digest(mldsa65_pk))
+    mapped_pk = mapped.public_key().public_bytes_raw()
+    return mapped_pk, mldsa65_handle(mapped_pk)
 
 
 def map_account_no_secret(account_id):

--- a/pytest/tools/mirror/mirror_utils.py
+++ b/pytest/tools/mirror/mirror_utils.py
@@ -228,7 +228,7 @@ def send_add_access_key(node, key, target_key, nonce, block_hash):
         f'sent add key tx for {target_key.account_id} {target_key.pk}: {res}')
 
 
-def send_mldsa65_add_key(node, key, action, nonce, block_hash, label):
+def send_mldsa65_setup_tx(node, key, action, nonce, block_hash, label):
     tx = transaction.sign_and_serialize_transaction(key.account_id, nonce,
                                                     [action], block_hash,
                                                     key.account_id,
@@ -238,13 +238,13 @@ def send_mldsa65_add_key(node, key, action, nonce, block_hash, label):
     assert 'error' not in res, f'ML-DSA-65 {label} tx failed: {res}'
     status = res['result']['status']
     assert 'SuccessValue' in status, f'ML-DSA-65 {label} tx failed: {status}'
-    logger.info(f'added ML-DSA-65 {label} to {key.account_id}')
+    logger.info(f'sent ML-DSA-65 {label} for {key.account_id}')
 
 
 def send_add_mldsa65_access_key(node, key, mldsa65_key, nonce, block_hash):
     action = transaction.create_full_access_key_action(
         mldsa65_key.decoded_pk(), key_type=transaction.KEY_TYPE_MLDSA65)
-    send_mldsa65_add_key(node, key, action, nonce, block_hash, 'access key')
+    send_mldsa65_setup_tx(node, key, action, nonce, block_hash, 'access key')
 
 
 def send_add_mldsa65_gas_key(node, key, mldsa65_key, num_nonces, nonce,
@@ -253,7 +253,26 @@ def send_add_mldsa65_gas_key(node, key, mldsa65_key, num_nonces, nonce,
         mldsa65_key.decoded_pk(),
         num_nonces,
         key_type=transaction.KEY_TYPE_MLDSA65)
-    send_mldsa65_add_key(node, key, action, nonce, block_hash, 'gas key')
+    send_mldsa65_setup_tx(node, key, action, nonce, block_hash, 'gas key')
+
+
+def fund_mldsa65_gas_key(node, key, mldsa65_key, amount, nonce, block_hash):
+    action = transaction.create_transfer_to_gas_key_action(
+        mldsa65_key.decoded_pk(), amount, transaction.KEY_TYPE_MLDSA65)
+    send_mldsa65_setup_tx(node, key, action, nonce, block_hash,
+                          'gas key funding')
+    # fork-network snapshots the last final block, and pre-fork traffic ends a
+    # couple of blocks later, so waiting for execution is not enough: the
+    # deposit has to be final or the forked state carries a zero balance.
+    for _ in range(TIMEOUT):
+        balance = get_gas_key_balance(node, mldsa65_key.account_id,
+                                      mldsa65_key.full_pk)
+        if balance:
+            logger.info(f'ML-DSA-65 gas key deposit final: {balance}')
+            return
+        time.sleep(1)
+    assert False, \
+        f'ML-DSA-65 gas key deposit never became final on {key.account_id}'
 
 
 def create_subaccount(node,
@@ -393,7 +412,8 @@ def send_gas_key_transfer(node, gas_key, receiver_id, amount, nonce,
                                                        block_hash,
                                                        gas_key.account_id,
                                                        gas_key.decoded_pk(),
-                                                       gas_key.decoded_sk())
+                                                       gas_key.decoded_sk(),
+                                                       gas_key.key_type)
     res = node.send_tx(tx)
     logger.info(
         f'sent gas key V1 transfer from {gas_key.account_id} nonce_index={nonce_index} to {receiver_id}: {res}'

--- a/pytest/tools/mirror/offline_test.py
+++ b/pytest/tools/mirror/offline_test.py
@@ -392,7 +392,8 @@ class MlDsa65Test(MirrorTestCase):
 
         pq = {
             k['public_key']: k
-            for k in keys if k['public_key'].startswith('ml-dsa-65-hash:')
+            for k in keys
+            if k['public_key'].startswith('ml-dsa-65-hash:')
         }
         assert len(pq) == 2, \
             f'expected 2 ML-DSA-65 keys on the forked test0, got {pks}'

--- a/pytest/tools/mirror/offline_test.py
+++ b/pytest/tools/mirror/offline_test.py
@@ -26,6 +26,10 @@ import mirror_utils
 MIRROR_DIR = pathlib.Path.home() / '.near' / 'test-mirror'
 TARGET_VALIDATORS = mirror_utils.TARGET_VALIDATORS
 
+MLDSA65_ACCESS_KEY = mirror_utils.mldsa65_public_key('mirror-pq-offline-test')
+MLDSA65_GAS_KEY = mirror_utils.mldsa65_public_key('mirror-pq-offline-test-gas')
+MLDSA65_GAS_NUM_NONCES = 3
+
 
 class TestContext:
     """Shared mutable state passed to all test case hooks."""
@@ -359,6 +363,78 @@ class GasKeyTest(MirrorTestCase):
         logger.info(f'{self.name}: all gas key checks passed')
 
 
+class MlDsa65Test(MirrorTestCase):
+    """ML-DSA-65 access and gas keys must survive the fork, remapped."""
+    name = 'mldsa65'
+
+    def pre_fork(self, ctx):
+        mirror_utils.send_add_mldsa65_access_key(ctx.node, ctx.signer_key,
+                                                 MLDSA65_ACCESS_KEY,
+                                                 ctx.next_nonce(), ctx.bhash)
+        mirror_utils.send_add_mldsa65_gas_key(ctx.node, ctx.signer_key,
+                                              MLDSA65_GAS_KEY,
+                                              MLDSA65_GAS_NUM_NONCES,
+                                              ctx.next_nonce(), ctx.bhash)
+        return []
+
+    def check_fork(self, node):
+        keys = node.get_access_key_list('test0',
+                                        finality='final')['result']['keys']
+        pks = [k['public_key'] for k in keys]
+
+        # Neither source key may survive.
+        for label, pk in [('access', MLDSA65_ACCESS_KEY),
+                          ('gas', MLDSA65_GAS_KEY)]:
+            handle = mirror_utils.mldsa65_handle(pk)
+            assert handle not in pks, \
+                f'forked state still carries source ML-DSA-65 {label} ' \
+                f'key {handle}'
+
+        pq = {
+            k['public_key']: k
+            for k in keys if k['public_key'].startswith('ml-dsa-65-hash:')
+        }
+        assert len(pq) == 2, \
+            f'expected 2 ML-DSA-65 keys on the forked test0, got {pks}'
+
+        _, access_mapped = mirror_utils.map_mldsa65_key_no_secret(
+            MLDSA65_ACCESS_KEY)
+        access = pq.get(access_mapped)
+        assert access is not None, \
+            f'mapped ML-DSA-65 access key {access_mapped} missing, ' \
+            f'got {sorted(pq)}'
+        assert access['access_key']['permission'] == 'FullAccess', \
+            f'mapped ML-DSA-65 access key is not full access: {access}'
+
+        gas_mapped_pk, gas_mapped = mirror_utils.map_mldsa65_key_no_secret(
+            MLDSA65_GAS_KEY)
+        assert gas_mapped in pq, \
+            f'mapped ML-DSA-65 gas key {gas_mapped} missing, got {sorted(pq)}'
+        # view_gas_key_nonces takes a full pubkey, not the handle state stores,
+        # so this queries the mapped key the way the mirror itself does.
+        nonces = mirror_utils.get_gas_key_nonces(
+            node, 'test0',
+            'ml-dsa-65:' + base58.b58encode(gas_mapped_pk).decode('ascii'))
+        assert nonces is not None, \
+            f'no gas key nonces for mapped {gas_mapped} on forked state'
+        assert len(nonces) == MLDSA65_GAS_NUM_NONCES, \
+            f'expected {MLDSA65_GAS_NUM_NONCES} nonce indexes on forked ' \
+            f'state, got {len(nonces)}'
+
+        logger.info(f'{self.name}: forked state carries both mapped '
+                    'ML-DSA-65 keys')
+
+    def check(self, node):
+        for label, pk in [('access', MLDSA65_ACCESS_KEY),
+                          ('gas', MLDSA65_GAS_KEY)]:
+            _, handle = mirror_utils.map_mldsa65_key_no_secret(pk)
+            nonce = node.get_nonce_for_pk('test0', handle, finality='final')
+            assert nonce is not None, \
+                f'mapped ML-DSA-65 {label} key {handle} not found on target'
+        logger.info(f'{self.name}: target chain carries both mapped '
+                    'ML-DSA-65 keys')
+
+
 def build_images(config, test_cases):
     """Phases 1-5: build target image (forked state) and source image (chain with traffic).
 
@@ -607,6 +683,7 @@ def main():
         ContractTest(),
         CreateSubaccountTest(),
         GasKeyTest(),
+        MlDsa65Test(),
     ]
     target_img, source_img, validator_keys, end_source_height = build_images(
         config, test_cases)

--- a/pytest/tools/mirror/offline_test.py
+++ b/pytest/tools/mirror/offline_test.py
@@ -380,8 +380,10 @@ class MlDsa65Test(MirrorTestCase):
         self.added_signer = mirror_utils.AddedKey(self.added_key)
         self.access_recipient = mirror_utils.ImplicitAccount()
         self.added_recipient = mirror_utils.ImplicitAccount()
+        self.gas_recipient = mirror_utils.ImplicitAccount()
         self.fork_access_nonce = None
-        self._sent = {'access': 0, 'added': 0}
+        self.fork_gas_nonces = None
+        self._sent = {'access': 0, 'added': 0, 'gas': 0}
 
     def signers(self):
         return [('access', self.access_signer, self.access_recipient),
@@ -394,6 +396,9 @@ class MlDsa65Test(MirrorTestCase):
         mirror_utils.send_add_mldsa65_gas_key(ctx.node, ctx.signer_key,
                                               self.gas_key, self.gas_num_nonces,
                                               ctx.next_nonce(), ctx.bhash)
+        mirror_utils.fund_mldsa65_gas_key(ctx.node,
+                                          ctx.signer_key, self.gas_key, 10**24,
+                                          ctx.next_nonce(), ctx.bhash)
         return []
 
     def check_fork(self, node):
@@ -440,6 +445,12 @@ class MlDsa65Test(MirrorTestCase):
         assert len(nonces) == self.gas_num_nonces, \
             f'expected {self.gas_num_nonces} nonce indexes on forked ' \
             f'state, got {len(nonces)}'
+        # Baseline for check(): replayed V1 txs must push these past this.
+        self.fork_gas_nonces = nonces
+        balance = mirror_utils.get_gas_key_balance(node, 'test0',
+                                                   gas_mapped.full_pk)
+        assert balance is not None and balance > 0, \
+            f'mapped ML-DSA-65 gas key has no balance on forked state: {balance}'
 
         logger.info(f'{self.name}: forked state carries both mapped '
                     'ML-DSA-65 keys')
@@ -469,6 +480,19 @@ class MlDsa65Test(MirrorTestCase):
                             f'{self._sent[label]} tx(s) to '
                             f'{recipient.account_id()}')
 
+        # The gas key signs V1 txs instead, so the mirror maps its full pubkey
+        # through NonceKind::GasKey(i) / view_gas_key_nonces rather than the
+        # access key path. One tx per nonce index: a gas key V1 nonce is keyed
+        # by (nonce, nonce_index), and * 1000000 + 1 keeps it above the current
+        # access key nonce.
+        nonce_index = self._sent['gas']
+        if nonce_index < self.txs_per_key:
+            mirror_utils.send_gas_key_transfer(ctx.node, self.gas_key,
+                                               self.gas_recipient.account_id(),
+                                               10**24, ctx.nonce * 1000000 + 1,
+                                               nonce_index, ctx.bhash)
+            self._sent['gas'] = nonce_index + 1
+
     def check(self, node):
         for label, mldsa_key in [('access', self.access_key),
                                  ('gas', self.gas_key),
@@ -489,10 +513,28 @@ class MlDsa65Test(MirrorTestCase):
                     f'no tx signed with the mapped ML-DSA-65 access key ' \
                     f'landed on target, nonce is still {nonce}'
 
+        # The mapped gas key's per-index nonces only move if the mirror
+        # re-signed V1 txs with it, which goes through fetch_gas_key_nonces
+        # with the full 1952-byte pubkey.
+        gas_mapped = mirror_utils.map_mldsa65_key_no_secret(self.gas_key)
+        nonces = mirror_utils.get_gas_key_nonces(node, 'test0',
+                                                 gas_mapped.full_pk)
+        assert nonces is not None, \
+            f'no gas key nonces for mapped {gas_mapped.pk} on target'
+        assert len(nonces) == self.gas_num_nonces, \
+            f'expected {self.gas_num_nonces} nonces on target, got {len(nonces)}'
+        for i in range(self.txs_per_key):
+            assert nonces[i] > self.fork_gas_nonces[i], \
+                f'no V1 tx signed with the mapped ML-DSA-65 gas key landed ' \
+                f'on target for nonce index {i}: {nonces[i]} vs forked ' \
+                f'{self.fork_gas_nonces[i]}'
+
         for label, count in self._sent.items():
             assert count == self.txs_per_key, \
                 f'ML-DSA-65 {label} key signed only {count} source txs'
-        for label, _, recipient in self.signers():
+        for label, recipient in [('access', self.access_recipient),
+                                 ('added', self.added_recipient),
+                                 ('gas', self.gas_recipient)]:
             mapped_id = mirror_utils.map_account_no_secret(
                 recipient.account_id())
             res = node.get_account(mapped_id, do_assert=False)

--- a/pytest/tools/mirror/offline_test.py
+++ b/pytest/tools/mirror/offline_test.py
@@ -18,6 +18,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from cluster import spin_up_node, init_cluster, load_config
 from configured_logger import logger
 import key
+import mldsa65
 import transaction
 import utils
 
@@ -25,10 +26,6 @@ import mirror_utils
 
 MIRROR_DIR = pathlib.Path.home() / '.near' / 'test-mirror'
 TARGET_VALIDATORS = mirror_utils.TARGET_VALIDATORS
-
-MLDSA65_ACCESS_KEY = mirror_utils.mldsa65_public_key('mirror-pq-offline-test')
-MLDSA65_GAS_KEY = mirror_utils.mldsa65_public_key('mirror-pq-offline-test-gas')
-MLDSA65_GAS_NUM_NONCES = 3
 
 
 class TestContext:
@@ -364,16 +361,38 @@ class GasKeyTest(MirrorTestCase):
 
 
 class MlDsa65Test(MirrorTestCase):
-    """ML-DSA-65 access and gas keys must survive the fork, remapped."""
+    """ML-DSA-65 access and gas keys must survive the fork, remapped, and the
+    mirror must replay the transactions they sign."""
     name = 'mldsa65'
+
+    def __init__(self):
+        self.access_key = mldsa65.MlDsa65Key.from_seed_testonly(
+            'test0', 'mirror-pq-offline-test')
+        self.gas_key = mldsa65.MlDsa65Key.from_seed_testonly(
+            'test0', 'mirror-pq-offline-test-gas')
+        self.gas_num_nonces = 3
+        self.txs_per_key = 2
+        # Added post-fork, so the mirror maps the AddKey action itself instead
+        # of picking the key up from the forked state.
+        self.added_key = mldsa65.MlDsa65Key.from_seed_testonly(
+            'test0', 'mirror-pq-offline-test-added')
+        self.access_signer = mirror_utils.AddedKey(self.access_key)
+        self.added_signer = mirror_utils.AddedKey(self.added_key)
+        self.access_recipient = mirror_utils.ImplicitAccount()
+        self.added_recipient = mirror_utils.ImplicitAccount()
+        self.fork_access_nonce = None
+        self._sent = {'access': 0, 'added': 0}
+
+    def signers(self):
+        return [('access', self.access_signer, self.access_recipient),
+                ('added', self.added_signer, self.added_recipient)]
 
     def pre_fork(self, ctx):
         mirror_utils.send_add_mldsa65_access_key(ctx.node, ctx.signer_key,
-                                                 MLDSA65_ACCESS_KEY,
+                                                 self.access_key,
                                                  ctx.next_nonce(), ctx.bhash)
         mirror_utils.send_add_mldsa65_gas_key(ctx.node, ctx.signer_key,
-                                              MLDSA65_GAS_KEY,
-                                              MLDSA65_GAS_NUM_NONCES,
+                                              self.gas_key, self.gas_num_nonces,
                                               ctx.next_nonce(), ctx.bhash)
         return []
 
@@ -383,57 +402,106 @@ class MlDsa65Test(MirrorTestCase):
         pks = [k['public_key'] for k in keys]
 
         # Neither source key may survive.
-        for label, pk in [('access', MLDSA65_ACCESS_KEY),
-                          ('gas', MLDSA65_GAS_KEY)]:
-            handle = mirror_utils.mldsa65_handle(pk)
-            assert handle not in pks, \
+        for label, mldsa_key in [('access', self.access_key),
+                                 ('gas', self.gas_key)]:
+            assert mldsa_key.pk not in pks, \
                 f'forked state still carries source ML-DSA-65 {label} ' \
-                f'key {handle}'
+                f'key {mldsa_key.pk}'
 
         pq = {
             k['public_key']: k
             for k in keys
-            if k['public_key'].startswith('ml-dsa-65-hash:')
+            if k['public_key'].startswith(mldsa65.HANDLE_PREFIX)
         }
         assert len(pq) == 2, \
             f'expected 2 ML-DSA-65 keys on the forked test0, got {pks}'
 
-        _, access_mapped = mirror_utils.map_mldsa65_key_no_secret(
-            MLDSA65_ACCESS_KEY)
-        access = pq.get(access_mapped)
+        access_mapped = mirror_utils.map_mldsa65_key_no_secret(self.access_key)
+        access = pq.get(access_mapped.pk)
         assert access is not None, \
-            f'mapped ML-DSA-65 access key {access_mapped} missing, ' \
+            f'mapped ML-DSA-65 access key {access_mapped.pk} missing, ' \
             f'got {sorted(pq)}'
         assert access['access_key']['permission'] == 'FullAccess', \
             f'mapped ML-DSA-65 access key is not full access: {access}'
+        # Baseline for check(): mirrored txs signed with the mapped key must
+        # push this nonce past what the forked state started with.
+        self.fork_access_nonce = access['access_key']['nonce']
 
-        gas_mapped_pk, gas_mapped = mirror_utils.map_mldsa65_key_no_secret(
-            MLDSA65_GAS_KEY)
-        assert gas_mapped in pq, \
-            f'mapped ML-DSA-65 gas key {gas_mapped} missing, got {sorted(pq)}'
+        gas_mapped = mirror_utils.map_mldsa65_key_no_secret(self.gas_key)
+        assert gas_mapped.pk in pq, \
+            f'mapped ML-DSA-65 gas key {gas_mapped.pk} missing, ' \
+            f'got {sorted(pq)}'
         # view_gas_key_nonces takes a full pubkey, not the handle state stores,
         # so this queries the mapped key the way the mirror itself does.
-        nonces = mirror_utils.get_gas_key_nonces(
-            node, 'test0',
-            'ml-dsa-65:' + base58.b58encode(gas_mapped_pk).decode('ascii'))
+        nonces = mirror_utils.get_gas_key_nonces(node, 'test0',
+                                                 gas_mapped.full_pk)
         assert nonces is not None, \
-            f'no gas key nonces for mapped {gas_mapped} on forked state'
-        assert len(nonces) == MLDSA65_GAS_NUM_NONCES, \
-            f'expected {MLDSA65_GAS_NUM_NONCES} nonce indexes on forked ' \
+            f'no gas key nonces for mapped {gas_mapped.pk} on forked state'
+        assert len(nonces) == self.gas_num_nonces, \
+            f'expected {self.gas_num_nonces} nonce indexes on forked ' \
             f'state, got {len(nonces)}'
 
         logger.info(f'{self.name}: forked state carries both mapped '
                     'ML-DSA-65 keys')
 
+    def post_fork(self, ctx):
+        mirror_utils.send_add_mldsa65_access_key(ctx.node,
+                                                 ctx.signer_key, self.added_key,
+                                                 ctx.next_nonce(), ctx.bhash)
+        # No senders: an ML-DSA-65 tx is ~5.3 KiB, so these keys send a couple
+        # of txs each from on_post_fork_block rather than one per block, which
+        # would crowd other test cases' txs out of the target chunks.
+        return []
+
+    def on_post_fork_block(self, ctx):
+        # Each ML-DSA-65 key funds an implicit account of its own, so nothing
+        # but a replayed ML-DSA-65-signed tx can create it on the target. The
+        # second transfer makes the mirror map a second nonce for the key.
+        for label, signer, recipient in self.signers():
+            sent = self._sent[label]
+            if sent >= self.txs_per_key:
+                continue
+            signer.send_if_inited(ctx.node, [(recipient.account_id(), 10**24)],
+                                  ctx.bhash)
+            if signer.inited():
+                self._sent[label] = sent + 1
+                logger.info(f'{self.name}: ML-DSA-65 {label} key sent '
+                            f'{self._sent[label]} tx(s) to '
+                            f'{recipient.account_id()}')
+
     def check(self, node):
-        for label, pk in [('access', MLDSA65_ACCESS_KEY),
-                          ('gas', MLDSA65_GAS_KEY)]:
-            _, handle = mirror_utils.map_mldsa65_key_no_secret(pk)
-            nonce = node.get_nonce_for_pk('test0', handle, finality='final')
+        for label, mldsa_key in [('access', self.access_key),
+                                 ('gas', self.gas_key),
+                                 ('added', self.added_key)]:
+            mapped = mirror_utils.map_mldsa65_key_no_secret(mldsa_key)
+            nonce = node.get_nonce_for_pk('test0', mapped.pk, finality='final')
             assert nonce is not None, \
-                f'mapped ML-DSA-65 {label} key {handle} not found on target'
-        logger.info(f'{self.name}: target chain carries both mapped '
-                    'ML-DSA-65 keys')
+                f'mapped ML-DSA-65 {label} key {mapped.pk} not found on target'
+            # The added key only exists on target because the mirror mapped a
+            # post-fork AddKey action; its nonce moves only if the mirror also
+            # signed replayed txs with the mapped ML-DSA-65 key.
+            if label == 'added':
+                assert nonce > 0, \
+                    f'no tx signed with the mapped ML-DSA-65 added key ' \
+                    f'landed on target, nonce is {nonce}'
+            elif label == 'access':
+                assert nonce > self.fork_access_nonce, \
+                    f'no tx signed with the mapped ML-DSA-65 access key ' \
+                    f'landed on target, nonce is still {nonce}'
+
+        for label, count in self._sent.items():
+            assert count == self.txs_per_key, \
+                f'ML-DSA-65 {label} key signed only {count} source txs'
+        for label, _, recipient in self.signers():
+            mapped_id = mirror_utils.map_account_no_secret(
+                recipient.account_id())
+            res = node.get_account(mapped_id, do_assert=False)
+            assert 'error' not in res, \
+                f'account {mapped_id} funded by the ML-DSA-65 {label} key ' \
+                f'not found on target'
+
+        logger.info(f'{self.name}: target chain carries the mapped ML-DSA-65 '
+                    'keys and the txs they signed')
 
 
 def build_images(config, test_cases):

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -8,7 +8,7 @@ use near_chain::{Chain, ChainGenesis, ChainStore, ChainStoreAccess};
 use near_chain_configs::{Genesis, GenesisConfig, GenesisValidationMode};
 use near_crypto::{PublicKey, SecretKey};
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
-use near_mirror::key_mapping::{map_account, map_key};
+use near_mirror::key_mapping::{map_account, map_key_handle};
 use near_o11y::default_subscriber_with_opentelemetry;
 use near_o11y::env_filter::make_env_filter;
 use near_parameters::RuntimeConfig;
@@ -1100,19 +1100,13 @@ impl ForkNetworkCommand {
                             has_full_key.insert(account_id.clone());
                         }
                         let new_account_id = map_account(&account_id, None);
-                        // TODO(post-quantum): fork-network does not support ML-DSA-65 yet -
-                        // skip hash-form entries since we lack the full
-                        // pubkey needed for key_mapping.
-                        let Some(full_pk) = public_key.full_pubkey() else {
-                            continue;
-                        };
-                        let replacement = map_key(&full_pk, None);
+                        let replacement = map_key_handle(&public_key, None);
                         let new_shard_id =
                             target_shard_layout.account_id_to_shard_id(&new_account_id);
                         let new_shard_idx =
                             target_shard_layout.get_shard_index(new_shard_id).unwrap();
 
-                        storage_mutator.remove_access_key(shard_uid, account_id, full_pk)?;
+                        storage_mutator.remove_access_key(shard_uid, account_id, public_key)?;
                         storage_mutator.set_access_key(
                             new_shard_idx,
                             new_account_id,
@@ -1126,19 +1120,14 @@ impl ForkNetworkCommand {
                             has_full_key.insert(account_id.clone());
                         }
                         let new_account_id = map_account(&account_id, None);
-                        // TODO(post-quantum): same skip as the AccessKey arm above for
-                        // hash-form ML-DSA-65 entries.
-                        let Some(full_pk) = public_key.full_pubkey() else {
-                            continue;
-                        };
-                        let replacement = map_key(&full_pk, None);
+                        let replacement = map_key_handle(&public_key, None);
                         let new_shard_id =
                             target_shard_layout.account_id_to_shard_id(&new_account_id);
                         let new_shard_idx =
                             target_shard_layout.get_shard_index(new_shard_id).unwrap();
 
                         storage_mutator
-                            .remove_gas_key_nonce(shard_uid, account_id, full_pk, index)?;
+                            .remove_gas_key_nonce(shard_uid, account_id, public_key, index)?;
                         storage_mutator.set_gas_key_nonce(
                             new_shard_idx,
                             new_account_id,

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -1,6 +1,6 @@
 use crate::metrics::{self, CommitStagesMetrics};
 use anyhow::Context;
-use near_crypto::PublicKey;
+use near_crypto::PublicKeyHandle;
 use near_mirror::key_mapping::map_account;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::bandwidth_scheduler::{
@@ -224,7 +224,7 @@ impl StorageMutator {
         &mut self,
         source_shard_uid: ShardUId,
         account_id: AccountId,
-        public_key: PublicKey,
+        public_key: impl Into<PublicKeyHandle>,
     ) -> anyhow::Result<()> {
         if self.target_shards.contains(&source_shard_uid) {
             let shard_idx =
@@ -238,7 +238,7 @@ impl StorageMutator {
         &mut self,
         shard_idx: ShardIndex,
         account_id: AccountId,
-        public_key: PublicKey,
+        public_key: impl Into<PublicKeyHandle>,
         access_key: AccessKey,
     ) -> anyhow::Result<()> {
         self.set(
@@ -252,7 +252,7 @@ impl StorageMutator {
         &mut self,
         source_shard_uid: ShardUId,
         account_id: AccountId,
-        public_key: PublicKey,
+        public_key: impl Into<PublicKeyHandle>,
         index: NonceIndex,
     ) -> anyhow::Result<()> {
         if self.target_shards.contains(&source_shard_uid) {
@@ -267,7 +267,7 @@ impl StorageMutator {
         &mut self,
         shard_idx: ShardIndex,
         account_id: AccountId,
-        public_key: PublicKey,
+        public_key: impl Into<PublicKeyHandle>,
         index: NonceIndex,
         nonce: Nonce,
     ) -> anyhow::Result<()> {

--- a/tools/mirror/README.md
+++ b/tools/mirror/README.md
@@ -51,3 +51,7 @@ about security, then we pass a `--secret-key-file` argument to the
 that makes things a little bit more delicate, since if the generated
 secret is ever lost, then it will no longer be possible to mirror any
 traffic to the target chain.
+
+ML-DSA-65 keys work the same way, except that the derivation input is
+the on-trie key handle - the SHA3-256 digest of the pubkey - rather than
+the pubkey itself, since the full pubkey is never stored in state.

--- a/tools/mirror/src/cli.rs
+++ b/tools/mirror/src/cli.rs
@@ -240,8 +240,8 @@ impl ShowKeysCmd {
             }
         };
         for key in &keys {
-            if let Some(k) = &key.original_key {
-                println!("original pub key: {}", k);
+            if let Some(k) = &key.original_handle {
+                println!("original handle: {}", k);
             }
             println!(
                 "mapped secret key: {}\nmapped public key: {}",

--- a/tools/mirror/src/genesis.rs
+++ b/tools/mirror/src/genesis.rs
@@ -253,16 +253,7 @@ pub(crate) fn map_records<P: AsRef<Path>>(
     near_chain_configs::stream_records_from_file(reader, |mut r| {
         match &mut r {
             StateRecord::AccessKey { account_id, public_key, access_key } => {
-                // TODO(post-quantum): Mirror does not yet support post-quantum keys;
-                // bail loudly if we hit one, matching the panic in
-                // key_mapping.rs.
-                let Some(full_pk) = public_key.full_pubkey() else {
-                    panic!(
-                        "mirror: cannot transform an ML-DSA-65 hash-form access \
-                         key entry for {account_id}",
-                    );
-                };
-                let replacement = crate::key_mapping::map_key(&full_pk, secret.as_ref());
+                let replacement = crate::key_mapping::map_key_handle(public_key, secret.as_ref());
                 let new_record = StateRecord::access_key(
                     crate::key_mapping::map_account(&account_id, secret.as_ref()),
                     &replacement.public_key(),
@@ -279,14 +270,7 @@ pub(crate) fn map_records<P: AsRef<Path>>(
                 records_seq.serialize_element(&new_record).unwrap();
             }
             StateRecord::GasKeyNonce { account_id, public_key, index, nonce } => {
-                // TODO(post-quantum): same as the AccessKey arm above.
-                let Some(full_pk) = public_key.full_pubkey() else {
-                    panic!(
-                        "mirror: cannot transform an ML-DSA-65 hash-form gas \
-                         key nonce entry for {account_id}",
-                    );
-                };
-                let replacement = crate::key_mapping::map_key(&full_pk, secret.as_ref());
+                let replacement = crate::key_mapping::map_key_handle(public_key, secret.as_ref());
                 let new_record = StateRecord::gas_key_nonce(
                     crate::key_mapping::map_account(&account_id, secret.as_ref()),
                     &replacement.public_key(),
@@ -351,14 +335,15 @@ pub(crate) fn map_records<P: AsRef<Path>>(
 
 #[cfg(test)]
 mod test {
-    use near_crypto::{KeyType, SecretKey};
+    use near_crypto::{KeyType, PublicKeyHandle, SecretKey};
     use near_primitives::account::{AccessKeyPermission, FunctionCallPermission, GasKeyInfo};
     use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
     use near_primitives::hash::CryptoHash;
     use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV0};
     use near_primitives::state_record::StateRecord;
+    use near_primitives::test_utils::account_new;
     use near_primitives::transaction::{Action, AddKeyAction, CreateAccountAction};
-    use near_primitives::types::Balance;
+    use near_primitives::types::{AccountId, Balance};
     use near_primitives_core::account::AccessKey;
 
     #[test]
@@ -564,10 +549,7 @@ mod test {
         let records = vec![
             StateRecord::Account {
                 account_id: "alice.near".parse().unwrap(),
-                account: near_primitives::test_utils::account_new(
-                    Balance::from_yoctonear(1_000_000),
-                    near_primitives::hash::CryptoHash::default(),
-                ),
+                account: account_new(Balance::from_yoctonear(1_000_000), CryptoHash::default()),
             },
             StateRecord::gas_key_nonce("alice.near".parse().unwrap(), &public_key, 3, 42),
         ];
@@ -596,10 +578,7 @@ mod test {
         let records = vec![
             StateRecord::Account {
                 account_id: "bob.near".parse().unwrap(),
-                account: near_primitives::test_utils::account_new(
-                    Balance::from_yoctonear(1_000_000),
-                    near_primitives::hash::CryptoHash::default(),
-                ),
+                account: account_new(Balance::from_yoctonear(1_000_000), CryptoHash::default()),
             },
             StateRecord::access_key(
                 "bob.near".parse().unwrap(),
@@ -632,5 +611,44 @@ mod test {
         // GasKeyFullAccess record should not suppress adding a full default access
         // key for mirror purposes.
         assert!(has_default_full_access_key(&out));
+    }
+
+    /// An account whose only full access key is post-quantum.
+    #[test]
+    fn test_map_records_mldsa65_access_key() {
+        let secret_key = SecretKey::from_seed(KeyType::MLDSA65, "pq-key");
+        let public_key = secret_key.public_key();
+        let account_id: AccountId = "pq.near".parse().unwrap();
+
+        let records = vec![
+            StateRecord::Account {
+                account_id: account_id.clone(),
+                account: account_new(Balance::from_yoctonear(1_000_000), CryptoHash::default()),
+            },
+            StateRecord::access_key(account_id.clone(), &public_key, AccessKey::full_access()),
+        ];
+        let out = run_map_records(&records);
+
+        // The forked state carries a mapped ML-DSA-65 key, not the source one.
+        let forked_handle = out
+            .iter()
+            .find_map(|r| match r {
+                StateRecord::AccessKey { public_key, access_key, .. }
+                    if access_key.permission == AccessKeyPermission::FullAccess
+                        && matches!(public_key, PublicKeyHandle::MlDsa65(_)) =>
+                {
+                    Some(public_key.clone())
+                }
+                _ => None,
+            })
+            .expect("mapped ML-DSA-65 access key should be in output");
+        assert_ne!(forked_handle, (&public_key).into());
+
+        // And it's the key mirror signs replayed transactions with.
+        let mapped_key = crate::key_mapping::map_key(&public_key, None);
+        assert_eq!(forked_handle, (&mapped_key.public_key()).into());
+
+        // The account already has a full access key, so no default one is added.
+        assert!(!has_default_full_access_key(&out));
     }
 }

--- a/tools/mirror/src/genesis.rs
+++ b/tools/mirror/src/genesis.rs
@@ -625,7 +625,7 @@ mod test {
                 account_id: account_id.clone(),
                 account: account_new(Balance::from_yoctonear(1_000_000), CryptoHash::default()),
             },
-            StateRecord::access_key(account_id.clone(), &public_key, AccessKey::full_access()),
+            StateRecord::access_key(account_id, &public_key, AccessKey::full_access()),
         ];
         let out = run_map_records(&records);
 

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -114,7 +114,9 @@ fn map_mldsa65(
 }
 
 // This maps the public key to a secret key so that we can sign
-// transactions on the target chain.
+// transactions on the target chain. If secret is None, then we just use the
+// bytes of the public key directly, otherwise we feed the public key to a key
+// derivation function.
 pub fn map_key(key: &PublicKey, secret: Option<&[u8; crate::secret::SECRET_LEN]>) -> SecretKey {
     map_key_handle(&key.into(), secret)
 }

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -1,6 +1,9 @@
 // cspell:words hkdf
 use hkdf::Hkdf;
-use near_crypto::{ED25519PublicKey, ED25519SecretKey, PublicKey, Secp256K1PublicKey, SecretKey};
+use near_crypto::{
+    ED25519PublicKey, ED25519SecretKey, ML_DSA_65_SEED_LENGTH, MlDsa65PublicKeyHandle, PublicKey,
+    PublicKeyHandle, Secp256K1PublicKey, SecretKey, ml_dsa_65_from_seed,
+};
 use near_primitives::types::AccountId;
 use near_primitives::utils::derive_near_implicit_account_id;
 use near_primitives_core::account::id::AccountType;
@@ -93,20 +96,40 @@ fn map_secp256k1(
     secp256k1_from_slice(&mut buf, public)
 }
 
-// This maps the public key to a secret key so that we can sign
-// transactions on the target chain.  If secret is None, then we just
-// use the bytes of the public key directly, otherwise we feed the
-// public key to a key derivation function.
-pub fn map_key(key: &PublicKey, secret: Option<&[u8; crate::secret::SECRET_LEN]>) -> SecretKey {
-    match key {
-        PublicKey::ED25519(k) => SecretKey::ED25519(map_ed25519(k, secret)),
-        PublicKey::SECP256K1(k) => SecretKey::SECP256K1(map_secp256k1(k, secret)),
-        // TODO(post-quantum): implement deterministic key mapping for
-        // ML-DSA-65 in mirror. For now, the mirror tool does not support
-        // cross-network mirroring of post-quantum keys.
-        PublicKey::MLDSA65(_) => {
-            panic!("mirror: ML-DSA-65 key mapping not yet implemented")
+fn map_mldsa65(
+    handle: &MlDsa65PublicKeyHandle,
+    secret: Option<&[u8; crate::secret::SECRET_LEN]>,
+) -> SecretKey {
+    let seed = match secret {
+        Some(secret) => {
+            let mut seed = [0; ML_DSA_65_SEED_LENGTH];
+            let hk = Hkdf::<Sha256>::new(None, secret);
+            hk.expand(&handle.0, &mut seed).unwrap();
+            seed
         }
+        None => handle.0,
+    };
+
+    ml_dsa_65_from_seed(&seed).expect("ML-DSA-65 key derivation from seed failed")
+}
+
+// This maps the public key to a secret key so that we can sign
+// transactions on the target chain.
+pub fn map_key(key: &PublicKey, secret: Option<&[u8; crate::secret::SECRET_LEN]>) -> SecretKey {
+    map_key_handle(&key.into(), secret)
+}
+
+// Maps the on-trie key handle to a secret key. If secret is None, then we just
+// use the bytes of the handle directly, otherwise we feed the handle to a key
+// derivation function.
+pub fn map_key_handle(
+    handle: &PublicKeyHandle,
+    secret: Option<&[u8; crate::secret::SECRET_LEN]>,
+) -> SecretKey {
+    match handle {
+        PublicKeyHandle::ED25519(k) => SecretKey::ED25519(map_ed25519(k, secret)),
+        PublicKeyHandle::SECP256K1(k) => SecretKey::SECP256K1(map_secp256k1(k, secret)),
+        PublicKeyHandle::MlDsa65(h) => map_mldsa65(h, secret),
     }
 }
 

--- a/tools/mirror/src/key_util.rs
+++ b/tools/mirror/src/key_util.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
-use near_crypto::{PublicKey, SecretKey};
+use near_crypto::{PublicKey, PublicKeyHandle, SecretKey};
 use near_epoch_manager::EpochManager;
 use near_epoch_manager::shard_assignment::{account_id_to_shard_id, shard_id_to_uid};
 use near_jsonrpc_primitives::types::query::{
@@ -18,7 +18,8 @@ use std::path::Path;
 pub(crate) const ACCESS_KEY_PAGE_SIZE: Option<NonZeroU32> = NonZeroU32::new(1000);
 
 pub(crate) struct SecretAccessKey {
-    pub(crate) original_key: Option<PublicKey>,
+    /// The source chain key this was mapped from, as it appears in the trie.
+    pub(crate) original_handle: Option<PublicKeyHandle>,
     pub(crate) mapped_key: SecretKey,
     pub(crate) permission: Option<AccessKeyPermissionView>,
 }
@@ -27,7 +28,7 @@ pub(crate) fn default_extra_key(
     secret: Option<&[u8; crate::secret::SECRET_LEN]>,
 ) -> SecretAccessKey {
     SecretAccessKey {
-        original_key: None,
+        original_handle: None,
         mapped_key: crate::key_mapping::default_extra_key(secret),
         permission: None,
     }
@@ -38,9 +39,9 @@ pub(crate) fn map_pub_key(
     secret: Option<&[u8; crate::secret::SECRET_LEN]>,
 ) -> anyhow::Result<SecretAccessKey> {
     let public_key: PublicKey = public_key.parse().context("Could not parse public key")?;
-    // we say original_key is None here because the user provided it on the command line in this case, so no need to print it again.
+    // we say original_handle is None here because the user provided it on the command line in this case, so no need to print it again.
     Ok(SecretAccessKey {
-        original_key: None,
+        original_handle: None,
         mapped_key: crate::key_mapping::map_key(&public_key, secret),
         permission: None,
     })
@@ -108,16 +109,10 @@ pub(crate) fn keys_from_source_db(
         let QueryResponseKind::AccessKeyList(l) = response.kind else {
             unreachable!();
         };
-        keys.extend(l.keys.into_iter().filter_map(|k| {
-            // TODO(post-quantum): Mirror does not support ML-DSA-65 today;
-            // hash-form entries can't be mapped because the full pubkey is not
-            // recoverable. See key_mapping.rs for the matching panic.
-            let full_pk = k.public_key.full_pubkey()?;
-            Some(SecretAccessKey {
-                mapped_key: crate::key_mapping::map_key(&full_pk, secret),
-                original_key: Some(full_pk),
-                permission: Some(k.access_key.permission),
-            })
+        keys.extend(l.keys.into_iter().map(|k| SecretAccessKey {
+            mapped_key: crate::key_mapping::map_key_handle(&k.public_key, secret),
+            original_handle: Some(k.public_key),
+            permission: Some(k.access_key.permission),
         }));
         match l.last_key {
             Some(cursor) => after_key = Some(cursor),
@@ -163,16 +158,10 @@ pub(crate) async fn keys_from_rpc(
                 response.kind
             );
         };
-        keys.extend(l.keys.into_iter().filter_map(|k| {
-            // TODO(post-quantum): Mirror does not support ML-DSA-65 today;
-            // hash-form entries can't be mapped because the full pubkey is not
-            // recoverable. See key_mapping.rs for the matching panic.
-            let full_pk = k.public_key.full_pubkey()?;
-            Some(SecretAccessKey {
-                mapped_key: crate::key_mapping::map_key(&full_pk, secret),
-                original_key: Some(full_pk),
-                permission: Some(k.access_key.permission),
-            })
+        keys.extend(l.keys.into_iter().map(|k| SecretAccessKey {
+            mapped_key: crate::key_mapping::map_key_handle(&k.public_key, secret),
+            original_handle: Some(k.public_key),
+            permission: Some(k.access_key.permission),
         }));
         match l.last_key {
             Some(cursor) => after_key = Some(cursor),

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -9,7 +9,7 @@ use near_client_primitives::types::{
     GetBlock, GetBlockError, GetChunkError, GetExecutionOutcomeError, GetReceiptError, Query,
     QueryError, Status,
 };
-use near_crypto::{PublicKey, SecretKey};
+use near_crypto::{PublicKey, PublicKeyHandle, SecretKey};
 use near_indexer::{Indexer, StreamerMessage};
 use near_primitives::action::{TransferToGasKeyAction, WithdrawFromGasKeyAction};
 use near_primitives::hash::CryptoHash;
@@ -434,12 +434,12 @@ trait ChainAccess {
 
     async fn get_receipt(&self, id: &CryptoHash) -> Result<Arc<Receipt>, ChainError>;
 
-    // returns all public keys with full permissions for the given account
+    // returns handles for all keys with full permissions for the given account
     async fn get_full_access_keys(
         &self,
         account_id: &AccountId,
         block_hash: &CryptoHash,
-    ) -> Result<Vec<PublicKey>, ChainError>;
+    ) -> Result<Vec<PublicKeyHandle>, ChainError>;
 }
 
 fn execution_status_good(status: &ExecutionStatusView) -> bool {
@@ -1240,7 +1240,8 @@ impl<T: ChainAccess> TxMirror<T> {
                 let mut key = None;
                 let mut first_key = None;
                 for k in &keys {
-                    let target_secret_key = crate::key_mapping::map_key(k, self.secret.as_ref());
+                    let target_secret_key =
+                        crate::key_mapping::map_key_handle(k, self.secret.as_ref());
                     if fetch_access_key_nonce(
                         target_view_client,
                         &target_signer_id,

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -6,7 +6,7 @@ use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
 use near_chain_primitives::error::EpochErrorResultToChainError;
-use near_crypto::PublicKey;
+use near_crypto::PublicKeyHandle;
 use near_epoch_manager::shard_assignment::{account_id_to_shard_id, shard_id_to_uid};
 use near_epoch_manager::{EpochManager, EpochManagerHandle};
 use near_primitives::block::BlockHeader;
@@ -184,7 +184,7 @@ impl crate::ChainAccess for ChainAccess {
         &self,
         account_id: &AccountId,
         block_hash: &CryptoHash,
-    ) -> Result<Vec<PublicKey>, ChainError> {
+    ) -> Result<Vec<PublicKeyHandle>, ChainError> {
         let mut ret = Vec::new();
         let header = self.chain.get_block_header(block_hash)?;
         let shard_id =
@@ -214,11 +214,7 @@ impl crate::ChainAccess for ChainAccess {
             };
             for k in l.keys {
                 if k.access_key.permission == AccessKeyPermissionView::FullAccess {
-                    // TODO(post-quantum): Mirror does not support ML-DSA-65
-                    // hash-form entries; skip them silently.
-                    if let Some(pk) = k.public_key.full_pubkey() {
-                        ret.push(pk);
-                    }
+                    ret.push(k.public_key);
                 }
             }
             match l.last_key {

--- a/tools/mirror/src/online.rs
+++ b/tools/mirror/src/online.rs
@@ -10,7 +10,7 @@ use near_client::ViewClientActor;
 use near_client_primitives::types::{
     GetBlock, GetBlockError, GetChunkError, GetExecutionOutcome, GetReceipt, GetShardChunk, Query,
 };
-use near_crypto::PublicKey;
+use near_crypto::PublicKeyHandle;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::ChunkHash;
@@ -209,7 +209,7 @@ impl crate::ChainAccess for ChainAccess {
         &self,
         account_id: &AccountId,
         block_hash: &CryptoHash,
-    ) -> Result<Vec<PublicKey>, ChainError> {
+    ) -> Result<Vec<PublicKeyHandle>, ChainError> {
         let mut ret = Vec::new();
         let mut after_key = None;
         loop {
@@ -230,11 +230,7 @@ impl crate::ChainAccess for ChainAccess {
             };
             for k in l.keys {
                 if k.access_key.permission == AccessKeyPermissionView::FullAccess {
-                    // TODO(post-quantum): Mirror does not support ML-DSA-65
-                    // hash-form entries; skip them silently.
-                    if let Some(pk) = k.public_key.full_pubkey() {
-                        ret.push(pk);
-                    }
+                    ret.push(k.public_key);
                 }
             }
             match l.last_key {


### PR DESCRIPTION
Fixes #16226

Mirror and fork-network now carry ML-DSA-65 keys across a fork instead of
panicking or silently dropping them.

## What changed

- `key_mapping`: new `map_key_handle(&PublicKeyHandle, secret)` — the mapping
  now works off the on-trie key handle, so it covers all three key types.
  ML-DSA-65 derives a secret from the 32-byte handle digest (or from
  HKDF(secret, handle) with `--secret-key-file`); `map_key` delegates to it.
- Removed `PublicKeyHandle::full_pubkey()` and every `TODO(post-quantum)`
  skip/panic it enabled: `genesis.rs`, `key_util.rs`, `{offline,online}.rs`,
  `fork-network/src/cli.rs`.
- `StorageMutator` access-key / gas-key-nonce methods take
  `impl Into<PublicKeyHandle>`.
- `show-keys` prints `original handle:` instead of `original pub key:`
  (`SecretAccessKey::original_key` → `original_handle`).
- `ml_dsa_65_from_seed` / `ML_DSA_65_SEED_LENGTH` no longer gated on the `rand`
  feature.

## Tests

- `tools/mirror/src/genesis.rs`: `test_map_records_mldsa65_access_key` — an
  account whose only full access key is ML-DSA-65 comes out remapped, not
  dropped, and matches the key mirror signs with.
- `pytest/tools/mirror/offline_test.py`: new `MlDsa65Test` case adds an
  ML-DSA-65 access key and gas key pre-fork, then asserts the forked state and
  the target chain carry the mapped keys (and the right nonce count) and not the
  source ones. Python-side ML-DSA-65 helpers via the `cryptography` package
  (added to `pytest/requirements.txt`); borsh `PublicKey` schema fixed to be an
  enum so non-ed25519 keys serialize.

## Follow-up

`show-keys from-pubkey` still only accepts full pubkeys, not the
`ml-dsa-65-hash:` form the view RPC returns — noted in
`docs/architecture/how/post_quantum_signatures.md`.
