### PR TITLE
feat(cloud-archive): the recent reader saves the prev epoch end

### DIFF
--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -1,6 +1,9 @@
 use near_chain::Error;
+use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::{get_block_shard_id, index_to_bytes};
+use near_store::adapter::StoreAdapter;
 use near_store::archive::cloud_storage::{
     BlockData, CloudRetrievalError, CloudStorage, EpochData, ShardData,
 };
@@ -15,6 +18,8 @@ pub enum CloudArchivalReaderError {
     Chain(#[from] Error),
     #[error("walked back to genesis without finding a state snapshot")]
     NoSnapshotFound,
+    #[error("the store carries no reader head")]
+    NoReaderHead,
 }
 
 /// Writes block-level columns from a cloud `BlockData` into `update`.
@@ -66,6 +71,57 @@ pub(crate) fn save_shard_data(update: &mut StoreUpdate, shard_id: ShardId, shard
     if let Some(outgoing_receipts) = shard_data.outgoing_receipts() {
         update.set_ser(DBCol::OutgoingReceipts, &block_shard_id, outgoing_receipts);
     }
+}
+
+/// Hash of the last block of the epoch before the one containing `block_hash`, or the
+/// genesis block when there is no earlier epoch.
+pub fn prev_epoch_end_hash(
+    store: &Store,
+    epoch_manager: &dyn EpochManagerAdapter,
+    block_hash: &CryptoHash,
+) -> Result<CryptoHash, Error> {
+    let chain_store = store.chain_store();
+    let epoch_start = epoch_manager.get_epoch_start_height(block_hash)?;
+    let genesis_height = chain_store.get_genesis_height();
+    // The genesis epoch has no earlier epoch; floor at the genesis block.
+    if epoch_start <= genesis_height {
+        return chain_store.get_block_hash_by_height(genesis_height);
+    }
+    let first_block_hash = chain_store.get_block_hash_by_height(epoch_start)?;
+    let first_block_header = chain_store.get_block_header(&first_block_hash)?;
+    Ok(*first_block_header.prev_hash())
+}
+
+/// Hash of the first block at or below `height` that the store holds.
+pub fn find_present_block_hash_at_or_below(
+    store: &Store,
+    height: BlockHeight,
+) -> Result<CryptoHash, Error> {
+    let chain_store = store.chain_store();
+    let genesis_height = chain_store.get_genesis_height();
+    for h in (genesis_height..=height).rev() {
+        match chain_store.get_block_hash_by_height(h) {
+            Ok(hash) => return Ok(hash),
+            Err(Error::DBNotFoundErr(_)) => continue,
+            Err(other) => return Err(other),
+        }
+    }
+    unreachable!("genesis block must be present")
+}
+
+/// The prev epoch end to start from at `height`.
+pub fn compute_initial_prev_epoch_end(
+    store: &Store,
+    epoch_manager: &dyn EpochManagerAdapter,
+    height: BlockHeight,
+) -> Result<CryptoHash, Error> {
+    // `height` may be a skipped slot, so walk down to the nearest present block.
+    let block_hash = find_present_block_hash_at_or_below(store, height)?;
+    // If the block itself ends an epoch, it is the prev-epoch end.
+    if epoch_manager.is_next_block_epoch_start(&block_hash)? {
+        return Ok(block_hash);
+    }
+    prev_epoch_end_hash(store, epoch_manager, &block_hash)
 }
 
 /// First present block at or below `height`. Errors if no such block exists

--- a/chain/client/src/archive/cloud_archival_writer.rs
+++ b/chain/client/src/archive/cloud_archival_writer.rs
@@ -1,5 +1,6 @@
 //! Cloud archival writer: moves finalized data from the hot store to the cloud storage.
 //! Runs in a loop until the cloud head catches up with the hot final head.
+use crate::archive::cloud_archival_utils::{compute_initial_prev_epoch_end, prev_epoch_end_hash};
 use futures::FutureExt;
 use near_async::futures::FutureSpawner;
 use near_async::time::Clock;
@@ -726,7 +727,11 @@ impl CloudArchivalWriter {
         // Publishing otherwise happens at the previous epoch's last block. We upload
         // idempotently on node start in case it didn't happen, e.g. fresh bucket.
         if self.config.archive_block_data {
-            let prev_epoch_end = self.compute_initial_prev_epoch_end(init_state.min_height)?;
+            let prev_epoch_end = compute_initial_prev_epoch_end(
+                &self.hot_store,
+                self.epoch_manager.as_ref(),
+                init_state.min_height,
+            )?;
             self.archive_next_epoch_data(prev_epoch_end).await?;
         }
 
@@ -833,23 +838,6 @@ impl CloudArchivalWriter {
         })
     }
 
-    /// Hash of the last block of the epoch before the one containing
-    /// `block_hash`, or the genesis block when there is no earlier epoch.
-    fn prev_epoch_end_hash(
-        &self,
-        block_hash: &CryptoHash,
-    ) -> Result<CryptoHash, near_chain_primitives::Error> {
-        let chain_store = self.hot_store.chain_store();
-        let epoch_start = self.epoch_manager.get_epoch_start_height(block_hash)?;
-        // The genesis epoch has no earlier epoch; floor at the genesis block.
-        if epoch_start <= self.genesis_height {
-            return chain_store.get_block_hash_by_height(self.genesis_height);
-        }
-        let first_block_hash = chain_store.get_block_hash_by_height(epoch_start)?;
-        let first_block_header = chain_store.get_block_header(&first_block_hash)?;
-        Ok(*first_block_header.prev_hash())
-    }
-
     /// Height of the last block of the epoch before the one containing `height`,
     /// flooring at genesis when there is no earlier epoch.
     fn prev_epoch_end_height(
@@ -858,7 +846,8 @@ impl CloudArchivalWriter {
     ) -> Result<BlockHeight, near_chain_primitives::Error> {
         let chain_store = self.hot_store.chain_store();
         let block_hash = chain_store.get_block_hash_by_height(height)?;
-        let prev_epoch_end = self.prev_epoch_end_hash(&block_hash)?;
+        let prev_epoch_end =
+            prev_epoch_end_hash(&self.hot_store, self.epoch_manager.as_ref(), &block_hash)?;
         Ok(chain_store.get_block_header(&prev_epoch_end)?.height())
     }
 
@@ -963,7 +952,12 @@ impl CloudArchivalWriter {
             store_update.set_shard_head(shard_id, height);
         }
         store_update.set_min_head(min_height);
-        store_update.set_prev_epoch_end(self.compute_initial_prev_epoch_end(min_height)?);
+        let prev_epoch_end = compute_initial_prev_epoch_end(
+            &self.hot_store,
+            self.epoch_manager.as_ref(),
+            min_height,
+        )?;
+        store_update.set_prev_epoch_end(prev_epoch_end);
         store_update.commit();
         // No shard retires during initialization.
         let head_updates: Vec<ShardHeadUpdate> = shard_heads
@@ -1002,34 +996,6 @@ impl CloudArchivalWriter {
             }
         }
         metrics::CLOUD_ARCHIVAL_HEAD_HEIGHT.with_label_values(&["min"]).set(min_height as i64);
-    }
-
-    fn compute_initial_prev_epoch_end(
-        &self,
-        height: BlockHeight,
-    ) -> Result<CryptoHash, near_chain_primitives::Error> {
-        // `height` may be a skipped slot, so walk down to the nearest present block.
-        let block_hash = self.find_present_block_at_or_below(height)?;
-        // If the block itself ends an epoch, it is the prev-epoch end.
-        if self.epoch_manager.is_next_block_epoch_start(&block_hash)? {
-            return Ok(block_hash);
-        }
-        self.prev_epoch_end_hash(&block_hash)
-    }
-
-    fn find_present_block_at_or_below(
-        &self,
-        height: BlockHeight,
-    ) -> Result<CryptoHash, near_chain_primitives::Error> {
-        let chain_store = self.hot_store.chain_store();
-        for h in (self.genesis_height..=height).rev() {
-            match chain_store.get_block_hash_by_height(h) {
-                Ok(hash) => return Ok(hash),
-                Err(near_chain_primitives::Error::DBNotFoundErr(_)) => continue,
-                Err(other) => return Err(other),
-            }
-        }
-        unreachable!("genesis block must be present")
     }
 
     /// Advances local heads after archiving at `height`. Only updates heads for

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -1,7 +1,10 @@
-use crate::archive::cloud_archival_utils::CloudArchivalReaderError;
+use crate::archive::cloud_archival_utils::{
+    CloudArchivalReaderError, compute_initial_prev_epoch_end,
+};
 use near_async::time::{Clock, Duration};
 use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::InterruptHandle;
+use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::types::BlockHeight;
 use near_store::adapter::StoreAdapter;
 
@@ -14,6 +17,27 @@ enum PullOutcome {
     Pulled { batch_end: BlockHeight },
     /// The bucket holds nothing past the reader's head.
     WaitingForBucket,
+}
+
+/// Takes the store a stopped node handed over, before the reader's loop starts.
+///
+/// The reader head goes onto that node's final head, since the node's own head can sit on
+/// a block that later reorged.
+pub fn take_over_store(
+    chain_store: &ChainStore,
+    epoch_manager: &dyn EpochManagerAdapter,
+) -> Result<(), CloudArchivalReaderError> {
+    let store = chain_store.store();
+    if store.cloud_archival_store().reader_head().is_some() {
+        return Ok(());
+    }
+    let final_head = chain_store.final_head()?;
+    let prev_epoch_end = compute_initial_prev_epoch_end(&store, epoch_manager, final_head.height)?;
+    let mut update = store.cloud_archival_store().store_update();
+    update.set_prev_epoch_end(prev_epoch_end);
+    update.set_reader_head(final_head.height);
+    update.commit();
+    Ok(())
 }
 
 /// Reads recent chain data out of cloud storage into a local store.
@@ -30,18 +54,13 @@ impl CloudArchivalRecentReader {
         Self { clock, chain_store, polling_interval, interrupt: InterruptHandle::new() }
     }
 
-    /// The height the reader resumes at. A store handed over by a stopped node carries
-    /// none yet and takes its final head, since that node's head can still reorg.
-    fn ensure_reader_head(&self) -> Result<BlockHeight, CloudArchivalReaderError> {
-        let store = self.chain_store.store();
-        if let Some(reader_head) = store.cloud_archival_store().reader_head() {
-            return Ok(reader_head);
-        }
-        let final_head = self.chain_store.final_head()?;
-        let mut update = store.cloud_archival_store().store_update();
-        update.set_reader_head(final_head.height);
-        update.commit();
-        Ok(final_head.height)
+    /// The height every component is written through.
+    fn reader_head(&self) -> Result<BlockHeight, CloudArchivalReaderError> {
+        self.chain_store
+            .store()
+            .cloud_archival_store()
+            .reader_head()
+            .ok_or(CloudArchivalReaderError::NoReaderHead)
     }
 
     /// Stops the loop after the iteration in flight.
@@ -51,7 +70,7 @@ impl CloudArchivalRecentReader {
 
     /// Follows the bucket, copying what it holds into the local store, until interrupted.
     pub async fn cloud_archival_loop(mut self) -> Result<(), CloudArchivalReaderError> {
-        let reader_head = self.ensure_reader_head()?;
+        let reader_head = self.reader_head()?;
         tracing::info!(target: "cloud_archival", reader_head, "following the cloud archive");
 
         while !self.interrupt.is_cancelled() {

--- a/core/store/src/adapter/cloud_archival_store.rs
+++ b/core/store/src/adapter/cloud_archival_store.rs
@@ -46,7 +46,7 @@ impl CloudArchivalStoreAdapter {
         self.store.get_ser(DBCol::BlockMisc, &cloud_shard_head_key(shard_id))
     }
 
-    /// Last block of the latest fully archivized epoch.
+    /// Last block of the epoch below the one being worked on.
     pub fn prev_epoch_end(&self) -> Option<CryptoHash> {
         self.store.get_ser(DBCol::BlockMisc, CLOUD_PREV_EPOCH_END_KEY)
     }

--- a/core/store/src/db/mod.rs
+++ b/core/store/src/db/mod.rs
@@ -48,8 +48,8 @@ pub const CLOUD_SHARD_HEAD_PREFIX: &[u8] = b"CLOUD_SHARD_HEAD:";
 /// Highest height every component this writer archives has reached in the
 /// bucket, whoever put it there. Drives the next batch range to upload.
 pub const CLOUD_MIN_HEAD_KEY: &[u8] = b"CLOUD_MIN_HEAD";
-/// Hash of the last block of the latest epoch this writer archived its assigned
-/// components for. GC stops at the start of that epoch.
+/// Hash of the last block of the epoch below the one being worked on. Its header
+/// names that epoch and the next one. GC stops at the start of that epoch.
 pub const CLOUD_PREV_EPOCH_END_KEY: &[u8] = b"CLOUD_PREV_EPOCH_END";
 /// Highest height a cloud-archive reader has written every component through. Present
 /// only in a reader's store, which a running node refuses; only the cloud-archive

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -20,7 +20,7 @@ use near_chain_configs::test_genesis::TestEpochConfigBuilder;
 use near_client::archive::cloud_archival_utils::find_snapshot_at_or_before;
 #[cfg(feature = "nightly")]
 use near_client::archive::cloud_archival_utils::save_block_data;
-use near_client::archive::cloud_recent_reader::CloudArchivalRecentReader;
+use near_client::archive::cloud_recent_reader::{CloudArchivalRecentReader, take_over_store};
 use near_primitives::block::Block;
 use near_primitives::chunk_apply_stats::ChunkApplyStats;
 use near_primitives::epoch_manager::EpochConfigStore;
@@ -353,6 +353,9 @@ impl CloudArchiveHarness {
             true,
             self.env.shared_state.genesis.config.transaction_validity_period,
         );
+        let reader_id: AccountId = Self::RECENT_READER_ACCOUNT.parse().unwrap();
+        let epoch_manager = self.env.node_for_account(&reader_id).client().epoch_manager.clone();
+        take_over_store(&chain_store, epoch_manager.as_ref()).expect("taking the store over");
         let reader = CloudArchivalRecentReader::new(
             self.env.test_loop.clock(),
             chain_store,
@@ -1961,7 +1964,13 @@ fn test_cloud_archival_recent_reader() {
     // the tail by the time the node switches over.
     h.run_until_epoch(h.gc_num_epochs_to_keep + 1);
     let reader = h.start_recent_reader();
-    let kept = h.recent_reader_store().chain_store().head().unwrap().height;
+    let store = h.recent_reader_store();
+    let kept = store.chain_store().final_head().unwrap().height;
+    assert_eq!(
+        store.cloud_archival_store().reader_head(),
+        Some(kept),
+        "the take-over did not seed the reader head from the final head"
+    );
     // Twice as far again, so gc would have taken the block held at the switch if
     // anything still gc-ed this database.
     h.run_until_epoch(2 * (h.gc_num_epochs_to_keep + 1));


### PR DESCRIPTION
The recent reader saves the prev epoch end, the last block of the epoch below the one it is working on. The writer keeps the same value under the same key, so the two helpers that resolve it move to the shared module.

The reader resolves it when it takes over the store a stopped node left. That step moves out of the follow loop, since it needs an epoch manager and the loop does not.
