### PR TITLE
fix(cloud-archive): download state snapshot parts with credentials

### DIFF
--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -5,7 +5,6 @@ use near_external_storage::{ExternalConnection, S3AccessConfig};
 use near_primitives::hash::CryptoHash;
 use near_primitives::state_part::{PartId, StatePart};
 use near_primitives::types::{EpochHeight, EpochId, ShardId};
-use near_store::archive::cloud_storage::CloudStorage;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -59,13 +58,6 @@ impl StateSyncConnection {
         let connection =
             ExternalConnection::new(location, credentials_file, Some(s3_access_config));
         Self { connection }
-    }
-
-    // TODO(cloud_archival): state parts come through here, and `get_file` below reads with no
-    // credentials, which a private bucket refuses. Give them a `CloudStorageFileID` and
-    // retrieve them like every other archive object.
-    pub fn from_cloud_storage(cloud_storage: &CloudStorage) -> Self {
-        Self { connection: cloud_storage.connection().clone() }
     }
 
     pub async fn get_file(
@@ -334,16 +326,52 @@ pub async fn download_and_apply_state_parts_sequentially(
 #[cfg(test)]
 mod test {
     use crate::sync::external::{
-        ExternalConnection, StateFileType, StateSyncConnection, get_num_parts_from_filename,
-        get_part_id_from_filename, is_part_filename,
+        ExternalConnection, StateFileType, StateSyncConnection, external_storage_location,
+        get_num_parts_from_filename, get_part_id_from_filename, is_part_filename,
     };
     use near_chain_configs::ExternalStorageLocation;
     use near_o11y::testonly::init_test_logger;
-    use near_primitives::types::ShardId;
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::state_part::PartId;
+    use near_primitives::types::{EpochId, ShardId};
+    use near_store::archive::cloud_storage::{BucketConfig, CloudStorage, CloudStorageFileID};
     use rand::distributions::{Alphanumeric, DistString};
+    use std::path::PathBuf;
 
     fn random_string(rand_len: usize) -> String {
         Alphanumeric.sample_string(&mut rand::thread_rng(), rand_len)
+    }
+
+    /// For every kind of state file, the archive's key is where the state sync dumper writes it.
+    #[test]
+    fn test_state_file_keys_match_dump_location() {
+        let chain_id = "test";
+        let epoch_id = EpochId(CryptoHash::hash_bytes(b"epoch"));
+        let epoch_height = 7;
+        let shard_id = ShardId::new(3);
+        let part_id = PartId::new(5, 15);
+        let cloud_storage = CloudStorage::new(
+            ExternalConnection::Filesystem { root_dir: PathBuf::new() },
+            chain_id.to_string(),
+            BucketConfig::canonical(),
+        );
+
+        let kinds = [
+            (
+                StateFileType::StatePart { part_id: part_id.idx, num_parts: part_id.total },
+                CloudStorageFileID::StatePart(epoch_height, epoch_id, shard_id, part_id),
+            ),
+            (
+                StateFileType::StateHeader,
+                CloudStorageFileID::StateHeader(epoch_height, epoch_id, shard_id),
+            ),
+        ];
+        for (file_type, file_id) in kinds {
+            assert_eq!(
+                cloud_storage.file_path(&file_id),
+                external_storage_location(chain_id, &epoch_id, epoch_height, shard_id, &file_type),
+            );
+        }
     }
 
     #[test]

--- a/core/store/src/archive/cloud_storage/file_id.rs
+++ b/core/store/src/archive/cloud_storage/file_id.rs
@@ -95,10 +95,7 @@ impl CloudStorage {
                 "header".into(),
             ),
             CloudStorageFileID::StatePart(epoch_height, epoch_id, shard_id, part_id) => (
-                format!(
-                    "epoch_height={}/epoch_id={}/shard_id={}",
-                    epoch_height, epoch_id.0, shard_id,
-                ),
+                format!("epoch_height={epoch_height}/epoch_id={}/shard_id={shard_id}", epoch_id.0),
                 format!("state_part_{:06}_of_{:06}", part_id.idx, part_id.total),
             ),
         };

--- a/core/store/src/archive/cloud_storage/file_id.rs
+++ b/core/store/src/archive/cloud_storage/file_id.rs
@@ -1,5 +1,6 @@
 use crate::archive::cloud_storage::CloudStorage;
 use crate::archive::cloud_storage::batch::BatchId;
+use near_primitives::state_part::PartId;
 use near_primitives::types::{EpochHeight, EpochId, ShardId};
 
 /// Cloud directories that can be safely listed (recursively).
@@ -43,6 +44,8 @@ pub enum CloudStorageFileID {
     ShardBatch(ShardId, BatchId),
     /// Identifier of the state snapshot header file for the given epoch and shard.
     StateHeader(EpochHeight, EpochId, ShardId),
+    /// Identifier of one state snapshot part file for the given epoch and shard.
+    StatePart(EpochHeight, EpochId, ShardId, PartId),
 }
 
 impl CloudStorageFileID {
@@ -56,6 +59,7 @@ impl CloudStorageFileID {
             CloudStorageFileID::BlockBatch(_) => "block_batch",
             CloudStorageFileID::ShardBatch(..) => "shard_batch",
             CloudStorageFileID::StateHeader(..) => "state_header",
+            CloudStorageFileID::StatePart(..) => "state_part",
         }
     }
 }
@@ -82,11 +86,20 @@ impl CloudStorage {
                 "data".into(),
             ),
             CloudStorageFileID::StateHeader(epoch_height, epoch_id, shard_id) => (
+                ListableCloudDir::StateHeader {
+                    epoch_height: *epoch_height,
+                    epoch_id: *epoch_id,
+                    shard_id: *shard_id,
+                }
+                .path(),
+                "header".into(),
+            ),
+            CloudStorageFileID::StatePart(epoch_height, epoch_id, shard_id, part_id) => (
                 format!(
-                    "epoch_height={}/epoch_id={}/headers/shard_id={}",
+                    "epoch_height={}/epoch_id={}/shard_id={}",
                     epoch_height, epoch_id.0, shard_id,
                 ),
-                "header".into(),
+                format!("state_part_{:06}_of_{:06}", part_id.idx, part_id.total),
             ),
         };
         dir_path = format!("chain_id={}/{}", self.chain_id, dir_path);

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -24,7 +24,7 @@ pub(super) mod epoch_data;
 pub(super) mod file_id;
 pub(super) mod shards;
 
-pub use file_id::ListableCloudDir;
+pub use file_id::{CloudStorageFileID, ListableCloudDir};
 
 /// Handles operations related to cloud storage used for archival data.
 pub struct CloudStorage {
@@ -41,14 +41,6 @@ impl CloudStorage {
         bucket_config: BucketConfig,
     ) -> Self {
         Self { external, chain_id, bucket_config }
-    }
-
-    pub fn connection(&self) -> &ExternalConnection {
-        &self.external
-    }
-
-    pub fn chain_id(&self) -> &str {
-        &self.chain_id
     }
 
     pub fn batch_size(&self) -> u32 {

--- a/core/store/src/archive/cloud_storage/retrieve.rs
+++ b/core/store/src/archive/cloud_storage/retrieve.rs
@@ -5,6 +5,7 @@ use crate::archive::cloud_storage::epoch_data::EpochData;
 use crate::archive::cloud_storage::file_id::{CloudStorageFileID, ListableCloudDir};
 use crate::archive::cloud_storage::shards::ShardBatch;
 use borsh::BorshDeserialize;
+use near_primitives::state_part::{PartId, StatePart};
 use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 
@@ -75,6 +76,18 @@ impl CloudStorage {
         shard_id: ShardId,
     ) -> Result<ShardStateSyncResponseHeader, CloudRetrievalError> {
         let file_id = CloudStorageFileID::StateHeader(epoch_height, epoch_id, shard_id);
+        self.retrieve(&file_id).await
+    }
+
+    /// Returns one part of a state snapshot from external storage.
+    pub async fn retrieve_state_part(
+        &self,
+        epoch_height: EpochHeight,
+        epoch_id: EpochId,
+        shard_id: ShardId,
+        part_id: PartId,
+    ) -> Result<StatePart, CloudRetrievalError> {
+        let file_id = CloudStorageFileID::StatePart(epoch_height, epoch_id, shard_id, part_id);
         self.retrieve(&file_id).await
     }
 

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -9,15 +9,12 @@ use near_client::archive::cloud_archival_reader::{
     bootstrap_range, find_present_block_at_or_below, find_snapshot_at_or_before,
 };
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
-use near_client::sync::external::{
-    StateFileType, StateSyncConnection, external_storage_location, list_state_parts,
-};
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::state_part::{PartId, StatePart};
+use near_primitives::state_part::PartId;
 use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
@@ -592,7 +589,7 @@ pub fn bootstrap_historical_reader(
             &snapshot_epoch_id,
             snapshot_epoch_height,
             shard_uid,
-            state_sync_state_root,
+            &state_header,
         ));
         assert!(has_state_root(&tries, shard_uid, state_sync_state_root));
 
@@ -649,21 +646,19 @@ async fn download_and_apply_state_snapshot(
     epoch_id: &EpochId,
     epoch_height: EpochHeight,
     shard_uid: ShardUId,
-    state_root: CryptoHash,
+    state_header: &ShardStateSyncResponseHeader,
 ) {
     let shard_id = shard_uid.shard_id();
-    let connection = StateSyncConnection::from_cloud_storage(cloud_storage);
-    let chain_id = cloud_storage.chain_id();
-    let num_parts =
-        list_state_parts(&connection, chain_id, epoch_id, epoch_height, shard_id).await.unwrap();
-    for part_id in 0..num_parts {
-        let file_type = StateFileType::StatePart { part_id, num_parts };
-        let location =
-            external_storage_location(chain_id, epoch_id, epoch_height, shard_id, &file_type);
-        let bytes = connection.get_file(shard_id, &location, &file_type).await.unwrap();
-        let partial_state = StatePart::from_bytes(bytes).unwrap().to_partial_state().unwrap();
-        let apply_result =
-            Trie::apply_state_part(&state_root, PartId::new(part_id, num_parts), partial_state);
+    let state_root = state_header.chunk_prev_state_root();
+    let num_parts = state_header.num_state_parts();
+    for part_index in 0..num_parts {
+        let part_id = PartId::new(part_index, num_parts);
+        let state_part = cloud_storage
+            .retrieve_state_part(epoch_height, *epoch_id, shard_id, part_id)
+            .await
+            .unwrap();
+        let partial_state = state_part.to_partial_state().unwrap();
+        let apply_result = Trie::apply_state_part(&state_root, part_id, partial_state);
         let mut store_update = tries.store_update();
         tries.apply_all(&apply_result.trie_changes, shard_uid, &mut store_update);
         store_update.commit();


### PR DESCRIPTION
State snapshot parts were the one object in the bucket the archive could not address. They came through the state sync connection instead, whose GCS download sends no credentials, so a private bucket refuses them. Parts now have a `CloudStorageFileID` and download signed like everything else in the archive.

The archive builds the part key itself, as it already does for the snapshot header, and one test pins both against the location the dumper writes.
