### PR TITLE
feat(spice): light-client state proof

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -9,8 +9,8 @@ use near_primitives::types::{
 };
 use near_primitives::views::{
     ChunkExecutionProofView, EpochSyncStatusView, ExecutionOutcomeWithIdView,
-    LightClientBlockLiteView, QueryRequest, StateChangesRequestView, StateSyncStatusView,
-    SyncStatusView, TxStatusView,
+    LightClientBlockLiteView, QueryRequest, StateChangesRequestView, StateProofTarget,
+    StateProofView, StateSyncStatusView, SyncStatusView, TxStatusView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 use near_time::Duration;
@@ -935,6 +935,19 @@ pub struct GetLightClientExecutionOutcomeProofResponse {
     pub outcome_proof: ExecutionOutcomeWithIdView,
 }
 
+#[derive(Debug)]
+pub struct GetLightClientStateProof {
+    pub chunk_id: SpiceChunkId,
+    pub target: StateProofTarget,
+    pub light_client_head: CryptoHash,
+}
+
+#[derive(Debug)]
+pub struct GetLightClientStateProofResponse {
+    pub chunk_execution_proof: ChunkExecutionProofView,
+    pub state_proof: StateProofView,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum GetLightClientProofError {
     #[error("Chunk {chunk_id:?} is not yet certified")]
@@ -957,6 +970,19 @@ pub enum GetLightClientProofError {
     UnknownTransactionOrReceipt { transaction_or_receipt_id: CryptoHash },
     #[error("Node doesn't track the shard where {transaction_or_receipt_id} is executed")]
     UnavailableShard { transaction_or_receipt_id: CryptoHash, shard_id: ShardId },
+    #[error("Node does not track shard {shard_id}")]
+    ShardNotTracked { shard_id: ShardId },
+    #[error(
+        "Account {account_id} is in shard {account_shard_id}, not the requested shard \
+         {requested_shard_id}"
+    )]
+    TargetShardMismatch {
+        account_id: AccountId,
+        account_shard_id: ShardId,
+        requested_shard_id: ShardId,
+    },
+    #[error("State for chunk {chunk_id:?} is not available on this node")]
+    StateNotAvailable { chunk_id: SpiceChunkId },
     #[error("Internal error: {error_message}")]
     InternalError { error_message: String },
 }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -23,12 +23,12 @@ pub use near_client_primitives::types::{
     GetChunkExtraExists, GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
     GetExecutionOutcomesForBlock, GetGasPrice, GetLightClientChunkExecutionProof,
     GetLightClientExecutionOutcomeProof, GetLightClientExecutionOutcomeProofResponse,
-    GetLightClientProofError, GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock,
-    GetProcessedReceiptIds, GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse,
-    GetShardChunk, GetSplitStorageInfo, GetStateChanges, GetStateChangesInBlock,
-    GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
-    GetValidatorInfo, GetValidatorOrdered, Query, QueryError, Status, StatusResponse, SyncStatus,
-    TxStatus, TxStatusError, TxStatusOutcome,
+    GetLightClientProofError, GetLightClientStateProof, GetLightClientStateProofResponse,
+    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProcessedReceiptIds,
+    GetProtocolConfig, GetReceipt, GetReceiptToTx, GetReceiptToTxResponse, GetShardChunk,
+    GetSplitStorageInfo, GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
+    GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
+    QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError, TxStatusOutcome,
 };
 pub use near_network::client::{
     BlockApproval, BlockResponse, ProcessTxRequest, ProcessTxResponse, SetNetworkInfo,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -24,7 +24,8 @@ use near_client_primitives::types::{
     GetBlockWithMerkleTree, GetChunkError, GetChunkExtraExists, GetExecutionOutcome,
     GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError,
     GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
-    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError, GetMaintenanceWindows,
+    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError,
+    GetLightClientStateProof, GetLightClientStateProofResponse, GetMaintenanceWindows,
     GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProcessedReceiptIds,
     GetProcessedReceiptIdsError, GetProtocolConfig, GetProtocolConfigError, GetReceipt,
     GetReceiptError, GetReceiptToTx, GetReceiptToTxError, GetReceiptToTxResponse,
@@ -44,18 +45,19 @@ use near_network::types::{
 };
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::epoch_info::EpochInfo;
-use near_primitives::errors::EpochError;
+use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{PartialMerkleTree, merklize};
 use near_primitives::network::AnnounceAccount;
 use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptOrigin, ReceiptToTxInfo};
 use near_primitives::shard_layout::{ShardLayout, ShardLayoutError};
 use near_primitives::sharding::ShardChunk;
+use near_primitives::state::PartialState;
 use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{
-    AccountId, BlockHeight, BlockId, BlockReference, EpochHeight, EpochId, EpochReference,
-    Finality, MaybeBlockId, ShardId, SpiceChunkId, SyncCheckpoint, TransactionOrReceiptId,
-    ValidatorInfoIdentifier, sorted_chunk_execution_roots,
+    AccountId, BlockHeight, BlockId, BlockReference, ChunkExecutionRoots, EpochHeight, EpochId,
+    EpochReference, Finality, MaybeBlockId, ShardId, SpiceChunkId, StoreValue, SyncCheckpoint,
+    TransactionOrReceiptId, ValidatorInfoIdentifier, sorted_chunk_execution_roots,
 };
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
@@ -64,10 +66,11 @@ use near_primitives::views::{
     ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView,
     LightClientBlockLiteView, LightClientBlockView, MaintenanceWindowsView, QueryRequest,
     QueryResponse, ReceiptView, SplitStorageInfoView, StateChangesKindsView, StateChangesView,
-    TxExecutionStatus, TxStatusView,
+    StateProofView, TxExecutionStatus, TxStatusView,
 };
 use near_store::adapter::StoreAdapter as _;
 use near_store::merkle_proof::MerkleProofAccess;
+use near_store::trie::AccessOptions;
 use near_store::{COLD_HEAD_KEY, DBCol, FINAL_HEAD_KEY, HEAD_KEY};
 use parking_lot::RwLock;
 use std::cmp::Ordering;
@@ -1783,6 +1786,76 @@ impl
             chunk_execution_proof,
             outcome_proof: outcome.into(),
         })
+    }
+}
+
+impl
+    Handler<
+        GetLightClientStateProof,
+        Result<GetLightClientStateProofResponse, GetLightClientProofError>,
+    > for ViewClientActor
+{
+    fn handle(
+        &mut self,
+        msg: GetLightClientStateProof,
+    ) -> Result<GetLightClientStateProofResponse, GetLightClientProofError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer = metrics::VIEW_CLIENT_MESSAGE_TIME
+            .with_label_values(&["GetLightClientStateProof"])
+            .start_timer();
+        let shard_id = msg.chunk_id.shard_id;
+        let chunk_block_header = self.chain.get_block_header(&msg.chunk_id.block_hash)?;
+        if !self
+            .shard_tracker
+            .cares_about_shard_checked(chunk_block_header.prev_hash(), shard_id)
+            .into_chain_error()?
+        {
+            return Err(GetLightClientProofError::ShardNotTracked { shard_id });
+        }
+        // Without this the server would answer an absent value for a target that lives in
+        // another shard, and that absence proof verifies against this chunk's state_root.
+        let account_shard_id = account_id_to_shard_id(
+            self.epoch_manager.as_ref(),
+            msg.target.account_id(),
+            chunk_block_header.epoch_id(),
+        )
+        .into_chain_error()?;
+        if account_shard_id != shard_id {
+            return Err(GetLightClientProofError::TargetShardMismatch {
+                account_id: msg.target.account_id().clone(),
+                account_shard_id,
+                requested_shard_id: shard_id,
+            });
+        }
+        let shard_uid =
+            shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, chunk_block_header.epoch_id())
+                .into_chain_error()?;
+
+        let chunk_execution_proof =
+            self.build_chunk_execution_proof(&msg.chunk_id, &msg.light_client_head)?;
+        let ChunkExecutionRoots::V1(roots) = &chunk_execution_proof.roots;
+        let state_root = roots.state_root;
+
+        let trie = self
+            .runtime
+            .get_tries()
+            .get_view_trie_for_shard(shard_uid, state_root)
+            .recording_reads_new_recorder();
+        let trie_key = msg.target.to_trie_key().to_vec();
+        let value = trie.get(&trie_key, AccessOptions::DEFAULT).map_err(|error| match error {
+            StorageError::MissingTrieValue(_) => {
+                GetLightClientProofError::StateNotAvailable { chunk_id: msg.chunk_id.clone() }
+            }
+            error => GetLightClientProofError::InternalError { error_message: error.to_string() },
+        })?;
+        let Some(partial_storage) = trie.recorded_storage() else {
+            return Err(GetLightClientProofError::InternalError {
+                error_message: "trie did not record a state proof".to_string(),
+            });
+        };
+        let PartialState::TrieValues(nodes) = partial_storage.nodes;
+        let state_proof = StateProofView { value: value.map(StoreValue::from), nodes };
+        Ok(GetLightClientStateProofResponse { chunk_execution_proof, state_proof })
     }
 }
 

--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -73,6 +73,21 @@ pub struct RpcLightClientExecutionOutcomeProofResponse {
     pub outcome_proof: near_primitives::views::ExecutionOutcomeWithIdView,
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientStateProofRequest {
+    pub chunk_id: near_primitives::types::SpiceChunkId,
+    pub target: near_primitives::views::StateProofTarget,
+    pub light_client_head: near_primitives::hash::CryptoHash,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RpcLightClientStateProofResponse {
+    pub chunk_execution_proof: near_primitives::views::ChunkExecutionProofView,
+    pub state_proof: near_primitives::views::StateProofView,
+}
+
 #[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
@@ -101,6 +116,19 @@ pub enum RpcLightClientProofError {
         transaction_or_receipt_id: near_primitives::hash::CryptoHash,
         shard_id: near_primitives::types::ShardId,
     },
+    #[error("Node does not track shard {shard_id}")]
+    ShardNotTracked { shard_id: near_primitives::types::ShardId },
+    #[error(
+        "Account {account_id} is in shard {account_shard_id}, not the requested shard \
+         {requested_shard_id}"
+    )]
+    TargetShardMismatch {
+        account_id: near_primitives::types::AccountId,
+        account_shard_id: near_primitives::types::ShardId,
+        requested_shard_id: near_primitives::types::ShardId,
+    },
+    #[error("State for chunk {chunk_id:?} is not available on this node")]
+    StateNotAvailable { chunk_id: near_primitives::types::SpiceChunkId },
     #[error("Chunk {chunk_id:?} is not yet certified")]
     ChunkNotCertified { chunk_id: near_primitives::types::SpiceChunkId },
     #[error(

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "NEAR Protocol JSON RPC API",
-    "version": "1.3.16"
+    "version": "1.3.17"
   },
   "paths": {
     "/EXPERIMENTAL_call_function": {
@@ -201,6 +201,34 @@
         }
       }
     },
+    "/EXPERIMENTAL_light_client_execution_outcome_proof": {
+      "post": {
+        "description": "Returns a transaction or receipt execution outcome together with its proof against the chunk's certified outcome root, verifiable against a trusted light client head.",
+        "operationId": "EXPERIMENTAL_light_client_execution_outcome_proof",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_light_client_execution_outcome_proof"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonRpcResponse_for_RpcLightClientExecutionOutcomeProofResponse_and_RpcLightClientProofError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/EXPERIMENTAL_light_client_proof": {
       "post": {
         "description": "Returns the proofs for a transaction execution.",
@@ -222,6 +250,34 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/JsonRpcResponse_for_RpcLightClientExecutionProofResponse_and_RpcLightClientProofError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/EXPERIMENTAL_light_client_state_proof": {
+      "post": {
+        "description": "Returns a value from a shard's state together with its trie proof against the chunk's certified state root, verifiable against a trusted light client head.",
+        "operationId": "EXPERIMENTAL_light_client_state_proof",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_light_client_state_proof"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonRpcResponse_for_RpcLightClientStateProofResponse_and_RpcLightClientProofError"
                 }
               }
             }
@@ -9496,6 +9552,33 @@
         "title": "JsonRpcRequest_for_EXPERIMENTAL_light_client_chunk_execution_proof",
         "type": "object"
       },
+      "JsonRpcRequest_for_EXPERIMENTAL_light_client_execution_outcome_proof": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          },
+          "method": {
+            "enum": [
+              "EXPERIMENTAL_light_client_execution_outcome_proof"
+            ],
+            "type": "string"
+          },
+          "params": {
+            "$ref": "#/components/schemas/RpcLightClientExecutionOutcomeProofRequest"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id",
+          "params",
+          "method"
+        ],
+        "title": "JsonRpcRequest_for_EXPERIMENTAL_light_client_execution_outcome_proof",
+        "type": "object"
+      },
       "JsonRpcRequest_for_EXPERIMENTAL_light_client_proof": {
         "properties": {
           "id": {
@@ -9521,6 +9604,33 @@
           "method"
         ],
         "title": "JsonRpcRequest_for_EXPERIMENTAL_light_client_proof",
+        "type": "object"
+      },
+      "JsonRpcRequest_for_EXPERIMENTAL_light_client_state_proof": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          },
+          "method": {
+            "enum": [
+              "EXPERIMENTAL_light_client_state_proof"
+            ],
+            "type": "string"
+          },
+          "params": {
+            "$ref": "#/components/schemas/RpcLightClientStateProofRequest"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id",
+          "params",
+          "method"
+        ],
+        "title": "JsonRpcRequest_for_EXPERIMENTAL_light_client_state_proof",
         "type": "object"
       },
       "JsonRpcRequest_for_EXPERIMENTAL_maintenance_windows": {
@@ -10896,6 +11006,46 @@
         "title": "JsonRpcResponse_for_RpcLightClientChunkExecutionProofResponse_and_RpcLightClientProofError",
         "type": "object"
       },
+      "JsonRpcResponse_for_RpcLightClientExecutionOutcomeProofResponse_and_RpcLightClientProofError": {
+        "oneOf": [
+          {
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/RpcLightClientExecutionOutcomeProofResponse"
+              }
+            },
+            "required": [
+              "result"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "error": {
+                "$ref": "#/components/schemas/ErrorWrapper_for_RpcLightClientProofError"
+              }
+            },
+            "required": [
+              "error"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id"
+        ],
+        "title": "JsonRpcResponse_for_RpcLightClientExecutionOutcomeProofResponse_and_RpcLightClientProofError",
+        "type": "object"
+      },
       "JsonRpcResponse_for_RpcLightClientExecutionProofResponse_and_RpcLightClientProofError": {
         "oneOf": [
           {
@@ -10974,6 +11124,46 @@
           "id"
         ],
         "title": "JsonRpcResponse_for_RpcLightClientNextBlockResponse_and_RpcLightClientNextBlockError",
+        "type": "object"
+      },
+      "JsonRpcResponse_for_RpcLightClientStateProofResponse_and_RpcLightClientProofError": {
+        "oneOf": [
+          {
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/RpcLightClientStateProofResponse"
+              }
+            },
+            "required": [
+              "result"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "error": {
+                "$ref": "#/components/schemas/ErrorWrapper_for_RpcLightClientProofError"
+              }
+            },
+            "required": [
+              "error"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id"
+        ],
+        "title": "JsonRpcResponse_for_RpcLightClientStateProofResponse_and_RpcLightClientProofError",
         "type": "object"
       },
       "JsonRpcResponse_for_RpcNetworkInfoResponse_and_RpcNetworkInfoError": {
@@ -14297,6 +14487,79 @@
         ],
         "type": "object"
       },
+      "RpcLightClientExecutionOutcomeProofRequest": {
+        "oneOf": [
+          {
+            "properties": {
+              "sender_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "transaction_hash": {
+                "$ref": "#/components/schemas/CryptoHash"
+              },
+              "type": {
+                "enum": [
+                  "transaction"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "transaction_hash",
+              "sender_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "receipt_id": {
+                "$ref": "#/components/schemas/CryptoHash"
+              },
+              "receiver_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "type": {
+                "enum": [
+                  "receipt"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "receipt_id",
+              "receiver_id"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "light_client_head": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        "required": [
+          "light_client_head"
+        ],
+        "title": "RpcLightClientExecutionOutcomeProofRequest",
+        "type": "object"
+      },
+      "RpcLightClientExecutionOutcomeProofResponse": {
+        "properties": {
+          "chunk_execution_proof": {
+            "$ref": "#/components/schemas/ChunkExecutionProofView"
+          },
+          "outcome_proof": {
+            "$ref": "#/components/schemas/ExecutionOutcomeWithIdView"
+          }
+        },
+        "required": [
+          "chunk_execution_proof",
+          "outcome_proof"
+        ],
+        "type": "object"
+      },
       "RpcLightClientExecutionProofRequest": {
         "oneOf": [
           {
@@ -14654,6 +14917,92 @@
             "properties": {
               "info": {
                 "properties": {
+                  "shard_id": {
+                    "$ref": "#/components/schemas/ShardId"
+                  }
+                },
+                "required": [
+                  "shard_id"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "enum": [
+                  "SHARD_NOT_TRACKED"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "info"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "info": {
+                "properties": {
+                  "account_id": {
+                    "$ref": "#/components/schemas/AccountId"
+                  },
+                  "account_shard_id": {
+                    "$ref": "#/components/schemas/ShardId"
+                  },
+                  "requested_shard_id": {
+                    "$ref": "#/components/schemas/ShardId"
+                  }
+                },
+                "required": [
+                  "account_id",
+                  "account_shard_id",
+                  "requested_shard_id"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "enum": [
+                  "TARGET_SHARD_MISMATCH"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "info"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "info": {
+                "properties": {
+                  "chunk_id": {
+                    "$ref": "#/components/schemas/SpiceChunkId"
+                  }
+                },
+                "required": [
+                  "chunk_id"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "enum": [
+                  "STATE_NOT_AVAILABLE"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "info"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "info": {
+                "properties": {
                   "chunk_id": {
                     "$ref": "#/components/schemas/SpiceChunkId"
                   }
@@ -14741,6 +15090,41 @@
             "type": "object"
           }
         ]
+      },
+      "RpcLightClientStateProofRequest": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "light_client_head": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "target": {
+            "$ref": "#/components/schemas/StateProofTarget"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "target",
+          "light_client_head"
+        ],
+        "title": "RpcLightClientStateProofRequest",
+        "type": "object"
+      },
+      "RpcLightClientStateProofResponse": {
+        "properties": {
+          "chunk_execution_proof": {
+            "$ref": "#/components/schemas/ChunkExecutionProofView"
+          },
+          "state_proof": {
+            "$ref": "#/components/schemas/StateProofView"
+          }
+        },
+        "required": [
+          "chunk_execution_proof",
+          "state_proof"
+        ],
+        "type": "object"
       },
       "RpcMaintenanceWindowsError": {
         "oneOf": [
@@ -21172,6 +21556,119 @@
         "required": [
           "key",
           "value"
+        ],
+        "type": "object"
+      },
+      "StateProofTarget": {
+        "description": "Which piece of a shard's state a light-client state proof targets.\n\nAn account that runs a global contract has no local code, so `LocalContractCode` is\nabsent for it. `Account::contract()` says which case applies.",
+        "oneOf": [
+          {
+            "properties": {
+              "account_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "target_type": {
+                "enum": [
+                  "account"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_type",
+              "account_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "account_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "target_type": {
+                "enum": [
+                  "local_contract_code"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_type",
+              "account_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "account_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "key": {
+                "$ref": "#/components/schemas/StoreKey"
+              },
+              "target_type": {
+                "enum": [
+                  "contract_data"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_type",
+              "account_id",
+              "key"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "account_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "target_type": {
+                "enum": [
+                  "access_key"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_type",
+              "account_id",
+              "public_key"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "StateProofView": {
+        "description": "A value read from a shard's state, with the trie nodes that prove it against the\nchunk's `state_root`. An absent `value` is proved the same way.",
+        "properties": {
+          "nodes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StoreValue"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true
+              }
+            ]
+          }
+        },
+        "required": [
+          "nodes"
         ],
         "type": "object"
       },

--- a/chain/jsonrpc/openapi/openrpc.json
+++ b/chain/jsonrpc/openapi/openrpc.json
@@ -9029,6 +9029,78 @@
         "title": "RpcLightClientChunkExecutionProofResponse",
         "type": "object"
       },
+      "RpcLightClientExecutionOutcomeProofRequest": {
+        "oneOf": [
+          {
+            "properties": {
+              "light_client_head": {
+                "$ref": "#/components/schemas/CryptoHash"
+              },
+              "sender_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "transaction_hash": {
+                "$ref": "#/components/schemas/CryptoHash"
+              },
+              "type": {
+                "const": "transaction",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "transaction_hash",
+              "sender_id",
+              "light_client_head"
+            ],
+            "title": "Transaction",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "light_client_head": {
+                "$ref": "#/components/schemas/CryptoHash"
+              },
+              "receipt_id": {
+                "$ref": "#/components/schemas/CryptoHash"
+              },
+              "receiver_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "type": {
+                "const": "receipt",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "receipt_id",
+              "receiver_id",
+              "light_client_head"
+            ],
+            "title": "Receipt",
+            "type": "object"
+          }
+        ],
+        "title": "RpcLightClientExecutionOutcomeProofRequest",
+        "type": "object"
+      },
+      "RpcLightClientExecutionOutcomeProofResponse": {
+        "properties": {
+          "chunk_execution_proof": {
+            "$ref": "#/components/schemas/ChunkExecutionProofView"
+          },
+          "outcome_proof": {
+            "$ref": "#/components/schemas/ExecutionOutcomeWithIdView"
+          }
+        },
+        "required": [
+          "chunk_execution_proof",
+          "outcome_proof"
+        ],
+        "title": "RpcLightClientExecutionOutcomeProofResponse",
+        "type": "object"
+      },
       "RpcLightClientExecutionProofRequest": {
         "oneOf": [
           {
@@ -9171,6 +9243,42 @@
           }
         },
         "title": "RpcLightClientNextBlockResponse",
+        "type": "object"
+      },
+      "RpcLightClientStateProofRequest": {
+        "properties": {
+          "chunk_id": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          },
+          "light_client_head": {
+            "$ref": "#/components/schemas/CryptoHash"
+          },
+          "target": {
+            "$ref": "#/components/schemas/StateProofTarget"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "target",
+          "light_client_head"
+        ],
+        "title": "RpcLightClientStateProofRequest",
+        "type": "object"
+      },
+      "RpcLightClientStateProofResponse": {
+        "properties": {
+          "chunk_execution_proof": {
+            "$ref": "#/components/schemas/ChunkExecutionProofView"
+          },
+          "state_proof": {
+            "$ref": "#/components/schemas/StateProofView"
+          }
+        },
+        "required": [
+          "chunk_execution_proof",
+          "state_proof"
+        ],
+        "title": "RpcLightClientStateProofResponse",
         "type": "object"
       },
       "RpcMaintenanceWindowsRequest": {
@@ -12165,6 +12273,114 @@
         "title": "StateItem",
         "type": "object"
       },
+      "StateProofTarget": {
+        "description": "Which piece of a shard's state a light-client state proof targets.\n\nAn account that runs a global contract has no local code, so `LocalContractCode` is\nabsent for it. `Account::contract()` says which case applies.",
+        "oneOf": [
+          {
+            "properties": {
+              "account_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "target_type": {
+                "const": "account",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_type",
+              "account_id"
+            ],
+            "title": "Account",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "account_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "target_type": {
+                "const": "local_contract_code",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_type",
+              "account_id"
+            ],
+            "title": "LocalContractCode",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "account_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "key": {
+                "$ref": "#/components/schemas/StoreKey"
+              },
+              "target_type": {
+                "const": "contract_data",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_type",
+              "account_id",
+              "key"
+            ],
+            "title": "ContractData",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "account_id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "public_key": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "target_type": {
+                "const": "access_key",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_type",
+              "account_id",
+              "public_key"
+            ],
+            "title": "AccessKey",
+            "type": "object"
+          }
+        ],
+        "title": "StateProofTarget"
+      },
+      "StateProofView": {
+        "description": "A value read from a shard's state, with the trie nodes that prove it against the\nchunk's `state_root`. An absent `value` is proved the same way.",
+        "properties": {
+          "nodes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "value": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/StoreValue"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "nodes"
+        ],
+        "title": "StateProofView",
+        "type": "object"
+      },
       "StateSyncConfig": {
         "properties": {
           "concurrency": {
@@ -14316,6 +14532,111 @@
         }
       },
       "summary": "Returns a proof of a chunk's certified execution roots for light clients",
+      "tags": [
+        {
+          "name": "light_client"
+        },
+        {
+          "name": "experimental"
+        }
+      ]
+    },
+    {
+      "name": "EXPERIMENTAL_light_client_execution_outcome_proof",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "light_client_head",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        {
+          "name": "receipt_id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        {
+          "name": "receiver_id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/AccountId"
+          }
+        },
+        {
+          "name": "sender_id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/AccountId"
+          }
+        },
+        {
+          "name": "transaction_hash",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        {
+          "name": "type",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$ref": "#/components/schemas/RpcLightClientExecutionOutcomeProofResponse"
+        }
+      },
+      "summary": "Returns an execution outcome and its proof against the chunk's certified outcome root",
+      "tags": [
+        {
+          "name": "light_client"
+        },
+        {
+          "name": "experimental"
+        }
+      ]
+    },
+    {
+      "name": "EXPERIMENTAL_light_client_state_proof",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "chunk_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SpiceChunkId"
+          }
+        },
+        {
+          "name": "light_client_head",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/CryptoHash"
+          }
+        },
+        {
+          "name": "target",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/StateProofTarget"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$ref": "#/components/schemas/RpcLightClientStateProofResponse"
+        }
+      },
+      "summary": "Returns a state value and its trie proof against the chunk's certified state root",
       "tags": [
         {
           "name": "light_client"

--- a/chain/jsonrpc/openapi/src/main.rs
+++ b/chain/jsonrpc/openapi/src/main.rs
@@ -24,8 +24,10 @@ use near_jsonrpc_primitives::types::{
     light_client::{
         RpcLightClientBlockProofRequest, RpcLightClientBlockProofResponse,
         RpcLightClientChunkExecutionProofRequest, RpcLightClientChunkExecutionProofResponse,
+        RpcLightClientExecutionOutcomeProofRequest, RpcLightClientExecutionOutcomeProofResponse,
         RpcLightClientExecutionProofResponse, RpcLightClientNextBlockError,
         RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse, RpcLightClientProofError,
+        RpcLightClientStateProofRequest, RpcLightClientStateProofResponse,
     },
     maintenance::{
         RpcMaintenanceWindowsError, RpcMaintenanceWindowsRequest, RpcMaintenanceWindowsResponse,
@@ -701,7 +703,7 @@ fn whole_spec(all_schemas: SchemasMap, all_paths: PathsMap) -> OpenApi {
         openapi: "3.0.0".to_string(),
         info: okapi::openapi3::Info {
             title: "NEAR Protocol JSON RPC API".to_string(),
-            version: "1.3.16".to_string(),
+            version: "1.3.17".to_string(),
             ..Default::default()
         },
         paths: all_paths,
@@ -905,6 +907,26 @@ fn main() {
         &mut all_paths,
         "EXPERIMENTAL_light_client_chunk_execution_proof".to_string(),
         "Returns a proof that a chunk's certified execution roots are committed by the chain, verifiable against a trusted light client head.".to_string(),
+    );
+    add_spec_for_path::<
+        RpcLightClientExecutionOutcomeProofRequest,
+        RpcLightClientExecutionOutcomeProofResponse,
+        RpcLightClientProofError,
+    >(
+        &mut all_schemas,
+        &mut all_paths,
+        "EXPERIMENTAL_light_client_execution_outcome_proof".to_string(),
+        "Returns a transaction or receipt execution outcome together with its proof against the chunk's certified outcome root, verifiable against a trusted light client head.".to_string(),
+    );
+    add_spec_for_path::<
+        RpcLightClientStateProofRequest,
+        RpcLightClientStateProofResponse,
+        RpcLightClientProofError,
+    >(
+        &mut all_schemas,
+        &mut all_paths,
+        "EXPERIMENTAL_light_client_state_proof".to_string(),
+        "Returns a value from a shard's state together with its trie proof against the chunk's certified state root, verifiable against a trusted light client head.".to_string(),
     );
     add_spec_for_path::<RpcProtocolConfigRequest, RpcProtocolConfigResponse, RpcProtocolConfigError>(
         &mut all_schemas,

--- a/chain/jsonrpc/openapi/src/openrpc.rs
+++ b/chain/jsonrpc/openapi/src/openrpc.rs
@@ -28,8 +28,10 @@ use near_jsonrpc_primitives::types::gas_price::{RpcGasPriceRequest, RpcGasPriceR
 use near_jsonrpc_primitives::types::light_client::{
     RpcLightClientBlockProofRequest, RpcLightClientBlockProofResponse,
     RpcLightClientChunkExecutionProofRequest, RpcLightClientChunkExecutionProofResponse,
+    RpcLightClientExecutionOutcomeProofRequest, RpcLightClientExecutionOutcomeProofResponse,
     RpcLightClientExecutionProofRequest, RpcLightClientExecutionProofResponse,
     RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse,
+    RpcLightClientStateProofRequest, RpcLightClientStateProofResponse,
 };
 use near_jsonrpc_primitives::types::maintenance::{
     RpcMaintenanceWindowsRequest, RpcMaintenanceWindowsResponse,
@@ -1229,6 +1231,25 @@ pub fn generate_openrpc() -> serde_json::Value {
         &mut all_schemas,
         "EXPERIMENTAL_light_client_chunk_execution_proof",
         "Returns a proof of a chunk's certified execution roots for light clients",
+        false,
+        &["light_client", "experimental"],
+    );
+    add_method::<
+        RpcLightClientExecutionOutcomeProofRequest,
+        RpcLightClientExecutionOutcomeProofResponse,
+    >(
+        &mut methods,
+        &mut all_schemas,
+        "EXPERIMENTAL_light_client_execution_outcome_proof",
+        "Returns an execution outcome and its proof against the chunk's certified outcome root",
+        false,
+        &["light_client", "experimental"],
+    );
+    add_method::<RpcLightClientStateProofRequest, RpcLightClientStateProofResponse>(
+        &mut methods,
+        &mut all_schemas,
+        "EXPERIMENTAL_light_client_state_proof",
+        "Returns a state value and its trie proof against the chunk's certified state root",
         false,
         &["light_client", "experimental"],
     );

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -9,7 +9,7 @@ use near_jsonrpc_primitives::types::light_client::{
     RpcLightClientBlockProofRequest, RpcLightClientChunkExecutionProofRequest,
     RpcLightClientExecutionOutcomeProofRequest, RpcLightClientExecutionProofRequest,
     RpcLightClientNextBlockError, RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse,
-    RpcLightClientProofError,
+    RpcLightClientProofError, RpcLightClientStateProofRequest,
 };
 use near_primitives::views::LightClientBlockView;
 use serde_json::Value;
@@ -47,6 +47,12 @@ impl RpcRequest for RpcLightClientExecutionOutcomeProofRequest {
     }
 }
 
+impl RpcRequest for RpcLightClientStateProofRequest {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
+        Params::parse(value)
+    }
+}
+
 impl RpcFrom<GetLightClientProofError> for RpcLightClientProofError {
     fn rpc_from(error: GetLightClientProofError) -> Self {
         match error {
@@ -66,6 +72,17 @@ impl RpcFrom<GetLightClientProofError> for RpcLightClientProofError {
             }
             GetLightClientProofError::UnavailableShard { transaction_or_receipt_id, shard_id } => {
                 Self::UnavailableShard { transaction_or_receipt_id, shard_id }
+            }
+            GetLightClientProofError::ShardNotTracked { shard_id } => {
+                Self::ShardNotTracked { shard_id }
+            }
+            GetLightClientProofError::TargetShardMismatch {
+                account_id,
+                account_shard_id,
+                requested_shard_id,
+            } => Self::TargetShardMismatch { account_id, account_shard_id, requested_shard_id },
+            GetLightClientProofError::StateNotAvailable { chunk_id } => {
+                Self::StateNotAvailable { chunk_id }
             }
             GetLightClientProofError::InternalError { error_message } => {
                 Self::InternalError { error_message }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -17,7 +17,8 @@ use near_client::{
     DebugStatus, GetBlock, GetBlockProof, GetBlockProofResponse, GetChunk, GetChunkExtraExists,
     GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice,
     GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
-    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError, GetMaintenanceWindows,
+    GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError,
+    GetLightClientStateProof, GetLightClientStateProofResponse, GetMaintenanceWindows,
     GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetReceiptToTx,
     GetReceiptToTxResponse, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo,
     GetValidatorOrdered, ProcessTxRequest, ProcessTxResponse, Query as ClientQuery, QueryError,
@@ -466,6 +467,10 @@ pub struct ViewClientSenderForRpc(
         GetLightClientExecutionOutcomeProof,
         Result<GetLightClientExecutionOutcomeProofResponse, GetLightClientProofError>,
     >,
+    AsyncSender<
+        GetLightClientStateProof,
+        Result<GetLightClientStateProofResponse, GetLightClientProofError>,
+    >,
     AsyncSender<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>,
     AsyncSender<GetGasPrice, Result<GasPriceView, GetGasPriceError>>,
     AsyncSender<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanceWindowsError>>,
@@ -784,6 +789,9 @@ impl JsonRpcHandler {
                     self.light_client_execution_outcome_proof(params)
                 })
                 .await
+            }
+            "EXPERIMENTAL_light_client_state_proof" => {
+                process_method_call(request, |params| self.light_client_state_proof(params)).await
             }
             "EXPERIMENTAL_protocol_config" => {
                 process_method_call(request, |params| self.protocol_config(params)).await
@@ -2539,6 +2547,27 @@ impl JsonRpcHandler {
                 outcome_proof: response.outcome_proof,
             },
         )
+    }
+
+    async fn light_client_state_proof(
+        &self,
+        request: near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofRequest,
+    ) -> Result<
+        near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofResponse,
+        near_jsonrpc_primitives::types::light_client::RpcLightClientProofError,
+    > {
+        let near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofRequest {
+            chunk_id,
+            target,
+            light_client_head,
+        } = request;
+        let response: GetLightClientStateProofResponse = self
+            .view_client_send(GetLightClientStateProof { chunk_id, target, light_client_head })
+            .await?;
+        Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientStateProofResponse {
+            chunk_execution_proof: response.chunk_execution_proof,
+            state_proof: response.state_proof,
+        })
     }
 
     async fn network_info(

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -40,6 +40,7 @@ use crate::transaction::{
     ExecutionStatus, FunctionCallAction, NonceMode, PartialExecutionOutcome,
     PartialExecutionStatus, SignedTransaction, StakeAction, TransferAction,
 };
+use crate::trie_key::TrieKey;
 use crate::trie_split::TrieSplit;
 use crate::types::{
     AccountId, AccountWithPublicKey, Balance, BlockHeight, ChunkExecutionRoots, EpochHeight,
@@ -2784,6 +2785,60 @@ pub struct ChunkExecutionProofView {
     pub roots_proof: MerklePath,
     pub certifying_block_header_lite: LightClientBlockLiteView,
     pub certifying_block_proof: MerklePath,
+}
+
+/// A value read from a shard's state, with the trie nodes that prove it against the
+/// chunk's `state_root`. An absent `value` is proved the same way.
+#[serde_as]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct StateProofView {
+    pub value: Option<StoreValue>,
+    #[serde_as(as = "Vec<Base64>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Vec<String>"))]
+    pub nodes: Vec<Arc<[u8]>>,
+}
+
+/// Which piece of a shard's state a light-client state proof targets.
+///
+/// An account that runs a global contract has no local code, so `LocalContractCode` is
+/// absent for it. `Account::contract()` says which case applies.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(tag = "target_type", rename_all = "snake_case")]
+pub enum StateProofTarget {
+    Account { account_id: AccountId },
+    LocalContractCode { account_id: AccountId },
+    ContractData { account_id: AccountId, key: StoreKey },
+    AccessKey { account_id: AccountId, public_key: PublicKey },
+}
+
+impl StateProofTarget {
+    pub fn account_id(&self) -> &AccountId {
+        match self {
+            StateProofTarget::Account { account_id }
+            | StateProofTarget::LocalContractCode { account_id }
+            | StateProofTarget::ContractData { account_id, .. }
+            | StateProofTarget::AccessKey { account_id, .. } => account_id,
+        }
+    }
+
+    pub fn to_trie_key(&self) -> TrieKey {
+        match self {
+            StateProofTarget::Account { account_id } => {
+                TrieKey::Account { account_id: account_id.clone() }
+            }
+            StateProofTarget::LocalContractCode { account_id } => {
+                TrieKey::ContractCode { account_id: account_id.clone() }
+            }
+            StateProofTarget::ContractData { account_id, key } => {
+                TrieKey::ContractData { account_id: account_id.clone(), key: key.clone().into() }
+            }
+            StateProofTarget::AccessKey { account_id, public_key } => {
+                TrieKey::access_key(account_id.clone(), public_key.clone())
+            }
+        }
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/core/store/src/spice_proof_verifier.rs
+++ b/core/store/src/spice_proof_verifier.rs
@@ -1,12 +1,17 @@
-//! Verification for SPICE light-client chunk-execution proofs.
+//! Verification for SPICE light-client proofs.
 //!
 //! A light client trusts a final head and its block merkle root. These functions
 //! recompute that root from a served proof without trusting the serving node.
 
+use crate::trie::AccessOptions;
+use crate::{PartialStorage, Trie};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{compute_root_from_path, compute_root_from_path_and_item};
-use near_primitives::types::{ChunkExecutionRoots, SpiceChunkId};
-use near_primitives::views::{ChunkExecutionProofView, ExecutionOutcomeWithIdView};
+use near_primitives::state::PartialState;
+use near_primitives::types::{ChunkExecutionRoots, SpiceChunkId, StoreValue};
+use near_primitives::views::{
+    ChunkExecutionProofView, ExecutionOutcomeWithIdView, StateProofTarget, StateProofView,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SpiceProofVerificationError {
@@ -24,6 +29,10 @@ pub enum SpiceProofVerificationError {
     UnexpectedOutcomeBlockHash { expected: CryptoHash, found: CryptoHash },
     #[error("execution outcome proof does not recompute the chunk's outcome_root")]
     InvalidOutcomeProof,
+    #[error("state proof does not reconstruct the claimed value at the chunk's state_root")]
+    InvalidStateProof,
+    #[error("state proof trie access failed: {0}")]
+    TrieError(String),
 }
 
 /// Checks that `expected_chunk_id`'s execution roots are committed by a block that
@@ -90,4 +99,41 @@ pub fn verify_execution_outcome_proof(
         return Err(SpiceProofVerificationError::InvalidOutcomeProof);
     }
     Ok(())
+}
+
+/// What a verified state proof says about `target` in one shard.
+#[derive(Debug)]
+pub enum StateProofOutcome<'a> {
+    Present(&'a StoreValue),
+    /// Absent from this chunk's shard. Absence from the chain is a stronger claim.
+    AbsentInShard,
+}
+
+/// Verifies a state trie proof against the chunk's `state_root`: reconstructs the
+/// trie from `state_proof` and checks the claimed value for `target`. Call after
+/// [`verify_chunk_execution_proof`] to bind `roots` to the trusted head.
+// TODO(spice): `AbsentInShard` for a contract-code, contract-data, or access-key target
+// can be raised to a global absence by pairing it with a `Present` account proof for the
+// same chunk, since a shard's state only holds accounts it owns. Proving an account itself
+// absent still needs an authenticated shard layout.
+pub fn verify_state_proof<'a>(
+    target: &StateProofTarget,
+    state_proof: &'a StateProofView,
+    roots: &ChunkExecutionRoots,
+) -> Result<StateProofOutcome<'a>, SpiceProofVerificationError> {
+    let ChunkExecutionRoots::V1(roots) = roots;
+    let partial_storage =
+        PartialStorage { nodes: PartialState::TrieValues(state_proof.nodes.clone()) };
+    let trie = Trie::from_recorded_storage(partial_storage, roots.state_root, false);
+    let trie_key = target.to_trie_key().to_vec();
+    let recovered_value = trie
+        .get(&trie_key, AccessOptions::DEFAULT)
+        .map_err(|error| SpiceProofVerificationError::TrieError(error.to_string()))?;
+    if recovered_value.as_deref() != state_proof.value.as_ref().map(|value| value.as_slice()) {
+        return Err(SpiceProofVerificationError::InvalidStateProof);
+    }
+    Ok(match state_proof.value.as_ref() {
+        Some(value) => StateProofOutcome::Present(value),
+        None => StateProofOutcome::AbsentInShard,
+    })
 }

--- a/test-loop-tests/src/tests/spice/light_client.rs
+++ b/test-loop-tests/src/tests/spice/light_client.rs
@@ -2,26 +2,35 @@ use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
 use crate::utils::account::{create_account_id, create_account_ids};
 use assert_matches::assert_matches;
+use borsh::BorshDeserialize as _;
 use near_async::messaging::Handler as _;
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess as _;
 use near_chain_configs::TrackedShardsConfig;
-use near_client::{GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof};
+use near_client::{
+    GetLightClientChunkExecutionProof, GetLightClientExecutionOutcomeProof,
+    GetLightClientStateProof,
+};
 use near_client_primitives::types::GetLightClientProofError;
 use near_epoch_manager::shard_assignment::account_id_to_shard_id;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
+use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::types::{
     Balance, ChunkExecutionRoots, ChunkExecutionRootsV1, Gas, SpiceChunkId, TransactionOrReceiptId,
 };
 use near_primitives::views::{
-    ChunkExecutionProofView, ExecutionStatusView, LightClientBlockLiteView,
+    ChunkExecutionProofView, ExecutionStatusView, LightClientBlockLiteView, StateProofTarget,
+    StateProofView,
 };
 use near_store::spice_proof_verifier::{
-    SpiceProofVerificationError, verify_chunk_execution_proof, verify_execution_outcome_proof,
+    SpiceProofVerificationError, StateProofOutcome, verify_chunk_execution_proof,
+    verify_execution_outcome_proof, verify_state_proof,
 };
+use near_test_contracts::rs_contract;
 
 /// Certifies the chain, then returns a final head strictly newer than the certifying block.
 fn run_until_certified_light_client_head(env: &mut TestLoopEnv) -> CryptoHash {
@@ -411,6 +420,209 @@ fn test_spice_light_client_outcome_proof_untracked_shard() {
 
     let result = env.node_mut(1).view_client_actor().handle(request());
     assert_matches!(result, Err(GetLightClientProofError::UnavailableShard { .. }));
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_light_client_state_proof() {
+    init_test_logger();
+
+    // See the outcome-proof test: this account is outside the first shard.
+    let contract_account = create_account_id("vault");
+    let mut env = TestLoopBuilder::new()
+        .validators(1, 0)
+        .num_shards(4)
+        .add_user_accounts([&contract_account], Balance::from_near(10))
+        .build();
+
+    let deploy_tx = env.validator().tx_deploy_test_contract(&contract_account);
+    env.validator_runner().run_tx(deploy_tx, Duration::seconds(20));
+
+    // rs_contract's write_key_value reads input as `key_bytes || value(u64 LE)` and
+    // does storage_write(key, value), so this creates a provable ContractData entry.
+    let storage_key = b"spice_key".to_vec();
+    let storage_value: u64 = 42;
+    let mut call_args = storage_key.clone();
+    call_args.extend_from_slice(&storage_value.to_le_bytes());
+    let call_tx = env.validator().tx_call(
+        &contract_account,
+        &contract_account,
+        "write_key_value",
+        call_args,
+        Balance::ZERO,
+        Gas::from_teragas(300),
+    );
+    let call_tx_hash = call_tx.get_hash();
+    env.validator_runner().run_tx(call_tx, Duration::seconds(20));
+    let receipt_id = env.validator().tx_receipt_id(call_tx_hash);
+
+    let tip_height = env.validator().head().height;
+    env.validator_runner().run_until_certified(tip_height);
+    let certified_head_height = env.validator().head().height;
+    env.validator_runner().run_until_final_head_height(certified_head_height + 1);
+
+    let light_client_head = env.validator().final_head().last_block_hash;
+
+    // The chunk that executed the write; its certified state_root is what the state
+    // proofs below are checked against.
+    let write_block_hash = env.validator().execution_outcome_with_proof(receipt_id).block_hash;
+    let epoch_manager = env.validator().client().epoch_manager.clone();
+    let epoch_id =
+        *env.validator().client().chain.get_block_header(&write_block_hash).unwrap().epoch_id();
+    let account_shard_id =
+        account_id_to_shard_id(epoch_manager.as_ref(), &contract_account, &epoch_id).unwrap();
+    let chunk_id = SpiceChunkId { block_hash: write_block_hash, shard_id: account_shard_id };
+
+    // Account record proves the deployed contract and a gas-reduced balance.
+    let account_target = StateProofTarget::Account { account_id: contract_account.clone() };
+    let account_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: account_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    let StateProofOutcome::Present(account_value) = verify_state_proof(
+        &account_target,
+        &account_response.state_proof,
+        &account_response.chunk_execution_proof.roots,
+    )
+    .unwrap() else {
+        panic!("contract account must be present")
+    };
+    let account = Account::try_from_slice(account_value.as_slice()).unwrap();
+    assert_eq!(account.local_contract_hash(), Some(CryptoHash::hash_bytes(rs_contract())));
+    assert!(account.amount() < Balance::from_near(10), "deploy and call gas should reduce balance");
+
+    // The contract-data key/value the call wrote is present and proves the exact value.
+    let data_target = StateProofTarget::ContractData {
+        account_id: contract_account.clone(),
+        key: storage_key.into(),
+    };
+    let data_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: data_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    let StateProofOutcome::Present(proved_value) = verify_state_proof(
+        &data_target,
+        &data_response.state_proof,
+        &data_response.chunk_execution_proof.roots,
+    )
+    .unwrap() else {
+        panic!("contract data must be present")
+    };
+    assert_eq!(proved_value.as_slice(), storage_value.to_le_bytes().as_slice());
+
+    // The chunk-execution proof in the response ties state_root to the trusted head.
+    let head_header = env.validator().client().chain.get_block_header(&light_client_head).unwrap();
+    verify_chunk_execution_proof(
+        &data_response.chunk_execution_proof,
+        &chunk_id,
+        head_header.block_merkle_root(),
+    )
+    .unwrap();
+
+    // Tampering the claimed value must be rejected by the trie proof.
+    let tampered_state_proof = StateProofView {
+        value: Some(b"tampered contract data".to_vec().into()),
+        ..data_response.state_proof.clone()
+    };
+    assert_matches!(
+        verify_state_proof(
+            &data_target,
+            &tampered_state_proof,
+            &data_response.chunk_execution_proof.roots,
+        ),
+        Err(SpiceProofVerificationError::InvalidStateProof)
+    );
+
+    let other_shard_id = epoch_manager
+        .get_shard_layout(&epoch_id)
+        .unwrap()
+        .shard_ids()
+        .find(|shard_id| *shard_id != account_shard_id)
+        .unwrap();
+    let result = env.validator_mut().view_client_actor().handle(GetLightClientStateProof {
+        chunk_id: SpiceChunkId { block_hash: write_block_hash, shard_id: other_shard_id },
+        target: account_target,
+        light_client_head,
+    });
+    assert_matches!(result, Err(GetLightClientProofError::TargetShardMismatch { .. }));
+
+    // The deployed code itself is provable, and its bytes are the contract we sent.
+    let code_target = StateProofTarget::LocalContractCode { account_id: contract_account.clone() };
+    let code_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: code_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    let StateProofOutcome::Present(proved_code) = verify_state_proof(
+        &code_target,
+        &code_response.state_proof,
+        &code_response.chunk_execution_proof.roots,
+    )
+    .unwrap() else {
+        panic!("contract code must be present")
+    };
+    assert_eq!(proved_code.as_slice(), rs_contract());
+
+    // The access key exercises the public-key to trie-handle encoding.
+    let access_key_target = StateProofTarget::AccessKey {
+        account_id: contract_account.clone(),
+        public_key: create_user_test_signer(&contract_account).public_key(),
+    };
+    let access_key_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id: chunk_id.clone(),
+            target: access_key_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    let StateProofOutcome::Present(access_key_value) = verify_state_proof(
+        &access_key_target,
+        &access_key_response.state_proof,
+        &access_key_response.chunk_execution_proof.roots,
+    )
+    .unwrap() else {
+        panic!("access key must be present")
+    };
+    AccessKey::try_from_slice(access_key_value.as_slice()).unwrap();
+
+    // A key the contract never wrote has no value, and that absence is provable.
+    let absent_target = StateProofTarget::ContractData {
+        account_id: contract_account,
+        key: b"never_written".to_vec().into(),
+    };
+    let absent_response = env
+        .validator_mut()
+        .view_client_actor()
+        .handle(GetLightClientStateProof {
+            chunk_id,
+            target: absent_target.clone(),
+            light_client_head,
+        })
+        .unwrap();
+    assert_matches!(
+        verify_state_proof(
+            &absent_target,
+            &absent_response.state_proof,
+            &absent_response.chunk_execution_proof.roots,
+        ),
+        Ok(StateProofOutcome::AbsentInShard)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #16250. Review that one first; this PR's diff is only the state proof.

`EXPERIMENTAL_light_client_state_proof` takes a chunk id and a target (account, contract code, contract data, or access key) and returns the value together with its trie proof at the chunk's certified `state_root`. It is served only against a final `light_client_head` that is strictly newer than the block certifying the chunk. `verify_state_proof` in `core/store/src/spice_proof_verifier.rs` rebuilds the trie from the served nodes and checks the claimed value, after `verify_chunk_execution_proof` has bound the roots to the trusted head.

The server refuses a target that lives in another shard (`TargetShardMismatch`). Without that check it would answer an absent value, and that absence proof verifies against the requested chunk's `state_root`, so a client that picked the wrong shard would get a sound proof of the wrong statement.

Two more errors: `ShardNotTracked`, since this request names a chunk and carries no transaction id for the existing `UnavailableShard` to report, and `StateNotAvailable` for a state root that is already garbage collected, which is a routine answer for an old chunk and worth telling apart from an internal fault.