### PR TITLE
feat(spice): light-client state proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4466,6 +4466,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.18",
  "time",
 ]

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -5,12 +5,12 @@ use near_primitives::network::PeerId;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, BlockReference, EpochId, EpochReference,
-    MaybeBlockId, ShardId, SpiceChunkId, TransactionOrReceiptId,
+    MaybeBlockId, ShardId, SpiceChunkId, StoreValue, TransactionOrReceiptId,
 };
 use near_primitives::views::{
     ChunkExecutionProofView, EpochSyncStatusView, ExecutionOutcomeWithIdView,
-    LightClientBlockLiteView, QueryRequest, StateChangesRequestView, StateSyncStatusView,
-    SyncStatusView, TxStatusView,
+    LightClientBlockLiteView, QueryRequest, StateChangesRequestView, StateProofTarget,
+    StateSyncStatusView, SyncStatusView, TxStatusView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 use near_time::Duration;
@@ -935,6 +935,20 @@ pub struct GetLightClientExecutionOutcomeProofResponse {
     pub outcome_proof: ExecutionOutcomeWithIdView,
 }
 
+#[derive(Debug)]
+pub struct GetLightClientStateProof {
+    pub chunk_id: SpiceChunkId,
+    pub target: StateProofTarget,
+    pub light_client_head: CryptoHash,
+}
+
+#[derive(Debug)]
+pub struct GetLightClientStateProofResponse {
+    pub chunk_execution_proof: ChunkExecutionProofView,
+    pub value: Option<StoreValue>,
+    pub state_proof: Vec<Arc<[u8]>>,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum GetLightClientProofError {
     #[error("Chunk {chunk_id:?} is not yet certified")]
@@ -957,6 +971,17 @@ pub enum GetLightClientProofError {
     UnknownTransactionOrReceipt { transaction_or_receipt_id: CryptoHash },
     #[error("Node does not track shard {shard_id}")]
     ShardNotTracked { shard_id: ShardId },
+    #[error(
+        "Account {account_id} is in shard {account_shard_id}, not the requested shard \
+         {requested_shard_id}"
+    )]
+    TargetShardMismatch {
+        account_id: AccountId,
+        account_shard_id: ShardId,
+        requested_shard_id: ShardId,
+    },
+    #[error("State for chunk {chunk_id:?} is not available on this node")]
+    StateNotAvailable { chunk_id: SpiceChunkId },
     #[error("Internal error: {error_message}")]
     InternalError { error_message: String },
 }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -23,12 +23,12 @@ pub use near_client_primitives::types::{
     GetChunkExtraExists, GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
     GetExecutionOutcomesForBlock, GetGasPrice, GetLightClientChunkExecutionProof,
     GetLightClientExecutionOutcomeProof, GetLightClientExecutionOutcomeProofResponse,
-    GetLightClientProofError, GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock,
-    GetProcessedReceiptIds, GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse,
-    GetShardChunk, GetSplitStorageInfo, GetStateChanges, GetStateChangesInBlock,
-    GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
-    GetValidatorInfo, GetValidatorOrdered, Query, QueryError, Status, StatusResponse, SyncStatus,
-    TxStatus, TxStatusError, TxStatusOutcome,
+    GetLightClientProofError, GetLightClientStateProof, GetLightClientStateProofResponse,
+    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProcessedReceiptIds,
+    GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse, GetShardChunk,
+    GetSplitStorageInfo, GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
+    GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
+    QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError, TxStatusOutcome,
 };
 pub use near_network::client::{
     BlockApproval, BlockResponse, ProcessTxRequest, ProcessTxResponse, SetNetworkInfo,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -24,7 +24,8 @@ use near_client_primitives::types::{
     GetBlockWithMerkleTree, GetChunkError, GetChunkExtraExists, GetExecutionOutcome,
     GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError,
     GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
-    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError, GetMaintenanceWindows,
+    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError,
+    GetLightClientStateProof, GetLightClientStateProofResponse, GetMaintenanceWindows,
     GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProcessedReceiptIds,
     GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError, GetReceipt,
     GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
@@ -44,18 +45,19 @@ use near_network::types::{
 };
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::epoch_info::EpochInfo;
-use near_primitives::errors::EpochError;
+use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{PartialMerkleTree, merklize};
 use near_primitives::network::AnnounceAccount;
 use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptOrigin, ReceiptToTxInfo};
 use near_primitives::shard_layout::{ShardLayout, ShardLayoutError};
 use near_primitives::sharding::ShardChunk;
+use near_primitives::state::PartialState;
 use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{
-    AccountId, BlockHeight, BlockId, BlockReference, EpochHeight, EpochId, EpochReference,
-    Finality, MaybeBlockId, ShardId, SpiceChunkId, SyncCheckpoint, TransactionOrReceiptId,
-    ValidatorInfoIdentifier, sorted_chunk_execution_roots,
+    AccountId, BlockHeight, BlockId, BlockReference, ChunkExecutionRoots, EpochHeight, EpochId,
+    EpochReference, Finality, MaybeBlockId, ShardId, SpiceChunkId, StoreValue, SyncCheckpoint,
+    TransactionOrReceiptId, ValidatorInfoIdentifier, sorted_chunk_execution_roots,
 };
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
@@ -68,6 +70,7 @@ use near_primitives::views::{
 };
 use near_store::adapter::StoreAdapter as _;
 use near_store::merkle_proof::MerkleProofAccess;
+use near_store::trie::AccessOptions;
 use near_store::{COLD_HEAD_KEY, DBCol, FINAL_HEAD_KEY, HEAD_KEY};
 use parking_lot::RwLock;
 use std::cmp::Ordering;
@@ -1771,6 +1774,76 @@ impl
             chunk_execution_proof,
             outcome_proof: outcome.into(),
         })
+    }
+}
+
+impl
+    Handler<
+        GetLightClientStateProof,
+        Result<GetLightClientStateProofResponse, GetLightClientProofError>,
+    > for ViewClientActor
+{
+    fn handle(
+        &mut self,
+        msg: GetLightClientStateProof,
+    ) -> Result<GetLightClientStateProofResponse, GetLightClientProofError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetLightClientStateProof"])
+            .start_timer();
+        let shard_id = msg.chunk_id.shard_id;
+        let chunk_block_header = self.chain.get_block_header(&msg.chunk_id.block_hash)?;
+        if !self
+            .shard_tracker
+            .cares_about_shard_checked(chunk_block_header.prev_hash(), shard_id)
+            .into_chain_error()?
+        {
+            return Err(GetLightClientProofError::ShardNotTracked { shard_id });
+        }
+        // Without this the server would answer an absent value for a target that lives in
+        // another shard, and that absence proof verifies against this chunk's state_root.
+        let account_shard_id = account_id_to_shard_id(
+            self.epoch_manager.as_ref(),
+            msg.target.account_id(),
+            chunk_block_header.epoch_id(),
+        )
+        .into_chain_error()?;
+        if account_shard_id != shard_id {
+            return Err(GetLightClientProofError::TargetShardMismatch {
+                account_id: msg.target.account_id().clone(),
+                account_shard_id,
+                requested_shard_id: shard_id,
+            });
+        }
+        let shard_uid =
+            shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, chunk_block_header.epoch_id())
+                .into_chain_error()?;
+
+        let chunk_execution_proof =
+            self.build_chunk_execution_proof(&msg.chunk_id, &msg.light_client_head)?;
+        let ChunkExecutionRoots::V1(roots) = &chunk_execution_proof.roots;
+        let state_root = roots.state_root;
+
+        let trie = self
+            .runtime
+            .get_tries()
+            .get_view_trie_for_shard(shard_uid, state_root)
+            .recording_reads_new_recorder();
+        let trie_key = msg.target.to_trie_key().to_vec();
+        let value = trie.get(&trie_key, AccessOptions::DEFAULT).map_err(|error| match error {
+            StorageError::MissingTrieValue(_) => {
+                GetLightClientProofError::StateNotAvailable { chunk_id: msg.chunk_id.clone() }
+            }
+            error => GetLightClientProofError::InternalError { error_message: error.to_string() },
+        })?;
+        let Some(partial_storage) = trie.recorded_storage() else {
+            return Err(GetLightClientProofError::InternalError {
+                error_message: "trie did not record a state proof".to_string(),
+            });
+        };
+        let PartialState::TrieValues(state_proof) = partial_storage.nodes;
+        let value = value.map(StoreValue::from);
+        Ok(GetLightClientStateProofResponse { chunk_execution_proof, value, state_proof })
     }
 }
 

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 arbitrary.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 schemars = { workspace = true, optional = true }
 thiserror.workspace = true
 time.workspace = true

--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -1,4 +1,6 @@
 use serde_json::Value;
+use serde_with::base64::Base64;
+use serde_with::serde_as;
 use std::sync::Arc;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -73,6 +75,25 @@ pub struct RpcLightClientExecutionOutcomeProofResponse {
     pub outcome_proof: near_primitives::views::ExecutionOutcomeWithIdView,
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientStateProofRequest {
+    pub chunk_id: near_primitives::types::SpiceChunkId,
+    pub target: near_primitives::views::StateProofTarget,
+    pub light_client_head: near_primitives::hash::CryptoHash,
+}
+
+#[serde_as]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientStateProofResponse {
+    pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
+    pub value: Option<near_primitives::types::StoreValue>,
+    #[serde_as(as = "Vec<Base64>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Vec<String>"))]
+    pub state_proof: Vec<Arc<[u8]>>,
+}
+
 #[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
@@ -103,6 +124,17 @@ pub enum RpcLightClientProofError {
     },
     #[error("Node does not track shard {shard_id}")]
     ShardNotTracked { shard_id: near_primitives::types::ShardId },
+    #[error(
+        "Account {account_id} is in shard {account_shard_id}, not the requested shard \
+         {requested_shard_id}"
+    )]
+    TargetShardMismatch {
+        account_id: near_primitives::types::AccountId,
+        account_shard_id: near_primitives::types::ShardId,
+        requested_shard_id: near_primitives::types::ShardId,
+    },
+    #[error("State for chunk {chunk_id:?} is not available on this node")]
+    StateNotAvailable { chunk_id: near_primitives::types::SpiceChunkId },
     #[error("Chunk {chunk_id:?} is not yet certified")]
     ChunkNotCertified { chunk_id: near_primitives::types::SpiceChunkId },
     #[error(

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -9,7 +9,7 @@ use near_jsonrpc_primitives::types::light_client::{
     RpcLightClientBlockProofRequest, RpcLightClientChunkExecutionProofRequest,
     RpcLightClientExecutionOutcomeProofRequest, RpcLightClientExecutionProofRequest,
     RpcLightClientNextBlockError, RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse,
-    RpcLightClientProofError,
+    RpcLightClientProofError, RpcLightClientStateProofRequest,
 };
 use near_primitives::views::LightClientBlockView;
 use serde_json::Value;
@@ -47,6 +47,12 @@ impl RpcRequest for RpcLightClientExecutionOutcomeProofRequest {
     }
 }
 
+impl RpcRequest for RpcLightClientStateProofRequest {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
+        Params::parse(value)
+    }
+}
+
 impl RpcFrom<GetLightClientProofError> for RpcLightClientProofError {
     fn rpc_from(error: GetLightClientProofError) -> Self {
         match error {
@@ -66,6 +72,14 @@ impl RpcFrom<GetLightClientProofError> for RpcLightClientProofError {
             }
             GetLightClientProofError::ShardNotTracked { shard_id } => {
                 Self::ShardNotTracked { shard_id }
+            }
+            GetLightClientProofError::TargetShardMismatch {
+                account_id,
+                account_shard_id,
+                requested_shard_id,
+            } => Self::TargetShardMismatch { account_id, account_shard_id, requested_shard_id },
+            GetLightClientProofError::StateNotAvailable { chunk_id } => {
+                Self::StateNotAvailable { chunk_id }
             }
             GetLightClientProofError::InternalError { error_message } => {
                 Self::InternalError { error_message }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -17,7 +17,8 @@ use near_client::{
     DebugStatus, GetBlock, GetBlockProof, GetBlockProofResponse, GetChunk, GetChunkExtraExists,
     GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice,
     GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
-    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError, GetMaintenanceWindows,
+    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError,
+    GetLightClientStateProof, GetLightClientStateProofResponse, GetMaintenanceWindows,
     GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetReceiptToTx,
     GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo,
     GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse, Query as ClientQuery, QueryError,
@@ -466,6 +467,10 @@ pub struct ViewClientSenderForRpc(
         GetLightClientExecutionOutcomeProof,
         Result<GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError>,
     >,
+    AsyncSender<
+        GetLightClientStateProof,
+        Result<GetLightClientStateProofResponse, GetLightClientProofError>,
+    >,
     AsyncSender<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>,
     AsyncSender<GetGasPrice, Result<GasPriceView, GetGasPriceError>>,
     AsyncSender<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanceWindowsError>>,
@@ -784,6 +789,9 @@ impl JsonRpcHandler {
                     self.light_client_execution_outcome_proof(params)
                 })
                 .await
+            }
+            "EXPERIMENTAL_light_client_state_proof" => {
+                process_method_call(request, |params| self.light_client_state_proof(params)).await
             }
             "EXPERIMENTAL_protocol_config" => {
                 process_method_call(request, |params| self.protocol_config(params)).await
@@ -2539,6 +2547,28 @@ impl JsonRpcHandler {
                 outcome_proof: response.outcome_proof,
             },
         )
+    }
+
+    async fn light_client_state_proof(
+        &self,
+        request: near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofRequest,
+    ) -> Result<
+        near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofResponse,
+        near_jsonrpc_primitives::types::light_client::RpcLightClientProofError,
+    > {
+        let near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofRequest {
+            chunk_id,
+            target,
+            light_client_head,
+        } = request;
+        let response: GetLightClientStateProofResponse = self
+            .view_client_send(GetLightClientStateProof { chunk_id, target, light_client_head })
+            .await?;
+        Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofResponse {
+            chunk_execution_proof: response.chunk_execution_proof,
+            value: response.value,
+            state_proof: response.state_proof,
+        })
     }
 
     async fn network_info(

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -40,6 +40,7 @@ use crate::transaction::{
     ExecutionStatus, FunctionCallAction, NonceMode, PartialExecutionOutcome,
     PartialExecutionStatus, SignedTransaction, StakeAction, TransferAction,
 };
+use crate::trie_key::TrieKey;
 use crate::trie_split::TrieSplit;
 use crate::types::{
     AccountId, AccountWithPublicKey, Balance, BlockHeight, ChunkExecutionRoots, EpochHeight,
@@ -2781,6 +2782,45 @@ pub struct ChunkExecutionProofView {
     pub roots_proof: MerklePath,
     pub certifying_block_header_lite: LightClientBlockLiteView,
     pub certifying_block_proof: MerklePath,
+}
+
+/// Which piece of a shard's state a light-client state proof targets.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(tag = "target_type", rename_all = "snake_case")]
+pub enum StateProofTarget {
+    Account { account_id: AccountId },
+    ContractCode { account_id: AccountId },
+    ContractData { account_id: AccountId, key: StoreKey },
+    AccessKey { account_id: AccountId, public_key: PublicKey },
+}
+
+impl StateProofTarget {
+    pub fn account_id(&self) -> &AccountId {
+        match self {
+            StateProofTarget::Account { account_id }
+            | StateProofTarget::ContractCode { account_id }
+            | StateProofTarget::ContractData { account_id, .. }
+            | StateProofTarget::AccessKey { account_id, .. } => account_id,
+        }
+    }
+
+    pub fn to_trie_key(&self) -> TrieKey {
+        match self {
+            StateProofTarget::Account { account_id } => {
+                TrieKey::Account { account_id: account_id.clone() }
+            }
+            StateProofTarget::ContractCode { account_id } => {
+                TrieKey::ContractCode { account_id: account_id.clone() }
+            }
+            StateProofTarget::ContractData { account_id, key } => {
+                TrieKey::ContractData { account_id: account_id.clone(), key: key.clone().into() }
+            }
+            StateProofTarget::AccessKey { account_id, public_key } => {
+                TrieKey::access_key(account_id.clone(), public_key.clone())
+            }
+        }
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/core/store/src/spice_proof_verifier.rs
+++ b/core/store/src/spice_proof_verifier.rs
@@ -1,12 +1,17 @@
-//! Verification for SPICE light-client chunk-execution proofs.
+//! Verification for SPICE light-client proofs.
 //!
 //! A light client trusts a final head and its block merkle root. These functions
 //! recompute that root from a served proof without trusting the serving node.
 
+use crate::trie::AccessOptions;
+use crate::{PartialStorage, Trie};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{compute_root_from_path, compute_root_from_path_and_item};
-use near_primitives::types::{ChunkExecutionRoots, SpiceChunkId};
-use near_primitives::views::{ChunkExecutionProofView, ExecutionOutcomeWithIdView};
+use near_primitives::state::{PartialState, TrieValue};
+use near_primitives::types::{ChunkExecutionRoots, SpiceChunkId, StoreValue};
+use near_primitives::views::{
+    ChunkExecutionProofView, ExecutionOutcomeWithIdView, StateProofTarget,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SpiceProofVerificationError {
@@ -24,6 +29,10 @@ pub enum SpiceProofVerificationError {
     UnexpectedOutcomeBlockHash { expected: CryptoHash, found: CryptoHash },
     #[error("execution outcome proof does not recompute the chunk's outcome_root")]
     InvalidOutcomeProof,
+    #[error("state proof does not reconstruct the claimed value at the chunk's state_root")]
+    InvalidStateProof,
+    #[error("state proof trie access failed: {0}")]
+    TrieError(String),
 }
 
 /// Checks that `expected_chunk_id`'s execution roots are committed by a block that
@@ -88,6 +97,28 @@ pub fn verify_execution_outcome_proof(
     let computed_outcome_root = compute_root_from_path(&outcome_proof.proof, outcome_hash);
     if computed_outcome_root != roots.outcome_root {
         return Err(SpiceProofVerificationError::InvalidOutcomeProof);
+    }
+    Ok(())
+}
+
+/// Verifies a state trie proof against the chunk's `state_root`: reconstructs the
+/// trie from `state_proof` and checks the claimed `value` for `target`. Call after
+/// [`verify_chunk_execution_proof`] to bind `roots` to the trusted head.
+pub fn verify_state_proof(
+    target: &StateProofTarget,
+    value: Option<&StoreValue>,
+    state_proof: &[TrieValue],
+    roots: &ChunkExecutionRoots,
+) -> Result<(), SpiceProofVerificationError> {
+    let ChunkExecutionRoots::V1(roots) = roots;
+    let partial_storage = PartialStorage { nodes: PartialState::TrieValues(state_proof.to_vec()) };
+    let trie = Trie::from_recorded_storage(partial_storage, roots.state_root, false);
+    let trie_key = target.to_trie_key().to_vec();
+    let recovered_value = trie
+        .get(&trie_key, AccessOptions::DEFAULT)
+        .map_err(|error| SpiceProofVerificationError::TrieError(error.to_string()))?;
+    if recovered_value.as_deref() != value.map(|value| value.as_slice()) {
+        return Err(SpiceProofVerificationError::InvalidStateProof);
     }
     Ok(())
 }

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -1,24 +1,33 @@
 use crate::setup::builder::TestLoopBuilder;
 use crate::utils::account::create_account_id;
 use assert_matches::assert_matches;
+use borsh::BorshDeserialize as _;
 use near_async::messaging::Handler as _;
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess as _;
-use near_client::{GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof};
+use near_client::{
+    GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
+    GetLightClientStateProof,
+};
 use near_client_primitives::types::GetLightClientProofError;
 use near_epoch_manager::shard_assignment::account_id_to_shard_id;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::CryptoHash;
+use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::types::{
-    Balance, ChunkExecutionRoots, ChunkExecutionRootsV1, Gas, SpiceChunkId, TransactionOrReceiptId,
+    Balance, ChunkExecutionRoots, ChunkExecutionRootsV1, Gas, SpiceChunkId, StoreValue,
+    TransactionOrReceiptId,
 };
 use near_primitives::views::{
-    ChunkExecutionProofView, ExecutionStatusView, LightClientBlockLiteView,
+    ChunkExecutionProofView, ExecutionStatusView, LightClientBlockLiteView, StateProofTarget,
 };
 use near_store::spice_proof_verifier::{
     SpiceProofVerificationError, verify_chunk_execution_proof, verify_execution_outcome_proof,
+    verify_state_proof,
 };
+use near_test_contracts::rs_contract;
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
@@ -301,6 +310,211 @@ fn test_spice_light_client_execution_outcome_proof() {
             light_client_head,
         });
     assert_matches!(result, Err(GetLightClientProofError::UnknownTransactionOrReceipt { .. }));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_state_proof() {
+    init_test_logger();
+
+    // See the outcome-proof test: this account is outside the first shard.
+    let contract_account = create_account_id("vault");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 0)
+        .num_shards(4)
+        .add_user_accounts([&contract_account], Balance::from_near(10))
+        .build();
+
+    let deploy_tx = env.validator().tx_deploy_test_contract(&contract_account);
+    env.validator_runner().run_tx(deploy_tx, Duration::seconds(20));
+
+    // rs_contract's write_key_value reads input as `key_bytes || value(u64 LE)` and
+    // does storage_write(key, value), so this creates a provable ContractData entry.
+    let storage_key = b"spice_key".to_vec();
+    let storage_value: u64 = 42;
+    let mut call_args = storage_key.clone();
+    call_args.extend_from_slice(&storage_value.to_le_bytes());
+    let call_tx = env.validator().tx_call(
+        &contract_account,
+        &contract_account,
+        "write_key_value",
+        call_args,
+        Balance::ZERO,
+        Gas::from_teragas(300),
+    );
+    let call_tx_hash = call_tx.get_hash();
+    env.validator_runner().run_tx(call_tx, Duration::seconds(20));
+    let receipt_id = env.validator().tx_receipt_id(call_tx_hash);
+
+    let tip_height = env.validator().head().height;
+    env.validator_runner().run_until_certified(tip_height);
+    let certified_head_height = env.validator().head().height;
+    env.validator_runner().run_until_final_head_height(certified_head_height + 1);
+
+    let light_client_head = env.validator().final_head().last_block_hash;
+
+    // The chunk that executed the write; its certified state_root is what the state
+    // proofs below are checked against.
+    let write_block_hash = env.validator().execution_outcome_with_proof(receipt_id).block_hash;
+    let epoch_manager = env.validator().client().epoch_manager.clone();
+    let epoch_id =
+        *env.validator().client().chain.get_block_header(&write_block_hash).unwrap().epoch_id();
+    let account_shard_id =
+        account_id_to_shard_id(epoch_manager.as_ref(), &contract_account, &epoch_id).unwrap();
+    let chunk_id = SpiceChunkId { block_hash: write_block_hash, shard_id: account_shard_id };
+
+    // Account record proves the deployed contract and a gas-reduced balance.
+    let account_target = StateProofTarget::Account { account_id: contract_account.clone() };
+    let account_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: account_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    verify_state_proof(
+        &account_target,
+        account_response.value.as_ref(),
+        &account_response.state_proof,
+        &account_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+    let account_bytes: Vec<u8> =
+        account_response.value.clone().expect("contract account must be present").into();
+    let account = Account::try_from_slice(&account_bytes).unwrap();
+    assert_eq!(account.local_contract_hash(), Some(CryptoHash::hash_bytes(rs_contract())));
+    assert!(account.amount() < Balance::from_near(10), "deploy and call gas should reduce balance");
+
+    // The contract-data key/value the call wrote is present and proves the exact value.
+    let data_target = StateProofTarget::ContractData {
+        account_id: contract_account.clone(),
+        key: storage_key.clone().into(),
+    };
+    let data_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: data_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    let proved_value: Vec<u8> =
+        data_response.value.clone().expect("contract data must be present").into();
+    assert_eq!(proved_value, storage_value.to_le_bytes());
+    verify_state_proof(
+        &data_target,
+        data_response.value.as_ref(),
+        &data_response.state_proof,
+        &data_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+
+    // The chunk-execution proof in the response ties state_root to the trusted head.
+    let head_header = env.validator().client().chain.get_block_header(&light_client_head).unwrap();
+    verify_chunk_execution_proof(
+        &data_response.chunk_execution_proof,
+        &chunk_id,
+        head_header.block_merkle_root(),
+    )
+    .unwrap();
+
+    // Tampering the claimed value must be rejected by the trie proof.
+    let tampered_value: StoreValue = b"tampered contract data".to_vec().into();
+    assert_matches!(
+        verify_state_proof(
+            &data_target,
+            Some(&tampered_value),
+            &data_response.state_proof,
+            &data_response.chunk_execution_proof.roots,
+        ),
+        Err(SpiceProofVerificationError::InvalidStateProof)
+    );
+
+    let other_shard_id = epoch_manager
+        .get_shard_layout(&epoch_id)
+        .unwrap()
+        .shard_ids()
+        .find(|shard_id| *shard_id != account_shard_id)
+        .unwrap();
+    let result = env.validator_mut().view_client_actor().handle(GetLightClientStateProof {
+        chunk_id: SpiceChunkId { block_hash: write_block_hash, shard_id: other_shard_id },
+        target: account_target.clone(),
+        light_client_head,
+    });
+    assert_matches!(result, Err(GetLightClientProofError::TargetShardMismatch { .. }));
+
+    // The deployed code itself is provable, and its bytes are the contract we sent.
+    let code_target = StateProofTarget::ContractCode { account_id: contract_account.clone() };
+    let code_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: code_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    let proved_code: Vec<u8> =
+        code_response.value.clone().expect("contract code must be present").into();
+    assert_eq!(proved_code, rs_contract());
+    verify_state_proof(
+        &code_target,
+        code_response.value.as_ref(),
+        &code_response.state_proof,
+        &code_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+
+    // The access key exercises the public-key to trie-handle encoding.
+    let access_key_target = StateProofTarget::AccessKey {
+        account_id: contract_account.clone(),
+        public_key: create_user_test_signer(&contract_account).public_key(),
+    };
+    let access_key_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: access_key_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    let access_key_bytes: Vec<u8> =
+        access_key_response.value.clone().expect("access key must be present").into();
+    AccessKey::try_from_slice(&access_key_bytes).unwrap();
+    verify_state_proof(
+        &access_key_target,
+        access_key_response.value.as_ref(),
+        &access_key_response.state_proof,
+        &access_key_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+
+    // A key the contract never wrote has no value, and that absence is provable.
+    let absent_target = StateProofTarget::ContractData {
+        account_id: contract_account.clone(),
+        key: b"never_written".to_vec().into(),
+    };
+    let absent_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: absent_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    assert!(absent_response.value.is_none());
+    verify_state_proof(
+        &absent_target,
+        None,
+        &absent_response.state_proof,
+        &absent_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #16250. Review that one first; this PR's diff is only the state proof.

`EXPERIMENTAL_light_client_state_proof` takes a chunk id and a target (account, contract code, contract data, or access key) and returns the value together with its trie proof at the chunk's certified `state_root`. It is served only against a final `light_client_head` that is strictly newer than the block certifying the chunk. `verify_state_proof` in `core/store/src/spice_proof_verifier.rs` rebuilds the trie from the served nodes and checks the claimed value, after `verify_chunk_execution_proof` has bound the roots to the trusted head.

The server refuses a target that lives in another shard (`TargetShardMismatch`). Without that check it would answer an absent value, and that absence proof verifies against the requested chunk's `state_root`, so a client that picked the wrong shard would get a sound proof of the wrong statement.

Other new errors: `StateNotAvailable` when the state at that root is gone, which is the routine answer for a chunk older than the garbage-collection window, and is worth telling apart from an internal fault.

**OpenAPI:** the method is not registered in the spec here, and the spec is not regenerated, so the OpenAPI CI job is expected to fail on this PR. A final PR in the stack registers both methods and regenerates the spec once, after the code is reviewed.