### PR TITLE
perf(state-sync): download parts unordered to avoid head-of-line blocking

### DIFF
--- a/chain/client/src/sync/state/downloader.rs
+++ b/chain/client/src/sync/state/downloader.rs
@@ -1,7 +1,7 @@
 use super::StateSyncDownloadSource;
 use super::chain_requests::StateHeaderValidationRequest;
 use super::task_tracker::TaskTracker;
-use super::util::get_state_header_if_exists_in_storage;
+use super::util::{get_state_header_if_exists_in_storage, increment_download_count};
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use near_async::messaging::AsyncSender;
@@ -186,6 +186,7 @@ impl StateSyncDownloader {
                     store_update.set(DBCol::StateParts, &key, &bytes);
                     store_update.commit();
                 } else {
+                    increment_download_count(shard_id, "part", "network", "validation_failed");
                     return Err(near_chain::Error::Other("Part data failed validation".to_owned()));
                 }
                 Ok(())

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -129,6 +129,9 @@ pub(super) async fn run_state_sync_for_shard(
                     total: num_parts,
                 };
             })
+            .inspect_err(|(part_id, err)| {
+                tracing::debug!(target: "sync", ?shard_id, part_id, ?err, "state part download failed");
+            })
             .collect::<Vec<_>>()
             .await;
         // Update the list of parts_to_download retaining only the ones that failed.

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -116,19 +116,18 @@ pub(super) async fn run_state_sync_for_shard(
                 );
                 let future =
                     respawn_for_parallelism(&*future_spawner, "state sync download part", future);
-                // Results arrive in completion order, so the part id can't be recovered from the
-                // position in the output and must be carried along.
-                async move { (part_id, future.await) }
+                // Results arrive in completion order, so the part id can't be recovered from
+                // the position in the output. Carry it in the error, the only branch that
+                // needs it, so the stream stays a `TryStream`.
+                async move { future.await.map_err(|err| (part_id, err)) }
             })
             .buffer_unordered(concurrency_limit.into())
-            .inspect(|(_, res)| {
-                if res.is_ok() {
-                    parts_downloaded += 1;
-                    *status.lock() = ShardSyncStatus::StateDownloadParts {
-                        done: parts_downloaded,
-                        total: num_parts,
-                    };
-                }
+            .inspect_ok(|_| {
+                parts_downloaded += 1;
+                *status.lock() = ShardSyncStatus::StateDownloadParts {
+                    done: parts_downloaded,
+                    total: num_parts,
+                };
             })
             .collect::<Vec<_>>()
             .await;
@@ -136,7 +135,7 @@ pub(super) async fn run_state_sync_for_shard(
         // Failed single attempts already wait `retry_backoff` inside the downloader
         // before returning, so the next round is paced without an extra delay here.
         parts_to_download =
-            results.into_iter().filter_map(|(part_id, res)| res.err().map(|_| part_id)).collect();
+            results.into_iter().filter_map(|res| res.err().map(|(part_id, _)| part_id)).collect();
     }
 
     return_if_cancelled!(cancel);

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -101,6 +101,9 @@ pub(super) async fn run_state_sync_for_shard(
     }
     while !parts_to_download.is_empty() {
         return_if_cancelled!(cancel);
+        // `buffer_unordered`, not `buffered`: the latter holds completed futures in their slots
+        // until all earlier ones yield, so one part stuck until the p2p timeout would block new
+        // requests and drop this shard's parallelism to one. Download order carries no meaning.
         let results = tokio_stream::iter(parts_to_download.clone())
             .map(|part_id| {
                 let future = downloader.ensure_shard_part_downloaded_single_attempt(
@@ -111,28 +114,29 @@ pub(super) async fn run_state_sync_for_shard(
                     part_id,
                     cancel.clone(),
                 );
-                respawn_for_parallelism(&*future_spawner, "state sync download part", future)
+                let future =
+                    respawn_for_parallelism(&*future_spawner, "state sync download part", future);
+                // Results arrive in completion order, so the part id can't be recovered from the
+                // position in the output and must be carried along.
+                async move { (part_id, future.await) }
             })
-            .buffered(concurrency_limit.into())
-            .inspect_ok(|_| {
-                parts_downloaded += 1;
-                *status.lock() = ShardSyncStatus::StateDownloadParts {
-                    done: parts_downloaded,
-                    total: num_parts,
-                };
+            .buffer_unordered(concurrency_limit.into())
+            .inspect(|(_, res)| {
+                if res.is_ok() {
+                    parts_downloaded += 1;
+                    *status.lock() = ShardSyncStatus::StateDownloadParts {
+                        done: parts_downloaded,
+                        total: num_parts,
+                    };
+                }
             })
             .collect::<Vec<_>>()
             .await;
         // Update the list of parts_to_download retaining only the ones that failed.
         // Failed single attempts already wait `retry_backoff` inside the downloader
         // before returning, so the next round is paced without an extra delay here.
-        parts_to_download = results
-            .iter()
-            .enumerate()
-            .filter_map(|(task_index, res)| {
-                res.as_ref().err().map(|_| parts_to_download[task_index])
-            })
-            .collect();
+        parts_to_download =
+            results.into_iter().filter_map(|(part_id, res)| res.err().map(|_| part_id)).collect();
     }
 
     return_if_cancelled!(cancel);


### PR DESCRIPTION
`buffered` yields in submission order: one part stuck on an unresponsive peer freezes the shard's other slots, dropping in-flight requests from `per_shard` to 1 for up to 11s (`state_sync_p2p_timeout` + `state_sync_retry_backoff`).

`buffer_unordered` refills a slot as soon as any request completes. Ordering is irrelevant here since parts are shuffled anyway, and the apply loop already uses it.