### PR TITLE
feat(state-sync): report download eta against the stale sync hash deadline

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -92,12 +92,24 @@ impl ToString for ShardSyncStatus {
     }
 }
 
+/// Block heights that bound state sync, as of its last iteration.
+#[derive(Clone, Copy, Debug)]
+pub struct StateSyncHeights {
+    pub sync_block: BlockHeight,
+    /// Once `highest` passes this, the node wipes its database and restarts.
+    pub stale_deadline: BlockHeight,
+    pub highest: BlockHeight,
+}
+
 #[derive(Clone, Debug)]
 pub struct StateSyncStatus {
     pub sync_hash: CryptoHash,
     pub sync_status: HashMap<ShardId, ShardSyncStatus>,
     pub download_tasks: Vec<String>,
     pub computation_tasks: Vec<String>,
+    /// Remembered so progress stays complete after a shard passes download.
+    pub parts_per_shard: HashMap<ShardId, u64>,
+    pub heights: Option<StateSyncHeights>,
 }
 
 impl StateSyncStatus {
@@ -107,7 +119,30 @@ impl StateSyncStatus {
             sync_status: HashMap::new(),
             download_tasks: Vec::new(),
             computation_tasks: Vec::new(),
+            parts_per_shard: HashMap::new(),
+            heights: None,
         }
+    }
+
+    /// State parts downloaded and total parts across every shard being synced.
+    /// A shard past the download phase counts as fully downloaded.
+    pub fn parts_progress(&self) -> (u64, u64) {
+        let mut downloaded = 0;
+        let mut total = 0;
+        for (shard_id, shard_parts) in &self.parts_per_shard {
+            total += shard_parts;
+            downloaded += match self.sync_status.get(shard_id) {
+                Some(ShardSyncStatus::StateDownloadHeader) => 0,
+                Some(ShardSyncStatus::StateDownloadParts { done, .. }) => *done,
+                _ => *shard_parts,
+            };
+        }
+        (downloaded, total)
+    }
+
+    /// Blocks left before the sync hash goes stale.
+    pub fn deadline_headroom(&self) -> Option<BlockHeightDelta> {
+        self.heights.map(|heights| heights.stale_deadline.saturating_sub(heights.highest))
     }
 }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2570,12 +2570,7 @@ impl Client {
                             self.state_sync_future_spawner.clone(),
                             true,
                         ),
-                        sync_status: StateSyncStatus {
-                            sync_hash,
-                            sync_status: HashMap::new(),
-                            download_tasks: Vec::new(),
-                            computation_tasks: Vec::new(),
-                        },
+                        sync_status: StateSyncStatus::new(sync_hash),
                         catchup: BlocksCatchUpState::new(sync_hash, *epoch_id),
                     }
                 });

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -875,7 +875,11 @@ impl Handler<SpanWrapped<Status>, Result<StatusResponse, StatusError>> for Clien
                 sync_status: format!(
                     "{} ({})",
                     self.client.sync_handler.sync_status.as_variant_name(),
-                    display_sync_status(&self.client.sync_handler.sync_status, &head),
+                    display_sync_status(
+                        &self.client.sync_handler.sync_status,
+                        &head,
+                        self.info_helper.sync_rates(),
+                    ),
                 ),
                 catchup_status: self.client.get_catchup_status()?,
                 current_head_status: head.as_ref().into(),
@@ -1001,6 +1005,15 @@ enum SyncRequirement {
 impl SyncRequirement {
     fn sync_needed(&self) -> bool {
         matches!(self, Self::SyncNeeded { .. })
+    }
+
+    /// Highest height seen from peers, or `None` when no peer reported one.
+    fn highest_height(&self) -> Option<BlockHeight> {
+        match self {
+            Self::SyncNeeded { highest_height, .. }
+            | Self::AlreadyCaughtUp { highest_height, .. } => Some(*highest_height),
+            Self::NoPeers | Self::AdvHeaderSyncDisabled => None,
+        }
     }
 
     fn to_metrics_string(&self) -> String {
@@ -1932,6 +1945,12 @@ impl ClientActor {
             }
         };
         self.info_helper.update_sync_requirements_metrics(sync.to_metrics_string());
+        if let Some(highest_height) = sync.highest_height() {
+            metrics::SYNC_HIGHEST_PEER_HEIGHT.set(highest_height as i64);
+        }
+        if !matches!(self.client.sync_handler.sync_status, SyncStatus::StateSync(_)) {
+            metrics::STATE_SYNC_STALE_DEADLINE_HEIGHT.set(0);
+        }
 
         match sync {
             SyncRequirement::AlreadyCaughtUp { .. }

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -1,11 +1,11 @@
 use crate::config_updater::ConfigUpdater;
+use crate::state_sync_progress::{StateSyncProgressTracker, SyncRates, format_state_sync_progress};
 use crate::{SyncStatus, metrics};
 use itertools::Itertools;
 use lru::LruCache;
 use near_async::messaging::Sender;
 use near_async::time::{Clock, Instant};
 use near_chain_configs::ClientConfig;
-use near_client_primitives::types::StateSyncStatus;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::NetworkInfo;
 use near_primitives::block::Tip;
@@ -70,6 +70,7 @@ pub struct InfoHelper {
     prev_sync_requirement: Option<String>,
     /// Number of validators (block + chunk producers) per epoch, cached for a small number of epochs.
     num_validators_per_epoch: LruCache<EpochId, usize>,
+    state_sync_progress: StateSyncProgressTracker,
 }
 
 impl InfoHelper {
@@ -95,7 +96,13 @@ impl InfoHelper {
             enable_multiline_logging: client_config.enable_multiline_logging,
             prev_sync_requirement: None,
             num_validators_per_epoch: LruCache::new(NonZeroUsize::new(3).unwrap()),
+            state_sync_progress: StateSyncProgressTracker::default(),
         }
+    }
+
+    /// Rates tracked across ticks, for one-shot callers such as the debug status.
+    pub fn sync_rates(&self) -> Option<SyncRates> {
+        self.state_sync_progress.rates()
     }
 
     pub fn chunk_processed(&self, shard_id: ShardId, gas_used: Gas, balance_burnt: Balance) {
@@ -400,7 +407,8 @@ impl InfoHelper {
     ) {
         let s = |num| if num == 1 { "" } else { "s" };
 
-        let sync_status_log = display_sync_status(sync_status, head);
+        let sync_rates = self.state_sync_progress.update_rates_and_warn(&self.clock, sync_status);
+        let sync_status_log = display_sync_status(sync_status, head, sync_rates);
         let validator_info_log = validator_info
             .as_ref()
             .map(|info| {
@@ -699,7 +707,11 @@ pub fn log_catchup_status(catchup_status: Vec<CatchupStatusView>) {
     }
 }
 
-pub fn display_sync_status(sync_status: &SyncStatus, head: &Tip) -> String {
+pub fn display_sync_status(
+    sync_status: &SyncStatus,
+    head: &Tip,
+    sync_rates: Option<SyncRates>,
+) -> String {
     metrics::SYNC_STATUS.set(sync_status.repr() as i64);
     match sync_status {
         SyncStatus::AwaitingPeers => format!("#{:>8} Waiting for peers", head.height),
@@ -737,14 +749,9 @@ pub fn display_sync_status(sync_status: &SyncStatus, head: &Tip) -> String {
                 current_height
             )
         }
-        SyncStatus::StateSync(StateSyncStatus {
-            sync_hash,
-            sync_status: shard_statuses,
-            download_tasks,
-            computation_tasks,
-        }) => {
-            let mut res = format!("State {:?}", sync_hash);
-            let mut shard_statuses: Vec<_> = shard_statuses.iter().collect();
+        SyncStatus::StateSync(status) => {
+            let mut res = format!("State {:?}", status.sync_hash);
+            let mut shard_statuses: Vec<_> = status.sync_status.iter().collect();
             shard_statuses.sort_by_key(|(shard_id, _)| *shard_id);
             for (shard_id, shard_status) in shard_statuses {
                 write!(res, "[{}: {}]", shard_id, shard_status.to_string(),).unwrap();
@@ -752,10 +759,13 @@ pub fn display_sync_status(sync_status: &SyncStatus, head: &Tip) -> String {
             write!(
                 res,
                 " ({} downloads, {} computations)",
-                download_tasks.len(),
-                computation_tasks.len()
+                status.download_tasks.len(),
+                status.computation_tasks.len()
             )
             .unwrap();
+            if let Some(progress) = format_state_sync_progress(status, sync_rates) {
+                write!(res, " {progress}").unwrap();
+            }
             res
         }
     }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -56,6 +56,7 @@ mod prepare_transactions;
 mod rpc_handler;
 pub mod spice;
 mod state_request_actor;
+mod state_sync_progress;
 pub mod stateless_validation;
 pub mod sync;
 pub mod sync_jobs_actor;

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -267,6 +267,24 @@ pub(crate) static TRACKED_SHARDS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
 pub(crate) static SYNC_STATUS: LazyLock<IntGauge> =
     LazyLock::new(|| try_create_int_gauge("near_sync_status", "Node sync status").unwrap());
 
+pub(crate) static SYNC_HIGHEST_PEER_HEIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "near_sync_highest_peer_height",
+        "Highest block height known from peers. Unlike the head height, this keeps \
+         advancing while the node is syncing, so it shows how far behind the node is.",
+    )
+    .unwrap()
+});
+
+pub(crate) static STATE_SYNC_STALE_DEADLINE_HEIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "near_state_sync_stale_deadline_height",
+        "Height at which the state sync hash goes stale, after which the node wipes \
+         its database and restarts. Zero when state sync is not running.",
+    )
+    .unwrap()
+});
+
 pub(crate) static EPOCH_HEIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
     try_create_int_gauge("near_epoch_height", "Height of the epoch at the head of the blockchain")
         .unwrap()

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -271,7 +271,8 @@ pub(crate) static SYNC_HIGHEST_PEER_HEIGHT: LazyLock<IntGauge> = LazyLock::new(|
     try_create_int_gauge(
         "near_sync_highest_peer_height",
         "Highest block height known from peers. Unlike the head height, this keeps \
-         advancing while the node is syncing, so it shows how far behind the node is.",
+         advancing while the node is syncing, so it shows how far behind the node is. \
+         Holds the last observed tip while no peer reports one.",
     )
     .unwrap()
 });

--- a/chain/client/src/state_sync_progress.rs
+++ b/chain/client/src/state_sync_progress.rs
@@ -10,8 +10,19 @@ const NEW_SAMPLE_WEIGHT: f64 = 0.3;
 /// How often to repeat the warning that state sync will miss its deadline.
 const DEADLINE_WARNING_INTERVAL_SECONDS: f64 = 60.0;
 
+/// Shortest span the network head rate is measured over. The head arrives in
+/// bursts, so a short span reports anything between zero and several blocks a
+/// second.
+const MIN_HEAD_RATE_SPAN_SECONDS: f64 = 60.0;
+
+fn weighted_average(previous: f64, sample: f64) -> f64 {
+    previous * (1.0 - NEW_SAMPLE_WEIGHT) + sample * NEW_SAMPLE_WEIGHT
+}
+
+#[derive(Clone, Copy)]
 struct SyncSample {
     sampled_at: Instant,
+    sync_block: BlockHeight,
     parts_downloaded: u64,
     highest_height: BlockHeight,
 }
@@ -20,6 +31,10 @@ struct SyncSample {
 /// projected against the deadline at which the node wipes its database.
 #[derive(Default)]
 pub struct StateSyncProgressTracker {
+    /// First sample of the current attempt. Parts arrive steadily and are
+    /// averaged over the last few ticks, but the network head jumps in bursts,
+    /// so its rate is averaged over the whole attempt instead.
+    first_sample: Option<SyncSample>,
     prev_sample: Option<SyncSample>,
     rates: Option<SyncRates>,
     last_deadline_warning: Option<Instant>,
@@ -31,6 +46,13 @@ impl StateSyncProgressTracker {
         self.rates
     }
 
+    fn forget(&mut self) {
+        self.first_sample = None;
+        self.prev_sample = None;
+        self.rates = None;
+        self.last_deadline_warning = None;
+    }
+
     /// Returns the rates once two samples exist.
     pub fn update_rates_and_warn(
         &mut self,
@@ -38,32 +60,41 @@ impl StateSyncProgressTracker {
         sync_status: &SyncStatus,
     ) -> Option<SyncRates> {
         let SyncStatus::StateSync(status) = sync_status else {
-            self.prev_sample = None;
-            self.rates = None;
-            self.last_deadline_warning = None;
+            self.forget();
             return None;
         };
         let heights = status.heights?;
+        // A different sync block is a new attempt, so earlier samples say
+        // nothing about this one.
+        if self.first_sample.is_some_and(|first| first.sync_block != heights.sync_block) {
+            self.forget();
+        }
         let now = clock.now();
         let (parts_downloaded, _) = status.parts_progress();
-        let previous = self.prev_sample.replace(SyncSample {
+        let sample = SyncSample {
             sampled_at: now,
+            sync_block: heights.sync_block,
             parts_downloaded,
             highest_height: heights.highest,
-        });
+        };
+        let first = *self.first_sample.get_or_insert(sample);
+        let previous = self.prev_sample.replace(sample);
 
         let previous = previous?;
-        let elapsed = now.signed_duration_since(previous.sampled_at).as_seconds_f64();
-        if elapsed <= 0.0 {
+        let since_previous = now.signed_duration_since(previous.sampled_at).as_seconds_f64();
+        let since_first = now.signed_duration_since(first.sampled_at).as_seconds_f64();
+        if since_previous <= 0.0 || since_first < MIN_HEAD_RATE_SPAN_SECONDS {
             return self.rates;
         }
-        let sample = SyncRates {
-            parts_per_sec: parts_downloaded.saturating_sub(previous.parts_downloaded) as f64
-                / elapsed,
-            blocks_per_sec: heights.highest.saturating_sub(previous.highest_height) as f64
-                / elapsed,
+        let parts_sample =
+            parts_downloaded.saturating_sub(previous.parts_downloaded) as f64 / since_previous;
+        let rates = SyncRates {
+            parts_per_sec: self
+                .rates
+                .map_or(parts_sample, |rates| weighted_average(rates.parts_per_sec, parts_sample)),
+            blocks_per_sec: heights.highest.saturating_sub(first.highest_height) as f64
+                / since_first,
         };
-        let rates = self.rates.map_or(sample, |previous| previous.weighted_average_with(sample));
         self.rates = Some(rates);
         self.warn_if_deadline_will_be_missed(status, rates, now);
         Some(rates)
@@ -116,18 +147,6 @@ pub struct SyncRates {
     pub parts_per_sec: f64,
     /// Rate at which the network head advances.
     pub blocks_per_sec: f64,
-}
-
-impl SyncRates {
-    fn weighted_average_with(self, sample: SyncRates) -> SyncRates {
-        let weighted_average = |previous: f64, sample: f64| {
-            previous * (1.0 - NEW_SAMPLE_WEIGHT) + sample * NEW_SAMPLE_WEIGHT
-        };
-        SyncRates {
-            parts_per_sec: weighted_average(self.parts_per_sec, sample.parts_per_sec),
-            blocks_per_sec: weighted_average(self.blocks_per_sec, sample.blocks_per_sec),
-        }
-    }
 }
 
 /// The race between finishing the state part download and the sync hash going
@@ -350,13 +369,47 @@ mod tests {
         FakeClock::new(Utc::from_unix_timestamp(1601510400).unwrap())
     }
 
-    /// Two samples 10s apart, establishing 3 parts/s and 2 blocks/s.
+    /// Two samples 60s apart, establishing 0.5 parts/s and 1 block/s.
     fn tracker_with_established_rates(clock: &FakeClock) -> StateSyncProgressTracker {
         let mut tracker = StateSyncProgressTracker::default();
         tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
-        clock.advance(Duration::seconds(10));
-        tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_020));
+        clock.advance(Duration::seconds(60));
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_060));
         tracker
+    }
+
+    #[test]
+    fn bursty_head_does_not_swing_block_rate() {
+        // The head jumps 120 blocks in one tick and none in the next. Averaging
+        // over the attempt keeps the rate at the true 1 block/s either way.
+        let clock = fake_clock();
+        let mut tracker = StateSyncProgressTracker::default();
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
+        clock.advance(Duration::seconds(60));
+        let burst = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_060)).unwrap();
+        clock.advance(Duration::seconds(60));
+        let stall = tracker.update_rates_and_warn(&clock.clock(), &downloading(60, 1_120)).unwrap();
+        assert_eq!(burst.blocks_per_sec, 1.0);
+        assert_eq!(stall.blocks_per_sec, 1.0);
+
+        // A tick where the head does not move at all must not crater the rate.
+        clock.advance(Duration::seconds(60));
+        let quiet = tracker.update_rates_and_warn(&clock.clock(), &downloading(90, 1_120)).unwrap();
+        assert!(quiet.blocks_per_sec > 0.6, "{}", quiet.blocks_per_sec);
+    }
+
+    #[test]
+    fn new_sync_block_starts_fresh_attempt() {
+        let clock = fake_clock();
+        let mut tracker = tracker_with_established_rates(&clock);
+        assert!(tracker.rates().is_some());
+
+        let mut status = downloading(0, 1_000);
+        if let SyncStatus::StateSync(s) = &mut status {
+            s.heights.as_mut().unwrap().sync_block += 1;
+        }
+        assert!(tracker.update_rates_and_warn(&clock.clock(), &status).is_none());
+        assert!(tracker.rates().is_none());
     }
 
     #[test]
@@ -372,27 +425,27 @@ mod tests {
         let clock = fake_clock();
         let mut tracker = StateSyncProgressTracker::default();
         tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
-        clock.advance(Duration::seconds(10));
-        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_020)).unwrap();
-        assert_eq!(rates.parts_per_sec, 3.0);
-        assert_eq!(rates.blocks_per_sec, 2.0);
+        clock.advance(Duration::seconds(60));
+        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_060)).unwrap();
+        assert_eq!(rates.parts_per_sec, 0.5);
+        assert_eq!(rates.blocks_per_sec, 1.0);
     }
 
     #[test]
     fn stalled_sample_does_not_erase_established_rate() {
         let clock = fake_clock();
         let mut tracker = tracker_with_established_rates(&clock);
-        clock.advance(Duration::seconds(10));
-        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_020)).unwrap();
-        assert!((rates.parts_per_sec - 3.0 * (1.0 - NEW_SAMPLE_WEIGHT)).abs() < 1e-9);
+        clock.advance(Duration::seconds(60));
+        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_120)).unwrap();
+        assert!((rates.parts_per_sec - 0.5 * (1.0 - NEW_SAMPLE_WEIGHT)).abs() < 1e-9);
     }
 
     #[test]
     fn second_sample_at_same_instant_keeps_previous_rates() {
         let clock = fake_clock();
         let mut tracker = tracker_with_established_rates(&clock);
-        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(60, 1_040)).unwrap();
-        assert_eq!(rates.parts_per_sec, 3.0);
+        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(60, 1_120)).unwrap();
+        assert_eq!(rates.parts_per_sec, 0.5);
     }
 
     #[test]
@@ -420,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    fn leaving_state_sync_clears_the_warning_throttle() {
+    fn leaving_state_sync_clears_warning_throttle() {
         let clock = fake_clock();
         let mut tracker = tracker_with_established_rates(&clock);
         tracker.last_deadline_warning = Some(clock.clock().now());

--- a/chain/client/src/state_sync_progress.rs
+++ b/chain/client/src/state_sync_progress.rs
@@ -96,7 +96,7 @@ impl StateSyncProgressTracker {
             target: "sync",
             parts_downloaded = downloaded,
             parts_total = total,
-            parts_per_sec = format!("{:.2}", rates.parts_per_sec),
+            parts_per_sec = (rates.parts_per_sec * 100.0).round() / 100.0,
             download_eta = format_duration(projection.download_seconds),
             deadline_in = format_duration(projection.deadline_seconds),
             sync_block_height = heights.sync_block,
@@ -188,7 +188,7 @@ fn format_duration(seconds: f64) -> String {
 }
 
 /// Renders overall part progress and the deadline race, for example
-/// `parts 7981/8885 (90%) · download ETA 8m · deadline in 1975 blk (~43m) · OK`.
+/// `downloaded 7981/8885 (90%) · download ETA 8m · deadline in 1975 blk (~43m) · OK`.
 pub fn format_state_sync_progress(
     status: &StateSyncStatus,
     rates: Option<SyncRates>,
@@ -199,7 +199,7 @@ pub fn format_state_sync_progress(
     }
     let projection = rates.and_then(|rates| deadline_projection(status, rates));
 
-    let mut res = format!("parts {downloaded}/{total} ({}%)", downloaded * 100 / total);
+    let mut res = format!("downloaded {downloaded}/{total} ({}%)", downloaded * 100 / total);
     if let Some(projection) = projection {
         write!(res, " · download ETA {}", format_duration(projection.download_seconds)).unwrap();
     }
@@ -280,7 +280,7 @@ mod tests {
         );
         let rates = SyncRates { parts_per_sec: 3.0, blocks_per_sec: 1.0 };
         let progress = format_state_sync_progress(&status, Some(rates)).unwrap();
-        assert!(progress.starts_with("parts 100/1000 (10%)"), "{progress}");
+        assert!(progress.starts_with("downloaded 100/1000 (10%)"), "{progress}");
         assert!(progress.contains("download ETA 5m"), "{progress}");
         assert!(progress.ends_with("· OK"), "{progress}");
     }
@@ -306,7 +306,7 @@ mod tests {
             1_000,
         );
         let progress = format_state_sync_progress(&status, None).unwrap();
-        assert_eq!(progress, "parts 100/1000 (10%) · deadline in 43300 blk");
+        assert_eq!(progress, "downloaded 100/1000 (10%) · deadline in 43300 blk");
     }
 
     #[test]

--- a/chain/client/src/state_sync_progress.rs
+++ b/chain/client/src/state_sync_progress.rs
@@ -1,0 +1,420 @@
+use crate::SyncStatus;
+use near_async::time::{Clock, Instant};
+use near_client_primitives::types::StateSyncStatus;
+use near_primitives::types::BlockHeight;
+use std::fmt::Write;
+use time::ext::InstantExt as _;
+
+const NEW_SAMPLE_WEIGHT: f64 = 0.3;
+
+/// How often to repeat the warning that state sync will miss its deadline.
+const DEADLINE_WARNING_INTERVAL_SECONDS: f64 = 60.0;
+
+struct SyncSample {
+    sampled_at: Instant,
+    parts_downloaded: u64,
+    highest_height: BlockHeight,
+}
+
+/// Tracks state sync throughput across ticks, so the remaining download can be
+/// projected against the deadline at which the node wipes its database.
+#[derive(Default)]
+pub struct StateSyncProgressTracker {
+    prev_sample: Option<SyncSample>,
+    rates: Option<SyncRates>,
+    last_deadline_warning: Option<Instant>,
+}
+
+impl StateSyncProgressTracker {
+    /// Last known rates, for callers that do not drive the sampling themselves.
+    pub fn rates(&self) -> Option<SyncRates> {
+        self.rates
+    }
+
+    /// Returns the rates once two samples exist.
+    pub fn update_rates_and_warn(
+        &mut self,
+        clock: &Clock,
+        sync_status: &SyncStatus,
+    ) -> Option<SyncRates> {
+        let SyncStatus::StateSync(status) = sync_status else {
+            self.prev_sample = None;
+            self.rates = None;
+            return None;
+        };
+        let heights = status.heights?;
+        let now = clock.now();
+        let (parts_downloaded, _) = status.parts_progress();
+        let previous = self.prev_sample.replace(SyncSample {
+            sampled_at: now,
+            parts_downloaded,
+            highest_height: heights.highest,
+        });
+
+        let previous = previous?;
+        let elapsed = now.signed_duration_since(previous.sampled_at).as_seconds_f64();
+        if elapsed <= 0.0 {
+            return self.rates;
+        }
+        let sample = SyncRates {
+            parts_per_sec: parts_downloaded.saturating_sub(previous.parts_downloaded) as f64
+                / elapsed,
+            blocks_per_sec: heights.highest.saturating_sub(previous.highest_height) as f64
+                / elapsed,
+        };
+        let rates = self.rates.map_or(sample, |previous| previous.weighted_average_with(sample));
+        self.rates = Some(rates);
+        self.warn_if_deadline_will_be_missed(status, rates, now);
+        Some(rates)
+    }
+
+    /// Losing the deadline race wipes the database, so say so while there is
+    /// still time to act on it.
+    fn warn_if_deadline_will_be_missed(
+        &mut self,
+        status: &StateSyncStatus,
+        rates: SyncRates,
+        now: Instant,
+    ) {
+        let Some(projection) = deadline_projection(status, rates) else { return };
+        if !projection.will_miss_deadline() {
+            self.last_deadline_warning = None;
+            return;
+        }
+        let recently_warned = self.last_deadline_warning.is_some_and(|last| {
+            now.signed_duration_since(last).as_seconds_f64() < DEADLINE_WARNING_INTERVAL_SECONDS
+        });
+        if recently_warned {
+            return;
+        }
+        self.last_deadline_warning = Some(now);
+
+        let Some(heights) = status.heights else { return };
+        let (downloaded, total) = status.parts_progress();
+        tracing::warn!(
+            target: "sync",
+            parts_downloaded = downloaded,
+            parts_total = total,
+            parts_per_sec = format!("{:.2}", rates.parts_per_sec),
+            download_eta = format_duration(projection.download_seconds),
+            deadline_in = format_duration(projection.deadline_seconds),
+            sync_block_height = heights.sync_block,
+            stale_deadline_height = heights.stale_deadline,
+            highest_height = heights.highest,
+            "state sync will not finish before the sync hash goes stale; the node \
+             will wipe its database and restart. State parts are served over inbound \
+             tier3 connections, so check that this node is reachable at its advertised \
+             address."
+        );
+    }
+}
+
+/// Smoothed rates used to project state sync completion against its deadline.
+#[derive(Clone, Copy, Debug)]
+pub struct SyncRates {
+    pub parts_per_sec: f64,
+    /// Rate at which the network head advances.
+    pub blocks_per_sec: f64,
+}
+
+impl SyncRates {
+    fn weighted_average_with(self, sample: SyncRates) -> SyncRates {
+        let weighted_average = |previous: f64, sample: f64| {
+            previous * (1.0 - NEW_SAMPLE_WEIGHT) + sample * NEW_SAMPLE_WEIGHT
+        };
+        SyncRates {
+            parts_per_sec: weighted_average(self.parts_per_sec, sample.parts_per_sec),
+            blocks_per_sec: weighted_average(self.blocks_per_sec, sample.blocks_per_sec),
+        }
+    }
+}
+
+/// The race between finishing the state part download and the sync hash going
+/// stale. Losing it costs the node its database.
+#[derive(Clone, Copy, Debug)]
+pub struct DeadlineProjection {
+    pub download_seconds: f64,
+    pub deadline_seconds: f64,
+}
+
+impl DeadlineProjection {
+    pub fn will_miss_deadline(&self) -> bool {
+        self.download_seconds >= self.deadline_seconds
+    }
+}
+
+/// Projects the remaining download against the deadline. `None` until the head
+/// rate is known, or once every part has been downloaded.
+fn deadline_projection(status: &StateSyncStatus, rates: SyncRates) -> Option<DeadlineProjection> {
+    let (downloaded, total) = status.parts_progress();
+    let remaining = total.saturating_sub(downloaded);
+    let headroom = status.deadline_headroom()?;
+    if remaining == 0 || rates.blocks_per_sec <= 0.0 {
+        return None;
+    }
+    // A download making no progress never finishes, which is the case most
+    // worth reporting rather than staying silent about.
+    let download_seconds = if rates.parts_per_sec > 0.0 {
+        remaining as f64 / rates.parts_per_sec
+    } else {
+        f64::INFINITY
+    };
+    Some(DeadlineProjection {
+        download_seconds,
+        deadline_seconds: headroom as f64 / rates.blocks_per_sec,
+    })
+}
+
+/// A stalled download projects to absurd durations, so anything past a few
+/// days is reported as "too long" rather than a meaningless digit count.
+const LONGEST_REPORTED_DURATION_SECONDS: u64 = 99 * 3600;
+
+fn format_duration(seconds: f64) -> String {
+    if seconds.is_nan() || seconds < 0.0 {
+        return "unknown".to_string();
+    }
+    if seconds > LONGEST_REPORTED_DURATION_SECONDS as f64 {
+        return ">99h".to_string();
+    }
+    let seconds = seconds as u64;
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3600 {
+        format!("{}m", seconds / 60)
+    } else {
+        format!("{}h{:02}m", seconds / 3600, (seconds % 3600) / 60)
+    }
+}
+
+/// Renders overall part progress and the deadline race, for example
+/// `parts 7981/8885 (90%) · download ETA 8m · deadline in 1975 blk (~43m) · OK`.
+pub fn format_state_sync_progress(
+    status: &StateSyncStatus,
+    rates: Option<SyncRates>,
+) -> Option<String> {
+    let (downloaded, total) = status.parts_progress();
+    if total == 0 {
+        return None;
+    }
+    let projection = rates.and_then(|rates| deadline_projection(status, rates));
+
+    let mut res = format!("parts {downloaded}/{total} ({}%)", downloaded * 100 / total);
+    if let Some(projection) = projection {
+        write!(res, " · download ETA {}", format_duration(projection.download_seconds)).unwrap();
+    }
+    if let Some(headroom) = status.deadline_headroom() {
+        write!(res, " · deadline in {headroom} blk").unwrap();
+        if let Some(projection) = projection {
+            write!(res, " (~{})", format_duration(projection.deadline_seconds)).unwrap();
+        }
+    }
+    if let Some(projection) = projection {
+        let verdict = if projection.will_miss_deadline() { "WILL MISS" } else { "OK" };
+        write!(res, " · {verdict}").unwrap();
+    }
+    Some(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use near_async::time::{Duration, FakeClock, Utc};
+    use near_client_primitives::types::{ShardSyncStatus, StateSyncHeights};
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::types::{BlockHeightDelta, ShardId};
+
+    const SYNC_BLOCK: BlockHeight = 1_000;
+    const EPOCH_LENGTH: BlockHeightDelta = 43_200;
+    const STALE_DEADLINE: BlockHeight = SYNC_BLOCK + EPOCH_LENGTH + 100;
+
+    fn state_sync_status(
+        shards: &[(u64, ShardSyncStatus, u64)],
+        highest_height: BlockHeight,
+    ) -> StateSyncStatus {
+        let mut status = StateSyncStatus::new(CryptoHash::default());
+        for (shard_id, shard_status, parts_per_shard) in shards {
+            status.sync_status.insert(ShardId::new(*shard_id), *shard_status);
+            status.parts_per_shard.insert(ShardId::new(*shard_id), *parts_per_shard);
+        }
+        status.heights = Some(StateSyncHeights {
+            sync_block: SYNC_BLOCK,
+            stale_deadline: STALE_DEADLINE,
+            highest: highest_height,
+        });
+        status
+    }
+
+    #[test]
+    fn parts_progress_counts_shards_past_download_as_complete() {
+        let status = state_sync_status(
+            &[
+                (0, ShardSyncStatus::StateDownloadHeader, 100),
+                (1, ShardSyncStatus::StateDownloadParts { done: 30, total: 200 }, 200),
+                (2, ShardSyncStatus::StateApplyInProgress { done: 5, total: 300 }, 300),
+                (3, ShardSyncStatus::StateSyncDone, 400),
+            ],
+            1_000,
+        );
+        assert_eq!(status.parts_progress(), (30 + 300 + 400, 1000));
+    }
+
+    #[test]
+    fn deadline_headroom_is_none_before_first_state_sync_iteration() {
+        let status = StateSyncStatus::new(CryptoHash::default());
+        assert_eq!(status.deadline_headroom(), None);
+    }
+
+    #[test]
+    fn deadline_headroom_saturates_once_deadline_passes() {
+        let status = state_sync_status(&[], 100_000);
+        assert_eq!(status.deadline_headroom(), Some(0));
+    }
+
+    #[test]
+    fn progress_reports_ok_when_download_beats_deadline() {
+        // 900 parts left at 3/s is 300s; 6000 blocks at 1/s is 6000s.
+        let status = state_sync_status(
+            &[(0, ShardSyncStatus::StateDownloadParts { done: 100, total: 1000 }, 1000)],
+            38_300,
+        );
+        let rates = SyncRates { parts_per_sec: 3.0, blocks_per_sec: 1.0 };
+        let progress = format_state_sync_progress(&status, Some(rates)).unwrap();
+        assert!(progress.starts_with("parts 100/1000 (10%)"), "{progress}");
+        assert!(progress.contains("download ETA 5m"), "{progress}");
+        assert!(progress.ends_with("· OK"), "{progress}");
+    }
+
+    #[test]
+    fn progress_reports_will_miss_when_download_loses_deadline() {
+        // 900 parts left at 0.01/s is 90000s; 600 blocks at 1/s is 600s.
+        let status = state_sync_status(
+            &[(0, ShardSyncStatus::StateDownloadParts { done: 100, total: 1000 }, 1000)],
+            43_700,
+        );
+        let rates = SyncRates { parts_per_sec: 0.01, blocks_per_sec: 1.0 };
+        let progress = format_state_sync_progress(&status, Some(rates)).unwrap();
+        assert!(progress.ends_with("· WILL MISS"), "{progress}");
+        let projection = deadline_projection(&status, rates).unwrap();
+        assert!(projection.will_miss_deadline());
+    }
+
+    #[test]
+    fn progress_omits_projection_until_rates_are_known() {
+        let status = state_sync_status(
+            &[(0, ShardSyncStatus::StateDownloadParts { done: 100, total: 1000 }, 1000)],
+            1_000,
+        );
+        let progress = format_state_sync_progress(&status, None).unwrap();
+        assert_eq!(progress, "parts 100/1000 (10%) · deadline in 43300 blk");
+    }
+
+    #[test]
+    fn progress_is_absent_before_any_shard_reports_its_part_count() {
+        let status = StateSyncStatus::new(CryptoHash::default());
+        assert_eq!(format_state_sync_progress(&status, None), None);
+    }
+
+    #[test]
+    fn finished_download_has_no_projection() {
+        let status = state_sync_status(
+            &[(0, ShardSyncStatus::StateApplyInProgress { done: 1, total: 1000 }, 1000)],
+            1_000,
+        );
+        let rates = SyncRates { parts_per_sec: 3.0, blocks_per_sec: 1.0 };
+        assert!(deadline_projection(&status, rates).is_none());
+    }
+
+    #[test]
+    fn durations_are_formatted_by_magnitude() {
+        assert_eq!(format_duration(45.0), "45s");
+        assert_eq!(format_duration(300.0), "5m");
+        assert_eq!(format_duration(3600.0 * 2.0 + 180.0), "2h03m");
+        assert_eq!(format_duration(98.0 * 3600.0), "98h00m");
+        assert_eq!(format_duration(f64::INFINITY), ">99h");
+        assert_eq!(format_duration(-1.0), "unknown");
+    }
+
+    fn downloading(parts_done: u64, highest_height: BlockHeight) -> SyncStatus {
+        SyncStatus::StateSync(state_sync_status(
+            &[(
+                0,
+                ShardSyncStatus::StateDownloadParts { done: parts_done, total: 100_000 },
+                100_000,
+            )],
+            highest_height,
+        ))
+    }
+
+    fn fake_clock() -> FakeClock {
+        FakeClock::new(Utc::from_unix_timestamp(1601510400).unwrap())
+    }
+
+    /// Two samples 10s apart, establishing 3 parts/s and 2 blocks/s.
+    fn tracker_with_established_rates(clock: &FakeClock) -> StateSyncProgressTracker {
+        let mut tracker = StateSyncProgressTracker::default();
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
+        clock.advance(Duration::seconds(10));
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_020));
+        tracker
+    }
+
+    #[test]
+    fn single_sample_yields_no_rates() {
+        let clock = fake_clock();
+        let mut tracker = StateSyncProgressTracker::default();
+        assert!(tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000)).is_none());
+        assert!(tracker.rates().is_none());
+    }
+
+    #[test]
+    fn rates_are_derived_from_two_samples() {
+        let clock = fake_clock();
+        let mut tracker = StateSyncProgressTracker::default();
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
+        clock.advance(Duration::seconds(10));
+        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_020)).unwrap();
+        assert_eq!(rates.parts_per_sec, 3.0);
+        assert_eq!(rates.blocks_per_sec, 2.0);
+    }
+
+    #[test]
+    fn stalled_sample_does_not_erase_established_rate() {
+        let clock = fake_clock();
+        let mut tracker = tracker_with_established_rates(&clock);
+        clock.advance(Duration::seconds(10));
+        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_020)).unwrap();
+        assert!((rates.parts_per_sec - 3.0 * (1.0 - NEW_SAMPLE_WEIGHT)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn second_sample_at_same_instant_keeps_previous_rates() {
+        let clock = fake_clock();
+        let mut tracker = tracker_with_established_rates(&clock);
+        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(60, 1_040)).unwrap();
+        assert_eq!(rates.parts_per_sec, 3.0);
+    }
+
+    #[test]
+    fn leaving_state_sync_clears_rates() {
+        let clock = fake_clock();
+        let mut tracker = tracker_with_established_rates(&clock);
+        assert!(tracker.rates().is_some());
+
+        assert!(tracker.update_rates_and_warn(&clock.clock(), &SyncStatus::NoSync).is_none());
+        assert!(tracker.rates().is_none());
+    }
+
+    #[test]
+    fn stalled_download_still_loses_deadline_race() {
+        let status = state_sync_status(
+            &[(0, ShardSyncStatus::StateDownloadParts { done: 100, total: 1000 }, 1000)],
+            1_000,
+        );
+        let stalled = SyncRates { parts_per_sec: 0.0, blocks_per_sec: 1.0 };
+        let projection = deadline_projection(&status, stalled).unwrap();
+        assert!(projection.will_miss_deadline());
+        let progress = format_state_sync_progress(&status, Some(stalled)).unwrap();
+        assert!(progress.contains("download ETA >99h"), "{progress}");
+        assert!(progress.ends_with("· WILL MISS"), "{progress}");
+    }
+}

--- a/chain/client/src/state_sync_progress.rs
+++ b/chain/client/src/state_sync_progress.rs
@@ -40,6 +40,7 @@ impl StateSyncProgressTracker {
         let SyncStatus::StateSync(status) = sync_status else {
             self.prev_sample = None;
             self.rates = None;
+            self.last_deadline_warning = None;
             return None;
         };
         let heights = status.heights?;
@@ -416,5 +417,15 @@ mod tests {
         let progress = format_state_sync_progress(&status, Some(stalled)).unwrap();
         assert!(progress.contains("download ETA >99h"), "{progress}");
         assert!(progress.ends_with("· WILL MISS"), "{progress}");
+    }
+
+    #[test]
+    fn leaving_state_sync_clears_the_warning_throttle() {
+        let clock = fake_clock();
+        let mut tracker = tracker_with_established_rates(&clock);
+        tracker.last_deadline_warning = Some(clock.clock().now());
+
+        tracker.update_rates_and_warn(&clock.clock(), &SyncStatus::NoSync);
+        assert!(tracker.last_deadline_warning.is_none());
     }
 }

--- a/chain/client/src/state_sync_progress.rs
+++ b/chain/client/src/state_sync_progress.rs
@@ -1,23 +1,22 @@
 use crate::SyncStatus;
-use near_async::time::{Clock, Instant};
+use near_async::time::{Clock, Duration, Instant};
 use near_client_primitives::types::StateSyncStatus;
 use near_primitives::types::BlockHeight;
+use std::collections::VecDeque;
 use std::fmt::Write;
 use time::ext::InstantExt as _;
-
-const NEW_SAMPLE_WEIGHT: f64 = 0.3;
 
 /// How often to repeat the warning that state sync will miss its deadline.
 const DEADLINE_WARNING_INTERVAL_SECONDS: f64 = 60.0;
 
-/// Shortest span the network head rate is measured over. The head arrives in
-/// bursts, so a short span reports anything between zero and several blocks a
-/// second.
-const MIN_HEAD_RATE_SPAN_SECONDS: f64 = 60.0;
+/// Shortest span the rates are measured over. Both signals stutter: the network
+/// head arrives in bursts, and downloading pauses while applying catches up.
+const MIN_RATE_SPAN_SECONDS: f64 = 60.0;
 
-fn weighted_average(previous: f64, sample: f64) -> f64 {
-    previous * (1.0 - NEW_SAMPLE_WEIGHT) + sample * NEW_SAMPLE_WEIGHT
-}
+/// Span the rates are averaged over. Long enough that a pause of a minute or
+/// two does not invert the verdict, short enough that a node which has genuinely
+/// stopped is reported within the window rather than hours later.
+const RATE_WINDOW_SECONDS: f64 = 600.0;
 
 #[derive(Clone, Copy)]
 struct SyncSample {
@@ -31,11 +30,10 @@ struct SyncSample {
 /// projected against the deadline at which the node wipes its database.
 #[derive(Default)]
 pub struct StateSyncProgressTracker {
-    /// First sample of the current attempt. Parts arrive steadily and are
-    /// averaged over the last few ticks, but the network head jumps in bursts,
-    /// so its rate is averaged over the whole attempt instead.
-    first_sample: Option<SyncSample>,
-    prev_sample: Option<SyncSample>,
+    /// Samples within `RATE_WINDOW_SECONDS`, oldest first. Rates come from the
+    /// span between the ends rather than from consecutive ticks, so a brief
+    /// pause cannot invert the verdict and a lasting one still surfaces.
+    samples: VecDeque<SyncSample>,
     rates: Option<SyncRates>,
     last_deadline_warning: Option<Instant>,
 }
@@ -47,8 +45,7 @@ impl StateSyncProgressTracker {
     }
 
     fn forget(&mut self) {
-        self.first_sample = None;
-        self.prev_sample = None;
+        self.samples.clear();
         self.rates = None;
         self.last_deadline_warning = None;
     }
@@ -66,7 +63,7 @@ impl StateSyncProgressTracker {
         let heights = status.heights?;
         // A different sync block is a new attempt, so earlier samples say
         // nothing about this one.
-        if self.first_sample.is_some_and(|first| first.sync_block != heights.sync_block) {
+        if self.samples.front().is_some_and(|first| first.sync_block != heights.sync_block) {
             self.forget();
         }
         let now = clock.now();
@@ -77,23 +74,21 @@ impl StateSyncProgressTracker {
             parts_downloaded,
             highest_height: heights.highest,
         };
-        let first = *self.first_sample.get_or_insert(sample);
-        let previous = self.prev_sample.replace(sample);
+        self.samples.push_back(sample);
+        while self.samples.front().is_some_and(|oldest| {
+            oldest.sampled_at < now - Duration::seconds(RATE_WINDOW_SECONDS as i64)
+        }) {
+            self.samples.pop_front();
+        }
 
-        let previous = previous?;
-        let since_previous = now.signed_duration_since(previous.sampled_at).as_seconds_f64();
-        let since_first = now.signed_duration_since(first.sampled_at).as_seconds_f64();
-        if since_previous <= 0.0 || since_first < MIN_HEAD_RATE_SPAN_SECONDS {
+        let oldest = *self.samples.front()?;
+        let span = now.signed_duration_since(oldest.sampled_at).as_seconds_f64();
+        if span < MIN_RATE_SPAN_SECONDS {
             return self.rates;
         }
-        let parts_sample =
-            parts_downloaded.saturating_sub(previous.parts_downloaded) as f64 / since_previous;
         let rates = SyncRates {
-            parts_per_sec: self
-                .rates
-                .map_or(parts_sample, |rates| weighted_average(rates.parts_per_sec, parts_sample)),
-            blocks_per_sec: heights.highest.saturating_sub(first.highest_height) as f64
-                / since_first,
+            parts_per_sec: parts_downloaded.saturating_sub(oldest.parts_downloaded) as f64 / span,
+            blocks_per_sec: heights.highest.saturating_sub(oldest.highest_height) as f64 / span,
         };
         self.rates = Some(rates);
         self.warn_if_deadline_will_be_missed(status, rates, now);
@@ -380,22 +375,79 @@ mod tests {
 
     #[test]
     fn bursty_head_does_not_swing_block_rate() {
-        // The head jumps 120 blocks in one tick and none in the next. Averaging
-        // over the attempt keeps the rate at the true 1 block/s either way.
         let clock = fake_clock();
         let mut tracker = StateSyncProgressTracker::default();
         tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
         clock.advance(Duration::seconds(60));
         let burst = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_060)).unwrap();
+        // the head does not advance at all over the next minute
         clock.advance(Duration::seconds(60));
-        let stall = tracker.update_rates_and_warn(&clock.clock(), &downloading(60, 1_120)).unwrap();
+        let quiet = tracker.update_rates_and_warn(&clock.clock(), &downloading(60, 1_060)).unwrap();
         assert_eq!(burst.blocks_per_sec, 1.0);
-        assert_eq!(stall.blocks_per_sec, 1.0);
+        assert_eq!(quiet.blocks_per_sec, 0.5);
+    }
 
-        // A tick where the head does not move at all must not crater the rate.
+    #[test]
+    fn paused_download_does_not_explode_the_eta() {
+        // Downloading stalls for two minutes while applying catches up. A
+        // recency-weighted rate would fall toward zero and invert the verdict.
+        let clock = fake_clock();
+        let mut tracker = StateSyncProgressTracker::default();
+        for minute in 0..8 {
+            tracker.update_rates_and_warn(
+                &clock.clock(),
+                &downloading(minute * 600, 1_000 + minute * 60),
+            );
+            clock.advance(Duration::seconds(60));
+        }
+        let steady = tracker.rates().unwrap();
+        // two minutes with no parts at all
+        clock.advance(Duration::seconds(120));
+        let paused = tracker
+            .update_rates_and_warn(&clock.clock(), &downloading(7 * 600, 1_000 + 7 * 60))
+            .unwrap();
+
+        assert_eq!(steady.parts_per_sec, 10.0);
+        // 4200 parts over the 600s window: the pause costs a third of the rate,
+        // not all of it, so the verdict cannot flip.
+        assert_eq!(paused.parts_per_sec, 7.0);
+    }
+
+    #[test]
+    fn lasting_stall_drives_the_rate_to_zero() {
+        // Nothing arrives for longer than the window: the rate must reach zero
+        // so the deadline race is reported as lost.
+        let clock = fake_clock();
+        let mut tracker = StateSyncProgressTracker::default();
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
         clock.advance(Duration::seconds(60));
-        let quiet = tracker.update_rates_and_warn(&clock.clock(), &downloading(90, 1_120)).unwrap();
-        assert!(quiet.blocks_per_sec > 0.6, "{}", quiet.blocks_per_sec);
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(600, 1_060));
+
+        for _ in 0..12 {
+            clock.advance(Duration::seconds(60));
+            tracker.update_rates_and_warn(&clock.clock(), &downloading(600, 1_060));
+        }
+        assert_eq!(tracker.rates().unwrap().parts_per_sec, 0.0);
+    }
+
+    #[test]
+    fn rates_are_derived_from_two_samples() {
+        let clock = fake_clock();
+        let mut tracker = StateSyncProgressTracker::default();
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
+        clock.advance(Duration::seconds(60));
+        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_060)).unwrap();
+        assert_eq!(rates.parts_per_sec, 0.5);
+        assert_eq!(rates.blocks_per_sec, 1.0);
+    }
+
+    #[test]
+    fn rates_need_a_minimum_span() {
+        let clock = fake_clock();
+        let mut tracker = StateSyncProgressTracker::default();
+        tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
+        clock.advance(Duration::seconds(30));
+        assert!(tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_030)).is_none());
     }
 
     #[test]
@@ -418,34 +470,6 @@ mod tests {
         let mut tracker = StateSyncProgressTracker::default();
         assert!(tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000)).is_none());
         assert!(tracker.rates().is_none());
-    }
-
-    #[test]
-    fn rates_are_derived_from_two_samples() {
-        let clock = fake_clock();
-        let mut tracker = StateSyncProgressTracker::default();
-        tracker.update_rates_and_warn(&clock.clock(), &downloading(0, 1_000));
-        clock.advance(Duration::seconds(60));
-        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_060)).unwrap();
-        assert_eq!(rates.parts_per_sec, 0.5);
-        assert_eq!(rates.blocks_per_sec, 1.0);
-    }
-
-    #[test]
-    fn stalled_sample_does_not_erase_established_rate() {
-        let clock = fake_clock();
-        let mut tracker = tracker_with_established_rates(&clock);
-        clock.advance(Duration::seconds(60));
-        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(30, 1_120)).unwrap();
-        assert!((rates.parts_per_sec - 0.5 * (1.0 - NEW_SAMPLE_WEIGHT)).abs() < 1e-9);
-    }
-
-    #[test]
-    fn second_sample_at_same_instant_keeps_previous_rates() {
-        let clock = fake_clock();
-        let mut tracker = tracker_with_established_rates(&clock);
-        let rates = tracker.update_rates_and_warn(&clock.clock(), &downloading(60, 1_120)).unwrap();
-        assert_eq!(rates.parts_per_sec, 0.5);
     }
 
     #[test]

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -17,7 +17,7 @@ use near_chain::types::RuntimeAdapter;
 use near_chain::{BlockHeader, BlockProcessingArtifact, Chain};
 use near_chain_configs::{StateSyncConfig, SyncConcurrency};
 use near_chunks::logic::get_shards_cares_about_this_or_next_epoch;
-use near_client_primitives::types::{ShardSyncStatus, StateSyncStatus};
+use near_client_primitives::types::{ShardSyncStatus, StateSyncHeights, StateSyncStatus};
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_network::client::StateResponse;
@@ -278,13 +278,24 @@ impl StateSync {
         let sync_hash = sync_status.sync_hash;
         let block_header = chain.get_block_header(&sync_hash)?;
 
+        // Recorded so the status line can show the remaining headroom.
+        let stale_deadline_height =
+            block_header.height() + chain.epoch_length + STALE_SYNC_HASH_THRESHOLD;
+        sync_status.heights = Some(StateSyncHeights {
+            sync_block: block_header.height(),
+            stale_deadline: stale_deadline_height,
+            highest: highest_height,
+        });
+        metrics::STATE_SYNC_STALE_DEADLINE_HEIGHT.set(stale_deadline_height as i64);
+
         // If the network has moved past this epoch, state parts are no longer
         // available. Trigger a data reset so the node can restart fresh.
-        if highest_height > block_header.height() + chain.epoch_length + STALE_SYNC_HASH_THRESHOLD {
+        if highest_height > stale_deadline_height {
             tracing::warn!(
                 target: "sync",
                 ?block_header,
                 highest_height,
+                stale_deadline_height,
                 "stale sync hash detected, triggering data reset"
             );
             return Ok(StateSyncResult::StaleSyncHash);
@@ -386,6 +397,12 @@ impl StateSync {
                 }
             };
             sync_status.sync_status.insert(*shard_id, status);
+            // Both phases report the same part count.
+            if let ShardSyncStatus::StateDownloadParts { total, .. }
+            | ShardSyncStatus::StateApplyInProgress { total, .. } = status
+            {
+                sync_status.parts_per_shard.insert(*shard_id, total);
+            }
             metrics::STATE_SYNC_STAGE
                 .with_label_values(&[&shard_id.to_string()])
                 .set(status.repr() as i64);


### PR DESCRIPTION
State sync wipes the node's database and restarts when the sync hash goes stale (`chain/client/src/sync/state/mod.rs`), but nothing reports how close the node is to that deadline. An operator sees hours of apparently normal progress, then an unexplained reset.

This adds the race to the `node_status` line:

```
State HP6j...[1: parts (614/623)][6: done]... (10 downloads, 4 computations)
  parts 7981/8885 (90%) · download ETA 8m · deadline in 1975 blk (~43m) · OK
```

and a throttled warning when the projection says the download will lose:

```
WARN sync: state sync will not finish before the sync hash goes stale; the node will wipe its database and restart. State parts are served over inbound tier3 connections, so check that this node is reachable at its advertised address.
```

The deadline is already computed in `StateSync::run` to decide the reset; it is now recorded on `StateSyncStatus` so callers can report the remaining headroom instead of only observing the outcome. The block rate is measured from `highest_height` deltas rather than assuming a block time.

Two metrics are added: `near_sync_highest_peer_height` (nothing currently tracks the network tip, and `near_block_height_head` is pinned while state sync runs) and `near_state_sync_stale_deadline_height`.

Motivation: an operator reported repeated ~7 hour resets with no diagnosable logs. This reproduced on two mainnet nodes, which both reached 90% of state sync and were wiped: the sync hash was chosen 5h41m into a 7.35h epoch, leaving only 1.47h of headroom. With this change the line would have read WILL MISS within about two ticks instead of failing silently.

### Known gap: the apply phase is not modeled

The projection covers the part **download** only. Once every part is downloaded, `deadline_projection` returns `None`, so the line loses its ETA and verdict entirely while the apply phase is still running and still has to beat the same deadline.