### PR TITLE
refactor(cloud-archive): a store adapter for the cloud heads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4145,7 +4145,6 @@ name = "near-cloud-archive-tool"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh",
  "clap",
  "near-chain-configs",
  "near-client",

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -47,7 +47,6 @@ use near_primitives::views::{
     QueryResponse, QueryResponseKind, ViewStateResult,
 };
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
-use near_store::db::CLOUD_PREV_EPOCH_END_KEY;
 use near_store::db::metadata::DbKind;
 use near_store::flat::FlatStorageManager;
 use near_store::trie::{FindSplitError, SnapshotError, find_trie_split, total_mem_usage};
@@ -663,9 +662,7 @@ fn get_epoch_start_height_from_cloud_head_prev_epoch(
     store: &Store,
     epoch_manager: &EpochManager,
 ) -> Result<Option<BlockHeight>, Error> {
-    let Some(prev_epoch_end) =
-        store.get_ser::<CryptoHash>(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY)
-    else {
+    let Some(prev_epoch_end) = store.cloud_archival_store().prev_epoch_end() else {
         return Ok(None);
     };
     let epoch_start_height = epoch_manager.get_epoch_start_height(&prev_epoch_end)?;

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -7,7 +7,6 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::types::{EpochHeight, EpochId};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
-use near_store::db::CLOUD_PREV_EPOCH_END_KEY;
 use near_store::{DBCol, Store, StoreUpdate};
 use std::sync::Arc;
 
@@ -102,7 +101,7 @@ fn should_keep_sync_hash(
 
 /// Returns the epoch height of the latest fully-archived epoch, if cloud archival is active.
 fn cloud_head_epoch_height(store: &Store) -> Option<EpochHeight> {
-    let prev_epoch_end: CryptoHash = store.get_ser(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY)?;
+    let prev_epoch_end = store.cloud_archival_store().prev_epoch_end()?;
     let block_info = store.epoch_store().get_block_info(&prev_epoch_end).ok()?;
     let epoch_info = store.epoch_store().get_epoch_info(block_info.epoch_id()).ok()?;
     Some(epoch_info.epoch_height())

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -17,10 +17,6 @@ use near_store::archive::cloud_storage::archive::CloudArchivingError;
 use near_store::archive::cloud_storage::metrics;
 use near_store::archive::cloud_storage::retrieve::CloudRetrievalError;
 use near_store::archive::cloud_storage::{BatchRange, compute_next_batch};
-use near_store::db::{
-    CLOUD_BLOCK_HEAD_KEY, CLOUD_MIN_HEAD_KEY, CLOUD_PREV_EPOCH_END_KEY, DBTransaction,
-    cloud_shard_head_key,
-};
 use near_store::{DBCol, FINAL_HEAD_KEY, Store};
 use std::collections::HashSet;
 use std::io;
@@ -334,7 +330,11 @@ impl CloudArchivalWriter {
     /// If the min cloud head lags the hot final head, archive the next height.
     /// Only archives components whose individual heads are behind.
     async fn try_archive_data_impl(&self) -> Result<CloudArchivingOutcome, CloudArchivingError> {
-        let min_head = self.get_local_min_head()?;
+        let min_head = self
+            .hot_store
+            .cloud_archival_store()
+            .min_head()
+            .expect("CLOUD_MIN_HEAD should exist in hot store after initialize");
         let batch_range = self.next_batch_after(min_head);
         let hot_final_height = self.get_hot_final_head_height()?;
         tracing::trace!(target: "cloud_archival", ?batch_range, hot_final_height, "try_archive");
@@ -543,7 +543,7 @@ impl CloudArchivalWriter {
         &self,
         batch_range: &BatchRange,
     ) -> Result<Option<BlockHeadUpdate>, CloudArchivingError> {
-        if let Some(head) = self.get_local_block_head()? {
+        if let Some(head) = self.hot_store.cloud_archival_store().block_head() {
             if head >= batch_range.end() {
                 return Ok(None);
             }
@@ -573,7 +573,7 @@ impl CloudArchivalWriter {
         for shard_batch in shard_batches {
             let shard_id = shard_batch.shard_uid.shard_id();
             let batch_end = shard_batch.range.end();
-            let lagging = match self.get_local_shard_head(shard_id)? {
+            let lagging = match self.hot_store.cloud_archival_store().shard_head(shard_id) {
                 Some(head) => head < batch_end,
                 None => true,
             };
@@ -614,7 +614,11 @@ impl CloudArchivalWriter {
         epoch_ending_block_hash: Option<CryptoHash>,
     ) -> Result<Vec<ShardBatchToArchive>, CloudArchivingError> {
         // The last archived epoch's end sits below `batch_range.start()`.
-        let prev_epoch_end = self.get_local_prev_epoch_end()?;
+        let prev_epoch_end = self
+            .hot_store
+            .cloud_archival_store()
+            .prev_epoch_end()
+            .expect("CLOUD_PREV_EPOCH_END should exist after initialize");
         let batch_start_epoch_id = self.epoch_manager.get_next_epoch_id(&prev_epoch_end)?;
         let resharding =
             self.resharding_info(batch_range, &prev_epoch_end, epoch_ending_block_hash)?;
@@ -941,34 +945,6 @@ impl CloudArchivalWriter {
         Ok(hot_final_head_height)
     }
 
-    /// Returns the writer's stored min head: the highest height up to which
-    /// all components are known archived (by us or another writer).
-    fn get_local_min_head(&self) -> io::Result<BlockHeight> {
-        Ok(self
-            .hot_store
-            .get_ser::<BlockHeight>(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY)
-            .expect("CLOUD_MIN_HEAD should exist in hot store after initialize"))
-    }
-
-    /// Returns the hash of the last block of the latest fully-archived epoch.
-    fn get_local_prev_epoch_end(&self) -> io::Result<CryptoHash> {
-        Ok(self
-            .hot_store
-            .get_ser::<CryptoHash>(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY)
-            .expect("CLOUD_PREV_EPOCH_END should exist after initialize"))
-    }
-
-    /// Returns the locally stored cloud block head height, if any.
-    fn get_local_block_head(&self) -> io::Result<Option<BlockHeight>> {
-        Ok(self.hot_store.get_ser::<BlockHeight>(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY))
-    }
-
-    /// Returns the locally stored cloud shard head height, if any.
-    fn get_local_shard_head(&self, shard_id: ShardId) -> io::Result<Option<BlockHeight>> {
-        let key = cloud_shard_head_key(shard_id);
-        Ok(self.hot_store.get_ser::<BlockHeight>(DBCol::BlockMisc, &key))
-    }
-
     /// Sets local heads during initialization, each to its own resolved height.
     /// Block and shard heads are stored as `BlockHeight` (always <=
     /// `hot_final_height - 1`, clamped during `resolve_init_state`).
@@ -978,26 +954,17 @@ impl CloudArchivalWriter {
         init_state: &ResolvedInitState,
     ) -> Result<(), CloudArchivalInitializationError> {
         let &ResolvedInitState { block_head, ref shard_heads, min_height, .. } = init_state;
-        let mut transaction = DBTransaction::new();
+        let mut store_update = self.hot_store.cloud_archival_store().store_update();
 
         if let Some(block_head) = block_head {
-            let height_bytes = borsh::to_vec(&block_head).unwrap();
-            transaction.set(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY.to_vec(), height_bytes);
+            store_update.set_block_head(block_head);
         }
-
         for &(shard_id, height) in shard_heads {
-            let height_bytes = borsh::to_vec(&height).unwrap();
-            transaction.set(DBCol::BlockMisc, cloud_shard_head_key(shard_id), height_bytes);
+            store_update.set_shard_head(shard_id, height);
         }
-
-        let min_head_bytes = borsh::to_vec(&min_height).unwrap();
-        transaction.set(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY.to_vec(), min_head_bytes);
-
-        let prev_epoch_end = self.compute_initial_prev_epoch_end(min_height)?;
-        let prev_epoch_end_bytes = borsh::to_vec(&prev_epoch_end).unwrap();
-        transaction.set(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY.to_vec(), prev_epoch_end_bytes);
-
-        self.hot_store.database().write(transaction);
+        store_update.set_min_head(min_height);
+        store_update.set_prev_epoch_end(self.compute_initial_prev_epoch_end(min_height)?);
+        store_update.commit();
         // No shard retires during initialization.
         let head_updates: Vec<ShardHeadUpdate> = shard_heads
             .iter()
@@ -1077,29 +1044,18 @@ impl CloudArchivalWriter {
         shards_update: &[ShardHeadUpdate],
         new_prev_epoch_end: Option<CryptoHash>,
     ) -> Result<(), near_chain_primitives::Error> {
-        let height_bytes = borsh::to_vec(&height).unwrap();
-        let mut transaction = DBTransaction::new();
+        let mut store_update = self.hot_store.cloud_archival_store().store_update();
         if let Some(block_update) = block_update {
-            let block_head_bytes = borsh::to_vec(&block_update.head).unwrap();
-            transaction.set(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY.to_vec(), block_head_bytes);
+            store_update.set_block_head(block_update.head);
         }
         for advanced in shards_update {
-            let shard_head_bytes = borsh::to_vec(&advanced.head).unwrap();
-            transaction.set(
-                DBCol::BlockMisc,
-                cloud_shard_head_key(advanced.shard_id),
-                shard_head_bytes,
-            );
+            store_update.set_shard_head(advanced.shard_id, advanced.head);
         }
-        transaction.set(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY.to_vec(), height_bytes);
+        store_update.set_min_head(height);
         if let Some(new_prev_epoch_end) = new_prev_epoch_end {
-            transaction.set(
-                DBCol::BlockMisc,
-                CLOUD_PREV_EPOCH_END_KEY.to_vec(),
-                borsh::to_vec(&new_prev_epoch_end).unwrap(),
-            );
+            store_update.set_prev_epoch_end(new_prev_epoch_end);
         }
-        self.hot_store.database().write(transaction);
+        store_update.commit();
         Self::report_head_heights(block_update.map(|u| u.head), shards_update, height);
         Ok(())
     }

--- a/core/store/src/adapter/cloud_archival_store.rs
+++ b/core/store/src/adapter/cloud_archival_store.rs
@@ -4,6 +4,7 @@ use crate::db::{
     cloud_shard_head_key, cloud_shard_head_key_shard_id,
 };
 use crate::{DBCol, Store, StoreUpdate};
+use borsh::BorshDeserialize;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, ShardId};
 
@@ -53,11 +54,14 @@ impl CloudArchivalStoreAdapter {
     /// Every shard the node has recorded a head for, in shard order.
     pub fn all_shard_heads(&self) -> Vec<(ShardId, BlockHeight)> {
         let mut heads = Vec::new();
-        for (key, value) in self.store.iter_prefix_ser(DBCol::BlockMisc, CLOUD_SHARD_HEAD_PREFIX) {
+        for (key, value) in self.store.iter_prefix(DBCol::BlockMisc, CLOUD_SHARD_HEAD_PREFIX) {
             let Some(shard_id) = cloud_shard_head_key_shard_id(&key) else {
                 continue;
             };
-            heads.push((shard_id, value));
+            let Ok(height) = BlockHeight::try_from_slice(&value) else {
+                continue;
+            };
+            heads.push((shard_id, height));
         }
         heads.sort_by_key(|(shard_id, _)| *shard_id);
         heads

--- a/core/store/src/adapter/cloud_archival_store.rs
+++ b/core/store/src/adapter/cloud_archival_store.rs
@@ -1,0 +1,110 @@
+use super::{StoreAdapter, StoreUpdateAdapter, StoreUpdateHolder};
+use crate::db::{
+    CLOUD_BLOCK_HEAD_KEY, CLOUD_MIN_HEAD_KEY, CLOUD_PREV_EPOCH_END_KEY, CLOUD_SHARD_HEAD_PREFIX,
+    cloud_shard_head_key, cloud_shard_head_key_shard_id,
+};
+use crate::{DBCol, Store, StoreUpdate};
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{BlockHeight, ShardId};
+
+/// What the node's own store holds for cloud archival.
+#[derive(Clone)]
+pub struct CloudArchivalStoreAdapter {
+    store: Store,
+}
+
+impl StoreAdapter for CloudArchivalStoreAdapter {
+    fn store_ref(&self) -> &Store {
+        &self.store
+    }
+}
+
+impl CloudArchivalStoreAdapter {
+    pub fn new(store: Store) -> Self {
+        Self { store }
+    }
+
+    pub fn store_update(&self) -> CloudArchivalStoreUpdateAdapter<'static> {
+        CloudArchivalStoreUpdateAdapter {
+            store_update: StoreUpdateHolder::Owned(self.store.store_update()),
+        }
+    }
+
+    /// Height up to which every archivized component has reached the bucket.
+    pub fn min_head(&self) -> Option<BlockHeight> {
+        self.store.get_ser(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY)
+    }
+
+    /// Height up to which block data has reached the bucket.
+    pub fn block_head(&self) -> Option<BlockHeight> {
+        self.store.get_ser(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY)
+    }
+
+    /// Height up to which one shard's data has reached the bucket.
+    pub fn shard_head(&self, shard_id: ShardId) -> Option<BlockHeight> {
+        self.store.get_ser(DBCol::BlockMisc, &cloud_shard_head_key(shard_id))
+    }
+
+    /// Last block of the latest fully archivized epoch.
+    pub fn prev_epoch_end(&self) -> Option<CryptoHash> {
+        self.store.get_ser(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY)
+    }
+
+    /// Every shard the node has recorded a head for, in shard order.
+    pub fn all_shard_heads(&self) -> Vec<(ShardId, BlockHeight)> {
+        let mut heads = Vec::new();
+        for (key, value) in self.store.iter_prefix_ser(DBCol::BlockMisc, CLOUD_SHARD_HEAD_PREFIX) {
+            let Some(shard_id) = cloud_shard_head_key_shard_id(&key) else {
+                continue;
+            };
+            heads.push((shard_id, value));
+        }
+        heads.sort_by_key(|(shard_id, _)| *shard_id);
+        heads
+    }
+}
+
+pub struct CloudArchivalStoreUpdateAdapter<'a> {
+    store_update: StoreUpdateHolder<'a>,
+}
+
+impl Into<StoreUpdate> for CloudArchivalStoreUpdateAdapter<'static> {
+    fn into(self) -> StoreUpdate {
+        self.store_update.into()
+    }
+}
+
+impl CloudArchivalStoreUpdateAdapter<'static> {
+    pub fn commit(self) {
+        let store_update: StoreUpdate = self.into();
+        store_update.commit();
+    }
+}
+
+impl<'a> StoreUpdateAdapter for CloudArchivalStoreUpdateAdapter<'a> {
+    fn store_update(&mut self) -> &mut StoreUpdate {
+        &mut self.store_update
+    }
+}
+
+impl<'a> CloudArchivalStoreUpdateAdapter<'a> {
+    pub fn new(store_update: &'a mut StoreUpdate) -> Self {
+        Self { store_update: StoreUpdateHolder::Reference(store_update) }
+    }
+
+    pub fn set_min_head(&mut self, height: BlockHeight) {
+        self.store_update.set_ser(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY, &height);
+    }
+
+    pub fn set_block_head(&mut self, height: BlockHeight) {
+        self.store_update.set_ser(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY, &height);
+    }
+
+    pub fn set_shard_head(&mut self, shard_id: ShardId, height: BlockHeight) {
+        self.store_update.set_ser(DBCol::BlockMisc, &cloud_shard_head_key(shard_id), &height);
+    }
+
+    pub fn set_prev_epoch_end(&mut self, block_hash: CryptoHash) {
+        self.store_update.set_ser(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY, &block_hash);
+    }
+}

--- a/core/store/src/adapter/mod.rs
+++ b/core/store/src/adapter/mod.rs
@@ -1,5 +1,6 @@
 pub mod chain_store;
 pub mod chunk_store;
+pub mod cloud_archival_store;
 pub mod epoch_store;
 pub mod flat_store;
 pub mod trie_store;
@@ -96,6 +97,10 @@ pub trait StoreAdapter {
         chain_store::ChainStoreAdapter::new(self.store())
     }
 
+    fn cloud_archival_store(&self) -> cloud_archival_store::CloudArchivalStoreAdapter {
+        cloud_archival_store::CloudArchivalStoreAdapter::new(self.store())
+    }
+
     fn chunk_store(&self) -> chunk_store::ChunkStoreAdapter {
         chunk_store::ChunkStoreAdapter::new(self.store())
     }
@@ -123,6 +128,12 @@ pub trait StoreUpdateAdapter: Sized {
 
     fn chain_store_update(&mut self) -> chain_store::ChainStoreUpdateAdapter<'_> {
         chain_store::ChainStoreUpdateAdapter::new(self.store_update())
+    }
+
+    fn cloud_archival_store_update(
+        &mut self,
+    ) -> cloud_archival_store::CloudArchivalStoreUpdateAdapter<'_> {
+        cloud_archival_store::CloudArchivalStoreUpdateAdapter::new(self.store_update())
     }
 
     fn chunk_store_update(&mut self) -> chunk_store::ChunkStoreUpdateAdapter<'_> {

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -64,6 +64,12 @@ pub fn cloud_shard_head_key(shard_id: ShardId) -> Vec<u8> {
     key
 }
 
+/// The shard a `cloud_shard_head_key` names, or `None` when the suffix is not a shard id.
+pub fn cloud_shard_head_key_shard_id(key: &[u8]) -> Option<ShardId> {
+    let suffix: [u8; 8] = key.get(CLOUD_SHARD_HEAD_PREFIX.len()..)?.try_into().ok()?;
+    Some(ShardId::new(u64::from_le_bytes(suffix)))
+}
+
 // `DBCol::Misc` keys
 pub const TRIE_STATE_RESHARDING_STATUS_KEY: &[u8] = b"TRIE_STATE_RESHARDING_STATUS";
 pub const LATEST_WITNESSES_INFO: &[u8] = b"LATEST_WITNESSES_INFO";

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -64,10 +64,10 @@ pub fn cloud_shard_head_key(shard_id: ShardId) -> Vec<u8> {
     key
 }
 
-/// The shard a `cloud_shard_head_key` names, or `None` when the suffix is not a shard id.
+/// The shard a `cloud_shard_head_key` names, or `None` when the key is not one.
 pub fn cloud_shard_head_key_shard_id(key: &[u8]) -> Option<ShardId> {
-    let suffix: [u8; 8] = key.get(CLOUD_SHARD_HEAD_PREFIX.len()..)?.try_into().ok()?;
-    Some(ShardId::new(u64::from_le_bytes(suffix)))
+    let suffix: [u8; 8] = key.strip_prefix(CLOUD_SHARD_HEAD_PREFIX)?.try_into().ok()?;
+    Some(ShardId::from_le_bytes(suffix))
 }
 
 // `DBCol::Misc` keys

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -38,7 +38,6 @@ use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, inde
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::bucket_config::BucketConfig;
-use near_store::db::cloud_shard_head_key;
 #[cfg(feature = "nightly")]
 use near_store::test_utils::create_test_store;
 use near_store::{DBCol, KeyForStateChanges, ShardUId, Store};
@@ -1635,7 +1634,8 @@ fn test_cloud_archival_writer_resharding_batch_boundary() {
 
     let parent_local_head = h
         .writer_store()
-        .get_ser::<BlockHeight>(DBCol::BlockMisc, &cloud_shard_head_key(r.parent_shard))
+        .cloud_archival_store()
+        .shard_head(r.parent_shard)
         .expect("removed parent shard head recorded");
     assert_eq!(
         parent_local_head, r.resharding_block_height,

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -26,7 +26,6 @@ use near_primitives::types::{
 use near_primitives::utils::{get_block_shard_id, index_to_bytes};
 use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::{CloudStorage, is_cloud_archive_reader_bootstrapped};
-use near_store::db::{CLOUD_MIN_HEAD_KEY, CLOUD_PREV_EPOCH_END_KEY};
 use near_store::flat::FlatStorageManager;
 use near_store::trie::AccessOptions;
 use near_store::{
@@ -243,9 +242,7 @@ pub(crate) fn get_state_header_for_epoch(
 
 pub(crate) fn get_local_min_head(env: &TestLoopEnv, writer_id: &AccountId) -> BlockHeight {
     let hot_store = get_hot_store(env, writer_id);
-    hot_store
-        .get_ser::<BlockHeight>(DBCol::BlockMisc, CLOUD_MIN_HEAD_KEY)
-        .expect("CLOUD_MIN_HEAD should exist")
+    hot_store.cloud_archival_store().min_head().expect("CLOUD_MIN_HEAD should exist")
 }
 
 /// Configures a client as a cloud archival writer with specific tracked shards.
@@ -408,8 +405,7 @@ pub fn snapshots_sanity_check(
 
     // Every epoch through the last one the writer finished archiving. A batch that
     // ended exactly at an epoch's last block published the next epoch's data too.
-    let last_archived_epoch_last_block: CryptoHash =
-        store.get_ser(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY).unwrap();
+    let last_archived_epoch_last_block = store.cloud_archival_store().prev_epoch_end().unwrap();
     let last_archived_epoch_id =
         client.epoch_manager.get_epoch_id(&last_archived_epoch_last_block).unwrap();
     let last_archived_epoch_info = EpochInfo::try_from_slice(

--- a/tools/cloud-archive/Cargo.toml
+++ b/tools/cloud-archive/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-borsh.workspace = true
 clap.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing.workspace = true

--- a/tools/cloud-archive/src/status.rs
+++ b/tools/cloud-archive/src/status.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use borsh::BorshDeserialize;
 use near_chain_configs::GenesisValidationMode;
 use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
@@ -9,13 +8,11 @@ use near_store::DBCol;
 use near_store::Mode;
 use near_store::NodeStorage;
 use near_store::Store;
+use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::CloudStorage;
 use near_store::archive::cloud_storage::ListableCloudDir;
 use near_store::archive::cloud_storage::bucket_config::BucketConfig;
 use near_store::archive::cloud_storage::opener::CloudStorageOpener;
-use near_store::db::CLOUD_BLOCK_HEAD_KEY;
-use near_store::db::CLOUD_PREV_EPOCH_END_KEY;
-use near_store::db::CLOUD_SHARD_HEAD_PREFIX;
 use near_store::db::FINAL_HEAD_KEY;
 use near_store::db::HEAD_KEY;
 use std::path::Path;
@@ -64,10 +61,9 @@ fn collect_external(cloud_storage: &Arc<CloudStorage>) -> anyhow::Result<Externa
 }
 
 fn collect_local(store: &Store) -> anyhow::Result<LocalStatus> {
-    let last_archived_epoch_last_block =
-        store.get_ser::<CryptoHash>(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY);
-    let cloud_block_head = store.get_ser(DBCol::BlockMisc, CLOUD_BLOCK_HEAD_KEY);
-    let cloud_shard_heads = read_local_shard_heads(store);
+    let last_archived_epoch_last_block = store.cloud_archival_store().prev_epoch_end();
+    let cloud_block_head = store.cloud_archival_store().block_head();
+    let cloud_shard_heads = store.cloud_archival_store().all_shard_heads();
     let chain_head =
         store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY).context("HEAD not found in DB")?.height;
     let chain_final_head = store
@@ -81,22 +77,6 @@ fn collect_local(store: &Store) -> anyhow::Result<LocalStatus> {
         chain_head,
         chain_final_head,
     })
-}
-
-fn read_local_shard_heads(store: &Store) -> Vec<(ShardId, BlockHeight)> {
-    let mut shard_heads = Vec::new();
-    for (key, value) in store.iter_prefix(DBCol::BlockMisc, CLOUD_SHARD_HEAD_PREFIX) {
-        let shard_id_bytes = &key[CLOUD_SHARD_HEAD_PREFIX.len()..];
-        let Ok(shard_id) = ShardId::try_from_slice(shard_id_bytes) else {
-            continue;
-        };
-        let Ok(height) = BlockHeight::try_from_slice(&value) else {
-            continue;
-        };
-        shard_heads.push((shard_id, height));
-    }
-    shard_heads.sort_by_key(|(shard_id, _)| *shard_id);
-    shard_heads
 }
 
 fn print_external(external: &ExternalStatus) {


### PR DESCRIPTION
Nine call sites across four crates spelled out the same `store.get_ser(DBCol::BlockMisc, CLOUD_*_KEY)` read. They go behind a store adapter, and nothing outside `near-store` names those keys now.

It gets its own adapter rather than a method on `ChainStoreAdapter`, since how far cloud archival has got is not chain data. Two things ride along: the status tool decoded the shard id out of the head key one crate away from the code that builds it, and the writer's writes move from a bare `DBTransaction` to `StoreUpdate`, which invalidates the deserialized-column cache the raw path skipped.
