### PR TITLE
perf(sync): verify peer height claims at the sync step

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1227,14 +1227,20 @@ impl Client {
         self.verified_peer_heights.note_claim(peer_id, block.header());
     }
 
+    pub(crate) fn prune_peer_height_claims(&mut self) {
+        let Ok(head) = self.chain.head() else {
+            return;
+        };
+        self.verified_peer_heights.prune_at_or_below(head.height);
+    }
+
     /// Pays for the approval checks the sync decision needs, and no others.
-    pub(crate) fn verify_best_peer_height_claim(&mut self) {
+    pub(crate) fn verify_best_peer_height_claim(&mut self, is_eligible: impl Fn(&PeerId) -> bool) {
         let Ok(head) = self.chain.head() else {
             return;
         };
         let min_height = self.sync_trigger_height(head.height);
-        self.verified_peer_heights.prune_at_or_below(head.height);
-        self.verified_peer_heights.check_claims_until_verified(min_height, |header| {
+        self.verified_peer_heights.check_claims_until_verified(min_height, is_eligible, |header| {
             self.chain.verify_header_approvals_without_ancestry(header).is_ok()
         });
     }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1206,18 +1206,36 @@ impl Client {
         Ok(Some(block))
     }
 
-    /// Record `peer_id`'s verified height if the relayed block is ahead of us
-    /// and its approvals verify as >2/3 of a known epoch's stake; far-ahead
-    /// blocks (unknown epoch) fail that check and are ignored.
-    pub(crate) fn note_verified_peer_height(&mut self, block: &Block, peer_id: &PeerId) {
-        let head_height = self.chain.head().map(|tip| tip.height).unwrap_or(0);
-        self.verified_peer_heights.prune_at_or_below(head_height);
-        let height = block.header().height();
-        if height <= head_height {
+    /// A claim at or below this height cannot change the sync decision, so it needs no proof.
+    pub(crate) fn sync_trigger_height(&self, head_height: BlockHeight) -> BlockHeight {
+        if self.sync_handler.sync_status.is_syncing() {
+            head_height
+        } else {
+            head_height + self.config.sync_height_threshold
+        }
+    }
+
+    /// Remember the height `peer_id` relayed. No approvals are checked here;
+    /// `verify_best_peer_height_claim` does that.
+    pub(crate) fn note_peer_height_claim(&mut self, block: &Block, peer_id: &PeerId) {
+        let Ok(head) = self.chain.head() else {
+            return;
+        };
+        if block.header().height() <= self.sync_trigger_height(head.height) {
             return;
         }
-        self.verified_peer_heights.record_if_verified(peer_id, block.hash(), height, || {
-            self.chain.verify_header_approvals_without_ancestry(block.header()).is_ok()
+        self.verified_peer_heights.note_claim(peer_id, block.header());
+    }
+
+    /// Pays for the approval checks the sync decision needs, and no others.
+    pub(crate) fn verify_best_peer_height_claim(&mut self) {
+        let Ok(head) = self.chain.head() else {
+            return;
+        };
+        let min_height = self.sync_trigger_height(head.height);
+        self.verified_peer_heights.prune_at_or_below(head.height);
+        self.verified_peer_heights.check_claims_until_verified(min_height, |header| {
+            self.chain.verify_header_approvals_without_ancestry(header).is_ok()
         });
     }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -622,8 +622,12 @@ impl Handler<SpanWrapped<BlockResponse>> for ClientActor {
     fn handle(&mut self, msg: SpanWrapped<BlockResponse>) {
         let BlockResponse { block, peer_id, was_requested } = msg.span_unwrap();
         tracing::debug!(target: "client", block_height = block.header().height(), block_hash = ?block.header().hash(), "received block response");
-        // Feed the verified-height signal before the branching below can drop the block.
-        self.client.note_verified_peer_height(&block, &peer_id);
+        // Record the claimed height before the branching below can drop the block. A block
+        // we requested proves nothing new: we asked for it to reach a height we already
+        // verified.
+        if !was_requested {
+            self.client.note_peer_height_claim(&block, &peer_id);
+        }
         let blocks_at_height =
             self.client.chain.chain_store().get_all_block_hashes_by_height(block.header().height());
         if was_requested || blocks_at_height.is_empty() {
@@ -1696,21 +1700,20 @@ impl ClientActor {
 
         let head = self.client.chain.head()?;
         let head = Tip::clone(&head);
-        let is_syncing = self.client.sync_handler.sync_status.is_syncing();
 
         let from_peers = if self.head_is_stale(&head)? {
             // Head hasn't advanced in ~1 epoch: we really are behind (a peer can't
             // fake this), so use the unvalidated claimed heights to pick who to sync
             // from; the proof and downstream checks re-validate the target.
-            self.sync_requirement_from_claimed_peers(head.clone(), is_syncing)?
+            self.sync_requirement_from_claimed_peers(head.clone())?
         } else {
             // Head is recent, so we still know the validator set for nearby heights
             // and can verify a peer's advertised height before entering sync.
-            self.sync_requirement_from_verified_peers(head.clone(), is_syncing)?
+            self.sync_requirement_from_verified_peers(head.clone())?
         };
-        // After state sync the verified peer heights sit below the new head: peers read as level
-        // with us, or leave NoPeers when there is only one. Our own header head is already ahead
-        // and no peer can forge it. It decides whether to keep syncing, not who to download from.
+        // After state sync the verified peer heights sit below the new head, so peers read as
+        // level with us. Our own header head is already ahead and no peer can forge it. It
+        // decides whether to keep syncing, not who to download from.
         if from_peers.sync_needed()
             || !matches!(self.client.sync_handler.sync_status, SyncStatus::BlockSync { .. })
         {
@@ -1748,7 +1751,6 @@ impl ClientActor {
     fn sync_requirement_from_claimed_peers(
         &self,
         head: Tip,
-        is_syncing: bool,
     ) -> Result<SyncRequirement, near_chain::Error> {
         let eligible_peers: Vec<_> = self
             .network_info
@@ -1764,16 +1766,14 @@ impl ClientActor {
         let peer_id = peer_info.peer_info.id.clone();
         let shutdown_height = self.client.config.expected_shutdown.get().unwrap_or(u64::MAX);
         let highest_height = peer_info.highest_block_height.min(shutdown_height);
-        Ok(self.sync_requirement(peer_id, highest_height, head, is_syncing))
+        Ok(self.sync_requirement(peer_id, highest_height, head))
     }
 
-    /// Per peer, uses min(SetNetworkInfo height, verified height): we act only on a
-    /// height confirmed from block approvals, and the slower SetNetworkInfo push
-    /// keeps us from syncing over a block we're about to process ourselves.
+    /// Sync decision from `best_actionable_peer_height`. The slower SetNetworkInfo push
+    /// keeps us from syncing over a block we are about to process.
     fn sync_requirement_from_verified_peers(
         &self,
         head: Tip,
-        is_syncing: bool,
     ) -> Result<SyncRequirement, near_chain::Error> {
         let invalid_peers = self
             .network_info
@@ -1788,8 +1788,22 @@ impl ClientActor {
             })
             .count();
         metrics::PEERS_WITH_INVALID_HASH.set(invalid_peers as i64);
-        let best_peer = self
-            .network_info
+        let Some((peer_id, height)) = self.best_actionable_peer_height(head.height) else {
+            tracing::debug!(target: "sync", connected_peers = self.network_info.connected_peers.len(), "no eligible peer to sync from");
+            return Ok(SyncRequirement::NoPeers);
+        };
+        let shutdown_height = self.client.config.expected_shutdown.get().unwrap_or(u64::MAX);
+        let highest_height = height.min(shutdown_height);
+        Ok(self.sync_requirement(peer_id, highest_height, head))
+    }
+
+    /// Per peer, `min(SetNetworkInfo height, verified height)`. Ties go to the peer
+    /// claiming the most, which only changes the name we log.
+    fn best_actionable_peer_height(
+        &self,
+        head_height: BlockHeight,
+    ) -> Option<(PeerId, BlockHeight)> {
+        self.network_info
             .connected_peers
             .iter()
             .filter_map(|peer| {
@@ -1798,17 +1812,17 @@ impl ClientActor {
                 if self.client.chain.is_block_invalid(&last_block.hash) {
                     return None;
                 }
-                let verified_height = self.client.verified_peer_heights.get(peer_id)?;
-                Some((peer_id.clone(), last_block.height.min(verified_height)))
+                let height = match self.client.verified_peer_heights.get_above(peer_id, head_height)
+                {
+                    Some(verified_height) => last_block.height.min(verified_height),
+                    // Nothing verified: cap at our head so the peer stays a candidate
+                    // but never a sync target.
+                    None => last_block.height.min(head_height),
+                };
+                Some((peer_id.clone(), height, last_block.height))
             })
-            .max_by_key(|(_, height)| *height);
-        let Some((peer_id, height)) = best_peer else {
-            tracing::debug!(target: "sync", connected_peers = self.network_info.connected_peers.len(), "no peer with a verified height");
-            return Ok(SyncRequirement::NoPeers);
-        };
-        let shutdown_height = self.client.config.expected_shutdown.get().unwrap_or(u64::MAX);
-        let highest_height = height.min(shutdown_height);
-        Ok(self.sync_requirement(peer_id, highest_height, head, is_syncing))
+            .max_by_key(|(_, height, claimed_height)| (*height, *claimed_height))
+            .map(|(peer_id, height, _)| (peer_id, height))
     }
 
     fn sync_requirement(
@@ -1816,14 +1830,8 @@ impl ClientActor {
         peer_id: PeerId,
         highest_height: BlockHeight,
         head: Tip,
-        is_syncing: bool,
     ) -> SyncRequirement {
-        let needed = if is_syncing {
-            highest_height > head.height
-        } else {
-            highest_height > head.height + self.client.config.sync_height_threshold
-        };
-        if needed {
+        if highest_height > self.client.sync_trigger_height(head.height) {
             SyncRequirement::SyncNeeded {
                 source: HighestHeightSource::Peer(peer_id),
                 highest_height,
@@ -1924,6 +1932,7 @@ impl ClientActor {
         let _span = tracing::debug_span!(target: "client", "run_sync_step").entered();
 
         let currently_syncing = self.client.sync_handler.sync_status.is_syncing();
+        self.client.verify_best_peer_height_claim();
         let sync = match self.syncing_info() {
             Ok(sync) => sync,
             Err(err) => {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -85,6 +85,7 @@ use near_telemetry::TelemetryEvent;
 use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use rand::{Rng, thread_rng};
+use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -1746,6 +1747,29 @@ impl ClientActor {
         Ok(now - head_time >= one_epoch)
     }
 
+    /// The stale-head path picks its target from the unverified claimed heights, so proving claims
+    /// there spends signature work the decision cannot use. Claims stay recorded and are proved
+    /// once the head is recent again.
+    fn verify_peer_height_claims_if_the_decision_can_use_them(&mut self) {
+        self.client.prune_peer_height_claims();
+        let Ok(head) = self.client.chain.head() else {
+            return;
+        };
+        if self.adv.disable_header_sync() || self.head_is_stale(&head).unwrap_or(true) {
+            return;
+        }
+        // Only a connected peer can be chosen to sync from, so proving a claim from any other
+        // peer spends a check the decision cannot use, and would end the step on a pass that
+        // decides nothing.
+        let connected: HashSet<PeerId> = self
+            .network_info
+            .connected_peers
+            .iter()
+            .map(|peer| peer.full_peer_info.peer_info.id.clone())
+            .collect();
+        self.client.verify_best_peer_height_claim(|peer_id| connected.contains(peer_id));
+    }
+
     /// Sync decision from the unvalidated `highest_height_peers`. Used only once
     /// our own clock already shows we are behind.
     fn sync_requirement_from_claimed_peers(
@@ -1932,7 +1956,7 @@ impl ClientActor {
         let _span = tracing::debug_span!(target: "client", "run_sync_step").entered();
 
         let currently_syncing = self.client.sync_handler.sync_status.is_syncing();
-        self.client.verify_best_peer_height_claim();
+        self.verify_peer_height_claims_if_the_decision_can_use_them();
         let sync = match self.syncing_info() {
             Ok(sync) => sync,
             Err(err) => {

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -22,6 +22,10 @@ const MAX_CHECKS_PER_STEP: usize = 4;
 struct PeerHeights {
     claim: Option<Arc<BlockHeader>>,
     verified_height: Option<BlockHeight>,
+    /// Set when a check on this peer's claim failed, so its later claims sort below every peer
+    /// that has not failed however high they are. Cleared by a header it holds passing, which is
+    /// why a peer relaying the real tip recovers without needing a check of its own.
+    failed_last_check: bool,
 }
 
 impl PeerHeights {
@@ -76,6 +80,19 @@ impl VerifiedPeerHeights {
         if self.by_peer.len() < MAX_PEER_CLAIMS {
             return true;
         }
+        // An entry kept only to remember a failed check holds no height, so it is the cheapest to
+        // lose. Without this the map fills with them and refuses every new claim.
+        let forgettable = self
+            .by_peer
+            .iter()
+            .filter(|(_, peer)| peer.known_height().is_none())
+            .map(|(peer_id, _)| peer_id)
+            .min()
+            .cloned();
+        if let Some(peer_id) = forgettable {
+            self.by_peer.remove(&peer_id);
+            return true;
+        }
         let lowest = self
             .by_peer
             .iter()
@@ -100,16 +117,23 @@ impl VerifiedPeerHeights {
 
     #[cfg(test)]
     fn has_claim_above(&self, min_height: BlockHeight) -> bool {
-        self.highest_claim_above(min_height).is_some()
+        self.highest_claim_above(min_height, &|_: &PeerId| true).is_some()
     }
 
-    fn highest_claim_above(&self, min_height: BlockHeight) -> Option<Arc<BlockHeader>> {
+    /// Peers that have not failed a check come first, and the highest claim wins among them. A
+    /// peer cannot buy priority by claiming a higher height once it has failed.
+    fn highest_claim_above(
+        &self,
+        min_height: BlockHeight,
+        is_eligible: &impl Fn(&PeerId) -> bool,
+    ) -> Option<Arc<BlockHeader>> {
         self.by_peer
-            .values()
-            .filter_map(|peer| peer.claim.as_ref())
-            .filter(|header| header.height() > min_height)
-            .max_by_key(|header| header.height())
-            .cloned()
+            .iter()
+            .filter(|(peer_id, _)| is_eligible(peer_id))
+            .filter_map(|(_, peer)| Some((peer, peer.claim.as_ref()?)))
+            .filter(|(_, header)| header.height() > min_height)
+            .max_by_key(|(peer, header)| (!peer.failed_last_check, header.height()))
+            .map(|(_, header)| header.clone())
     }
 
     /// Settles every claim on this header: one outcome answers all of them.
@@ -117,11 +141,12 @@ impl VerifiedPeerHeights {
         self.by_peer.retain(|_, peer| {
             if peer.claim.as_ref().is_some_and(|claim| claim.hash() == header_hash) {
                 peer.claim = None;
+                peer.failed_last_check = !passed;
                 if passed {
                     peer.record_verified_height(height);
                 }
             }
-            peer.claim.is_some() || peer.verified_height.is_some()
+            peer.claim.is_some() || peer.verified_height.is_some() || peer.failed_last_check
         });
     }
 
@@ -132,10 +157,11 @@ impl VerifiedPeerHeights {
     pub fn check_claims_until_verified(
         &mut self,
         min_height: BlockHeight,
+        is_eligible: impl Fn(&PeerId) -> bool,
         mut check_approvals: impl FnMut(&BlockHeader) -> bool,
     ) {
         let mut checks = 0;
-        while let Some(header) = self.highest_claim_above(min_height) {
+        while let Some(header) = self.highest_claim_above(min_height, &is_eligible) {
             let mut passed = self.verified_header_hashes.contains(header.hash());
             if !passed {
                 if checks == MAX_CHECKS_PER_STEP {
@@ -187,7 +213,7 @@ mod tests {
     }
 
     fn check_all(heights: &mut VerifiedPeerHeights, passed: bool) {
-        heights.check_claims_until_verified(0, |_| passed);
+        heights.check_claims_until_verified(0, |_| true, |_| passed);
     }
 
     #[test]
@@ -199,7 +225,7 @@ mod tests {
         for _ in 0..MAX_PEER_CLAIMS {
             check_all(&mut heights, false);
         }
-        assert!(heights.by_peer.is_empty());
+        assert!(heights.by_peer.values().all(|peer| peer.claim.is_none()));
         let newcomer = peer("newcomer");
         heights.note_claim(&newcomer, &header(50, 2));
         assert!(heights.by_peer.contains_key(&newcomer));
@@ -248,10 +274,14 @@ mod tests {
         heights.note_claim(&peer("b"), &header(30, 2));
         heights.note_claim(&peer("c"), &header(20, 3));
         let mut checked = Vec::new();
-        heights.check_claims_until_verified(10, |header| {
-            checked.push(header.height());
-            false
-        });
+        heights.check_claims_until_verified(
+            10,
+            |_| true,
+            |header| {
+                checked.push(header.height());
+                false
+            },
+        );
         assert_eq!(checked, vec![30, 20]);
     }
 
@@ -262,10 +292,14 @@ mod tests {
         heights.note_claim(&p1, &header(30, 1));
         heights.note_claim(&p2, &header(20, 2));
         heights.note_claim(&p3, &header(10, 3));
-        heights.check_claims_until_verified(0, |header| match header.height() {
-            20 => true,
-            _ => false,
-        });
+        heights.check_claims_until_verified(
+            0,
+            |_| true,
+            |header| match header.height() {
+                20 => true,
+                _ => false,
+            },
+        );
         assert_eq!(heights.get_above(&p2, 0), Some(20));
         assert_eq!(heights.get_above(&p1, 0), None);
         assert!(heights.has_claim_above(0), "the claim at 10 is still unchecked");
@@ -279,10 +313,14 @@ mod tests {
         heights.note_claim(&p1, &claim);
         heights.note_claim(&p2, &claim);
         let mut checks = 0;
-        heights.check_claims_until_verified(0, |_| {
-            checks += 1;
-            true
-        });
+        heights.check_claims_until_verified(
+            0,
+            |_| true,
+            |_| {
+                checks += 1;
+                true
+            },
+        );
         assert_eq!(checks, 1);
         assert_eq!(heights.get_above(&p1, 0), Some(10));
         assert_eq!(heights.get_above(&p2, 0), Some(10));
@@ -301,14 +339,17 @@ mod tests {
     #[test]
     fn check_claims_until_verified_rechecks_a_header_that_failed() {
         let mut heights = VerifiedPeerHeights::default();
-        let p = peer("a");
         let mut checks = 0;
-        for _ in 0..2 {
-            heights.note_claim(&p, &header(10, 1));
-            heights.check_claims_until_verified(0, |_| {
-                checks += 1;
-                false
-            });
+        for index in 0..2 {
+            heights.note_claim(&peer(&format!("p{index}")), &header(10, 1));
+            heights.check_claims_until_verified(
+                0,
+                |_| true,
+                |_| {
+                    checks += 1;
+                    false
+                },
+            );
         }
         assert_eq!(
             checks, 2,
@@ -317,15 +358,122 @@ mod tests {
     }
 
     #[test]
+    fn check_claims_until_verified_serves_a_peer_whose_claim_is_never_the_highest() {
+        let mut heights = VerifiedPeerHeights::default();
+        let honest = peer("honest");
+        heights.note_claim(&honest, &header(100, 1));
+        for round in 0..40u64 {
+            for index in 0..(4 * MAX_CHECKS_PER_STEP) {
+                let claim = header(1000 + round * 100 + index as u64, 2);
+                heights.note_claim(&peer(&format!("loud{index}")), &claim);
+            }
+            heights.check_claims_until_verified(0, |_| true, |header| header.height() == 100);
+        }
+        assert_eq!(heights.get_above(&honest, 0), Some(100), "honest peer starved by rotation");
+    }
+
+    #[test]
+    fn settle_claims_clears_the_failed_flag_for_every_peer_holding_a_passing_header() {
+        let mut heights = VerifiedPeerHeights::default();
+        let demoted = peer("demoted");
+        heights.note_claim(&demoted, &header(200, 1));
+        check_all(&mut heights, false);
+        assert!(heights.by_peer[&demoted].failed_last_check);
+        let tip = header(300, 2);
+        heights.note_claim(&demoted, &tip);
+        heights.note_claim(&peer("other"), &tip);
+        check_all(&mut heights, true);
+        assert!(!heights.by_peer[&demoted].failed_last_check);
+        assert_eq!(heights.get_above(&demoted, 0), Some(300));
+    }
+
+    #[test]
+    fn check_claims_until_verified_still_reaches_a_demoted_peer_when_nothing_else_passes() {
+        let mut heights = VerifiedPeerHeights::default();
+        let demoted = peer("demoted");
+        heights.note_claim(&demoted, &header(200, 1));
+        check_all(&mut heights, false);
+        heights.note_claim(&demoted, &header(300, 2));
+        heights.note_claim(&peer("fresh"), &header(250, 3));
+        let mut checked = Vec::new();
+        heights.check_claims_until_verified(
+            0,
+            |_| true,
+            |header| {
+                checked.push(header.height());
+                false
+            },
+        );
+        assert_eq!(
+            checked,
+            vec![250, 300],
+            "the fresh peer goes first, the demoted one still runs"
+        );
+    }
+
+    #[test]
+    fn check_claims_until_verified_serves_an_honest_peer_despite_the_amnesty_cycle() {
+        let mut heights = VerifiedPeerHeights::default();
+        let honest = peer("honest");
+        for round in 0..20u64 {
+            heights.note_claim(&honest, &header(100, 1));
+            let tip = header(200 + round, 7);
+            for index in 0..(4 * MAX_CHECKS_PER_STEP) {
+                heights.note_claim(&peer(&format!("loud{index}")), &tip);
+            }
+            heights.check_claims_until_verified(
+                0,
+                |_| true,
+                |header| header.height() == 200 + round,
+            );
+            for index in 0..(4 * MAX_CHECKS_PER_STEP) {
+                let bad = header(9000 + round * 100 + index as u64, 8);
+                heights.note_claim(&peer(&format!("loud{index}")), &bad);
+            }
+            heights.check_claims_until_verified(0, |_| true, |header| header.height() == 100);
+        }
+        assert_eq!(
+            heights.get_above(&honest, 0),
+            Some(100),
+            "amnesty cycle starved the honest peer"
+        );
+    }
+
+    #[test]
+    fn check_claims_until_verified_ignores_claims_from_ineligible_peers() {
+        let mut heights = VerifiedPeerHeights::default();
+        let connected = peer("connected");
+        let gone = peer("gone");
+        heights.note_claim(&gone, &header(900, 1));
+        heights.note_claim(&connected, &header(100, 2));
+        let mut checked = Vec::new();
+        heights.check_claims_until_verified(
+            0,
+            |peer_id| *peer_id == connected,
+            |header| {
+                checked.push(header.height());
+                true
+            },
+        );
+        assert_eq!(checked, vec![100], "a gone peer must not spend the step or end it on a pass");
+        assert_eq!(heights.get_above(&connected, 0), Some(100));
+        assert_eq!(heights.get_above(&gone, 0), None);
+    }
+
+    #[test]
     fn check_claims_until_verified_skips_a_header_that_passed() {
         let mut heights = VerifiedPeerHeights::default();
         let mut checks = 0;
         for seed in 0..2 {
             heights.note_claim(&peer(&format!("p{seed}")), &header(10, 1));
-            heights.check_claims_until_verified(0, |_| {
-                checks += 1;
-                true
-            });
+            heights.check_claims_until_verified(
+                0,
+                |_| true,
+                |_| {
+                    checks += 1;
+                    true
+                },
+            );
         }
         assert_eq!(checks, 1);
     }
@@ -370,10 +518,14 @@ mod tests {
             heights.note_claim(&peer(&index.to_string()), &header(10 + index as u64, index as u64));
         }
         let mut checks = 0;
-        heights.check_claims_until_verified(0, |_| {
-            checks += 1;
-            false
-        });
+        heights.check_claims_until_verified(
+            0,
+            |_| true,
+            |_| {
+                checks += 1;
+                false
+            },
+        );
         assert_eq!(checks, MAX_CHECKS_PER_STEP);
         assert!(heights.has_claim_above(0), "the rest wait for the next step");
     }

--- a/chain/client/src/verified_peer_heights.rs
+++ b/chain/client/src/verified_peer_heights.rs
@@ -1,17 +1,49 @@
 use lru::LruCache;
+use near_primitives::block_header::BlockHeader;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::BlockHeight;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+/// Each claim holds a header of several kilobytes. Peers that disconnect while we are behind keep
+/// their claim until our head passes it, so the map needs a cap of its own above any real peer count.
+const MAX_PEER_CLAIMS: usize = 128;
+
+/// A full approval pass is ~100 signature checks, about 2.8ms. With one claim per peer an
+/// unbounded walk could spend a third of a second in one sync step, so stop after a few and
+/// let the next step take the rest.
+const MAX_CHECKS_PER_STEP: usize = 4;
+
+/// What one peer has shown us: the highest header it relayed that we have not
+/// settled yet, and the highest height its approvals verified for.
+#[derive(Default)]
+struct PeerHeights {
+    claim: Option<Arc<BlockHeader>>,
+    verified_height: Option<BlockHeight>,
+}
+
+impl PeerHeights {
+    fn known_height(&self) -> Option<BlockHeight> {
+        self.claim.as_ref().map(|claim| claim.height()).max(self.verified_height)
+    }
+
+    fn record_verified_height(&mut self, height: BlockHeight) {
+        self.verified_height = Some(self.verified_height.map_or(height, |known| known.max(height)));
+    }
+}
 
 /// Highest block height each peer is *verified* to have reached, via a relayed
 /// block whose approvals we checked against a known epoch's validators (>2/3
-/// stake).
+/// stake). Relayed headers stay unchecked until the sync decision needs one.
 pub struct VerifiedPeerHeights {
-    by_peer: HashMap<PeerId, BlockHeight>,
+    by_peer: HashMap<PeerId, PeerHeights>,
     /// Headers whose approvals already verified; bounds the signature checks
     /// to one pass per distinct header, however many peers relay or replay it.
+    /// Failures are not recorded: the verifier also reports one when the header's epoch is
+    /// merely unknown, so remembering it would reject a valid far-ahead header for good once
+    /// sync makes that epoch known. `MAX_CHECKS_PER_STEP` bounds the cost of rechecking.
     verified_header_hashes: LruCache<CryptoHash, ()>,
 }
 
@@ -25,36 +57,114 @@ impl Default for VerifiedPeerHeights {
 }
 
 impl VerifiedPeerHeights {
-    /// Record `height` for `peer_id` if the header is verified: by an earlier
-    /// call, or established now by `verify_approvals` (invoked at most once
-    /// per distinct header). Keeps the highest height per peer.
-    pub fn record_if_verified(
-        &mut self,
-        peer_id: &PeerId,
-        header_hash: &CryptoHash,
-        height: BlockHeight,
-        verify_approvals: impl FnOnce() -> bool,
-    ) {
-        if self.get(peer_id).is_some_and(|verified| verified >= height) {
-            return;
-        }
-        if !self.verified_header_hashes.contains(header_hash) {
-            if !verify_approvals() {
+    /// Keeps the highest header per peer, and none at or below what we already know.
+    pub fn note_claim(&mut self, peer_id: &PeerId, header: &BlockHeader) {
+        let height = header.height();
+        if let Some(peer) = self.by_peer.get(peer_id) {
+            if peer.known_height().is_some_and(|known| known >= height) {
                 return;
             }
-            self.verified_header_hashes.put(*header_hash, ());
+        } else if !self.evict_lowest_peer_below(height) {
+            return;
         }
-        self.by_peer.insert(peer_id.clone(), height);
+        self.by_peer.entry(peer_id.clone()).or_default().claim = Some(Arc::new(header.clone()));
     }
 
-    pub fn get(&self, peer_id: &PeerId) -> Option<BlockHeight> {
-        self.by_peer.get(peer_id).copied()
+    /// Frees a slot for a peer we have not seen, by dropping the lowest claim when it is lower than
+    /// the incoming one. Returns whether a slot is available.
+    fn evict_lowest_peer_below(&mut self, height: BlockHeight) -> bool {
+        if self.by_peer.len() < MAX_PEER_CLAIMS {
+            return true;
+        }
+        let lowest = self
+            .by_peer
+            .iter()
+            .filter_map(|(peer_id, peer)| Some((peer.known_height()?, peer_id)))
+            .min();
+        let Some((lowest_height, lowest_peer)) = lowest else {
+            return false;
+        };
+        if lowest_height >= height {
+            return false;
+        }
+        let lowest_peer = lowest_peer.clone();
+        self.by_peer.remove(&lowest_peer);
+        true
     }
 
-    /// Entries at or below our head can't indicate a peer ahead of us; pruning
-    /// them bounds the map as the head advances and peers churn.
+    /// A height at or below `head_height` can't show a peer ahead of us, so it reads
+    /// as absent however long it stays in the map.
+    pub fn get_above(&self, peer_id: &PeerId, head_height: BlockHeight) -> Option<BlockHeight> {
+        self.by_peer.get(peer_id)?.verified_height.filter(|height| *height > head_height)
+    }
+
+    #[cfg(test)]
+    fn has_claim_above(&self, min_height: BlockHeight) -> bool {
+        self.highest_claim_above(min_height).is_some()
+    }
+
+    fn highest_claim_above(&self, min_height: BlockHeight) -> Option<Arc<BlockHeader>> {
+        self.by_peer
+            .values()
+            .filter_map(|peer| peer.claim.as_ref())
+            .filter(|header| header.height() > min_height)
+            .max_by_key(|header| header.height())
+            .cloned()
+    }
+
+    /// Settles every claim on this header: one outcome answers all of them.
+    fn settle_claims(&mut self, header_hash: &CryptoHash, height: BlockHeight, passed: bool) {
+        self.by_peer.retain(|_, peer| {
+            if peer.claim.as_ref().is_some_and(|claim| claim.hash() == header_hash) {
+                peer.claim = None;
+                if passed {
+                    peer.record_verified_height(height);
+                }
+            }
+            peer.claim.is_some() || peer.verified_height.is_some()
+        });
+    }
+
+    /// Settles claims above `min_height`, highest first, and stops at the first that
+    /// passes. Walking past a failed claim keeps a bogus high claim from hiding an
+    /// honest lower one. A header that already passed costs nothing to settle again, so
+    /// only fresh checks count against `MAX_CHECKS_PER_STEP`.
+    pub fn check_claims_until_verified(
+        &mut self,
+        min_height: BlockHeight,
+        mut check_approvals: impl FnMut(&BlockHeader) -> bool,
+    ) {
+        let mut checks = 0;
+        while let Some(header) = self.highest_claim_above(min_height) {
+            let mut passed = self.verified_header_hashes.contains(header.hash());
+            if !passed {
+                if checks == MAX_CHECKS_PER_STEP {
+                    return;
+                }
+                checks += 1;
+                passed = check_approvals(&header);
+                if passed {
+                    self.verified_header_hashes.put(*header.hash(), ());
+                }
+            }
+            self.settle_claims(header.hash(), header.height(), passed);
+            if passed {
+                return;
+            }
+        }
+    }
+
+    /// Bounds the map as the head advances and peers churn.
     pub fn prune_at_or_below(&mut self, height: BlockHeight) {
-        self.by_peer.retain(|_, recorded| *recorded > height);
+        self.by_peer.retain(|_, peer| {
+            if peer.claim.as_ref().is_some_and(|claim| claim.height() <= height) {
+                peer.claim = None;
+            }
+            if peer.verified_height.is_some_and(|verified| verified <= height) {
+                peer.verified_height = None;
+            }
+            peer.claim.is_some() || peer.verified_height.is_some()
+        });
     }
 }
 
@@ -62,61 +172,223 @@ impl VerifiedPeerHeights {
 mod tests {
     use super::*;
     use near_crypto::{KeyType, SecretKey};
+    use near_primitives::block_header::{BlockHeaderInnerLiteV2, BlockHeaderV7};
 
     fn peer(seed: &str) -> PeerId {
         PeerId::new(SecretKey::from_seed(KeyType::ED25519, seed).public_key())
     }
 
-    fn header_hash(seed: &[u8]) -> CryptoHash {
-        CryptoHash::hash_bytes(seed)
+    /// `seed` only varies the hash, so two claims at one height stay distinct.
+    fn header(height: BlockHeight, seed: u64) -> Arc<BlockHeader> {
+        let inner_lite = BlockHeaderInnerLiteV2 { height, timestamp: seed, ..Default::default() };
+        let mut header = BlockHeaderV7 { inner_lite, ..Default::default() };
+        header.init();
+        Arc::new(BlockHeader::BlockHeaderV7(header))
+    }
+
+    fn check_all(heights: &mut VerifiedPeerHeights, passed: bool) {
+        heights.check_claims_until_verified(0, |_| passed);
     }
 
     #[test]
-    fn record_keeps_max_height_per_peer() {
+    fn note_claim_is_accepted_after_every_claim_settled_as_failed() {
+        let mut heights = VerifiedPeerHeights::default();
+        for index in 0..MAX_PEER_CLAIMS {
+            heights.note_claim(&peer(&format!("p{index}")), &header(100 + index as u64, 1));
+        }
+        for _ in 0..MAX_PEER_CLAIMS {
+            check_all(&mut heights, false);
+        }
+        assert!(heights.by_peer.is_empty());
+        let newcomer = peer("newcomer");
+        heights.note_claim(&newcomer, &header(50, 2));
+        assert!(heights.by_peer.contains_key(&newcomer));
+    }
+
+    #[test]
+    fn note_claim_evicts_the_lowest_peer_when_the_map_is_full() {
+        let mut heights = VerifiedPeerHeights::default();
+        for index in 0..MAX_PEER_CLAIMS {
+            heights.note_claim(&peer(&format!("p{index}")), &header(100 + index as u64, 1));
+        }
+        let lowest = peer("p0");
+        let newcomer = peer("newcomer");
+        heights.note_claim(&newcomer, &header(500, 2));
+        assert_eq!(heights.by_peer.len(), MAX_PEER_CLAIMS);
+        assert!(!heights.by_peer.contains_key(&lowest));
+        assert!(heights.by_peer.contains_key(&newcomer));
+    }
+
+    #[test]
+    fn note_claim_refuses_a_claim_below_every_peer_when_the_map_is_full() {
+        let mut heights = VerifiedPeerHeights::default();
+        for index in 0..MAX_PEER_CLAIMS {
+            heights.note_claim(&peer(&format!("p{index}")), &header(100 + index as u64, 1));
+        }
+        let newcomer = peer("newcomer");
+        heights.note_claim(&newcomer, &header(50, 2));
+        assert_eq!(heights.by_peer.len(), MAX_PEER_CLAIMS);
+        assert!(!heights.by_peer.contains_key(&newcomer));
+    }
+
+    #[test]
+    fn note_claim_keeps_highest_per_peer() {
         let mut heights = VerifiedPeerHeights::default();
         let p = peer("a");
-        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || true);
-        heights.record_if_verified(&p, &header_hash(b"h5"), 5, || true);
-        assert_eq!(heights.get(&p), Some(10));
+        heights.note_claim(&p, &header(10, 1));
+        heights.note_claim(&p, &header(5, 2));
+        check_all(&mut heights, true);
+        assert_eq!(heights.get_above(&p, 0), Some(10));
     }
 
     #[test]
-    fn failed_verification_records_nothing() {
+    fn highest_claim_above_min_height_is_checked_first() {
         let mut heights = VerifiedPeerHeights::default();
-        let p = peer("a");
-        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || false);
-        assert_eq!(heights.get(&p), None);
-    }
-
-    #[test]
-    fn known_header_skips_verification() {
-        let mut heights = VerifiedPeerHeights::default();
-        let (p1, p2) = (peer("a"), peer("b"));
-        let hash = header_hash(b"h10");
-        heights.record_if_verified(&p1, &hash, 10, || true);
-        heights.record_if_verified(&p2, &hash, 10, || panic!("must not re-verify"));
-        assert_eq!(heights.get(&p2), Some(10));
-    }
-
-    #[test]
-    fn already_verified_height_skips_verification() {
-        let mut heights = VerifiedPeerHeights::default();
-        let p = peer("a");
-        heights.record_if_verified(&p, &header_hash(b"h10"), 10, || true);
-        heights.record_if_verified(&p, &header_hash(b"other"), 10, || {
-            panic!("must not verify below already verified height")
+        heights.note_claim(&peer("a"), &header(10, 1));
+        heights.note_claim(&peer("b"), &header(30, 2));
+        heights.note_claim(&peer("c"), &header(20, 3));
+        let mut checked = Vec::new();
+        heights.check_claims_until_verified(10, |header| {
+            checked.push(header.height());
+            false
         });
-        assert_eq!(heights.get(&p), Some(10));
+        assert_eq!(checked, vec![30, 20]);
     }
 
     #[test]
-    fn prune_at_or_below_drops_caught_up_entries() {
+    fn check_stops_at_the_first_claim_that_passes() {
+        let mut heights = VerifiedPeerHeights::default();
+        let (p1, p2, p3) = (peer("a"), peer("b"), peer("c"));
+        heights.note_claim(&p1, &header(30, 1));
+        heights.note_claim(&p2, &header(20, 2));
+        heights.note_claim(&p3, &header(10, 3));
+        heights.check_claims_until_verified(0, |header| match header.height() {
+            20 => true,
+            _ => false,
+        });
+        assert_eq!(heights.get_above(&p2, 0), Some(20));
+        assert_eq!(heights.get_above(&p1, 0), None);
+        assert!(heights.has_claim_above(0), "the claim at 10 is still unchecked");
+    }
+
+    #[test]
+    fn one_check_verifies_every_peer_that_relayed_the_header() {
         let mut heights = VerifiedPeerHeights::default();
         let (p1, p2) = (peer("a"), peer("b"));
-        heights.record_if_verified(&p1, &header_hash(b"h10"), 10, || true);
-        heights.record_if_verified(&p2, &header_hash(b"h20"), 20, || true);
+        let claim = header(10, 1);
+        heights.note_claim(&p1, &claim);
+        heights.note_claim(&p2, &claim);
+        let mut checks = 0;
+        heights.check_claims_until_verified(0, |_| {
+            checks += 1;
+            true
+        });
+        assert_eq!(checks, 1);
+        assert_eq!(heights.get_above(&p1, 0), Some(10));
+        assert_eq!(heights.get_above(&p2, 0), Some(10));
+    }
+
+    #[test]
+    fn failed_check_leaves_the_peer_unverified_and_drops_the_claim() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        heights.note_claim(&p, &header(10, 1));
+        check_all(&mut heights, false);
+        assert_eq!(heights.get_above(&p, 0), None);
+        assert!(!heights.has_claim_above(0));
+    }
+
+    #[test]
+    fn check_claims_until_verified_rechecks_a_header_that_failed() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        let mut checks = 0;
+        for _ in 0..2 {
+            heights.note_claim(&p, &header(10, 1));
+            heights.check_claims_until_verified(0, |_| {
+                checks += 1;
+                false
+            });
+        }
+        assert_eq!(
+            checks, 2,
+            "a failure must not be remembered: the epoch may just be unknown yet"
+        );
+    }
+
+    #[test]
+    fn check_claims_until_verified_skips_a_header_that_passed() {
+        let mut heights = VerifiedPeerHeights::default();
+        let mut checks = 0;
+        for seed in 0..2 {
+            heights.note_claim(&peer(&format!("p{seed}")), &header(10, 1));
+            heights.check_claims_until_verified(0, |_| {
+                checks += 1;
+                true
+            });
+        }
+        assert_eq!(checks, 1);
+    }
+
+    #[test]
+    fn higher_claim_keeps_the_height_we_already_verified() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        heights.note_claim(&p, &header(10, 1));
+        check_all(&mut heights, true);
+        heights.note_claim(&p, &header(11, 2));
+        assert_eq!(heights.get_above(&p, 0), Some(10));
+        check_all(&mut heights, true);
+        assert_eq!(heights.get_above(&p, 0), Some(11));
+    }
+
+    #[test]
+    fn failed_higher_claim_keeps_the_height_we_already_verified() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        heights.note_claim(&p, &header(10, 1));
+        check_all(&mut heights, true);
+        heights.note_claim(&p, &header(11, 2));
+        check_all(&mut heights, false);
+        assert_eq!(heights.get_above(&p, 0), Some(10));
+    }
+
+    #[test]
+    fn get_above_hides_a_claim_at_or_below_our_head() {
+        let mut heights = VerifiedPeerHeights::default();
+        let p = peer("a");
+        heights.note_claim(&p, &header(10, 1));
+        check_all(&mut heights, true);
+        assert_eq!(heights.get_above(&p, 9), Some(10));
+        assert_eq!(heights.get_above(&p, 10), None);
+    }
+
+    #[test]
+    fn one_step_checks_at_most_max_checks_per_step_claims() {
+        let mut heights = VerifiedPeerHeights::default();
+        for index in 0..MAX_CHECKS_PER_STEP + 2 {
+            heights.note_claim(&peer(&index.to_string()), &header(10 + index as u64, index as u64));
+        }
+        let mut checks = 0;
+        heights.check_claims_until_verified(0, |_| {
+            checks += 1;
+            false
+        });
+        assert_eq!(checks, MAX_CHECKS_PER_STEP);
+        assert!(heights.has_claim_above(0), "the rest wait for the next step");
+    }
+
+    #[test]
+    fn prune_at_or_below_drops_caught_up_claims() {
+        let mut heights = VerifiedPeerHeights::default();
+        let (p1, p2) = (peer("a"), peer("b"));
+        heights.note_claim(&p1, &header(10, 1));
+        check_all(&mut heights, true);
+        heights.note_claim(&p2, &header(20, 2));
+        check_all(&mut heights, true);
+        assert_eq!(heights.get_above(&p1, 0), Some(10));
         heights.prune_at_or_below(10);
-        assert_eq!(heights.get(&p1), None);
-        assert_eq!(heights.get(&p2), Some(20));
+        assert_eq!(heights.get_above(&p1, 0), None);
+        assert_eq!(heights.get_above(&p2, 0), Some(20));
     }
 }

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -26,6 +26,26 @@ periodically in the client actor — if the node is behind by more than
 The sync handler classifies the node into one of two categories based on how
 far behind it is, and routes it through the appropriate path.
 
+### Picking the target height
+
+The height to sync to comes from a peer, and a claim is acted on only once its
+approvals verify against a known epoch's validators (>2/3 stake). That check is
+a pass over about 100 signatures, so the node runs it at the sync step rather
+than when the block arrives; the relay path only records which header a peer
+claimed.
+
+Each step checks the claims that could start sync, highest first, and stops at
+the first that passes, since that is the only claim the decision needs. It walks
+past a claim that fails, so a bogus high claim cannot hide an honest lower one,
+and a peer whose claim failed is passed over for a few steps so it cannot take
+every check. Only a few checks run per step, which bounds the signature work by
+time rather than by how many blocks peers send.
+
+A peer with no proved height reads as level with our head: still a candidate to
+download from, never the target. Once the head has not advanced for about one
+epoch the node falls back to the unvalidated claimed heights, since the
+validator sets it knows no longer cover the tip.
+
 ### The two horizons
 
 ```

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -37,9 +37,12 @@ claimed.
 Each step checks the claims that could start sync, highest first, and stops at
 the first that passes, since that is the only claim the decision needs. It walks
 past a claim that fails, so a bogus high claim cannot hide an honest lower one,
-and a peer whose claim failed is passed over for a few steps so it cannot take
-every check. Only a few checks run per step, which bounds the signature work by
-time rather than by how many blocks peers send.
+and a peer whose claim failed sorts below every peer that has not failed, however
+high it claims, until one of its headers passes. Without that a few peers claiming
+ever higher heights would take every check. Only a few checks run per step, which
+bounds the signature work by time rather than by how many blocks peers send. Only
+claims from connected peers are checked, since no other peer can be chosen to sync
+from.
 
 A peer with no proved height reads as level with our head: still a candidate to
 download from, never the target. Once the head has not advanced for about one


### PR DESCRIPTION
#16133 made sync target selection depend on approval-verified peer heights, and the check runs in the `BlockResponse` handler for every relayed block above our head: one pass over about 100 approval signatures, on the client actor. Most of those passes cannot change any decision, and the peer chooses when we run them.

This moves the check to the sync step. The relay path only records which header a peer claimed, with no signature work. Each sync step then checks the claims that could start sync, highest first, and stops at the first that passes, since that is the only claim the decision needs. At most `MAX_CHECKS_PER_STEP` fresh checks run per step.

Ordering by claimed height alone is not safe, because the peer picks that number. So a peer whose claim fails a check sorts below every peer that has not failed, however high it claims, until a header it holds passes. Without that, a few peers claiming ever higher heights take every check and a lower honest claim is never proved. The demotion costs position, not silence: a demoted peer is still checked once the others are done, and a peer relaying the real tip alongside everyone else is cleared by the same check that proves that tip. An honest peer whose claim failed only because we did not know its epoch yet therefore recovers on its own.

- A failed claim is walked past, so a bogus high claim cannot hide an honest lower one.
- A header that passes is remembered, so one check answers every peer that relayed it. A failure is not remembered: the verifier also reports one when the header's epoch is simply not known yet, and caching that would reject a valid far-ahead header for good.
- A peer with no proved height reads as level with our head, so it stays a candidate to download from but never sets the target.
- Claims are proved only when the decision can use them. The stale-head path picks its target from the unverified claimed heights, so verification is skipped there and the claims are proved once the head is recent again. That also removes most of the cost during a long sync, since a far-behind node is the one running on `sync_step_period`.
- Only claims from connected peers are checked. No other peer can be chosen to sync from, so proving one would spend a check the decision discards and could end the step on a pass that decides nothing.
- The claim map is capped at `MAX_PEER_CLAIMS`. A claim now holds a header, and any peer can add one without proving anything.

Deferring the check does not delay the decision. Verification runs at the top of `run_sync_step`, right before `syncing_info`, so a claim is proved in the same step that uses it; master proves it earlier but still cannot act until that step.

Measured with a temporary counter around the approval pass, master -> this branch:

- `examples::basic::test_basic_token_transfer` (steady state, no sync): 18 -> 0
- `tests::sync::far_horizon::test_far_horizon_restart_during_block_sync`: 364 -> 2
- `tests::sync::far_horizon::test_far_horizon_full_pipeline`: 517 -> 2

This is an alternative to #16266 rather than a follow-up: both rewrite `note_verified_peer_height`. #16266 skips claims that cannot start sync, which removes the passes honest traffic generates but leaves the cost set by how many blocks peers send. This also decides when the work happens. If #16266 lands first, this needs rebasing on top of it.

Not done here: while a claim is waiting, the sync step still runs on `sync_check_period` (10s), so working through several failing claims takes several steps. Shortening the period while claims are pending would drain them faster, and is a separate change.

