### PR TITLE
test(spice): fault injection for data distribution

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -194,6 +194,9 @@ pub(crate) const FALLBACK_WITNESS_PULL_GRACE: BlockHeight = 2;
 /// fallback eligible within this many blocks. Only decides whether to buffer the parts.
 pub(crate) const FALLBACK_WITNESS_PUSH_LOOKAHEAD: BlockHeight = 2;
 
+/// Share of the parts an item is encoded into that suffice to decode it.
+pub const DATA_PARTS_RATIO: f64 = 0.6;
+
 /// Max number of entries `(data_id, ordinals)` a single batched request may carry.
 /// This caps the encodes (CPU).
 pub(crate) const MAX_REQUESTED_DATA_IDS: usize = 32;
@@ -489,7 +492,6 @@ impl SpiceDataDistributorActor {
         contract_code_response_validator_sender: Sender<SpiceContractCodeResponseMessage>,
     ) -> Self {
         const RECENTLY_DECODED_DATA_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
-        const DATA_PARTS_RATIO: f64 = 0.6;
         const PENDING_PARTIAL_DATA_CAP: NonZeroUsize = NonZeroUsize::new(10).unwrap();
         const PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE: NonZeroUsize =
             NonZeroUsize::new(30).unwrap();

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -194,6 +194,9 @@ pub(crate) const FALLBACK_WITNESS_PULL_GRACE: BlockHeight = 2;
 /// fallback eligible within this many blocks. Only decides whether to buffer the parts.
 pub(crate) const FALLBACK_WITNESS_PUSH_LOOKAHEAD: BlockHeight = 2;
 
+/// How often the distributor re-requests the data it is still waiting on.
+pub const DATA_REQUEST_INTERVAL: Duration = Duration::milliseconds(1000);
+
 /// Share of the parts an item is encoded into that suffice to decode it.
 pub const DATA_PARTS_RATIO: f64 = 0.6;
 
@@ -743,6 +746,11 @@ impl SpiceDataDistributorActor {
         };
 
         // TODO(spice): Check that encoded_length isn't too large.
+        // TODO(spice-data-distribution): verify every part before inserting any, keep the ones that
+        // verified, and report the sender for the rest. Today the first bad part aborts the loop
+        // without undoing the inserts before it, so what a message contributes depends on where the
+        // bad part sits; and the tracker below is allocated for an unverified commitment, sized by a
+        // length the sender chose, before a single proof is checked.
         let encoded_length = commitment.encoded_length;
         let total_parts = producers.len();
         let entry = waiting.parts_by_commitment.entry(commitment.clone()).or_insert_with(|| {
@@ -1364,7 +1372,7 @@ impl SpiceDataDistributorActor {
         ctx.run_later(
             "SpiceDataDistributorActor request waiting on data",
             // TODO(spice): Make duration configurable.
-            Duration::milliseconds(1000),
+            DATA_REQUEST_INTERVAL,
             move |act, ctx| {
                 act.schedule_data_fetching(ctx);
             },

--- a/core/primitives/src/spice/partial_data.rs
+++ b/core/primitives/src/spice/partial_data.rs
@@ -100,6 +100,12 @@ impl SpicePartialData {
         }
     }
 
+    pub fn id(&self) -> &SpiceDataIdentifier {
+        match self {
+            Self::V1(v1) => &v1.inner.id,
+        }
+    }
+
     pub fn into_verified(self, public_key: &PublicKey) -> Option<SpiceVerifiedPartialData> {
         match self {
             Self::V1(v1) => {

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -554,6 +554,7 @@ impl TestLoopBuilder {
             bucket_config: self.bucket_config.clone(),
             task_delay_fn: self.task_delay_fn.clone(),
             spice_endorsement_delay: Arc::new(Mutex::new(Default::default())),
+            spice_data_faults: Default::default(),
         };
         (self.test_loop, shared_state)
     }

--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -554,7 +554,7 @@ impl TestLoopBuilder {
             bucket_config: self.bucket_config.clone(),
             task_delay_fn: self.task_delay_fn.clone(),
             spice_endorsement_delay: Arc::new(Mutex::new(Default::default())),
-            spice_data_faults: Default::default(),
+            spice_partial_data_faults: Default::default(),
         };
         (self.test_loop, shared_state)
     }

--- a/test-loop-tests/src/setup/mod.rs
+++ b/test-loop-tests/src/setup/mod.rs
@@ -4,4 +4,5 @@ pub mod env;
 pub(crate) mod peer_manager_actor;
 pub(crate) mod rpc;
 pub mod setup;
+pub mod spice_partial_data_faults;
 pub mod state;

--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -462,6 +462,16 @@ impl TestLoopNetworkSharedState {
         guard.senders.get(peer_id).unwrap().clone()
     }
 
+    /// Whether a message from `origin` reaches `account_id` rather than being dropped as a severed
+    /// link. For handlers that deliver messages themselves instead of going through
+    /// `senders_for_account`.
+    pub(crate) fn is_link_allowed(&self, origin: &AccountId, account_id: &AccountId) -> bool {
+        let guard = self.0.lock();
+        let origin_peer_id = &guard.account_to_peer_id[origin];
+        let peer_id = &guard.account_to_peer_id[account_id];
+        !Self::is_peer_link_disallowed(&guard, origin_peer_id, peer_id)
+    }
+
     pub(crate) fn senders_for_peer(
         &self,
         origin: &PeerId,

--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -42,7 +42,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::{AccountId, ShardId};
 use parking_lot::{Mutex, MutexGuard};
-use std::collections::{BTreeMap, BTreeSet, btree_map};
+use std::collections::{BTreeMap, BTreeSet, HashSet, btree_map};
 use std::sync::Arc;
 
 /// Subset of ClientSenderForNetwork required for the TestLoop network.
@@ -104,6 +104,10 @@ pub enum HandlerResult {
 
 pub type NetworkRequestHandler = Box<dyn Fn(NetworkRequests) -> HandlerResult>;
 
+/// Sees every outgoing request without consuming it, so several observers coexist and none of them
+/// competes with the handlers above.
+pub type NetworkRequestObserver = Box<dyn Fn(&NetworkRequests)>;
+
 /// A custom actor for the TestLoop framework that can be used to send network messages across clients
 /// in a multi-node test.
 ///
@@ -129,6 +133,7 @@ pub type NetworkRequestHandler = Box<dyn Fn(NetworkRequests) -> HandlerResult>;
 /// - Override handler to modify data and simulate malicious behavior.
 pub struct TestLoopPeerManagerActor {
     handlers: Vec<NetworkRequestHandler>,
+    observers: Vec<NetworkRequestObserver>,
 
     clock: Clock,
     client_sender: ClientSenderForTestLoopNetwork,
@@ -192,12 +197,19 @@ impl TestLoopPeerManagerActor {
         ];
         Self {
             handlers,
+            observers: Vec::new(),
             clock,
             client_sender,
             shared_state: shared_state.clone(),
             genesis_id,
             last_block_headers: BTreeMap::new(),
         }
+    }
+
+    /// Register an observer of every outgoing request. Observers run before the handlers and cannot
+    /// consume a request, so registering one never changes which handler takes it.
+    pub fn register_observer(&mut self, observer: NetworkRequestObserver) {
+        self.observers.push(observer);
     }
 
     /// Register a new handler to override the default handlers.
@@ -462,14 +474,23 @@ impl TestLoopNetworkSharedState {
         guard.senders.get(peer_id).unwrap().clone()
     }
 
-    /// Whether a message from `origin` reaches `account_id` rather than being dropped as a severed
-    /// link. For handlers that deliver messages themselves instead of going through
-    /// `senders_for_account`.
-    pub(crate) fn is_link_allowed(&self, origin: &AccountId, account_id: &AccountId) -> bool {
+    /// The recipients a message from `origin` reaches, dropping the ones behind a severed link. For
+    /// handlers that deliver messages themselves instead of going through `senders_for_account`.
+    pub(crate) fn reachable_from(
+        &self,
+        origin: &AccountId,
+        recipients: &HashSet<AccountId>,
+    ) -> Vec<AccountId> {
         let guard = self.0.lock();
         let origin_peer_id = &guard.account_to_peer_id[origin];
-        let peer_id = &guard.account_to_peer_id[account_id];
-        !Self::is_peer_link_disallowed(&guard, origin_peer_id, peer_id)
+        recipients
+            .iter()
+            .filter(|recipient| {
+                let peer_id = &guard.account_to_peer_id[*recipient];
+                !Self::is_peer_link_disallowed(&guard, origin_peer_id, peer_id)
+            })
+            .cloned()
+            .collect()
     }
 
     pub(crate) fn senders_for_peer(
@@ -592,6 +613,10 @@ impl Handler<PeerManagerMessageRequest, PeerManagerMessageResponse> for TestLoop
         let PeerManagerMessageRequest::NetworkRequests(request) = msg else {
             panic!("Unexpected message: {:?}", msg);
         };
+
+        for observer in &self.observers {
+            observer(&request);
+        }
 
         // Iterate over the handlers in reverse order to allow for overriding the default handlers.
         let mut request = Some(request);

--- a/test-loop-tests/src/setup/spice_partial_data_faults.rs
+++ b/test-loop-tests/src/setup/spice_partial_data_faults.rs
@@ -1,0 +1,275 @@
+//! Fault injection for spice partial data: the knobs a test arms, what the handler saw, and the
+//! network handler that applies them.
+
+use crate::setup::env::TestLoopEnv;
+use crate::setup::peer_manager_actor::{HandlerResult, TestLoopNetworkSharedState};
+use crate::setup::state::{NETWORK_DELAY, NodeExecutionData};
+use near_async::messaging::CanSend as _;
+use near_async::test_loop::data::TestLoopData;
+use near_async::test_loop::sender::TestLoopSender;
+use near_async::time::Duration;
+use near_client::spice::data_distributor_actor::SpiceDataDistributorActor;
+use near_network::recv_permit::RecvMessagePermit;
+use near_network::spice::data_distribution::SpiceIncomingPartialData;
+use near_network::types::{NetworkRequests, NetworkResponses};
+use near_primitives::hash::hash;
+use near_primitives::merkle::compute_root_from_path_and_item;
+use near_primitives::spice::partial_data::{
+    SpiceDataCommitment, SpiceDataIdentifier, SpicePartialData,
+};
+use near_primitives::test_utils::create_test_signer;
+use near_primitives::types::{AccountId, SpiceChunkId};
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// Shared state for the spice partial data fault handler installed by
+/// `TestLoopEnv::install_spice_partial_data_faults`. Locked separately so a test can read what the
+/// handler saw without touching the faults it armed.
+#[derive(Clone, Default)]
+pub struct SpicePartialDataFaultState {
+    pub faults: Arc<Mutex<SpicePartialDataFaults>>,
+    pub observed: Arc<Mutex<SpicePartialDataObserved>>,
+    wiring: Arc<Mutex<SpicePartialDataFaultWiring>>,
+}
+
+/// Faults applied to spice partial data on its way out of a node, keyed by the account sending it,
+/// so a test names producers rather than nodes. Every set starts empty, and arming one mid-run
+/// takes effect on the next message.
+///
+/// Keying by sender covers every way partial data leaves a node: the push, the all-stake fallback
+/// push, and the response to a data request. Contract accesses and contract code travel as their
+/// own messages and are never faulted.
+// TODO(spice-data-distribution): fault contract code responses too, so a test can drop them or
+// answer with bytes that do not hash to the requested code.
+#[derive(Default)]
+pub struct SpicePartialDataFaults {
+    /// Partial data these accounts send never arrives.
+    pub drop_from: HashSet<AccountId>,
+    /// Partial data these accounts send arrives this much later than usual (test-loop time).
+    pub delay_from: HashMap<AccountId, Duration>,
+    /// One byte of one part is flipped and the message re-signed, so the fault is attributable to
+    /// the sender rather than to a broken signature.
+    pub corrupt_from: HashSet<AccountId>,
+    /// These accounts send their parts a second time under a conflicting commitment.
+    pub equivocate_from: HashSet<AccountId>,
+    /// Limits every fault above to one kind of data. `None` faults both kinds.
+    pub only_kind: Option<SpiceDataKind>,
+}
+
+/// Which kind of partial data a fault applies to.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SpiceDataKind {
+    Witness,
+    ReceiptProof,
+}
+
+impl SpiceDataKind {
+    fn of(id: &SpiceDataIdentifier) -> Self {
+        match id {
+            SpiceDataIdentifier::Witness { .. } => Self::Witness,
+            SpiceDataIdentifier::ReceiptProof { .. } => Self::ReceiptProof,
+        }
+    }
+}
+
+/// Where the handler delivers the faulty copies it makes, and which nodes already have it.
+#[derive(Default)]
+struct SpicePartialDataFaultWiring {
+    installed_for: HashSet<String>,
+    senders: HashMap<AccountId, TestLoopSender<SpiceDataDistributorActor>>,
+}
+
+/// What the spice partial data fault handler saw. Counted per fault kind, so a test arming several
+/// can still tell which of them fired.
+#[derive(Default)]
+pub struct SpicePartialDataObserved {
+    /// Messages dropped, delayed, corrupted, and sent again under a conflicting commitment. One
+    /// message can be counted by more than one of these.
+    pub dropped: usize,
+    pub delayed: usize,
+    pub corrupted: usize,
+    pub equivocated: usize,
+    /// Data requests seen per requesting node. Empty on a healthy chain, where pushes are enough,
+    /// so it shows which nodes a fault pushed onto the recovery path.
+    // TODO(spice-data-distribution): record the producer asked and the ordinals requested, so a
+    // test can assert how a missing set was split across sources and how often one source is
+    // asked.
+    pub data_requests: HashMap<AccountId, usize>,
+    /// Chunks each account endorsed. A node that produces nothing can only endorse after receiving
+    /// and validating the witness, so this is where data delivery is observable. Endorsements are
+    /// sent once per recipient and re-broadcast until they are on chain, so they are collected as a
+    /// set of chunks rather than counted.
+    pub endorsements: HashMap<AccountId, HashSet<SpiceChunkId>>,
+}
+
+impl TestLoopEnv {
+    /// Installs spice partial data fault injection on every node and returns the shared knobs
+    /// alongside what the handler sees. Call again after `add_node` / `restart_node` to instrument
+    /// nodes added since.
+    pub fn install_spice_partial_data_faults(
+        &mut self,
+    ) -> (Arc<Mutex<SpicePartialDataFaults>>, Arc<Mutex<SpicePartialDataObserved>>) {
+        let state = self.shared_state.spice_partial_data_faults.clone();
+        {
+            let mut wiring = state.wiring.lock();
+            wiring.senders = self
+                .node_datas
+                .iter()
+                .map(|n| (n.account_id.clone(), n.spice_data_distributor_sender.clone()))
+                .collect();
+        }
+        let network = self.shared_state.network_shared_state.clone();
+        for node in &self.node_datas {
+            if !state.wiring.lock().installed_for.insert(node.identifier.clone()) {
+                continue;
+            }
+            install_spice_partial_data_fault_handler(
+                &mut self.test_loop.data,
+                node,
+                state.clone(),
+                network.clone(),
+            );
+        }
+        (state.faults.clone(), state.observed)
+    }
+}
+
+fn install_spice_partial_data_fault_handler(
+    data: &mut TestLoopData,
+    node: &NodeExecutionData,
+    state: SpicePartialDataFaultState,
+    network: TestLoopNetworkSharedState,
+) {
+    let me = node.account_id.clone();
+    let peer_actor = data.get_mut(&node.peer_manager_sender.actor_handle());
+
+    // Counting is an observer, not a handler: another handler claiming endorsements would otherwise
+    // decide whether any of this is seen, depending on which was registered last.
+    let observed = state.observed.clone();
+    let requester = me.clone();
+    peer_actor.register_observer(Box::new(move |request| match request {
+        NetworkRequests::SpiceDataRequest { .. } => {
+            *observed.lock().data_requests.entry(requester.clone()).or_default() += 1;
+        }
+        NetworkRequests::SpiceChunkEndorsement(_target, endorsement) => {
+            let chunk_id = SpiceChunkId {
+                block_hash: *endorsement.block_hash(),
+                shard_id: endorsement.shard_id(),
+            };
+            observed
+                .lock()
+                .endorsements
+                .entry(endorsement.account_id().clone())
+                .or_default()
+                .insert(chunk_id);
+        }
+        _ => {}
+    }));
+
+    peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
+        let NetworkRequests::SpicePartialData { partial_data, recipients } = &request else {
+            return HandlerResult::Unhandled(request);
+        };
+        let sender = partial_data.sender().clone();
+        let kind = SpiceDataKind::of(partial_data.id());
+        let (drop_it, delay, corrupt, equivocate) = {
+            let faults = state.faults.lock();
+            if faults.only_kind.is_some_and(|only| only != kind) {
+                return HandlerResult::Unhandled(request);
+            }
+            (
+                faults.drop_from.contains(&sender),
+                faults.delay_from.get(&sender).copied(),
+                faults.corrupt_from.contains(&sender),
+                faults.equivocate_from.contains(&sender),
+            )
+        };
+        if drop_it {
+            state.observed.lock().dropped += 1;
+            return HandlerResult::Handled(NetworkResponses::NoResponse);
+        }
+        if delay.is_none() && !corrupt && !equivocate {
+            return HandlerResult::Unhandled(request);
+        }
+        {
+            let mut observed = state.observed.lock();
+            observed.delayed += delay.is_some() as usize;
+            observed.corrupted += corrupt as usize;
+            observed.equivocated += equivocate as usize;
+        }
+
+        let mut to_send = Vec::new();
+        if equivocate {
+            to_send.push(with_conflicting_commitment(partial_data));
+        }
+        to_send.push(if corrupt {
+            with_corrupted_part(partial_data)
+        } else {
+            partial_data.clone()
+        });
+
+        // The peer manager would deliver a rewritten request, but it cannot delay one or turn one
+        // request into two, which is what the delay and equivocate faults need. So these messages
+        // go out from here, which skips the routing — including its severed-link check, redone
+        // below.
+        // TODO(spice-data-distribution): count what each recipient is handed, so a test can assert
+        // on delivery directly instead of inferring it from whether the recipient endorsed.
+        let delay = NETWORK_DELAY + delay.unwrap_or(Duration::ZERO);
+        let reachable = network.reachable_from(&me, recipients);
+        let recipient_actors: Vec<_> = {
+            let wiring = state.wiring.lock();
+            reachable
+                .iter()
+                .filter_map(|recipient| wiring.senders.get(recipient))
+                .map(|actor| actor.clone().with_delay(delay))
+                .collect()
+        };
+        for recipient_actor in recipient_actors {
+            for data in &to_send {
+                recipient_actor.send(SpiceIncomingPartialData {
+                    data: data.clone(),
+                    recv_permit: RecvMessagePermit::none(),
+                });
+            }
+        }
+        HandlerResult::Handled(NetworkResponses::NoResponse)
+    }));
+}
+
+/// Builds a `SpicePartialData` whose first part has a flipped byte, keeping the commitment, so the
+/// part fails its merkle proof. A push carries one part, so such a message contributes nothing.
+// TODO(spice-data-distribution): a pull response carries several parts, and how much of one the
+// receiver keeps depends on where the bad part sits. Corrupting a chosen ordinal is only worth
+// testing once the receiver verifies every part before inserting any.
+fn with_corrupted_part(data: &SpicePartialData) -> SpicePartialData {
+    let signer = create_test_signer(data.sender().as_str());
+    let mut verified = data
+        .clone()
+        .into_verified(&signer.public_key())
+        .expect("test-loop nodes sign with create_test_signer keys");
+    let part = verified.parts.first_mut().expect("pushed data carries a part");
+    let byte = part.part.first_mut().expect("part is not empty");
+    *byte ^= 1;
+    SpicePartialData::new(verified.id, verified.commitment, verified.parts, &signer)
+}
+
+/// Builds a second `SpicePartialData` carrying the sender's first part with a flipped byte, under a
+/// commitment of its own: the root comes from the part's own merkle path, so the part verifies and
+/// the recipient tracks a second commitment for the item, holding parts under both.
+fn with_conflicting_commitment(data: &SpicePartialData) -> SpicePartialData {
+    let signer = create_test_signer(data.sender().as_str());
+    let verified = data
+        .clone()
+        .into_verified(&signer.public_key())
+        .expect("test-loop nodes sign with create_test_signer keys");
+    let mut part = verified.parts.into_iter().next().expect("partial data carries a part");
+    let byte = part.part.first_mut().expect("part is not empty");
+    *byte ^= 1;
+    let commitment = SpiceDataCommitment {
+        root: compute_root_from_path_and_item(&part.merkle_proof, &part.part),
+        hash: hash(verified.commitment.hash.as_bytes()),
+        encoded_length: verified.commitment.encoded_length,
+    };
+    SpicePartialData::new(verified.id, commitment, vec![part], &signer)
+}

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -32,7 +32,7 @@ use near_network::types::StateRequestSenderForNetwork;
 use near_parameters::RuntimeConfigStore;
 use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::network::PeerId;
-use near_primitives::types::{AccountId, Nonce};
+use near_primitives::types::{AccountId, Nonce, SpiceChunkId};
 use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_store::archive::cloud_storage::CloudStorage;
@@ -47,7 +47,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tempfile::TempDir;
 
-const NETWORK_DELAY: Duration = Duration::milliseconds(10);
+pub(crate) const NETWORK_DELAY: Duration = Duration::milliseconds(10);
 
 /// This is the state associate with the test loop environment.
 /// This state is shared across all nodes and none of it belongs to a specific node.
@@ -81,6 +81,8 @@ pub struct SharedState {
     pub task_delay_fn: Option<Arc<dyn Fn(&AccountId, &str) -> Option<Duration> + Send + Sync>>,
     /// Per-node installation state for the spice endorsement-delay handler.
     pub spice_endorsement_delay: Arc<Mutex<SpiceEndorsementDelayState>>,
+    /// Fault injection for spice data distribution, armed by tests.
+    pub spice_data_faults: SpiceDataFaultState,
 }
 
 /// Shared state for the spice endorsement-delay network handler installed by
@@ -89,6 +91,66 @@ pub struct SharedState {
 pub struct SpiceEndorsementDelayState {
     pub installed_for: HashSet<String>,
     pub senders: HashMap<AccountId, TestLoopSender<SpiceCoreWriterActor>>,
+}
+
+/// Shared state for the spice data fault handler installed by
+/// `TestLoopEnv::install_spice_data_faults`. Locked separately so a test can read what the handler
+/// saw without touching the faults it armed.
+#[derive(Clone, Default)]
+pub struct SpiceDataFaultState {
+    pub faults: Arc<Mutex<SpiceDataFaults>>,
+    pub observed: Arc<Mutex<SpiceDataObserved>>,
+    pub(crate) wiring: Arc<Mutex<SpiceDataFaultWiring>>,
+}
+
+/// Faults applied to spice partial data on its way out of a node, keyed by the account sending it,
+/// so a test names producers rather than nodes. Every set starts empty, and arming one mid-run
+/// takes effect on the next message.
+///
+/// Keying by sender covers every way partial data leaves a node: the push, the all-stake fallback
+/// push, and the response to a data request. Contract accesses and contract code travel as their
+/// own messages and are never faulted.
+#[derive(Default)]
+pub struct SpiceDataFaults {
+    /// Partial data these accounts send never arrives.
+    pub drop_from: HashSet<AccountId>,
+    /// Partial data these accounts send arrives this much later than usual.
+    pub delay_from: HashMap<AccountId, Duration>,
+    /// One byte of one part is flipped and the message re-signed, so the fault is attributable to
+    /// the sender rather than to a broken signature.
+    pub corrupt_from: HashSet<AccountId>,
+    /// These accounts send their parts a second time under a conflicting commitment.
+    pub equivocate_from: HashSet<AccountId>,
+}
+
+/// Where the handler delivers the faulty copies it makes, and which nodes already have it.
+#[derive(Default)]
+pub struct SpiceDataFaultWiring {
+    pub(crate) installed_for: HashSet<String>,
+    pub(crate) senders: HashMap<AccountId, TestLoopSender<SpiceDataDistributorActor>>,
+}
+
+/// What the spice data fault handler saw. Counted per fault kind, so a test arming several can
+/// still tell which of them fired.
+#[derive(Default)]
+pub struct SpiceDataObserved {
+    /// Messages dropped, delayed, corrupted, and sent again under a conflicting commitment. One
+    /// message can be counted by more than one of these.
+    pub dropped: usize,
+    pub delayed: usize,
+    pub corrupted: usize,
+    pub equivocated: usize,
+    /// Data requests seen per requesting node. Empty on a healthy chain, where pushes are enough,
+    /// so it shows which nodes a fault pushed onto the recovery path.
+    // TODO(spice-data-distribution): record the producer asked and the ordinals requested, so a
+    // test can assert how a missing set was split across sources and how often one source is
+    // asked.
+    pub data_requests: HashMap<AccountId, usize>,
+    /// Chunks each account endorsed. A node that produces nothing can only endorse after receiving
+    /// and validating the witness, so this is where data delivery is observable. Endorsements are
+    /// sent once per recipient and re-broadcast until they are on chain, so they are collected as a
+    /// set of chunks rather than counted.
+    pub endorsements: HashMap<AccountId, HashSet<SpiceChunkId>>,
 }
 
 /// This is the state associated with each node in the test loop environment before being built.

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -5,6 +5,7 @@ use super::peer_manager_actor::{
     TestLoopNetworkSharedState, TestLoopPeerManagerActor, TxRequestHandleSenderForTestLoopNetwork,
     ViewClientSenderForTestLoopNetwork,
 };
+use super::spice_partial_data_faults::SpicePartialDataFaultState;
 use near_async::messaging::{IntoMultiSender, IntoSender, Sender};
 use near_async::test_loop::data::TestLoopDataHandle;
 use near_async::test_loop::sender::TestLoopSender;
@@ -32,7 +33,7 @@ use near_network::types::StateRequestSenderForNetwork;
 use near_parameters::RuntimeConfigStore;
 use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::network::PeerId;
-use near_primitives::types::{AccountId, Nonce, SpiceChunkId};
+use near_primitives::types::{AccountId, Nonce};
 use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_store::archive::cloud_storage::CloudStorage;
@@ -82,7 +83,7 @@ pub struct SharedState {
     /// Per-node installation state for the spice endorsement-delay handler.
     pub spice_endorsement_delay: Arc<Mutex<SpiceEndorsementDelayState>>,
     /// Fault injection for spice data distribution, armed by tests.
-    pub spice_data_faults: SpiceDataFaultState,
+    pub spice_partial_data_faults: SpicePartialDataFaultState,
 }
 
 /// Shared state for the spice endorsement-delay network handler installed by
@@ -91,66 +92,6 @@ pub struct SharedState {
 pub struct SpiceEndorsementDelayState {
     pub installed_for: HashSet<String>,
     pub senders: HashMap<AccountId, TestLoopSender<SpiceCoreWriterActor>>,
-}
-
-/// Shared state for the spice data fault handler installed by
-/// `TestLoopEnv::install_spice_data_faults`. Locked separately so a test can read what the handler
-/// saw without touching the faults it armed.
-#[derive(Clone, Default)]
-pub struct SpiceDataFaultState {
-    pub faults: Arc<Mutex<SpiceDataFaults>>,
-    pub observed: Arc<Mutex<SpiceDataObserved>>,
-    pub(crate) wiring: Arc<Mutex<SpiceDataFaultWiring>>,
-}
-
-/// Faults applied to spice partial data on its way out of a node, keyed by the account sending it,
-/// so a test names producers rather than nodes. Every set starts empty, and arming one mid-run
-/// takes effect on the next message.
-///
-/// Keying by sender covers every way partial data leaves a node: the push, the all-stake fallback
-/// push, and the response to a data request. Contract accesses and contract code travel as their
-/// own messages and are never faulted.
-#[derive(Default)]
-pub struct SpiceDataFaults {
-    /// Partial data these accounts send never arrives.
-    pub drop_from: HashSet<AccountId>,
-    /// Partial data these accounts send arrives this much later than usual.
-    pub delay_from: HashMap<AccountId, Duration>,
-    /// One byte of one part is flipped and the message re-signed, so the fault is attributable to
-    /// the sender rather than to a broken signature.
-    pub corrupt_from: HashSet<AccountId>,
-    /// These accounts send their parts a second time under a conflicting commitment.
-    pub equivocate_from: HashSet<AccountId>,
-}
-
-/// Where the handler delivers the faulty copies it makes, and which nodes already have it.
-#[derive(Default)]
-pub struct SpiceDataFaultWiring {
-    pub(crate) installed_for: HashSet<String>,
-    pub(crate) senders: HashMap<AccountId, TestLoopSender<SpiceDataDistributorActor>>,
-}
-
-/// What the spice data fault handler saw. Counted per fault kind, so a test arming several can
-/// still tell which of them fired.
-#[derive(Default)]
-pub struct SpiceDataObserved {
-    /// Messages dropped, delayed, corrupted, and sent again under a conflicting commitment. One
-    /// message can be counted by more than one of these.
-    pub dropped: usize,
-    pub delayed: usize,
-    pub corrupted: usize,
-    pub equivocated: usize,
-    /// Data requests seen per requesting node. Empty on a healthy chain, where pushes are enough,
-    /// so it shows which nodes a fault pushed onto the recovery path.
-    // TODO(spice-data-distribution): record the producer asked and the ordinals requested, so a
-    // test can assert how a missing set was split across sources and how often one source is
-    // asked.
-    pub data_requests: HashMap<AccountId, usize>,
-    /// Chunks each account endorsed. A node that produces nothing can only endorse after receiving
-    /// and validating the witness, so this is where data delivery is observable. Endorsements are
-    /// sent once per recipient and re-broadcast until they are on chain, so they are collected as a
-    /// set of chunks rather than counted.
-    pub endorsements: HashMap<AccountId, HashSet<SpiceChunkId>>,
 }
 
 /// This is the state associated with each node in the test loop environment before being built.

--- a/test-loop-tests/src/tests/spice/data_faults.rs
+++ b/test-loop-tests/src/tests/spice/data_faults.rs
@@ -2,22 +2,25 @@
 //! asserts the fault fired and that the nodes which produce nothing still endorsed — which they
 //! can only do after receiving and validating the witness. The producers certify among themselves
 //! either way, so chain progress alone would prove nothing; see
-//! `test_spice_data_faults_starve_the_recipients`.
+//! `test_spice_partial_data_faults_starve_the_recipients`.
 //!
 //! Faults are keyed by the sending account, so every recipient sees the same treatment and all of
 //! them are asserted on: a fault reaching only some recipients is a harness bug.
 // TODO(spice-data-distribution): assert how many chunks the recipient endorsed rather than that it
-// endorsed at all. Under dropped or delayed pushes it recovers one chunk of the four it runs for,
-// which having endorsed cannot tell apart from recovering every one.
+// endorsed at all. Under dropped or delayed pushes the slower recipient recovers a fraction of what
+// the faster one does, which having endorsed cannot tell apart from recovering every chunk.
 
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
-use crate::setup::state::{NodeExecutionData, SpiceDataFaults, SpiceDataObserved};
+use crate::setup::spice_partial_data_faults::{
+    SpiceDataKind, SpicePartialDataFaults, SpicePartialDataObserved,
+};
+use crate::setup::state::NodeExecutionData;
 use near_async::time::Duration;
-use near_client::spice::data_distributor_actor::DATA_PARTS_RATIO;
+use near_client::spice::data_distributor_actor::{DATA_PARTS_RATIO, DATA_REQUEST_INTERVAL};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::reed_solomon::reed_solomon_num_data_parts;
-use near_primitives::types::{AccountId, BlockHeight};
+use near_primitives::types::{AccountId, BlockHeight, ShardId};
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -29,20 +32,47 @@ struct Setup {
     env: TestLoopEnv,
     producers: Vec<AccountId>,
     recipients: Vec<AccountId>,
-    faults: Arc<Mutex<SpiceDataFaults>>,
-    observed: Arc<Mutex<SpiceDataObserved>>,
+    faults: Arc<Mutex<SpicePartialDataFaults>>,
+    observed: Arc<Mutex<SpicePartialDataObserved>>,
 }
 
 fn setup() -> Setup {
+    setup_with_shards(1, NUM_PRODUCERS)
+}
+
+/// A setup with `num_shards` shards and `num_producers` producers spread over them. Receipt proofs
+/// only travel between shards, so testing them needs more than one.
+fn setup_with_shards(num_shards: usize, num_producers: usize) -> Setup {
     init_test_logger();
-    let mut env = TestLoopBuilder::new().validators(NUM_PRODUCERS, NUM_VALIDATORS).build();
+    let mut builder = TestLoopBuilder::new().validators(num_producers, NUM_VALIDATORS);
+    if num_shards > 1 {
+        builder = builder.num_shards(num_shards);
+    }
+    let mut env = builder.build();
     let account_ids = |nodes: &[NodeExecutionData]| {
         nodes.iter().map(|n| n.account_id.clone()).collect::<Vec<_>>()
     };
-    let producers = account_ids(&env.node_datas[..NUM_PRODUCERS]);
-    let recipients = account_ids(&env.node_datas[NUM_PRODUCERS..]);
-    let (faults, observed) = env.install_spice_data_faults();
+    let producers = account_ids(&env.node_datas[..num_producers]);
+    let recipients = account_ids(&env.node_datas[num_producers..]);
+    let (faults, observed) = env.install_spice_partial_data_faults();
     Setup { env, producers, recipients, faults, observed }
+}
+
+/// The shards of the current epoch, and the producers of each.
+fn shard_producers(env: &TestLoopEnv, observer: &AccountId) -> Vec<(ShardId, Vec<AccountId>)> {
+    let node = env.node_for_account(observer);
+    let epoch_id = node.client().chain.head().unwrap().epoch_id;
+    let epoch_manager = node.client().epoch_manager.as_ref();
+    epoch_manager
+        .shard_ids(&epoch_id)
+        .unwrap()
+        .into_iter()
+        .map(|shard_id| {
+            let producers =
+                epoch_manager.get_epoch_chunk_producers_for_shard(&epoch_id, shard_id).unwrap();
+            (shard_id, producers)
+        })
+        .collect()
 }
 
 /// Runs `heights` blocks past the certified frontier, panicking if the chain stalls.
@@ -51,18 +81,24 @@ fn run_past_certified_frontier(env: &mut TestLoopEnv, observer: &AccountId, heig
     env.runner_for_account(observer).run_until_certified(target);
 }
 
-/// Heights a push needs to reach every recipient.
+/// Heights to run when the data arrives by push.
 const PUSH_HEIGHTS: BlockHeight = 4;
-/// Heights recovery needs. Requests go to one producer, which serves the recipients unevenly, so
-/// the slowest of them wants roughly twice the room the push path does.
-const RECOVERY_HEIGHTS: BlockHeight = 8;
+/// Heights to run when the data has to be pulled. Four is not enough: pulls all go to the one
+/// producer still answering, and it serves its requesters unevenly.
+const PULL_HEIGHTS: BlockHeight = 8;
 
-/// Parts that have to arrive by push for a recipient to decode without asking anyone.
-fn decode_threshold() -> usize {
-    reed_solomon_num_data_parts(NUM_PRODUCERS, DATA_PARTS_RATIO)
+/// Parts of an item that have to arrive for a recipient to decode it without asking anyone. Faults
+/// are armed against whole producer sets, which only lines up with the data while there is one
+/// shard, so this asserts that rather than assuming it.
+fn single_shard_decode_threshold(env: &TestLoopEnv, observer: &AccountId) -> usize {
+    let shards = shard_producers(env, observer);
+    let [(_, producers)] = &shards[..] else {
+        panic!("faults are armed per producer set, which needs a single shard");
+    };
+    reed_solomon_num_data_parts(producers.len(), DATA_PARTS_RATIO)
 }
 
-fn assert_endorsed(observed: &SpiceDataObserved, recipients: &[AccountId]) {
+fn assert_endorsed(observed: &SpicePartialDataObserved, recipients: &[AccountId]) {
     for recipient in recipients {
         assert!(observed.endorsements.contains_key(recipient), "{recipient} never endorsed");
     }
@@ -70,18 +106,18 @@ fn assert_endorsed(observed: &SpiceDataObserved, recipients: &[AccountId]) {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_spice_data_faults_with_dropped_pushes() {
+fn test_spice_partial_data_faults_with_dropped_pushes() {
     let Setup { mut env, producers, recipients, faults, observed } = setup();
     // All but one producer goes silent, leaving too few parts to decode from pushes alone, so a
     // recipient can only finish an item by requesting it from the one that still answers.
     let silent = &producers[1..];
     assert!(
-        NUM_PRODUCERS - silent.len() < decode_threshold(),
+        NUM_PRODUCERS - silent.len() < single_shard_decode_threshold(&env, &recipients[0]),
         "the producers left alone still push enough parts to decode, so recovery never runs"
     );
     faults.lock().drop_from.extend(silent.iter().cloned());
 
-    run_past_certified_frontier(&mut env, &recipients[0], RECOVERY_HEIGHTS);
+    run_past_certified_frontier(&mut env, &recipients[0], PULL_HEIGHTS);
 
     let observed = observed.lock();
     assert!(observed.dropped > 0, "no push was dropped");
@@ -96,20 +132,19 @@ fn test_spice_data_faults_with_dropped_pushes() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_spice_data_faults_with_delayed_pushes() {
+fn test_spice_partial_data_faults_with_delayed_pushes() {
     let Setup { mut env, producers, recipients, faults, observed } = setup();
-    // Longer than the request interval, so a recipient starts requesting before the pushes land.
     let delayed = &producers[1..];
     assert!(
-        NUM_PRODUCERS - delayed.len() < decode_threshold(),
+        NUM_PRODUCERS - delayed.len() < single_shard_decode_threshold(&env, &recipients[0]),
         "the producers left alone still push enough parts to decode, so recovery never runs"
     );
-    faults
-        .lock()
-        .delay_from
-        .extend(delayed.iter().cloned().map(|producer| (producer, Duration::seconds(2))));
+    // A recipient has to start requesting before the pushes land.
+    let delay = Duration::seconds(2);
+    assert!(delay > DATA_REQUEST_INTERVAL, "the delay has to outlast a request round");
+    faults.lock().delay_from.extend(delayed.iter().cloned().map(|producer| (producer, delay)));
 
-    run_past_certified_frontier(&mut env, &recipients[0], RECOVERY_HEIGHTS);
+    run_past_certified_frontier(&mut env, &recipients[0], PULL_HEIGHTS);
 
     let observed = observed.lock();
     assert!(observed.delayed > 0, "no push was delayed");
@@ -124,23 +159,30 @@ fn test_spice_data_faults_with_delayed_pushes() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_spice_data_faults_with_corrupted_parts() {
+fn test_spice_partial_data_faults_with_corrupted_parts() {
     let Setup { mut env, producers, recipients, faults, observed } = setup();
     // The part is signed but fails its merkle proof, so a recipient has to reject the part without
     // rejecting the item. The producers left alone still push enough parts to decode.
-    assert!(NUM_PRODUCERS - 1 >= decode_threshold(), "one silent producer alone stops the decode");
+    assert!(
+        NUM_PRODUCERS - 1 >= single_shard_decode_threshold(&env, &recipients[0]),
+        "one silent producer alone stops the decode"
+    );
     faults.lock().corrupt_from.insert(producers[0].clone());
 
     run_past_certified_frontier(&mut env, &recipients[0], PUSH_HEIGHTS);
 
     let observed = observed.lock();
     assert!(observed.corrupted > 0, "no part was corrupted");
+    assert!(
+        observed.data_requests.is_empty(),
+        "the corrupted part pushed a recipient into pulling"
+    );
     assert_endorsed(&observed, &recipients);
 }
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_spice_data_faults_with_equivocating_producer() {
+fn test_spice_partial_data_faults_with_equivocating_producer() {
     let Setup { mut env, producers, recipients, faults, observed } = setup();
     // Two commitments for one item from one producer, both holding a part that verifies. The
     // honest one still decodes, so the conflicting tracker must not displace it.
@@ -150,15 +192,19 @@ fn test_spice_data_faults_with_equivocating_producer() {
 
     let observed = observed.lock();
     assert!(observed.equivocated > 0, "no conflicting commitment was sent");
+    assert!(
+        observed.data_requests.is_empty(),
+        "the conflicting commitment pushed a recipient into pulling"
+    );
     assert_endorsed(&observed, &recipients);
 }
 
-/// The fault-free baseline for the four tests above: pushes alone carry every witness, so the
-/// recipients endorse without ever requesting. Without this the `data_requests` assertions there
-/// would also pass on a chain that requests all the time for unrelated reasons.
+/// The fault-free baseline for the fault tests: pushes alone carry every witness, so the recipients
+/// endorse without ever requesting. Without it the `data_requests` assertions elsewhere would also
+/// pass on a chain that requests all the time for unrelated reasons.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_spice_data_faults_none_armed() {
+fn test_spice_partial_data_faults_none_armed() {
     let Setup { mut env, producers: _, recipients, faults: _, observed } = setup();
 
     run_past_certified_frontier(&mut env, &recipients[0], PUSH_HEIGHTS);
@@ -169,12 +215,12 @@ fn test_spice_data_faults_none_armed() {
     assert_endorsed(&observed, &recipients);
 }
 
-/// The control for the four tests above: with every producer silent the recipients have nothing to
+/// The control for the fault tests: with every producer silent the recipients have nothing to
 /// validate and never endorse, while the producers keep certifying among themselves. If this ever
-/// starts endorsing, the other tests are passing without the data path being exercised.
+/// starts endorsing, the others are passing without the data path being exercised.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_spice_data_faults_starve_the_recipients() {
+fn test_spice_partial_data_faults_starve_the_recipients() {
     let Setup { mut env, producers, recipients, faults, observed } = setup();
     faults.lock().drop_from.extend(producers.iter().cloned());
 
@@ -188,4 +234,63 @@ fn test_spice_data_faults_starve_the_recipients() {
             "{recipient} endorsed without data"
         );
     }
+}
+
+/// Receipt proofs only travel between shards, so this is the one test with more than one. It
+/// certifies first with nothing armed, proving the proofs flow, then drops the ones a whole shard
+/// sends: without them the other shard cannot apply, and certification stops for good while blocks
+/// keep being produced.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_partial_data_faults_starve_receipt_proofs() {
+    /// Enough for the shards to exchange receipt proofs and certify a few chunks.
+    const HEALTHY_BLOCKS: usize = 4;
+    /// Enough for anything already in flight to land, and then for a stall to be unambiguous.
+    const STARVED_BLOCKS: usize = 8;
+
+    let Setup { mut env, producers, recipients, faults, observed } = setup_with_shards(2, 8);
+    let mut shards = shard_producers(&env, &recipients[0]);
+    shards.sort_by_key(|(shard_id, _)| *shard_id);
+    let [(_, silenced), (_, other)] = &shards[..] else { panic!("expected two shards") };
+    assert_eq!(silenced.len() + other.len(), producers.len(), "every producer serves a shard");
+
+    env.runner_for_account(&recipients[0]).run_for_number_of_blocks(HEALTHY_BLOCKS);
+    let healthy = env.node_for_account(&recipients[0]).last_certified_block_header().height();
+    assert!(healthy > 0, "nothing certified before a fault was armed");
+
+    faults.lock().only_kind = Some(SpiceDataKind::ReceiptProof);
+    faults.lock().drop_from.extend(silenced.iter().cloned());
+
+    env.runner_for_account(&recipients[0]).run_for_number_of_blocks(STARVED_BLOCKS);
+    let draining = env.node_for_account(&recipients[0]).last_certified_block_header().height();
+    env.runner_for_account(&recipients[0]).run_for_number_of_blocks(STARVED_BLOCKS);
+
+    let node = env.node_for_account(&recipients[0]);
+    let certified = node.last_certified_block_header().height();
+    assert_eq!(certified, draining, "certification kept going without the receipt proofs");
+    assert!(node.head().height > certified, "blocks stopped being produced too");
+    assert!(observed.lock().dropped > 0, "no receipt proof was dropped");
+}
+
+/// Faults and delayed endorsements are separate handlers on the same peer manager, and the
+/// endorsement one consumes what it delays. Counting endorsements is an observer rather than a
+/// handler so that arming both still records them.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_partial_data_faults_alongside_delayed_endorsements() {
+    /// Blocks an endorsement is held back for.
+    const ENDORSEMENT_DELAY: BlockHeight = 2;
+    /// Blocks to run. Certification crawls while endorsements are held back, so this waits on
+    /// blocks rather than on certified height.
+    const BLOCKS: usize = 14;
+
+    let Setup { mut env, producers, recipients, faults, observed } = setup();
+    env.delay_endorsements_propagation(ENDORSEMENT_DELAY);
+    faults.lock().corrupt_from.insert(producers[0].clone());
+
+    env.runner_for_account(&recipients[0]).run_for_number_of_blocks(BLOCKS);
+
+    let observed = observed.lock();
+    assert!(observed.corrupted > 0, "no part was corrupted");
+    assert_endorsed(&observed, &recipients);
 }

--- a/test-loop-tests/src/tests/spice/data_faults.rs
+++ b/test-loop-tests/src/tests/spice/data_faults.rs
@@ -1,0 +1,191 @@
+//! Spice data distribution under injected faults. Each test arms a fault against a producer, then
+//! asserts the fault fired and that the nodes which produce nothing still endorsed — which they
+//! can only do after receiving and validating the witness. The producers certify among themselves
+//! either way, so chain progress alone would prove nothing; see
+//! `test_spice_data_faults_starve_the_recipients`.
+//!
+//! Faults are keyed by the sending account, so every recipient sees the same treatment and all of
+//! them are asserted on: a fault reaching only some recipients is a harness bug.
+// TODO(spice-data-distribution): assert how many chunks the recipient endorsed rather than that it
+// endorsed at all. Under dropped or delayed pushes it recovers one chunk of the four it runs for,
+// which having endorsed cannot tell apart from recovering every one.
+
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::env::TestLoopEnv;
+use crate::setup::state::{NodeExecutionData, SpiceDataFaults, SpiceDataObserved};
+use near_async::time::Duration;
+use near_client::spice::data_distributor_actor::DATA_PARTS_RATIO;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::reed_solomon::reed_solomon_num_data_parts;
+use near_primitives::types::{AccountId, BlockHeight};
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+const NUM_PRODUCERS: usize = 4;
+/// Chunk validators that produce nothing, so they have to receive every witness.
+const NUM_VALIDATORS: usize = 2;
+
+struct Setup {
+    env: TestLoopEnv,
+    producers: Vec<AccountId>,
+    recipients: Vec<AccountId>,
+    faults: Arc<Mutex<SpiceDataFaults>>,
+    observed: Arc<Mutex<SpiceDataObserved>>,
+}
+
+fn setup() -> Setup {
+    init_test_logger();
+    let mut env = TestLoopBuilder::new().validators(NUM_PRODUCERS, NUM_VALIDATORS).build();
+    let account_ids = |nodes: &[NodeExecutionData]| {
+        nodes.iter().map(|n| n.account_id.clone()).collect::<Vec<_>>()
+    };
+    let producers = account_ids(&env.node_datas[..NUM_PRODUCERS]);
+    let recipients = account_ids(&env.node_datas[NUM_PRODUCERS..]);
+    let (faults, observed) = env.install_spice_data_faults();
+    Setup { env, producers, recipients, faults, observed }
+}
+
+/// Runs `heights` blocks past the certified frontier, panicking if the chain stalls.
+fn run_past_certified_frontier(env: &mut TestLoopEnv, observer: &AccountId, heights: BlockHeight) {
+    let target = env.node_for_account(observer).last_certified_block_header().height() + heights;
+    env.runner_for_account(observer).run_until_certified(target);
+}
+
+/// Heights a push needs to reach every recipient.
+const PUSH_HEIGHTS: BlockHeight = 4;
+/// Heights recovery needs. Requests go to one producer, which serves the recipients unevenly, so
+/// the slowest of them wants roughly twice the room the push path does.
+const RECOVERY_HEIGHTS: BlockHeight = 8;
+
+/// Parts that have to arrive by push for a recipient to decode without asking anyone.
+fn decode_threshold() -> usize {
+    reed_solomon_num_data_parts(NUM_PRODUCERS, DATA_PARTS_RATIO)
+}
+
+fn assert_endorsed(observed: &SpiceDataObserved, recipients: &[AccountId]) {
+    for recipient in recipients {
+        assert!(observed.endorsements.contains_key(recipient), "{recipient} never endorsed");
+    }
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_data_faults_with_dropped_pushes() {
+    let Setup { mut env, producers, recipients, faults, observed } = setup();
+    // All but one producer goes silent, leaving too few parts to decode from pushes alone, so a
+    // recipient can only finish an item by requesting it from the one that still answers.
+    let silent = &producers[1..];
+    assert!(
+        NUM_PRODUCERS - silent.len() < decode_threshold(),
+        "the producers left alone still push enough parts to decode, so recovery never runs"
+    );
+    faults.lock().drop_from.extend(silent.iter().cloned());
+
+    run_past_certified_frontier(&mut env, &recipients[0], RECOVERY_HEIGHTS);
+
+    let observed = observed.lock();
+    assert!(observed.dropped > 0, "no push was dropped");
+    for recipient in &recipients {
+        assert!(
+            observed.data_requests.contains_key(recipient),
+            "{recipient} never had to request the dropped data"
+        );
+    }
+    assert_endorsed(&observed, &recipients);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_data_faults_with_delayed_pushes() {
+    let Setup { mut env, producers, recipients, faults, observed } = setup();
+    // Longer than the request interval, so a recipient starts requesting before the pushes land.
+    let delayed = &producers[1..];
+    assert!(
+        NUM_PRODUCERS - delayed.len() < decode_threshold(),
+        "the producers left alone still push enough parts to decode, so recovery never runs"
+    );
+    faults
+        .lock()
+        .delay_from
+        .extend(delayed.iter().cloned().map(|producer| (producer, Duration::seconds(2))));
+
+    run_past_certified_frontier(&mut env, &recipients[0], RECOVERY_HEIGHTS);
+
+    let observed = observed.lock();
+    assert!(observed.delayed > 0, "no push was delayed");
+    for recipient in &recipients {
+        assert!(
+            observed.data_requests.contains_key(recipient),
+            "the delay never outlasted {recipient}'s request interval"
+        );
+    }
+    assert_endorsed(&observed, &recipients);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_data_faults_with_corrupted_parts() {
+    let Setup { mut env, producers, recipients, faults, observed } = setup();
+    // The part is signed but fails its merkle proof, so a recipient has to reject the part without
+    // rejecting the item. The producers left alone still push enough parts to decode.
+    assert!(NUM_PRODUCERS - 1 >= decode_threshold(), "one silent producer alone stops the decode");
+    faults.lock().corrupt_from.insert(producers[0].clone());
+
+    run_past_certified_frontier(&mut env, &recipients[0], PUSH_HEIGHTS);
+
+    let observed = observed.lock();
+    assert!(observed.corrupted > 0, "no part was corrupted");
+    assert_endorsed(&observed, &recipients);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_data_faults_with_equivocating_producer() {
+    let Setup { mut env, producers, recipients, faults, observed } = setup();
+    // Two commitments for one item from one producer, both holding a part that verifies. The
+    // honest one still decodes, so the conflicting tracker must not displace it.
+    faults.lock().equivocate_from.insert(producers[0].clone());
+
+    run_past_certified_frontier(&mut env, &recipients[0], PUSH_HEIGHTS);
+
+    let observed = observed.lock();
+    assert!(observed.equivocated > 0, "no conflicting commitment was sent");
+    assert_endorsed(&observed, &recipients);
+}
+
+/// The fault-free baseline for the four tests above: pushes alone carry every witness, so the
+/// recipients endorse without ever requesting. Without this the `data_requests` assertions there
+/// would also pass on a chain that requests all the time for unrelated reasons.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_data_faults_none_armed() {
+    let Setup { mut env, producers: _, recipients, faults: _, observed } = setup();
+
+    run_past_certified_frontier(&mut env, &recipients[0], PUSH_HEIGHTS);
+
+    let observed = observed.lock();
+    assert_eq!(observed.dropped + observed.delayed + observed.corrupted + observed.equivocated, 0);
+    assert!(observed.data_requests.is_empty(), "a healthy chain requested data");
+    assert_endorsed(&observed, &recipients);
+}
+
+/// The control for the four tests above: with every producer silent the recipients have nothing to
+/// validate and never endorse, while the producers keep certifying among themselves. If this ever
+/// starts endorsing, the other tests are passing without the data path being exercised.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_data_faults_starve_the_recipients() {
+    let Setup { mut env, producers, recipients, faults, observed } = setup();
+    faults.lock().drop_from.extend(producers.iter().cloned());
+
+    run_past_certified_frontier(&mut env, &recipients[0], PUSH_HEIGHTS);
+
+    let observed = observed.lock();
+    assert!(observed.dropped > 0, "no push was dropped");
+    for recipient in &recipients {
+        assert!(
+            !observed.endorsements.contains_key(recipient),
+            "{recipient} endorsed without data"
+        );
+    }
+}

--- a/test-loop-tests/src/tests/spice/mod.rs
+++ b/test-loop-tests/src/tests/spice/mod.rs
@@ -2,6 +2,7 @@ mod all_stake_fallback;
 mod basic;
 mod congestion;
 mod core_statement_limit;
+mod data_faults;
 mod garbage_collection;
 mod light_client;
 mod malicious_chunk_producer;

--- a/test-loop-tests/src/tests/spice/utils.rs
+++ b/test-loop-tests/src/tests/spice/utils.rs
@@ -1,15 +1,23 @@
 use crate::setup::env::TestLoopEnv;
-use crate::setup::peer_manager_actor::HandlerResult;
-use crate::setup::state::{NodeExecutionData, SpiceEndorsementDelayState};
+use crate::setup::peer_manager_actor::{HandlerResult, TestLoopNetworkSharedState};
+use crate::setup::state::{
+    NETWORK_DELAY, NodeExecutionData, SpiceDataFaultState, SpiceDataFaults, SpiceDataObserved,
+    SpiceEndorsementDelayState,
+};
 use near_async::messaging::CanSend as _;
 use near_async::test_loop::data::TestLoopData;
+use near_async::time::Duration;
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::recv_permit::RecvMessagePermit;
+use near_network::spice::data_distribution::SpiceIncomingPartialData;
 use near_network::types::NetworkRequests;
 use near_network::types::NetworkResponses;
-use near_primitives::hash::CryptoHash;
+use near_primitives::hash::{CryptoHash, hash};
+use near_primitives::merkle::compute_root_from_path_and_item;
 use near_primitives::spice::chunk_endorsement::SpiceChunkEndorsement;
-use near_primitives::types::{AccountId, BlockHeight};
+use near_primitives::spice::partial_data::{SpiceDataCommitment, SpicePartialData};
+use near_primitives::test_utils::create_test_signer;
+use near_primitives::types::{AccountId, BlockHeight, SpiceChunkId};
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -45,6 +53,156 @@ impl TestLoopEnv {
             install_endorsement_delay_handler(&mut self.test_loop.data, node, state.clone());
         }
     }
+}
+
+impl TestLoopEnv {
+    /// Installs spice data fault injection on every node and returns the shared knobs alongside
+    /// what the handler sees. Call again after `add_node` / `restart_node` to instrument nodes
+    /// added since.
+    pub fn install_spice_data_faults(
+        &mut self,
+    ) -> (Arc<Mutex<SpiceDataFaults>>, Arc<Mutex<SpiceDataObserved>>) {
+        let state = self.shared_state.spice_data_faults.clone();
+        {
+            let mut wiring = state.wiring.lock();
+            wiring.senders = self
+                .node_datas
+                .iter()
+                .map(|n| (n.account_id.clone(), n.spice_data_distributor_sender.clone()))
+                .collect();
+        }
+        let network = self.shared_state.network_shared_state.clone();
+        for node in &self.node_datas {
+            if !state.wiring.lock().installed_for.insert(node.identifier.clone()) {
+                continue;
+            }
+            install_spice_data_fault_handler(
+                &mut self.test_loop.data,
+                node,
+                state.clone(),
+                network.clone(),
+            );
+        }
+        (state.faults.clone(), state.observed)
+    }
+}
+
+fn install_spice_data_fault_handler(
+    data: &mut TestLoopData,
+    node: &NodeExecutionData,
+    state: SpiceDataFaultState,
+    network: TestLoopNetworkSharedState,
+) {
+    let me = node.account_id.clone();
+    let peer_actor = data.get_mut(&node.peer_manager_sender.actor_handle());
+    peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
+        if let NetworkRequests::SpiceDataRequest { .. } = &request {
+            *state.observed.lock().data_requests.entry(me.clone()).or_default() += 1;
+            return HandlerResult::Unhandled(request);
+        }
+        if let NetworkRequests::SpiceChunkEndorsement(_target, endorsement) = &request {
+            let chunk_id = SpiceChunkId {
+                block_hash: *endorsement.block_hash(),
+                shard_id: endorsement.shard_id(),
+            };
+            state
+                .observed
+                .lock()
+                .endorsements
+                .entry(endorsement.account_id().clone())
+                .or_default()
+                .insert(chunk_id);
+            return HandlerResult::Unhandled(request);
+        }
+        let NetworkRequests::SpicePartialData { partial_data, recipients } = &request else {
+            return HandlerResult::Unhandled(request);
+        };
+        let sender = partial_data.sender().clone();
+        let (drop_it, delay, corrupt, equivocate) = {
+            let faults = state.faults.lock();
+            (
+                faults.drop_from.contains(&sender),
+                faults.delay_from.get(&sender).copied(),
+                faults.corrupt_from.contains(&sender),
+                faults.equivocate_from.contains(&sender),
+            )
+        };
+        if drop_it {
+            state.observed.lock().dropped += 1;
+            return HandlerResult::Handled(NetworkResponses::NoResponse);
+        }
+        if delay.is_none() && !corrupt && !equivocate {
+            return HandlerResult::Unhandled(request);
+        }
+        {
+            let mut observed = state.observed.lock();
+            observed.delayed += delay.is_some() as usize;
+            observed.corrupted += corrupt as usize;
+            observed.equivocated += equivocate as usize;
+        }
+
+        let mut to_send = Vec::new();
+        if equivocate {
+            to_send.push(with_conflicting_commitment(partial_data));
+        }
+        to_send.push(if corrupt {
+            with_corrupted_part(partial_data)
+        } else {
+            partial_data.clone()
+        });
+
+        // Delivered here rather than passed on, so the faulty copies keep the delay and the extra
+        // message the normal path cannot express. Severed links have to be honoured by hand
+        // because that check lives in the routing this bypasses.
+        // TODO(spice-data-distribution): count what each recipient is handed, so a test can assert
+        // on delivery directly instead of inferring it from whether the recipient endorsed.
+        let delay = NETWORK_DELAY + delay.unwrap_or(Duration::ZERO);
+        let senders: Vec<_> = {
+            let wiring = state.wiring.lock();
+            recipients
+                .iter()
+                .filter(|recipient| network.is_link_allowed(&me, recipient))
+                .filter_map(|recipient| wiring.senders.get(recipient))
+                .map(|sender| sender.clone().with_delay(delay))
+                .collect()
+        };
+        for recipient_sender in senders {
+            for data in &to_send {
+                recipient_sender.send(SpiceIncomingPartialData {
+                    data: data.clone(),
+                    recv_permit: RecvMessagePermit::none(),
+                });
+            }
+        }
+        HandlerResult::Handled(NetworkResponses::NoResponse)
+    }));
+}
+
+/// Flips a byte of the first part, keeping the commitment, so the part fails its merkle proof.
+fn with_corrupted_part(data: &SpicePartialData) -> SpicePartialData {
+    let signer = create_test_signer(data.sender().as_str());
+    let mut verified = data.clone().into_verified(&signer.public_key()).unwrap();
+    let part = verified.parts.first_mut().expect("pushed data carries a part");
+    let byte = part.part.first_mut().expect("part is not empty");
+    *byte ^= 1;
+    SpicePartialData::new(verified.id, verified.commitment, verified.parts, &signer)
+}
+
+/// Re-sends the sender's first part with a flipped byte under a commitment built around it: the
+/// root comes from the part's own merkle path, so the part verifies and the recipient tracks a
+/// second commitment for the item, holding parts under both.
+fn with_conflicting_commitment(data: &SpicePartialData) -> SpicePartialData {
+    let signer = create_test_signer(data.sender().as_str());
+    let verified = data.clone().into_verified(&signer.public_key()).unwrap();
+    let mut part = verified.parts.into_iter().next().expect("partial data carries a part");
+    let byte = part.part.first_mut().expect("part is not empty");
+    *byte ^= 1;
+    let commitment = SpiceDataCommitment {
+        root: compute_root_from_path_and_item(&part.merkle_proof, &part.part),
+        hash: hash(verified.commitment.hash.as_bytes()),
+        encoded_length: verified.commitment.encoded_length,
+    };
+    SpicePartialData::new(verified.id, commitment, vec![part], &signer)
 }
 
 fn install_endorsement_delay_handler(

--- a/test-loop-tests/src/tests/spice/utils.rs
+++ b/test-loop-tests/src/tests/spice/utils.rs
@@ -1,23 +1,15 @@
 use crate::setup::env::TestLoopEnv;
-use crate::setup::peer_manager_actor::{HandlerResult, TestLoopNetworkSharedState};
-use crate::setup::state::{
-    NETWORK_DELAY, NodeExecutionData, SpiceDataFaultState, SpiceDataFaults, SpiceDataObserved,
-    SpiceEndorsementDelayState,
-};
+use crate::setup::peer_manager_actor::HandlerResult;
+use crate::setup::state::{NodeExecutionData, SpiceEndorsementDelayState};
 use near_async::messaging::CanSend as _;
 use near_async::test_loop::data::TestLoopData;
-use near_async::time::Duration;
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::recv_permit::RecvMessagePermit;
-use near_network::spice::data_distribution::SpiceIncomingPartialData;
 use near_network::types::NetworkRequests;
 use near_network::types::NetworkResponses;
-use near_primitives::hash::{CryptoHash, hash};
-use near_primitives::merkle::compute_root_from_path_and_item;
+use near_primitives::hash::CryptoHash;
 use near_primitives::spice::chunk_endorsement::SpiceChunkEndorsement;
-use near_primitives::spice::partial_data::{SpiceDataCommitment, SpicePartialData};
-use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::{AccountId, BlockHeight, SpiceChunkId};
+use near_primitives::types::{AccountId, BlockHeight};
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -53,156 +45,6 @@ impl TestLoopEnv {
             install_endorsement_delay_handler(&mut self.test_loop.data, node, state.clone());
         }
     }
-}
-
-impl TestLoopEnv {
-    /// Installs spice data fault injection on every node and returns the shared knobs alongside
-    /// what the handler sees. Call again after `add_node` / `restart_node` to instrument nodes
-    /// added since.
-    pub fn install_spice_data_faults(
-        &mut self,
-    ) -> (Arc<Mutex<SpiceDataFaults>>, Arc<Mutex<SpiceDataObserved>>) {
-        let state = self.shared_state.spice_data_faults.clone();
-        {
-            let mut wiring = state.wiring.lock();
-            wiring.senders = self
-                .node_datas
-                .iter()
-                .map(|n| (n.account_id.clone(), n.spice_data_distributor_sender.clone()))
-                .collect();
-        }
-        let network = self.shared_state.network_shared_state.clone();
-        for node in &self.node_datas {
-            if !state.wiring.lock().installed_for.insert(node.identifier.clone()) {
-                continue;
-            }
-            install_spice_data_fault_handler(
-                &mut self.test_loop.data,
-                node,
-                state.clone(),
-                network.clone(),
-            );
-        }
-        (state.faults.clone(), state.observed)
-    }
-}
-
-fn install_spice_data_fault_handler(
-    data: &mut TestLoopData,
-    node: &NodeExecutionData,
-    state: SpiceDataFaultState,
-    network: TestLoopNetworkSharedState,
-) {
-    let me = node.account_id.clone();
-    let peer_actor = data.get_mut(&node.peer_manager_sender.actor_handle());
-    peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
-        if let NetworkRequests::SpiceDataRequest { .. } = &request {
-            *state.observed.lock().data_requests.entry(me.clone()).or_default() += 1;
-            return HandlerResult::Unhandled(request);
-        }
-        if let NetworkRequests::SpiceChunkEndorsement(_target, endorsement) = &request {
-            let chunk_id = SpiceChunkId {
-                block_hash: *endorsement.block_hash(),
-                shard_id: endorsement.shard_id(),
-            };
-            state
-                .observed
-                .lock()
-                .endorsements
-                .entry(endorsement.account_id().clone())
-                .or_default()
-                .insert(chunk_id);
-            return HandlerResult::Unhandled(request);
-        }
-        let NetworkRequests::SpicePartialData { partial_data, recipients } = &request else {
-            return HandlerResult::Unhandled(request);
-        };
-        let sender = partial_data.sender().clone();
-        let (drop_it, delay, corrupt, equivocate) = {
-            let faults = state.faults.lock();
-            (
-                faults.drop_from.contains(&sender),
-                faults.delay_from.get(&sender).copied(),
-                faults.corrupt_from.contains(&sender),
-                faults.equivocate_from.contains(&sender),
-            )
-        };
-        if drop_it {
-            state.observed.lock().dropped += 1;
-            return HandlerResult::Handled(NetworkResponses::NoResponse);
-        }
-        if delay.is_none() && !corrupt && !equivocate {
-            return HandlerResult::Unhandled(request);
-        }
-        {
-            let mut observed = state.observed.lock();
-            observed.delayed += delay.is_some() as usize;
-            observed.corrupted += corrupt as usize;
-            observed.equivocated += equivocate as usize;
-        }
-
-        let mut to_send = Vec::new();
-        if equivocate {
-            to_send.push(with_conflicting_commitment(partial_data));
-        }
-        to_send.push(if corrupt {
-            with_corrupted_part(partial_data)
-        } else {
-            partial_data.clone()
-        });
-
-        // Delivered here rather than passed on, so the faulty copies keep the delay and the extra
-        // message the normal path cannot express. Severed links have to be honoured by hand
-        // because that check lives in the routing this bypasses.
-        // TODO(spice-data-distribution): count what each recipient is handed, so a test can assert
-        // on delivery directly instead of inferring it from whether the recipient endorsed.
-        let delay = NETWORK_DELAY + delay.unwrap_or(Duration::ZERO);
-        let senders: Vec<_> = {
-            let wiring = state.wiring.lock();
-            recipients
-                .iter()
-                .filter(|recipient| network.is_link_allowed(&me, recipient))
-                .filter_map(|recipient| wiring.senders.get(recipient))
-                .map(|sender| sender.clone().with_delay(delay))
-                .collect()
-        };
-        for recipient_sender in senders {
-            for data in &to_send {
-                recipient_sender.send(SpiceIncomingPartialData {
-                    data: data.clone(),
-                    recv_permit: RecvMessagePermit::none(),
-                });
-            }
-        }
-        HandlerResult::Handled(NetworkResponses::NoResponse)
-    }));
-}
-
-/// Flips a byte of the first part, keeping the commitment, so the part fails its merkle proof.
-fn with_corrupted_part(data: &SpicePartialData) -> SpicePartialData {
-    let signer = create_test_signer(data.sender().as_str());
-    let mut verified = data.clone().into_verified(&signer.public_key()).unwrap();
-    let part = verified.parts.first_mut().expect("pushed data carries a part");
-    let byte = part.part.first_mut().expect("part is not empty");
-    *byte ^= 1;
-    SpicePartialData::new(verified.id, verified.commitment, verified.parts, &signer)
-}
-
-/// Re-sends the sender's first part with a flipped byte under a commitment built around it: the
-/// root comes from the part's own merkle path, so the part verifies and the recipient tracks a
-/// second commitment for the item, holding parts under both.
-fn with_conflicting_commitment(data: &SpicePartialData) -> SpicePartialData {
-    let signer = create_test_signer(data.sender().as_str());
-    let verified = data.clone().into_verified(&signer.public_key()).unwrap();
-    let mut part = verified.parts.into_iter().next().expect("partial data carries a part");
-    let byte = part.part.first_mut().expect("part is not empty");
-    *byte ^= 1;
-    let commitment = SpiceDataCommitment {
-        root: compute_root_from_path_and_item(&part.merkle_proof, &part.part),
-        hash: hash(verified.commitment.hash.as_bytes()),
-        encoded_length: verified.commitment.encoded_length,
-    };
-    SpicePartialData::new(verified.id, commitment, vec![part], &signer)
 }
 
 fn install_endorsement_delay_handler(


### PR DESCRIPTION
Part a2 of spice data distribution overhaul

Add fault injection for spice data distribution: drop, delay, corrupt a part, and equivocate, installed on every node's test-loop peer manager.
The PRs building the data-manager [sketch](https://github.com/near/nearcore/pull/16053) each need these, so the harness lands first.
Faults are keyed by the sending account rather than by call site, so one setting covers every way partial data leaves a node: the push, the all-stake fallback push, and the response to a  data request.
A silenced producer is then left with no path at all.
Delay and equivocation cannot be expressed by rewriting the outgoing request, so the handler sends those copies itself, and it has to check severed links by hand because that check lives in the routing it skips.

Assertions look at the recipient, not the chain.
Chunk producers are chunk validators for their own chunks, so they certify among themselves even when nothing reaches anyone else, and chain progress says nothing about distribution.
Each test therefore asserts that the validators which produce nothing endorsed, which they can only do after receiving and validating a witness.
Each test also states how many parts have to arrive for a decode, so changing the producer count cannot turn a recovery test into a push test without anyone noticing; DATA_PARTS_RATIO becomes `pub` so that number follows production.
A starvation control drops everything and asserts they never endorse, and a fault-free baseline checks that a healthy chain sends no data requests at all.

The equivocating producer sends a real second commitment, its root recomputed from the corrupted part's own merkle path, so both commitments hold a part that verifies and the recipient tracks two of them for one item.

Three gaps are left to the PRs that need them, marked TODO(spice-data-distribution): requests are counted per requester, without the producer asked or the ordinals wanted; nothing counts  what reaches a recipient, so delivery is guessed from endorsements; and the tests check that a recipient endorsed at all, not how many chunks it endorsed — under drops, the slower of two  identical recipients gets two of eight.
