### PR TITLE
chore(ci): bump redis to 0.26.1 to fix cargo udeps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,12 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.5.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "archery"
@@ -6333,15 +6336,16 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea8c51b5dc1d8e5fd3350ec8167f464ec0995e79f2e90a075b63371500d557f"
+checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
 dependencies = [
+ "arc-swap",
  "combine",
  "itoa",
+ "num-bigint 0.4.6",
  "percent-encoding",
  "ryu",
- "sha1_smol",
  "url",
 ]
 
@@ -7271,12 +7275,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,7 +307,7 @@ rand_core = "0.6.1"
 rand_hc = "0.3.1"
 rand_xorshift = "0.3"
 rayon = "1.10"
-redis = "0.23.0"
+redis = { version = "0.26.1", default-features = false }
 reed-solomon-erasure = { version = "6.0.0", features = ["simd-accel"] }
 regex = "1.7.1"
 reqwest = { version = "0.13", features = ["blocking", "native-tls-vendored", "form", "query"] }


### PR DESCRIPTION
The `Unused Dependencies` job runs `cargo +nightly udeps`. Nightly `1.100.0-nightly (e7769602a 2026-08-24)` changed type inference, and `redis 0.23.0` stopped compiling:

```
error[E0277]: the trait bound `!: FromRedisValue` is not satisfied
   --> redis-0.23.0/src/script.rs:150:37
150 |                     self.load_cmd().query(con)?;
```

`query::<T>()` is unconstrained there. Old inference picked `()`, new inference picks `!`. Upstream removed the call in 0.26.

This bumps `redis` to 0.26.1, the first version with the fix, and turns off default features. `tools/state-viewer/src/state_dump.rs` is the only user and needs none of them: it calls `Client::open`, `get_connection`, and `Commands::{zadd, set}`. Turning off `acl`, `streams`, `geospatial`, and `script` drops command helpers we never call. Turning off `keep-alive` keeps a second `socket2` major version out of the lock (0.5 next to the 0.6 that tokio, hyper-util, and quinn already use). `redis 0.23.0` had no `keep-alive` feature, so socket behavior does not change.

No source changes. `arc-swap` moves 1.5.0 -> 1.9.2 to unify with `near-network`.