### PR TITLE
feat(spice): certify scheduled chunks only by the all-stake fallback

### DIFF
--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -21,16 +21,18 @@ pub const SPICE_FALLBACK_CERTIFICATION_DELAY: BlockHeight = 20;
 /// fallback-only chunk is eligible from the start: it has no delay to wait out, and
 /// `certifiable_since_height` is only set in a later block than the chunk's own.
 pub fn fallback_eligible(
-    carrying_height: BlockHeight,
+    epoch_manager: &dyn EpochManagerAdapter,
+    chunk_block_header: &BlockHeader,
     chunk_info: &SpiceUncertifiedChunkInfo,
-) -> bool {
-    if chunk_info.is_fallback_only {
-        return true;
+    carrying_height: BlockHeight,
+) -> Result<bool, Error> {
+    if is_fallback_only_chunk(epoch_manager, chunk_block_header, chunk_info.chunk_id.shard_id)? {
+        return Ok(true);
     }
     let Some(certifiable_since) = chunk_info.certifiable_since_height else {
-        return false;
+        return Ok(false);
     };
-    carrying_height.saturating_sub(certifiable_since) >= SPICE_FALLBACK_CERTIFICATION_DELAY
+    Ok(carrying_height.saturating_sub(certifiable_since) >= SPICE_FALLBACK_CERTIFICATION_DELAY)
 }
 
 /// Whether `endorsers`, all attesting one execution result, certify the chunk in a block at
@@ -46,17 +48,19 @@ pub fn endorsers_certify_chunk(
     endorsers: &HashSet<AccountId>,
 ) -> Result<bool, Error> {
     let epoch_id = chunk_block_header.epoch_id();
-    if !chunk_info.is_fallback_only {
-        let designated = epoch_manager.get_chunk_validator_assignments(
-            epoch_id,
-            chunk_info.chunk_id.shard_id,
-            chunk_block_header.height(),
-        )?;
-        if designated.is_endorsed(endorsers) {
-            return Ok(true);
-        }
+    let shard_id = chunk_info.chunk_id.shard_id;
+    if is_fallback_only_chunk(epoch_manager, chunk_block_header, shard_id)? {
+        return Ok(all_stake_fallback_assignment(epoch_manager, epoch_id)?.is_endorsed(endorsers));
     }
-    if !fallback_eligible(carrying_height, chunk_info) {
+    let designated = epoch_manager.get_chunk_validator_assignments(
+        epoch_id,
+        shard_id,
+        chunk_block_header.height(),
+    )?;
+    if designated.is_endorsed(endorsers) {
+        return Ok(true);
+    }
+    if !fallback_eligible(epoch_manager, chunk_block_header, chunk_info, carrying_height)? {
         return Ok(false);
     }
     Ok(all_stake_fallback_assignment(epoch_manager, epoch_id)?.is_endorsed(endorsers))

--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -17,11 +17,16 @@ use std::collections::HashSet;
 pub const SPICE_FALLBACK_CERTIFICATION_DELAY: BlockHeight = 20;
 
 /// Whether the chunk may certify via the all-stake fallback in a block at `carrying_height`: true
-/// once its designated validators have had `SPICE_FALLBACK_CERTIFICATION_DELAY` blocks to act.
+/// once its designated validators have had `SPICE_FALLBACK_CERTIFICATION_DELAY` blocks to act. A
+/// fallback-only chunk is eligible from the start: it has no delay to wait out, and
+/// `certifiable_since_height` is only set in a later block than the chunk's own.
 pub fn fallback_eligible(
     carrying_height: BlockHeight,
     chunk_info: &SpiceUncertifiedChunkInfo,
 ) -> bool {
+    if chunk_info.is_fallback_only {
+        return true;
+    }
     let Some(certifiable_since) = chunk_info.certifiable_since_height else {
         return false;
     };
@@ -41,13 +46,15 @@ pub fn endorsers_certify_chunk(
     endorsers: &HashSet<AccountId>,
 ) -> Result<bool, Error> {
     let epoch_id = chunk_block_header.epoch_id();
-    let designated = epoch_manager.get_chunk_validator_assignments(
-        epoch_id,
-        chunk_info.chunk_id.shard_id,
-        chunk_block_header.height(),
-    )?;
-    if designated.is_endorsed(endorsers) {
-        return Ok(true);
+    if !chunk_info.is_fallback_only {
+        let designated = epoch_manager.get_chunk_validator_assignments(
+            epoch_id,
+            chunk_info.chunk_id.shard_id,
+            chunk_block_header.height(),
+        )?;
+        if designated.is_endorsed(endorsers) {
+            return Ok(true);
+        }
     }
     if !fallback_eligible(carrying_height, chunk_info) {
         return Ok(false);

--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -1,10 +1,15 @@
 //! The all-stake fallback: if a chunk's designated validators do not certify it in time, it may instead
 //! be certified by 2/3 of total epoch stake.
 
+use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::block::BlockHeader;
 use near_primitives::errors::EpochError;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
-use near_primitives::types::{AccountId, BlockHeight, EpochId, ShardId, SpiceUncertifiedChunkInfo};
+use near_primitives::types::{
+    AccountId, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId, ShardIndex,
+    SpiceUncertifiedChunkInfo,
+};
 
 /// Blocks a chunk must stay certifiable-but-uncertified before the all-stake fallback opens for it.
 /// Well below epoch length (to rescue liveness before the one-epoch lag guard stalls consensus).
@@ -53,4 +58,56 @@ pub fn fallback_endorsers(
         .map(|validator| validator.take_account_id())
         .filter(|account_id| !designated.contains(account_id))
         .collect())
+}
+
+/// A slot opens every `epoch_length / num_shards` heights and picks one shard, so the witness
+/// traffic does not land on every shard at once. The first block past a slot takes it, so skipped
+/// heights delay a slot rather than dropping it, until a gap runs past the next one. `epoch_height`
+/// offsets which shard a slot picks, so slots do not line up with epoch boundaries.
+pub(super) fn is_fallback_only_height_for_shard_index(
+    epoch_length: BlockHeightDelta,
+    epoch_height: EpochHeight,
+    num_shards: usize,
+    shard_index: ShardIndex,
+    height: BlockHeight,
+    prev_height: BlockHeight,
+) -> bool {
+    // Zero when epoch_length < num_shards, which leaves the epoch with no slots at all. Only
+    // tests reach that: production epoch lengths far exceed shard counts.
+    let blocks_between = epoch_length / num_shards as u64;
+    if blocks_between == 0 {
+        return false;
+    }
+    let slot = height / blocks_between;
+    if slot == prev_height / blocks_between {
+        return false;
+    }
+    let num_shards = num_shards as u64;
+    let shard_for_slot = slot % num_shards;
+    let epoch_offset = epoch_height % num_shards;
+    shard_index as u64 == (shard_for_slot + epoch_offset) % num_shards
+}
+
+/// The fallback-only schedule, resolved from the previous block: the epoch manager does not know a
+/// block while that block's chunks are recorded.
+pub fn is_fallback_only_chunk(
+    epoch_manager: &dyn EpochManagerAdapter,
+    chunk_block_header: &BlockHeader,
+    shard_id: ShardId,
+) -> Result<bool, Error> {
+    let prev_hash = chunk_block_header.prev_hash();
+    // Absent only on header versions that predate spice, which never carry a slot.
+    let Some(prev_height) = chunk_block_header.prev_height() else {
+        return Ok(false);
+    };
+    let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
+    let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
+    Ok(is_fallback_only_height_for_shard_index(
+        epoch_manager.get_epoch_config(&epoch_id)?.epoch_length,
+        epoch_manager.get_epoch_height_from_prev_block(prev_hash)?,
+        shard_layout.num_shards() as usize,
+        shard_layout.get_shard_index(shard_id)?,
+        chunk_block_header.height(),
+        prev_height,
+    ))
 }

--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -64,50 +64,57 @@ pub fn fallback_endorsers(
 /// traffic does not land on every shard at once. The first block past a slot takes it, so skipped
 /// heights delay a slot rather than dropping it, until a gap runs past the next one. `epoch_height`
 /// offsets which shard a slot picks, so slots do not line up with epoch boundaries.
-pub(super) fn is_fallback_only_height_for_shard_index(
+pub(super) fn fallback_only_shard_index(
     epoch_length: BlockHeightDelta,
     epoch_height: EpochHeight,
     num_shards: usize,
-    shard_index: ShardIndex,
     height: BlockHeight,
     prev_height: BlockHeight,
-) -> bool {
+) -> Option<ShardIndex> {
     // Zero when epoch_length < num_shards, which leaves the epoch with no slots at all. Only
     // tests reach that: production epoch lengths far exceed shard counts.
     let blocks_between = epoch_length / num_shards as u64;
     if blocks_between == 0 {
-        return false;
+        return None;
     }
     let slot = height / blocks_between;
     if slot == prev_height / blocks_between {
-        return false;
+        return None;
     }
     let num_shards = num_shards as u64;
     let shard_for_slot = slot % num_shards;
     let epoch_offset = epoch_height % num_shards;
-    shard_index as u64 == (shard_for_slot + epoch_offset) % num_shards
+    Some(((shard_for_slot + epoch_offset) % num_shards) as ShardIndex)
 }
 
-/// The fallback-only schedule, resolved from the previous block: the epoch manager does not know a
-/// block while that block's chunks are recorded.
+/// The shard whose chunk in `chunk_block_header`'s block certifies only via the all-stake
+/// fallback, if the block takes a slot.
+pub fn fallback_only_shard(
+    epoch_manager: &dyn EpochManagerAdapter,
+    chunk_block_header: &BlockHeader,
+) -> Result<Option<ShardId>, Error> {
+    // Absent only on header versions that predate spice, which never carry a slot.
+    let Some(prev_height) = chunk_block_header.prev_height() else {
+        return Ok(None);
+    };
+    let epoch_id = chunk_block_header.epoch_id();
+    let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
+    let Some(shard_index) = fallback_only_shard_index(
+        epoch_manager.get_epoch_config(epoch_id)?.epoch_length,
+        epoch_manager.get_epoch_info(epoch_id)?.epoch_height(),
+        shard_layout.num_shards() as usize,
+        chunk_block_header.height(),
+        prev_height,
+    ) else {
+        return Ok(None);
+    };
+    Ok(Some(shard_layout.get_shard_id(shard_index)?))
+}
+
 pub fn is_fallback_only_chunk(
     epoch_manager: &dyn EpochManagerAdapter,
     chunk_block_header: &BlockHeader,
     shard_id: ShardId,
 ) -> Result<bool, Error> {
-    let prev_hash = chunk_block_header.prev_hash();
-    // Absent only on header versions that predate spice, which never carry a slot.
-    let Some(prev_height) = chunk_block_header.prev_height() else {
-        return Ok(false);
-    };
-    let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
-    let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
-    Ok(is_fallback_only_height_for_shard_index(
-        epoch_manager.get_epoch_config(&epoch_id)?.epoch_length,
-        epoch_manager.get_epoch_height_from_prev_block(prev_hash)?,
-        shard_layout.num_shards() as usize,
-        shard_layout.get_shard_index(shard_id)?,
-        chunk_block_header.height(),
-        prev_height,
-    ))
+    Ok(fallback_only_shard(epoch_manager, chunk_block_header)? == Some(shard_id))
 }

--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -61,15 +61,15 @@ pub fn fallback_endorsers(
 }
 
 /// A slot opens every `epoch_length / num_shards` heights and picks one shard, so the witness
-/// traffic does not land on every shard at once. The first block past a slot takes it, so skipped
-/// heights delay a slot rather than dropping it, until a gap runs past the next one. `epoch_height`
-/// offsets which shard a slot picks, so slots do not line up with epoch boundaries.
+/// traffic does not land on every shard at once. Only the block at the slot height takes it. An
+/// honest producer makes one block per height, so two forks cannot both take the same slot. If the
+/// slot height is skipped, the shard waits for its next slot. `epoch_height` offsets which shard a
+/// slot picks, so slots do not line up with epoch boundaries.
 pub(super) fn fallback_only_shard_index(
     epoch_length: BlockHeightDelta,
     epoch_height: EpochHeight,
     num_shards: usize,
     height: BlockHeight,
-    prev_height: BlockHeight,
 ) -> Option<ShardIndex> {
     // Zero when epoch_length < num_shards, which leaves the epoch with no slots at all. Only
     // tests reach that: production epoch lengths far exceed shard counts.
@@ -77,10 +77,10 @@ pub(super) fn fallback_only_shard_index(
     if blocks_between == 0 {
         return None;
     }
-    let slot = height / blocks_between;
-    if slot == prev_height / blocks_between {
+    if height % blocks_between != 0 {
         return None;
     }
+    let slot = height / blocks_between;
     let num_shards = num_shards as u64;
     let shard_for_slot = slot % num_shards;
     let epoch_offset = epoch_height % num_shards;
@@ -93,10 +93,6 @@ pub fn fallback_only_shard(
     epoch_manager: &dyn EpochManagerAdapter,
     chunk_block_header: &BlockHeader,
 ) -> Result<Option<ShardId>, Error> {
-    // Absent only on header versions that predate spice, which never carry a slot.
-    let Some(prev_height) = chunk_block_header.prev_height() else {
-        return Ok(None);
-    };
     let epoch_id = chunk_block_header.epoch_id();
     let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
     let Some(shard_index) = fallback_only_shard_index(
@@ -104,7 +100,6 @@ pub fn fallback_only_shard(
         epoch_manager.get_epoch_info(epoch_id)?.epoch_height(),
         shard_layout.num_shards() as usize,
         chunk_block_header.height(),
-        prev_height,
     ) else {
         return Ok(None);
     };

--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -77,7 +77,7 @@ pub(super) fn fallback_only_shard_index(
     if blocks_between == 0 {
         return None;
     }
-    if height % blocks_between != 0 {
+    if !height.is_multiple_of(blocks_between) {
         return None;
     }
     let slot = height / blocks_between;

--- a/chain/chain/src/spice/all_stake_fallback.rs
+++ b/chain/chain/src/spice/all_stake_fallback.rs
@@ -10,6 +10,7 @@ use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId, ShardIndex,
     SpiceUncertifiedChunkInfo,
 };
+use std::collections::HashSet;
 
 /// Blocks a chunk must stay certifiable-but-uncertified before the all-stake fallback opens for it.
 /// Well below epoch length (to rescue liveness before the one-epoch lag guard stalls consensus).
@@ -25,6 +26,33 @@ pub fn fallback_eligible(
         return false;
     };
     carrying_height.saturating_sub(certifiable_since) >= SPICE_FALLBACK_CERTIFICATION_DELAY
+}
+
+/// Whether `endorsers`, all attesting one execution result, certify the chunk in a block at
+/// `carrying_height`.
+///
+/// The producer and block validation both decide inclusion with this, so a producer never builds a
+/// certification its own validation rejects.
+pub fn endorsers_certify_chunk(
+    epoch_manager: &dyn EpochManagerAdapter,
+    chunk_block_header: &BlockHeader,
+    chunk_info: &SpiceUncertifiedChunkInfo,
+    carrying_height: BlockHeight,
+    endorsers: &HashSet<AccountId>,
+) -> Result<bool, Error> {
+    let epoch_id = chunk_block_header.epoch_id();
+    let designated = epoch_manager.get_chunk_validator_assignments(
+        epoch_id,
+        chunk_info.chunk_id.shard_id,
+        chunk_block_header.height(),
+    )?;
+    if designated.is_endorsed(endorsers) {
+        return Ok(true);
+    }
+    if !fallback_eligible(carrying_height, chunk_info) {
+        return Ok(false);
+    }
+    Ok(all_stake_fallback_assignment(epoch_manager, epoch_id)?.is_endorsed(endorsers))
 }
 
 /// The epoch's full validator set as a shard-independent assignment weighted by real stake. The

--- a/chain/chain/src/spice/ancestry_endorsements.rs
+++ b/chain/chain/src/spice/ancestry_endorsements.rs
@@ -68,9 +68,9 @@ impl<'a> AncestryEndorsements<'a> {
         self.on_chain.get(chunk_id).is_some_and(|endorsers| endorsers.contains_key(account_id))
     }
 
-    /// Chunks awaiting a designated endorsement on chain (with repeats per missing validator).
-    pub(crate) fn pending_designated_chunks(&self) -> impl Iterator<Item = &'a SpiceChunkId> + '_ {
-        self.pending_designated.iter().map(|(chunk_id, _)| *chunk_id)
+    /// Every chunk still uncertified in the ancestry.
+    pub(crate) fn uncertified_chunk_ids(&self) -> impl Iterator<Item = &'a SpiceChunkId> + '_ {
+        self.uncertified_chunks.keys().copied()
     }
 
     /// Endorsements (designated and non-designated) already on chain for `chunk_id`.

--- a/chain/chain/src/spice/ancestry_endorsements.rs
+++ b/chain/chain/src/spice/ancestry_endorsements.rs
@@ -55,6 +55,14 @@ impl<'a> AncestryEndorsements<'a> {
             .is_some_and(|info| fallback_eligible(carrying_height, info))
     }
 
+    /// `chunk_id`'s record, absent once the chunk is certified in the ancestry.
+    pub(crate) fn uncertified_chunk_info(
+        &self,
+        chunk_id: &SpiceChunkId,
+    ) -> Option<&'a SpiceUncertifiedChunkInfo> {
+        self.uncertified_chunks.get(chunk_id).copied()
+    }
+
     /// Whether `(chunk_id, account_id)`'s endorsement is already on chain in the ancestry.
     pub(crate) fn is_on_chain(&self, chunk_id: &SpiceChunkId, account_id: &AccountId) -> bool {
         self.on_chain.get(chunk_id).is_some_and(|endorsers| endorsers.contains_key(account_id))

--- a/chain/chain/src/spice/ancestry_endorsements.rs
+++ b/chain/chain/src/spice/ancestry_endorsements.rs
@@ -1,6 +1,5 @@
-use crate::spice::all_stake_fallback::fallback_eligible;
 use near_primitives::spice::chunk_endorsement::SpiceStoredVerifiedEndorsement;
-use near_primitives::types::{AccountId, BlockHeight, SpiceChunkId, SpiceUncertifiedChunkInfo};
+use near_primitives::types::{AccountId, SpiceChunkId, SpiceUncertifiedChunkInfo};
 use std::collections::{HashMap, HashSet};
 
 /// Endorsement state derived from the uncertified chunks as of the previous block: the context
@@ -41,18 +40,6 @@ impl<'a> AncestryEndorsements<'a> {
         account_id: &'a AccountId,
     ) -> bool {
         self.pending_designated.contains(&(chunk_id, account_id))
-    }
-
-    /// Whether `chunk_id` is still uncertified and may now certify via the all-stake fallback in a
-    /// block at `carrying_height`.
-    pub(crate) fn is_fallback_eligible(
-        &self,
-        chunk_id: &SpiceChunkId,
-        carrying_height: BlockHeight,
-    ) -> bool {
-        self.uncertified_chunks
-            .get(chunk_id)
-            .is_some_and(|info| fallback_eligible(carrying_height, info))
     }
 
     /// `chunk_id`'s record, absent once the chunk is certified in the ancestry.

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,6 +1,6 @@
 use crate::metrics;
 use crate::spice::all_stake_fallback::{
-    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers,
+    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
 };
 use crate::spice::ancestry_endorsements::AncestryEndorsements;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
@@ -1040,6 +1040,7 @@ pub fn record_uncertified_chunks_for_block(
             present_endorsements: Vec::new(),
             present_fallback_endorsements: Vec::new(),
             certifiable_since_height: None,
+            is_fallback_only: is_fallback_only_chunk(epoch_manager, block.header(), shard_id)?,
         });
     }
 

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,6 +1,6 @@
 use crate::metrics;
 use crate::spice::all_stake_fallback::{
-    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
+    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers,
 };
 use crate::spice::ancestry_endorsements::AncestryEndorsements;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
@@ -1040,7 +1040,6 @@ pub fn record_uncertified_chunks_for_block(
             present_endorsements: Vec::new(),
             present_fallback_endorsements: Vec::new(),
             certifiable_since_height: None,
-            is_fallback_only: is_fallback_only_chunk(epoch_manager, block.header(), shard_id)?,
         });
     }
 

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,6 +1,6 @@
 use crate::metrics;
 use crate::spice::all_stake_fallback::{
-    endorsers_certify_chunk, fallback_eligible, fallback_endorsers,
+    endorsers_certify_chunk, fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
 };
 use crate::spice::ancestry_endorsements::AncestryEndorsements;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
@@ -176,9 +176,16 @@ impl SpiceCoreReader {
         carrying_prev_hash: &CryptoHash,
         chunk_id: &SpiceChunkId,
     ) -> Result<bool, Error> {
-        Ok(self
-            .uncertified_chunk_info(carrying_prev_hash, chunk_id)?
-            .is_some_and(|chunk_info| fallback_eligible(carrying_height, &chunk_info)))
+        let Some(chunk_info) = self.uncertified_chunk_info(carrying_prev_hash, chunk_id)? else {
+            return Ok(false);
+        };
+        let chunk_block_header = self.chain_store.get_block_header(&chunk_id.block_hash)?;
+        fallback_eligible(
+            self.epoch_manager.as_ref(),
+            &chunk_block_header,
+            &chunk_info,
+            carrying_height,
+        )
     }
 
     /// Returns ChunkExtra for a given chunk, trying the ChunkExtra column first
@@ -387,10 +394,10 @@ impl SpiceCoreReader {
     /// certifying block.
     fn fallback_endorsements(
         &self,
+        chunk_block_header: &BlockHeader,
         chunk_info: &SpiceUncertifiedChunkInfo,
     ) -> Result<Vec<SpiceCoreStatement>, Error> {
         let chunk_id = &chunk_info.chunk_id;
-        let chunk_block_header = self.chain_store.get_block_header(&chunk_id.block_hash)?;
         let epoch_id = chunk_block_header.epoch_id();
         let endorsers = fallback_endorsers(
             self.epoch_manager.as_ref(),
@@ -464,8 +471,15 @@ impl SpiceCoreReader {
         // Once uncertified past the fallback window, also include the non-designated endorsements.
         // height() + 1 underestimates the next block's height, but eligibility is monotone in it
         // so anything eligible here stays eligible at the height validation checks against.
-        if fallback_eligible(block_header.height() + 1, &chunk_info) {
-            statements.extend(self.fallback_endorsements(&chunk_info)?);
+        let chunk_block_header =
+            self.chain_store.get_block_header(&chunk_info.chunk_id.block_hash)?;
+        if fallback_eligible(
+            self.epoch_manager.as_ref(),
+            &chunk_block_header,
+            &chunk_info,
+            block_header.height() + 1,
+        )? {
+            statements.extend(self.fallback_endorsements(&chunk_block_header, &chunk_info)?);
         }
 
         if let Some(execution_result) = get_execution_result_from_store(
@@ -663,6 +677,8 @@ impl SpiceCoreReader {
         let mut endorsed_chunk_accounts: HashSet<(&SpiceChunkId, &AccountId)> = HashSet::new();
         let mut block_execution_results = HashMap::new();
         let mut max_endorsed_height_created = HashMap::new();
+        // Eligibility is per chunk, while a block may carry one endorsement per validator for it.
+        let mut fallback_eligible_by_chunk: HashMap<&SpiceChunkId, bool> = HashMap::new();
 
         for (index, core_statement) in block.spice_core_statements().iter().enumerate() {
             match core_statement {
@@ -676,21 +692,34 @@ impl SpiceCoreReader {
                             reason: "endorsement is irrelevant",
                         });
                     }
-                    // Non-designated endorsements are admissible only once the chunk is
-                    // fallback-eligible and still uncertified.
-                    if !ancestry_endorsements.is_pending_designated(chunk_id, account_id) {
-                        if !ancestry_endorsements
-                            .is_fallback_eligible(chunk_id, block.header().height())
-                        {
-                            return Err(InvalidCoreStatement {
-                                index,
-                                reason: "endorsement is irrelevant",
-                            });
-                        }
-                    }
-
+                    let Some(chunk_info) = ancestry_endorsements.uncertified_chunk_info(chunk_id)
+                    else {
+                        return Err(InvalidCoreStatement {
+                            index,
+                            reason: "endorsement is irrelevant",
+                        });
+                    };
                     let endorsement_block =
                         get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
+                    // Non-designated endorsements are admissible only once the chunk is
+                    // fallback-eligible.
+                    if !ancestry_endorsements.is_pending_designated(chunk_id, account_id)
+                        && !*fallback_eligible_by_chunk.entry(chunk_id).or_insert_with(|| {
+                            fallback_eligible(
+                                self.epoch_manager.as_ref(),
+                                endorsement_block.header(),
+                                chunk_info,
+                                block.header().height(),
+                            )
+                            .expect("epoch of an uncertified chunk's block is known")
+                        })
+                    {
+                        return Err(InvalidCoreStatement {
+                            index,
+                            reason: "endorsement is irrelevant",
+                        });
+                    }
+
                     let (signed_data, signature) = self
                         .verify_endorsement_signature(
                             endorsement_block.header().epoch_id(),
@@ -983,9 +1012,19 @@ pub fn record_uncertified_chunks_for_block(
         chunk_info
             .missing_endorsements
             .retain(|account_id| !chunk_endorsements.is_some_and(|e| e.contains_key(account_id)));
+        // A fallback-only chunk never certifies by its designated assignment, so it may hold every
+        // designated endorsement and stay uncertified.
         assert!(
-            !chunk_info.missing_endorsements.is_empty(),
-            "when there are no missing endorsements execution result should be present"
+            !chunk_info.missing_endorsements.is_empty()
+                || is_fallback_only_chunk(
+                    epoch_manager,
+                    chain_store_update
+                        .chain_store()
+                        .get_block_header(&chunk_info.chunk_id.block_hash)?
+                        .as_ref(),
+                    chunk_info.chunk_id.shard_id
+                )?,
+            "chunk holding every designated endorsement should have been certified"
         );
 
         // Record non-designated endorsements (not in the designated assignment, so not tracked

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -735,7 +735,7 @@ impl SpiceCoreReader {
 
         // TODO(spice): Add validation that endorsements for blocks are included only when previous
         // block is fully endorsed (as part of block we are validating or it's ancestry).
-        for chunk_id in ancestry_endorsements.pending_designated_chunks() {
+        for chunk_id in ancestry_endorsements.uncertified_chunk_ids() {
             if block_execution_results.contains_key(chunk_id) {
                 continue;
             }
@@ -747,9 +747,10 @@ impl SpiceCoreReader {
             let block = get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
             let height = block.header().height();
             if height < *max_endorsed_height_created {
-                // We cannot be waiting on an endorsement for chunk created at height that is less
-                // than maximum endorsed height for the chunk as that would mean that child is
-                // endorsed before parent.
+                // A chunk below the maximum endorsed height for its shard cannot still be
+                // uncertified, or a child would be endorsed before its parent. Keyed off
+                // uncertified, not off a missing designated endorsement: a fallback-only chunk
+                // can hold every designated one and stay uncertified.
                 return Err(SkippedExecutionResult { chunk_id: chunk_id.clone() });
             }
         }

--- a/chain/chain/src/spice/core.rs
+++ b/chain/chain/src/spice/core.rs
@@ -1,6 +1,6 @@
 use crate::metrics;
 use crate::spice::all_stake_fallback::{
-    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers,
+    endorsers_certify_chunk, fallback_eligible, fallback_endorsers,
 };
 use crate::spice::ancestry_endorsements::AncestryEndorsements;
 use crate::{Chain, ChainStoreAccess, ChainStoreUpdate};
@@ -156,6 +156,18 @@ impl SpiceCoreReader {
         get_uncertified_chunks(&self.chain_store, block_hash)
     }
 
+    /// `chunk_id`'s record as of `carrying_prev_hash`, absent once the chunk is certified there.
+    pub fn uncertified_chunk_info(
+        &self,
+        carrying_prev_hash: &CryptoHash,
+        chunk_id: &SpiceChunkId,
+    ) -> Result<Option<SpiceUncertifiedChunkInfo>, Error> {
+        Ok(self
+            .get_uncertified_chunks(carrying_prev_hash)?
+            .into_iter()
+            .find(|chunk_info| &chunk_info.chunk_id == chunk_id))
+    }
+
     /// Whether `chunk_id` may certify via the all-stake fallback in a block at `carrying_height`
     /// built on `carrying_prev_hash`. False once the chunk is certified there.
     pub fn fallback_eligible_in_carrying_block(
@@ -164,11 +176,9 @@ impl SpiceCoreReader {
         carrying_prev_hash: &CryptoHash,
         chunk_id: &SpiceChunkId,
     ) -> Result<bool, Error> {
-        let uncertified_chunks = self.get_uncertified_chunks(carrying_prev_hash)?;
-        Ok(uncertified_chunks
-            .iter()
-            .find(|chunk_info| &chunk_info.chunk_id == chunk_id)
-            .is_some_and(|chunk_info| fallback_eligible(carrying_height, chunk_info)))
+        Ok(self
+            .uncertified_chunk_info(carrying_prev_hash, chunk_id)?
+            .is_some_and(|chunk_info| fallback_eligible(carrying_height, &chunk_info)))
     }
 
     /// Returns ChunkExtra for a given chunk, trying the ChunkExtra column first
@@ -746,42 +756,29 @@ impl SpiceCoreReader {
 
         for (chunk_id, mut on_chain_endorsements) in in_block_endorsements {
             let chunk_block = get_block(self.chain_store.store_ref(), &chunk_id.block_hash)?;
-            let chunk_validator_assignments = self
-                .epoch_manager
-                .get_chunk_validator_assignments(
-                    &chunk_block.header().epoch_id(),
-                    chunk_id.shard_id,
-                    chunk_block.header().height(),
-                )
-                .expect(
-                    "since we are waiting for endorsement we should know it's validator assignments",
-                );
             // Add the on-chain ancestry endorsements (designated and non-designated) to the in-block
-            // ones, grouped by attested result; the designated tally ignores non-designated accounts.
+            // ones, grouped by attested result.
             for (account_id, endorsement) in ancestry_endorsements.on_chain_for(chunk_id) {
                 on_chain_endorsements
                     .entry(endorsement.execution_result_hash.clone())
                     .or_default()
                     .insert(account_id, endorsement.signature.clone());
             }
-            // Once fallback-eligible, the chunk may also certify via 2/3 of total epoch stake.
-            let fallback_assignment = ancestry_endorsements
-                .is_fallback_eligible(chunk_id, block.header().height())
-                .then(|| {
-                    all_stake_fallback_assignment(
-                        self.epoch_manager.as_ref(),
-                        chunk_block.header().epoch_id(),
-                    )
-                    .expect("epoch of an uncertified chunk's block is known")
-                });
+            let Some(chunk_info) = ancestry_endorsements.uncertified_chunk_info(chunk_id) else {
+                continue;
+            };
             for (execution_result_hash, validator_signatures) in on_chain_endorsements {
-                let endorsed = chunk_validator_assignments
-                    .compute_endorsement_state(validator_signatures.clone())
-                    .is_endorsed
-                    || fallback_assignment.as_ref().is_some_and(|all| {
-                        all.compute_endorsement_state(validator_signatures).is_endorsed
-                    });
-                if !endorsed {
+                let endorsers =
+                    validator_signatures.keys().map(|account_id| (*account_id).clone()).collect();
+                if !endorsers_certify_chunk(
+                    self.epoch_manager.as_ref(),
+                    chunk_block.header(),
+                    chunk_info,
+                    block.header().height(),
+                    &endorsers,
+                )
+                .expect("epoch of an uncertified chunk's block is known")
+                {
                     continue;
                 }
 

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -1,5 +1,5 @@
 use crate::spice::activation::{SpiceMessageGate, SpiceMessageKind, spice_enabled_for_block};
-use crate::spice::all_stake_fallback::{all_stake_fallback_assignment, fallback_eligible};
+use crate::spice::all_stake_fallback::all_stake_fallback_assignment;
 use crate::spice::core::SpiceCoreReader;
 use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
@@ -173,7 +173,6 @@ impl SpiceCoreWriterActor {
     ) -> Result<bool, Error> {
         let chunk_block = self.chain_store.get_block_header(&chunk_id.block_hash)?;
         let epoch_id = chunk_block.epoch_id();
-        let chunk_info = self.core_reader.uncertified_chunk_info(carrying_prev_hash, chunk_id)?;
         let designated = self.epoch_manager.get_chunk_validator_assignments(
             epoch_id,
             chunk_id.shard_id,
@@ -187,7 +186,11 @@ impl SpiceCoreWriterActor {
         ) {
             return Ok(true);
         }
-        if !chunk_info.is_some_and(|info| fallback_eligible(carrying_height, &info)) {
+        if !self.core_reader.fallback_eligible_in_carrying_block(
+            carrying_height,
+            carrying_prev_hash,
+            chunk_id,
+        )? {
             return Ok(false);
         }
         let all_validators = all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?;

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -1,5 +1,5 @@
 use crate::spice::activation::{SpiceMessageGate, SpiceMessageKind, spice_enabled_for_block};
-use crate::spice::all_stake_fallback::all_stake_fallback_assignment;
+use crate::spice::all_stake_fallback::{all_stake_fallback_assignment, fallback_eligible};
 use crate::spice::core::SpiceCoreReader;
 use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
@@ -173,6 +173,7 @@ impl SpiceCoreWriterActor {
     ) -> Result<bool, Error> {
         let chunk_block = self.chain_store.get_block_header(&chunk_id.block_hash)?;
         let epoch_id = chunk_block.epoch_id();
+        let chunk_info = self.core_reader.uncertified_chunk_info(carrying_prev_hash, chunk_id)?;
         let designated = self.epoch_manager.get_chunk_validator_assignments(
             epoch_id,
             chunk_id.shard_id,
@@ -186,11 +187,7 @@ impl SpiceCoreWriterActor {
         ) {
             return Ok(true);
         }
-        if !self.core_reader.fallback_eligible_in_carrying_block(
-            carrying_height,
-            carrying_prev_hash,
-            chunk_id,
-        )? {
+        if !chunk_info.is_some_and(|info| fallback_eligible(carrying_height, &info)) {
             return Ok(false);
         }
         let all_validators = all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?;

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -174,10 +174,7 @@ impl SpiceCoreWriterActor {
     ) -> Result<bool, Error> {
         let chunk_block = self.chain_store.get_block_header(&chunk_id.block_hash)?;
         let epoch_id = chunk_block.epoch_id();
-        // A property of the chunk's own block, not of the chain the carrying block sits on.
-        let is_fallback_only =
-            is_fallback_only_chunk(self.epoch_manager.as_ref(), &chunk_block, chunk_id.shard_id)?;
-        if !is_fallback_only {
+        if !is_fallback_only_chunk(self.epoch_manager.as_ref(), &chunk_block, chunk_id.shard_id)? {
             let designated = self.epoch_manager.get_chunk_validator_assignments(
                 epoch_id,
                 chunk_id.shard_id,

--- a/chain/chain/src/spice/core_writer_actor.rs
+++ b/chain/chain/src/spice/core_writer_actor.rs
@@ -1,5 +1,5 @@
 use crate::spice::activation::{SpiceMessageGate, SpiceMessageKind, spice_enabled_for_block};
-use crate::spice::all_stake_fallback::all_stake_fallback_assignment;
+use crate::spice::all_stake_fallback::{all_stake_fallback_assignment, is_fallback_only_chunk};
 use crate::spice::core::SpiceCoreReader;
 use itertools::Itertools;
 use near_async::messaging::{Handler, Sender};
@@ -162,7 +162,8 @@ impl SpiceCoreWriterActor {
     }
 
     /// Whether `chunk_id`'s stored endorsements certify `result_hash`: by 2/3 of its designated
-    /// assignment, or, once fallback-eligible, by 2/3 of total epoch stake. `endorsers` seeds it.
+    /// assignment, or, once fallback-eligible, by 2/3 of total epoch stake. A fallback-only chunk
+    /// skips the designated rule. `endorsers` seeds it.
     fn endorsed_by_designated_or_fallback(
         &self,
         chunk_id: &SpiceChunkId,
@@ -173,25 +174,30 @@ impl SpiceCoreWriterActor {
     ) -> Result<bool, Error> {
         let chunk_block = self.chain_store.get_block_header(&chunk_id.block_hash)?;
         let epoch_id = chunk_block.epoch_id();
-        let designated = self.epoch_manager.get_chunk_validator_assignments(
-            epoch_id,
-            chunk_id.shard_id,
-            chunk_block.height(),
-        )?;
-        if self.core_reader.reaches_endorsement_threshold(
-            chunk_id,
-            result_hash,
-            &designated,
-            endorsers.clone(),
-        ) {
-            return Ok(true);
-        }
-        if !self.core_reader.fallback_eligible_in_carrying_block(
-            carrying_height,
-            carrying_prev_hash,
-            chunk_id,
-        )? {
-            return Ok(false);
+        // A property of the chunk's own block, not of the chain the carrying block sits on.
+        let is_fallback_only =
+            is_fallback_only_chunk(self.epoch_manager.as_ref(), &chunk_block, chunk_id.shard_id)?;
+        if !is_fallback_only {
+            let designated = self.epoch_manager.get_chunk_validator_assignments(
+                epoch_id,
+                chunk_id.shard_id,
+                chunk_block.height(),
+            )?;
+            if self.core_reader.reaches_endorsement_threshold(
+                chunk_id,
+                result_hash,
+                &designated,
+                endorsers.clone(),
+            ) {
+                return Ok(true);
+            }
+            if !self.core_reader.fallback_eligible_in_carrying_block(
+                carrying_height,
+                carrying_prev_hash,
+                chunk_id,
+            )? {
+                return Ok(false);
+            }
         }
         let all_validators = all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?;
         Ok(self.core_reader.reaches_endorsement_threshold(

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -1,5 +1,6 @@
 use crate::spice::all_stake_fallback::{
-    SPICE_FALLBACK_CERTIFICATION_DELAY, fallback_only_shard_index, is_fallback_only_chunk,
+    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, fallback_only_shard_index,
+    is_fallback_only_chunk,
 };
 use crate::spice::tests::core::{
     block_certification_core_statements, build_block, endorsement_into_core_statement,
@@ -14,6 +15,7 @@ use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, EpochHeight, ShardId, SpiceChunkId,
 };
+use std::collections::HashSet;
 use std::sync::Arc;
 
 fn first_shard_chunk_id(block: &Block) -> SpiceChunkId {
@@ -524,4 +526,81 @@ fn test_schedule_fires_at_a_slot_boundary_on_a_real_chain() {
     let (fallback_only_block, _) =
         grow_chain_to_fallback_only_block(&mut chain, epoch_length as usize);
     assert_eq!(fallback_only_block.header().height() % blocks_between, 0);
+}
+
+// Enough validators that a chunk's designated assignment stays under 2/3 of total stake, asserted
+// below.
+fn validators_with_minority_designated_stake() -> Vec<String> {
+    (0..150).map(|i| format!("test{i}")).collect()
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_rejects_designated_only_certification_of_fallback_only_chunk() {
+    let validators = validators_with_minority_designated_stake();
+    let (mut chain, core_reader) = setup_with_validators(&validators);
+    let (fallback_only_block, shard_id) = grow_chain_to_fallback_only_block(&mut chain, 40);
+    let chunk_header = fallback_only_block
+        .chunks()
+        .iter_raw()
+        .find(|chunk| chunk.shard_id() == shard_id)
+        .unwrap()
+        .clone();
+    // Certifying the parent leaves the fallback-only chunk as the oldest uncertified one.
+    let parent = chain.chain_store().get_block(fallback_only_block.header().prev_hash()).unwrap();
+    let parent_certification = certify_block_designated(&chain, &parent);
+    let tip = append_block(&mut chain, &fallback_only_block, parent_certification);
+    let uncertified = core_reader.get_uncertified_chunks(tip.hash()).unwrap();
+    let chunk_id = SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id };
+    assert!(uncertified.iter().all(|info| info.chunk_id.block_hash != *parent.hash()));
+    assert!(uncertified.iter().any(|info| info.chunk_id == chunk_id && info.is_fallback_only));
+
+    let (designated, non_designated) =
+        split_designated(&chain, &fallback_only_block, &chunk_header, &validators);
+    let all_stake = all_stake_fallback_assignment(
+        chain.epoch_manager.as_ref(),
+        fallback_only_block.header().epoch_id(),
+    )
+    .unwrap();
+    // The whole designated set must fall short of 2/3 of total stake, or a designated-only block
+    // would certify on the all-stake path and prove nothing about the designated rule.
+    let mut endorsers: HashSet<AccountId> = designated.iter().cloned().collect();
+    assert!(!all_stake.is_endorsed(&endorsers));
+
+    let designated_only = build_block(
+        &chain,
+        &tip,
+        endorsements_and_execution_result(&designated, &fallback_only_block, &chunk_header),
+    );
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&designated_only),
+        Err(InvalidSpiceCoreStatementsError::InvalidCoreStatement {
+            reason: "execution results included without enough corresponding endorsement",
+            ..
+        })
+    );
+
+    // Topping the designated set up to 2/3 of total stake certifies, so the rejection above is the
+    // designated rule being skipped, not an unreachable threshold. Stakes are not uniform, so the
+    // set is grown against the assignment rather than by a count.
+    for account in non_designated {
+        if all_stake.is_endorsed(&endorsers) {
+            break;
+        }
+        endorsers.insert(account);
+    }
+    assert!(all_stake.is_endorsed(&endorsers), "fallback set must be able to certify");
+    let mut all_stake_endorsers: Vec<AccountId> = endorsers.into_iter().collect();
+    all_stake_endorsers.sort();
+
+    let all_stake_block = build_block(
+        &chain,
+        &tip,
+        endorsements_and_execution_result(
+            &all_stake_endorsers,
+            &fallback_only_block,
+            &chunk_header,
+        ),
+    );
+    core_reader.validate_core_statements_in_block(&all_stake_block).unwrap();
 }

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -236,7 +236,7 @@ fn test_validate_admits_non_designated_endorsement_only_when_eligible() {
 }
 
 // Splits `validators` into (designated, non_designated) for `chunk` as of `block`.
-fn split_designated(
+pub(super) fn split_designated(
     chain: &Chain,
     block: &Block,
     chunk: &ShardChunkHeader,
@@ -494,7 +494,10 @@ fn test_a_skipped_slot_height_drops_the_slot() {
 
 // Walks the chain until a block carries a fallback-only chunk. Each step certifies the block two
 // heights back, since a block may not skip an earlier chunk's execution result.
-fn grow_chain_to_fallback_only_block(chain: &mut Chain, bound: usize) -> (Arc<Block>, ShardId) {
+pub(super) fn grow_chain_to_fallback_only_block(
+    chain: &mut Chain,
+    bound: usize,
+) -> (Arc<Block>, ShardId) {
     let mut blocks = vec![chain.genesis_block()];
     for _ in 0..bound {
         let parent = blocks.last().unwrap().clone();
@@ -532,7 +535,7 @@ fn test_schedule_fires_at_a_slot_boundary_on_a_real_chain() {
 
 // Enough validators that a chunk's designated assignment stays under 2/3 of total stake, asserted
 // below.
-fn validators_with_minority_designated_stake() -> Vec<String> {
+pub(super) fn validators_with_minority_designated_stake() -> Vec<String> {
     (0..150).map(|i| format!("test{i}")).collect()
 }
 
@@ -647,4 +650,50 @@ fn test_ordinary_chunk_waits_the_full_delay_after_becoming_certifiable() {
     let info = ordinary_chunk_info(Some(certifiable_since));
     assert!(!fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY - 1, &info));
     assert!(fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY, &info));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_validate_rejects_skipping_an_uncertified_fallback_only_chunk() {
+    let validators = validators_with_minority_designated_stake();
+    let (mut chain, core_reader) = setup_with_validators(&validators);
+    let (fallback_only_block, shard_id) = grow_chain_to_fallback_only_block(&mut chain, 40);
+    let chunk_of = |block: &Block| {
+        block.chunks().iter_raw().find(|chunk| chunk.shard_id() == shard_id).unwrap().clone()
+    };
+    let chunk_header = chunk_of(&fallback_only_block);
+    let parent = chain.chain_store().get_block(fallback_only_block.header().prev_hash()).unwrap();
+    let parent_certification = certify_block_designated(&chain, &parent);
+    let next_block = append_block(&mut chain, &fallback_only_block, parent_certification);
+
+    // Every designated endorsement lands, which empties missing_endorsements without certifying
+    // the chunk: only 2/3 of total stake can do that.
+    let (designated, _) =
+        split_designated(&chain, &fallback_only_block, &chunk_header, &validators);
+    let tip = append_block(
+        &mut chain,
+        &next_block,
+        endorsement_statements(&designated, &fallback_only_block, &chunk_header),
+    );
+    let chunk_id = SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id };
+    let chunk_info = core_reader
+        .get_uncertified_chunks(tip.hash())
+        .unwrap()
+        .into_iter()
+        .find(|info| info.chunk_id == chunk_id)
+        .expect("the fallback-only chunk is still uncertified");
+    assert!(chunk_info.missing_endorsements.is_empty());
+
+    // Certifying the same shard one height later would endorse a child before its parent.
+    let later_chunk = chunk_of(&next_block);
+    let (later_designated, _) = split_designated(&chain, &next_block, &later_chunk, &validators);
+    let skipping_block = build_block(
+        &chain,
+        &tip,
+        endorsements_and_execution_result(&later_designated, &next_block, &later_chunk),
+    );
+    assert_matches!(
+        core_reader.validate_core_statements_in_block(&skipping_block),
+        Err(InvalidSpiceCoreStatementsError::SkippedExecutionResult { .. })
+    );
 }

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -1,4 +1,7 @@
-use crate::spice::all_stake_fallback::SPICE_FALLBACK_CERTIFICATION_DELAY;
+use crate::spice::all_stake_fallback::{
+    SPICE_FALLBACK_CERTIFICATION_DELAY, is_fallback_only_chunk,
+    is_fallback_only_height_for_shard_index,
+};
 use crate::spice::tests::core::{
     block_certification_core_statements, build_block, endorsement_into_core_statement,
     process_block, setup, setup_with_validators, test_chunk_endorsement,
@@ -9,7 +12,9 @@ use assert_matches::assert_matches;
 use near_primitives::block_body::SpiceCoreStatement;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
 use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::types::{AccountId, BlockHeight, SpiceChunkId};
+use near_primitives::types::{
+    AccountId, BlockHeight, BlockHeightDelta, EpochHeight, ShardId, SpiceChunkId,
+};
 use std::sync::Arc;
 
 fn first_shard_chunk_id(block: &Block) -> SpiceChunkId {
@@ -420,4 +425,163 @@ fn test_fallback_eligible_when_one_block_certifies_several_blocks() {
     };
     assert!(!eligible_at(stamped + SPICE_FALLBACK_CERTIFICATION_DELAY - 1));
     assert!(eligible_at(stamped + SPICE_FALLBACK_CERTIFICATION_DELAY));
+}
+
+const FALLBACK_ONLY_SCHEDULE_EPOCH_LENGTH: BlockHeightDelta = 400;
+const FALLBACK_ONLY_SCHEDULE_NUM_SHARDS: usize = 4;
+
+/// The heights at which `shard_index` takes a slot, walking `heights` as a chain: each block's
+/// parent is the entry before it.
+fn fallback_only_heights(
+    epoch_height: EpochHeight,
+    shard_index: usize,
+    heights: impl IntoIterator<Item = BlockHeight>,
+) -> Vec<BlockHeight> {
+    let mut slots = Vec::new();
+    let mut parent = None;
+    for height in heights {
+        let prev_height = parent.unwrap_or_else(|| height.saturating_sub(1));
+        if is_fallback_only_height_for_shard_index(
+            FALLBACK_ONLY_SCHEDULE_EPOCH_LENGTH,
+            epoch_height,
+            FALLBACK_ONLY_SCHEDULE_NUM_SHARDS,
+            shard_index,
+            height,
+            prev_height,
+        ) {
+            slots.push(height);
+        }
+        parent = Some(height);
+    }
+    slots
+}
+
+#[test]
+fn test_each_shard_takes_one_slot_per_cycle() {
+    let scheduled: Vec<_> = (0..FALLBACK_ONLY_SCHEDULE_NUM_SHARDS)
+        .map(|shard_index| fallback_only_heights(0, shard_index, 1000..1400))
+        .collect();
+    assert_eq!(scheduled, vec![vec![1200], vec![1300], vec![1000], vec![1100]]);
+}
+
+#[test]
+fn test_slots_rotate_across_epochs() {
+    let scheduled: Vec<_> = (0..FALLBACK_ONLY_SCHEDULE_NUM_SHARDS as u64)
+        .map(|epoch_height| fallback_only_heights(epoch_height, 0, 1000..1400))
+        .collect();
+    assert_eq!(scheduled, vec![vec![1200], vec![1100], vec![1000], vec![1300]]);
+}
+
+#[test]
+fn test_schedule_picks_one_shard_at_the_maximum_height() {
+    // blocks_between is 1 here, so the largest height qualifies and the shard arithmetic runs on it.
+    let num_shards = FALLBACK_ONLY_SCHEDULE_NUM_SHARDS;
+    let scheduled = (0..num_shards)
+        .filter(|shard_index| {
+            is_fallback_only_height_for_shard_index(
+                num_shards as BlockHeightDelta,
+                EpochHeight::MAX,
+                num_shards,
+                *shard_index,
+                BlockHeight::MAX,
+                BlockHeight::MAX - 1,
+            )
+        })
+        .count();
+    assert_eq!(scheduled, 1);
+}
+
+#[test]
+fn test_no_fallback_only_chunk_when_epoch_shorter_than_shard_count() {
+    assert!((1000..1010).all(|height| !is_fallback_only_height_for_shard_index(
+        5,
+        0,
+        6,
+        0,
+        height,
+        height - 1
+    )));
+}
+
+#[test]
+fn test_a_skipped_height_delays_a_slot_instead_of_dropping_it() {
+    let without_the_slot_height = (1000..1400).filter(|height| *height != 1200);
+    assert_eq!(fallback_only_heights(0, 0, without_the_slot_height), vec![1201]);
+}
+
+#[test]
+fn test_a_gap_past_the_next_slot_drops_the_slots_inside_it() {
+    let long_gap = (1000..1400).filter(|height| !(1150..1350).contains(height));
+    assert_eq!(fallback_only_heights(0, 0, long_gap.clone()), Vec::<BlockHeight>::new());
+    assert_eq!(fallback_only_heights(0, 1, long_gap), vec![1350]);
+}
+
+// Walks the chain until a block carries a fallback-only chunk. Each step certifies the block two
+// heights back, since a block may not skip an earlier chunk's execution result.
+fn grow_chain_to_fallback_only_block(chain: &mut Chain, bound: usize) -> (Arc<Block>, ShardId) {
+    let mut blocks = vec![chain.genesis_block()];
+    for _ in 0..bound {
+        let parent = blocks.last().unwrap().clone();
+        let statements = if blocks.len() >= 3 {
+            certify_block_designated(chain, &blocks[blocks.len() - 2])
+        } else {
+            vec![]
+        };
+        let block = append_block(chain, &parent, statements);
+        let fallback_only_shard =
+            block.chunks().iter_raw().map(|chunk| chunk.shard_id()).find(|shard_id| {
+                is_fallback_only_chunk(chain.epoch_manager.as_ref(), block.header(), *shard_id)
+                    .unwrap()
+            });
+        if let Some(shard_id) = fallback_only_shard {
+            return (block, shard_id);
+        }
+        blocks.push(block);
+    }
+    panic!("no fallback-only block within {bound} heights");
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_recorded_chunk_info_marks_the_scheduled_shard_fallback_only() {
+    let (mut chain, core_reader) = setup();
+    let (fallback_only_block, fallback_only_shard) =
+        grow_chain_to_fallback_only_block(&mut chain, 40);
+    let fallback_only_chunks: Vec<_> = core_reader
+        .get_uncertified_chunks(fallback_only_block.hash())
+        .unwrap()
+        .into_iter()
+        .filter(|chunk_info| chunk_info.is_fallback_only)
+        .map(|chunk_info| chunk_info.chunk_id)
+        .collect();
+    assert_eq!(
+        fallback_only_chunks,
+        vec![SpiceChunkId {
+            block_hash: *fallback_only_block.hash(),
+            shard_id: fallback_only_shard
+        }]
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_fallback_only_mark_survives_in_later_blocks() {
+    let (mut chain, core_reader) = setup();
+    let (fallback_only_block, fallback_only_shard) =
+        grow_chain_to_fallback_only_block(&mut chain, 40);
+    let scheduled =
+        SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id: fallback_only_shard };
+
+    let later = advance_to_height(
+        &mut chain,
+        &fallback_only_block,
+        fallback_only_block.header().height() + 3,
+    );
+
+    let still_marked = core_reader
+        .get_uncertified_chunks(later.hash())
+        .unwrap()
+        .into_iter()
+        .any(|chunk_info| chunk_info.chunk_id == scheduled && chunk_info.is_fallback_only);
+    assert!(still_marked, "the mark was lost when the chunk was carried forward");
 }

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -1,6 +1,6 @@
 use crate::spice::all_stake_fallback::{
-    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, fallback_only_shard_index,
-    is_fallback_only_chunk,
+    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, fallback_eligible,
+    fallback_only_shard_index, is_fallback_only_chunk,
 };
 use crate::spice::tests::core::{
     block_certification_core_statements, build_block, endorsement_into_core_statement,
@@ -11,9 +11,11 @@ use crate::{Block, Chain};
 use assert_matches::assert_matches;
 use near_primitives::block_body::SpiceCoreStatement;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
+use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, EpochHeight, ShardId, SpiceChunkId,
+    SpiceUncertifiedChunkInfo,
 };
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -603,4 +605,46 @@ fn test_validate_rejects_designated_only_certification_of_fallback_only_chunk() 
         ),
     );
     core_reader.validate_core_statements_in_block(&all_stake_block).unwrap();
+}
+
+fn chunk_info(
+    certifiable_since_height: Option<BlockHeight>,
+    is_fallback_only: bool,
+) -> SpiceUncertifiedChunkInfo {
+    SpiceUncertifiedChunkInfo {
+        chunk_id: SpiceChunkId { block_hash: CryptoHash::default(), shard_id: ShardId::new(0) },
+        missing_endorsements: vec![],
+        present_endorsements: vec![],
+        present_fallback_endorsements: vec![],
+        certifiable_since_height,
+        is_fallback_only,
+    }
+}
+
+fn fallback_only_chunk_info(
+    certifiable_since_height: Option<BlockHeight>,
+) -> SpiceUncertifiedChunkInfo {
+    chunk_info(certifiable_since_height, true)
+}
+
+fn ordinary_chunk_info(certifiable_since_height: Option<BlockHeight>) -> SpiceUncertifiedChunkInfo {
+    chunk_info(certifiable_since_height, false)
+}
+
+#[test]
+fn test_fallback_only_chunk_is_eligible_before_it_is_certifiable() {
+    // A scheduled chunk has no delay to wait out, so it certifies as soon as its endorsements
+    // arrive. certifiable_since_height is only set in a later block than the chunk's own, so
+    // gating on it would add a wait this chunk is meant not to have.
+    assert!(fallback_eligible(1, &fallback_only_chunk_info(None)));
+    assert!(fallback_eligible(1, &fallback_only_chunk_info(Some(1))));
+}
+
+#[test]
+fn test_ordinary_chunk_waits_the_full_delay_after_becoming_certifiable() {
+    assert!(!fallback_eligible(BlockHeight::MAX, &ordinary_chunk_info(None)));
+    let certifiable_since = 100;
+    let info = ordinary_chunk_info(Some(certifiable_since));
+    assert!(!fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY - 1, &info));
+    assert!(fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY, &info));
 }

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -636,7 +636,7 @@ fn ordinary_chunk_info(certifiable_since_height: Option<BlockHeight>) -> SpiceUn
 
 #[test]
 fn test_fallback_only_chunk_is_eligible_before_it_is_certifiable() {
-    // A scheduled chunk has no delay to wait out, so it certifies as soon as its endorsements
+    // A fallback-only chunk has no delay to wait out, so it certifies as soon as its endorsements
     // arrive. certifiable_since_height is only set in a later block than the chunk's own, so
     // gating on it would add a wait this chunk is meant not to have.
     assert!(fallback_eligible(1, &fallback_only_chunk_info(None)));

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -1,6 +1,6 @@
 use crate::spice::all_stake_fallback::{
-    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, fallback_eligible,
-    fallback_only_shard_index, is_fallback_only_chunk,
+    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, fallback_only_shard_index,
+    is_fallback_only_chunk,
 };
 use crate::spice::tests::core::{
     block_certification_core_statements, build_block, endorsement_into_core_statement,
@@ -11,11 +11,9 @@ use crate::{Block, Chain};
 use assert_matches::assert_matches;
 use near_primitives::block_body::SpiceCoreStatement;
 use near_primitives::errors::InvalidSpiceCoreStatementsError;
-use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, EpochHeight, ShardId, SpiceChunkId,
-    SpiceUncertifiedChunkInfo,
 };
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -520,19 +518,6 @@ pub(super) fn grow_chain_to_fallback_only_block(
     panic!("no fallback-only block within {bound} heights");
 }
 
-#[test]
-#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_schedule_fires_at_a_slot_boundary_on_a_real_chain() {
-    let (mut chain, _core_reader) = setup();
-    let epoch_id = chain.epoch_manager.get_epoch_id(chain.genesis_block().hash()).unwrap();
-    let epoch_length = chain.epoch_manager.get_epoch_config(&epoch_id).unwrap().epoch_length;
-    let num_shards = chain.epoch_manager.get_shard_layout(&epoch_id).unwrap().num_shards();
-    let blocks_between = epoch_length / num_shards;
-    let (fallback_only_block, _) =
-        grow_chain_to_fallback_only_block(&mut chain, epoch_length as usize);
-    assert_eq!(fallback_only_block.header().height() % blocks_between, 0);
-}
-
 // Enough validators that a chunk's designated assignment stays under 2/3 of total stake, asserted
 // below.
 pub(super) fn validators_with_minority_designated_stake() -> Vec<String> {
@@ -558,7 +543,15 @@ fn test_validate_rejects_designated_only_certification_of_fallback_only_chunk() 
     let uncertified = core_reader.get_uncertified_chunks(tip.hash()).unwrap();
     let chunk_id = SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id };
     assert!(uncertified.iter().all(|info| info.chunk_id.block_hash != *parent.hash()));
-    assert!(uncertified.iter().any(|info| info.chunk_id == chunk_id && info.is_fallback_only));
+    assert!(uncertified.iter().any(|info| info.chunk_id == chunk_id));
+    assert!(
+        is_fallback_only_chunk(
+            chain.epoch_manager.as_ref(),
+            fallback_only_block.header(),
+            shard_id
+        )
+        .unwrap()
+    );
 
     let (designated, non_designated) =
         split_designated(&chain, &fallback_only_block, &chunk_header, &validators);
@@ -610,48 +603,6 @@ fn test_validate_rejects_designated_only_certification_of_fallback_only_chunk() 
     core_reader.validate_core_statements_in_block(&all_stake_block).unwrap();
 }
 
-fn chunk_info(
-    certifiable_since_height: Option<BlockHeight>,
-    is_fallback_only: bool,
-) -> SpiceUncertifiedChunkInfo {
-    SpiceUncertifiedChunkInfo {
-        chunk_id: SpiceChunkId { block_hash: CryptoHash::default(), shard_id: ShardId::new(0) },
-        missing_endorsements: vec![],
-        present_endorsements: vec![],
-        present_fallback_endorsements: vec![],
-        certifiable_since_height,
-        is_fallback_only,
-    }
-}
-
-fn fallback_only_chunk_info(
-    certifiable_since_height: Option<BlockHeight>,
-) -> SpiceUncertifiedChunkInfo {
-    chunk_info(certifiable_since_height, true)
-}
-
-fn ordinary_chunk_info(certifiable_since_height: Option<BlockHeight>) -> SpiceUncertifiedChunkInfo {
-    chunk_info(certifiable_since_height, false)
-}
-
-#[test]
-fn test_fallback_only_chunk_is_eligible_before_it_is_certifiable() {
-    // A fallback-only chunk has no delay to wait out, so it certifies as soon as its endorsements
-    // arrive. certifiable_since_height is only set in a later block than the chunk's own, so
-    // gating on it would add a wait this chunk is meant not to have.
-    assert!(fallback_eligible(1, &fallback_only_chunk_info(None)));
-    assert!(fallback_eligible(1, &fallback_only_chunk_info(Some(1))));
-}
-
-#[test]
-fn test_ordinary_chunk_waits_the_full_delay_after_becoming_certifiable() {
-    assert!(!fallback_eligible(BlockHeight::MAX, &ordinary_chunk_info(None)));
-    let certifiable_since = 100;
-    let info = ordinary_chunk_info(Some(certifiable_since));
-    assert!(!fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY - 1, &info));
-    assert!(fallback_eligible(certifiable_since + SPICE_FALLBACK_CERTIFICATION_DELAY, &info));
-}
-
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_validate_rejects_skipping_an_uncertified_fallback_only_chunk() {
@@ -696,4 +647,17 @@ fn test_validate_rejects_skipping_an_uncertified_fallback_only_chunk() {
         core_reader.validate_core_statements_in_block(&skipping_block),
         Err(InvalidSpiceCoreStatementsError::SkippedExecutionResult { .. })
     );
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_schedule_fires_at_a_slot_boundary_on_a_real_chain() {
+    let (mut chain, _core_reader) = setup();
+    let epoch_id = chain.epoch_manager.get_epoch_id(chain.genesis_block().hash()).unwrap();
+    let epoch_length = chain.epoch_manager.get_epoch_config(&epoch_id).unwrap().epoch_length;
+    let num_shards = chain.epoch_manager.get_shard_layout(&epoch_id).unwrap().num_shards();
+    let blocks_between = epoch_length / num_shards;
+    let (fallback_only_block, _) =
+        grow_chain_to_fallback_only_block(&mut chain, epoch_length as usize);
+    assert_eq!(fallback_only_block.header().height() % blocks_between, 0);
 }

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -1,6 +1,5 @@
 use crate::spice::all_stake_fallback::{
-    SPICE_FALLBACK_CERTIFICATION_DELAY, is_fallback_only_chunk,
-    is_fallback_only_height_for_shard_index,
+    SPICE_FALLBACK_CERTIFICATION_DELAY, fallback_only_shard_index, is_fallback_only_chunk,
 };
 use crate::spice::tests::core::{
     block_certification_core_statements, build_block, endorsement_into_core_statement,
@@ -441,14 +440,14 @@ fn fallback_only_heights(
     let mut parent = None;
     for height in heights {
         let prev_height = parent.unwrap_or_else(|| height.saturating_sub(1));
-        if is_fallback_only_height_for_shard_index(
+        if fallback_only_shard_index(
             FALLBACK_ONLY_SCHEDULE_EPOCH_LENGTH,
             epoch_height,
             FALLBACK_ONLY_SCHEDULE_NUM_SHARDS,
-            shard_index,
             height,
             prev_height,
-        ) {
+        ) == Some(shard_index)
+        {
             slots.push(height);
         }
         parent = Some(height);
@@ -476,31 +475,21 @@ fn test_slots_rotate_across_epochs() {
 fn test_schedule_picks_one_shard_at_the_maximum_height() {
     // blocks_between is 1 here, so the largest height qualifies and the shard arithmetic runs on it.
     let num_shards = FALLBACK_ONLY_SCHEDULE_NUM_SHARDS;
-    let scheduled = (0..num_shards)
-        .filter(|shard_index| {
-            is_fallback_only_height_for_shard_index(
-                num_shards as BlockHeightDelta,
-                EpochHeight::MAX,
-                num_shards,
-                *shard_index,
-                BlockHeight::MAX,
-                BlockHeight::MAX - 1,
-            )
-        })
-        .count();
-    assert_eq!(scheduled, 1);
+    let scheduled = fallback_only_shard_index(
+        num_shards as BlockHeightDelta,
+        EpochHeight::MAX,
+        num_shards,
+        BlockHeight::MAX,
+        BlockHeight::MAX - 1,
+    );
+    assert!(scheduled.is_some_and(|shard_index| shard_index < num_shards));
 }
 
 #[test]
 fn test_no_fallback_only_chunk_when_epoch_shorter_than_shard_count() {
-    assert!((1000..1010).all(|height| !is_fallback_only_height_for_shard_index(
-        5,
-        0,
-        6,
-        0,
-        height,
-        height - 1
-    )));
+    assert!(
+        (1000..1010).all(|height| fallback_only_shard_index(5, 0, 6, height, height - 1).is_none())
+    );
 }
 
 #[test]
@@ -543,45 +532,13 @@ fn grow_chain_to_fallback_only_block(chain: &mut Chain, bound: usize) -> (Arc<Bl
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_recorded_chunk_info_marks_the_scheduled_shard_fallback_only() {
-    let (mut chain, core_reader) = setup();
-    let (fallback_only_block, fallback_only_shard) =
-        grow_chain_to_fallback_only_block(&mut chain, 40);
-    let fallback_only_chunks: Vec<_> = core_reader
-        .get_uncertified_chunks(fallback_only_block.hash())
-        .unwrap()
-        .into_iter()
-        .filter(|chunk_info| chunk_info.is_fallback_only)
-        .map(|chunk_info| chunk_info.chunk_id)
-        .collect();
-    assert_eq!(
-        fallback_only_chunks,
-        vec![SpiceChunkId {
-            block_hash: *fallback_only_block.hash(),
-            shard_id: fallback_only_shard
-        }]
-    );
-}
-
-#[test]
-#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_fallback_only_mark_survives_in_later_blocks() {
-    let (mut chain, core_reader) = setup();
-    let (fallback_only_block, fallback_only_shard) =
-        grow_chain_to_fallback_only_block(&mut chain, 40);
-    let scheduled =
-        SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id: fallback_only_shard };
-
-    let later = advance_to_height(
-        &mut chain,
-        &fallback_only_block,
-        fallback_only_block.header().height() + 3,
-    );
-
-    let still_marked = core_reader
-        .get_uncertified_chunks(later.hash())
-        .unwrap()
-        .into_iter()
-        .any(|chunk_info| chunk_info.chunk_id == scheduled && chunk_info.is_fallback_only);
-    assert!(still_marked, "the mark was lost when the chunk was carried forward");
+fn test_schedule_fires_at_a_slot_boundary_on_a_real_chain() {
+    let (mut chain, _core_reader) = setup();
+    let epoch_id = chain.epoch_manager.get_epoch_id(chain.genesis_block().hash()).unwrap();
+    let epoch_length = chain.epoch_manager.get_epoch_config(&epoch_id).unwrap().epoch_length;
+    let num_shards = chain.epoch_manager.get_shard_layout(&epoch_id).unwrap().num_shards();
+    let blocks_between = epoch_length / num_shards;
+    let (fallback_only_block, _) =
+        grow_chain_to_fallback_only_block(&mut chain, epoch_length as usize);
+    assert_eq!(fallback_only_block.header().height() % blocks_between, 0);
 }

--- a/chain/chain/src/spice/tests/all_stake_fallback.rs
+++ b/chain/chain/src/spice/tests/all_stake_fallback.rs
@@ -429,30 +429,23 @@ fn test_fallback_eligible_when_one_block_certifies_several_blocks() {
 const FALLBACK_ONLY_SCHEDULE_EPOCH_LENGTH: BlockHeightDelta = 400;
 const FALLBACK_ONLY_SCHEDULE_NUM_SHARDS: usize = 4;
 
-/// The heights at which `shard_index` takes a slot, walking `heights` as a chain: each block's
-/// parent is the entry before it.
+/// The heights in `heights` at which `shard_index` takes a slot.
 fn fallback_only_heights(
     epoch_height: EpochHeight,
     shard_index: usize,
     heights: impl IntoIterator<Item = BlockHeight>,
 ) -> Vec<BlockHeight> {
-    let mut slots = Vec::new();
-    let mut parent = None;
-    for height in heights {
-        let prev_height = parent.unwrap_or_else(|| height.saturating_sub(1));
-        if fallback_only_shard_index(
-            FALLBACK_ONLY_SCHEDULE_EPOCH_LENGTH,
-            epoch_height,
-            FALLBACK_ONLY_SCHEDULE_NUM_SHARDS,
-            height,
-            prev_height,
-        ) == Some(shard_index)
-        {
-            slots.push(height);
-        }
-        parent = Some(height);
-    }
-    slots
+    heights
+        .into_iter()
+        .filter(|height| {
+            fallback_only_shard_index(
+                FALLBACK_ONLY_SCHEDULE_EPOCH_LENGTH,
+                epoch_height,
+                FALLBACK_ONLY_SCHEDULE_NUM_SHARDS,
+                *height,
+            ) == Some(shard_index)
+        })
+        .collect()
 }
 
 #[test]
@@ -480,29 +473,19 @@ fn test_schedule_picks_one_shard_at_the_maximum_height() {
         EpochHeight::MAX,
         num_shards,
         BlockHeight::MAX,
-        BlockHeight::MAX - 1,
     );
     assert!(scheduled.is_some_and(|shard_index| shard_index < num_shards));
 }
 
 #[test]
 fn test_no_fallback_only_chunk_when_epoch_shorter_than_shard_count() {
-    assert!(
-        (1000..1010).all(|height| fallback_only_shard_index(5, 0, 6, height, height - 1).is_none())
-    );
+    assert!((1000..1010).all(|height| fallback_only_shard_index(5, 0, 6, height).is_none()));
 }
 
 #[test]
-fn test_a_skipped_height_delays_a_slot_instead_of_dropping_it() {
+fn test_a_skipped_slot_height_drops_the_slot() {
     let without_the_slot_height = (1000..1400).filter(|height| *height != 1200);
-    assert_eq!(fallback_only_heights(0, 0, without_the_slot_height), vec![1201]);
-}
-
-#[test]
-fn test_a_gap_past_the_next_slot_drops_the_slots_inside_it() {
-    let long_gap = (1000..1400).filter(|height| !(1150..1350).contains(height));
-    assert_eq!(fallback_only_heights(0, 0, long_gap.clone()), Vec::<BlockHeight>::new());
-    assert_eq!(fallback_only_heights(0, 1, long_gap), vec![1350]);
+    assert_eq!(fallback_only_heights(0, 0, without_the_slot_height), Vec::<BlockHeight>::new());
 }
 
 // Walks the chain until a block carries a fallback-only chunk. Each step certifies the block two

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -2065,7 +2065,6 @@ fn uncertified_chunk_info(block_hash: CryptoHash, shard_id: ShardId) -> SpiceUnc
         present_endorsements: vec![],
         present_fallback_endorsements: vec![],
         certifiable_since_height: None,
-        is_fallback_only: false,
     }
 }
 

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -1885,7 +1885,7 @@ pub(super) fn process_block(chain: &mut Chain, block: Arc<Block>) {
     .unwrap();
 }
 
-fn endorse_chunk(
+pub(super) fn endorse_chunk(
     chain: &Chain,
     core_writer_actor: &mut SpiceCoreWriterActor,
     chunk_id: &SpiceChunkId,

--- a/chain/chain/src/spice/tests/core.rs
+++ b/chain/chain/src/spice/tests/core.rs
@@ -2065,6 +2065,7 @@ fn uncertified_chunk_info(block_hash: CryptoHash, shard_id: ShardId) -> SpiceUnc
         present_endorsements: vec![],
         present_fallback_endorsements: vec![],
         certifiable_since_height: None,
+        is_fallback_only: false,
     }
 }
 

--- a/chain/chain/src/spice/tests/core_writer_actor.rs
+++ b/chain/chain/src/spice/tests/core_writer_actor.rs
@@ -2,6 +2,10 @@ use crate::spice::core::SpiceCoreReader;
 use crate::spice::core_writer_actor::{
     ExecutionResultEndorsed, InvalidSpiceEndorsementError, ProcessChunkError, SpiceCoreWriterActor,
 };
+use crate::spice::tests::all_stake_fallback::{
+    grow_chain_to_fallback_only_block, split_designated, validators_with_minority_designated_stake,
+};
+use crate::spice::tests::core::endorse_chunk;
 use crate::test_utils::{
     get_chain_with_genesis, get_fake_next_block_chunk_headers, process_block_sync,
 };
@@ -841,4 +845,59 @@ fn find_irrelevant_validator(
         })
         .unwrap();
     irrelevant_validator.clone()
+}
+
+// Checks the writer reads the fallback-only flag from the chunk's own block instead of from the
+// head's uncertified chunks, which never list a chunk whose block is off the head's chain.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_designated_endorsements_do_not_certify_a_fallback_only_chunk_off_the_head_chain() {
+    // Enough validators that a chunk's designated assignment stays under 2/3 of total stake,
+    // asserted below.
+    let validators = validators_with_minority_designated_stake();
+    let validators_spec =
+        ValidatorsSpec::desired_roles(&validators.iter().map(|v| v.as_str()).collect_vec(), &[]);
+    let genesis = TestGenesisBuilder::new()
+        .genesis_time_from_clock(&Clock::real())
+        .shard_layout(ShardLayout::multi_shard(3, 0))
+        .validators_spec(validators_spec)
+        .build();
+    let (mut chain, mut core_writer_actor) = setup_with_genesis(genesis);
+
+    let (fallback_only_block, shard_id) = grow_chain_to_fallback_only_block(&mut chain, 40);
+    let parent = chain.chain_store().get_block(fallback_only_block.header().prev_hash()).unwrap();
+
+    // A longer branch off the same parent takes the head.
+    let fork_block = build_block(&mut chain, &parent, vec![]);
+    process_block(&mut chain, fork_block.clone());
+    let fork_tip = build_block(&mut chain, &fork_block, vec![]);
+    process_block(&mut chain, fork_tip.clone());
+    let head = chain.chain_store().head().unwrap();
+    assert_eq!(head.last_block_hash, *fork_tip.hash());
+    let chunk_id = SpiceChunkId { block_hash: *fallback_only_block.hash(), shard_id };
+    assert!(
+        core_writer_actor
+            .core_reader
+            .uncertified_chunk_info(&head.last_block_hash, &chunk_id)
+            .unwrap()
+            .is_none(),
+        "the chunk should be absent from the head's uncertified set",
+    );
+
+    // Every designated validator endorses. Only 2/3 of total stake may certify a fallback-only
+    // chunk, and the designated set alone is below that, so nothing should be stored.
+    let chunks = fallback_only_block.chunks();
+    let chunk_header =
+        chunks.iter_raw().find(|chunk| chunk.shard_id() == shard_id).unwrap().clone();
+    drop(chunks);
+    let (designated, _) =
+        split_designated(&chain, &fallback_only_block, &chunk_header, &validators);
+    let designated: Vec<String> = designated.iter().map(|account| account.to_string()).collect();
+    endorse_chunk(&chain, &mut core_writer_actor, &chunk_id, &designated);
+
+    let execution_results = core_writer_actor
+        .core_reader
+        .get_execution_results_by_shard_id(fallback_only_block.header())
+        .unwrap();
+    assert_eq!(execution_results.get(&shard_id), None);
 }

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -1114,7 +1114,7 @@ impl SpiceDataDistributorActor {
                 if chunk_info.is_fallback_only {
                     // Eligible from its own block, before we applied the chunk that produces the
                     // witness. Later blocks retry.
-                    tracing::debug!(target: "spice_data_distribution", ?data_id, "witness for the fallback-only chunk is not applied yet");
+                    tracing::debug!(target: "spice_data_distribution", ?data_id, "witness for the fallback-only chunk not yet produced - chunk not applied");
                 } else {
                     tracing::warn!(target: "spice_data_distribution", ?data_id, "no witness to push for the all-stake fallback");
                 }

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -23,7 +23,9 @@ use near_chain::Block;
 use near_chain::spice::activation::{
     SpiceMessageGate, SpiceMessageKind, spice_enabled_at_head_on_startup, spice_enabled_for_block,
 };
-use near_chain::spice::all_stake_fallback::{fallback_eligible, fallback_endorsers};
+use near_chain::spice::all_stake_fallback::{
+    fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
+};
 use near_chain::spice::core::SpiceCoreReader;
 use near_chain::spice::core_writer_actor::ProcessedBlock;
 use near_chain::stateless_validation::metrics::PROCESS_CONTRACT_CODE_REQUEST_TIME;
@@ -1012,10 +1014,15 @@ impl SpiceDataDistributorActor {
 
         for chunk_info in self.core_reader.get_uncertified_chunks(block_hash)? {
             let chunk_id = &chunk_info.chunk_id;
-            if !fallback_eligible(carrying_height, &chunk_info) {
+            let chunk_block = self.chain_store.get_block(&chunk_id.block_hash)?;
+            if !fallback_eligible(
+                self.epoch_manager.as_ref(),
+                chunk_block.header(),
+                &chunk_info,
+                carrying_height,
+            )? {
                 continue;
             }
-            let chunk_block = self.chain_store.get_block(&chunk_id.block_hash)?;
             let epoch_id = chunk_block.header().epoch_id();
             if self.epoch_manager.get_validator_by_account_id(epoch_id, me).is_err() {
                 continue;
@@ -1078,17 +1085,22 @@ impl SpiceDataDistributorActor {
 
         for chunk_info in &uncertified_chunks {
             let chunk_id = &chunk_info.chunk_id;
-            if !fallback_eligible(carrying_height, chunk_info) {
+            if self.pushed_fallback_witnesses.contains(chunk_id) {
                 continue;
             }
-            if self.pushed_fallback_witnesses.contains(chunk_id) {
+            let chunk_block = self.chain_store.get_block(&chunk_id.block_hash)?;
+            if !fallback_eligible(
+                self.epoch_manager.as_ref(),
+                chunk_block.header(),
+                chunk_info,
+                carrying_height,
+            )? {
                 continue;
             }
             let data_id = SpiceDataIdentifier::Witness {
                 block_hash: chunk_id.block_hash,
                 shard_id: chunk_id.shard_id,
             };
-            let chunk_block = self.chain_store.get_block(&chunk_id.block_hash)?;
             // The designated recipients of the initial distribution are not needed here:
             // fallback_endorsers already excludes every designated validator.
             let (_, producers) = self.recipients_and_producers(&data_id, &chunk_block)?;
@@ -1111,7 +1123,11 @@ impl SpiceDataDistributorActor {
             }
             let Some(mut distribution_data) = self.get_distribution_data(&data_id, producers.len())
             else {
-                if chunk_info.is_fallback_only {
+                if is_fallback_only_chunk(
+                    self.epoch_manager.as_ref(),
+                    chunk_block.header(),
+                    chunk_id.shard_id,
+                )? {
                     // Eligible from its own block, before we applied the chunk that produces the
                     // witness. Later blocks retry.
                     tracing::debug!(target: "spice_data_distribution", ?data_id, "witness for the fallback-only chunk not yet produced - chunk not applied");

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -1111,7 +1111,13 @@ impl SpiceDataDistributorActor {
             }
             let Some(mut distribution_data) = self.get_distribution_data(&data_id, producers.len())
             else {
-                tracing::warn!(target: "spice_data_distribution", ?data_id, "no witness to push for the all-stake fallback");
+                if chunk_info.is_fallback_only {
+                    // Eligible from its own block, before we applied the chunk that produces the
+                    // witness. Later blocks retry.
+                    tracing::debug!(target: "spice_data_distribution", ?data_id, "witness for the fallback-only chunk is not applied yet");
+                } else {
+                    tracing::warn!(target: "spice_data_distribution", ?data_id, "no witness to push for the all-stake fallback");
+                }
                 continue;
             };
             let my_part = distribution_data.parts.swap_remove(my_producer_index);

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -3279,25 +3279,31 @@ fn test_witness_is_pushed_only_once() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_fallback_only_witness_is_pushed_without_waiting_for_the_delay() {
+fn test_fallback_only_witness_is_pushed_on_the_block_after_the_witness_is_saved() {
     // More validators than mandates per shard, so some are outside every chunk's designated set.
     let (_genesis, mut chain) = setup(2, 100);
     let chunk_id = grow_chain_to_fallback_only_chunk(&mut chain);
-    let witness = save_test_witness_for_chunk(&chain, &chunk_id);
 
-    let head_block = latest_block(&chain);
+    let chunk_block = latest_block(&chain);
     let producer = chain
         .epoch_manager
-        .get_epoch_chunk_producers_for_shard(head_block.header().epoch_id(), chunk_id.shard_id)
+        .get_epoch_chunk_producers_for_shard(chunk_block.header().epoch_id(), chunk_id.shard_id)
         .unwrap()
         .swap_remove(0);
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
-    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+    // A scheduled chunk is eligible on its own block, but its witness only exists once the
+    // producer applies the chunk, which needs the previous block certified.
+    actor.handle(ProcessedBlock { block_hash: *chunk_block.hash() });
+    assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
+
+    let witness = save_test_witness_for_chunk(&chain, &chunk_id);
+    let next_block = produce_block(&mut chain, &chunk_block);
+    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
 
     let mut pushes = drain_outgoing_partial_data(&mut outgoing_rc);
-    assert_eq!(pushes.len(), 1, "the scheduled chunk's witness was not pushed on its own block");
+    assert_eq!(pushes.len(), 1, "the push was not retried once the witness was saved");
     let (partial_data, recipients) = pushes.swap_remove(0);
     assert_eq!(partial_data.block_hash(), &witness.chunk_id().block_hash);
     assert_eq!(recipients, fallback_witness_recipients(&chain, &chunk_id));
@@ -3353,6 +3359,70 @@ fn pushed_witness_data(chain: &Chain, chunk_id: &SpiceChunkId) -> SpicePartialDa
     incoming.data
 }
 
+/// Processes into `chain` every block of `source` up to and including `target`.
+fn catch_up_to(chain: &mut Chain, source: &Chain, target: &Block) {
+    let mut blocks = Vec::new();
+    let mut block = source.chain_store.get_block(target.hash()).unwrap();
+    while !chain.chain_store.block_exists(block.hash()) {
+        blocks.push(block.clone());
+        block = source.chain_store.get_block(block.header().prev_hash()).unwrap();
+    }
+    for block in blocks.into_iter().rev() {
+        process_block_sync(
+            chain,
+            block.into(),
+            Provenance::PRODUCED,
+            &mut BlockProcessingArtifact::default(),
+        )
+        .unwrap();
+    }
+}
+
+/// The non-designated validator the fallback push for `chunk_id` targets.
+fn fallback_witness_recipient(chain: &Chain, chunk_id: &SpiceChunkId) -> AccountId {
+    fallback_witness_recipients(chain, chunk_id)
+        .into_iter()
+        .sorted()
+        .next()
+        .expect("no non-designated validator; increase the validator count")
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_pushed_fallback_only_witness_waits_for_its_block_to_arrive() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (genesis, mut chain) = setup(2, 100);
+    // Cloned before the chunk block exists, so this receiver lags behind the push below.
+    let mut receiver_chain = new_chain(&chain, &genesis);
+
+    let chunk_id = grow_chain_to_fallback_only_chunk(&mut chain);
+    let data = pushed_witness_data(&chain, &chunk_id);
+    let validator = fallback_witness_recipient(&chain, &chunk_id);
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &receiver_chain, &validator);
+
+    // A scheduled chunk is eligible on its own block, so the push can reach a receiver that does
+    // not have that block yet. The parts wait for it rather than being refused.
+    actor.handle(SpiceIncomingPartialData { data, recv_permit: RecvMessagePermit::none() });
+    assert_eq!(actor.pending_partial_data_size(), 1);
+    assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
+
+    let chunk_block = chain.chain_store.get_block(&chunk_id.block_hash).unwrap();
+    catch_up_to(&mut receiver_chain, &chain, &chunk_block);
+    actor.handle(ProcessedBlock { block_hash: *chunk_block.hash() });
+
+    let message = outgoing_rc.try_recv().unwrap();
+    let OutgoingMessage::ChunkStateWitnessMessage(SpiceChunkStateWitnessMessage {
+        witness, ..
+    }) = message
+    else {
+        panic!("expected the pushed witness to be reassembled");
+    };
+    assert_eq!(witness.chunk_id(), &chunk_id);
+    assert_eq!(actor.pending_partial_data_size(), 0);
+}
+
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_pushed_fallback_witness_is_kept_when_head_is_within_the_lookahead() {
@@ -3364,11 +3434,7 @@ fn test_pushed_fallback_witness_is_kept_when_head_is_within_the_lookahead() {
     let chunk_id =
         grow_chain_toward_fallback_opening(&mut chain, shard_id, FALLBACK_WITNESS_PUSH_LOOKAHEAD);
     let data = pushed_witness_data(&chain, &chunk_id);
-    let validator = fallback_witness_recipients(&chain, &chunk_id)
-        .into_iter()
-        .sorted()
-        .next()
-        .expect("no non-designated validator; increase the validator count");
+    let validator = fallback_witness_recipient(&chain, &chunk_id);
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);
@@ -3396,11 +3462,7 @@ fn test_pushed_fallback_witness_is_dropped_when_head_is_beyond_the_lookahead() {
         FALLBACK_WITNESS_PUSH_LOOKAHEAD + 1,
     );
     let data = pushed_witness_data(&chain, &chunk_id);
-    let validator = fallback_witness_recipients(&chain, &chunk_id)
-        .into_iter()
-        .sorted()
-        .next()
-        .expect("no non-designated validator; increase the validator count");
+    let validator = fallback_witness_recipient(&chain, &chunk_id);
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -3176,11 +3176,11 @@ fn grow_chain_to_fallback_only_chunk(chain: &mut Chain) -> SpiceChunkId {
     for _ in 0..100 {
         let block = produce_block(chain, &latest_block(chain));
         let chunks = block.chunks();
-        let scheduled = chunks.iter_raw().find(|chunk| {
+        let fallback_only = chunks.iter_raw().find(|chunk| {
             is_fallback_only_chunk(chain.epoch_manager.as_ref(), block.header(), chunk.shard_id())
                 .unwrap()
         });
-        if let Some(chunk) = scheduled {
+        if let Some(chunk) = fallback_only {
             return SpiceChunkId { block_hash: *block.hash(), shard_id: chunk.shard_id() };
         }
     }
@@ -3293,7 +3293,7 @@ fn test_fallback_only_witness_is_pushed_on_the_block_after_the_witness_is_saved(
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
-    // A scheduled chunk is eligible on its own block, but its witness only exists once the
+    // A fallback-only chunk is eligible on its own block, but its witness only exists once the
     // producer applies the chunk, which needs the previous block certified.
     actor.handle(ProcessedBlock { block_hash: *chunk_block.hash() });
     assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
@@ -3402,8 +3402,8 @@ fn test_pushed_fallback_only_witness_waits_for_its_block_to_arrive() {
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &receiver_chain, &validator);
 
-    // A scheduled chunk is eligible on its own block, so the push can reach a receiver that does
-    // not have that block yet. The parts wait for it rather than being refused.
+    // A fallback-only chunk is eligible on its own block, so the push can reach a receiver that
+    // does not have that block yet. The parts wait for it rather than being refused.
     actor.handle(SpiceIncomingPartialData { data, recv_permit: RecvMessagePermit::none() });
     assert_eq!(actor.pending_partial_data_size(), 1);
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -17,7 +17,7 @@ use near_chain::Block;
 use near_chain::ChainStoreAccess;
 use near_chain::spice::activation::SpiceMessageKind;
 use near_chain::spice::all_stake_fallback::{
-    SPICE_FALLBACK_CERTIFICATION_DELAY, fallback_endorsers,
+    SPICE_FALLBACK_CERTIFICATION_DELAY, fallback_endorsers, is_fallback_only_chunk,
 };
 use near_chain::spice::core::SpiceCoreReader;
 use near_chain::spice::core_writer_actor::{ProcessedBlock, SpiceCoreWriterActor};
@@ -3171,6 +3171,22 @@ fn save_test_witness_for_chunk(chain: &Chain, chunk_id: &SpiceChunkId) -> SpiceC
     witness
 }
 
+/// The chain's first chunk that the schedule marks fallback-only.
+fn grow_chain_to_fallback_only_chunk(chain: &mut Chain) -> SpiceChunkId {
+    for _ in 0..100 {
+        let block = produce_block(chain, &latest_block(chain));
+        let chunks = block.chunks();
+        let scheduled = chunks.iter_raw().find(|chunk| {
+            is_fallback_only_chunk(chain.epoch_manager.as_ref(), block.header(), chunk.shard_id())
+                .unwrap()
+        });
+        if let Some(chunk) = scheduled {
+            return SpiceChunkId { block_hash: *block.hash(), shard_id: chunk.shard_id() };
+        }
+    }
+    panic!("no fallback-only chunk within 100 blocks");
+}
+
 /// What the push targets: the fallback endorsers of `chunk_id`, less its producers, who already
 /// hold the witness.
 fn fallback_witness_recipients(chain: &Chain, chunk_id: &SpiceChunkId) -> HashSet<AccountId> {
@@ -3259,6 +3275,32 @@ fn test_witness_is_pushed_only_once() {
     let next_block = produce_block(&mut chain, &head_block);
     actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
     assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_fallback_only_witness_is_pushed_without_waiting_for_the_delay() {
+    // More validators than mandates per shard, so some are outside every chunk's designated set.
+    let (_genesis, mut chain) = setup(2, 100);
+    let chunk_id = grow_chain_to_fallback_only_chunk(&mut chain);
+    let witness = save_test_witness_for_chunk(&chain, &chunk_id);
+
+    let head_block = latest_block(&chain);
+    let producer = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(head_block.header().epoch_id(), chunk_id.shard_id)
+        .unwrap()
+        .swap_remove(0);
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
+    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+
+    let mut pushes = drain_outgoing_partial_data(&mut outgoing_rc);
+    assert_eq!(pushes.len(), 1, "the scheduled chunk's witness was not pushed on its own block");
+    let (partial_data, recipients) = pushes.swap_remove(0);
+    assert_eq!(partial_data.block_hash(), &witness.chunk_id().block_hash);
+    assert_eq!(recipients, fallback_witness_recipients(&chain, &chunk_id));
 }
 
 #[test]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1481,9 +1481,6 @@ pub struct SpiceUncertifiedChunkInfo {
     /// designated validators could act. Set once, then carried forward. The all-stake fallback
     /// opens `SPICE_FALLBACK_CERTIFICATION_DELAY` blocks later.
     pub certifiable_since_height: Option<BlockHeight>,
-    /// Whether the epoch's schedule picked this chunk to certify only via the all-stake fallback,
-    /// never via its designated assignment. Resolved once when the chunk is first recorded.
-    pub is_fallback_only: bool,
 }
 
 impl SpiceUncertifiedChunkInfo {

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1481,6 +1481,9 @@ pub struct SpiceUncertifiedChunkInfo {
     /// designated validators could act. Set once, then carried forward. The all-stake fallback
     /// opens `SPICE_FALLBACK_CERTIFICATION_DELAY` blocks later.
     pub certifiable_since_height: Option<BlockHeight>,
+    /// Whether the epoch's schedule picked this chunk to certify only via the all-stake fallback,
+    /// never via its designated assignment. Resolved once when the chunk is first recorded.
+    pub is_fallback_only: bool,
 }
 
 impl SpiceUncertifiedChunkInfo {

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -1,5 +1,6 @@
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::drop_condition::DropCondition;
+use crate::setup::env::TestLoopEnv;
 use crate::utils::account::create_account_id;
 use crate::utils::node::TestLoopNode;
 use itertools::Itertools;
@@ -406,6 +407,29 @@ fn assert_certified_by_all_stake(
     );
 }
 
+/// Runs to `epoch_length`, then asserts every chunk the schedule marked fallback-only over that
+/// span certified through the all-stake path.
+fn assert_every_fallback_only_chunk_certifies(
+    env: &mut TestLoopEnv,
+    epoch_length: BlockHeightDelta,
+) {
+    // The schedule is read off block headers, so the blocks have to exist first.
+    env.node_runner(0).run_until_head_height(epoch_length);
+    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
+    assert_eq!(
+        fallback_schedule.len() as u64,
+        NUM_SHARDS,
+        "one slot per shard over the first epoch_length blocks"
+    );
+
+    // The schedule is ascending, so certifying the last entry means every one of them is certified.
+    let (last_height, _) = *fallback_schedule.last().unwrap();
+    env.node_runner(0).run_until_certified(last_height);
+    for &(chunk_height, shard_id) in &fallback_schedule {
+        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
+    }
+}
+
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn slow_test_spice_fallback_only_chunk_certifies_on_a_healthy_network() {
@@ -422,21 +446,7 @@ fn slow_test_spice_fallback_only_chunk_certifies_on_a_healthy_network() {
         .clients(accounts)
         .build();
 
-    // The schedule is read off block headers, so the blocks have to exist first.
-    env.node_runner(0).run_until_head_height(epoch_length);
-    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
-    assert_eq!(
-        fallback_schedule.len() as u64,
-        NUM_SHARDS,
-        "one slot per shard over the first epoch_length blocks"
-    );
-
-    // The schedule is ascending, so certifying the last entry means every one of them is certified.
-    let (last_height, _) = *fallback_schedule.last().unwrap();
-    env.node_runner(0).run_until_certified(last_height);
-    for &(chunk_height, shard_id) in &fallback_schedule {
-        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
-    }
+    assert_every_fallback_only_chunk_certifies(&mut env, epoch_length);
 }
 
 #[test]
@@ -459,19 +469,7 @@ fn slow_test_spice_fallback_only_chunk_certifies_when_execution_lags() {
     env.delay_endorsements_propagation(execution_delay);
     let mut env = env.warmup();
 
-    env.node_runner(0).run_until_head_height(epoch_length);
-    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
-    assert_eq!(
-        fallback_schedule.len() as u64,
-        NUM_SHARDS,
-        "one slot per shard over the first epoch_length blocks"
-    );
-
-    let (last_height, _) = *fallback_schedule.last().unwrap();
-    env.node_runner(0).run_until_certified(last_height);
-    for &(chunk_height, shard_id) in &fallback_schedule {
-        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
-    }
+    assert_every_fallback_only_chunk_certifies(&mut env, epoch_length);
 }
 
 #[test]
@@ -491,17 +489,5 @@ fn slow_test_spice_fallback_only_chunk_certifies_when_validators_track_all_shard
         .track_all_shards()
         .build();
 
-    env.node_runner(0).run_until_head_height(epoch_length);
-    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
-    assert_eq!(
-        fallback_schedule.len() as u64,
-        NUM_SHARDS,
-        "one slot per shard over the first epoch_length blocks"
-    );
-
-    let (last_height, _) = *fallback_schedule.last().unwrap();
-    env.node_runner(0).run_until_certified(last_height);
-    for &(chunk_height, shard_id) in &fallback_schedule {
-        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
-    }
+    assert_every_fallback_only_chunk_certifies(&mut env, epoch_length);
 }

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -415,7 +415,7 @@ fn slow_test_spice_fallback_only_chunk_certifies_on_a_healthy_network() {
     let (accounts, genesis, epoch_config_store) =
         FallbackSetup::new().epoch_length(epoch_length).build();
     // Unlike the outage tests above, no endorsements are dropped: the all-stake path runs because
-    // the chunk is scheduled, not because the designated set went missing.
+    // the chunk is fallback-only, not because the designated set went missing.
     let mut env = TestLoopBuilder::new()
         .genesis(genesis)
         .epoch_config_store(epoch_config_store)

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -4,7 +4,9 @@ use crate::utils::account::create_account_id;
 use crate::utils::node::TestLoopNode;
 use itertools::Itertools;
 use near_async::time::Duration;
-use near_chain::spice::all_stake_fallback::all_stake_fallback_assignment;
+use near_chain::spice::all_stake_fallback::{
+    SPICE_FALLBACK_CERTIFICATION_DELAY, all_stake_fallback_assignment, is_fallback_only_chunk,
+};
 use near_chain_configs::Genesis;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_o11y::testonly::init_test_logger;
@@ -13,11 +15,18 @@ use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::gas::Gas;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::{AccountId, AccountInfo, Balance, BlockHeightDelta};
+use near_primitives::types::{
+    AccountId, AccountInfo, Balance, BlockHeight, BlockHeightDelta, NumShards, ShardId,
+    SpiceChunkId,
+};
 use std::collections::HashSet;
 
+/// Shards in [`FallbackSetup`].
+const NUM_SHARDS: NumShards = 6;
+
 /// Genesis, epoch config, and client accounts for the fallback tests: 14 equal-stake validators
-/// over 6 shards with 2 mandates each, keeping each chunk's designated subset under 1/3 of stake.
+/// over `NUM_SHARDS` shards with 2 mandates each, keeping each chunk's designated subset under 1/3
+/// of stake.
 #[derive(Default)]
 struct FallbackSetup {
     epoch_length: Option<BlockHeightDelta>,
@@ -56,7 +65,7 @@ impl FallbackSetup {
             ValidatorsSpec::raw(all_validators, num_producers, num_producers, num_validators);
 
         let mut genesis_builder = TestLoopBuilder::new_genesis_builder()
-            .shard_layout(ShardLayout::multi_shard(6, 0))
+            .shard_layout(ShardLayout::multi_shard(NUM_SHARDS, 0))
             .validators_spec(validators_spec);
         if let Some(epoch_length) = self.epoch_length {
             genesis_builder = genesis_builder.epoch_length(epoch_length);
@@ -304,4 +313,163 @@ fn slow_test_spice_all_stake_fallback_certifies_chunk_accessing_contract_code() 
     );
     let frontier = env.rpc_node().last_certified_block_header();
     assert_certified_via_fallback(&env.rpc_node(), frontier.as_ref());
+}
+
+fn fallback_only_certification_schedule(
+    node: &TestLoopNode,
+    from_height: BlockHeight,
+    to_height: BlockHeight,
+) -> Vec<(BlockHeight, ShardId)> {
+    let client = node.client();
+    let chain_store = client.chain.chain_store();
+    let epoch_manager = client.epoch_manager.as_ref();
+    let mut fallback_schedule = Vec::new();
+    for height in from_height..=to_height {
+        let block = node.block(chain_store.get_block_hash_by_height(height).unwrap());
+        let shard_layout = epoch_manager.get_shard_layout(block.header().epoch_id()).unwrap();
+        for shard_id in shard_layout.shard_ids() {
+            if is_fallback_only_chunk(epoch_manager, block.header(), shard_id).unwrap() {
+                fallback_schedule.push((height, shard_id));
+            }
+        }
+    }
+    fallback_schedule
+}
+
+/// The height of the block carrying `chunk_id`'s execution result, with every account that endorsed
+/// the chunk on chain up to and including it.
+fn certifying_height_and_endorsers(
+    node: &TestLoopNode,
+    chunk_id: &SpiceChunkId,
+) -> Option<(BlockHeight, HashSet<AccountId>)> {
+    let chain_store = node.client().chain.chain_store();
+    let chunk_height = chain_store.get_block_header(&chunk_id.block_hash).unwrap().height();
+    let mut endorsers = HashSet::new();
+    for height in chunk_height..=node.head().height {
+        let Ok(block_hash) = chain_store.get_block_hash_by_height(height) else {
+            continue;
+        };
+        let block = node.block(block_hash);
+        endorsers.extend(
+            block
+                .spice_core_statements()
+                .iter_endorsements()
+                .filter(|endorsement| endorsement.chunk_id() == chunk_id)
+                .map(|endorsement| endorsement.account_id().clone()),
+        );
+        if block.spice_core_statements().iter_execution_results().any(|(id, _)| id == chunk_id) {
+            return Some((height, endorsers));
+        }
+    }
+    None
+}
+
+/// Asserts the chunk certified with non-designated validators endorsing it on chain. An ordinary
+/// chunk never admits those on a healthy network: it is not fallback-eligible until it has been
+/// stuck for the full window.
+fn assert_certified_by_all_stake(
+    node: &TestLoopNode,
+    chunk_height: BlockHeight,
+    shard_id: ShardId,
+) {
+    let client = node.client();
+    let chain_store = client.chain.chain_store();
+    let epoch_manager = client.epoch_manager.as_ref();
+    let chunk_block_hash = chain_store.get_block_hash_by_height(chunk_height).unwrap();
+    let chunk_id = SpiceChunkId { block_hash: chunk_block_hash, shard_id };
+    let chunk_block = chain_store.get_block_header(&chunk_block_hash).unwrap();
+
+    // The designated set alone must fall short of 2/3 of total stake, or the chunk could certify
+    // before any non-designated endorsement lands. This is the 2/3 form, not the 1/3 form
+    // `assert_fallback_has_enough_stake` checks for the outage tests.
+    let designated = epoch_manager
+        .get_chunk_validator_assignments(chunk_block.epoch_id(), shard_id, chunk_height)
+        .unwrap();
+    let all_stake = all_stake_fallback_assignment(epoch_manager, chunk_block.epoch_id()).unwrap();
+    let designated_accounts: HashSet<AccountId> =
+        designated.assignments().iter().map(|(account_id, _)| account_id.clone()).collect();
+    assert!(!all_stake.is_endorsed(&designated_accounts));
+
+    let (certifying_height, endorsers) = certifying_height_and_endorsers(node, &chunk_id)
+        .unwrap_or_else(|| panic!("fallback-only chunk {chunk_id:?} was not certified"));
+    // Inside the ordinary fallback window, so the schedule opened the all-stake path rather than
+    // the chunk sitting stuck long enough for the normal one to open.
+    let delay = certifying_height - chunk_height;
+    assert!(
+        delay < SPICE_FALLBACK_CERTIFICATION_DELAY,
+        "fallback-only chunk {chunk_id:?} took {delay} blocks, no better than the ordinary window",
+    );
+
+    assert!(
+        endorsers.iter().any(|account_id| !designated.contains(account_id)),
+        "fallback-only chunk {chunk_id:?} has only designated endorsers on chain",
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_fallback_only_chunk_certifies_on_a_healthy_network() {
+    init_test_logger();
+
+    let epoch_length = 25;
+    let (accounts, genesis, epoch_config_store) =
+        FallbackSetup::new().epoch_length(epoch_length).build();
+    // Unlike the outage tests above, no endorsements are dropped: the all-stake path runs because
+    // the chunk is scheduled, not because the designated set went missing.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .build();
+
+    // The schedule is read off block headers, so the blocks have to exist first.
+    env.node_runner(0).run_until_head_height(epoch_length);
+    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
+    assert_eq!(
+        fallback_schedule.len() as u64,
+        NUM_SHARDS,
+        "one slot per shard over the first epoch_length blocks"
+    );
+
+    // The schedule is ascending, so certifying the last entry means every one of them is certified.
+    let (last_height, _) = *fallback_schedule.last().unwrap();
+    env.node_runner(0).run_until_certified(last_height);
+    for &(chunk_height, shard_id) in &fallback_schedule {
+        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
+    }
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_fallback_only_chunk_certifies_when_execution_lags() {
+    init_test_logger();
+
+    let epoch_length = 25;
+    let (accounts, genesis, epoch_config_store) =
+        FallbackSetup::new().epoch_length(epoch_length).build();
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .delay_warmup()
+        .build();
+    // Holding endorsements back puts certification behind consensus, so a chunk's endorsements can
+    // reach the chain in the same block that first makes the chunk certifiable.
+    let execution_delay = 4;
+    env.delay_endorsements_propagation(execution_delay);
+    let mut env = env.warmup();
+
+    env.node_runner(0).run_until_head_height(epoch_length);
+    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
+    assert_eq!(
+        fallback_schedule.len() as u64,
+        NUM_SHARDS,
+        "one slot per shard over the first epoch_length blocks"
+    );
+
+    let (last_height, _) = *fallback_schedule.last().unwrap();
+    env.node_runner(0).run_until_certified(last_height);
+    for &(chunk_height, shard_id) in &fallback_schedule {
+        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
+    }
 }

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -473,3 +473,35 @@ fn slow_test_spice_fallback_only_chunk_certifies_when_execution_lags() {
         assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
     }
 }
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_fallback_only_chunk_certifies_when_validators_track_all_shards() {
+    init_test_logger();
+
+    let epoch_length = 25;
+    let (accounts, genesis, epoch_config_store) =
+        FallbackSetup::new().epoch_length(epoch_length).build();
+    // Every validator tracks every shard, so they apply the chunk themselves and never need the
+    // witness that gets pushed to them.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts)
+        .track_all_shards()
+        .build();
+
+    env.node_runner(0).run_until_head_height(epoch_length);
+    let fallback_schedule = fallback_only_certification_schedule(&env.node(0), 1, epoch_length);
+    assert_eq!(
+        fallback_schedule.len() as u64,
+        NUM_SHARDS,
+        "one slot per shard over the first epoch_length blocks"
+    );
+
+    let (last_height, _) = *fallback_schedule.last().unwrap();
+    env.node_runner(0).run_until_certified(last_height);
+    for &(chunk_height, shard_id) in &fallback_schedule {
+        assert_certified_by_all_stake(&env.node(0), chunk_height, shard_id);
+    }
+}


### PR DESCRIPTION
Builds on #16240 and #16242.

A scheduled chunk certifies only on 2/3 of total epoch stake. Its designated assignment is never consulted, and there is no time-based escape. This runs the all-stake fallback once per shard per epoch length on a healthy network, instead of leaving it untested until an outage.

`endorsers_certify_chunk` skips the designated threshold for such a chunk, so validation and the core writer both follow it. `fallback_eligible` returns true before the `certifiable_since_height` gate, since a scheduled chunk has no delay to wait out. Every reader derives the mark from the chunk's own block header via `fallback_only_shard`; validation caches it per chunk for the block. `missing_endorsements` and the skipped-result guard get carve-outs, since such a chunk may hold every designated endorsement and stay uncertified.

Distribution is unchanged. A scheduled chunk is fallback-eligible from its own block, so the push from #16212 fires right away, and its designated validators already hold the witness from the initial distribution. Every epoch validator ends up with it, as in a real rescue.

