### PR TITLE
refactor(cloud-archive): split the reader module into recent, historical and utils

### DIFF
--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -1,11 +1,9 @@
-use anyhow::bail;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::{get_block_shard_id, index_to_bytes};
 use near_store::archive::cloud_storage::{
     BlockData, CloudRetrievalError, CloudStorage, EpochData, ShardData,
 };
-use near_store::{DBCol, Store, StoreUpdate, set_cloud_reader_store};
-use std::collections::HashSet;
+use near_store::{DBCol, Store, StoreUpdate};
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
 #[derive(thiserror::Error, Debug)]
@@ -54,92 +52,8 @@ pub fn save_epoch_data(store: &Store, epoch_id: &EpochId, epoch_data: &EpochData
     update.commit();
 }
 
-/// Downloads block, epoch, and per-shard chunk data for `[start_height,
-/// end_height]` from cloud storage and writes it into the local store.
-pub fn bootstrap_range(
-    store: &Store,
-    cloud_storage: &CloudStorage,
-    start_height: BlockHeight,
-    end_height: BlockHeight,
-) -> anyhow::Result<()> {
-    // Before the first write, so an interrupted bootstrap leaves the store marked too.
-    let mut update = store.store_update();
-    set_cloud_reader_store(&mut update);
-    update.commit();
-
-    let mut saved_epochs = HashSet::<EpochId>::new();
-    let mut first_epoch_data: Option<EpochData> = None;
-
-    let range_length = end_height - start_height + 1;
-    let log_interval = std::cmp::max(cloud_storage.batch_size() as u64, range_length / 100);
-
-    // Fetch one batch per iteration and consume all its heights, so each
-    // batch blob is downloaded and decompressed once rather than per height.
-    let mut height = start_height;
-    while height <= end_height {
-        let batch = cloud_storage.get_block_batch_for_height(height)?;
-        let last_in_batch = std::cmp::min(batch.end_height(), end_height);
-        let mut update = store.store_update();
-        for h in height..=last_in_batch {
-            let Some(block_data) = batch.get_block_at_height(h) else {
-                continue;
-            };
-            let epoch_id = *block_data.block().header().epoch_id();
-            if saved_epochs.insert(epoch_id) {
-                let epoch_data = save_new_epoch(store, cloud_storage, &epoch_id)?;
-                first_epoch_data.get_or_insert(epoch_data);
-            }
-            save_block_data(&mut update, block_data);
-            if (h - start_height).is_multiple_of(log_interval) || h == end_height {
-                let percent_done = (h - start_height + 1) * 100 / range_length;
-                tracing::info!(height = h, end_height, percent_done, "bootstrap progress");
-            }
-        }
-        update.commit();
-        height = last_in_batch + 1;
-    }
-
-    let Some(first_epoch_data) = first_epoch_data else {
-        bail!("no block found in [{start_height}, {end_height}]");
-    };
-
-    // Reconstruct chunks over the requested range.
-    // TODO(cloud_archival): support resharding; the layout is read once, so a
-    // mid-range layout change would iterate the wrong shards.
-    let shard_layout = first_epoch_data.shard_layout().clone();
-    for shard_id in shard_layout.shard_ids() {
-        save_shard_range(store, cloud_storage, shard_id, start_height, end_height)?;
-    }
-
-    Ok(())
-}
-
-/// Writes one shard's data across `[start_height, end_height]`.
-fn save_shard_range(
-    store: &Store,
-    cloud_storage: &CloudStorage,
-    shard_id: ShardId,
-    start_height: BlockHeight,
-    end_height: BlockHeight,
-) -> anyhow::Result<()> {
-    let mut height = start_height;
-    while height <= end_height {
-        let batch = cloud_storage.get_shard_batch_for_height(height, shard_id)?;
-        let last_in_batch = std::cmp::min(batch.end_height(), end_height);
-        let mut update = store.store_update();
-        for h in height..=last_in_batch {
-            if let Some(shard_data) = batch.get_data_at_height(h) {
-                save_shard_data(&mut update, shard_id, shard_data);
-            }
-        }
-        update.commit();
-        height = last_in_batch + 1;
-    }
-    Ok(())
-}
-
 /// Writes one shard's columns from its cloud `ShardData` into `update`.
-fn save_shard_data(update: &mut StoreUpdate, shard_id: ShardId, shard_data: &ShardData) {
+pub(crate) fn save_shard_data(update: &mut StoreUpdate, shard_id: ShardId, shard_data: &ShardData) {
     // TODO(cloud_archival): reconstruct the remaining shard columns and apply
     // per-block state deltas.
     let block_shard_id = get_block_shard_id(shard_data.block_hash(), shard_id);
@@ -210,7 +124,7 @@ pub fn find_snapshot_at_or_before(
 }
 
 /// Downloads and saves epoch-level data for a new epoch.
-fn save_new_epoch(
+pub(crate) fn save_new_epoch(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_id: &EpochId,
@@ -223,20 +137,4 @@ fn save_new_epoch(
         "saved epoch data"
     );
     Ok(epoch_data)
-}
-
-/// Reads recent chain data out of cloud storage into a local store.
-#[derive(Clone)]
-pub struct CloudArchivalRecentReader {}
-
-impl CloudArchivalRecentReader {
-    pub fn new() -> Self {
-        Self {}
-    }
-
-    // TODO(cloud_archival): follow the bucket, which is what makes this async.
-    #[allow(clippy::unused_async)]
-    pub async fn cloud_archival_loop(self) -> Result<(), CloudArchivalReaderError> {
-        Ok(())
-    }
 }

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -1,0 +1,90 @@
+use crate::archive::cloud_archival_utils::{save_block_data, save_new_epoch, save_shard_data};
+use anyhow::bail;
+use near_primitives::types::{BlockHeight, EpochId, ShardId};
+use near_store::archive::cloud_storage::{CloudStorage, EpochData};
+use near_store::{Store, set_cloud_reader_store};
+use std::collections::HashSet;
+
+/// Downloads block, epoch, and per-shard chunk data for `[start_height,
+/// end_height]` from cloud storage and writes it into the local store.
+pub fn bootstrap_range(
+    store: &Store,
+    cloud_storage: &CloudStorage,
+    start_height: BlockHeight,
+    end_height: BlockHeight,
+) -> anyhow::Result<()> {
+    // Before the first write, so an interrupted bootstrap leaves the store marked too.
+    let mut update = store.store_update();
+    set_cloud_reader_store(&mut update);
+    update.commit();
+
+    let mut saved_epochs = HashSet::<EpochId>::new();
+    let mut first_epoch_data: Option<EpochData> = None;
+
+    let range_length = end_height - start_height + 1;
+    let log_interval = std::cmp::max(cloud_storage.batch_size() as u64, range_length / 100);
+
+    // Fetch one batch per iteration and consume all its heights, so each
+    // batch blob is downloaded and decompressed once rather than per height.
+    let mut height = start_height;
+    while height <= end_height {
+        let batch = cloud_storage.get_block_batch_for_height(height)?;
+        let last_in_batch = std::cmp::min(batch.end_height(), end_height);
+        let mut update = store.store_update();
+        for h in height..=last_in_batch {
+            let Some(block_data) = batch.get_block_at_height(h) else {
+                continue;
+            };
+            let epoch_id = *block_data.block().header().epoch_id();
+            if saved_epochs.insert(epoch_id) {
+                let epoch_data = save_new_epoch(store, cloud_storage, &epoch_id)?;
+                first_epoch_data.get_or_insert(epoch_data);
+            }
+            save_block_data(&mut update, block_data);
+            if (h - start_height).is_multiple_of(log_interval) || h == end_height {
+                let percent_done = (h - start_height + 1) * 100 / range_length;
+                tracing::info!(height = h, end_height, percent_done, "bootstrap progress");
+            }
+        }
+        update.commit();
+        height = last_in_batch + 1;
+    }
+
+    let Some(first_epoch_data) = first_epoch_data else {
+        bail!("no block found in [{start_height}, {end_height}]");
+    };
+
+    // Reconstruct chunks over the requested range.
+    // TODO(cloud_archival): support resharding; the layout is read once, so a
+    // mid-range layout change would iterate the wrong shards.
+    let shard_layout = first_epoch_data.shard_layout().clone();
+    for shard_id in shard_layout.shard_ids() {
+        save_shard_range(store, cloud_storage, shard_id, start_height, end_height)?;
+    }
+
+    Ok(())
+}
+
+/// Writes one shard's data across `[start_height, end_height]`.
+fn save_shard_range(
+    store: &Store,
+    cloud_storage: &CloudStorage,
+    shard_id: ShardId,
+    start_height: BlockHeight,
+    end_height: BlockHeight,
+) -> anyhow::Result<()> {
+    let mut height = start_height;
+    while height <= end_height {
+        let batch = cloud_storage.get_shard_batch_for_height(height, shard_id)?;
+        let last_in_batch = std::cmp::min(batch.end_height(), end_height);
+        let mut update = store.store_update();
+        for h in height..=last_in_batch {
+            if let Some(shard_data) = batch.get_data_at_height(h) {
+                save_shard_data(&mut update, shard_id, shard_data);
+            }
+        }
+        update.commit();
+        height = last_in_batch + 1;
+    }
+    Ok(())
+}

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -1,0 +1,17 @@
+use crate::archive::cloud_archival_utils::CloudArchivalReaderError;
+
+/// Reads recent chain data out of cloud storage into a local store.
+#[derive(Clone)]
+pub struct CloudArchivalRecentReader {}
+
+impl CloudArchivalRecentReader {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    // TODO(cloud_archival): follow the bucket, which is what makes this async.
+    #[allow(clippy::unused_async)]
+    pub async fn cloud_archival_loop(self) -> Result<(), CloudArchivalReaderError> {
+        Ok(())
+    }
+}

--- a/chain/client/src/archive/mod.rs
+++ b/chain/client/src/archive/mod.rs
@@ -1,3 +1,5 @@
-pub mod cloud_archival_reader;
+pub mod cloud_archival_utils;
 pub mod cloud_archival_writer;
+pub mod cloud_historical_reader;
+pub mod cloud_recent_reader;
 pub mod cold_store_actor;

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -16,11 +16,10 @@ use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
 use near_chain_configs::MIN_GC_NUM_EPOCHS_TO_KEEP;
 use near_chain_configs::test_genesis::TestEpochConfigBuilder;
+use near_client::archive::cloud_archival_utils::find_snapshot_at_or_before;
 #[cfg(feature = "nightly")]
-use near_client::archive::cloud_archival_reader::save_block_data;
-use near_client::archive::cloud_archival_reader::{
-    CloudArchivalRecentReader, find_snapshot_at_or_before,
-};
+use near_client::archive::cloud_archival_utils::save_block_data;
+use near_client::archive::cloud_recent_reader::CloudArchivalRecentReader;
 use near_primitives::block::Block;
 use near_primitives::chunk_apply_stats::ChunkApplyStats;
 use near_primitives::epoch_manager::EpochConfigStore;

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -5,10 +5,11 @@ use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
 use near_chain::types::Tip;
 use near_chain_configs::{ClientConfig, CloudArchivalWriterConfig, TrackedShardsConfig};
-use near_client::archive::cloud_archival_reader::{
-    bootstrap_range, find_present_block_at_or_below, find_snapshot_at_or_before,
+use near_client::archive::cloud_archival_utils::{
+    find_present_block_at_or_below, find_snapshot_at_or_before,
 };
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
+use near_client::archive::cloud_historical_reader::bootstrap_range;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;

--- a/tools/cloud-archive/src/bootstrap_reader.rs
+++ b/tools/cloud-archive/src/bootstrap_reader.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use near_chain_configs::GenesisValidationMode;
-use near_client::archive::cloud_archival_reader::bootstrap_range;
+use near_client::archive::cloud_historical_reader::bootstrap_range;
 use near_primitives::types::BlockHeight;
 use near_store::{Mode, NodeStorage};
 use std::path::Path;


### PR DESCRIPTION
A pure move: the reader module splits into the historical bootstrap, the recent reader, and the helpers both call. The recent reader grows next and gets its own file first.

Every line lands byte-identical. `save_shard_data` and `save_new_epoch` gain `pub(crate)`, their callers having moved to another module.
