### PR TITLE
chore(early-kickout): make ChunkProducers a stable column family (DB 49 -> 50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,6 +5166,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
+ "strum",
  "tempfile",
  "testlib",
  "thiserror 2.0.18",

--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -16,8 +16,8 @@ pub enum CloudArchivalReaderError {
 
 /// Writes block-level columns from a cloud `BlockData` into `update`.
 ///
-/// Block, BlockHeader, BlockInfo (content-addressed by hash) and, on nightly,
-/// ChunkProducers all use `insert_ser` (insert-only columns). BlockHeight and
+/// Block, BlockHeader, BlockInfo (content-addressed by hash) and ChunkProducers
+/// all use `insert_ser` (insert-only columns). BlockHeight and
 /// BlockMerkleTree use `set_ser` (regular columns, keyed by height or hash, safe
 /// to overwrite).
 pub fn save_block_data(update: &mut StoreUpdate, block_data: &BlockData) {
@@ -32,7 +32,6 @@ pub fn save_block_data(update: &mut StoreUpdate, block_data: &BlockData) {
     update.set_ser(DBCol::BlockHeight, &index_to_bytes(height), &block_hash);
     update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_data.block_merkle_tree());
 
-    #[cfg(feature = "nightly")]
     for (shard_id, stake) in block_data.chunk_producers() {
         update.insert_ser(
             DBCol::ChunkProducers,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -2320,8 +2320,8 @@ impl EpochManager {
         shard_layout: &ShardLayout,
         prev_hash: &CryptoHash,
     ) -> Option<HashMap<ShardId, ValidatorId>> {
-        // `DBCol::ChunkProducers` only exists under nightly (as does an enabled
-        // EarlyKickout); stable always uses the legacy sampler.
+        // The aggregator's access to `DBCol::ChunkProducers` stays nightly-gated (an
+        // enabled EarlyKickout is nightly-only); stable always uses the legacy sampler.
         #[cfg(feature = "nightly")]
         {
             use near_primitives::utils::get_block_shard_id;

--- a/core/store/src/archive/cloud_storage/blocks.rs
+++ b/core/store/src/archive/cloud_storage/blocks.rs
@@ -32,7 +32,7 @@ pub struct BlockDataV1 {
     /// Read from `DBCol::BlockMerkleTree`.
     block_merkle_tree: PartialMerkleTree,
     /// Rows of `DBCol::ChunkProducers` for this block, keyed by shard_id; empty
-    /// when EarlyKickout/nightly is off.
+    /// until EarlyKickout activates.
     chunk_producers: Vec<(ShardId, ValidatorStake)>,
 }
 
@@ -64,7 +64,6 @@ pub fn build_block_data(
     Ok(Some(BlockData::V1(block_data)))
 }
 
-#[cfg(feature = "nightly")]
 fn read_chunk_producers(
     store: &Store,
     block_hash: &CryptoHash,
@@ -82,14 +81,6 @@ fn read_chunk_producers(
             Ok((shard_id, stake))
         })
         .collect()
-}
-
-#[cfg(not(feature = "nightly"))]
-fn read_chunk_producers(
-    _store: &Store,
-    _block_hash: &CryptoHash,
-) -> Result<Vec<(ShardId, ValidatorStake)>, Error> {
-    Ok(Vec::new())
 }
 
 impl BlockData {

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -144,11 +144,6 @@ fn block_on_future<F: Future>(fut: F) -> F::Output {
 
 /// Columns the cloud-archive reader reproduces from cloud data.
 pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
-    // From BlockData.
-    #[cfg(feature = "nightly")]
-    if col == DBCol::ChunkProducers {
-        return true;
-    }
     matches!(
         col,
         // From BlockData.
@@ -156,6 +151,7 @@ pub fn is_cloud_archive_reader_bootstrapped(col: DBCol) -> bool {
             | DBCol::BlockInfo
             | DBCol::NextBlockHashes
             | DBCol::BlockMerkleTree
+            | DBCol::ChunkProducers
             // Reconstructed from BlockData.
             | DBCol::BlockHeader
             | DBCol::BlockHeight

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -140,8 +140,7 @@ pub fn update_cold_db(
 }
 
 // Copy ChunkProducers by prefix-scan on the block hash. Returns Some(result) if it
-// handled `col`, else None. The nightly-only DBCol variant is confined to this fn.
-#[cfg(feature = "nightly")]
+// handled `col`, else None.
 fn maybe_copy_chunk_producers(
     col: DBCol,
     cold_db: &ColdDB,
@@ -165,16 +164,6 @@ fn maybe_copy_chunk_producers(
     }
     cold_db.write(transaction);
     Some(Ok(()))
-}
-
-#[cfg(not(feature = "nightly"))]
-fn maybe_copy_chunk_producers(
-    _col: DBCol,
-    _cold_db: &ColdDB,
-    _hot_store: &Store,
-    _block_hash_key: &[u8],
-) -> Option<io::Result<()>> {
-    None
 }
 
 // Correctly set the key and value on DBTransaction, taking reference counting

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -414,15 +414,12 @@ pub enum DBCol {
     #[cfg(feature = "protocol_feature_spice")]
     SpiceInvalidChunks,
     /// Pre-computed chunk producer for the chunk anchored at the given block (its
-    /// grandparent), sampled at height `anchor.height+2` in the epoch after the anchor.
-    /// Populated during header sync and block processing, gated behind `EarlyKickout`
-    /// protocol feature. Authoritative source for historical chunk producer lookups.
+    /// grandparent), sampled at height `anchor.height+2` in the anchor's own epoch.
+    /// The column family exists on every build, but rows are only populated (during
+    /// header sync and block processing) once the `EarlyKickout` protocol feature is
+    /// active. Authoritative source for historical chunk producer lookups.
     /// - *Rows*: BlockHash || ShardId (anchor_block_hash, shard_id) — 40 bytes
     /// - *Content type*: [near_primitives::types::validator_stake::ValidatorStake]
-    // TODO(early-kickout): bump DB_VERSION before moving to stable so that
-    // older databases get a proper migration and read-only opens don't fail on the
-    // missing column family.
-    #[cfg(feature = "nightly")]
     ChunkProducers,
 }
 
@@ -512,7 +509,6 @@ impl DBCol {
             | DBCol::SpiceEndorsementStats
             | DBCol::SpiceInvalidChunks
             | DBCol::ChunkCertifyingBlock => true,
-            #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => true,
             _ => false,
         }
@@ -687,7 +683,6 @@ impl DBCol {
             | DBCol::StateSyncHashes
             | DBCol::StateSyncNewChunks
             => false,
-            #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => true,
         }
     }
@@ -784,7 +779,6 @@ impl DBCol {
             // GC'd with the anchor block/header it belongs to: a row for anchor A is dropped
             // once A falls below the GC boundary, far below the near-head consensus read
             // horizon (a chunk's grandparent anchor is head-2), so no live read is lost.
-            #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => GcPolicy::Delete,
         }
     }
@@ -890,7 +884,6 @@ impl DBCol {
             DBCol::ChunkCertifyingBlock => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::SpiceInvalidChunks => &[DBKeyType::BlockHeight, DBKeyType::ChunkHash],
-            #[cfg(feature = "nightly")]
             DBCol::ChunkProducers => &[DBKeyType::BlockHash, DBKeyType::ShardId],
         }
     }

--- a/core/store/src/db/metadata.rs
+++ b/core/store/src/db/metadata.rs
@@ -1,11 +1,8 @@
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
-
 /// Database version type.
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion =
-    if ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) { 49 } else { 48 };
+pub const DB_VERSION: DbVersion = 50;
 
 /// Minimum supported database version. This is a property of the current binary.
 pub const MIN_SUPPORTED_DB_VERSION: DbVersion = 45;

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -15,6 +15,7 @@ use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction,
 };
 use near_primitives::types::{Balance, Gas};
+use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::AccountId;
 use near_store::archive::cold_storage::{
@@ -224,8 +225,9 @@ fn test_storage_after_commit_of_cold_update() {
             col == DBCol::StateChangesForSplitStates
                 || col == DBCol::StateHeaders
                 || col == DBCol::StateShardUIdMapping
-                // Stays empty until EarlyKickout activates.
-                || col == DBCol::ChunkProducers
+                // Empty until EarlyKickout activates.
+                || (col == DBCol::ChunkProducers
+                    && !ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION))
                 || num_checks > 0
         );
     }
@@ -373,8 +375,9 @@ fn test_cold_db_copy_with_height_skips() {
                 col == DBCol::StateChangesForSplitStates
                     || col == DBCol::StateHeaders
                     || col == DBCol::StateShardUIdMapping
-                    // Stays empty until EarlyKickout activates.
-                    || col == DBCol::ChunkProducers
+                    // Empty until EarlyKickout activates.
+                    || (col == DBCol::ChunkProducers
+                        && !ProtocolFeature::EarlyKickout.enabled(PROTOCOL_VERSION))
                     || num_checks > 0
             );
         }

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -224,6 +224,8 @@ fn test_storage_after_commit_of_cold_update() {
             col == DBCol::StateChangesForSplitStates
                 || col == DBCol::StateHeaders
                 || col == DBCol::StateShardUIdMapping
+                // Stays empty until EarlyKickout activates.
+                || col == DBCol::ChunkProducers
                 || num_checks > 0
         );
     }
@@ -371,6 +373,8 @@ fn test_cold_db_copy_with_height_skips() {
                 col == DBCol::StateChangesForSplitStates
                     || col == DBCol::StateHeaders
                     || col == DBCol::StateShardUIdMapping
+                    // Stays empty until EarlyKickout activates.
+                    || col == DBCol::ChunkProducers
                     || num_checks > 0
             );
         }

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -67,6 +67,7 @@ near-chain-primitives.workspace = true
 
 [dev-dependencies]
 near-time.workspace = true
+strum.workspace = true
 zstd.workspace = true
 bencher.workspace = true
 primitive-types.workspace = true

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -536,7 +536,17 @@ mod tests {
     ///
     /// Hot store only. The cold store follows the same version gate but is not covered
     /// here.
+    ///
+    /// Stable builds only. On nightly, `StoreOpener::ensure_version` overwrites the
+    /// freshly migrated version with the 10000 sentinel, and `open_dbs` then reopens
+    /// expecting `DB_VERSION`, so the migrating open fails. That applies to every
+    /// version bump, not just this one, so there is no nightly upgrade path here to
+    /// assert against.
     #[test]
+    #[cfg_attr(
+        feature = "nightly",
+        ignore = "nightly overwrites the migrated version with the 10000 sentinel, so the migrating open fails"
+    )]
     fn slow_test_migration_49_to_50_creates_chunk_producers_column() {
         // A fresh database is created at DB_VERSION with every column family present,
         // so build the version-49 shape by stamping the old version and then dropping

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -578,7 +578,7 @@ mod tests {
             panic!("read-only open of a v49 database without the column family must fail");
         };
         assert!(
-            err.to_string().contains("ChunkProducers"),
+            err.to_string().contains(<&str>::from(DBCol::ChunkProducers)),
             "expected a missing-column-family error, got: {err}"
         );
 

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -70,6 +70,7 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
                 self.config.config.cold_store.as_ref(),
                 is_snapshot,
             ),
+            49 => Ok(()), // DBCol::ChunkProducers column added, no need to perform a migration
             DB_VERSION.. => unreachable!(),
         }
     }
@@ -489,4 +490,109 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
     tracing::info!(target: "migrations", ?latest_known_height, "completed deletion of old block headers from hot store");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Migrator;
+    use crate::config::load_test_config;
+    use near_chain_configs::Genesis;
+    use near_network::tcp;
+    use near_store::db::ColdDB;
+    use near_store::db::metadata::{DB_VERSION, DbVersion};
+    use near_store::{DBCol, Mode, NodeStorage, Store, StoreConfig, StoreMigrator};
+    use std::cell::RefCell;
+    use strum::IntoEnumIterator;
+
+    /// Delegates to the real [`Migrator`] and records which versions it was asked to
+    /// migrate, so a test can assert the migration actually ran rather than that the
+    /// database happened to already be current.
+    struct RecordingMigrator<'a> {
+        inner: Migrator<'a>,
+        migrated: RefCell<Vec<DbVersion>>,
+    }
+
+    impl<'a> StoreMigrator for RecordingMigrator<'a> {
+        fn check_support(&self, version: DbVersion) -> Result<(), &'static str> {
+            self.inner.check_support(version)
+        }
+
+        fn migrate(
+            &self,
+            hot_store: &Store,
+            cold_db: Option<&ColdDB>,
+            version: DbVersion,
+            is_snapshot: bool,
+        ) -> anyhow::Result<()> {
+            self.migrated.borrow_mut().push(version);
+            self.inner.migrate(hot_store, cold_db, version, is_snapshot)
+        }
+    }
+
+    /// A version-49 database has no `DBCol::ChunkProducers` column family. Assert the
+    /// full upgrade path for such a database: a read-only open fails on the missing
+    /// column family, a read-write open migrates it to 50 and materializes the column,
+    /// and a read-only open then succeeds.
+    ///
+    /// Hot store only. The cold store follows the same version gate but is not covered
+    /// here.
+    #[test]
+    fn slow_test_migration_49_to_50_creates_chunk_producers_column() {
+        // A fresh database is created at DB_VERSION with every column family present,
+        // so build the version-49 shape by stamping the old version and then dropping
+        // the column family via a filtered checkpoint.
+        let (_hot_dir, hot_opener) = NodeStorage::test_opener();
+        let hot_storage = hot_opener.open().unwrap();
+        let hot_store = hot_storage.get_hot_store();
+        hot_store.set_db_version(49);
+
+        // Build the opener first: its resolved path is where the checkpoint has to land.
+        // `DBCol::DbVersion` stays in the keep-list so the checkpoint carries version 49
+        // forward.
+        let checkpoint_dir = tempfile::tempdir().unwrap();
+        let store_config = StoreConfig::test_config();
+        let checkpoint_opener =
+            NodeStorage::opener(checkpoint_dir.path(), &store_config, None, None);
+        let columns_to_keep: Vec<DBCol> =
+            DBCol::iter().filter(|&col| col != DBCol::ChunkProducers).collect();
+        hot_store
+            .database()
+            .create_checkpoint(checkpoint_opener.path(), Some(&columns_to_keep))
+            .unwrap();
+        drop(hot_storage);
+
+        // Read-only cannot create the missing column family. Assert on the message, not
+        // just on `is_err`: a wrong checkpoint path would fail with `DbDoesNotExist` and
+        // make the rest of this test vacuous.
+        let Err(err) = checkpoint_opener.open_in_mode(Mode::ReadOnly) else {
+            panic!("read-only open of a v49 database without the column family must fail");
+        };
+        assert!(
+            err.to_string().contains("ChunkProducers"),
+            "expected a missing-column-family error, got: {err}"
+        );
+
+        let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+        let near_config = load_test_config("test0", tcp::ListenerAddr::reserve_for_test(), genesis);
+        let migrator = RecordingMigrator {
+            inner: Migrator::new(&near_config, checkpoint_dir.path()),
+            migrated: RefCell::new(Vec::new()),
+        };
+        // `Mode::ReadWriteExisting`, not `Mode::ReadWrite`: the latter can create, so a
+        // wrong path would silently open a fresh DB already at DB_VERSION and every
+        // assertion below would pass without a migration having run.
+        let migrated_opener = NodeStorage::opener(checkpoint_dir.path(), &store_config, None, None)
+            .with_migrator(&migrator);
+        let migrated_storage = migrated_opener.open_in_mode(Mode::ReadWriteExisting).unwrap();
+        let migrated_store = migrated_storage.get_hot_store();
+        assert_eq!(migrated_store.get_db_version().unwrap(), DB_VERSION);
+        // The checkpoint really was at 49 and the `49 => Ok(())` arm really ran.
+        assert_eq!(migrator.migrated.borrow().as_slice(), &[49]);
+        // The column family now exists and is readable. It is empty until EarlyKickout
+        // activates.
+        assert_eq!(migrated_store.iter(DBCol::ChunkProducers).count(), 0);
+        drop(migrated_storage);
+
+        checkpoint_opener.open_in_mode(Mode::ReadOnly).unwrap();
+    }
 }

--- a/test-loop-tests/src/tests/sync/migration_epoch_sync_proof.rs
+++ b/test-loop-tests/src/tests/sync/migration_epoch_sync_proof.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 /// must seed a proof, not defer), then runs forward so the runtime extends it.
 #[test]
 fn test_migration_48_to_49_epoch_sync_proof_min_gc() {
-    // DB_VERSION 49 and the proof machinery only exist with ContinuousEpochSync.
+    // The 48 -> 49 proof machinery only exists with ContinuousEpochSync.
     if !ProtocolFeature::ContinuousEpochSync.enabled(PROTOCOL_VERSION) {
         return;
     }

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -827,8 +827,7 @@ fn writer_kvs(
             }
         }
         // ChunkProducers rows are keyed by block hash across all shards of the
-        // next epoch, so one prefix scan captures every row for this block.
-        #[cfg(feature = "nightly")]
+        // anchor's own epoch, so one prefix scan captures every row for this block.
         for (key, value) in writer.iter_prefix(DBCol::ChunkProducers, block_hash.as_ref()) {
             kvs.get_mut(&DBCol::ChunkProducers).unwrap().insert(key.into_vec(), value.into_vec());
         }


### PR DESCRIPTION
`DBCol::ChunkProducers` is the DB column behind Early Kickout. Today it only
exists on nightly builds. This PR makes the column family exist on every build,
so it is in place well before the protocol feature turns on.

Why it has to land first:
- A read-only process cannot create a missing column family.
- Once Early Kickout is active, a missing row for the current epoch fails closed
  with `ChunkProducerNotInDB`. That is a liveness failure, not a soft fallback.

This is column plumbing only. No code path writes a row on a stable node.

Changes:
- Un-gate the `DBCol::ChunkProducers` variant and its four property arms in `columns.rs`.
- Bump `DB_VERSION` from 49 to 50 and add a no-op `49 => Ok(())` migration arm. The
  existing `ContinuousEpochSync` condition on `DB_VERSION` was already dead, so it
  becomes a plain constant. That feature is stable at protocol version 85 and every
  build configuration is at 87 or above, so the `else` branch was unreachable.
- Un-gate the paths that touch the column but never produce rows on their own: the
  cold-copy prefix scan, the cloud-archive column classifier, the cloud `BlockData`
  reader, and the cloud-archive writer. The writer only forwards rows it was handed,
  so on a stable node it writes nothing.
- Add `DBCol::ChunkProducers` to the expected-empty list in the two cold-storage tests.
  On a stable build it is a cold column with no rows.
- Fix comments this change makes wrong. One of them was already wrong: the column doc
  said rows are sampled in the epoch after the anchor, but the seeder and the reader
  both use the anchor's own epoch. `seed_chunk_producers` says so explicitly, and both
  call sites pass the anchor's own epoch.

The store writer, the epoch-manager seeder and reader, GC, and the protocol version
move all stay gated. They come in a follow-up PR.

Things reviewers should know:
- Deployment order. Every hot and cold DB that will run the follow-up PR must finish a
  read-write 49 to 50 open before the new protocol version activates. Read-only
  processes cannot migrate themselves. So this PR has to be deployed and migrated
  fleet-wide, not just merged.
- GC stays nightly-gated. Rows can reach a stable node two ways: a nightly DB opened
  later by a stable binary, or a stable cloud-archive reader bootstrapping from a bucket
  a nightly writer produced. Neither is a production path. But GC walks forward from the
  tail and does not rescan, so any such row that crosses the tail while GC is gated is
  orphaned for good. Turning GC on later does not reclaim it. The follow-up PR carries a
  one-shot sweep.
- Nightly databases must be recreated. A nightly build stamps DB version 10000 after
  migrating, then fails that same startup with `unexpected DbVersion 10000; expected 50`.
  This hits forknet and localnet, not test-loop, which is in-memory. It is pre-existing
  behaviour for every DB version bump and is not changed here.
- Cold copy is no longer free on stable. A split-storage archival node now runs one empty
  prefix scan and one empty write per copied block. Only archival nodes pay it.
- No CHANGELOG entry yet. It goes in when the full feature is stabilized.
- The `Unused Dependencies` check is red for a reason unrelated to this PR. `redis 0.23.0`,
  a pre-existing `tools/state-viewer` dependency, no longer compiles under the nightly
  toolchain that cargo-udeps needs. It fails the same way on PRs that touch no Cargo files.
  `Cargo machete`, the other unused-dependency check, passes.

Test: `slow_test_migration_49_to_50_creates_chunk_producers_column` in
`nearcore/src/migrations.rs`.
- Builds a real version-49 RocksDB with the column family dropped.
- Checks a read-only open fails on the missing column family, and asserts on the error
  message, so a wrong path cannot make the rest of the test vacuous.
- Migrates it read-write, then checks the column is there and a read-only open works.
- A wrapper around the real `Migrator` records which versions it was asked to migrate, so
  the test proves the migration ran rather than that the DB was already current.
- Hot store only. The cold store is not covered.
- Stable builds only, via `cfg_attr(feature = "nightly", ignore)`. This is the 10000
  sentinel above: on nightly the migrating open fails, so there is no nightly upgrade path
  for the test to assert against. The `ignore` form is deliberate. A runtime `cfg!` early
  return reports the test as passed on nightly while running none of its assertions.
