### PR TITLE
feat(spice): light-client execution-outcome proof

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -8,8 +8,9 @@ use near_primitives::types::{
     MaybeBlockId, ShardId, SpiceChunkId, TransactionOrReceiptId,
 };
 use near_primitives::views::{
-    EpochSyncStatusView, ExecutionOutcomeWithIdView, LightClientBlockLiteView, QueryRequest,
-    StateChangesRequestView, StateSyncStatusView, SyncStatusView, TxStatusView,
+    ChunkExecutionProofView, EpochSyncStatusView, ExecutionOutcomeWithIdView,
+    LightClientBlockLiteView, QueryRequest, StateChangesRequestView, StateSyncStatusView,
+    SyncStatusView, TxStatusView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 use near_time::Duration;
@@ -922,6 +923,18 @@ pub struct GetLightClientChunkExecutionProof {
     pub light_client_head: CryptoHash,
 }
 
+#[derive(Debug)]
+pub struct GetLightClientExecutionOutcomeProof {
+    pub id: TransactionOrReceiptId,
+    pub light_client_head: CryptoHash,
+}
+
+#[derive(Debug)]
+pub struct GetLightClientExecutionOutcomeProofResponse {
+    pub chunk_execution_proof: ChunkExecutionProofView,
+    pub outcome_proof: ExecutionOutcomeWithIdView,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum GetLightClientProofError {
     #[error("Chunk {chunk_id:?} is not yet certified")]
@@ -940,6 +953,10 @@ pub enum GetLightClientProofError {
          {error_message}"
     )]
     UnknownBlock { error_message: String },
+    #[error("{transaction_or_receipt_id} does not exist")]
+    UnknownTransactionOrReceipt { transaction_or_receipt_id: CryptoHash },
+    #[error("Node doesn't track the shard where {transaction_or_receipt_id} is executed")]
+    UnavailableShard { transaction_or_receipt_id: CryptoHash, shard_id: ShardId },
     #[error("Internal error: {error_message}")]
     InternalError { error_message: String },
 }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -22,6 +22,7 @@ pub use near_client_primitives::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
     GetChunkExtraExists, GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
     GetExecutionOutcomesForBlock, GetGasPrice, GetLightClientChunkExecutionProof,
+    GetLightClientExecutionOutcomeProof, GetLightClientExecutionOutcomeProofResponse,
     GetLightClientProofError, GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock,
     GetProcessedReceiptIds, GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse,
     GetShardChunk, GetSplitStorageInfo, GetStateChanges, GetStateChangesInBlock,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -23,7 +23,8 @@ use near_client_primitives::types::{
     Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError, GetBlockProofResponse,
     GetBlockWithMerkleTree, GetChunkError, GetChunkExtraExists, GetExecutionOutcome,
     GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError,
-    GetLightClientChunkExecutionProof, GetLightClientProofError, GetMaintenanceWindows,
+    GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
+    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError, GetMaintenanceWindows,
     GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProcessedReceiptIds,
     GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError, GetReceipt,
     GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
@@ -1690,6 +1691,24 @@ impl ViewClientActor {
             certifying_block_proof,
         })
     }
+
+    /// The shard that executes `account_id` in `block_hash`'s epoch, and whether this
+    /// node tracks it there.
+    fn account_shard_at_block(
+        &self,
+        account_id: &AccountId,
+        block_hash: &CryptoHash,
+    ) -> Result<(ShardId, bool), GetLightClientProofError> {
+        let header = self.chain.get_block_header(block_hash)?;
+        let shard_id =
+            account_id_to_shard_id(self.epoch_manager.as_ref(), account_id, header.epoch_id())
+                .into_chain_error()?;
+        let tracked = self
+            .shard_tracker
+            .cares_about_shard_checked(header.prev_hash(), shard_id)
+            .into_chain_error()?;
+        Ok((shard_id, tracked))
+    }
 }
 
 impl
@@ -1707,6 +1726,63 @@ impl
             .with_label_values(&["GetLightClientChunkExecutionProof"])
             .start_timer();
         self.build_chunk_execution_proof(&msg.chunk_id, &msg.light_client_head)
+    }
+}
+
+impl
+    Handler<
+        GetLightClientExecutionOutcomeProof,
+        Result<GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError>,
+    > for ViewClientActor
+{
+    fn handle(
+        &mut self,
+        msg: GetLightClientExecutionOutcomeProof,
+    ) -> Result<GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetLightClientExecutionOutcomeProof"])
+            .start_timer();
+        let (id, account_id) = match msg.id {
+            TransactionOrReceiptId::Transaction { transaction_hash, sender_id } => {
+                (transaction_hash, sender_id)
+            }
+            TransactionOrReceiptId::Receipt { receipt_id, receiver_id } => {
+                (receipt_id, receiver_id)
+            }
+        };
+        let outcome = match self.chain.get_execution_outcome(&id) {
+            Ok(outcome) => outcome,
+            Err(near_chain::Error::DBNotFoundErr(_)) => {
+                let (shard_id, tracked) =
+                    self.account_shard_at_block(&account_id, &msg.light_client_head)?;
+                if !tracked {
+                    return Err(GetLightClientProofError::UnavailableShard {
+                        transaction_or_receipt_id: id,
+                        shard_id,
+                    });
+                }
+                return Err(GetLightClientProofError::UnknownTransactionOrReceipt {
+                    transaction_or_receipt_id: id,
+                });
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let block_hash = outcome.block_hash;
+        let epoch_id = *self.chain.get_block_header(&block_hash)?.epoch_id();
+        // The executor, not the account named in the request, decides which shard ran
+        // this outcome. An unverified request hint would name a chunk whose outcome_root
+        // does not commit the outcome.
+        let executor_id = &outcome.outcome_with_id.outcome.executor_id;
+        let shard_id = account_id_to_shard_id(self.epoch_manager.as_ref(), executor_id, &epoch_id)
+            .into_chain_error()?;
+        let chunk_id = SpiceChunkId { block_hash, shard_id };
+        let chunk_execution_proof =
+            self.build_chunk_execution_proof(&chunk_id, &msg.light_client_head)?;
+        Ok(GetLightClientExecutionOutcomeProofResponse {
+            chunk_execution_proof,
+            outcome_proof: outcome.into(),
+        })
     }
 }
 

--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -58,6 +58,21 @@ pub struct RpcLightClientChunkExecutionProofResponse {
     pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientExecutionOutcomeProofRequest {
+    #[serde(flatten)]
+    pub id: near_primitives::types::TransactionOrReceiptId,
+    pub light_client_head: near_primitives::hash::CryptoHash,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientExecutionOutcomeProofResponse {
+    pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
+    pub outcome_proof: near_primitives::views::ExecutionOutcomeWithIdView,
+}
+
 #[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -7,8 +7,9 @@ use near_client_primitives::types::{
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::light_client::{
     RpcLightClientBlockProofRequest, RpcLightClientChunkExecutionProofRequest,
-    RpcLightClientExecutionProofRequest, RpcLightClientNextBlockError,
-    RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse, RpcLightClientProofError,
+    RpcLightClientExecutionOutcomeProofRequest, RpcLightClientExecutionProofRequest,
+    RpcLightClientNextBlockError, RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse,
+    RpcLightClientProofError,
 };
 use near_primitives::views::LightClientBlockView;
 use serde_json::Value;
@@ -40,6 +41,12 @@ impl RpcRequest for RpcLightClientChunkExecutionProofRequest {
     }
 }
 
+impl RpcRequest for RpcLightClientExecutionOutcomeProofRequest {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
+        Params::parse(value)
+    }
+}
+
 impl RpcFrom<GetLightClientProofError> for RpcLightClientProofError {
     fn rpc_from(error: GetLightClientProofError) -> Self {
         match error {
@@ -53,6 +60,12 @@ impl RpcFrom<GetLightClientProofError> for RpcLightClientProofError {
             } => Self::LightClientHeadTooOld { chunk_id, certifying_block_height, head_height },
             GetLightClientProofError::UnknownBlock { error_message } => {
                 Self::UnknownBlock { error_message }
+            }
+            GetLightClientProofError::UnknownTransactionOrReceipt { transaction_or_receipt_id } => {
+                Self::UnknownTransactionOrReceipt { transaction_or_receipt_id }
+            }
+            GetLightClientProofError::UnavailableShard { transaction_or_receipt_id, shard_id } => {
+                Self::UnavailableShard { transaction_or_receipt_id, shard_id }
             }
             GetLightClientProofError::InternalError { error_message } => {
                 Self::InternalError { error_message }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -16,7 +16,8 @@ use near_chain_configs::{ClientConfig, GenesisConfig, ProtocolConfigView};
 use near_client::{
     DebugStatus, GetBlock, GetBlockProof, GetBlockProofResponse, GetChunk, GetChunkExtraExists,
     GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice,
-    GetLightClientChunkExecutionProof, GetLightClientProofError, GetMaintenanceWindows,
+    GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
+    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError, GetMaintenanceWindows,
     GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetReceiptToTx,
     GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo,
     GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse, Query as ClientQuery, QueryError,
@@ -461,6 +462,10 @@ pub struct ViewClientSenderForRpc(
         GetLightClientChunkExecutionProof,
         Result<ChunkExecutionProofView, GetLightClientProofError>,
     >,
+    AsyncSender<
+        GetLightClientExecutionOutcomeProof,
+        Result<GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError>,
+    >,
     AsyncSender<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>,
     AsyncSender<GetGasPrice, Result<GasPriceView, GetGasPriceError>>,
     AsyncSender<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanceWindowsError>>,
@@ -771,6 +776,12 @@ impl JsonRpcHandler {
             "EXPERIMENTAL_light_client_chunk_execution_proof" => {
                 process_method_call(request, |params| {
                     self.light_client_chunk_execution_proof(params)
+                })
+                .await
+            }
+            "EXPERIMENTAL_light_client_execution_outcome_proof" => {
+                process_method_call(request, |params| {
+                    self.light_client_execution_outcome_proof(params)
                 })
                 .await
             }
@@ -2506,6 +2517,28 @@ impl JsonRpcHandler {
         Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientChunkExecutionProofResponse {
             chunk_execution_proof,
         })
+    }
+
+    async fn light_client_execution_outcome_proof(
+        &self,
+        request: near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionOutcomeProofRequest,
+    ) -> Result<
+        near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionOutcomeProofResponse,
+        near_jsonrpc_primitives::types::light_client::RpcLightClientProofError,
+    > {
+        let near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionOutcomeProofRequest {
+            id,
+            light_client_head,
+        } = request;
+        let response: GetLightClientExecutionOutcomeProofResponse = self
+            .view_client_send(GetLightClientExecutionOutcomeProof { id, light_client_head })
+            .await?;
+        Ok(
+            near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionOutcomeProofResponse {
+                chunk_execution_proof: response.chunk_execution_proof,
+                outcome_proof: response.outcome_proof,
+            },
+        )
     }
 
     async fn network_info(

--- a/core/store/src/spice_proof_verifier.rs
+++ b/core/store/src/spice_proof_verifier.rs
@@ -5,8 +5,8 @@
 
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{compute_root_from_path, compute_root_from_path_and_item};
-use near_primitives::types::SpiceChunkId;
-use near_primitives::views::ChunkExecutionProofView;
+use near_primitives::types::{ChunkExecutionRoots, SpiceChunkId};
+use near_primitives::views::{ChunkExecutionProofView, ExecutionOutcomeWithIdView};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SpiceProofVerificationError {
@@ -18,6 +18,12 @@ pub enum SpiceProofVerificationError {
     InvalidRootsProof,
     #[error("certifying block is not committed in the light client head's block merkle root")]
     InvalidBlockProof,
+    #[error("proof is for outcome {found}, not the requested outcome {expected}")]
+    UnexpectedOutcomeId { expected: CryptoHash, found: CryptoHash },
+    #[error("outcome claims block {found}, but the roots are for block {expected}")]
+    UnexpectedOutcomeBlockHash { expected: CryptoHash, found: CryptoHash },
+    #[error("execution outcome proof does not recompute the chunk's outcome_root")]
+    InvalidOutcomeProof,
 }
 
 /// Checks that `expected_chunk_id`'s execution roots are committed by a block that
@@ -52,6 +58,36 @@ pub fn verify_chunk_execution_proof(
         compute_root_from_path(&proof.certifying_block_proof, certifying_block_hash);
     if &computed_head_root != light_client_head_block_merkle_root {
         return Err(SpiceProofVerificationError::InvalidBlockProof);
+    }
+    Ok(())
+}
+
+/// Checks that `expected_id`'s outcome hashes to a value committed by the chunk's
+/// `outcome_root`. Call after [`verify_chunk_execution_proof`] to bind `roots` to the
+/// trusted head.
+pub fn verify_execution_outcome_proof(
+    outcome_proof: &ExecutionOutcomeWithIdView,
+    expected_id: &CryptoHash,
+    roots: &ChunkExecutionRoots,
+) -> Result<(), SpiceProofVerificationError> {
+    let ChunkExecutionRoots::V1(roots) = roots;
+    if &outcome_proof.id != expected_id {
+        return Err(SpiceProofVerificationError::UnexpectedOutcomeId {
+            expected: *expected_id,
+            found: outcome_proof.id,
+        });
+    }
+    // block_hash is not one of the hashed fields, so a server can set it to anything.
+    if outcome_proof.block_hash != roots.chunk_id.block_hash {
+        return Err(SpiceProofVerificationError::UnexpectedOutcomeBlockHash {
+            expected: roots.chunk_id.block_hash,
+            found: outcome_proof.block_hash,
+        });
+    }
+    let outcome_hash = CryptoHash::hash_borsh(outcome_proof.to_hashes());
+    let computed_outcome_root = compute_root_from_path(&outcome_proof.proof, outcome_hash);
+    if computed_outcome_root != roots.outcome_root {
+        return Err(SpiceProofVerificationError::InvalidOutcomeProof);
     }
     Ok(())
 }

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -1,15 +1,36 @@
 use crate::setup::builder::TestLoopBuilder;
+use crate::setup::env::TestLoopEnv;
+use crate::utils::account::{create_account_id, create_account_ids};
 use assert_matches::assert_matches;
 use near_async::messaging::Handler as _;
+use near_async::time::Duration;
 use near_chain::ChainStoreAccess as _;
-use near_client::GetLightClientChunkExecutionProof;
+use near_chain_configs::TrackedShardsConfig;
+use near_client::{GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof};
 use near_client_primitives::types::GetLightClientProofError;
+use near_epoch_manager::shard_assignment::account_id_to_shard_id;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{ChunkExecutionRoots, ChunkExecutionRootsV1, SpiceChunkId};
-use near_primitives::views::{ChunkExecutionProofView, LightClientBlockLiteView};
-use near_store::spice_proof_verifier::{SpiceProofVerificationError, verify_chunk_execution_proof};
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::types::{
+    Balance, ChunkExecutionRoots, ChunkExecutionRootsV1, Gas, SpiceChunkId, TransactionOrReceiptId,
+};
+use near_primitives::views::{
+    ChunkExecutionProofView, ExecutionStatusView, LightClientBlockLiteView,
+};
+use near_store::spice_proof_verifier::{
+    SpiceProofVerificationError, verify_chunk_execution_proof, verify_execution_outcome_proof,
+};
+
+/// Certifies the chain, then returns a final head strictly newer than the certifying block.
+fn run_until_certified_light_client_head(env: &mut TestLoopEnv) -> CryptoHash {
+    let tip_height = env.validator().head().height;
+    env.validator_runner().run_until_certified(tip_height);
+    let certified_head_height = env.validator().head().height;
+    env.validator_runner().run_until_final_head_height(certified_head_height + 1);
+    env.validator().final_head().last_block_hash
+}
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
@@ -18,16 +39,7 @@ fn test_spice_light_client_chunk_execution_proof() {
 
     let mut env = TestLoopBuilder::new().validators(1, 0).build();
 
-    // Certify the chain through the current tip, then let finality advance strictly
-    // past it. The handler serves from the certifying-block index (written at
-    // finality), and the head must be strictly after a chunk's certifying block for
-    // the block merkle proof to recompute the head's block_merkle_root from it.
-    let tip_height = env.validator().head().height;
-    env.validator_runner().run_until_certified(tip_height);
-    let certified_head_height = env.validator().head().height;
-    env.validator_runner().run_until_final_head_height(certified_head_height + 1);
-
-    let light_client_head = env.validator().final_head().last_block_hash;
+    let light_client_head = run_until_certified_light_client_head(&mut env);
     let head_header = env.validator().client().chain.get_block_header(&light_client_head).unwrap();
     let trusted_block_merkle_root = *head_header.block_merkle_root();
 
@@ -102,6 +114,303 @@ fn test_spice_light_client_chunk_execution_proof() {
             light_client_head,
         });
     assert_matches!(result, Err(GetLightClientProofError::ChunkNotCertified { .. }));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_execution_outcome_proof() {
+    init_test_logger();
+
+    // `vault` sorts after every boundary account of the 4-shard layout, so the
+    // target lives outside the first shard and the handler must resolve it.
+    let contract_account = create_account_id("vault");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 0)
+        .num_shards(4)
+        .add_user_accounts([&contract_account], Balance::from_near(10))
+        .build();
+
+    let deploy_tx = env.validator().tx_deploy_test_contract(&contract_account);
+    env.validator_runner().run_tx(deploy_tx, Duration::seconds(20));
+
+    let call_tx = env.validator().tx_call(
+        &contract_account,
+        &contract_account,
+        "log_something",
+        Vec::new(),
+        Balance::ZERO,
+        Gas::from_teragas(300),
+    );
+    let call_tx_hash = call_tx.get_hash();
+    env.validator_runner().run_tx(call_tx, Duration::seconds(20));
+    let receipt_id = env.validator().tx_receipt_id(call_tx_hash);
+
+    let light_client_head = run_until_certified_light_client_head(&mut env);
+    let head_header = env.validator().client().chain.get_block_header(&light_client_head).unwrap();
+    let trusted_block_merkle_root = *head_header.block_merkle_root();
+
+    // The handler resolves which chunk executed the receipt, so the client learns the
+    // chunk id from the served proof instead of naming it in the request.
+    let response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientExecutionOutcomeProof {
+            id: TransactionOrReceiptId::Receipt {
+                receipt_id,
+                receiver_id: contract_account.clone(),
+            },
+            light_client_head,
+        })
+        .unwrap();
+    assert_eq!(response.outcome_proof.id, receipt_id);
+
+    let chunk_id = response.chunk_execution_proof.roots.chunk_id().clone();
+    let epoch_manager = env.validator().client().epoch_manager.clone();
+    let epoch_id =
+        *env.validator().client().chain.get_block_header(&chunk_id.block_hash).unwrap().epoch_id();
+    let account_shard_id =
+        account_id_to_shard_id(epoch_manager.as_ref(), &contract_account, &epoch_id).unwrap();
+    assert_eq!(chunk_id.shard_id, account_shard_id);
+    let first_shard_id =
+        epoch_manager.get_shard_layout(&epoch_id).unwrap().shard_ids().next().unwrap();
+    assert_ne!(account_shard_id, first_shard_id);
+
+    verify_chunk_execution_proof(
+        &response.chunk_execution_proof,
+        &chunk_id,
+        &trusted_block_merkle_root,
+    )
+    .unwrap();
+    verify_execution_outcome_proof(
+        &response.outcome_proof,
+        &receipt_id,
+        &response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+
+    // Only the id check stops a server from answering with another outcome of the same
+    // chunk, whose merkle path is just as genuine.
+    assert_matches!(
+        verify_execution_outcome_proof(
+            &response.outcome_proof,
+            &call_tx_hash,
+            &response.chunk_execution_proof.roots,
+        ),
+        Err(SpiceProofVerificationError::UnexpectedOutcomeId { .. })
+    );
+
+    // block_hash is not hashed into the outcome, so it is checked against the roots.
+    let mut relabeled_outcome = response.outcome_proof.clone();
+    relabeled_outcome.block_hash = CryptoHash::hash_bytes(b"not the executing block");
+    assert_matches!(
+        verify_execution_outcome_proof(
+            &relabeled_outcome,
+            &receipt_id,
+            &response.chunk_execution_proof.roots,
+        ),
+        Err(SpiceProofVerificationError::UnexpectedOutcomeBlockHash { .. })
+    );
+
+    // A server lying about the result must be rejected: changing the outcome status
+    // changes the outcome hash, which then does not recompute the chunk's outcome_root.
+    let mut tampered_outcome = response.outcome_proof.clone();
+    tampered_outcome.outcome.status = ExecutionStatusView::SuccessValue(b"forged result".to_vec());
+    assert_matches!(
+        verify_execution_outcome_proof(
+            &tampered_outcome,
+            &receipt_id,
+            &response.chunk_execution_proof.roots
+        ),
+        Err(SpiceProofVerificationError::InvalidOutcomeProof)
+    );
+
+    // The same outcome must not verify against a different chunk's outcome_root.
+    let ChunkExecutionRoots::V1(good_roots) = &response.chunk_execution_proof.roots;
+    let tampered_roots = ChunkExecutionRoots::V1(ChunkExecutionRootsV1 {
+        outcome_root: CryptoHash::hash_bytes(b"tampered outcome root"),
+        ..good_roots.clone()
+    });
+    assert_matches!(
+        verify_execution_outcome_proof(&response.outcome_proof, &receipt_id, &tampered_roots),
+        Err(SpiceProofVerificationError::InvalidOutcomeProof)
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_outcome_proof_by_transaction_id() {
+    init_test_logger();
+
+    let [sender, receiver] = create_account_ids(["vault", "alice"]);
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 0)
+        .num_shards(4)
+        .add_user_accounts([&sender, &receiver], Balance::from_near(10))
+        .build();
+
+    let transfer_tx = env.validator().tx_send_money(&sender, &receiver, Balance::from_near(1));
+    let transfer_tx_hash = transfer_tx.get_hash();
+    env.validator_runner().run_tx(transfer_tx, Duration::seconds(20));
+
+    let light_client_head = run_until_certified_light_client_head(&mut env);
+    let head_header = env.validator().client().chain.get_block_header(&light_client_head).unwrap();
+    let trusted_block_merkle_root = *head_header.block_merkle_root();
+
+    // A transaction is converted in the signer's shard, which the handler resolves
+    // through a separate branch from the receipt one.
+    let response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientExecutionOutcomeProof {
+            id: TransactionOrReceiptId::Transaction {
+                transaction_hash: transfer_tx_hash,
+                sender_id: sender.clone(),
+            },
+            light_client_head,
+        })
+        .unwrap();
+    assert_eq!(response.outcome_proof.id, transfer_tx_hash);
+
+    let chunk_id = response.chunk_execution_proof.roots.chunk_id().clone();
+    let epoch_manager = env.validator().client().epoch_manager.clone();
+    let epoch_id =
+        *env.validator().client().chain.get_block_header(&chunk_id.block_hash).unwrap().epoch_id();
+    assert_eq!(
+        chunk_id.shard_id,
+        account_id_to_shard_id(epoch_manager.as_ref(), &sender, &epoch_id).unwrap()
+    );
+
+    verify_chunk_execution_proof(
+        &response.chunk_execution_proof,
+        &chunk_id,
+        &trusted_block_merkle_root,
+    )
+    .unwrap();
+    verify_execution_outcome_proof(
+        &response.outcome_proof,
+        &transfer_tx_hash,
+        &response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_outcome_proof_bad_request() {
+    init_test_logger();
+
+    let [sender, receiver] = create_account_ids(["vault", "alice"]);
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 0)
+        .num_shards(4)
+        .add_user_accounts([&sender, &receiver], Balance::from_near(10))
+        .build();
+
+    let transfer_tx = env.validator().tx_send_money(&sender, &receiver, Balance::from_near(1));
+    let transfer_tx_hash = transfer_tx.get_hash();
+    env.validator_runner().run_tx(transfer_tx, Duration::seconds(20));
+    let receipt_id = env.validator().tx_receipt_id(transfer_tx_hash);
+
+    let light_client_head = run_until_certified_light_client_head(&mut env);
+
+    let epoch_manager = env.validator().client().epoch_manager.clone();
+    let epoch_id = env.validator().head().epoch_id;
+    let sender_shard_id =
+        account_id_to_shard_id(epoch_manager.as_ref(), &sender, &epoch_id).unwrap();
+    let receiver_shard_id =
+        account_id_to_shard_id(epoch_manager.as_ref(), &receiver, &epoch_id).unwrap();
+    assert_ne!(sender_shard_id, receiver_shard_id, "the wrong hint must name another shard");
+
+    // The transfer receipt executes in the receiver's shard.
+    let response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientExecutionOutcomeProof {
+            id: TransactionOrReceiptId::Receipt { receipt_id, receiver_id: receiver.clone() },
+            light_client_head,
+        })
+        .unwrap();
+    let chunk_id = response.chunk_execution_proof.roots.chunk_id().clone();
+    assert_eq!(chunk_id.shard_id, receiver_shard_id);
+
+    // The request names an account only as a hint for the lookup. The handler must
+    // ignore a wrong one and follow the outcome's executor instead.
+    let misleading_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientExecutionOutcomeProof {
+            id: TransactionOrReceiptId::Receipt { receipt_id, receiver_id: sender },
+            light_client_head,
+        })
+        .unwrap();
+    assert_eq!(
+        misleading_response.chunk_execution_proof.roots.chunk_id(),
+        &chunk_id,
+        "a wrong account in the request must not move the proof to another chunk"
+    );
+    verify_execution_outcome_proof(
+        &misleading_response.outcome_proof,
+        &receipt_id,
+        &misleading_response.chunk_execution_proof.roots,
+    )
+    .unwrap();
+
+    let unknown_id = CryptoHash::hash_bytes(b"no such receipt");
+    let result =
+        env.validator_mut().view_client_actor().handle(GetLightClientExecutionOutcomeProof {
+            id: TransactionOrReceiptId::Receipt { receipt_id: unknown_id, receiver_id: receiver },
+            light_client_head,
+        });
+    assert_matches!(result, Err(GetLightClientProofError::UnknownTransactionOrReceipt { .. }));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_outcome_proof_untracked_shard() {
+    init_test_logger();
+
+    let [sender, receiver] = create_account_ids(["vault", "alice"]);
+    let observer = create_account_id("observer");
+    let shard_layout = ShardLayout::multi_shard(4, 1);
+    let receiver_shard_id = shard_layout.account_id_to_shard_id(&receiver);
+    let observed_shard_uid = shard_layout
+        .shard_uids()
+        .find(|shard_uid| shard_uid.shard_id() != receiver_shard_id)
+        .unwrap();
+
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 0)
+        .shard_layout(shard_layout)
+        .add_non_validator_client(&observer)
+        .add_user_accounts([&sender, &receiver], Balance::from_near(10))
+        .config_modifier(move |config, client_index| {
+            if client_index == 1 {
+                config.tracked_shards_config =
+                    TrackedShardsConfig::Shards(vec![observed_shard_uid]);
+            }
+        })
+        .build();
+
+    let transfer_tx = env.validator().tx_send_money(&sender, &receiver, Balance::from_near(1));
+    let transfer_tx_hash = transfer_tx.get_hash();
+    env.validator_runner().run_tx(transfer_tx, Duration::seconds(20));
+    let receipt_id = env.validator().tx_receipt_id(transfer_tx_hash);
+
+    let light_client_head = run_until_certified_light_client_head(&mut env);
+    let head_height =
+        env.validator().client().chain.get_block_header(&light_client_head).unwrap().height();
+    env.node_runner(1).run_until_final_head_height(head_height);
+
+    let request = || GetLightClientExecutionOutcomeProof {
+        id: TransactionOrReceiptId::Receipt { receipt_id, receiver_id: receiver.clone() },
+        light_client_head,
+    };
+
+    // The validator tracks every shard, so the same request is servable there.
+    env.validator_mut().view_client_actor().handle(request()).unwrap();
+
+    let result = env.node_mut(1).view_client_actor().handle(request());
+    assert_matches!(result, Err(GetLightClientProofError::UnavailableShard { .. }));
 }
 
 #[test]


### PR DESCRIPTION
First of a stack finishing the work #16180 left for later. This PR adds the execution-outcome proof; the state proof follows on top of it.

`EXPERIMENTAL_light_client_execution_outcome_proof` takes a transaction or receipt id and returns the chunk-execution proof for the chunk that executed it, plus the `ExecutionOutcomeWithIdView` whose merkle path recomputes that chunk's `outcome_root`. It is served only against a final `light_client_head` that is strictly newer than the block certifying the chunk. The client learns which chunk executed the outcome from the response.

The server picks the shard from the outcome's `executor_id`, not from the account named in the request, since that hint is unverified and would otherwise name a chunk whose `outcome_root` does not commit the outcome.

`verify_execution_outcome_proof` in `core/store/src/spice_proof_verifier.rs` takes the requested id and checks `block_hash` against the roots' chunk. Neither is covered by the hashed outcome, so without those checks a server could answer with a different outcome of the same chunk, or relabel this one. Call it after `verify_chunk_execution_proof` has bound the roots to the trusted head.

`GetLightClientProofError` gains `UnknownTransactionOrReceipt`, which the RPC error enum already had. A request whose shard this node does not track returns the existing `UnavailableShard`, the same answer `light_client_proof` gives for that condition, so no new RPC error name appears here.