### PR TITLE
feat(spice): certify scheduled chunks only by the all-stake fallback

### DIFF
--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -10,21 +10,55 @@ use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId, ShardIndex,
     SpiceUncertifiedChunkInfo,
 };
+use std::collections::HashSet;
 
 /// Blocks a chunk must stay certifiable-but-uncertified before the all-stake fallback opens for it.
 /// Well below epoch length (to rescue liveness before the one-epoch lag guard stalls consensus).
 pub const SPICE_FALLBACK_CERTIFICATION_DELAY: BlockHeight = 20;
 
-/// Whether the chunk may certify via the all-stake fallback in a block at `carrying_height`: true
-/// once its designated validators have had `SPICE_FALLBACK_CERTIFICATION_DELAY` blocks to act.
+/// Whether the chunk may certify via the all-stake fallback in a block at `carrying_height`. A
+/// fallback-only chunk is eligible from the start: waiting until it is certifiable would open the
+/// rule a block after its endorsements land, and no block can justify a result with no endorsement.
 pub fn fallback_eligible(
     carrying_height: BlockHeight,
     chunk_info: &SpiceUncertifiedChunkInfo,
 ) -> bool {
+    if chunk_info.is_fallback_only {
+        return true;
+    }
     let Some(certifiable_since) = chunk_info.certifiable_since_height else {
         return false;
     };
     carrying_height.saturating_sub(certifiable_since) >= SPICE_FALLBACK_CERTIFICATION_DELAY
+}
+
+/// Whether `endorsers`, all attesting one execution result, certify the chunk in a block at
+/// `carrying_height`.
+///
+/// The producer and block validation both decide inclusion with this, so a producer never builds a
+/// certification its own validation rejects.
+pub fn endorsers_certify_chunk(
+    epoch_manager: &dyn EpochManagerAdapter,
+    chunk_block_header: &BlockHeader,
+    chunk_info: &SpiceUncertifiedChunkInfo,
+    carrying_height: BlockHeight,
+    endorsers: &HashSet<AccountId>,
+) -> Result<bool, Error> {
+    let epoch_id = chunk_block_header.epoch_id();
+    if !chunk_info.is_fallback_only {
+        let designated = epoch_manager.get_chunk_validator_assignments(
+            epoch_id,
+            chunk_info.chunk_id.shard_id,
+            chunk_block_header.height(),
+        )?;
+        if designated.is_endorsed(endorsers) {
+            return Ok(true);
+        }
+    }
+    if !fallback_eligible(carrying_height, chunk_info) {
+        return Ok(false);
+    }
+    Ok(all_stake_fallback_assignment(epoch_manager, epoch_id)?.is_endorsed(endorsers))
 }
 
 /// The epoch's full validator set as a shard-independent assignment weighted by real stake. The

--- a/chain/chain/src/spice/ancestry_endorsements.rs
+++ b/chain/chain/src/spice/ancestry_endorsements.rs
@@ -68,9 +68,9 @@ impl<'a> AncestryEndorsements<'a> {
         self.on_chain.get(chunk_id).is_some_and(|endorsers| endorsers.contains_key(account_id))
     }
 
-    /// Chunks awaiting a designated endorsement on chain (with repeats per missing validator).
-    pub(crate) fn pending_designated_chunks(&self) -> impl Iterator<Item = &'a SpiceChunkId> + '_ {
-        self.pending_designated.iter().map(|(chunk_id, _)| *chunk_id)
+    /// Every chunk still uncertified in the ancestry.
+    pub(crate) fn uncertified_chunk_ids(&self) -> impl Iterator<Item = &'a SpiceChunkId> + '_ {
+        self.uncertified_chunks.keys().copied()
     }
 
     /// Endorsements (designated and non-designated) already on chain for `chunk_id`.

--- a/chain/chain/src/spice/ancestry_endorsements.rs
+++ b/chain/chain/src/spice/ancestry_endorsements.rs
@@ -55,6 +55,14 @@ impl<'a> AncestryEndorsements<'a> {
             .is_some_and(|info| fallback_eligible(carrying_height, info))
     }
 
+    /// `chunk_id`'s record, absent once the chunk is certified in the ancestry.
+    pub(crate) fn uncertified_chunk_info(
+        &self,
+        chunk_id: &SpiceChunkId,
+    ) -> Option<&'a SpiceUncertifiedChunkInfo> {
+        self.uncertified_chunks.get(chunk_id).copied()
+    }
+
     /// Whether `(chunk_id, account_id)`'s endorsement is already on chain in the ancestry.
     pub(crate) fn is_on_chain(&self, chunk_id: &SpiceChunkId, account_id: &AccountId) -> bool {
         self.on_chain.get(chunk_id).is_some_and(|endorsers| endorsers.contains_key(account_id))

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,6 +1,6 @@
 use crate::metrics;
 use crate::spice::all_stake_fallback::{
-    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
+    endorsers_certify_chunk, fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
 };
 use crate::spice::ancestry_endorsements::AncestryEndorsements;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
@@ -156,6 +156,18 @@ impl SpiceCoreReader {
         get_uncertified_chunks(&self.chain_store, block_hash)
     }
 
+    /// `chunk_id`'s record as of `carrying_prev_hash`, absent once the chunk is certified there.
+    pub fn uncertified_chunk_info(
+        &self,
+        carrying_prev_hash: &CryptoHash,
+        chunk_id: &SpiceChunkId,
+    ) -> Result<Option<SpiceUncertifiedChunkInfo>, Error> {
+        Ok(self
+            .get_uncertified_chunks(carrying_prev_hash)?
+            .into_iter()
+            .find(|chunk_info| &chunk_info.chunk_id == chunk_id))
+    }
+
     /// Whether `chunk_id` may certify via the all-stake fallback in a block at `carrying_height`
     /// built on `carrying_prev_hash`. False once the chunk is certified there.
     pub fn fallback_eligible_in_carrying_block(
@@ -164,11 +176,9 @@ impl SpiceCoreReader {
         carrying_prev_hash: &CryptoHash,
         chunk_id: &SpiceChunkId,
     ) -> Result<bool, Error> {
-        let uncertified_chunks = self.get_uncertified_chunks(carrying_prev_hash)?;
-        Ok(uncertified_chunks
-            .iter()
-            .find(|chunk_info| &chunk_info.chunk_id == chunk_id)
-            .is_some_and(|chunk_info| fallback_eligible(carrying_height, chunk_info)))
+        Ok(self
+            .uncertified_chunk_info(carrying_prev_hash, chunk_id)?
+            .is_some_and(|chunk_info| fallback_eligible(carrying_height, &chunk_info)))
     }
 
     /// Returns ChunkExtra for a given chunk, trying the ChunkExtra column first
@@ -746,42 +756,29 @@ impl SpiceCoreReader {
 
         for (chunk_id, mut on_chain_endorsements) in in_block_endorsements {
             let chunk_block = get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
-            let chunk_validator_assignments = self
-                .epoch_manager
-                .get_chunk_validator_assignments(
-                    &chunk_block.header().epoch_id(),
-                    chunk_id.shard_id,
-                    chunk_block.header().height(),
-                )
-                .expect(
-                    "since we are waiting for endorsement we should know it's validator assignments",
-                );
             // Add the on-chain ancestry endorsements (designated and non-designated) to the in-block
-            // ones, grouped by attested result; the designated tally ignores non-designated accounts.
+            // ones, grouped by attested result.
             for (account_id, endorsement) in ancestry_endorsements.on_chain_for(chunk_id) {
                 on_chain_endorsements
                     .entry(endorsement.execution_result_hash.clone())
                     .or_default()
                     .insert(account_id, endorsement.signature.clone());
             }
-            // Once fallback-eligible, the chunk may also certify via 2/3 of total epoch stake.
-            let fallback_assignment = ancestry_endorsements
-                .is_fallback_eligible(chunk_id, block.header().height())
-                .then(|| {
-                    all_stake_fallback_assignment(
-                        self.epoch_manager.as_ref(),
-                        chunk_block.header().epoch_id(),
-                    )
-                    .expect("epoch of an uncertified chunk's block is known")
-                });
+            let Some(chunk_info) = ancestry_endorsements.uncertified_chunk_info(chunk_id) else {
+                continue;
+            };
             for (execution_result_hash, validator_signatures) in on_chain_endorsements {
-                let endorsed = chunk_validator_assignments
-                    .compute_endorsement_state(validator_signatures.clone())
-                    .is_endorsed
-                    || fallback_assignment.as_ref().is_some_and(|all| {
-                        all.compute_endorsement_state(validator_signatures).is_endorsed
-                    });
-                if !endorsed {
+                let endorsers =
+                    validator_signatures.keys().map(|account_id| (*account_id).clone()).collect();
+                if !endorsers_certify_chunk(
+                    self.epoch_manager.as_ref(),
+                    chunk_block.header(),
+                    chunk_info,
+                    block.header().height(),
+                    &endorsers,
+                )
+                .expect("epoch of an uncertified chunk's block is known")
+                {
                     continue;
                 }
 
@@ -985,9 +982,11 @@ pub fn record_uncertified_chunks_for_block(
         chunk_info
             .missing_endorsements
             .retain(|account_id| !chunk_endorsements.is_some_and(|e| e.contains_key(account_id)));
+        // A fallback-only chunk never certifies by its designated assignment, so it may hold every
+        // designated endorsement and stay uncertified.
         assert!(
-            !chunk_info.missing_endorsements.is_empty(),
-            "when there are no missing endorsements execution result should be present"
+            !chunk_info.missing_endorsements.is_empty() || chunk_info.is_fallback_only,
+            "chunk holding every designated endorsement should have been certified"
         );
 
         // Record non-designated endorsements (not in the designated assignment, so not tracked

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -735,7 +735,7 @@ impl SpiceCoreReader {
 
         // TODO(spice): Add validation that endorsements for blocks are included only when previous
         // block is fully endorsed (as part of block we are validating or it's ancestry).
-        for chunk_id in ancestry_endorsements.pending_designated_chunks() {
+        for chunk_id in ancestry_endorsements.uncertified_chunk_ids() {
             if block_execution_results.contains_key(chunk_id) {
                 continue;
             }
@@ -747,9 +747,10 @@ impl SpiceCoreReader {
             let block = get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
             let height = block.header().height();
             if height < *max_endorsed_height_created {
-                // We cannot be waiting on an endorsement for chunk created at height that is less
-                // than maximum endorsed height for the chunk as that would mean that child is
-                // endorsed before parent.
+                // A chunk below the maximum endorsed height for its shard cannot still be
+                // uncertified, or a child would be endorsed before its parent. Keyed off
+                // uncertified, not off a missing designated endorsement: a fallback-only chunk
+                // can hold every designated one and stay uncertified.
                 return Err(SkippedExecutionResult { chunk_id: chunk_id.clone() });
             }
         }

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -1,5 +1,5 @@
 use crate::spice::activation::{SpiceMessageGate, SpiceMessageKind, spice_enabled_for_block};
-use crate::spice::all_stake_fallback::all_stake_fallback_assignment;
+use crate::spice::all_stake_fallback::{all_stake_fallback_assignment, fallback_eligible};
 use crate::spice::core::SpiceCoreReader;
 use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
@@ -162,7 +162,8 @@ impl SpiceCoreWriterActor {
     }
 
     /// Whether `chunk_id`'s stored endorsements certify `result_hash`: by 2/3 of its designated
-    /// assignment, or, once fallback-eligible, by 2/3 of total epoch stake. `endorsers` seeds it.
+    /// assignment, or, once fallback-eligible, by 2/3 of total epoch stake. A fallback-only chunk
+    /// skips the designated rule. `endorsers` seeds it.
     fn endorsed_by_designated_or_fallback(
         &self,
         chunk_id: &SpiceChunkId,
@@ -173,24 +174,24 @@ impl SpiceCoreWriterActor {
     ) -> Result<bool, Error> {
         let chunk_block = self.chain_store.get_block_header(&chunk_id.block_hash)?;
         let epoch_id = chunk_block.epoch_id();
-        let designated = self.epoch_manager.get_chunk_validator_assignments(
-            epoch_id,
-            chunk_id.shard_id,
-            chunk_block.height(),
-        )?;
-        if self.core_reader.reaches_endorsement_threshold(
-            chunk_id,
-            result_hash,
-            &designated,
-            endorsers.clone(),
-        ) {
-            return Ok(true);
+        let chunk_info = self.core_reader.uncertified_chunk_info(carrying_prev_hash, chunk_id)?;
+        let is_fallback_only = chunk_info.as_ref().is_some_and(|info| info.is_fallback_only);
+        if !is_fallback_only {
+            let designated = self.epoch_manager.get_chunk_validator_assignments(
+                epoch_id,
+                chunk_id.shard_id,
+                chunk_block.height(),
+            )?;
+            if self.core_reader.reaches_endorsement_threshold(
+                chunk_id,
+                result_hash,
+                &designated,
+                endorsers.clone(),
+            ) {
+                return Ok(true);
+            }
         }
-        if !self.core_reader.fallback_eligible_in_carrying_block(
-            carrying_height,
-            carrying_prev_hash,
-            chunk_id,
-        )? {
+        if !chunk_info.is_some_and(|info| fallback_eligible(carrying_height, &info)) {
             return Ok(false);
         }
         let all_validators = all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?;

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -1,5 +1,5 @@
 use crate::spice::activation::{SpiceMessageGate, SpiceMessageKind, spice_enabled_for_block};
-use crate::spice::all_stake_fallback::{all_stake_fallback_assignment, fallback_eligible};
+use crate::spice::all_stake_fallback::{all_stake_fallback_assignment, is_fallback_only_chunk};
 use crate::spice::core::SpiceCoreReader;
 use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
@@ -174,8 +174,9 @@ impl SpiceCoreWriterActor {
     ) -> Result<bool, Error> {
         let chunk_block = self.chain_store.get_block_header(&chunk_id.block_hash)?;
         let epoch_id = chunk_block.epoch_id();
-        let chunk_info = self.core_reader.uncertified_chunk_info(carrying_prev_hash, chunk_id)?;
-        let is_fallback_only = chunk_info.as_ref().is_some_and(|info| info.is_fallback_only);
+        // A property of the chunk's own block, not of the chain the carrying block sits on.
+        let is_fallback_only =
+            is_fallback_only_chunk(self.epoch_manager.as_ref(), &chunk_block, chunk_id.shard_id)?;
         if !is_fallback_only {
             let designated = self.epoch_manager.get_chunk_validator_assignments(
                 epoch_id,
@@ -190,9 +191,13 @@ impl SpiceCoreWriterActor {
             ) {
                 return Ok(true);
             }
-        }
-        if !chunk_info.is_some_and(|info| fallback_eligible(carrying_height, &info)) {
-            return Ok(false);
+            if !self.core_reader.fallback_eligible_in_carrying_block(
+                carrying_height,
+                carrying_prev_hash,
+                chunk_id,
+            )? {
+                return Ok(false);
+            }
         }
         let all_validators = all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?;
         Ok(self.core_reader.reaches_endorsement_threshold(

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -237,7 +237,7 @@ fn test_validate_admits_non_designated_endorsement_only_when_eligible() {
 }
 
 // Splits `validators` into (designated, non_designated) for `chunk` as of `block`.
-fn split_designated(
+pub(super) fn split_designated(
     chain: &Chain,
     block: &Block,
     chunk: &ShardChunkHeader,
@@ -495,7 +495,10 @@ fn test_no_fallback_only_chunk_when_epoch_shorter_than_shard_count() {
 
 // Walks the chain until a block carries a fallback-only chunk. Each step certifies the block two
 // heights back, since a block may not skip an earlier chunk's execution result.
-fn grow_chain_to_fallback_only_block(chain: &mut Chain, bound: usize) -> (Arc<Block>, ShardId) {
+pub(super) fn grow_chain_to_fallback_only_block(
+    chain: &mut Chain,
+    bound: usize,
+) -> (Arc<Block>, ShardId) {
     let mut blocks = vec![chain.genesis_block()];
     for _ in 0..bound {
         let parent = blocks.last().unwrap().clone();
@@ -565,7 +568,7 @@ fn test_fallback_only_mark_survives_in_later_blocks() {
 
 // Enough validators that a chunk's designated assignment stays under 2/3 of total stake, asserted
 // below.
-fn validators_with_minority_designated_stake() -> Vec<String> {
+pub(super) fn validators_with_minority_designated_stake() -> Vec<String> {
     (0..150).map(|i| format!("test{i}")).collect()
 }
 
@@ -680,4 +683,50 @@ fn test_ordinary_chunk_waits_the_full_delay_after_becoming_certifiable() {
     let info = ordinary_chunk_info(Some(certifiable_since));
     assert!(!fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY - 1, &info));
     assert!(fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY, &info));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_rejects_skipping_an_uncertified_fallback_only_chunk() {
+    let validators = validators_with_minority_designated_stake();
+    let (mut chain, core_reader) = setup_with_validators(&validators);
+    let (fallback_only_block, shard_id) = grow_chain_to_fallback_only_block(&mut chain, 40);
+    let chunk_of = |block: &Block| {
+        block.chunks().iter_raw().find(|chunk| chunk.shard_id() == shard_id).unwrap().clone()
+    };
+    let chunk_header = chunk_of(&fallback_only_block);
+    let parent = chain.chain_store().get_block(fallback_only_block.header().prev_hash()).unwrap();
+    let parent_certification = certify_block_designated(&chain, &parent);
+    let next_block = append_block(&mut chain, &fallback_only_block, parent_certification);
+
+    // Every designated endorsement lands, which empties missing_endorsements without certifying
+    // the chunk: only 2/3 of total stake can do that.
+    let (designated, _) =
+        split_designated(&chain, &fallback_only_block, &chunk_header, &validators);
+    let tip = append_block(
+        &mut chain,
+        &next_block,
+        endorsement_statements(&designated, &fallback_only_block, &chunk_header),
+    );
+    let chunk_id = SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id };
+    let chunk_info = core_reader
+        .get_uncertified_chunks(tip.hash())
+        .unwrap()
+        .into_iter()
+        .find(|info| info.chunk_id == chunk_id)
+        .expect("the fallback-only chunk is still uncertified");
+    assert!(chunk_info.missing_endorsements.is_empty());
+
+    // Certifying the same shard one height later would endorse a child before its parent.
+    let later_chunk = chunk_of(&next_block);
+    let (later_designated, _) = split_designated(&chain, &next_block, &later_chunk, &validators);
+    let skipping_block = build_block(
+        &chain,
+        &tip,
+        endorsements_and_execution_result(&later_designated, &next_block, &later_chunk),
+    );
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&skipping_block),
+        Err(InvalidSpiceCoreStatementsError::SkippedExecutionResult { .. })
+    );
 }

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -1,5 +1,5 @@
 use crate::spice::all_stake_fallback::{
-    SPICE_FALLBACK_CERTIFICATION_DELAY, is_fallback_only_chunk,
+    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, is_fallback_only_chunk,
     is_fallback_only_height_for_shard_index,
 };
 use crate::spice::tests::core::{
@@ -15,6 +15,7 @@ use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, EpochHeight, ShardId, SpiceChunkId,
 };
+use std::collections::HashSet;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -558,4 +559,81 @@ fn test_fallback_only_mark_survives_in_later_blocks() {
         .into_iter()
         .any(|chunk_info| chunk_info.chunk_id == scheduled && chunk_info.is_fallback_only);
     assert!(still_marked, "the mark was lost when the chunk was carried forward");
+}
+
+// Enough validators that a chunk's designated assignment stays under 2/3 of total stake, asserted
+// below.
+fn validators_with_minority_designated_stake() -> Vec<String> {
+    (0..150).map(|i| format!("test{i}")).collect()
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_rejects_designated_only_certification_of_fallback_only_chunk() {
+    let validators = validators_with_minority_designated_stake();
+    let (mut chain, core_reader) = setup_with_validators(&validators);
+    let (fallback_only_block, shard_id) = grow_chain_to_fallback_only_block(&mut chain, 40);
+    let chunk_header = fallback_only_block
+        .chunks()
+        .iter_raw()
+        .find(|chunk| chunk.shard_id() == shard_id)
+        .unwrap()
+        .clone();
+    // Certifying the parent leaves the fallback-only chunk as the oldest uncertified one.
+    let parent = chain.chain_store().get_block(fallback_only_block.header().prev_hash()).unwrap();
+    let parent_certification = certify_block_designated(&chain, &parent);
+    let tip = append_block(&mut chain, &fallback_only_block, parent_certification);
+    let uncertified = core_reader.get_uncertified_chunks(tip.hash()).unwrap();
+    let chunk_id = SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id };
+    assert!(uncertified.iter().all(|info| info.chunk_id.block_hash != *parent.hash()));
+    assert!(uncertified.iter().any(|info| info.chunk_id == chunk_id && info.is_fallback_only));
+
+    let (designated, non_designated) =
+        split_designated(&chain, &fallback_only_block, &chunk_header, &validators);
+    let all_stake = all_stake_fallback_assignment(
+        chain.epoch_manager.as_ref(),
+        fallback_only_block.header().epoch_id(),
+    )
+    .unwrap();
+    // The whole designated set must fall short of 2/3 of total stake, or a designated-only block
+    // would certify on the all-stake path and prove nothing about the designated rule.
+    let mut endorsers: HashSet<AccountId> = designated.iter().cloned().collect();
+    assert!(!all_stake.is_endorsed(&endorsers));
+
+    let designated_only = build_block(
+        &chain,
+        &tip,
+        endorsements_and_execution_result(&designated, &fallback_only_block, &chunk_header),
+    );
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&designated_only),
+        Err(InvalidSpiceCoreStatementsError::InvalidCoreStatement {
+            reason: "execution results included without enough corresponding endorsement",
+            ..
+        })
+    );
+
+    // Topping the designated set up to 2/3 of total stake certifies, so the rejection above is the
+    // designated rule being skipped, not an unreachable threshold. Stakes are not uniform, so the
+    // set is grown against the assignment rather than by a count.
+    for account in non_designated {
+        if all_stake.is_endorsed(&endorsers) {
+            break;
+        }
+        endorsers.insert(account);
+    }
+    assert!(all_stake.is_endorsed(&endorsers), "fallback set must be able to certify");
+    let mut all_stake_endorsers: Vec<AccountId> = endorsers.into_iter().collect();
+    all_stake_endorsers.sort();
+
+    let all_stake_block = build_block(
+        &chain,
+        &tip,
+        endorsements_and_execution_result(
+            &all_stake_endorsers,
+            &fallback_only_block,
+            &chunk_header,
+        ),
+    );
+    core_reader.validate_core_statements_in_block(&all_stake_block).unwrap();
 }

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -1,6 +1,6 @@
 use crate::spice::all_stake_fallback::{
-    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, is_fallback_only_chunk,
-    is_fallback_only_height_for_shard_index,
+    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, fallback_eligible,
+    is_fallback_only_chunk, is_fallback_only_height_for_shard_index,
 };
 use crate::spice::tests::core::{
     block_certification_core_statements, build_block, endorsement_into_core_statement,
@@ -11,9 +11,11 @@ use crate::{Block, Chain};
 use assert_matches::assert_matches;
 use near_primitives::block_body::SpiceCoreStatement;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
+use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, EpochHeight, ShardId, SpiceChunkId,
+    SpiceUncertifiedChunkInfo,
 };
 use std::collections::HashSet;
 use std::ops::Range;
@@ -636,4 +638,46 @@ fn test_validate_rejects_designated_only_certification_of_fallback_only_chunk() 
         ),
     );
     core_reader.validate_core_statements_in_block(&all_stake_block).unwrap();
+}
+
+fn chunk_info(
+    certifiable_since_height: Option<BlockHeight>,
+    is_fallback_only: bool,
+) -> SpiceUncertifiedChunkInfo {
+    SpiceUncertifiedChunkInfo {
+        chunk_id: SpiceChunkId { block_hash: CryptoHash::default(), shard_id: ShardId::new(0) },
+        missing_endorsements: vec![],
+        present_endorsements: vec![],
+        present_fallback_endorsements: vec![],
+        certifiable_since_height,
+        is_fallback_only,
+    }
+}
+
+fn fallback_only_chunk_info(
+    certifiable_since_height: Option<BlockHeight>,
+) -> SpiceUncertifiedChunkInfo {
+    chunk_info(certifiable_since_height, true)
+}
+
+fn ordinary_chunk_info(certifiable_since_height: Option<BlockHeight>) -> SpiceUncertifiedChunkInfo {
+    chunk_info(certifiable_since_height, false)
+}
+
+#[test]
+fn test_fallback_only_chunk_is_eligible_before_it_is_certifiable() {
+    // A scheduled chunk has no delay to wait out, so it certifies as soon as its endorsements
+    // arrive. certifiable_since_height is only set in a later block than the chunk's own, so
+    // gating on it would add a wait this chunk is meant not to have.
+    assert!(fallback_eligible(1, &fallback_only_chunk_info(None)));
+    assert!(fallback_eligible(1, &fallback_only_chunk_info(Some(1))));
+}
+
+#[test]
+fn test_ordinary_chunk_waits_the_full_delay_after_becoming_certifiable() {
+    assert!(!fallback_eligible(BlockHeight::MAX, &ordinary_chunk_info(None)));
+    let certifiable_since = 100;
+    let info = ordinary_chunk_info(Some(certifiable_since));
+    assert!(!fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY - 1, &info));
+    assert!(fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY, &info));
 }

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -1885,7 +1885,7 @@ pub(super) fn process_block(chain: &mut Chain, block: Arc<Block>) {
     .unwrap();
 }
 
-fn endorse_chunk(
+pub(super) fn endorse_chunk(
     chain: &Chain,
     core_writer_actor: &mut SpiceCoreWriterActor,
     chunk_id: &SpiceChunkId,

--- a/chain/chain/src/spice/tests/core_writer_actor.rs
+++ b/chain/chain/src/spice/tests/core_writer_actor.rs
@@ -2,6 +2,10 @@ use crate::spice::core::SpiceCoreReader;
 use crate::spice::core_writer_actor::{
     ExecutionResultEndorsed, InvalidSpiceEndorsementError, ProcessChunkError, SpiceCoreWriterActor,
 };
+use crate::spice::tests::all_stake_fallback::{
+    grow_chain_to_fallback_only_block, split_designated, validators_with_minority_designated_stake,
+};
+use crate::spice::tests::core::endorse_chunk;
 use crate::test_utils::{
     get_chain_with_genesis, get_fake_next_block_chunk_headers, process_block_sync,
 };
@@ -841,4 +845,59 @@ fn find_irrelevant_validator(
         })
         .unwrap();
     irrelevant_validator.clone()
+}
+
+// Checks the writer reads the fallback-only flag from the chunk's own block instead of from the
+// head's uncertified chunks, which never list a chunk whose block is off the head's chain.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_designated_endorsements_do_not_certify_a_fallback_only_chunk_off_the_head_chain() {
+    // Enough validators that a chunk's designated assignment stays under 2/3 of total stake,
+    // asserted below.
+    let validators = validators_with_minority_designated_stake();
+    let validators_spec =
+        ValidatorsSpec::desired_roles(&validators.iter().map(|v| v.as_str()).collect_vec(), &[]);
+    let genesis = TestGenesisBuilder::new()
+        .genesis_time_from_clock(&Clock::real())
+        .shard_layout(ShardLayout::multi_shard(3, 0))
+        .validators_spec(validators_spec)
+        .build();
+    let (mut chain, mut core_writer_actor) = setup_with_genesis(genesis);
+
+    let (fallback_only_block, shard_id) = grow_chain_to_fallback_only_block(&mut chain, 40);
+    let parent = chain.chain_store().get_block(fallback_only_block.header().prev_hash()).unwrap();
+
+    // A longer branch off the same parent takes the head.
+    let fork_block = build_block(&mut chain, &parent, vec![]);
+    process_block(&mut chain, fork_block.clone());
+    let fork_tip = build_block(&mut chain, &fork_block, vec![]);
+    process_block(&mut chain, fork_tip.clone());
+    let head = chain.chain_store().head().unwrap();
+    assert_eq!(head.last_block_hash, *fork_tip.hash());
+    let chunk_id = SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id };
+    assert!(
+        core_writer_actor
+            .core_reader
+            .uncertified_chunk_info(&head.last_block_hash, &chunk_id)
+            .unwrap()
+            .is_none(),
+        "the chunk should be absent from the head's uncertified set",
+    );
+
+    // Every designated validator endorses. Only 2/3 of total stake may certify a fallback-only
+    // chunk, and the designated set alone is below that, so nothing should be stored.
+    let chunks = fallback_only_block.chunks();
+    let chunk_header =
+        chunks.iter_raw().find(|chunk| chunk.shard_id() == shard_id).unwrap().clone();
+    drop(chunks);
+    let (designated, _) =
+        split_designated(&chain, &fallback_only_block, &chunk_header, &validators);
+    let designated: Vec<String> = designated.iter().map(|account| account.to_string()).collect();
+    endorse_chunk(&chain, &mut core_writer_actor, &chunk_id, &designated);
+
+    let execution_results = core_writer_actor
+        .core_reader
+        .get_execution_results_by_shard_id(fallback_only_block.header())
+        .unwrap();
+    assert_eq!(execution_results.get(&shard_id), None);
 }

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -15,7 +15,7 @@ use near_async::time::Clock;
 use near_chain::Block;
 use near_chain::ChainStoreAccess;
 use near_chain::spice::all_stake_fallback::{
-    SPICE_FALLBACK_CERTIFICATION_DELAY, fallback_endorsers,
+    SPICE_FALLBACK_CERTIFICATION_DELAY, fallback_endorsers, is_fallback_only_chunk,
 };
 use near_chain::spice::core::SpiceCoreReader;
 use near_chain::spice::core_writer_actor::{ProcessedBlock, SpiceCoreWriterActor};
@@ -2715,6 +2715,22 @@ fn save_test_witness_for_chunk(chain: &Chain, chunk_id: &SpiceChunkId) -> SpiceC
     witness
 }
 
+/// The chain's first chunk that the schedule marks fallback-only.
+fn grow_chain_to_fallback_only_chunk(chain: &mut Chain) -> SpiceChunkId {
+    for _ in 0..100 {
+        let block = produce_block(chain, &latest_block(chain));
+        let chunks = block.chunks();
+        let scheduled = chunks.iter_raw().find(|chunk| {
+            is_fallback_only_chunk(chain.epoch_manager.as_ref(), block.header(), chunk.shard_id())
+                .unwrap()
+        });
+        if let Some(chunk) = scheduled {
+            return SpiceChunkId { block_hash: *block.hash(), shard_id: chunk.shard_id() };
+        }
+    }
+    panic!("no fallback-only chunk within 100 blocks");
+}
+
 /// What the push targets: the fallback endorsers of `chunk_id`, less its producers, who already
 /// hold the witness.
 fn fallback_witness_recipients(chain: &Chain, chunk_id: &SpiceChunkId) -> HashSet<AccountId> {
@@ -2803,6 +2819,32 @@ fn test_witness_is_pushed_only_once() {
     let next_block = produce_block(&mut chain, &head_block);
     actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
     assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_fallback_only_witness_is_pushed_without_waiting_for_the_delay() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (_genesis, mut chain) = setup(2, 100);
+    let chunk_id = grow_chain_to_fallback_only_chunk(&mut chain);
+    let witness = save_test_witness_for_chunk(&chain, &chunk_id);
+
+    let head_block = latest_block(&chain);
+    let producer = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(head_block.header().epoch_id(), chunk_id.shard_id)
+        .unwrap()
+        .swap_remove(0);
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
+    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+
+    let mut pushes = drain_outgoing_partial_data(&mut outgoing_rc);
+    assert_eq!(pushes.len(), 1, "the scheduled chunk's witness was not pushed on its own block");
+    let (partial_data, recipients) = pushes.swap_remove(0);
+    assert_eq!(partial_data.block_hash(), &witness.chunk_id().block_hash);
+    assert_eq!(recipients, fallback_witness_recipients(&chain, &chunk_id));
 }
 
 #[test]

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -4,7 +4,9 @@ use crate::utils::account::create_account_id;
 use crate::utils::node::TestLoopNode;
 use itertools::Itertools;
 use near_async::time::Duration;
-use near_chain::spice::all_stake_fallback::all_stake_fallback_assignment;
+use near_chain::spice::all_stake_fallback::{
+    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, is_fallback_only_chunk,
+};
 use near_chain_configs::Genesis;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_o11y::testonly::init_test_logger;
@@ -13,11 +15,18 @@ use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::gas::Gas;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::{AccountId, AccountInfo, Balance, BlockHeightDelta};
+use near_primitives::types::{
+    AccountId, AccountInfo, Balance, BlockHeight, BlockHeightDelta, NumShards, ShardId,
+    SpiceChunkId,
+};
 use std::collections::HashSet;
 
+/// Shards in [`FallbackSetup`].
+const NUM_SHARDS: NumShards = 6;
+
 /// Genesis, epoch config, and client accounts for the fallback tests: 14 equal-stake validators
-/// over 6 shards with 2 mandates each, keeping each chunk's designated subset under 1/3 of stake.
+/// over `NUM_SHARDS` shards with 2 mandates each, keeping each chunk's designated subset under 1/3
+/// of stake.
 #[derive(Default)]
 struct FallbackSetup {
     epoch_length: Option<BlockHeightDelta>,
@@ -56,7 +65,7 @@ impl FallbackSetup {
             ValidatorsSpec::raw(all_validators, num_producers, num_producers, num_validators);
 
         let mut genesis_builder = TestLoopBuilder::new_genesis_builder()
-            .shard_layout(ShardLayout::multi_shard(6, 0))
+            .shard_layout(ShardLayout::multi_shard(NUM_SHARDS, 0))
             .validators_spec(validators_spec);
         if let Some(epoch_length) = self.epoch_length {
             genesis_builder = genesis_builder.epoch_length(epoch_length);
@@ -304,4 +313,163 @@ fn slow_test_spice_all_stake_fallback_certifies_chunk_accessing_contract_code() 
     );
     let frontier = env.rpc_node().last_certified_block_header();
     assert_certified_via_fallback(&env.rpc_node(), frontier.as_ref());
+}
+
+fn fallback_only_certification_schedule(
+    node: &TestLoopNode,
+    from_height: BlockHeight,
+    to_height: BlockHeight,
+) -> Vec<(BlockHeight, ShardId)> {
+    let client = node.client();
+    let chain_store = client.chain.chain_store();
+    let epoch_manager = client.epoch_manager.as_ref();
+    let mut fallback_schedule = Vec::new();
+    for height in from_height..=to_height {
+        let block = node.block(chain_store.get_block_hash_by_height(height).unwrap());
+        let shard_layout = epoch_manager.get_shard_layout(block.header().epoch_id()).unwrap();
+        for shard_id in shard_layout.shard_ids() {
+            if is_fallback_only_chunk(epoch_manager, block.header(), shard_id).unwrap() {
+                fallback_schedule.push((height, shard_id));
+            }
+        }
+    }
+    fallback_schedule
+}
+
+/// The height of the block carrying `chunk_id`'s execution result, with every account that endorsed
+/// the chunk on chain up to and including it.
+fn certifying_height_and_endorsers(
+    node: &TestLoopNode,
+    chunk_id: &SpiceChunkId,
+) -> Option<(BlockHeight, HashSet<AccountId>)> {
+    let chain_store = node.client().chain.chain_store();
+    let chunk_height = chain_store.get_block_header(&chunk_id.block_hash).unwrap().height();
+    let mut endorsers = HashSet::new();
+    for height in chunk_height..=node.head().height {
+        let Ok(block_hash) = chain_store.get_block_hash_by_height(height) else {
+            continue;
+        };
+        let block = node.block(block_hash);
+        endorsers.extend(
+            block
+                .spice_core_statements()
+                .iter_endorsements()
+                .filter(|endorsement| endorsement.chunk_id() == chunk_id)
+                .map(|endorsement| endorsement.account_id().clone()),
+        );
+        if block.spice_core_statements().iter_execution_results().any(|(id, _)| id == chunk_id) {
+            return Some((height, endorsers));
+        }
+    }
+    None
+}
+
+/// Asserts the chunk certified with non-designated validators endorsing it on chain. An ordinary
+/// chunk never admits those on a healthy network: it is not fallback-eligible until it has been
+/// stuck for the full window.
+fn assert_certified_by_all_stake(
+    node: &TestLoopNode,
+    chunk_height: BlockHeight,
+    shard_id: ShardId,
+) {
+    let client = node.client();
+    let chain_store = client.chain.chain_store();
+    let epoch_manager = client.epoch_manager.as_ref();
+    let chunk_block_hash = chain_store.get_block_hash_by_height(chunk_height).unwrap();
+    let chunk_id = SpiceChunkId { block_hash: chunk_block_hash, shard_id };
+    let chunk_block = chain_store.get_block_header(&chunk_block_hash).unwrap();
+
+    // The designated set alone must fall short of 2/3 of total stake, or the chunk could certify
+    // before any non-designated endorsement lands. This is the 2/3 form, not the 1/3 form
+    // `assert_fallback_has_enough_stake` checks for the outage tests.
+    let designated = epoch_manager
+        .get_chunk_validator_assignments(chunk_block.epoch_id(), shard_id, chunk_height)
+        .unwrap();
+    let all_stake = all_stake_fallback_assignment(epoch_manager, chunk_block.epoch_id()).unwrap();
+    let designated_accounts: HashSet<AccountId> =
+        designated.assignments().iter().map(|(account_id, _)| account_id.clone()).collect();
+    assert!(!all_stake.is_endorsed(&designated_accounts));
+
+    let (certifying_height, endorsers) = certifying_height_and_endorsers(node, &chunk_id)
+        .unwrap_or_else(|| panic!("fallback-only chunk {chunk_id:?} was not certified"));
+    // Inside the ordinary fallback window, so the schedule opened the all-stake path rather than
+    // the chunk sitting stuck long enough for the normal one to open.
+    let delay = certifying_height - chunk_height;
+    assert!(
+        delay < SPICE_FALLBACK_CERTIFICATION_DELAY,
+        "fallback-only chunk {chunk_id:?} took {delay} blocks, no better than the ordinary window",
+    );
+
+    assert!(
+        endorsers.iter().any(|account_id| !designated.contains(account_id)),
+        "fallback-only chunk {chunk_id:?} has only designated endorsers on chain",
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_fallback_only_chunk_certifies_on_a_healthy_network() {
+    init_test_logger();
+
+    let epoch_length = 25;
+    let (accounts, genesis, epoch_config_store) =
+        FallbackSetup::new().epoch_length(epoch_length).build();
+    // Unlike the outage tests above, no endorsements are dropped: the all-stake path runs because
+    // the chunk is scheduled, not because the designated set went missing.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .build();
+
+    // The schedule is read off block headers, so the blocks have to exist first.
+    env.node_runner(0).run_until_head_height(epoch_length);
+    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
+    assert_eq!(
+        fallback_schedule.len() as u64,
+        NUM_SHARDS,
+        "every shard is scheduled once per epoch length"
+    );
+
+    // The schedule is ascending, so certifying the last entry means every one of them is certified.
+    let (last_height, _) = *fallback_schedule.last().unwrap();
+    env.node_runner(0).run_until_certified(last_height);
+    for &(chunk_height, shard_id) in &fallback_schedule {
+        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
+    }
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_fallback_only_chunk_certifies_when_execution_lags() {
+    init_test_logger();
+
+    let epoch_length = 25;
+    let (accounts, genesis, epoch_config_store) =
+        FallbackSetup::new().epoch_length(epoch_length).build();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .delay_warmup()
+        .build();
+    // Holding endorsements back puts certification behind consensus, so a chunk's endorsements can
+    // reach the chain in the same block that first makes the chunk certifiable.
+    let execution_delay = 4;
+    env.delay_endorsements_propagation(execution_delay);
+    let mut env = env.warmup();
+
+    env.node_runner(0).run_until_head_height(epoch_length);
+    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
+    assert_eq!(
+        fallback_schedule.len() as u64,
+        NUM_SHARDS,
+        "every shard is scheduled once per epoch length"
+    );
+
+    let (last_height, _) = *fallback_schedule.last().unwrap();
+    env.node_runner(0).run_until_certified(last_height);
+    for &(chunk_height, shard_id) in &fallback_schedule {
+        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
+    }
 }

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -473,3 +473,35 @@ fn slow_test_spice_fallback_only_chunk_certifies_when_execution_lags() {
         assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
     }
 }
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_fallback_only_chunk_certifies_when_validators_track_all_shards() {
+    init_test_logger();
+
+    let epoch_length = 25;
+    let (accounts, genesis, epoch_config_store) =
+        FallbackSetup::new().epoch_length(epoch_length).build();
+    // Every validator tracks every shard, so they apply the chunk themselves and never need the
+    // witness that gets pushed to them.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .track_all_shards()
+        .build();
+
+    env.node_runner(0).run_until_head_height(epoch_length);
+    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
+    assert_eq!(
+        fallback_schedule.len() as u64,
+        NUM_SHARDS,
+        "every shard is scheduled once per epoch length"
+    );
+
+    let (last_height, _) = *fallback_schedule.last().unwrap();
+    env.node_runner(0).run_until_certified(last_height);
+    for &(chunk_height, shard_id) in &fallback_schedule {
+        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
+    }
+}


### PR DESCRIPTION
Builds on #16240, which records which chunks the epoch schedule marks fallback-only. This one makes the rule act on it.

A scheduled chunk certifies only on 2/3 of total epoch stake. The designated rule never applies to it, and there is no time-based escape: if 2/3 of total stake does not endorse it, it does not certify. That exercises the all-stake fallback once per shard per epoch length on a healthy network, instead of leaving it untested until an outage.

**Certification rule.** Three places skip the designated threshold for a scheduled chunk: block validation, the core writer, and `fallback_eligible`, which returns true before the `certifiable_since` gate. The `missing_endorsements` assert gains a carve-out, since such a chunk may hold every designated endorsement and stay uncertified. The producer is untouched.

**Distribution.** No change, and that is the point. A scheduled chunk is fallback-eligible from its own block, so the witness push added in #16212 fires for it immediately. Its designated validators already hold the witness from the initial distribution, and `fallback_endorsers` covers every remaining epoch validator. The two sets together are the whole validator set, with the same messages and the same recipients a real rescue produces. Nothing pulls unless a push fails to arrive within `FALLBACK_WITNESS_PULL_GRACE`, which is also what a rescue does.

**Measured.** A healthy 14-validator, 6-shard test loop certifies every scheduled chunk in the epoch, and `assert_certified_by_all_stake` checks each one cleared 2/3 of total stake rather than the designated threshold. No existing SPICE test needed changing.

**Known gap, not addressed here.** There is no config flag or kill switch to disable the schedule without a release.