### PR TITLE
feat(cloud-archive): the recent reader takes over a store

### DIFF
--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -1,3 +1,4 @@
+use near_chain::Error;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::{get_block_shard_id, index_to_bytes};
 use near_store::archive::cloud_storage::{
@@ -10,6 +11,8 @@ use near_store::{DBCol, Store, StoreUpdate};
 pub enum CloudArchivalReaderError {
     #[error(transparent)]
     Retrieval(#[from] CloudRetrievalError),
+    #[error(transparent)]
+    Chain(#[from] Error),
     #[error("walked back to genesis without finding a state snapshot")]
     NoSnapshotFound,
 }

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -2,7 +2,7 @@ use crate::archive::cloud_archival_utils::{save_block_data, save_new_epoch, save
 use anyhow::bail;
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
 use near_store::Store;
-use near_store::adapter::StoreAdapter;
+use near_store::adapter::StoreUpdateAdapter;
 use near_store::archive::cloud_storage::{CloudStorage, EpochData};
 use std::collections::HashSet;
 
@@ -14,16 +14,6 @@ pub fn bootstrap_range(
     start_height: BlockHeight,
     end_height: BlockHeight,
 ) -> anyhow::Result<()> {
-    // Before the first write, so an interrupted bootstrap leaves a store a node
-    // refuses. Seeded below the range, nothing in it being written yet.
-    // TODO(cloud_archival): advance this head as the range is written, and resume
-    // from it.
-    if store.cloud_archival_store().reader_head().is_none() {
-        let mut update = store.cloud_archival_store().store_update();
-        update.set_reader_head(start_height - 1);
-        update.commit();
-    }
-
     let mut saved_epochs = HashSet::<EpochId>::new();
     let mut first_epoch_data: Option<EpochData> = None;
 
@@ -52,6 +42,9 @@ pub fn bootstrap_range(
                 tracing::info!(height = h, end_height, percent_done, "bootstrap progress");
             }
         }
+        // A presence marker, so far: nothing reads the height it names.
+        // TODO(cloud_archival): resume from it, counting the shard rows too.
+        update.cloud_archival_store_update().set_reader_head(last_in_batch);
         update.commit();
         height = last_in_batch + 1;
     }

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -1,8 +1,9 @@
 use crate::archive::cloud_archival_utils::{save_block_data, save_new_epoch, save_shard_data};
 use anyhow::bail;
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
+use near_store::Store;
+use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::{CloudStorage, EpochData};
-use near_store::{Store, set_cloud_reader_store};
 use std::collections::HashSet;
 
 /// Downloads block, epoch, and per-shard chunk data for `[start_height,
@@ -13,10 +14,15 @@ pub fn bootstrap_range(
     start_height: BlockHeight,
     end_height: BlockHeight,
 ) -> anyhow::Result<()> {
-    // Before the first write, so an interrupted bootstrap leaves the store marked too.
-    let mut update = store.store_update();
-    set_cloud_reader_store(&mut update);
-    update.commit();
+    // Before the first write, so an interrupted bootstrap leaves a store a node
+    // refuses. Seeded below the range, nothing in it being written yet.
+    // TODO(cloud_archival): advance this head as the range is written, and resume
+    // from it.
+    if store.cloud_archival_store().reader_head().is_none() {
+        let mut update = store.cloud_archival_store().store_update();
+        update.set_reader_head(start_height - 1);
+        update.commit();
+    }
 
     let mut saved_epochs = HashSet::<EpochId>::new();
     let mut first_epoch_data: Option<EpochData> = None;

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -55,11 +55,18 @@ impl CloudArchivalRecentReader {
         tracing::info!(target: "cloud_archival", reader_head, "following the cloud archive");
 
         while !self.interrupt.is_cancelled() {
-            let outcome = self.try_pull_next_batch()?;
-            tracing::trace!(target: "cloud_archival", ?outcome, "pull");
-            let sleep_duration = match outcome {
-                PullOutcome::Pulled { .. } => Duration::ZERO,
-                PullOutcome::WaitingForBucket => self.polling_interval,
+            let sleep_duration = match self.try_pull_next_batch() {
+                Ok(outcome) => {
+                    tracing::trace!(target: "cloud_archival", ?outcome, "pull");
+                    match outcome {
+                        PullOutcome::Pulled { .. } => Duration::ZERO,
+                        PullOutcome::WaitingForBucket => self.polling_interval,
+                    }
+                }
+                Err(error) => {
+                    tracing::error!(target: "cloud_archival", ?error, "pulling a batch failed");
+                    self.polling_interval
+                }
             };
             self.clock.sleep(sleep_duration).await;
         }

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -1,17 +1,78 @@
 use crate::archive::cloud_archival_utils::CloudArchivalReaderError;
+use near_async::time::{Clock, Duration};
+use near_chain::{ChainStore, ChainStoreAccess};
+use near_chain_configs::InterruptHandle;
+use near_primitives::types::BlockHeight;
+use near_store::adapter::StoreAdapter;
+
+/// Result of one recent-reader iteration.
+#[derive(Debug)]
+enum PullOutcome {
+    /// Took the batch ending at this height.
+    // TODO(cloud_archival): drop the allow once the pull constructs this.
+    #[allow(dead_code)]
+    Pulled { batch_end: BlockHeight },
+    /// The bucket holds nothing past the reader's head.
+    WaitingForBucket,
+}
 
 /// Reads recent chain data out of cloud storage into a local store.
 #[derive(Clone)]
-pub struct CloudArchivalRecentReader {}
+pub struct CloudArchivalRecentReader {
+    clock: Clock,
+    chain_store: ChainStore,
+    polling_interval: Duration,
+    interrupt: InterruptHandle,
+}
 
 impl CloudArchivalRecentReader {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(clock: Clock, chain_store: ChainStore, polling_interval: Duration) -> Self {
+        Self { clock, chain_store, polling_interval, interrupt: InterruptHandle::new() }
     }
 
-    // TODO(cloud_archival): follow the bucket, which is what makes this async.
-    #[allow(clippy::unused_async)]
-    pub async fn cloud_archival_loop(self) -> Result<(), CloudArchivalReaderError> {
+    /// The height the reader resumes at. A store handed over by a stopped node carries
+    /// none yet and takes its final head, since that node's head can still reorg.
+    fn ensure_reader_head(&self) -> Result<BlockHeight, CloudArchivalReaderError> {
+        let store = self.chain_store.store();
+        if let Some(reader_head) = store.cloud_archival_store().reader_head() {
+            return Ok(reader_head);
+        }
+        let final_head = self.chain_store.final_head()?;
+        let mut update = store.cloud_archival_store().store_update();
+        update.set_reader_head(final_head.height);
+        update.commit();
+        Ok(final_head.height)
+    }
+
+    /// Stops the loop after the iteration in flight.
+    pub fn stop(&self) {
+        self.interrupt.stop();
+    }
+
+    /// Follows the bucket, copying what it holds into the local store, until interrupted.
+    pub async fn cloud_archival_loop(mut self) -> Result<(), CloudArchivalReaderError> {
+        let reader_head = self.ensure_reader_head()?;
+        tracing::info!(target: "cloud_archival", reader_head, "following the cloud archive");
+
+        while !self.interrupt.is_cancelled() {
+            let outcome = self.try_pull_next_batch()?;
+            tracing::trace!(target: "cloud_archival", ?outcome, "pull");
+            let sleep_duration = match outcome {
+                PullOutcome::Pulled { .. } => Duration::ZERO,
+                PullOutcome::WaitingForBucket => self.polling_interval,
+            };
+            self.clock.sleep(sleep_duration).await;
+        }
+        tracing::debug!(target: "cloud_archival", "stopping the recent reader");
         Ok(())
+    }
+
+    /// Takes the batch after the reader head, when the bucket holds all of it.
+    // TODO(cloud_archival): drop the allow once the pull writes through the store.
+    #[allow(clippy::needless_pass_by_ref_mut)]
+    fn try_pull_next_batch(&mut self) -> Result<PullOutcome, CloudArchivalReaderError> {
+        // TODO(cloud_archival): compute the batch at the reader head, take it when the
+        // bucket covers it, and move the reader head onto its end.
+        Ok(PullOutcome::WaitingForBucket)
     }
 }

--- a/core/store/src/adapter/cloud_archival_store.rs
+++ b/core/store/src/adapter/cloud_archival_store.rs
@@ -1,7 +1,7 @@
 use super::{StoreAdapter, StoreUpdateAdapter, StoreUpdateHolder};
 use crate::db::{
-    CLOUD_BLOCK_HEAD_KEY, CLOUD_MIN_HEAD_KEY, CLOUD_PREV_EPOCH_END_KEY, CLOUD_SHARD_HEAD_PREFIX,
-    cloud_shard_head_key, cloud_shard_head_key_shard_id,
+    CLOUD_BLOCK_HEAD_KEY, CLOUD_MIN_HEAD_KEY, CLOUD_PREV_EPOCH_END_KEY, CLOUD_READER_HEAD_KEY,
+    CLOUD_SHARD_HEAD_PREFIX, cloud_shard_head_key, cloud_shard_head_key_shard_id,
 };
 use crate::{DBCol, Store, StoreUpdate};
 use borsh::BorshDeserialize;
@@ -49,6 +49,12 @@ impl CloudArchivalStoreAdapter {
     /// Last block of the latest fully archivized epoch.
     pub fn prev_epoch_end(&self) -> Option<CryptoHash> {
         self.store.get_ser(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY)
+    }
+
+    /// Height a reader has written every component through, absent unless this store
+    /// is a reader's.
+    pub fn reader_head(&self) -> Option<BlockHeight> {
+        self.store.get_ser(DBCol::BlockMisc, CLOUD_READER_HEAD_KEY)
     }
 
     /// Every shard the node has recorded a head for, in shard order.
@@ -110,5 +116,9 @@ impl<'a> CloudArchivalStoreUpdateAdapter<'a> {
 
     pub fn set_prev_epoch_end(&mut self, block_hash: CryptoHash) {
         self.store_update.set_ser(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY, &block_hash);
+    }
+
+    pub fn set_reader_head(&mut self, height: BlockHeight) {
+        self.store_update.set_ser(DBCol::BlockMisc, CLOUD_READER_HEAD_KEY, &height);
     }
 }

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -51,12 +51,13 @@ pub const CLOUD_MIN_HEAD_KEY: &[u8] = b"CLOUD_MIN_HEAD";
 /// Hash of the last block of the latest epoch this writer archived its assigned
 /// components for. GC stops at the start of that epoch.
 pub const CLOUD_PREV_EPOCH_END_KEY: &[u8] = b"CLOUD_PREV_EPOCH_END";
-/// Set once a cloud-archive reader has written into this store. A running node refuses
-/// such a store; only the cloud-archive tool may use it.
+/// Highest height a cloud-archive reader has written every component through. Present
+/// only in a reader's store, which a running node refuses; only the cloud-archive
+/// tool may use one.
 // TODO(cloud_archival): consider supporting a normal node on a store that was a recent
 // reader's. It is missing at least the epoch info for the epoch after the head; what else
 // it needs is unknown.
-pub const CLOUD_READER_STORE_KEY: &[u8] = b"CLOUD_READER_STORE";
+pub const CLOUD_READER_HEAD_KEY: &[u8] = b"CLOUD_READER_HEAD";
 
 pub fn cloud_shard_head_key(shard_id: ShardId) -> Vec<u8> {
     let mut key = CLOUD_SHARD_HEAD_PREFIX.to_vec();

--- a/core/store/src/utils/mod.rs
+++ b/core/store/src/utils/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod sync_utils;
 pub mod test_utils;
 
-use crate::db::{CLOUD_READER_STORE_KEY, GENESIS_CONGESTION_INFO_KEY, GENESIS_HEIGHT_KEY};
+use crate::db::{GENESIS_CONGESTION_INFO_KEY, GENESIS_HEIGHT_KEY};
 use crate::trie::AccessOptions;
 use crate::{
     DBCol, GENESIS_STATE_ROOTS_KEY, KeyLookupMode, Store, StoreUpdate, TrieAccess, TrieUpdate,
@@ -576,14 +576,6 @@ pub fn remove_account(
 
 pub fn get_genesis_state_roots(store: &Store) -> Option<Vec<StateRoot>> {
     store.get_ser::<Vec<StateRoot>>(DBCol::BlockMisc, GENESIS_STATE_ROOTS_KEY)
-}
-
-pub fn is_cloud_reader_store(store: &Store) -> bool {
-    store.get_ser::<bool>(DBCol::BlockMisc, CLOUD_READER_STORE_KEY).unwrap_or(false)
-}
-
-pub fn set_cloud_reader_store(store_update: &mut StoreUpdate) {
-    store_update.set_ser(DBCol::BlockMisc, CLOUD_READER_STORE_KEY, &true);
 }
 
 pub fn get_genesis_congestion_infos(store: &Store) -> Option<Vec<CongestionInfo>> {

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -50,7 +50,7 @@ use near_store::adapter::StoreAdapter as _;
 use near_store::db::metadata::DbKind;
 use near_store::genesis::initialize_sharded_genesis_state;
 use near_store::metrics::spawn_db_metrics_loop;
-use near_store::{NodeStorage, Store, StoreOpenerError, is_cloud_reader_store};
+use near_store::{NodeStorage, Store, StoreOpenerError};
 use near_telemetry::TelemetryActor;
 use parking_lot::RwLock;
 use std::path::{Path, PathBuf};
@@ -395,7 +395,7 @@ pub async fn start_with_config_and_synchronization_impl(
 ) -> anyhow::Result<NearNode> {
     let storage = open_storage(home_dir, &config)?;
     // Before any actor is spawned, so the GC actor never starts on this store.
-    if is_cloud_reader_store(&storage.get_hot_store()) {
+    if storage.get_hot_store().cloud_archival_store().reader_head().is_some() {
         anyhow::bail!(
             "this store was written by a cloud-archive reader and cannot be used by a running \
              node; point the cloud-archive tool at it instead"

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -344,7 +344,7 @@ impl CloudArchiveHarness {
 
     /// Kills the RPC node the recent reader takes over from and brings up the
     /// reader on the database that node leaves behind. No gc runs on it from here.
-    fn start_recent_reader(&self) {
+    fn start_recent_reader(&self) -> CloudArchivalRecentReader {
         self.env.kill_node(Self::RECENT_READER_ACCOUNT);
         // TODO(cloud_archival): consider splitting the chain store, we do not need
         // transaction_validity_period in our use case.
@@ -358,12 +358,14 @@ impl CloudArchiveHarness {
             chain_store,
             Self::RECENT_READER_POLLING_INTERVAL,
         );
+        let handle = reader.clone();
         self.env
             .test_loop
             .future_spawner("CloudArchivalRecentReader")
             .spawn("cloud archival recent reader", async move {
                 reader.cloud_archival_loop().await.expect("the recent reader stopped")
             });
+        handle
     }
 
     fn recent_reader_store(&self) -> Store {
@@ -1958,7 +1960,7 @@ fn test_cloud_archival_recent_reader() {
     // One epoch past the garbage-collection window, so the probe height is below
     // the tail by the time the node switches over.
     h.run_until_epoch(h.gc_num_epochs_to_keep + 1);
-    h.start_recent_reader();
+    let reader = h.start_recent_reader();
     let kept = h.recent_reader_store().chain_store().head().unwrap().height;
     // Twice as far again, so gc would have taken the block held at the switch if
     // anything still gc-ed this database.
@@ -1991,5 +1993,6 @@ fn test_cloud_archival_recent_reader() {
         "the reader did not catch up: head {head}, bucket head {bucket_head}"
     );
 
+    reader.stop();
     h.shutdown();
 }

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -12,8 +12,9 @@ use crate::utils::cloud_archival::{
     simulate_lagging_shard, snapshots_sanity_check, stop_and_restart_node,
 };
 use borsh::to_vec;
+use near_async::futures::FutureSpawnerExt;
 use near_async::time::Duration;
-use near_chain::ChainStoreAccess;
+use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::MIN_GC_NUM_EPOCHS_TO_KEEP;
 use near_chain_configs::test_genesis::TestEpochConfigBuilder;
 use near_client::archive::cloud_archival_utils::find_snapshot_at_or_before;
@@ -260,6 +261,7 @@ impl CloudArchiveHarness {
     const DEFAULT_EPOCH_LENGTH: BlockHeightDelta = 10;
     /// The node the recent reader takes over from. Every test runs one.
     const RECENT_READER_ACCOUNT: &str = "recent_reader";
+    const RECENT_READER_POLLING_INTERVAL: Duration = Duration::seconds(1);
     const RESHARDING_BOUNDARY_ACCOUNT: &str = "boundary";
     const TEST_BATCH_SIZE: u32 = 4;
     const USER_ACCOUNT: &str = "user_account";
@@ -342,10 +344,26 @@ impl CloudArchiveHarness {
 
     /// Kills the RPC node the recent reader takes over from and brings up the
     /// reader on the database that node leaves behind. No gc runs on it from here.
-    fn start_recent_reader(&self) -> CloudArchivalRecentReader {
+    fn start_recent_reader(&self) {
         self.env.kill_node(Self::RECENT_READER_ACCOUNT);
-        // TODO(cloud_archival): run the reader over the database that node leaves.
-        CloudArchivalRecentReader::new()
+        // TODO(cloud_archival): consider splitting the chain store, we do not need
+        // transaction_validity_period in our usecase.
+        let chain_store = ChainStore::new(
+            self.recent_reader_store(),
+            true,
+            self.env.shared_state.genesis.config.transaction_validity_period,
+        );
+        let reader = CloudArchivalRecentReader::new(
+            self.env.test_loop.clock(),
+            chain_store,
+            Self::RECENT_READER_POLLING_INTERVAL,
+        );
+        self.env
+            .test_loop
+            .future_spawner("CloudArchivalRecentReader")
+            .spawn("cloud archival recent reader", async move {
+                reader.cloud_archival_loop().await.expect("the recent reader stopped")
+            });
     }
 
     fn recent_reader_store(&self) -> Store {

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -347,7 +347,7 @@ impl CloudArchiveHarness {
     fn start_recent_reader(&self) {
         self.env.kill_node(Self::RECENT_READER_ACCOUNT);
         // TODO(cloud_archival): consider splitting the chain store, we do not need
-        // transaction_validity_period in our usecase.
+        // transaction_validity_period in our use case.
         let chain_store = ChainStore::new(
             self.recent_reader_store(),
             true,


### PR DESCRIPTION
The recent reader takes over the database a stopped RPC node leaves behind and runs its follow loop. The step that takes a batch is empty, so the pull fills in one function.

`CLOUD_READER_HEAD` is where it resumes: the height every component is written through. A handed-over store has none and takes its final head. Its presence marks a store as a reader's, which a running node refuses, so `CLOUD_READER_STORE` goes. The bootstrap seeds it before its first write.
