### PR TITLE
chore(network): make network.proto pass buf lint

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -6,8 +6,9 @@ lint:
   use:
     - DEFAULT
   ignore_only:
-    # Renaming the package to network.v1, or moving the file into a network/
-    # directory, changes the package and so fails the WIRE breaking check.
+    # network.proto predates both rules. Renaming the package fails the WIRE
+    # breaking check; matching the directory means moving the file out of the
+    # crate that owns it.
     PACKAGE_DIRECTORY_MATCH:
       - chain/network/src/network_protocol/network.proto
     PACKAGE_VERSION_SUFFIX:

--- a/buf.yaml
+++ b/buf.yaml
@@ -2,3 +2,13 @@ version: v1
 breaking:
   use:
     - WIRE
+lint:
+  use:
+    - DEFAULT
+  ignore_only:
+    # Renaming the package to network.v1, or moving the file into a network/
+    # directory, changes the package and so fails the WIRE breaking check.
+    PACKAGE_DIRECTORY_MATCH:
+      - chain/network/src/network_protocol/network.proto
+    PACKAGE_VERSION_SUFFIX:
+      - chain/network/src/network_protocol/network.proto

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -144,7 +144,7 @@ message Handshake {
   // (it may change in the future), however peers may communicate with the newer version
   // of the NEAR network protocol, than the NEAR protocol version approved by the quorum of
   // the validators. If B doesn't support protocol_version, it sends back HandshakeFailure
-  // with reason ProtocolVersionMismatch.
+  // with reason REASON_PROTOCOL_VERSION_MISMATCH.
   uint32 protocol_version = 1;
   // Oldest version of the NEAR network protocol that the peer supports.
   uint32 oldest_supported_version = 2;
@@ -152,14 +152,14 @@ message Handshake {
   PublicKey sender_peer_id = 3;
   // PeerId of the receiver that the sender expects.
   // In case of mismatch, receiver sends back HandshakeFailure with
-  // reason InvalidTarget.
+  // reason REASON_INVALID_TARGET.
   PublicKey target_peer_id = 4;
   // TCP port on which sender is listening for inbound connections.
   uint32 sender_listen_port = 5;
   // Basic info about the NEAR chain that the sender belongs to.
   // Sender expects receiver to belong to the same chain.
   // In case of mismatch, receiver sends back HandshakeFailure with
-  // reason GenesisMismatch.
+  // reason REASON_GENESIS_MISMATCH.
   PeerChainInfo sender_chain_info = 6;
   // Edge (sender,receiver) signed by sender, which once signed by
   // receiver may be broadcasted to the network to prove that the
@@ -179,13 +179,13 @@ message Handshake {
 // Response to Handshake, in case the Handshake was rejected.
 message HandshakeFailure {
   enum Reason {
-    UNKNOWN = 0;
+    REASON_UNSPECIFIED = 0;
     // Peer doesn't support protocol_version indicated in the handshake.
-    ProtocolVersionMismatch = 1;
+    REASON_PROTOCOL_VERSION_MISMATCH = 1;
     // Peer doesn't belong to the chain indicated in the handshake.
-    GenesisMismatch = 2;
+    REASON_GENESIS_MISMATCH = 2;
     // target_id doesn't match the id of the peer.
-    InvalidTarget = 3;
+    REASON_INVALID_TARGET = 3;
   }
   // Reason for rejecting the Handshake.
   Reason reason = 1;
@@ -218,7 +218,7 @@ message PeerAddr {
 }
 
 message AccountData {
-  reserved 1,3;
+  reserved 1, 3;
 
   // PeerId of the node owning the account_key.
   // Used to route the message over TIER1.
@@ -259,7 +259,7 @@ message AccountData {
 // Accounts provides a mapping AccountId -> PeerId, providing knowledge
 // about which NEAR peer controls which NEAR account.
 message RoutingTableUpdate {
-  reserved 3,4;
+  reserved 3, 4;
   repeated Edge edges = 1;
   // list of known NEAR validator accounts
   repeated AnnounceAccount accounts = 2;
@@ -409,11 +409,11 @@ message RoutingSyncV2 {
 // Inter-process tracing information.
 message TraceContext {
   enum SamplingPriority {
-    UNKNOWN = 0;
-    AutoReject = 1;
-    UserReject = 2;
-    AutoKeep = 3;
-    UserKeep = 4;
+    SAMPLING_PRIORITY_UNSPECIFIED = 0;
+    SAMPLING_PRIORITY_AUTO_REJECT = 1;
+    SAMPLING_PRIORITY_USER_REJECT = 2;
+    SAMPLING_PRIORITY_AUTO_KEEP = 3;
+    SAMPLING_PRIORITY_USER_KEEP = 4;
   }
   // 16 bytes representing TraceId: https://docs.rs/opentelemetry/latest/opentelemetry/trace/struct.TraceId.html
   bytes trace_id = 1;
@@ -470,9 +470,9 @@ message PeerMessage {
   // Leaving 1,2,3 unused allows us to ensure that there will be no collision
   // between borsh and protobuf encodings:
   // https://docs.google.com/document/d/1gCWmt9O-h_-5JDXIqbKxAaSS3Q9pryB1f9DDY1mMav4/edit
-  reserved 1,2,3;
+  reserved 1, 2, 3;
   // Deprecated fields.
-  reserved 20,21,22,23,24,28;
+  reserved 20, 21, 22, 23, 24, 28;
 
   // Inter-process tracing information.
   TraceContext trace_context = 26;

--- a/chain/network/src/network_protocol/proto_conv/handshake.rs
+++ b/chain/network/src/network_protocol/proto_conv/handshake.rs
@@ -144,20 +144,20 @@ impl From<(&PeerInfo, &HandshakeFailureReason)> for proto::HandshakeFailure {
                 oldest_supported_version,
             } => Self {
                 peer_info: MF::some(pi.into()),
-                reason: proto::handshake_failure::Reason::ProtocolVersionMismatch.into(),
+                reason: proto::handshake_failure::Reason::REASON_PROTOCOL_VERSION_MISMATCH.into(),
                 version: *version,
                 oldest_supported_version: *oldest_supported_version,
                 ..Self::default()
             },
             HandshakeFailureReason::GenesisMismatch(genesis_id) => Self {
                 peer_info: MF::some(pi.into()),
-                reason: proto::handshake_failure::Reason::GenesisMismatch.into(),
+                reason: proto::handshake_failure::Reason::REASON_GENESIS_MISMATCH.into(),
                 genesis_id: MF::some(genesis_id.into()),
                 ..Self::default()
             },
             HandshakeFailureReason::InvalidTarget => Self {
                 peer_info: MF::some(pi.into()),
-                reason: proto::handshake_failure::Reason::InvalidTarget.into(),
+                reason: proto::handshake_failure::Reason::REASON_INVALID_TARGET.into(),
                 ..Self::default()
             },
         }
@@ -179,21 +179,23 @@ impl TryFrom<&proto::HandshakeFailure> for (PeerInfo, HandshakeFailureReason) {
     fn try_from(x: &proto::HandshakeFailure) -> Result<Self, Self::Error> {
         let pi = try_from_required(&x.peer_info).map_err(Self::Error::PeerInfo)?;
         let hfr = match x.reason.enum_value_or_default() {
-            proto::handshake_failure::Reason::ProtocolVersionMismatch => {
+            proto::handshake_failure::Reason::REASON_PROTOCOL_VERSION_MISMATCH => {
                 HandshakeFailureReason::ProtocolVersionMismatch {
                     version: x.version,
                     oldest_supported_version: x.oldest_supported_version,
                 }
             }
-            proto::handshake_failure::Reason::GenesisMismatch => {
+            proto::handshake_failure::Reason::REASON_GENESIS_MISMATCH => {
                 HandshakeFailureReason::GenesisMismatch(
                     try_from_required(&x.genesis_id).map_err(Self::Error::GenesisId)?,
                 )
             }
-            proto::handshake_failure::Reason::InvalidTarget => {
+            proto::handshake_failure::Reason::REASON_INVALID_TARGET => {
                 HandshakeFailureReason::InvalidTarget
             }
-            proto::handshake_failure::Reason::UNKNOWN => return Err(Self::Error::UnknownReason),
+            proto::handshake_failure::Reason::REASON_UNSPECIFIED => {
+                return Err(Self::Error::UnknownReason);
+            }
         };
         Ok((pi, hfr))
     }

--- a/chain/network/src/network_protocol/proto_conv/trace_context.rs
+++ b/chain/network/src/network_protocol/proto_conv/trace_context.rs
@@ -28,12 +28,12 @@ pub(crate) fn extract_span_context(
         // out so that the rest of the spans aren't completely lost.
         let span_id = extract_span_id(&trace_context.span_id).unwrap_or(SpanId::INVALID);
         let sampled = match trace_context.sampling_priority.enum_value() {
-            Ok(SamplingPriority::UserReject) | Ok(SamplingPriority::AutoReject) => {
-                TraceFlags::default()
-            }
-            Ok(SamplingPriority::UserKeep) | Ok(SamplingPriority::AutoKeep) => TraceFlags::SAMPLED,
+            Ok(SamplingPriority::SAMPLING_PRIORITY_USER_REJECT)
+            | Ok(SamplingPriority::SAMPLING_PRIORITY_AUTO_REJECT) => TraceFlags::default(),
+            Ok(SamplingPriority::SAMPLING_PRIORITY_USER_KEEP)
+            | Ok(SamplingPriority::SAMPLING_PRIORITY_AUTO_KEEP) => TraceFlags::SAMPLED,
             // Treat the sampling as DEFERRED instead of erring on extracting the span context
-            Ok(SamplingPriority::UNKNOWN) | Err(_) => TRACE_FLAG_DEFERRED,
+            Ok(SamplingPriority::SAMPLING_PRIORITY_UNSPECIFIED) | Err(_) => TRACE_FLAG_DEFERRED,
         };
         let trace_state = TraceState::default();
         Ok(SpanContext::new(trace_id, span_id, sampled, true, trace_state))
@@ -57,9 +57,9 @@ pub(crate) fn inject_trace_context(cx: &Context) -> MessageField<TraceContext> {
 
         if span_context.trace_flags() & TRACE_FLAG_DEFERRED != TRACE_FLAG_DEFERRED {
             let sampling_priority = if span_context.is_sampled() {
-                SamplingPriority::AutoKeep
+                SamplingPriority::SAMPLING_PRIORITY_AUTO_KEEP
             } else {
-                SamplingPriority::AutoReject
+                SamplingPriority::SAMPLING_PRIORITY_AUTO_REJECT
             };
             trace_context.sampling_priority = EnumOrUnknown::new(sampling_priority);
         }


### PR DESCRIPTION
`network.proto` fails 20 `buf lint` rules. Nothing in CI runs `buf lint`, so this has gone unnoticed. This clears 18 of them and configures the other two away.

The enum values in `HandshakeFailure.Reason` and `TraceContext.SamplingPriority` are renamed to satisfy `ENUM_VALUE_PREFIX`, `ENUM_VALUE_UPPER_SNAKE_CASE` and `ENUM_ZERO_VALUE_SUFFIX`. Proto3 encodes enums as their number and no number changes, so this is wire-compatible: `buf breaking` against master is clean. The generated-code call sites in `proto_conv/handshake.rs` and `proto_conv/trace_context.rs` are updated to match.

`buf format` adds a space after the commas in four `reserved` lists.

The two remaining rules, `PACKAGE_VERSION_SUFFIX` and `PACKAGE_DIRECTORY_MATCH`, are excepted in `buf.yaml`. Satisfying them means renaming the package to `network.v1`, which `buf breaking` reports as `File package changed from "network" to "network.v1"` and so fails the very check this repo runs.