### PR TITLE
perf(sync): verify peer heights only when they can trigger sync

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1206,14 +1206,28 @@ impl Client {
         Ok(Some(block))
     }
 
-    /// Record `peer_id`'s verified height if the relayed block is ahead of us
-    /// and its approvals verify as >2/3 of a known epoch's stake; far-ahead
-    /// blocks (unknown epoch) fail that check and are ignored.
+    /// A height that fails this test cannot change the sync decision, so it needs no proof.
+    pub(crate) fn peer_height_requires_sync(
+        &self,
+        peer_height: BlockHeight,
+        head_height: BlockHeight,
+    ) -> bool {
+        let threshold = if self.sync_handler.sync_status.is_syncing() {
+            0
+        } else {
+            self.config.sync_height_threshold
+        };
+        peer_height > head_height + threshold
+    }
+
+    /// Record `peer_id`'s verified height if the relayed block's approvals verify as
+    /// >2/3 of a known epoch's stake; far-ahead blocks (unknown epoch) fail that
+    /// check and are ignored.
     pub(crate) fn note_verified_peer_height(&mut self, block: &Block, peer_id: &PeerId) {
         let head_height = self.chain.head().map(|tip| tip.height).unwrap_or(0);
         self.verified_peer_heights.prune_at_or_below(head_height);
         let height = block.header().height();
-        if height <= head_height {
+        if !self.peer_height_requires_sync(height, head_height) {
             return;
         }
         self.verified_peer_heights.record_if_verified(peer_id, block.hash(), height, || {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -623,7 +623,11 @@ impl Handler<SpanWrapped<BlockResponse>> for ClientActor {
         let BlockResponse { block, peer_id, was_requested } = msg.span_unwrap();
         tracing::debug!(target: "client", block_height = block.header().height(), block_hash = ?block.header().hash(), "received block response");
         // Feed the verified-height signal before the branching below can drop the block.
-        self.client.note_verified_peer_height(&block, &peer_id);
+        // A block we requested proves nothing new: we asked for it to reach a height we
+        // already proved, so its approvals need no check here.
+        if !was_requested {
+            self.client.note_verified_peer_height(&block, &peer_id);
+        }
         let blocks_at_height =
             self.client.chain.chain_store().get_all_block_hashes_by_height(block.header().height());
         if was_requested || blocks_at_height.is_empty() {
@@ -1696,21 +1700,20 @@ impl ClientActor {
 
         let head = self.client.chain.head()?;
         let head = Tip::clone(&head);
-        let is_syncing = self.client.sync_handler.sync_status.is_syncing();
 
         let from_peers = if self.head_is_stale(&head)? {
             // Head hasn't advanced in ~1 epoch: we really are behind (a peer can't
             // fake this), so use the unvalidated claimed heights to pick who to sync
             // from; the proof and downstream checks re-validate the target.
-            self.sync_requirement_from_claimed_peers(head.clone(), is_syncing)?
+            self.sync_requirement_from_claimed_peers(head.clone())?
         } else {
             // Head is recent, so we still know the validator set for nearby heights
             // and can verify a peer's advertised height before entering sync.
-            self.sync_requirement_from_verified_peers(head.clone(), is_syncing)?
+            self.sync_requirement_from_verified_peers(head.clone())?
         };
-        // After state sync the verified peer heights sit below the new head: peers read as level
-        // with us, or leave NoPeers when there is only one. Our own header head is already ahead
-        // and no peer can forge it. It decides whether to keep syncing, not who to download from.
+        // After state sync the verified peer heights sit below the new head, so peers read as
+        // level with us. Our own header head is already ahead and no peer can forge it. It
+        // decides whether to keep syncing, not who to download from.
         if from_peers.sync_needed()
             || !matches!(self.client.sync_handler.sync_status, SyncStatus::BlockSync { .. })
         {
@@ -1748,7 +1751,6 @@ impl ClientActor {
     fn sync_requirement_from_claimed_peers(
         &self,
         head: Tip,
-        is_syncing: bool,
     ) -> Result<SyncRequirement, near_chain::Error> {
         let eligible_peers: Vec<_> = self
             .network_info
@@ -1764,16 +1766,15 @@ impl ClientActor {
         let peer_id = peer_info.peer_info.id.clone();
         let shutdown_height = self.client.config.expected_shutdown.get().unwrap_or(u64::MAX);
         let highest_height = peer_info.highest_block_height.min(shutdown_height);
-        Ok(self.sync_requirement(peer_id, highest_height, head, is_syncing))
+        Ok(self.sync_requirement(peer_id, highest_height, head))
     }
 
-    /// Per peer, uses min(SetNetworkInfo height, verified height): we act only on a
-    /// height confirmed from block approvals, and the slower SetNetworkInfo push
-    /// keeps us from syncing over a block we're about to process ourselves.
+    /// Sync decision from the SetNetworkInfo heights, each capped by what we proved for
+    /// that peer. Their slower push keeps us from syncing over a block we are about to
+    /// process.
     fn sync_requirement_from_verified_peers(
         &self,
         head: Tip,
-        is_syncing: bool,
     ) -> Result<SyncRequirement, near_chain::Error> {
         let invalid_peers = self
             .network_info
@@ -1798,17 +1799,24 @@ impl ClientActor {
                 if self.client.chain.is_block_invalid(&last_block.hash) {
                     return None;
                 }
-                let verified_height = self.client.verified_peer_heights.get(peer_id)?;
-                Some((peer_id.clone(), last_block.height.min(verified_height)))
+                let verified_height =
+                    self.client.verified_peer_heights.get_above(peer_id, head.height);
+                let height = match verified_height {
+                    Some(verified_height) => last_block.height.min(verified_height),
+                    // Nothing proved above our head: read the peer as level with us, so it
+                    // stays a candidate but never a sync target.
+                    None => last_block.height.min(head.height),
+                };
+                Some((peer_id.clone(), height, last_block.height))
             })
-            .max_by_key(|(_, height)| *height);
-        let Some((peer_id, height)) = best_peer else {
-            tracing::debug!(target: "sync", connected_peers = self.network_info.connected_peers.len(), "no peer with a verified height");
+            .max_by_key(|(_, height, claimed_height)| (*height, *claimed_height));
+        let Some((peer_id, height, _)) = best_peer else {
+            tracing::debug!(target: "sync", connected_peers = self.network_info.connected_peers.len(), "no eligible peer to sync from");
             return Ok(SyncRequirement::NoPeers);
         };
         let shutdown_height = self.client.config.expected_shutdown.get().unwrap_or(u64::MAX);
         let highest_height = height.min(shutdown_height);
-        Ok(self.sync_requirement(peer_id, highest_height, head, is_syncing))
+        Ok(self.sync_requirement(peer_id, highest_height, head))
     }
 
     fn sync_requirement(
@@ -1816,14 +1824,8 @@ impl ClientActor {
         peer_id: PeerId,
         highest_height: BlockHeight,
         head: Tip,
-        is_syncing: bool,
     ) -> SyncRequirement {
-        let needed = if is_syncing {
-            highest_height > head.height
-        } else {
-            highest_height > head.height + self.client.config.sync_height_threshold
-        };
-        if needed {
+        if self.client.peer_height_requires_sync(highest_height, head.height) {
             SyncRequirement::SyncNeeded {
                 source: HighestHeightSource::Peer(peer_id),
                 highest_height,

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -5,29 +5,38 @@ use near_primitives::types::BlockHeight;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
+/// Outcome of checking a header's approvals. Only the block producer for a height
+/// can sign a header carrying a weak approval set, and checking one costs a full pass
+/// over ~100 signatures, so a failure is remembered rather than retried.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApprovalCheckResult {
+    Passed,
+    Failed,
+}
+
 /// Highest block height each peer is *verified* to have reached, via a relayed
 /// block whose approvals we checked against a known epoch's validators (>2/3
 /// stake).
 pub struct VerifiedPeerHeights {
     by_peer: HashMap<PeerId, BlockHeight>,
-    /// Headers whose approvals already verified; bounds the signature checks
-    /// to one pass per distinct header, however many peers relay or replay it.
-    verified_header_hashes: LruCache<CryptoHash, ()>,
+    /// Outcome per header; bounds the signature checks to one pass per distinct
+    /// header, however many peers relay or replay it.
+    approval_check_results: LruCache<CryptoHash, ApprovalCheckResult>,
 }
 
 impl Default for VerifiedPeerHeights {
     fn default() -> Self {
         Self {
             by_peer: HashMap::new(),
-            verified_header_hashes: LruCache::new(NonZeroUsize::new(32).unwrap()),
+            approval_check_results: LruCache::new(NonZeroUsize::new(32).unwrap()),
         }
     }
 }
 
 impl VerifiedPeerHeights {
-    /// Record `height` for `peer_id` if the header is verified: by an earlier
-    /// call, or established now by `verify_approvals` (invoked at most once
-    /// per distinct header). Keeps the highest height per peer.
+    /// Record `height` for `peer_id` if the header's approvals check out: by an
+    /// earlier call, or by `verify_approvals` now, which runs at most once per
+    /// distinct header whichever way it turns out. Keeps the highest height per peer.
     pub fn record_if_verified(
         &mut self,
         peer_id: &PeerId,
@@ -38,11 +47,19 @@ impl VerifiedPeerHeights {
         if self.get(peer_id).is_some_and(|verified| verified >= height) {
             return;
         }
-        if !self.verified_header_hashes.contains(header_hash) {
-            if !verify_approvals() {
-                return;
+        let check_result = match self.approval_check_results.get(header_hash).copied() {
+            Some(check_result) => check_result,
+            None => {
+                let check_result = match verify_approvals() {
+                    true => ApprovalCheckResult::Passed,
+                    false => ApprovalCheckResult::Failed,
+                };
+                self.approval_check_results.put(*header_hash, check_result);
+                check_result
             }
-            self.verified_header_hashes.put(*header_hash, ());
+        };
+        if check_result == ApprovalCheckResult::Failed {
+            return;
         }
         self.by_peer.insert(peer_id.clone(), height);
     }
@@ -91,6 +108,16 @@ mod tests {
         let p = peer("a");
         heights.record_if_verified(&p, &header_hash(b"h10"), 10, || false);
         assert_eq!(heights.get(&p), None);
+    }
+
+    #[test]
+    fn failed_header_is_not_verified_again() {
+        let mut heights = VerifiedPeerHeights::default();
+        let (p1, p2) = (peer("a"), peer("b"));
+        let hash = header_hash(b"h10");
+        heights.record_if_verified(&p1, &hash, 10, || false);
+        heights.record_if_verified(&p2, &hash, 10, || panic!("must not re-verify a failed header"));
+        assert_eq!(heights.get(&p2), None);
     }
 
     #[test]

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -5,38 +5,29 @@ use near_primitives::types::BlockHeight;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
-/// Outcome of checking a header's approvals. Only the block producer for a height
-/// can sign a header carrying a weak approval set, and checking one costs a full pass
-/// over ~100 signatures, so a failure is remembered rather than retried.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ApprovalCheckResult {
-    Passed,
-    Failed,
-}
-
 /// Highest block height each peer is *verified* to have reached, via a relayed
 /// block whose approvals we checked against a known epoch's validators (>2/3
 /// stake).
 pub struct VerifiedPeerHeights {
     by_peer: HashMap<PeerId, BlockHeight>,
-    /// Outcome per header; bounds the signature checks to one pass per distinct
-    /// header, however many peers relay or replay it.
-    approval_check_results: LruCache<CryptoHash, ApprovalCheckResult>,
+    /// Headers whose approvals already verified; bounds the signature checks
+    /// to one pass per distinct header, however many peers relay or replay it.
+    verified_header_hashes: LruCache<CryptoHash, ()>,
 }
 
 impl Default for VerifiedPeerHeights {
     fn default() -> Self {
         Self {
             by_peer: HashMap::new(),
-            approval_check_results: LruCache::new(NonZeroUsize::new(32).unwrap()),
+            verified_header_hashes: LruCache::new(NonZeroUsize::new(32).unwrap()),
         }
     }
 }
 
 impl VerifiedPeerHeights {
-    /// Record `height` for `peer_id` if the header's approvals check out: by an
-    /// earlier call, or by `verify_approvals` now, which runs at most once per
-    /// distinct header whichever way it turns out. Keeps the highest height per peer.
+    /// Record `height` for `peer_id` if the header is verified: by an earlier
+    /// call, or established now by `verify_approvals` (invoked at most once
+    /// per distinct header). Keeps the highest height per peer.
     pub fn record_if_verified(
         &mut self,
         peer_id: &PeerId,
@@ -47,19 +38,11 @@ impl VerifiedPeerHeights {
         if self.get(peer_id).is_some_and(|verified| verified >= height) {
             return;
         }
-        let check_result = match self.approval_check_results.get(header_hash).copied() {
-            Some(check_result) => check_result,
-            None => {
-                let check_result = match verify_approvals() {
-                    true => ApprovalCheckResult::Passed,
-                    false => ApprovalCheckResult::Failed,
-                };
-                self.approval_check_results.put(*header_hash, check_result);
-                check_result
+        if !self.verified_header_hashes.contains(header_hash) {
+            if !verify_approvals() {
+                return;
             }
-        };
-        if check_result == ApprovalCheckResult::Failed {
-            return;
+            self.verified_header_hashes.put(*header_hash, ());
         }
         self.by_peer.insert(peer_id.clone(), height);
     }
@@ -108,16 +91,6 @@ mod tests {
         let p = peer("a");
         heights.record_if_verified(&p, &header_hash(b"h10"), 10, || false);
         assert_eq!(heights.get(&p), None);
-    }
-
-    #[test]
-    fn failed_header_is_not_verified_again() {
-        let mut heights = VerifiedPeerHeights::default();
-        let (p1, p2) = (peer("a"), peer("b"));
-        let hash = header_hash(b"h10");
-        heights.record_if_verified(&p1, &hash, 10, || false);
-        heights.record_if_verified(&p2, &hash, 10, || panic!("must not re-verify a failed header"));
-        assert_eq!(heights.get(&p2), None);
     }
 
     #[test]

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -47,12 +47,17 @@ impl VerifiedPeerHeights {
         self.by_peer.insert(peer_id.clone(), height);
     }
 
-    pub fn get(&self, peer_id: &PeerId) -> Option<BlockHeight> {
+    fn get(&self, peer_id: &PeerId) -> Option<BlockHeight> {
         self.by_peer.get(peer_id).copied()
     }
 
-    /// Entries at or below our head can't indicate a peer ahead of us; pruning
-    /// them bounds the map as the head advances and peers churn.
+    /// An entry at or below `head_height` can't show a peer ahead of us, so it
+    /// reads as absent however long it stays in the map.
+    pub fn get_above(&self, peer_id: &PeerId, head_height: BlockHeight) -> Option<BlockHeight> {
+        self.get(peer_id).filter(|height| *height > head_height)
+    }
+
+    /// Bounds the map as the head advances and peers churn.
     pub fn prune_at_or_below(&mut self, height: BlockHeight) {
         self.by_peer.retain(|_, recorded| *recorded > height);
     }
@@ -107,6 +112,16 @@ mod tests {
             panic!("must not verify below already verified height")
         });
         assert_eq!(heights.get(&p), Some(10));
+    }
+
+    #[test]
+    fn get_above_hides_entries_at_or_below_head() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || true);
+        assert_eq!(heights.get_above(&p, 9), Some(10));
+        assert_eq!(heights.get_above(&p, 10), None);
+        assert_eq!(heights.get_above(&p, 11), None);
     }
 
     #[test]

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -26,6 +26,27 @@ periodically in the client actor — if the node is behind by more than
 The sync handler classifies the node into one of two categories based on how
 far behind it is, and routes it through the appropriate path.
 
+### Picking the target height
+
+The height to sync to comes from a peer, and a peer's claim is acted on only
+once its approvals verify against a known epoch's validators (>2/3 stake).
+That check is a pass over about 100 signatures, so the node pays for it only
+when the claim could change the decision:
+
+- A claim at or below `head + sync_height_threshold` is ignored: it cannot
+  start sync. While already syncing the bar is the head itself.
+- A block the node requested proves nothing new. It was requested to reach a
+  height already proved, and block processing checks its approvals anyway.
+- Each distinct header is checked once, whether it passes or fails, however
+  many peers relay it.
+
+A peer with no proved height reads as level with our head, so it stays a
+candidate to download from but never sets the target. Once the head has not
+advanced for about one epoch, the node falls back to the unvalidated claimed
+heights, because the validator sets it knows no longer cover the tip. During
+block sync the node's own header head can also set the target, since header
+sync has already validated it.
+
 ### The two horizons
 
 ```


### PR DESCRIPTION
#16133 made sync target selection depend on approval-verified peer heights, and the check ran synchronously in the `BlockResponse` handler for every relayed block above our head: one pass over ~100 approval signatures, on the client actor. Most of those passes could not change any decision.

This verifies a peer's claimed height only when the claim could start or continue block sync:

- A claim at or below `head + sync_height_threshold` is skipped, since it cannot start sync. While already syncing the bar is the head itself. `Client::sync_trigger_height` is now the single definition of that bar, used both when recording a claim and when deciding, so the two cannot drift.
- A block we requested is skipped. We requested it to reach a height we already proved, and `validate_header` verifies its approvals when the block is processed.
- A peer with no verified height now reads as level with our head instead of being dropped from the candidate list. Dropping it made a healthy caught-up node report `NoPeers`, which would leave `near_sync_requirements_current` meaningless.

Measured with a temporary counter around the approval pass, before → after:

- `examples::basic::test_basic_token_transfer` (steady state, no sync): 18 → 0
- `tests::sync::far_horizon::test_far_horizon_restart_during_block_sync`: 364 → 2
- `tests::sync::far_horizon::test_far_horizon_full_pipeline`: 517 → 5

A pass costs about 2.8ms: `cargo bench -p near-crypto --bench signatures` reports 28µs per ED25519 verify in a release build.

Note on #16256: during block sync, requested blocks no longer refresh the target, so the `OwnHeaderHead` fallback carries more of that phase. With this change in place, disabling that branch fails 5 of the 12 `far_horizon` tests.

This addresses the first half of #16134, "check if this is impactful": it removes the unnecessary work instead of relocating it.

A second commit that cached failed approval checks was reverted. Caching a failure conflates a deterministic signature or approval failure with a transient one, since the verifier also returns an error when the header's epoch is not known yet, and the transient case costs no signature work at all (`partial_verify_orphan_header_signature` looks up the block producer first and fails there). It also would not defend against the case that motivated it: only a block producer can sign a header with a weak approval set, and it can vary that header freely, so every relay misses a per-header cache. Limiting that cost needs a cap on how many approval checks the client actor runs per second, leaving the rest unproved until the next window. A per-header cache cannot do it, because the sender picks the header. Neither master nor this PR has such a cap.
