### PR TITLE
fix(indexer): properly handle skipping two consecutive heights

### DIFF
--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -366,7 +366,12 @@ pub async fn start(
                             if indexer_config.skip_broken_blocks {
                                 build_streamer_message_attempts = 0;
                                 tracing::error!(target: INDEXER, ?block_height, ?err, "skip height - failed to build streamer message");
-                                continue;
+                                // Record the skipped height as synced so the next outer iteration resumes right after it
+                                db.put(b"last_synced_block_height", &block_height.to_string())
+                                    .unwrap();
+                                last_synced_block_height = Some(block_height);
+                                // break the inner loop, the next outer iteration resumes from `last_synced_block_height + 1`.
+                                break;
                             }
                             panic!(
                                 "failed to build streamer message at height {block_height} after {MAX_BUILD_STREAMER_MESSAGE_ATTEMPTS} attempts: {err:?}"

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -33,6 +33,7 @@ const INTERVAL: Duration = Duration::milliseconds(250);
 /// `StreamWhileSyncing` mode the node is ~always syncing, so every failure is
 /// counted - otherwise the budget would never be enforced.
 const MAX_BUILD_STREAMER_MESSAGE_ATTEMPTS: u32 = 10;
+const LAST_SYNCED_BLOCK_HEIGHT_KEY: &[u8] = b"last_synced_block_height";
 
 /// This function supposed to return the entire `StreamerMessage`.
 /// It fetches the block and all related parts (chunks, outcomes, state changes etc.)
@@ -367,9 +368,11 @@ pub async fn start(
                                 build_streamer_message_attempts = 0;
                                 tracing::error!(target: INDEXER, ?block_height, ?err, "skip height - failed to build streamer message");
                                 // Record the skipped height as synced so the next outer iteration resumes right after it
-                                db.put(b"last_synced_block_height", &block_height.to_string())
-                                    .unwrap();
-                                last_synced_block_height = Some(block_height);
+                                record_synced_block_height(
+                                    &db,
+                                    &mut last_synced_block_height,
+                                    block_height,
+                                );
                                 // break the inner loop, the next outer iteration resumes from `last_synced_block_height + 1`.
                                 break;
                             }
@@ -399,10 +402,19 @@ pub async fn start(
             };
 
             metrics::NUM_STREAMER_MESSAGES_SENT.inc();
-            db.put(b"last_synced_block_height", &block_height.to_string()).unwrap();
-            last_synced_block_height = Some(block_height);
+            record_synced_block_height(&db, &mut last_synced_block_height, block_height);
         }
     }
+}
+
+/// Persists the synced block height to the indexer db and updates the in-memory copy.
+fn record_synced_block_height(
+    db: &rocksdb::DB,
+    last_synced_block_height: &mut Option<BlockHeight>,
+    block_height: BlockHeight,
+) {
+    db.put(LAST_SYNCED_BLOCK_HEIGHT_KEY, &block_height.to_string()).unwrap();
+    *last_synced_block_height = Some(block_height);
 }
 
 fn get_start_syncing_block_height(
@@ -419,7 +431,7 @@ fn get_start_syncing_block_height(
     // Otherwise determine the start height based on the sync mode
     match indexer_config.sync_mode {
         crate::SyncModeEnum::FromInterruption => {
-            match db.get(b"last_synced_block_height").unwrap() {
+            match db.get(LAST_SYNCED_BLOCK_HEIGHT_KEY).unwrap() {
                 Some(value) => String::from_utf8(value).unwrap().parse::<u64>().unwrap(),
                 None => latest_block_height,
             }

--- a/test-loop-tests/src/tests/indexer.rs
+++ b/test-loop-tests/src/tests/indexer.rs
@@ -24,6 +24,7 @@ use near_primitives::views::{
     AccountContractView, ActionView, ExecutionStatusView, ReceiptEnumView, ReceiptView,
 };
 use near_store::{DBCol, StoreConfig};
+use std::collections::HashSet;
 use std::iter::repeat_with;
 use tokio::sync::mpsc;
 
@@ -461,6 +462,31 @@ fn test_indexer_skip_broken_block() {
     assert_eq!(msg.block.header.height, broken_height + 1);
 }
 
+/// Two consecutive broken blocks are correctly skipped when `skip_broken_blocks` is enabled.
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_indexer_skip_adjacent_broken_blocks() {
+    init_test_logger();
+
+    let mut env = setup();
+    let broken_heights = drop_receipts_of_consecutive_delayed_local_txs(&mut env);
+    let first_broken = *broken_heights.iter().min().unwrap();
+    let last_broken = *broken_heights.iter().max().unwrap();
+    assert_eq!(first_broken + 1, last_broken);
+
+    let mut indexer_receiver =
+        start_indexer_skipping_broken_blocks(&env, SyncModeEnum::BlockHeight(first_broken - 1));
+    // The height before the broken ones still streams normally.
+    let msg = receive_indexer_message(&mut env, &mut indexer_receiver);
+    assert_eq!(msg.block.header.height, first_broken - 1);
+
+    // Streaming must get past every broken height instead of looping on them.
+    let height = receive_indexer_message(&mut env, &mut indexer_receiver).block.header.height;
+    assert!(!broken_heights.contains(&height), "height {height} should have been skipped");
+    assert_eq!(height, first_broken + 2);
+}
+
 /// The very same block must instead terminate a regular indexer: silently
 /// dropping it would leave an unnoticed gap in the stream.
 #[test]
@@ -508,6 +534,63 @@ fn drop_receipt_of_local_tx(env: &mut TestLoopEnv) -> BlockHeight {
     );
 
     broken_height
+}
+
+/// Runs local transactions whose receipts spill over into consecutive blocks and
+/// drops all of those receipts from the store, leaving a run of adjacent heights
+/// that can no longer be built. Returns those heights.
+fn drop_receipts_of_consecutive_delayed_local_txs(env: &mut TestLoopEnv) -> HashSet<BlockHeight> {
+    deploy_test_contract(env);
+    // Each local receipt burns more than half the chunk gas limit, so only two of
+    // them fit in a chunk and the third one is delayed into the next block.
+    let gas_to_burn = GAS_LIMIT.checked_div(2).unwrap().checked_add(Gas::from_gas(1)).unwrap();
+    let txs = repeat_with(|| create_burn_gas_tx(env, gas_to_burn)).take(3).collect_vec();
+    for tx in &txs {
+        env.validator().submit_tx(tx.clone());
+    }
+
+    let receipt_ids = txs
+        .iter()
+        .map(|tx| {
+            let tx_outcome = env
+                .validator_runner()
+                .run_until_outcome_available(tx.get_hash(), Duration::seconds(5));
+            let ExecutionStatus::SuccessReceiptId(receipt_id) =
+                tx_outcome.outcome_with_id.outcome.status
+            else {
+                panic!("failed to convert transaction to receipt");
+            };
+            receipt_id
+        })
+        .collect_vec();
+    let broken_heights = receipt_ids
+        .iter()
+        .map(|receipt_id| {
+            let outcome = env
+                .validator_runner()
+                .run_until_outcome_available(*receipt_id, Duration::seconds(5));
+            env.validator().block(outcome.block_hash).header().height()
+        })
+        .collect::<HashSet<_>>();
+
+    // Get the broken heights off the chain head, so that the streamer has a later
+    // height to resume at once it gives up on them.
+    env.validator_runner().run_for_number_of_blocks(3);
+
+    let store = env.validator().store();
+    let mut store_update = store.store_update();
+    for receipt_id in &receipt_ids {
+        store_update.decrement_refcount(DBCol::Receipts, receipt_id.as_ref());
+    }
+    store_update.commit();
+    for receipt_id in &receipt_ids {
+        assert!(
+            !store.exists(DBCol::Receipts, receipt_id.as_ref()),
+            "receipt should be gone from the store"
+        );
+    }
+
+    broken_heights
 }
 
 fn user_account() -> AccountId {


### PR DESCRIPTION
There is a bug in the indexer - when `skip_broken_blocks`  is set to true and two consecutive blocks are broken, the indexer gets stuck.

This PR fixes the bug


The code correctly detected when streamer failed to build a message for a block, but it used `continue` to skip to the next block height.  If building the next block failed, it called `break` and went back to syncing from `last_synced_height`, which was the previous height that was supposed to be skipped. The indexer was stuck processing the same two heights forever.

The mechanism for retrying the same height is a bit convoluted - on failure the code calls `break` which comes out of the inner loop and restarts syncing from the first unsynced height. To properly move to the next height we have to update `last_synced_height` and then reuse the retry mechanism to start retrying from the next height onwards.