### PR TITLE
fix(spice): collect invalid chunks via height-keyed SpiceInvalidChunks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1648,6 +1648,8 @@ impl Chain {
         chain_store_update.save_body_head(&tip)?;
         // Reset final head to genesis since at this point we don't have the last final block.
         chain_store_update.save_final_head(&final_head)?;
+        // TODO(#16264): the gc loops start at tail and chunk_tail, so nothing collects the heights
+        // this skips. Leaks blocks, chunks, partial chunks and their receipt refcounts.
         // New Tail can not be earlier than `prev_block.header.inner_lite.height`
         chain_store_update.update_tail(new_tail);
         // New Chunk Tail can not be earlier than minimum of height_created in Block `prev_block`

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1157,10 +1157,13 @@ impl Chain {
                         // Invalid chunks (SPICE) have no ShardChunk in
                         // DBCol::Chunks because the header commits to
                         // malicious content. The executor uses
-                        // DBCol::InvalidChunks to detect these and skips
+                        // DBCol::SpiceInvalidChunks to detect these and skips
                         // the chunk body read.
                         if !self.chain_store.chunk_exists(chunk_hash)
-                            && self.chain_store.is_invalid_chunk(chunk_hash).is_none()
+                            && self
+                                .chain_store
+                                .is_invalid_chunk(chunk_header.height_created(), chunk_hash)
+                                .is_none()
                         {
                             missing.push(chunk_header.clone());
                         }

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -12,12 +12,14 @@ use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::ReceiptSource;
 use near_primitives::shard_layout::{ShardLayout, get_block_shard_uid};
+use near_primitives::sharding::ChunkHash;
 use near_primitives::spice::chunk_endorsement::SpiceStoredVerifiedEndorsement;
 use near_primitives::state_sync::{StateHeaderKey, StatePartKey};
 use near_primitives::types::{BlockHeight, BlockHeightDelta, EpochId, NumBlocks, ShardId};
 use near_primitives::utils::{
     get_block_shard_id, get_block_shard_id_rev, get_endorsements_key_prefix,
     get_execution_results_key, get_outcome_id_block_hash, get_receipt_proof_key,
+    get_spice_invalid_chunk_key_prefix, get_spice_invalid_chunk_key_rev,
     get_uncertified_execution_results_key, index_to_bytes,
 };
 use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
@@ -27,6 +29,13 @@ use near_store::{DBCol, GcPolicy, KeyForStateChanges, ShardTries, ShardUId};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InvalidChunkReceipts {
+    Delete,
+    /// `clear_redundant_chunk_data` never releases receipts, and nothing else can recompute them.
+    KeepForLegacyArchival,
+}
 
 #[derive(Clone)]
 pub enum GCMode {
@@ -555,15 +564,15 @@ impl<'a> ChainStoreUpdate<'a> {
         let chunk_tail = self.chunk_tail();
         for height in chunk_tail..min_chunk_height {
             let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height);
-            for chunk_hash in chunk_hashes {
+            for chunk_hash in &chunk_hashes {
                 // 1. Delete chunk-related data
-                let chunk = self.get_chunk(&chunk_hash)?;
+                let chunk = self.get_chunk(chunk_hash)?;
                 debug_assert_eq!(chunk.height_created(), height);
                 for transaction in chunk.to_transactions() {
                     self.gc_col(DBCol::Transactions, transaction.get_hash().as_bytes());
                 }
 
-                let partial_chunk = self.get_partial_chunk(&chunk_hash);
+                let partial_chunk = self.get_partial_chunk(chunk_hash);
                 if let Ok(partial_chunk) = partial_chunk {
                     for receipts in partial_chunk.prev_outgoing_receipts() {
                         for receipt in &receipts.0 {
@@ -578,6 +587,12 @@ impl<'a> ChainStoreUpdate<'a> {
                 self.gc_col(DBCol::PartialChunks, chunk_hash);
                 self.gc_col(DBCol::InvalidChunks, chunk_hash);
             }
+
+            self.gc_spice_invalid_chunks_at_height(
+                height,
+                &chunk_hashes,
+                InvalidChunkReceipts::Delete,
+            );
 
             let header_hashes = self.chain_store().get_all_header_hashes_by_height(height);
             for header_hash in header_hashes {
@@ -627,18 +642,23 @@ impl<'a> ChainStoreUpdate<'a> {
         let mut remaining = gc_height_limit;
         while height < gc_stop_height && remaining > 0 {
             let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height);
-            height += 1;
-            if !chunk_hashes.is_empty() {
-                remaining -= 1;
-                for chunk_hash in chunk_hashes {
-                    let chunk_hash = chunk_hash.as_bytes();
-                    self.gc_col(DBCol::PartialChunks, chunk_hash);
-                    // Data in DBCol::InvalidChunks isn't technically redundant (it
-                    // cannot be calculated from other data) but it is data we
-                    // don't need for anything so it can be deleted as well.
-                    self.gc_col(DBCol::InvalidChunks, chunk_hash);
-                }
+            for chunk_hash in &chunk_hashes {
+                let chunk_hash = chunk_hash.as_bytes();
+                self.gc_col(DBCol::PartialChunks, chunk_hash);
+                // Data in DBCol::InvalidChunks isn't technically redundant (it
+                // cannot be calculated from other data) but it is data we
+                // don't need for anything so it can be deleted as well.
+                self.gc_col(DBCol::InvalidChunks, chunk_hash);
             }
+            let collected_invalid_chunks = self.gc_spice_invalid_chunks_at_height(
+                height,
+                &chunk_hashes,
+                InvalidChunkReceipts::KeepForLegacyArchival,
+            );
+            if !chunk_hashes.is_empty() || collected_invalid_chunks {
+                remaining -= 1;
+            }
+            height += 1;
         }
         self.update_chunk_tail(height);
     }
@@ -785,6 +805,50 @@ impl<'a> ChainStoreUpdate<'a> {
         };
         self.merge(store_update.into());
         Ok(())
+    }
+
+    /// Deletes the invalid chunks created at `height`, with their partial chunks. The
+    /// `ChunkHashesByHeight` loop cannot reach them, since the index never lists an invalid chunk.
+    ///
+    /// For `chunk_hashes_in_height_index` that loop already deleted the partial chunk and released
+    /// the receipts, so only the row is left: a producer keeps its own bad chunk in `Chunks` too.
+    ///
+    /// Returns whether the height held any invalid chunk, so a height-limited caller can count it.
+    fn gc_spice_invalid_chunks_at_height(
+        &mut self,
+        height: BlockHeight,
+        chunk_hashes_in_height_index: &HashSet<ChunkHash>,
+        receipts_cleanup: InvalidChunkReceipts,
+    ) -> bool {
+        if !cfg!(feature = "protocol_feature_spice") {
+            return false;
+        }
+
+        let mut found_invalid_chunk = false;
+        let store = self.store();
+        let key_prefix = get_spice_invalid_chunk_key_prefix(height);
+        for (key, _) in store.iter_prefix(DBCol::spice_invalid_chunks(), &key_prefix) {
+            found_invalid_chunk = true;
+            let Some((_, chunk_hash)) = get_spice_invalid_chunk_key_rev(&key) else {
+                tracing::warn!(target: "garbage_collection", ?key, "malformed invalid chunk key");
+                self.gc_col(DBCol::spice_invalid_chunks(), &key);
+                continue;
+            };
+            if !chunk_hashes_in_height_index.contains(&chunk_hash) {
+                if receipts_cleanup == InvalidChunkReceipts::Delete
+                    && let Ok(partial_chunk) = self.get_partial_chunk(&chunk_hash)
+                {
+                    for receipts in partial_chunk.prev_outgoing_receipts() {
+                        for receipt in &receipts.0 {
+                            self.gc_col(DBCol::Receipts, receipt.receipt_id().as_bytes());
+                        }
+                    }
+                }
+                self.gc_col(DBCol::PartialChunks, chunk_hash.as_bytes());
+            }
+            self.gc_col(DBCol::spice_invalid_chunks(), &key);
+        }
+        found_invalid_chunk
     }
 
     fn gc_spice_core_data(&mut self, block_hash: &CryptoHash, shard_layout: &ShardLayout) {
@@ -979,15 +1043,15 @@ impl<'a> ChainStoreUpdate<'a> {
 
     fn clear_chunk_data_at_height(&mut self, height: BlockHeight) -> Result<(), Error> {
         let chunk_hashes = self.store().chunk_store().get_all_chunk_hashes_by_height(height);
-        for chunk_hash in chunk_hashes {
+        for chunk_hash in &chunk_hashes {
             // 1. Delete chunk-related data
-            let chunk = self.get_chunk(&chunk_hash)?;
+            let chunk = self.get_chunk(chunk_hash)?;
             debug_assert_eq!(chunk.height_created(), height);
             for transaction in chunk.to_transactions() {
                 self.gc_col(DBCol::Transactions, transaction.get_hash().as_bytes());
             }
 
-            let partial_chunk = self.get_partial_chunk(&chunk_hash);
+            let partial_chunk = self.get_partial_chunk(chunk_hash);
             if let Ok(partial_chunk) = partial_chunk {
                 for receipts in partial_chunk.prev_outgoing_receipts() {
                     for receipt in &receipts.0 {
@@ -1002,6 +1066,8 @@ impl<'a> ChainStoreUpdate<'a> {
             self.gc_col(DBCol::PartialChunks, chunk_hash);
             self.gc_col(DBCol::InvalidChunks, chunk_hash);
         }
+
+        self.gc_spice_invalid_chunks_at_height(height, &chunk_hashes, InvalidChunkReceipts::Delete);
 
         // 4. Delete chunk hashes per height
         let key = index_to_bytes(height);

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -31,10 +31,12 @@ use std::fmt;
 use std::sync::Arc;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum InvalidChunkReceipts {
-    Delete,
-    /// `clear_redundant_chunk_data` never releases receipts, and nothing else can recompute them.
-    KeepForLegacyArchival,
+enum InvalidChunkCleanup {
+    DeleteEvidence,
+    /// `clear_redundant_chunk_data` drops only what cold storage does not take, and
+    /// `SpiceInvalidChunks` is a cold column. A node still migrating to split storage has not
+    /// copied the row yet.
+    NonSplitArchival,
 }
 
 #[derive(Clone)]
@@ -591,7 +593,7 @@ impl<'a> ChainStoreUpdate<'a> {
             self.gc_spice_invalid_chunks_at_height(
                 height,
                 &chunk_hashes,
-                InvalidChunkReceipts::Delete,
+                InvalidChunkCleanup::DeleteEvidence,
             );
 
             let header_hashes = self.chain_store().get_all_header_hashes_by_height(height);
@@ -653,7 +655,7 @@ impl<'a> ChainStoreUpdate<'a> {
             let collected_invalid_chunks = self.gc_spice_invalid_chunks_at_height(
                 height,
                 &chunk_hashes,
-                InvalidChunkReceipts::KeepForLegacyArchival,
+                InvalidChunkCleanup::NonSplitArchival,
             );
             if !chunk_hashes.is_empty() || collected_invalid_chunks {
                 remaining -= 1;
@@ -807,7 +809,7 @@ impl<'a> ChainStoreUpdate<'a> {
         Ok(())
     }
 
-    /// Deletes the invalid chunks created at `height`, with their partial chunks. The
+    /// Collects the invalid chunks created at `height`, with their partial chunks. The
     /// `ChunkHashesByHeight` loop cannot reach them, since the index never lists an invalid chunk.
     ///
     /// For `chunk_hashes_in_height_index` that loop already deleted the partial chunk and released
@@ -818,7 +820,7 @@ impl<'a> ChainStoreUpdate<'a> {
         &mut self,
         height: BlockHeight,
         chunk_hashes_in_height_index: &HashSet<ChunkHash>,
-        receipts_cleanup: InvalidChunkReceipts,
+        cleanup: InvalidChunkCleanup,
     ) -> bool {
         if !cfg!(feature = "protocol_feature_spice") {
             return false;
@@ -834,10 +836,15 @@ impl<'a> ChainStoreUpdate<'a> {
                 self.gc_col(DBCol::spice_invalid_chunks(), &key);
                 continue;
             };
-            if !chunk_hashes_in_height_index.contains(&chunk_hash) {
-                if receipts_cleanup == InvalidChunkReceipts::Delete
-                    && let Ok(partial_chunk) = self.get_partial_chunk(&chunk_hash)
-                {
+            let handled_by_height_index = chunk_hashes_in_height_index.contains(&chunk_hash);
+            if cleanup == InvalidChunkCleanup::NonSplitArchival {
+                if !handled_by_height_index {
+                    self.gc_col(DBCol::PartialChunks, chunk_hash.as_bytes());
+                }
+                continue;
+            }
+            if !handled_by_height_index {
+                if let Ok(partial_chunk) = self.get_partial_chunk(&chunk_hash) {
                     for receipts in partial_chunk.prev_outgoing_receipts() {
                         for receipt in &receipts.0 {
                             self.gc_col(DBCol::Receipts, receipt.receipt_id().as_bytes());
@@ -1067,7 +1074,11 @@ impl<'a> ChainStoreUpdate<'a> {
             self.gc_col(DBCol::InvalidChunks, chunk_hash);
         }
 
-        self.gc_spice_invalid_chunks_at_height(height, &chunk_hashes, InvalidChunkReceipts::Delete);
+        self.gc_spice_invalid_chunks_at_height(
+            height,
+            &chunk_hashes,
+            InvalidChunkCleanup::DeleteEvidence,
+        );
 
         // 4. Delete chunk hashes per height
         let key = index_to_bytes(height);
@@ -1291,4 +1302,57 @@ fn gc_state(
     }
     chain_store_update.merge(trie_store_update.into());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::get_chain;
+    use near_async::time::Clock;
+    use near_primitives::hash::hash;
+    use near_primitives::utils::get_spice_invalid_chunk_key;
+
+    fn plant_invalid_chunk(chain: &Chain, height: BlockHeight) -> Vec<u8> {
+        let chunk_hash = ChunkHash(hash(format!("invalid chunk at {height}").as_bytes()));
+        let key = get_spice_invalid_chunk_key(height, &chunk_hash);
+        let mut store_update = chain.chain_store().store().store_update();
+        store_update.insert(DBCol::spice_invalid_chunks(), key.clone(), vec![0]);
+        store_update.commit();
+        key
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn non_split_archival_gc_keeps_invalid_chunk_evidence() {
+        let mut chain = get_chain(Clock::real());
+        let height = chain.chain_store().chunk_tail();
+        let key = plant_invalid_chunk(&chain, height);
+
+        let mut update = chain.mut_chain_store().store_update();
+        update.clear_redundant_chunk_data(height + 1, 10);
+        update.commit().unwrap();
+
+        let store = chain.chain_store().store();
+        assert!(chain.chain_store().chunk_tail() > height, "gc did not pass the height");
+        assert!(
+            store.exists(DBCol::spice_invalid_chunks(), &key),
+            "non-split archival gc dropped evidence cold storage has not copied yet",
+        );
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn hot_gc_deletes_invalid_chunk_evidence() {
+        let mut chain = get_chain(Clock::real());
+        let height = chain.chain_store().chunk_tail();
+        let key = plant_invalid_chunk(&chain, height);
+
+        let mut update = chain.mut_chain_store().store_update();
+        update.clear_chunk_data_and_headers(height + 1).unwrap();
+        update.commit().unwrap();
+
+        let store = chain.chain_store().store();
+        assert!(chain.chain_store().chunk_tail() > height, "gc did not pass the height");
+        assert!(!store.exists(DBCol::spice_invalid_chunks(), &key), "hot gc kept evidence");
+    }
 }

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -32,7 +32,8 @@ use near_primitives::types::{
     StateChangesKinds, StateChangesKindsExt, StateChangesRequest,
 };
 use near_primitives::utils::{
-    get_block_shard_id, get_outcome_id_block_hash_rev, index_to_bytes, to_timestamp,
+    get_block_shard_id, get_outcome_id_block_hash_rev, get_spice_invalid_chunk_key, index_to_bytes,
+    to_timestamp,
 };
 use near_primitives::views::LightClientBlockView;
 use near_store::adapter::chain_store::ChainStoreAdapter;
@@ -174,7 +175,11 @@ pub trait ChainStoreAccess {
     fn get_blocks_to_catchup(&self, prev_hash: &CryptoHash) -> Vec<CryptoHash>;
 
     /// Returns encoded chunk if it's invalid otherwise None.
-    fn is_invalid_chunk(&self, chunk_hash: &ChunkHash) -> Option<Arc<EncodedShardChunk>>;
+    fn is_invalid_chunk(
+        &self,
+        height_created: BlockHeight,
+        chunk_hash: &ChunkHash,
+    ) -> Option<Arc<EncodedShardChunk>>;
 
     fn get_transaction(&self, tx_hash: &CryptoHash) -> Option<Arc<SignedTransaction>>;
 
@@ -978,8 +983,12 @@ impl ChainStoreAccess for ChainStore {
         ChainStoreAdapter::get_blocks_to_catchup(self, hash)
     }
 
-    fn is_invalid_chunk(&self, chunk_hash: &ChunkHash) -> Option<Arc<EncodedShardChunk>> {
-        self.chunk_store().is_invalid_chunk(chunk_hash)
+    fn is_invalid_chunk(
+        &self,
+        height_created: BlockHeight,
+        chunk_hash: &ChunkHash,
+    ) -> Option<Arc<EncodedShardChunk>> {
+        self.chunk_store().is_invalid_chunk(height_created, chunk_hash)
     }
 
     fn get_transaction(&self, tx_hash: &CryptoHash) -> Option<Arc<SignedTransaction>> {
@@ -1354,11 +1363,14 @@ impl<'a> ChainStoreAccess for ChainStoreUpdate<'a> {
         self.chain_store.get_blocks_to_catchup(prev_hash)
     }
 
-    fn is_invalid_chunk(&self, chunk_hash: &ChunkHash) -> Option<Arc<EncodedShardChunk>> {
-        if let Some(chunk) = self.chain_store_cache_update.invalid_chunks.get(chunk_hash) {
-            Some(Arc::clone(chunk))
-        } else {
-            self.chain_store.is_invalid_chunk(chunk_hash)
+    fn is_invalid_chunk(
+        &self,
+        height_created: BlockHeight,
+        chunk_hash: &ChunkHash,
+    ) -> Option<Arc<EncodedShardChunk>> {
+        match self.chain_store_cache_update.invalid_chunks.get(chunk_hash) {
+            Some(chunk) => Some(Arc::clone(chunk)),
+            None => self.chain_store.is_invalid_chunk(height_created, chunk_hash),
         }
     }
 
@@ -2051,7 +2063,11 @@ impl<'a> ChainStoreUpdate<'a> {
             store_update.delete(DBCol::StateDlInfos, hash.as_ref());
         }
         for (chunk_hash, chunk) in &self.chain_store_cache_update.invalid_chunks {
-            store_update.insert_ser(DBCol::InvalidChunks, chunk_hash.as_ref(), chunk);
+            store_update.insert_ser(
+                DBCol::spice_invalid_chunks(),
+                &get_spice_invalid_chunk_key(chunk.height_created(), chunk_hash),
+                chunk,
+            );
         }
         for block_height in &self.chain_store_cache_update.processed_block_heights {
             store_update.set_ser(DBCol::ProcessedBlockHeights, &index_to_bytes(*block_height), &());

--- a/chain/client/src/spice/chunk_executor_actor/per_shard.rs
+++ b/chain/client/src/spice/chunk_executor_actor/per_shard.rs
@@ -597,7 +597,10 @@ impl PerShardChunkExecutor {
                         // Chunk is new but invalid (malicious producer): include proof.
                         self.chain_store
                             .chunk_store()
-                            .is_invalid_chunk(chunk_header.chunk_hash())
+                            .is_invalid_chunk(
+                                chunk_header.height_created(),
+                                chunk_header.chunk_hash(),
+                            )
                             .map(|enc| Box::new(enc.content().clone()))
                     } else {
                         None
@@ -656,7 +659,9 @@ impl PerShardChunkExecutor {
         match get_chunk_clone_from_header(&chunk_store, chunk_header) {
             Ok(chunk) => Ok(Some(chunk)),
             Err(Error::ChunkMissing(_))
-                if chunk_store.is_invalid_chunk(chunk_header.chunk_hash()).is_some() =>
+                if chunk_store
+                    .is_invalid_chunk(chunk_header.height_created(), chunk_header.chunk_hash())
+                    .is_some() =>
             {
                 Ok(None)
             }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1362,6 +1362,14 @@ impl EncodedShardChunk {
     }
 
     #[inline]
+    pub fn height_created(&self) -> BlockHeight {
+        match self {
+            Self::V1(chunk) => chunk.header.inner.height_created,
+            Self::V2(chunk) => chunk.header.height_created(),
+        }
+    }
+
+    #[inline]
     pub fn encoded_merkle_root(&self) -> &CryptoHash {
         match self {
             Self::V1(chunk) => &chunk.header.inner.encoded_merkle_root,

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "clock")]
 use crate::block::BlockHeader;
 use crate::hash::{CryptoHash, hash};
+use crate::sharding::ChunkHash;
 use crate::types::{ChunkExecutionResultHash, ShardId};
 use crate::universal_state_init::UniversalStateInit;
 use chrono;
@@ -232,6 +233,28 @@ pub fn get_endorsements_key(
 
 pub fn get_execution_results_key(block_hash: &CryptoHash, shard_id: ShardId) -> Vec<u8> {
     get_block_shard_id(block_hash, shard_id)
+}
+
+pub fn get_spice_invalid_chunk_key(height_created: BlockHeight, chunk_hash: &ChunkHash) -> Vec<u8> {
+    const BYTES_LEN: usize = size_of::<BlockHeight>() + size_of::<CryptoHash>();
+    let mut res = Vec::with_capacity(BYTES_LEN);
+    res.extend_from_slice(&index_to_bytes(height_created));
+    res.extend_from_slice(chunk_hash.as_ref());
+    res
+}
+
+pub fn get_spice_invalid_chunk_key_prefix(height_created: BlockHeight) -> Vec<u8> {
+    index_to_bytes(height_created).to_vec()
+}
+
+pub fn get_spice_invalid_chunk_key_rev(key: &[u8]) -> Option<(BlockHeight, ChunkHash)> {
+    const HEIGHT_LEN: usize = size_of::<BlockHeight>();
+    if key.len() != HEIGHT_LEN + size_of::<CryptoHash>() {
+        return None;
+    }
+    let (height_bytes, chunk_hash_bytes) = key.split_at(HEIGHT_LEN);
+    let height_created = BlockHeight::from_le_bytes(height_bytes.try_into().ok()?);
+    Some((height_created, ChunkHash(CryptoHash::try_from(chunk_hash_bytes).ok()?)))
 }
 
 pub fn get_uncertified_execution_results_key(hash: &ChunkExecutionResultHash) -> Vec<u8> {

--- a/core/store/src/adapter/chunk_store.rs
+++ b/core/store/src/adapter/chunk_store.rs
@@ -11,7 +11,8 @@ use near_primitives::stateless_validation::contract_distribution::CodeHash;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_primitives::utils::{
-    get_block_shard_id, get_contract_accesses_key, get_witnesses_key, index_to_bytes,
+    get_block_shard_id, get_contract_accesses_key, get_spice_invalid_chunk_key, get_witnesses_key,
+    index_to_bytes,
 };
 use std::collections::HashSet;
 use std::io;
@@ -70,8 +71,16 @@ impl ChunkStoreAdapter {
     }
 
     /// Returns encoded chunk if it's invalid otherwise None.
-    pub fn is_invalid_chunk(&self, chunk_hash: &ChunkHash) -> Option<Arc<EncodedShardChunk>> {
-        self.store.get_ser(DBCol::InvalidChunks, chunk_hash.as_ref())
+    pub fn is_invalid_chunk(
+        &self,
+        height_created: BlockHeight,
+        chunk_hash: &ChunkHash,
+    ) -> Option<Arc<EncodedShardChunk>> {
+        if !cfg!(feature = "protocol_feature_spice") {
+            return None;
+        }
+        let key = get_spice_invalid_chunk_key(height_created, chunk_hash);
+        self.store.get_ser(DBCol::spice_invalid_chunks(), &key)
     }
 
     /// Information from applying chunk.

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -193,7 +193,7 @@ pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
 fn is_cloud_archive_reader_skipped(col: DBCol) -> bool {
     // TODO(spice): decide how the reader handles spice columns.
     #[cfg(feature = "protocol_feature_spice")]
-    if col == DBCol::ReceiptProofs {
+    if col == DBCol::ReceiptProofs || col == DBCol::SpiceInvalidChunks {
         return true;
     }
     matches!(

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -406,6 +406,13 @@ pub enum DBCol {
     /// - *Content type*: [near_primitives::hash::CryptoHash] (certifying block hash)
     #[cfg(feature = "protocol_feature_spice")]
     ChunkCertifyingBlock,
+    /// For spice, chunks that failed to decode or verify. Unlike [`DBCol::InvalidChunks`], the
+    /// height prefix lets garbage collection reach these rows: an invalid chunk gets no
+    /// [`DBCol::Chunks`] row, so [`DBCol::ChunkHashesByHeight`] does not list it.
+    /// - *Rows*: BlockHeight || ChunkHash (height_created, chunk_hash)
+    /// - *Content type*: [near_primitives::sharding::EncodedShardChunk]
+    #[cfg(feature = "protocol_feature_spice")]
+    SpiceInvalidChunks,
     /// Pre-computed chunk producer for the chunk anchored at the given block (its
     /// grandparent), sampled at height `anchor.height+2` in the epoch after the anchor.
     /// Populated during header sync and block processing, gated behind `EarlyKickout`
@@ -503,6 +510,7 @@ impl DBCol {
             | DBCol::ExecutionResults
             | DBCol::UncertifiedExecutionResults
             | DBCol::SpiceEndorsementStats
+            | DBCol::SpiceInvalidChunks
             | DBCol::ChunkCertifyingBlock => true,
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => true,
@@ -611,6 +619,9 @@ impl DBCol {
             | DBCol::ContractAccesses => false,
             #[cfg(feature = "protocol_feature_spice")]
             | DBCol::ChunkCertifyingBlock => false,
+            // SpiceInvalidChunks is only needed at head, while the chunk is executed.
+            #[cfg(feature = "protocol_feature_spice")]
+            | DBCol::SpiceInvalidChunks => false,
             // TODO
             DBCol::ChallengedBlocks => false,
             DBCol::Misc => false,
@@ -726,6 +737,7 @@ impl DBCol {
             | DBCol::ReceiptProofs
             | DBCol::SpiceEndorsementStats
             | DBCol::UncertifiedChunks
+            | DBCol::SpiceInvalidChunks
             | DBCol::UncertifiedExecutionResults
             | DBCol::Witnesses => GcPolicy::Delete,
 
@@ -877,9 +889,18 @@ impl DBCol {
             DBCol::ContractAccesses => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::ChunkCertifyingBlock => &[DBKeyType::BlockHash, DBKeyType::ShardId],
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::SpiceInvalidChunks => &[DBKeyType::BlockHeight, DBKeyType::ChunkHash],
             #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => &[DBKeyType::BlockHash, DBKeyType::ShardId],
         }
+    }
+
+    pub fn spice_invalid_chunks() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::SpiceInvalidChunks;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
     }
 
     pub fn witnesses() -> DBCol {

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -619,9 +619,8 @@ impl DBCol {
             | DBCol::ContractAccesses => false,
             #[cfg(feature = "protocol_feature_spice")]
             | DBCol::ChunkCertifyingBlock => false,
-            // SpiceInvalidChunks is only needed at head, while the chunk is executed.
             #[cfg(feature = "protocol_feature_spice")]
-            | DBCol::SpiceInvalidChunks => false,
+            | DBCol::SpiceInvalidChunks => true,
             // TODO
             DBCol::ChallengedBlocks => false,
             DBCol::Misc => false,

--- a/test-loop-tests/src/tests/spice/garbage_collection.rs
+++ b/test-loop-tests/src/tests/spice/garbage_collection.rs
@@ -3,12 +3,24 @@ use crate::utils::account::{create_validators_spec, validators_spec_clients_with
 use crate::utils::node::TestLoopNode;
 use near_async::time::Duration;
 use near_chain::spice::core::get_last_certified_block_header;
+#[cfg(feature = "test_features")]
+use near_client::NetworkAdversarialMessage;
+#[cfg(feature = "test_features")]
+use near_client::client_actor::AdvProduceChunksMode;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
+#[cfg(feature = "test_features")]
+use near_primitives::sharding::ChunkHash;
+#[cfg(feature = "test_features")]
+use near_primitives::types::BlockHeight;
 use near_primitives::types::ShardId;
 use near_primitives::utils::{get_block_shard_id, get_block_shard_id_rev};
+#[cfg(feature = "test_features")]
+use near_primitives::utils::{get_spice_invalid_chunk_key, get_spice_invalid_chunk_key_rev};
 use near_store::DBCol;
+#[cfg(feature = "test_features")]
+use std::collections::HashSet;
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
@@ -147,4 +159,67 @@ fn test_spice_chunk_certifying_block_index_is_collected_with_its_block() {
         indexed_chunks += 1;
     }
     assert!(indexed_chunks > 0, "expected the index to hold chunks of retained blocks");
+}
+
+#[cfg(feature = "test_features")]
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_invalid_chunks_are_collected() {
+    init_test_logger();
+
+    let mut env =
+        TestLoopBuilder::new().validators(4, 0).epoch_length(5).gc_num_epochs_to_keep(1).build();
+
+    let (malicious_node, honest_node) = (0, 1);
+    env.node_runner(malicious_node).send_adversarial_message(
+        NetworkAdversarialMessage::AdvProduceChunks(
+            AdvProduceChunksMode::ProduceWithCorruptedTxRoot,
+        ),
+    );
+
+    let mut seen_invalid_chunks: HashSet<(BlockHeight, ChunkHash)> = HashSet::new();
+    env.node_runner(honest_node).run_until(
+        |node| {
+            seen_invalid_chunks.extend(stored_invalid_chunks(node));
+            let chunk_tail = node.chunk_tail();
+            seen_invalid_chunks.iter().any(|(height, _)| *height < chunk_tail)
+        },
+        Duration::seconds(60),
+    );
+
+    let node = env.node(honest_node);
+    let chunk_tail = node.chunk_tail();
+    let collected: Vec<_> =
+        seen_invalid_chunks.iter().filter(|(height, _)| *height < chunk_tail).collect();
+    assert!(!collected.is_empty(), "gc did not pass any invalid chunk");
+    for (height, chunk_hash) in collected {
+        assert!(!node.store().exists(
+            DBCol::spice_invalid_chunks(),
+            &get_spice_invalid_chunk_key(*height, chunk_hash)
+        ));
+        for col in [DBCol::PartialChunks, DBCol::Chunks] {
+            assert!(!node.store().exists(col, chunk_hash.as_ref()));
+        }
+    }
+
+    for (height, _) in stored_invalid_chunks(&node) {
+        assert!(height >= chunk_tail, "invalid chunk at height {height}, chunk_tail {chunk_tail}");
+    }
+
+    let producer = env.node(malicious_node);
+    let producer_chunk_tail = producer.chunk_tail();
+    for (height, _) in stored_invalid_chunks(&producer) {
+        assert!(
+            height >= producer_chunk_tail,
+            "producer kept invalid chunk at height {height}, chunk_tail {producer_chunk_tail}",
+        );
+    }
+}
+
+#[cfg(feature = "test_features")]
+fn stored_invalid_chunks(node: &TestLoopNode) -> HashSet<(BlockHeight, ChunkHash)> {
+    node.store()
+        .iter(DBCol::spice_invalid_chunks())
+        .map(|(key, _)| get_spice_invalid_chunk_key_rev(&key).unwrap())
+        .collect()
 }

--- a/test-loop-tests/src/tests/spice/malicious_chunk_producer.rs
+++ b/test-loop-tests/src/tests/spice/malicious_chunk_producer.rs
@@ -45,7 +45,7 @@ fn test_spice_chain_with_malicious_chunk_producer() {
     let chain_store = node.client().chain.chain_store();
     let epoch_manager = &node.client().epoch_manager;
     let mut invalid_chunk_count = 0;
-    for (_, value) in node.store().iter(DBCol::InvalidChunks) {
+    for (_, value) in node.store().iter(DBCol::spice_invalid_chunks()) {
         let chunk: EncodedShardChunk = borsh::from_slice(&value).unwrap();
         let header = chunk.cloned_header();
         let shard_id = header.shard_id();
@@ -105,7 +105,7 @@ fn test_spice_block_sync_with_malicious_chunks() {
     env.node_runner(honest_node).run_for_number_of_blocks(cache_horizon as usize + 10);
 
     // Sanity check: honest node detected at least one malicious chunk.
-    assert!(env.node(honest_node).store().iter(DBCol::InvalidChunks).count() > 0);
+    assert!(env.node(honest_node).store().iter(DBCol::spice_invalid_chunks()).count() > 0);
 
     // Add a late-joining non-validator node that will block-sync.
     // It must track all shards so it actually fetches and validates chunks.
@@ -128,9 +128,9 @@ fn test_spice_block_sync_with_malicious_chunks() {
     // chunk that the honest node detected.
     let sync_store = env.node_for_account(&sync_account).store();
     let honest_store = env.node(honest_node).store();
-    for (key, _) in honest_store.iter(DBCol::InvalidChunks) {
+    for (key, _) in honest_store.iter(DBCol::spice_invalid_chunks()) {
         assert!(
-            sync_store.exists(DBCol::InvalidChunks, key.as_ref()),
+            sync_store.exists(DBCol::spice_invalid_chunks(), key.as_ref()),
             "syncing node missing invalid chunk that the honest node detected",
         );
     }
@@ -165,7 +165,7 @@ fn test_spice_witness_validation_with_invalid_chunk() {
     let chain_store = node.client().chain.chain_store();
     let epoch_manager = &node.client().epoch_manager;
     let mut invalid_chunk_count = 0;
-    for (_, value) in node.store().iter(DBCol::InvalidChunks) {
+    for (_, value) in node.store().iter(DBCol::spice_invalid_chunks()) {
         let chunk: EncodedShardChunk = borsh::from_slice(&value).unwrap();
         let header = chunk.cloned_header();
         let shard_id = header.shard_id();

--- a/test-loop-tests/src/tests/spice/malicious_chunk_producer.rs
+++ b/test-loop-tests/src/tests/spice/malicious_chunk_producer.rs
@@ -1,17 +1,21 @@
-use crate::setup::builder::TestLoopBuilder;
+use crate::setup::builder::{ArchivalKind, TestLoopBuilder};
 use crate::utils::account::create_account_id;
+use crate::utils::node::TestLoopNode;
 use assert_matches::assert_matches;
+use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
 use near_chain::near_chain_primitives::Error;
 use near_chain_configs::TrackedShardsConfig;
 use near_client::NetworkAdversarialMessage;
 use near_client::client_actor::AdvProduceChunksMode;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::block::Tip;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::EncodedShardChunk;
-use near_primitives::types::Gas;
-use near_primitives::utils::get_endorsements_key_prefix;
+use near_primitives::types::{BlockHeight, Gas};
+use near_primitives::utils::{get_endorsements_key_prefix, get_spice_invalid_chunk_key_rev};
 use near_store::DBCol;
+use near_store::db::{COLD_HEAD_KEY, Database};
 
 /// Test that a malicious chunk producer sending chunks with corrupted tx_root
 /// triggers the invalid chunk path, and under SPICE the chain still progresses
@@ -197,4 +201,65 @@ fn test_spice_witness_validation_with_invalid_chunk() {
         invalid_chunk_count += 1;
     }
     assert!(invalid_chunk_count > 0, "expected at least one invalid chunk stored as evidence");
+}
+
+/// A malicious chunk's encoded body is the only record of what the producer sent: it gets no
+/// `DBCol::Chunks` row, and `DBCol::PartialChunks` is not archived. Cold storage must keep it.
+#[cfg(feature = "test_features")]
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_invalid_chunk_copied_to_cold_storage() {
+    init_test_logger();
+
+    let epoch_length = 5;
+    let mut env = TestLoopBuilder::new()
+        .validators(4, 0)
+        .epoch_length(epoch_length)
+        .enable_archival_node(ArchivalKind::Cold)
+        .build();
+
+    let malicious_node = 0;
+    env.node_runner(malicious_node).send_adversarial_message(
+        NetworkAdversarialMessage::AdvProduceChunks(
+            AdvProduceChunksMode::ProduceWithCorruptedTxRoot,
+        ),
+    );
+
+    env.archival_runner()
+        .run_until(|node| !stored_invalid_chunk_keys(node).is_empty(), Duration::seconds(60));
+
+    let invalid_chunk_keys = stored_invalid_chunk_keys(&env.archival_node());
+    let last_invalid_chunk_height = invalid_chunk_keys
+        .iter()
+        .map(|key| get_spice_invalid_chunk_key_rev(key).unwrap().0)
+        .max()
+        .unwrap();
+
+    env.archival_runner().run_until(
+        |node| cold_head_height(node) > last_invalid_chunk_height,
+        Duration::seconds(60),
+    );
+
+    let archival_idx = env.archival_data_idx();
+    let cold_store_sender = env.node_datas[archival_idx].cold_store_sender.as_ref().unwrap();
+    let cold_store_actor = env.test_loop.data.get(&cold_store_sender.actor_handle());
+    let cold_db = cold_store_actor.get_cold_db();
+
+    for key in &invalid_chunk_keys {
+        let (height_created, chunk_hash) = get_spice_invalid_chunk_key_rev(key).unwrap();
+        assert!(
+            cold_db.get_raw_bytes(DBCol::spice_invalid_chunks(), key).is_some(),
+            "invalid chunk {chunk_hash:?} at height {height_created} missing from cold storage",
+        );
+    }
+}
+
+#[cfg(feature = "test_features")]
+fn stored_invalid_chunk_keys(node: &TestLoopNode) -> Vec<Box<[u8]>> {
+    node.store().iter(DBCol::spice_invalid_chunks()).map(|(key, _)| key).collect()
+}
+
+#[cfg(feature = "test_features")]
+fn cold_head_height(node: &TestLoopNode) -> BlockHeight {
+    node.store().get_ser::<Tip>(DBCol::BlockMisc, COLD_HEAD_KEY).map_or(0, |tip| tip.height)
 }

--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -62,6 +62,10 @@ impl<'a> TestLoopNode<'a> {
         self.client().chain.tail()
     }
 
+    pub fn chunk_tail(&self) -> BlockHeight {
+        self.client().chain.chain_store().chunk_tail()
+    }
+
     pub fn head(&self) -> Arc<Tip> {
         self.client().chain.head().unwrap()
     }


### PR DESCRIPTION
Fixes #16095. Three commits: introduce the column, collect it, archive it.

Invalid chunks were never garbage collected. GC reaches chunks through `DBCol::ChunkHashesByHeight`, which is written only for chunks that get a `DBCol::Chunks` row. Under SPICE an invalid chunk deliberately gets no `Chunks` row, so its hash never enters the index and neither it nor its `DBCol::PartialChunks` row is ever reached.

SPICE invalid chunks move to a new `DBCol::SpiceInvalidChunks` keyed by `height_created || chunk_hash`. Every reader already holds the chunk header, so no call site needed new plumbing.

The height prefix is what lets GC reach them, and no separate sweep is needed. `clear_chunk_data_and_headers`, `clear_chunk_data_at_height` and `clear_redundant_chunk_data` each gain a per-height prefix scan next to the `ChunkHashesByHeight` pass they already run. Work per tick is exactly the heights being processed, and the deletes share the `ChainStoreUpdate` that advances `chunk_tail`, so a crash cannot leave a height behind.

A producer of a bad chunk also keeps it in `Chunks`, so the `ChunkHashesByHeight` loop already deleted it and released its receipts. The height pass skips those hashes. Without the skip the shared transaction deletes the same key twice; removing it makes `test_spice_invalid_chunks_are_collected` fail on the `StoreUpdate::commit` assertion.

The last commit makes the column cold. An invalid chunk's encoded body is the only record of what the producer sent: it gets no `Chunks` row, and `PartialChunks` is not archived. Before this PR the GC leak was the only thing retaining it, so collecting it would otherwise have left archival nodes with nothing. `test_spice_invalid_chunk_copied_to_cold_storage` runs a malicious producer against a split-storage archival node and asserts the row reaches the cold DB; setting `is_cold` back to false makes it fail.

Making the column cold also changes what `clear_redundant_chunk_data` may delete. That path drops only columns cold storage does not take, and it runs on any archival node whose store is not yet `DbKind::Hot`, which includes one still migrating to split storage (`chain/client/src/gc_actor.rs:76-78`). The cold-head clamp on `gc_stop_height` does not apply there (`chain/chain/src/runtime/mod.rs:465-475`), so deleting the row could drop evidence before the initial cold migration copies it. `InvalidChunkCleanup::NonSplitArchival` therefore keeps the row and its receipts, and drops only the redundant partial chunk. Two unit tests in `garbage_collection.rs` pin the two modes apart; test-loop cannot reach this path, since it never builds a non-split archival node (`test-loop-tests/src/setup/setup.rs:397`).

`every_retained_column_is_classified_for_cloud_archive` requires any newly cold column to be classified for the cloud-archive reader as well. The encoded body cannot be reproduced from `BlockData` or `ShardData`, so the column joins `ReceiptProofs` in `is_cloud_archive_reader_skipped`, under that function's existing `TODO(spice)`. Split-storage archival keeps the evidence; cloud archival does not yet.

`DBCol::InvalidChunks` stays in place, but nothing writes it now: `save_invalid_chunk` is only reached on the SPICE path.

Supersedes #16203, which instead scanned the whole column on every GC tick. That is O(column) twice a second, and the rows are created by an adversary, so a chunk producer could make each tick arbitrarily expensive. Keying by height removes the scan.