### PR TITLE
fix(rpc): use the confirming block's shard layout for outcome proofs

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -4066,11 +4066,13 @@ impl Chain {
     /// If sharding changes before we can find a block with a new chunk for the shard,
     /// find the first block that contains a new chunk for any of the shards that split from the
     /// original shard
+    /// The returned shard id and shard index both belong to the returned block's shard layout,
+    /// which can differ from the layout of `block_hash`.
     pub fn get_next_block_hash_with_new_chunk(
         &self,
         block_hash: &CryptoHash,
         shard_id: ShardId,
-    ) -> Result<Option<(CryptoHash, ShardId)>, Error> {
+    ) -> Result<Option<(CryptoHash, ShardId, ShardIndex)>, Error> {
         let mut block_hash = *block_hash;
         let mut epoch_id = *self.get_block_header(&block_hash)?.epoch_id();
         let mut shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
@@ -4104,7 +4106,7 @@ impl Chain {
                 let chunk_header =
                     &chunks.get(shard_index).ok_or(Error::InvalidShardId(shard_id))?;
                 if chunk_header.height_included() == block.header().height() {
-                    return Ok(Some((block_hash, shard_id)));
+                    return Ok(Some((block_hash, shard_id, shard_index)));
                 }
             }
         }

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -1144,43 +1144,48 @@ impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecuti
                 let mut outcome_proof = outcome;
                 let epoch_id =
                     *self.chain.get_block(&outcome_proof.block_hash)?.header().epoch_id();
-                let shard_layout =
-                    self.epoch_manager.get_shard_layout(&epoch_id).into_chain_error()?;
                 let target_shard_id =
                     account_id_to_shard_id(self.epoch_manager.as_ref(), &account_id, &epoch_id)
                         .into_chain_error()?;
-                let target_shard_index = shard_layout
-                    .get_shard_index(target_shard_id)
-                    .map_err(Into::into)
-                    .into_chain_error()?;
                 let res = self.chain.get_next_block_hash_with_new_chunk(
                     &outcome_proof.block_hash,
                     target_shard_id,
                 )?;
-                if let Some((h, target_shard_id)) = res {
-                    outcome_proof.block_hash = h;
-                    // Here we assume the number of shards is small so this reconstruction
-                    // should be fast
-                    let outcome_roots = self
-                        .chain
-                        .get_block(&h)?
-                        .chunks()
-                        .iter()
-                        .map(|header| *header.prev_outcome_root())
-                        .collect::<Vec<_>>();
-                    if target_shard_index >= outcome_roots.len() {
-                        return Err(GetExecutionOutcomeError::InconsistentState {
-                            number_or_shards: outcome_roots.len(),
-                            execution_outcome_shard_id: target_shard_id,
-                        });
-                    }
-                    Ok(GetExecutionOutcomeResponse {
-                        outcome_proof: outcome_proof.into(),
-                        outcome_root_proof: merklize(&outcome_roots).1[target_shard_index].clone(),
-                    })
-                } else {
-                    Err(GetExecutionOutcomeError::NotConfirmed { transaction_or_receipt_id: id })
+                let Some((confirming_block_hash, confirming_shard_id, confirming_shard_index)) =
+                    res
+                else {
+                    return Err(GetExecutionOutcomeError::NotConfirmed {
+                        transaction_or_receipt_id: id,
+                    });
+                };
+                outcome_proof.block_hash = confirming_block_hash;
+                let confirming_block = self.chain.get_block(&confirming_block_hash)?;
+                // Here we assume the number of shards is small so this reconstruction
+                // should be fast
+                let outcome_roots = confirming_block
+                    .chunks()
+                    .iter()
+                    .map(|header| *header.prev_outcome_root())
+                    .collect::<Vec<_>>();
+                let (outcome_root, outcome_root_paths) = merklize(&outcome_roots);
+                if &outcome_root != confirming_block.header().outcome_root() {
+                    return Err(GetExecutionOutcomeError::InternalError {
+                        error_message: "recomputed outcome root disagrees with the confirming \
+                                        block's committed root"
+                            .to_string(),
+                    });
                 }
+                let Some(outcome_root_proof) = outcome_root_paths.get(confirming_shard_index)
+                else {
+                    return Err(GetExecutionOutcomeError::InconsistentState {
+                        number_or_shards: outcome_roots.len(),
+                        execution_outcome_shard_id: confirming_shard_id,
+                    });
+                };
+                Ok(GetExecutionOutcomeResponse {
+                    outcome_proof: outcome_proof.into(),
+                    outcome_root_proof: outcome_root_proof.clone(),
+                })
             }
             Err(near_chain::Error::DBNotFoundErr(_)) => {
                 let head = self.chain.head()?;

--- a/test-loop-tests/src/tests/light_client.rs
+++ b/test-loop-tests/src/tests/light_client.rs
@@ -399,7 +399,7 @@ fn test_light_client_execution_outcome_proof_across_resharding() {
 
     let mut env = TestLoopBuilder::new()
         .protocol_version(PROTOCOL_VERSION - 1)
-        .shard_layout(base_shard_layout.clone())
+        .shard_layout(base_shard_layout)
         .epoch_length(epoch_length)
         .add_user_account(&user, Balance::from_near(10))
         .epoch_config_store(epoch_config_store)

--- a/test-loop-tests/src/tests/light_client.rs
+++ b/test-loop-tests/src/tests/light_client.rs
@@ -403,48 +403,47 @@ fn test_light_client_execution_outcome_proof_across_resharding() {
         .epoch_length(epoch_length)
         .add_user_account(&user, Balance::from_near(10))
         .epoch_config_store(epoch_config_store)
+        .enable_rpc()
         .build();
 
     // One transaction per block, so every block in the range holds an outcome for the user's
     // shard. The last block before the layout change is therefore always covered.
-    let epoch_manager = env.validator().client().epoch_manager.clone();
+    let epoch_manager = env.rpc_node().client().epoch_manager.clone();
     let mut tx_hashes = Vec::new();
-    while epoch_manager.get_shard_layout(&env.validator().head().epoch_id).unwrap()
+    while epoch_manager.get_shard_layout(&env.rpc_node().head().epoch_id).unwrap()
         != new_shard_layout
     {
-        let tx = env.validator().tx_send_money(&user, &user, Balance::from_millinear(1));
-        tx_hashes.push(env.validator().submit_tx(tx));
-        env.validator_runner().run_for_number_of_blocks(1);
+        let tx = env.rpc_node().tx_send_money(&user, &user, Balance::from_millinear(1));
+        tx_hashes.push(env.rpc_node().submit_tx(tx));
+        env.rpc_runner().run_for_number_of_blocks(1);
         assert!(tx_hashes.len() < 20 * epoch_length as usize, "shard layout never changed");
     }
 
     // An outcome is only confirmed by a later block with a new chunk for its shard.
     let last_tx_hash = *tx_hashes.last().unwrap();
-    env.validator_runner().run_until_outcome_available(last_tx_hash, Duration::seconds(5));
-    env.validator_runner().run_for_number_of_blocks(1);
+    env.rpc_runner().run_until_outcome_available(last_tx_hash, Duration::seconds(5));
+    env.rpc_runner().run_for_number_of_blocks(1);
 
-    let responses = {
-        let mut node = env.validator_mut();
-        let view_client = node.view_client_actor();
-        tx_hashes
-            .iter()
-            .map(|tx_hash| {
-                let id = TransactionOrReceiptId::Transaction {
-                    transaction_hash: *tx_hash,
-                    sender_id: user.clone(),
-                };
-                view_client.handle(GetExecutionOutcome { id }).unwrap()
-            })
-            .collect::<Vec<_>>()
-    };
+    let mut responses = Vec::new();
+    {
+        let mut rpc = env.rpc_node_mut();
+        let view_client = rpc.view_client_actor();
+        for tx_hash in &tx_hashes {
+            let id = TransactionOrReceiptId::Transaction {
+                transaction_hash: *tx_hash,
+                sender_id: user.clone(),
+            };
+            responses.push(view_client.handle(GetExecutionOutcome { id }).unwrap());
+        }
+    }
 
-    let node = env.validator();
-    let chain = &node.client().chain;
+    let rpc = env.rpc_node();
+    let chain = &rpc.client().chain;
     let mut covered_layout_change = false;
     for (tx_hash, response) in tx_hashes.iter().zip(responses) {
         let execution_outcome = chain.get_execution_outcome(tx_hash).unwrap();
-        let execution_epoch_id =
-            *chain.get_block_header(&execution_outcome.block_hash).unwrap().epoch_id();
+        let execution_header = chain.get_block_header(&execution_outcome.block_hash).unwrap();
+        let execution_epoch_id = *execution_header.epoch_id();
 
         // The handler replaces the block hash with the block that confirms the outcome.
         let confirming_block_hash = response.outcome_proof.block_hash;

--- a/test-loop-tests/src/tests/light_client.rs
+++ b/test-loop-tests/src/tests/light_client.rs
@@ -1,23 +1,29 @@
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
 use crate::utils::account::create_account_id;
+use crate::utils::setups::derive_new_epoch_config_from_boundary;
 use near_async::messaging::Handler;
 use near_async::time::Duration;
+use near_chain_configs::test_genesis::TestEpochConfigBuilder;
 use near_client::{GetBlockProof, GetExecutionOutcome, GetNextLightClientBlock};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block_header::{
     Approval, ApprovalInner, compute_bp_hash_from_validator_stakes,
 };
+use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{
     combine_hash, compute_root_from_path_and_item, verify_hash, verify_path,
 };
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{AccountId, Balance, TransactionOrReceiptId};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{LightClientBlockLiteView, LightClientBlockView};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
 fn light_client_block_hash(block: &LightClientBlockView) -> CryptoHash {
     LightClientBlockLiteView {
@@ -357,4 +363,116 @@ fn check_outcome_proofs(
         // block hash -> light client head's block merkle root.
         assert!(verify_hash(block_merkle_root, &block_proof.proof, outcome_proof.block_hash));
     }
+}
+
+/// A shard that is not split still moves one slot up in the chunk vector when a shard below it
+/// splits. An outcome in that shard's last chunk before the change is confirmed by a block in the
+/// new layout, so the outer merkle path must be taken at the new position.
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_light_client_execution_outcome_proof_across_resharding() {
+    init_test_logger();
+
+    let user = create_account_id("user");
+    let base_shard_layout = ShardLayout::multi_shard(3, 3);
+    let epoch_length = 5;
+
+    let base_epoch_config = TestEpochConfigBuilder::new()
+        .shard_layout(base_shard_layout.clone())
+        .epoch_length(epoch_length)
+        .build();
+    let (new_epoch_config, new_shard_layout) =
+        derive_new_epoch_config_from_boundary(&base_epoch_config, &create_account_id("boundary"));
+
+    // The user's shard is untouched by the split, but the split happens below it, so its position
+    // in the chunk vector moves up by one. This is the case that must be covered.
+    let user_shard_id = base_shard_layout.account_id_to_shard_id(&user);
+    let old_shard_index = base_shard_layout.get_shard_index(user_shard_id).unwrap();
+    let new_shard_index = new_shard_layout.get_shard_index(user_shard_id).unwrap();
+    assert_eq!(new_shard_index, old_shard_index + 1);
+
+    let epoch_config_store = EpochConfigStore::test(BTreeMap::from([
+        (PROTOCOL_VERSION - 1, Arc::new(base_epoch_config)),
+        (PROTOCOL_VERSION, Arc::new(new_epoch_config)),
+    ]));
+
+    let mut env = TestLoopBuilder::new()
+        .protocol_version(PROTOCOL_VERSION - 1)
+        .shard_layout(base_shard_layout.clone())
+        .epoch_length(epoch_length)
+        .add_user_account(&user, Balance::from_near(10))
+        .epoch_config_store(epoch_config_store)
+        .build();
+
+    // One transaction per block, so every block in the range holds an outcome for the user's
+    // shard. The last block before the layout change is therefore always covered.
+    let epoch_manager = env.validator().client().epoch_manager.clone();
+    let mut tx_hashes = Vec::new();
+    while epoch_manager.get_shard_layout(&env.validator().head().epoch_id).unwrap()
+        != new_shard_layout
+    {
+        let tx = env.validator().tx_send_money(&user, &user, Balance::from_millinear(1));
+        tx_hashes.push(env.validator().submit_tx(tx));
+        env.validator_runner().run_for_number_of_blocks(1);
+        assert!(tx_hashes.len() < 20 * epoch_length as usize, "shard layout never changed");
+    }
+
+    // An outcome is only confirmed by a later block with a new chunk for its shard.
+    let last_tx_hash = *tx_hashes.last().unwrap();
+    env.validator_runner().run_until_outcome_available(last_tx_hash, Duration::seconds(5));
+    env.validator_runner().run_for_number_of_blocks(1);
+
+    let responses = {
+        let mut node = env.validator_mut();
+        let view_client = node.view_client_actor();
+        tx_hashes
+            .iter()
+            .map(|tx_hash| {
+                let id = TransactionOrReceiptId::Transaction {
+                    transaction_hash: *tx_hash,
+                    sender_id: user.clone(),
+                };
+                view_client.handle(GetExecutionOutcome { id }).unwrap()
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let node = env.validator();
+    let chain = &node.client().chain;
+    let mut covered_layout_change = false;
+    for (tx_hash, response) in tx_hashes.iter().zip(responses) {
+        let execution_outcome = chain.get_execution_outcome(tx_hash).unwrap();
+        let execution_epoch_id =
+            *chain.get_block_header(&execution_outcome.block_hash).unwrap().epoch_id();
+
+        // The handler replaces the block hash with the block that confirms the outcome.
+        let confirming_block_hash = response.outcome_proof.block_hash;
+        let confirming_header = chain.get_block_header(&confirming_block_hash).unwrap();
+        let chunk_outcome_root = compute_root_from_path_and_item(
+            &response.outcome_proof.proof,
+            &response.outcome_proof.to_hashes(),
+        );
+        assert!(
+            verify_path(
+                *confirming_header.outcome_root(),
+                &response.outcome_root_proof,
+                &chunk_outcome_root,
+            ),
+            "outcome root proof for {tx_hash} does not reconstruct the outcome root of the \
+             confirming block at height {}",
+            confirming_header.height(),
+        );
+
+        if epoch_manager.get_shard_layout(&execution_epoch_id).unwrap()
+            != epoch_manager.get_shard_layout(confirming_header.epoch_id()).unwrap()
+        {
+            covered_layout_change = true;
+        }
+    }
+    assert!(
+        covered_layout_change,
+        "no outcome was confirmed by a block in a different shard layout, so the test did not \
+         cover the resharding boundary",
+    );
 }


### PR DESCRIPTION
`GetExecutionOutcome` computed the shard's position in the chunk vector from the layout of the epoch that executed the outcome, then used that position to select the outer merkle path from a confirming block that can be in a later epoch with a different layout.

A split inserts two children at the parent's slot, so every shard after the split point moves up one position while keeping its shard id. An outcome in such a shard's last chunk before the change gets the merkle path of a neighbouring leaf. The response is still a success, but the path does not reconstruct the confirming block's `outcome_root`, so a conforming verifier rejects a valid execution. The bounds check cannot catch this, because a split only grows the vector and the smaller old index stays in range.

`Chain::get_next_block_hash_with_new_chunk` already computes the correct index against the confirming block's layout and then discards it. It now returns that index, and the handler uses it instead of deriving one from the wrong layout.

The handler also recomputes the outcome root and compares it against the confirming block header before returning, so a future mismatch fails loudly instead of serving a path that does not verify. The chunk execution proof path already does the same check.

Adds a test-loop test that sends one transaction per block across a layout change and verifies every outcome proof against the confirming block's `outcome_root`. It fails without the fix.

Regressed in #12181, which replaced the shard id taken from the search result with an index computed before the search.