### PR TITLE
feat(epoch-sync): split a monolithic epoch sync proof into batches of epochs data. _DO_NOT_MERGE_: WIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4102,6 +4102,7 @@ dependencies = [
  "near-primitives",
  "near-store",
  "near-telemetry",
+ "near-time",
  "near-vm-runner",
  "node-runtime",
  "num-rational 0.3.2",

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -111,6 +111,17 @@ impl StateSyncStatus {
 }
 
 #[derive(Clone, Debug)]
+pub struct FetchingEpochSyncBatchesState {
+    // Peer from whom we have downloaded the manifest,
+    pub manifest_source_peer_id: PeerId,
+    pub manifest_source_peer_height: BlockHeight,
+    pub total_batches: u64,
+    pub verified_batches: u64,
+    pub in_flight: u64,
+    pub attempt_time: near_time::Utc,
+}
+
+#[derive(Clone, Debug)]
 pub enum EpochSyncStatus {
     /// Epoch sync decided but no request sent yet.
     NotStarted,
@@ -120,6 +131,12 @@ pub enum EpochSyncStatus {
         source_peer_id: PeerId,
         attempt_time: near_time::Utc,
     },
+    FetchingManifest {
+        source_peer_id: PeerId,
+        source_peer_height: BlockHeight,
+        attempt_time: near_time::Utc,
+    },
+    FetchingBatches(FetchingEpochSyncBatchesState),
     /// Epoch sync proof applied successfully.
     Done,
 }
@@ -215,6 +232,8 @@ impl From<EpochSyncStatus> for EpochSyncStatusView {
                     attempt_time: attempt_time.to_string(),
                 }
             }
+            EpochSyncStatus::FetchingManifest { .. } => todo!(),
+            EpochSyncStatus::FetchingBatches { .. } => todo!(),
             EpochSyncStatus::Done => EpochSyncStatusView::Done,
         }
     }

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -55,6 +55,7 @@ near-pool.workspace = true
 near-primitives = { workspace = true, features = ["clock"] }
 near-store.workspace = true
 near-telemetry.workspace = true
+near-time.workspace = true
 near-vm-runner.workspace = true
 node-runtime.workspace = true
 

--- a/chain/client/src/adapter.rs
+++ b/chain/client/src/adapter.rs
@@ -27,6 +27,10 @@ pub fn client_sender_for_network(
         chunk_endorsement: chunk_endorsement_handler.into_async_sender(),
         epoch_sync_request: client_addr.clone().into_sender(),
         epoch_sync_response: client_addr.clone().into_sender(),
+        epoch_sync_manifest_request: client_addr.clone().into_sender(),
+        epoch_sync_manifest_response: client_addr.clone().into_sender(),
+        epoch_sync_batch_request: client_addr.clone().into_sender(),
+        epoch_sync_batch_response: client_addr.clone().into_sender(),
         optimistic_block_receiver: client_addr.into_sender(),
         current_epoch_height_request: view_client_addr.into_async_sender(),
     }

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -1,18 +1,23 @@
 use crate::client_actor::{ClientActor, ShutdownReason};
+use crate::sync::handler::SyncHandler;
 use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt};
 use near_async::messaging::{CanSend, Handler};
 use near_async::time::Clock;
 use near_chain::types::Tip;
 use near_chain::{BlockHeader, Chain, ChainStoreAccess, Error};
 use near_chain_configs::EpochSyncConfig;
-use near_client_primitives::types::{EpochSyncStatus, SyncStatus};
+use near_client_primitives::types::{EpochSyncStatus, FetchingEpochSyncBatchesState, SyncStatus};
 use near_crypto::Signature;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::epoch_sync::{
     derive_epoch_sync_proof_from_last_block, find_target_epoch_to_produce_proof_for,
     get_epoch_info_block_producers,
 };
-use near_network::client::{EpochSyncRequestMessage, EpochSyncResponseMessage};
+use near_network::client::{
+    EpochSyncBatchRequestMessage, EpochSyncBatchResponseMessage, EpochSyncManifestRequestMessage,
+    EpochSyncManifestResponseMessage, EpochSyncRequestMessage, EpochSyncResponseMessage,
+};
+use near_network::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use near_network::types::{
     HighestHeightPeerInfo, NetworkRequestWithPermit, NetworkRequests, PeerManagerAdapter,
     PeerManagerMessageRequest,
@@ -20,8 +25,10 @@ use near_network::types::{
 use near_primitives::block::{Approval, ApprovalInner, compute_bp_hash_from_validator_stakes};
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_sync::{
-    CompressedEpochSyncProof, EpochSyncProof, EpochSyncProofCurrentEpochData,
-    EpochSyncProofEpochData, EpochSyncProofLastEpochData, EpochSyncProofV1,
+    CompressedEpochSyncProof, CompressedEpochSyncProofBatch, CompressedEpochSyncProofManifest,
+    EPOCHS_PER_BATCH_V1, EpochSyncProof, EpochSyncProofBatch, EpochSyncProofBatchV1,
+    EpochSyncProofCurrentEpochData, EpochSyncProofEpochData, EpochSyncProofLastEpochData,
+    EpochSyncProofManifest, EpochSyncProofManifestV1, EpochSyncProofV1, MAX_NUMBER_OF_BATCHES,
 };
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
@@ -34,6 +41,7 @@ use near_store::{Store, metrics};
 use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::instrument;
 
 /// Maximum age of an epoch sync proof, in number of epochs.
@@ -49,6 +57,160 @@ const EPOCH_SYNC_PROOF_MAX_AGE_NUM_EPOCHS: u64 = {
     3
 };
 
+/// Timeout for a single batch request.
+const EPOCH_SYNC_BATCH_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Maximum number of batch requests outstanding at any time.
+const MAX_IN_FLIGHT_BATCH_REQUESTS: u64 = 8;
+
+pub enum EpochDataBatchStatus {
+    Missing,
+    Requested { attempt_time: near_time::Utc },
+    Verified(Vec<EpochSyncProofEpochData>),
+}
+
+pub struct EpochSyncProofAssembler {
+    manifest: EpochSyncProofManifestV1,
+    batches: Vec<EpochDataBatchStatus>,
+}
+
+impl EpochSyncProofAssembler {
+    pub fn new(manifest: EpochSyncProofManifestV1) -> Result<Self, Error> {
+        if manifest.total_epochs == 0 {
+            return Err(Error::Other(String::from("manifest covers no epochs")));
+        }
+
+        let expected_num_batches = manifest.expected_num_batches();
+        if expected_num_batches > MAX_NUMBER_OF_BATCHES {
+            return Err(Error::Other(format!(
+                "manifest declares {expected_num_batches} batches, at most {MAX_NUMBER_OF_BATCHES} allowed",
+            )));
+        }
+
+        if manifest.batches_metadata.len() as u64 != expected_num_batches {
+            return Err(Error::Other(format!(
+                "manifest has {} batch metadata entries but declares {expected_num_batches} batches",
+                manifest.batches_metadata.len(),
+            )));
+        }
+
+        let batches = (0..expected_num_batches).map(|_| EpochDataBatchStatus::Missing).collect();
+
+        Ok(Self { manifest, batches })
+    }
+
+    pub fn total_batches(&self) -> usize {
+        self.batches.len()
+    }
+
+    pub fn is_awaiting_batches(&self, batch_index: u64) -> bool {
+        self.batches
+            .get(batch_index as usize)
+            .is_some_and(|status| matches!(status, EpochDataBatchStatus::Requested { .. }))
+    }
+
+    pub fn try_add_batch(
+        &mut self,
+        batch_index: u64,
+        batch: EpochSyncProofBatchV1,
+    ) -> Result<(), Error> {
+        let entry = self
+            .batches
+            .get_mut(batch_index as usize)
+            .ok_or_else(|| Error::Other(String::from("invalid batch index")))?;
+
+        let metadata = self
+            .manifest
+            .batches_metadata
+            .get(batch_index as usize)
+            .ok_or_else(|| Error::Other(String::from("invalid batch index")))?;
+
+        match entry {
+            EpochDataBatchStatus::Requested { .. } => {
+                // We expect that every batch is full except the last one.
+                let epochs_before_batch = batch_index.saturating_mul(EPOCHS_PER_BATCH_V1);
+                let expected_epochs = self
+                    .manifest
+                    .total_epochs
+                    .saturating_sub(epochs_before_batch)
+                    .min(EPOCHS_PER_BATCH_V1);
+                if batch.epochs.len() as u64 != expected_epochs {
+                    return Err(Error::Other(format!(
+                        "batch {batch_index} carries {} epochs, expected {expected_epochs}",
+                        batch.epochs.len(),
+                    )));
+                }
+
+                let Some(first_epoch) = &batch.epochs.first() else {
+                    return Err(Error::Other(String::from("Batch was empty")));
+                };
+
+                if batch_index > 0 {
+                    if first_epoch.last_final_block_header.epoch_id() != &metadata.first_epoch_id {
+                        return Err(Error::Other(format!(
+                            "batch {batch_index} starts at epoch {:?}, manifest declares {:?}",
+                            first_epoch.last_final_block_header.epoch_id(),
+                            metadata.first_epoch_id,
+                        )));
+                    }
+                    if !EpochSync::verify_block_producer_handoff(
+                        &first_epoch.block_producers,
+                        first_epoch.use_versioned_bp_hash_format,
+                        &metadata.first_bp_hash,
+                    )? {
+                        return Err(Error::Other(format!(
+                            "block producers of batch {batch_index}'s first epoch do not match the manifest",
+                        )));
+                    }
+                }
+
+                *entry = EpochDataBatchStatus::Verified(batch.epochs);
+                Ok(())
+            }
+            EpochDataBatchStatus::Missing => {
+                Err(Error::Other(String::from("batch was not requested")))
+            }
+            EpochDataBatchStatus::Verified(_) => {
+                Err(Error::Other(String::from("batch already exists")))
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn mark_requested_for_test(&mut self, batch_index: u64) {
+        self.batches[batch_index as usize] =
+            EpochDataBatchStatus::Requested { attempt_time: near_time::Utc::UNIX_EPOCH };
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.batches.iter().all(|batch| matches!(batch, EpochDataBatchStatus::Verified(_)))
+    }
+
+    pub fn try_build(&self) -> Result<EpochSyncProofV1, Error> {
+        let all_epochs = self
+            .batches
+            .iter()
+            .map(|batch| {
+                if let EpochDataBatchStatus::Verified(epochs) = batch {
+                    Ok(epochs)
+                } else {
+                    Err(Error::Other(String::from("Not all batch are ready")))
+                }
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        Ok(EpochSyncProofV1 {
+            all_epochs: all_epochs.into_iter().flatten().cloned().collect(),
+            last_epoch: self.manifest.last_epoch.clone(),
+            current_epoch: self.manifest.current_epoch.clone(),
+        })
+    }
+}
+
+struct BatchedEpochSyncProof {
+    manifest: CompressedEpochSyncProofManifest,
+    batches: Vec<CompressedEpochSyncProofBatch>,
+}
+
 pub struct EpochSync {
     clock: Clock,
     network_adapter: PeerManagerAdapter,
@@ -58,6 +220,8 @@ pub struct EpochSync {
     /// The last epoch sync proof and the epoch ID it was computed for.
     /// We reuse the same proof as long as the current epoch ID is the same.
     last_epoch_sync_response_cache: Arc<Mutex<Option<(EpochId, CompressedEpochSyncProof)>>>,
+    last_batched_response_cache: Arc<Mutex<Option<(EpochId, Arc<BatchedEpochSyncProof>)>>>,
+    proof_assembler: Option<EpochSyncProofAssembler>,
 }
 
 impl EpochSync {
@@ -75,6 +239,8 @@ impl EpochSync {
             async_computation_spawner,
             config,
             last_epoch_sync_response_cache: Arc::new(Mutex::new(None)),
+            last_batched_response_cache: Arc::new(Mutex::new(None)),
+            proof_assembler: None,
         }
     }
 
@@ -127,7 +293,7 @@ impl EpochSync {
     /// request is still in flight. Handles both initial send (NotStarted) and
     /// retry on timeout (InProgress).
     pub fn run(
-        &self,
+        &mut self,
         status: &mut EpochSyncStatus,
         highest_height_peers: &[HighestHeightPeerInfo],
     ) -> Result<(), Error> {
@@ -135,14 +301,140 @@ impl EpochSync {
             EpochSyncStatus::InProgress { attempt_time, source_peer_id, .. } => {
                 if *attempt_time + self.config.timeout_for_epoch_sync < self.clock.now_utc() {
                     tracing::warn!(target: "sync", %source_peer_id, "epoch sync from peer timed out, retrying");
+                    self.request_full_proof(status, highest_height_peers)
                 } else {
-                    return Ok(());
+                    Ok(())
                 }
             }
-            EpochSyncStatus::NotStarted => {}
-            EpochSyncStatus::Done => return Ok(()),
+            EpochSyncStatus::FetchingManifest {
+                source_peer_id,
+                source_peer_height: _,
+                attempt_time,
+            } => {
+                if *attempt_time + self.config.timeout_for_epoch_sync < self.clock.now_utc() {
+                    tracing::warn!(target: "sync", %source_peer_id, "epoch sync from peer timed out, retrying");
+                    self.request_manifest(status, highest_height_peers)
+                } else {
+                    Ok(())
+                }
+            }
+            EpochSyncStatus::FetchingBatches(state) => {
+                *status = self.check_batches_status(state)?;
+                Ok(())
+            }
+            EpochSyncStatus::NotStarted => {
+                if ProtocolFeature::BatchedEpochSync.enabled(PROTOCOL_VERSION) {
+                    self.request_manifest(status, highest_height_peers)
+                } else {
+                    self.request_full_proof(status, highest_height_peers)
+                }
+            }
+            EpochSyncStatus::Done => Ok(()),
+        }
+    }
+
+    fn check_batches_status(
+        &mut self,
+        FetchingEpochSyncBatchesState {
+            manifest_source_peer_id,
+            manifest_source_peer_height,
+            total_batches,
+            verified_batches,
+            attempt_time,
+            in_flight: _,
+        }: &FetchingEpochSyncBatchesState,
+    ) -> Result<EpochSyncStatus, Error> {
+        if *attempt_time + self.config.timeout_for_epoch_sync < self.clock.now_utc() {
+            tracing::warn!(target: "sync", %manifest_source_peer_id, "epoch sync from peer timed out, restarting epoch sync");
+            self.proof_assembler = None;
+            return Ok(EpochSyncStatus::NotStarted);
         }
 
+        let Some(assembler) = self.proof_assembler.as_mut() else {
+            tracing::error!(target: "sync", "no proof assembler while fetching batches, this is a bug, restarting epoch sync");
+            return Ok(EpochSyncStatus::NotStarted);
+        };
+
+        let mut in_flight = assembler
+            .batches
+            .iter()
+            .filter(|status| matches!(status, EpochDataBatchStatus::Requested { .. }))
+            .count() as u64;
+
+        for (batch_index, status) in assembler.batches.iter_mut().enumerate() {
+            match status {
+                EpochDataBatchStatus::Verified(_) => {}
+                EpochDataBatchStatus::Missing => {
+                    if in_flight < MAX_IN_FLIGHT_BATCH_REQUESTS {
+                        self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                            // TODO: consider requesting batches from multiple peers in parallel
+                            NetworkRequests::EpochSyncBatchRequest {
+                                peer_id: manifest_source_peer_id.clone(),
+                                batch_index: batch_index as u64,
+                            },
+                        ));
+                        *status =
+                            EpochDataBatchStatus::Requested { attempt_time: self.clock.now_utc() };
+                        in_flight += 1;
+                    }
+                }
+                EpochDataBatchStatus::Requested { attempt_time } => {
+                    // retry we haven't gotten back a response yet
+                    if *attempt_time + EPOCH_SYNC_BATCH_REQUEST_TIMEOUT < self.clock.now_utc() {
+                        self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                            // TODO: consider requesting batches from multiple peers in parallel
+                            NetworkRequests::EpochSyncBatchRequest {
+                                peer_id: manifest_source_peer_id.clone(),
+                                batch_index: batch_index as u64,
+                            },
+                        ));
+                        *status =
+                            EpochDataBatchStatus::Requested { attempt_time: self.clock.now_utc() };
+                    }
+                }
+            }
+        }
+
+        Ok(EpochSyncStatus::FetchingBatches(FetchingEpochSyncBatchesState {
+            manifest_source_peer_id: manifest_source_peer_id.clone(),
+            manifest_source_peer_height: *manifest_source_peer_height,
+            total_batches: *total_batches,
+            verified_batches: *verified_batches,
+            attempt_time: *attempt_time,
+            in_flight,
+        }))
+    }
+
+    fn request_manifest(
+        &self,
+        status: &mut EpochSyncStatus,
+        highest_height_peers: &[HighestHeightPeerInfo],
+    ) -> Result<(), Error> {
+        // TODO(#11976): Implement a more robust logic for picking a peer to request epoch sync from.
+        let peer = highest_height_peers
+            .choose(&mut rand::thread_rng())
+            .ok_or_else(|| Error::Other("No peers to request epoch sync from".to_string()))?;
+
+        tracing::info!(target: "sync", peer_id=?peer.peer_info.id, "bootstrapping node via epoch sync");
+
+        *status = EpochSyncStatus::FetchingManifest {
+            source_peer_id: peer.peer_info.id.clone(),
+            source_peer_height: peer.highest_block_height,
+            attempt_time: self.clock.now_utc(),
+        };
+
+        self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+            NetworkRequests::EpochSyncManifestRequest { peer_id: peer.peer_info.id.clone() },
+        ));
+
+        Ok(())
+    }
+
+    fn request_full_proof(
+        &self,
+        status: &mut EpochSyncStatus,
+        highest_height_peers: &[HighestHeightPeerInfo],
+    ) -> Result<(), Error> {
         // TODO(#11976): Implement a more robust logic for picking a peer to request epoch sync from.
         let peer = highest_height_peers
             .choose(&mut rand::thread_rng())
@@ -163,6 +455,52 @@ impl EpochSync {
         Ok(())
     }
 
+    #[instrument(skip(store, cache))]
+    fn derive_batched_epoch_sync_proof(
+        store: Store,
+        transaction_validity_period: BlockHeightDelta,
+        cache: Arc<Mutex<Option<(EpochId, Arc<BatchedEpochSyncProof>)>>>,
+    ) -> Result<Arc<BatchedEpochSyncProof>, Error> {
+        let target_epoch_last_block_hash =
+            find_target_epoch_to_produce_proof_for(&store, transaction_validity_period)?;
+        let chain_store = store.chain_store();
+        let target_epoch_last_block_header =
+            chain_store.get_block_header(&target_epoch_last_block_hash)?;
+
+        let mut guard = cache.lock();
+        if let Some((epoch_id, response)) = &*guard {
+            if epoch_id == target_epoch_last_block_header.epoch_id() {
+                return Ok(response.clone());
+            }
+        }
+        let proof = derive_epoch_sync_proof_from_last_block(
+            &store.epoch_store(),
+            &target_epoch_last_block_hash,
+            true,
+        )?;
+        let (manifest, batches) = proof.into_v1().split_into_batches();
+
+        let (manifest, _) =
+            CompressedEpochSyncProofManifest::encode(&EpochSyncProofManifest::V1(manifest))
+                .map_err(|err| {
+                    Error::Other(format!("failed to compress epoch sync manifest: {err:?}"))
+                })?;
+        let batches = batches
+            .into_iter()
+            .map(|batches| {
+                CompressedEpochSyncProofBatch::encode(&EpochSyncProofBatch::V1(batches))
+                    .map(|(batches, _)| batches)
+                    .map_err(|err| {
+                        Error::Other(format!("failed to compress epoch sync proof batch: {err:?}"))
+                    })
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        let response = Arc::new(BatchedEpochSyncProof { manifest, batches });
+        *guard = Some((*target_epoch_last_block_header.epoch_id(), response.clone()));
+        Ok(response)
+    }
+
     /// Validates an epoch sync proof: checks peer identity, proof freshness,
     /// and cryptographic correctness. Does not write any data to the store.
     /// Returns `Ok(true)` if the proof is valid, `Ok(false)` if the proof
@@ -175,15 +513,25 @@ impl EpochSync {
         source_peer: &PeerId,
         epoch_manager: &dyn EpochManagerAdapter,
     ) -> Result<bool, Error> {
-        let SyncStatus::EpochSync(EpochSyncStatus::InProgress {
-            source_peer_id,
-            source_peer_height,
-            ..
-        }) = status
-        else {
-            tracing::warn!(target: "sync", %source_peer, "ignoring unexpected epoch sync proof");
-            return Ok(false);
+        let (source_peer_id, source_peer_height) = match status {
+            SyncStatus::EpochSync(EpochSyncStatus::InProgress {
+                source_peer_id,
+                source_peer_height,
+                ..
+            }) => (source_peer_id, source_peer_height),
+            SyncStatus::EpochSync(EpochSyncStatus::FetchingBatches(
+                FetchingEpochSyncBatchesState {
+                    manifest_source_peer_id,
+                    manifest_source_peer_height,
+                    ..
+                },
+            )) => (manifest_source_peer_id, manifest_source_peer_height),
+            _ => {
+                tracing::warn!(target: "sync", %source_peer, "ignoring unexpected epoch sync proof");
+                return Ok(false);
+            }
         };
+
         if *source_peer_id != *source_peer {
             tracing::warn!(target: "sync", %source_peer, expected_peer = %source_peer_id, "ignoring epoch sync proof from unexpected peer");
             return Ok(false);
@@ -343,23 +691,7 @@ impl EpochSync {
         }
 
         // Verify block producer handoff to the second epoch after genesis.
-        let second_next_epoch_id_after_genesis = EpochId(*self.genesis.hash());
-        let second_next_epoch_info_after_genesis =
-            epoch_manager.get_epoch_info(&second_next_epoch_id_after_genesis)?;
-        if all_epochs[0].block_producers
-            != get_epoch_info_block_producers(&second_next_epoch_info_after_genesis)
-        {
-            return Err(Error::InvalidEpochSyncProof(
-                "invalid block producers for second epoch after genesis".to_string(),
-            ));
-        }
-        if all_epochs[0].last_final_block_header.epoch_id() != &second_next_epoch_id_after_genesis {
-            return Err(Error::InvalidEpochSyncProof(format!(
-                "epoch_id mismatch for all_epochs[0] last final block header: expected {:?}, got {:?}",
-                second_next_epoch_id_after_genesis,
-                all_epochs[0].last_final_block_header.epoch_id(),
-            )));
-        }
+        Self::verify_first_epoch_against_genesis(&self.genesis, &all_epochs[0], epoch_manager)?;
         Self::verify_final_block_endorsement(&all_epochs[0])?;
 
         // Verify the data of each epoch, in chronological order. When verifying each epoch,
@@ -497,6 +829,35 @@ impl EpochSync {
 
     /// Verifies that EpochSyncProofPastEpochData's block_producers is valid,
     /// returning true if it is.
+    /// Verifies that the first epoch of a proof is the epoch following genesis, against the
+    /// block producers this node derives from its own genesis. This is the root of the
+    /// induction the rest of the proof rests on, so it deliberately uses nothing the sender
+    /// supplied.
+    fn verify_first_epoch_against_genesis(
+        genesis: &BlockHeader,
+        first_epoch: &EpochSyncProofEpochData,
+        epoch_manager: &dyn EpochManagerAdapter,
+    ) -> Result<(), Error> {
+        let second_next_epoch_id_after_genesis = EpochId(*genesis.hash());
+        let second_next_epoch_info_after_genesis =
+            epoch_manager.get_epoch_info(&second_next_epoch_id_after_genesis)?;
+        if first_epoch.block_producers
+            != get_epoch_info_block_producers(&second_next_epoch_info_after_genesis)
+        {
+            return Err(Error::InvalidEpochSyncProof(
+                "invalid block producers for second epoch after genesis".to_string(),
+            ));
+        }
+        if first_epoch.last_final_block_header.epoch_id() != &second_next_epoch_id_after_genesis {
+            return Err(Error::InvalidEpochSyncProof(format!(
+                "epoch_id mismatch for all_epochs[0] last final block header: expected {:?}, got {:?}",
+                second_next_epoch_id_after_genesis,
+                first_epoch.last_final_block_header.epoch_id(),
+            )));
+        }
+        Ok(())
+    }
+
     fn verify_block_producer_handoff(
         block_producers: &Vec<ValidatorStake>,
         use_versioned_bp_hash_format: bool,
@@ -571,6 +932,59 @@ impl EpochSync {
         }
 
         Ok(())
+    }
+}
+
+impl ClientActor {
+    fn spawn_batched_epoch_sync_response(
+        &self,
+        task_name: &'static str,
+        respond: impl FnOnce(&BatchedEpochSyncProof) -> Option<NetworkRequests> + Send + 'static,
+        response_permit: OutgoingPermit,
+    ) {
+        if !ProtocolFeature::BatchedEpochSync.enabled(PROTOCOL_VERSION) {
+            tracing::debug!(target: "sync", task_name, "ignoring batched epoch sync request, feature is not enabled");
+            return;
+        }
+
+        let store = self.client.chain.chain_store.store();
+        let transaction_validity_period = self.client.chain.transaction_validity_period();
+        let cache = self.client.sync_handler.epoch_sync.last_batched_response_cache.clone();
+        let network_adapter = self.client.network_adapter.clone();
+        self.client.sync_handler.epoch_sync.async_computation_spawner.spawn(task_name, move || {
+            let response = match EpochSync::derive_batched_epoch_sync_proof(
+                store,
+                transaction_validity_period,
+                cache,
+            ) {
+                Ok(response) => response,
+                Err(err) => {
+                    tracing::error!(target: "sync", ?err, "failed to derive batched epoch sync proof");
+                    return;
+                }
+            };
+            if let Some(request) = respond(&response) {
+                network_adapter.send(NetworkRequestWithPermit { request, permit: response_permit });
+            }
+        })
+    }
+
+    fn request_data_reset_if_stale(&mut self) -> bool {
+        let tip_height = match self.client.chain.header_head() {
+            Ok(head) => head.height,
+            Err(err) => {
+                tracing::error!(target: "sync", ?err, "failed to read header head while handling epoch sync proof");
+                return true;
+            }
+        };
+        if tip_height == self.client.chain.genesis().height() {
+            return false;
+        }
+        tracing::info!(target: "sync", "stale node validated epoch sync proof, requesting data reset");
+        if let Some(tx) = self.shutdown_signal.take() {
+            let _ = tx.send(ShutdownReason::EpochSyncDataReset);
+        }
+        true
     }
 }
 
@@ -664,19 +1078,7 @@ impl Handler<EpochSyncResponseMessage> for ClientActor {
         }
 
         // If the proof is valid but the node is stale (data beyond genesis), shut down for data reset immediately
-        let tip_height = match self.client.chain.header_head() {
-            Ok(head) => head.height,
-            Err(err) => {
-                tracing::error!(target: "sync", ?err, "failed to read header head while handling epoch sync proof");
-                return;
-            }
-        };
-        let genesis_height = self.client.chain.genesis().height();
-        if tip_height != genesis_height {
-            tracing::info!(target: "sync", "stale node validated epoch sync proof, requesting data reset");
-            if let Some(tx) = self.shutdown_signal.take() {
-                let _ = tx.send(ShutdownReason::EpochSyncDataReset);
-            }
+        if self.request_data_reset_if_stale() {
             return;
         }
 
@@ -692,11 +1094,378 @@ impl Handler<EpochSyncResponseMessage> for ClientActor {
     }
 }
 
+impl Handler<EpochSyncManifestRequestMessage> for ClientActor {
+    fn handle(
+        &mut self,
+        EpochSyncManifestRequestMessage { from_peer, recv_permit: _, response_permit }: EpochSyncManifestRequestMessage,
+    ) {
+        self.spawn_batched_epoch_sync_response(
+            "respond to epoch sync manifest request",
+            move |response| {
+                Some(NetworkRequests::EpochSyncManifestResponse {
+                    peer_id: from_peer,
+                    manifest: response.manifest.clone(),
+                })
+            },
+            response_permit,
+        );
+    }
+}
+
+impl Handler<EpochSyncManifestResponseMessage> for ClientActor {
+    fn handle(
+        &mut self,
+        EpochSyncManifestResponseMessage { from_peer, manifest, recv_permit: _ }: EpochSyncManifestResponseMessage,
+    ) {
+        let SyncStatus::EpochSync(EpochSyncStatus::FetchingManifest {
+            source_peer_id,
+            source_peer_height,
+            attempt_time,
+        }) = &self.client.sync_handler.sync_status
+        else {
+            tracing::warn!(target: "sync", %from_peer, "ignoring unsolicited epoch sync response");
+            return;
+        };
+
+        let (manifest, _) = match manifest.decode() {
+            Ok(manifest) => manifest,
+            Err(err) => {
+                tracing::error!(target: "sync", ?err, "failed to uncompress epoch sync proof manifest");
+                return;
+            }
+        };
+
+        if *source_peer_id != from_peer {
+            tracing::warn!(target: "sync", %from_peer, "ignoring epoch sync response from a wrong peer");
+            return;
+        }
+
+        let assembler = match EpochSyncProofAssembler::new(manifest.into_v1()) {
+            Ok(assembler) => assembler,
+            Err(err) => {
+                tracing::warn!(target: "sync", %from_peer, ?err, "ignoring invalid manifest");
+                return;
+            }
+        };
+        let total_batches = assembler.total_batches() as u64;
+        self.client.sync_handler.epoch_sync.proof_assembler = Some(assembler);
+        self.client.sync_handler.sync_status =
+            SyncStatus::EpochSync(EpochSyncStatus::FetchingBatches(FetchingEpochSyncBatchesState {
+                manifest_source_peer_id: source_peer_id.clone(),
+                manifest_source_peer_height: *source_peer_height,
+                attempt_time: *attempt_time,
+                total_batches,
+                verified_batches: 0,
+                in_flight: 0,
+            }))
+    }
+}
+
+impl Handler<EpochSyncBatchRequestMessage> for ClientActor {
+    fn handle(
+        &mut self,
+        EpochSyncBatchRequestMessage {
+            from_peer,
+            batch_index,
+            recv_permit: _,
+            response_permit,
+        }: EpochSyncBatchRequestMessage,
+    ) {
+        self.spawn_batched_epoch_sync_response(
+            "respond to epoch sync batch request",
+            move |response| {
+                let Some(batch) = response.batches.get(batch_index as usize) else {
+                    tracing::debug!(
+                        target: "sync",
+                        %from_peer,
+                        batch_index,
+                        num_batches = response.batches.len(),
+                        "ignoring epoch sync batch request for an unknown batch",
+                    );
+                    return None;
+                };
+                Some(NetworkRequests::EpochSyncBatchResponse {
+                    peer_id: from_peer,
+                    batch_index,
+                    batch: batch.clone(),
+                })
+            },
+            response_permit,
+        );
+    }
+}
+
+impl Handler<EpochSyncBatchResponseMessage> for ClientActor {
+    fn handle(
+        &mut self,
+        EpochSyncBatchResponseMessage {
+            from_peer,
+            batch_index,
+            batch,
+            recv_permit: _,
+        }: EpochSyncBatchResponseMessage,
+    ) {
+        let SyncStatus::EpochSync(EpochSyncStatus::FetchingBatches(
+            FetchingEpochSyncBatchesState { manifest_source_peer_id, verified_batches, .. },
+        )) = &mut self.client.sync_handler.sync_status
+        else {
+            tracing::warn!(target: "sync", %from_peer, "ignoring unsolicited epoch proof batch response");
+            return;
+        };
+
+        // As of today, we only request batches from the same peer we requested the manifest from.
+        if *manifest_source_peer_id != from_peer {
+            tracing::warn!(target: "sync", %from_peer, "ignoring epoch sync response from a wrong peer");
+            return;
+        }
+
+        let Some(assembler) = self.client.sync_handler.epoch_sync.proof_assembler.as_mut() else {
+            tracing::error!(target: "sync", "proof assembler is missing, this should never happen");
+            return;
+        };
+
+        if !assembler.is_awaiting_batches(batch_index) {
+            tracing::debug!(target: "sync", %from_peer, batch_index, "ignoring epoch sync proof batch that was not requested");
+            return;
+        }
+
+        let (batch, _) = match batch.decode() {
+            Ok(batch) => batch,
+            Err(err) => {
+                tracing::error!(target: "sync", batch_index, ?err, "failed to uncompress epoch sync proof batch");
+                return;
+            }
+        };
+
+        let batch = batch.into_v1();
+        if batch_index == 0 {
+            if let Err(err) = batch
+                .epochs
+                .first()
+                .ok_or_else(|| Error::Other(String::from("batch 0 was empty")))
+                .and_then(|first_epoch| {
+                    EpochSync::verify_first_epoch_against_genesis(
+                        &self.client.sync_handler.epoch_sync.genesis,
+                        first_epoch,
+                        self.client.epoch_manager.as_ref(),
+                    )
+                })
+            {
+                tracing::warn!(target: "sync", %from_peer, ?err, "rejecting epoch sync proof batch 0 that is not anchored at genesis");
+                return;
+            }
+        }
+
+        match assembler.try_add_batch(batch_index, batch) {
+            Ok(_) => *verified_batches += 1,
+            Err(err) => {
+                tracing::error!(target: "sync", ?err, "Failed to add batch");
+                return;
+            }
+        }
+
+        if !assembler.is_ready() {
+            return;
+        }
+
+        let proof = match assembler.try_build() {
+            Ok(proof) => proof,
+            Err(err) => {
+                tracing::error!(target: "sync", ?err, "failed to build epoch sync proof");
+                return;
+            }
+        };
+
+        let restart_epoch_sync = |sync_handler: &mut SyncHandler| {
+            sync_handler.epoch_sync.proof_assembler = None;
+            sync_handler.sync_status.update(SyncStatus::EpochSync(EpochSyncStatus::NotStarted));
+        };
+
+        match self.client.sync_handler.epoch_sync.validate_proof(
+            &self.client.sync_handler.sync_status,
+            &self.client.chain,
+            &proof,
+            &from_peer,
+            self.client.epoch_manager.as_ref(),
+        ) {
+            Ok(true) => {}
+            Ok(false) => {
+                restart_epoch_sync(&mut self.client.sync_handler);
+                return;
+            }
+            Err(err) => {
+                tracing::error!(target: "sync", %from_peer, ?err, "failed to validate epoch sync proof");
+                restart_epoch_sync(&mut self.client.sync_handler);
+                return;
+            }
+        }
+
+        // If the proof is valid but the node is stale (data beyond genesis), shut down for data reset immediately
+        if self.request_data_reset_if_stale() {
+            return;
+        }
+
+        self.client.sync_handler.epoch_sync.proof_assembler = None;
+
+        // Apply the validated proof to the store.
+        if let Err(err) = self.client.sync_handler.epoch_sync.apply_validated_proof(
+            &mut self.client.sync_handler.sync_status,
+            &mut self.client.chain,
+            proof,
+            self.client.epoch_manager.as_ref(),
+        ) {
+            tracing::error!(target: "sync", ?err, "failed to apply epoch sync proof");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::EpochSync;
+    use super::{EpochSync, EpochSyncProofAssembler};
     use near_chain::Error;
+    use near_primitives::block::{Block, compute_bp_hash_from_validator_stakes};
+    use near_primitives::epoch_sync::{
+        EPOCHS_PER_BATCH_V1, EpochSyncProofCurrentEpochData, EpochSyncProofEpochData,
+        EpochSyncProofLastEpochData, EpochSyncProofV1,
+    };
+    use near_primitives::genesis::genesis_block;
     use near_primitives::hash::CryptoHash;
+    use near_primitives::test_utils::{TestBlockBuilder, create_test_signer};
+    use near_primitives::types::validator_stake::ValidatorStake;
+    use near_primitives::types::{Balance, EpochId};
+    use near_primitives::validator_signer::ValidatorSigner;
+    use near_primitives::version::PROTOCOL_VERSION;
+    use near_time::{Clock, Utc};
+    use std::sync::Arc;
+
+    fn test_epoch_id(index: usize) -> EpochId {
+        EpochId(CryptoHash::hash_bytes(format!("epoch{index}").as_bytes()))
+    }
+
+    fn test_block_producers(index: usize) -> Vec<ValidatorStake> {
+        vec![ValidatorStake::test(format!("bp{index}").parse().unwrap())]
+    }
+
+    fn test_proof(
+        num_epochs: usize,
+        genesis: &Block,
+        signer: &Arc<ValidatorSigner>,
+    ) -> EpochSyncProofV1 {
+        let all_epochs = (0..num_epochs)
+            .map(|index| {
+                let block =
+                    TestBlockBuilder::from_prev_block(Clock::real(), genesis, signer.clone())
+                        .height(index as u64 + 1)
+                        .epoch_id(test_epoch_id(index))
+                        .next_epoch_id(test_epoch_id(index + 1))
+                        .next_bp_hash(compute_bp_hash_from_validator_stakes(
+                            &test_block_producers(index + 1),
+                            true,
+                        ))
+                        .build();
+                EpochSyncProofEpochData {
+                    block_producers: test_block_producers(index),
+                    use_versioned_bp_hash_format: true,
+                    last_final_block_header: Arc::new(block.header().clone()),
+                    this_epoch_endorsements_for_last_final_block: vec![],
+                }
+            })
+            .collect();
+
+        let genesis_header = Arc::new(genesis.header().clone());
+        EpochSyncProofV1 {
+            all_epochs,
+            last_epoch: EpochSyncProofLastEpochData {
+                epoch_info: Default::default(),
+                next_epoch_info: Default::default(),
+                next_next_epoch_info: Default::default(),
+                first_block_in_epoch: Default::default(),
+                last_block_in_epoch: Default::default(),
+                second_last_block_in_epoch: Default::default(),
+            },
+            current_epoch: EpochSyncProofCurrentEpochData {
+                first_block_header_in_epoch: genesis_header.clone(),
+                last_block_header_in_prev_epoch: genesis_header.clone(),
+                second_last_block_header_in_prev_epoch: genesis_header,
+                merkle_proof_for_first_block: vec![],
+                partial_merkle_tree_for_first_block: Default::default(),
+            },
+        }
+    }
+
+    /// Splitting a proof and feeding the batches back through the assembler must reproduce the
+    /// proof exactly, including when the batches arrive out of order.
+    #[test]
+    fn split_into_batches_and_reassemble_roundtrip() {
+        let signer = Arc::new(create_test_signer("test"));
+        let genesis = genesis_block(
+            PROTOCOL_VERSION,
+            vec![],
+            Utc::UNIX_EPOCH,
+            0,
+            Balance::from_yoctonear(1),
+            Balance::from_yoctonear(1),
+            &vec![],
+        );
+
+        // One full batch plus a remainder, so that both the boundary anchor between batches and
+        // the short last batch are exercised.
+        let num_epochs = EPOCHS_PER_BATCH_V1 as usize + 1;
+        let proof = test_proof(num_epochs, &genesis, &signer);
+
+        let (manifest, batches) = proof.clone().split_into_batches();
+        assert_eq!(manifest.total_epochs, num_epochs as u64);
+        assert_eq!(manifest.expected_num_batches(), 2);
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].epochs.len(), EPOCHS_PER_BATCH_V1 as usize);
+        assert_eq!(batches[1].epochs.len(), 1);
+
+        let mut assembler = EpochSyncProofAssembler::new(manifest).unwrap();
+        assert_eq!(assembler.total_batches(), 2);
+        assert!(!assembler.is_ready());
+
+        // Out of order on purpose: a batch is placed by its index and checked against the
+        // manifest, so it must not depend on its neighbours having arrived.
+        for batch_index in [1, 0] {
+            assert!(!assembler.is_awaiting_batches(batch_index));
+            assembler.mark_requested_for_test(batch_index);
+            assert!(assembler.is_awaiting_batches(batch_index));
+            assembler
+                .try_add_batch(batch_index, batches[batch_index as usize].clone())
+                .expect("batch produced by split_into_batches must be accepted");
+        }
+
+        assert!(assembler.is_ready());
+        assert_eq!(assembler.try_build().unwrap(), proof);
+    }
+
+    #[test]
+    fn try_add_batch_rejects_mismatched_batch() {
+        let signer = Arc::new(create_test_signer("test"));
+        let genesis = genesis_block(
+            PROTOCOL_VERSION,
+            vec![],
+            Utc::UNIX_EPOCH,
+            0,
+            Balance::from_yoctonear(1),
+            Balance::from_yoctonear(1),
+            &vec![],
+        );
+        let num_epochs = EPOCHS_PER_BATCH_V1 as usize + 1;
+        let (manifest, batches) = test_proof(num_epochs, &genesis, &signer).split_into_batches();
+
+        // Serving batch 0's epochs under index 1 fails the length check.
+        let mut assembler = EpochSyncProofAssembler::new(manifest.clone()).unwrap();
+        assembler.mark_requested_for_test(1);
+        assert!(assembler.try_add_batch(1, batches[0].clone()).is_err());
+
+        // A batch that is the right length but starts at the wrong epoch fails the anchor check.
+        let mut short_batch = batches[1].clone();
+        short_batch.epochs = vec![batches[0].epochs[0].clone()];
+        let mut assembler = EpochSyncProofAssembler::new(manifest).unwrap();
+        assembler.mark_requested_for_test(1);
+        assert!(assembler.try_add_batch(1, short_batch).is_err());
+    }
 
     /// Regression test: an attacker-supplied epoch sync proof may carry a block header whose height
     /// is u64::MAX. `verify_block_endorsements` computes `block_height + 1`, which would overflow

--- a/chain/client/src/sync/handler.rs
+++ b/chain/client/src/sync/handler.rs
@@ -165,7 +165,9 @@ impl SyncHandler {
                 *current_height = head.height;
                 *hh = highest_height;
             }
-            status => unreachable!("unexpected sync status in handle_sync_needed: {:?}", status),
+            status @ (SyncStatus::AwaitingPeers | SyncStatus::NoSync) => {
+                unreachable!("unexpected sync status in handle_sync_needed: {:?}", status)
+            }
         }
         Ok(None)
     }

--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -6,7 +6,9 @@ use near_async::messaging::{AsyncSender, Sender};
 use near_async::{MultiSend, MultiSenderFrom};
 use near_o11y::span_wrapped_msg::SpanWrapped;
 use near_primitives::block::{Approval, Block, BlockHeader};
-use near_primitives::epoch_sync::CompressedEpochSyncProof;
+use near_primitives::epoch_sync::{
+    CompressedEpochSyncProof, CompressedEpochSyncProofBatch, CompressedEpochSyncProofManifest,
+};
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
@@ -169,6 +171,42 @@ pub struct EpochSyncResponseMessage {
 }
 
 #[derive(Debug)]
+pub struct EpochSyncManifestRequestMessage {
+    pub from_peer: PeerId,
+    pub recv_permit: RecvMessagePermit,
+    /// Outgoing-queue reservation for the response message. Acquired in
+    /// the network layer when this request arrived. The client holds it
+    /// through proof derivation and uses it when sending the response.
+    pub response_permit: OutgoingPermit,
+}
+
+#[derive(Debug)]
+pub struct EpochSyncManifestResponseMessage {
+    pub from_peer: PeerId,
+    pub manifest: CompressedEpochSyncProofManifest,
+    pub recv_permit: RecvMessagePermit,
+}
+
+#[derive(Debug)]
+pub struct EpochSyncBatchRequestMessage {
+    pub from_peer: PeerId,
+    pub batch_index: u64,
+    pub recv_permit: RecvMessagePermit,
+    /// Outgoing-queue reservation for the response message. Acquired in
+    /// the network layer when this request arrived. The client holds it
+    /// through proof derivation and uses it when sending the response.
+    pub response_permit: OutgoingPermit,
+}
+
+#[derive(Debug)]
+pub struct EpochSyncBatchResponseMessage {
+    pub from_peer: PeerId,
+    pub batch_index: u64,
+    pub batch: CompressedEpochSyncProofBatch,
+    pub recv_permit: RecvMessagePermit,
+}
+
+#[derive(Debug)]
 pub struct OptimisticBlockMessage {
     pub optimistic_block: OptimisticBlock,
     pub from_peer: PeerId,
@@ -195,6 +233,10 @@ pub struct ClientSenderForNetwork {
     pub chunk_endorsement: AsyncSender<ChunkEndorsementMessage, ()>,
     pub epoch_sync_request: Sender<EpochSyncRequestMessage>,
     pub epoch_sync_response: Sender<EpochSyncResponseMessage>,
+    pub epoch_sync_manifest_request: Sender<EpochSyncManifestRequestMessage>,
+    pub epoch_sync_manifest_response: Sender<EpochSyncManifestResponseMessage>,
+    pub epoch_sync_batch_request: Sender<EpochSyncBatchRequestMessage>,
+    pub epoch_sync_batch_response: Sender<EpochSyncBatchResponseMessage>,
     pub optimistic_block_receiver: Sender<SpanWrapped<OptimisticBlockMessage>>,
     pub current_epoch_height_request: AsyncSender<GetCurrentEpochHeight, Option<EpochHeight>>,
 }

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -7,6 +7,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use bytesize::{KIB, MIB};
 pub use edge::*;
+use near_primitives::epoch_sync::CompressedEpochSyncProofBatch;
+use near_primitives::epoch_sync::CompressedEpochSyncProofManifest;
 use near_primitives::genesis::GenesisId;
 use near_primitives::spice::chunk_endorsement::SpiceChunkEndorsement;
 use near_primitives::spice::partial_data::SpicePartialData;
@@ -451,6 +453,16 @@ pub enum PeerMessage {
 
     EpochSyncRequest,
     EpochSyncResponse(CompressedEpochSyncProof),
+
+    EpochSyncManifestRequest,
+    EpochSyncManifestResponse(CompressedEpochSyncProofManifest),
+    EpochSyncBatchRequest {
+        batch_index: u64,
+    },
+    EpochSyncBatchResponse {
+        batch_index: u64,
+        batch: CompressedEpochSyncProofBatch,
+    },
 }
 
 impl fmt::Display for PeerMessage {
@@ -516,7 +528,9 @@ impl PeerMessage {
             | PeerMessage::LastEdge(_)
             | PeerMessage::PeersRequest(_)
             | PeerMessage::Challenge(_) // challenges are disabled
-            | PeerMessage::EpochSyncRequest => MAX_SMALL_MESSAGE_SIZE,
+            | PeerMessage::EpochSyncRequest
+            | PeerMessage::EpochSyncBatchRequest { .. }
+            | PeerMessage::EpochSyncManifestRequest => MAX_SMALL_MESSAGE_SIZE,
 
             PeerMessage::PeersResponse(_)
             | PeerMessage::Transaction(_)
@@ -525,7 +539,9 @@ impl PeerMessage {
             | PeerMessage::SyncSnapshotHosts(_)
             | PeerMessage::BlockHeaders(_)
             | PeerMessage::Block(_)
-            | PeerMessage::OptimisticBlock(_) => MAX_MEDIUM_MESSAGE_SIZE,
+            | PeerMessage::OptimisticBlock(_)
+            | PeerMessage::EpochSyncBatchResponse { .. }
+            | PeerMessage::EpochSyncManifestResponse(_) => MAX_MEDIUM_MESSAGE_SIZE,
 
             PeerMessage::VersionedStateResponse(_) => MAX_LARGE_MESSAGE_SIZE,
             PeerMessage::EpochSyncResponse(_) => MAX_HUGE_MESSAGE_SIZE,

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -462,6 +462,21 @@ message OptimisticBlock {
   CryptoHash hash = 3;
 }
 
+message EpochSyncManifestRequest {}
+
+message EpochSyncManifestResponse {
+  bytes compressed_manifest = 1;
+}
+
+message EpochSyncBatchRequest {
+  uint64 batch_index = 1;
+}
+
+message EpochSyncBatchResponse {
+  uint64 batch_index = 1;
+  bytes compressed_batch = 2;
+}
+
 // PeerMessage is a wrapper of all message types exchanged between NEAR nodes.
 // The wire format of a single message M consists of len(M)+4 bytes:
 // <len(M)> : 4 bytes : little endian uint32
@@ -517,6 +532,10 @@ message PeerMessage {
 
     EpochSyncRequest epoch_sync_request = 34;
     EpochSyncResponse epoch_sync_response = 35;
+    EpochSyncManifestRequest epoch_sync_manifest_request = 38;
+    EpochSyncManifestResponse epoch_sync_manifest_response = 39;
+    EpochSyncBatchRequest epoch_sync_batch_request = 40;
+    EpochSyncBatchResponse epoch_sync_batch_response = 41;
 
     OptimisticBlock optimistic_block = 36;
     RoutedMessageV3 routed_v3 = 37;

--- a/chain/network/src/network_protocol/proto_conv/peer_message.rs
+++ b/chain/network/src/network_protocol/proto_conv/peer_message.rs
@@ -345,6 +345,30 @@ impl From<&PeerMessage> for proto::PeerMessage {
                         ..Default::default()
                     })
                 }
+                PeerMessage::EpochSyncManifestRequest => {
+                    ProtoMT::EpochSyncManifestRequest(proto::EpochSyncManifestRequest {
+                        special_fields: Default::default(),
+                    })
+                }
+                PeerMessage::EpochSyncManifestResponse(manifest) => {
+                    ProtoMT::EpochSyncManifestResponse(proto::EpochSyncManifestResponse {
+                        compressed_manifest: manifest.as_slice().to_vec(),
+                        special_fields: Default::default(),
+                    })
+                }
+                PeerMessage::EpochSyncBatchRequest { batch_index } => {
+                    ProtoMT::EpochSyncBatchRequest(proto::EpochSyncBatchRequest {
+                        batch_index: *batch_index,
+                        special_fields: Default::default(),
+                    })
+                }
+                PeerMessage::EpochSyncBatchResponse { batch_index, batch } => {
+                    ProtoMT::EpochSyncBatchResponse(proto::EpochSyncBatchResponse {
+                        batch_index: *batch_index,
+                        compressed_batch: batch.as_slice().to_vec(),
+                        special_fields: Default::default(),
+                    })
+                }
             }),
             ..Default::default()
         }
@@ -529,6 +553,21 @@ impl TryFrom<&proto::PeerMessage> for PeerMessage {
             ProtoMT::EpochSyncResponse(esr) => PeerMessage::EpochSyncResponse(
                 CompressedData::from_boxed_slice(esr.compressed_proof.clone().into_boxed_slice()),
             ),
+            ProtoMT::EpochSyncManifestRequest(_) => PeerMessage::EpochSyncManifestRequest,
+            ProtoMT::EpochSyncManifestResponse(esmr) => {
+                PeerMessage::EpochSyncManifestResponse(CompressedData::from_boxed_slice(
+                    esmr.compressed_manifest.clone().into_boxed_slice(),
+                ))
+            }
+            ProtoMT::EpochSyncBatchRequest(escr) => {
+                PeerMessage::EpochSyncBatchRequest { batch_index: escr.batch_index }
+            }
+            ProtoMT::EpochSyncBatchResponse(escr) => PeerMessage::EpochSyncBatchResponse {
+                batch_index: escr.batch_index,
+                batch: CompressedData::from_boxed_slice(
+                    escr.compressed_batch.clone().into_boxed_slice(),
+                ),
+            },
         })
     }
 }

--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -56,7 +56,11 @@ impl tcp::Tier {
             | PeerMessage::StateRequestHeader(..)
             | PeerMessage::StateRequestPart(..)
             | PeerMessage::EpochSyncRequest
-            | PeerMessage::EpochSyncResponse(..) => self == tcp::Tier::T2,
+            | PeerMessage::EpochSyncResponse(..)
+            | PeerMessage::EpochSyncManifestRequest
+            | PeerMessage::EpochSyncManifestResponse(..)
+            | PeerMessage::EpochSyncBatchRequest { .. }
+            | PeerMessage::EpochSyncBatchResponse { .. } => self == tcp::Tier::T2,
         }
     }
 

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -2,10 +2,11 @@ use crate::accounts_data::{AccountDataCache, AccountDataError};
 use crate::announce_accounts::AnnounceAccountCache;
 use crate::client::{
     BlockApproval, BlockHeadersRequest, BlockHeadersResponse, BlockRequest, BlockResponse,
-    ChunkEndorsementMessage, ClientSenderForNetwork, EpochSyncRequestMessage,
-    EpochSyncResponseMessage, OptimisticBlockMessage, ProcessTxRequest,
-    SpiceChunkEndorsementMessage, StateRequestHeader, StateRequestPart, StateResponse,
-    StateResponseReceived, TxStatusRequest, TxStatusResponse,
+    ChunkEndorsementMessage, ClientSenderForNetwork, EpochSyncBatchRequestMessage,
+    EpochSyncBatchResponseMessage, EpochSyncManifestRequestMessage,
+    EpochSyncManifestResponseMessage, EpochSyncRequestMessage, EpochSyncResponseMessage,
+    OptimisticBlockMessage, ProcessTxRequest, SpiceChunkEndorsementMessage, StateRequestHeader,
+    StateRequestPart, StateResponse, StateResponseReceived, TxStatusRequest, TxStatusResponse,
 };
 use crate::concurrency::demux;
 use crate::concurrency::outgoing_queue_limiter::OutgoingQueueLimiter;
@@ -53,6 +54,7 @@ use near_async::futures::{FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{CanSend, CanSendAsync, Sender};
 use near_async::{new_owned_future_spawner, time};
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
+use near_primitives::epoch_sync::MAX_UNCOMPRESSED_BATCH_SIZE_V1;
 use near_primitives::genesis::GenesisId;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
@@ -93,6 +95,10 @@ pub(crate) const INCOMING_SEMAPHORE_PERMITS: usize = 1_000_000_000;
 
 /// Number of bytes reserved for the epoch sync response
 pub(crate) const EPOCH_SYNC_RESPONSE_BYTES: usize = 300 * 1024 * 1024;
+
+pub(crate) const EPOCH_SYNC_MANIFEST_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(crate) const EPOCH_SYNC_BATCH_RESPONSE_BYTES: usize = MAX_UNCOMPRESSED_BATCH_SIZE_V1.0 as usize;
 
 // Number of bytes reserved for the state sync response
 pub(crate) const STATE_SYNC_RESPONSE_BYTES: usize = 30 * 1024 * 1024;
@@ -1289,6 +1295,65 @@ impl NetworkState {
                 });
                 None
             }
+            PeerMessage::EpochSyncManifestRequest => {
+                if let Some(response_permit) =
+                    self.outgoing_queue_limiter.try_acquire(EPOCH_SYNC_MANIFEST_RESPONSE_BYTES)
+                {
+                    self.client.send(EpochSyncManifestRequestMessage {
+                        from_peer: peer_id,
+                        recv_permit,
+                        response_permit,
+                    });
+                } else {
+                    metrics::MessageDropped::OutgoingQueueLimitExceeded
+                        .inc_msg_type("EpochSyncManifestResponse");
+                    tracing::warn!(
+                        target: "network",
+                        %peer_id,
+                        "outgoing queue saturated; dropping epoch sync manifest request",
+                    );
+                }
+                None
+            }
+            PeerMessage::EpochSyncManifestResponse(manifest) => {
+                self.client.send(EpochSyncManifestResponseMessage {
+                    from_peer: peer_id,
+                    manifest,
+                    recv_permit,
+                });
+                None
+            }
+            PeerMessage::EpochSyncBatchRequest { batch_index } => {
+                if let Some(response_permit) =
+                    self.outgoing_queue_limiter.try_acquire(EPOCH_SYNC_BATCH_RESPONSE_BYTES)
+                {
+                    self.client.send(EpochSyncBatchRequestMessage {
+                        from_peer: peer_id,
+                        batch_index,
+                        recv_permit,
+                        response_permit,
+                    });
+                } else {
+                    metrics::MessageDropped::OutgoingQueueLimitExceeded
+                        .inc_msg_type("EpochSyncChunkResponse");
+                    tracing::warn!(
+                        target: "network",
+                        %peer_id,
+                        batch_index,
+                        "outgoing queue saturated; dropping epoch sync chunk request",
+                    );
+                }
+                None
+            }
+            PeerMessage::EpochSyncBatchResponse { batch_index, batch } => {
+                self.client.send(EpochSyncBatchResponseMessage {
+                    from_peer: peer_id,
+                    batch_index,
+                    batch,
+                    recv_permit,
+                });
+                None
+            }
             PeerMessage::OptimisticBlock(ob) => {
                 self.client.send(
                     OptimisticBlockMessage {
@@ -1300,7 +1365,19 @@ impl NetworkState {
                 );
                 None
             }
-            msg => {
+
+            PeerMessage::Tier1Handshake(_)
+            | PeerMessage::Tier2Handshake(_)
+            | PeerMessage::Tier3Handshake(_)
+            | PeerMessage::HandshakeFailure(_, _)
+            | PeerMessage::Disconnect(_)
+            | PeerMessage::SyncSnapshotHosts(_)
+            | PeerMessage::LastEdge(_)
+            | PeerMessage::SyncRoutingTable(_)
+            | PeerMessage::RequestUpdateNonce(_)
+            | PeerMessage::SyncAccountsData(_)
+            | PeerMessage::PeersRequest(_)
+            | PeerMessage::PeersResponse(_) => {
                 tracing::error!(target: "network", ?msg, "peer received unexpected type");
                 None
             }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1344,6 +1344,51 @@ impl PeerManagerActor {
                 };
                 if sent { NetworkResponses::NoResponse } else { NetworkResponses::RouteNotFound }
             }
+            NetworkRequests::EpochSyncManifestRequest { peer_id } => {
+                if self.transport.send_message(
+                    tcp::Tier::T2,
+                    peer_id,
+                    PeerMessage::EpochSyncManifestRequest.into(),
+                ) {
+                    NetworkResponses::NoResponse
+                } else {
+                    NetworkResponses::RouteNotFound
+                }
+            }
+            NetworkRequests::EpochSyncManifestResponse { peer_id, manifest } => {
+                // Use the pre-acquired permit if the caller supplied one.
+                let msg: Arc<PeerMessage> = PeerMessage::EpochSyncManifestResponse(manifest).into();
+                let sent = match permit {
+                    Some(p) => {
+                        self.transport.send_message_with_permit(tcp::Tier::T2, peer_id, msg, p)
+                    }
+                    None => self.transport.send_message(tcp::Tier::T2, peer_id, msg),
+                };
+                if sent { NetworkResponses::NoResponse } else { NetworkResponses::RouteNotFound }
+            }
+            NetworkRequests::EpochSyncBatchRequest { peer_id, batch_index } => {
+                if self.transport.send_message(
+                    tcp::Tier::T2,
+                    peer_id,
+                    PeerMessage::EpochSyncBatchRequest { batch_index }.into(),
+                ) {
+                    NetworkResponses::NoResponse
+                } else {
+                    NetworkResponses::RouteNotFound
+                }
+            }
+            NetworkRequests::EpochSyncBatchResponse { peer_id, batch_index, batch } => {
+                // Use the pre-acquired permit if the caller supplied one.
+                let msg: Arc<PeerMessage> =
+                    PeerMessage::EpochSyncBatchResponse { batch_index, batch }.into();
+                let sent = match permit {
+                    Some(p) => {
+                        self.transport.send_message_with_permit(tcp::Tier::T2, peer_id, msg, p)
+                    }
+                    None => self.transport.send_message(tcp::Tier::T2, peer_id, msg),
+                };
+                if sent { NetworkResponses::NoResponse } else { NetworkResponses::RouteNotFound }
+            }
             NetworkRequests::ChunkContractAccesses(validators, accesses) => {
                 for validator in validators {
                     self.state.send_message_to_account(

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -90,7 +90,7 @@ impl Config {
     ///
     /// # Errors
     ///
-    /// If at least one error is present, returns the list of all configuration errors.  
+    /// If at least one error is present, returns the list of all configuration errors.
     pub fn validate(&self) -> Result<(), Vec<(RateLimitedPeerMessageKey, TokenBucketError)>> {
         let mut errors = Vec::new();
         for (key, message_config) in &self.rate_limits {
@@ -117,6 +117,22 @@ impl Config {
         config.rate_limits.insert(
             RateLimitedPeerMessageKey::EpochSyncResponse,
             SingleMessageConfig::new(1, 1.0 / 30.0, None),
+        );
+        config.rate_limits.insert(
+            RateLimitedPeerMessageKey::EpochSyncManifestRequest,
+            SingleMessageConfig::new(1, 1.0 / 30.0, None),
+        );
+        config.rate_limits.insert(
+            RateLimitedPeerMessageKey::EpochSyncManifestResponse,
+            SingleMessageConfig::new(1, 1.0 / 30.0, None),
+        );
+        config.rate_limits.insert(
+            RateLimitedPeerMessageKey::EpochSyncChunkRequest,
+            SingleMessageConfig::new(8, 0.5, None),
+        );
+        config.rate_limits.insert(
+            RateLimitedPeerMessageKey::EpochSyncChunkResponse,
+            SingleMessageConfig::new(8, 0.5, None),
         );
         // SyncRoutingTable carries forged-edge OOM potential. The sender side already throttles
         // via routing_table_update_rate_limit (qps=1, burst=1) per peer, so 1 msg/s sustained
@@ -261,6 +277,10 @@ pub enum RateLimitedPeerMessageKey {
     PartialEncodedContractDeploys,
     EpochSyncRequest,
     EpochSyncResponse,
+    EpochSyncManifestRequest,
+    EpochSyncManifestResponse,
+    EpochSyncChunkRequest,
+    EpochSyncChunkResponse,
     OptimisticBlock,
     SpicePartialData,
     SpiceChunkEndorsement,
@@ -355,6 +375,10 @@ fn get_key_and_token_cost(message: &PeerMessage) -> Option<(RateLimitedPeerMessa
         PeerMessage::VersionedStateResponse(_) => Some((VersionedStateResponse, 1)),
         PeerMessage::EpochSyncRequest => Some((EpochSyncRequest, 1)),
         PeerMessage::EpochSyncResponse(_) => Some((EpochSyncResponse, 1)),
+        PeerMessage::EpochSyncManifestRequest => Some((EpochSyncManifestRequest, 1)),
+        PeerMessage::EpochSyncManifestResponse(_) => Some((EpochSyncManifestResponse, 1)),
+        PeerMessage::EpochSyncBatchRequest { .. } => Some((EpochSyncChunkRequest, 1)),
+        PeerMessage::EpochSyncBatchResponse { .. } => Some((EpochSyncChunkResponse, 1)),
         PeerMessage::Tier1Handshake(_)
         | PeerMessage::Tier2Handshake(_)
         | PeerMessage::Tier3Handshake(_)

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -19,7 +19,9 @@ use near_async::messaging::{AsyncSender, Sender};
 use near_async::{MultiSend, MultiSenderFrom, time};
 use near_crypto::PublicKey;
 use near_primitives::block::{ApprovalMessage, Block};
-use near_primitives::epoch_sync::CompressedEpochSyncProof;
+use near_primitives::epoch_sync::{
+    CompressedEpochSyncProof, CompressedEpochSyncProofBatch, CompressedEpochSyncProofManifest,
+};
 use near_primitives::genesis::GenesisId;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
@@ -236,17 +238,34 @@ pub enum SnapshotHostEvent {
 #[allow(clippy::large_enum_variant)]
 pub enum NetworkRequests {
     /// Sends block, either when block was just produced or when requested.
-    Block { block: Arc<Block> },
+    Block {
+        block: Arc<Block>,
+    },
     /// Sends optimistic block as soon as the production window for the height starts.
-    OptimisticBlock { chunk_producers: Arc<Vec<AccountId>>, optimistic_block: OptimisticBlock },
+    OptimisticBlock {
+        chunk_producers: Arc<Vec<AccountId>>,
+        optimistic_block: OptimisticBlock,
+    },
     /// Sends approval.
-    Approval { approval_message: ApprovalMessage },
+    Approval {
+        approval_message: ApprovalMessage,
+    },
     /// Request block with given hash from given peer.
-    BlockRequest { hash: CryptoHash, peer_id: PeerId },
+    BlockRequest {
+        hash: CryptoHash,
+        peer_id: PeerId,
+    },
     /// Request given block headers.
-    BlockHeadersRequest { hashes: Vec<CryptoHash>, peer_id: PeerId },
+    BlockHeadersRequest {
+        hashes: Vec<CryptoHash>,
+        peer_id: PeerId,
+    },
     /// Request state header for given shard and given sync hash.
-    StateRequestHeader { shard_id: ShardId, sync_hash: CryptoHash, sync_prev_prev_hash: CryptoHash },
+    StateRequestHeader {
+        shard_id: ShardId,
+        sync_hash: CryptoHash,
+        sync_prev_prev_hash: CryptoHash,
+    },
     /// Request state part for given shard and given sync hash.
     StateRequestPart {
         shard_id: ShardId,
@@ -263,7 +282,10 @@ pub enum NetworkRequests {
         peer_id: PeerId,
     },
     /// Ban given peer.
-    BanPeer { peer_id: PeerId, ban_reason: ReasonForBan },
+    BanPeer {
+        peer_id: PeerId,
+        ban_reason: ReasonForBan,
+    },
     /// Announce account
     AnnounceAccount(AnnounceAccount),
     /// Broadcast information about a hosted snapshot.
@@ -276,14 +298,20 @@ pub enum NetworkRequests {
         create_time: time::Instant,
     },
     /// Information about chunk such as its header, some subset of parts and/or incoming receipts
-    PartialEncodedChunkResponse { route_back: CryptoHash, response: PartialEncodedChunkResponseMsg },
+    PartialEncodedChunkResponse {
+        route_back: CryptoHash,
+        response: PartialEncodedChunkResponseMsg,
+    },
     /// Information about chunk such as its header, some subset of parts and/or incoming receipts
     PartialEncodedChunkMessage {
         account_id: AccountId,
         partial_encoded_chunk: PartialEncodedChunkWithArcReceipts,
     },
     /// Forwarding a chunk part to a validator tracking the shard
-    PartialEncodedChunkForward { account_id: AccountId, forward: PartialEncodedChunkForwardMsg },
+    PartialEncodedChunkForward {
+        account_id: AccountId,
+        forward: PartialEncodedChunkForwardMsg,
+    },
     /// Valid transaction but since we are not validators we send this transaction to current validators.
     ForwardTx(AccountId, SignedTransaction),
     /// Query transaction status
@@ -297,9 +325,31 @@ pub enum NetworkRequests {
     /// Message from chunk validator to all other chunk validators to forward state witness part.
     PartialEncodedStateWitnessForward(Vec<AccountId>, VersionedPartialEncodedStateWitness),
     /// Requests an epoch sync
-    EpochSyncRequest { peer_id: PeerId },
+    EpochSyncRequest {
+        peer_id: PeerId,
+    },
     /// Response to an epoch sync request
-    EpochSyncResponse { peer_id: PeerId, proof: CompressedEpochSyncProof },
+    EpochSyncResponse {
+        peer_id: PeerId,
+        proof: CompressedEpochSyncProof,
+    },
+    EpochSyncManifestRequest {
+        peer_id: PeerId,
+    },
+    EpochSyncManifestResponse {
+        peer_id: PeerId,
+        manifest: CompressedEpochSyncProofManifest,
+    },
+    EpochSyncBatchRequest {
+        peer_id: PeerId,
+        batch_index: u64,
+    },
+    /// Response to a batched epoch sync proof chunk request.
+    EpochSyncBatchResponse {
+        peer_id: PeerId,
+        batch_index: u64,
+        batch: CompressedEpochSyncProofBatch,
+    },
     /// Message from chunk producer to chunk validators containing the code-hashes of contracts
     /// accessed for the main state transition in the witness.
     ChunkContractAccesses(Vec<AccountId>, ChunkContractAccesses),
@@ -313,11 +363,17 @@ pub enum NetworkRequests {
     /// containing the code of the newly-deployed contracts during the main state transition of the witness.
     PartialEncodedContractDeploys(Vec<AccountId>, PartialEncodedContractDeploys),
     /// Message containing spice partial data.
-    SpicePartialData { partial_data: SpicePartialData, recipients: HashSet<AccountId> },
+    SpicePartialData {
+        partial_data: SpicePartialData,
+        recipients: HashSet<AccountId>,
+    },
     /// Message for a spice chunk endorsement, sent by a chunk validator to all validators.
     SpiceChunkEndorsement(AccountId, SpiceChunkEndorsement),
     /// Message requesting spice partial data.
-    SpiceDataRequest { request: SpiceDataRequest, producer: AccountId },
+    SpiceDataRequest {
+        request: SpiceDataRequest,
+        producer: AccountId,
+    },
     /// SPICE: Message from chunk producer to chunk validators with code-hashes of accessed contracts.
     SpiceChunkContractAccesses(Vec<AccountId>, SpiceChunkContractAccesses),
     /// SPICE: Message from chunk validator to chunk producer requesting missing contract code.

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -352,6 +352,7 @@ pub enum ProtocolFeature {
     FixDelegateActionDepositWithFunctionCallError,
     Spice,
     ContinuousEpochSync,
+    BatchedEpochSync,
     /// Fix `action_delete_account` not subtracting the global contract
     /// identifier storage usage. Previously only local contract code was
     /// subtracted, overstating storage usage for accounts with global
@@ -605,6 +606,7 @@ impl ProtocolFeature {
 
             // Nightly features:
             ProtocolFeature::FixContractLoadingCost => 129,
+            ProtocolFeature::BatchedEpochSync => 130,
             // TODO(#11201): When stabilizing this feature in mainnet, also remove the temporary code
             // that always enables this for mocknet (see config_mocknet function).
             ProtocolFeature::ShuffleShardAssignments => 143,

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -2,6 +2,7 @@ use crate::epoch_block_info::BlockInfo;
 use crate::epoch_info::EpochInfo;
 use crate::hash::CryptoHash;
 use crate::merkle::PartialMerkleTree;
+use crate::types::EpochId;
 use crate::types::validator_stake::ValidatorStake;
 use crate::utils::compression::CompressedData;
 use crate::version::BLOCK_HEADER_V3_PROTOCOL_VERSION;
@@ -66,6 +67,7 @@ pub struct EpochSyncProofV1 {
 }
 
 const MAX_UNCOMPRESSED_EPOCH_SYNC_PROOF_SIZE: u64 = ByteSize::mib(500).0;
+const MAX_UNCOMPRESSED_MANIFEST_SIZE_V1: ByteSize = ByteSize::mib(5);
 const EPOCH_SYNC_COMPRESSION_LEVEL: i32 = 3;
 
 #[derive(
@@ -201,4 +203,164 @@ pub struct EpochSyncProofCurrentEpochData {
     /// (as there is only one unique correct partial merkle tree for a specific root and a specific
     /// block ordinal).
     pub partial_merkle_tree_for_first_block: PartialMerkleTree,
+}
+
+pub const EPOCHS_PER_BATCH_V1: u64 = 128;
+pub const MAX_UNCOMPRESSED_BATCH_SIZE_V1: ByteSize = ByteSize::kib(128 * EPOCHS_PER_BATCH_V1);
+pub const MAX_NUMBER_OF_BATCHES: u64 = 1_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+#[borsh(use_discriminant = true)]
+#[repr(u8)]
+pub enum EpochSyncProofManifest {
+    V1(EpochSyncProofManifestV1) = 0,
+}
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+pub struct EpochSyncProofManifestV1 {
+    /// Total number of epochs the proof covers
+    pub total_epochs: u64,
+    pub batches_metadata: Vec<EpochSyncProofBatchMetadata>,
+    /// Some extra data for the last epoch before the current epoch.
+    pub last_epoch: EpochSyncProofLastEpochData,
+    /// Extra information to initialize the current epoch we're syncing to.
+    pub current_epoch: EpochSyncProofCurrentEpochData,
+}
+
+impl EpochSyncProofManifestV1 {
+    pub fn expected_num_batches(&self) -> u64 {
+        self.total_epochs.div_ceil(EPOCHS_PER_BATCH_V1)
+    }
+}
+
+impl EpochSyncProofManifest {
+    pub fn into_v1(self) -> EpochSyncProofManifestV1 {
+        match self {
+            EpochSyncProofManifest::V1(manifest) => manifest,
+        }
+    }
+}
+
+impl EpochSyncProofV1 {
+    pub fn split_into_batches(self) -> (EpochSyncProofManifestV1, Vec<EpochSyncProofBatchV1>) {
+        let EpochSyncProofV1 { all_epochs, last_epoch, current_epoch } = self;
+        let total_epochs = all_epochs.len() as u64;
+        let epochs_per_batch = EPOCHS_PER_BATCH_V1 as usize;
+        let num_batches = all_epochs.len().div_ceil(epochs_per_batch);
+
+        let batches_metadata = (0..num_batches)
+            .map(|batch_index| {
+                if batch_index == 0 {
+                    EpochSyncProofBatchMetadata {
+                        first_epoch_id: EpochId::default(),
+                        first_bp_hash: CryptoHash::default(),
+                    }
+                } else {
+                    let prev_epoch_last_header =
+                        &all_epochs[batch_index * epochs_per_batch - 1].last_final_block_header;
+                    EpochSyncProofBatchMetadata {
+                        first_epoch_id: *prev_epoch_last_header.next_epoch_id(),
+                        first_bp_hash: *prev_epoch_last_header.next_bp_hash(),
+                    }
+                }
+            })
+            .collect();
+
+        let mut remaining_epochs = all_epochs.into_iter();
+        let batches = (0..num_batches)
+            .map(|_| EpochSyncProofBatchV1 {
+                epochs: remaining_epochs.by_ref().take(epochs_per_batch).collect(),
+            })
+            .collect();
+
+        (
+            EpochSyncProofManifestV1 { total_epochs, batches_metadata, last_epoch, current_epoch },
+            batches,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+#[borsh(use_discriminant = true)]
+#[repr(u8)]
+pub enum EpochSyncProofBatch {
+    V1(EpochSyncProofBatchV1) = 0,
+}
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+pub struct EpochSyncProofBatchV1 {
+    /// A contiguous run of `all_epochs`.
+    pub epochs: Vec<EpochSyncProofEpochData>,
+}
+
+impl EpochSyncProofBatch {
+    pub fn into_v1(self) -> EpochSyncProofBatchV1 {
+        match self {
+            EpochSyncProofBatch::V1(batch) => batch,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+pub struct EpochSyncProofBatchMetadata {
+    pub first_epoch_id: EpochId,
+    pub first_bp_hash: CryptoHash,
+}
+
+const EPOCH_SYNC_BATCH_COMPRESSION_LEVEL: i32 = EPOCH_SYNC_COMPRESSION_LEVEL;
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    derive_more::From,
+    derive_more::AsRef,
+    ProtocolSchema,
+)]
+pub struct CompressedEpochSyncProofManifest(Box<[u8]>);
+impl
+    CompressedData<
+        EpochSyncProofManifest,
+        { MAX_UNCOMPRESSED_MANIFEST_SIZE_V1.0 },
+        EPOCH_SYNC_BATCH_COMPRESSION_LEVEL,
+    > for CompressedEpochSyncProofManifest
+{
+}
+
+impl Debug for CompressedEpochSyncProofManifest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompressedEpochSyncProofManifest")
+            .field("len", &self.0.len())
+            .field("manifest", &self.decode())
+            .finish()
+    }
+}
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    derive_more::From,
+    derive_more::AsRef,
+    ProtocolSchema,
+)]
+pub struct CompressedEpochSyncProofBatch(Box<[u8]>);
+impl
+    CompressedData<
+        EpochSyncProofBatch,
+        { MAX_UNCOMPRESSED_BATCH_SIZE_V1.0 },
+        EPOCH_SYNC_BATCH_COMPRESSION_LEVEL,
+    > for CompressedEpochSyncProofBatch
+{
+}
+
+impl Debug for CompressedEpochSyncProofBatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompressedEpochSyncProofBatch")
+            .field("len", &self.0.len())
+            .field("batch", &self.decode())
+            .finish()
+    }
 }

--- a/test-loop-tests/src/setup/peer_manager_actor.rs
+++ b/test-loop-tests/src/setup/peer_manager_actor.rs
@@ -12,9 +12,10 @@ use near_client::spice::data_distributor_actor::SpiceDistributorOutgoingReceipts
 use near_client::{BlockApproval, BlockResponse, SetNetworkInfo};
 use near_network::client::{
     BlockHeadersRequest, BlockHeadersResponse, BlockRequest, ChunkEndorsementMessage,
-    EpochSyncRequestMessage, EpochSyncResponseMessage, OptimisticBlockMessage, ProcessTxRequest,
-    ProcessTxResponse, SpiceChunkEndorsementMessage, StateRequestHeader, StateRequestPart,
-    StateResponse, StateResponseReceived,
+    EpochSyncBatchRequestMessage, EpochSyncBatchResponseMessage, EpochSyncManifestRequestMessage,
+    EpochSyncManifestResponseMessage, EpochSyncRequestMessage, EpochSyncResponseMessage,
+    OptimisticBlockMessage, ProcessTxRequest, ProcessTxResponse, SpiceChunkEndorsementMessage,
+    StateRequestHeader, StateRequestPart, StateResponse, StateResponseReceived,
 };
 use near_network::concurrency::outgoing_queue_limiter::OutgoingPermit;
 use near_network::recv_permit::RecvMessagePermit;
@@ -54,6 +55,10 @@ pub struct ClientSenderForTestLoopNetwork {
     pub block_approval: AsyncSender<SpanWrapped<BlockApproval>, ()>,
     pub epoch_sync_request: Sender<EpochSyncRequestMessage>,
     pub epoch_sync_response: Sender<EpochSyncResponseMessage>,
+    pub epoch_sync_manifest_request: Sender<EpochSyncManifestRequestMessage>,
+    pub epoch_sync_manifest_response: Sender<EpochSyncManifestResponseMessage>,
+    pub epoch_sync_batch_request: Sender<EpochSyncBatchRequestMessage>,
+    pub epoch_sync_batch_response: Sender<EpochSyncBatchResponseMessage>,
     pub optimistic_block_receiver: Sender<SpanWrapped<OptimisticBlockMessage>>,
     pub network_info: AsyncSender<SpanWrapped<SetNetworkInfo>, ()>,
     pub state_response: AsyncSender<SpanWrapped<StateResponseReceived>, ()>,
@@ -713,6 +718,54 @@ fn network_message_to_client_handler(
                 EpochSyncResponseMessage {
                     from_peer: my_peer_id,
                     proof,
+                    recv_permit: RecvMessagePermit::none(),
+                },
+            );
+            HandlerResult::Handled(NetworkResponses::NoResponse)
+        }
+        NetworkRequests::EpochSyncManifestRequest { peer_id } => {
+            let my_peer_id = shared_state.account_to_peer_id(&my_account_id);
+            assert_ne!(peer_id, my_peer_id, "Sending message to self not supported.");
+            shared_state.senders_for_peer(&my_peer_id, &peer_id).client_sender.send(
+                EpochSyncManifestRequestMessage {
+                    from_peer: my_peer_id,
+                    recv_permit: RecvMessagePermit::none(),
+                    response_permit: OutgoingPermit::fake_for_test(),
+                },
+            );
+            HandlerResult::Handled(NetworkResponses::NoResponse)
+        }
+        NetworkRequests::EpochSyncManifestResponse { peer_id, manifest } => {
+            let my_peer_id = shared_state.account_to_peer_id(&my_account_id);
+            shared_state.senders_for_peer(&my_peer_id, &peer_id).client_sender.send(
+                EpochSyncManifestResponseMessage {
+                    from_peer: my_peer_id,
+                    manifest,
+                    recv_permit: RecvMessagePermit::none(),
+                },
+            );
+            HandlerResult::Handled(NetworkResponses::NoResponse)
+        }
+        NetworkRequests::EpochSyncBatchRequest { peer_id, batch_index } => {
+            let my_peer_id = shared_state.account_to_peer_id(&my_account_id);
+            assert_ne!(peer_id, my_peer_id, "Sending message to self not supported.");
+            shared_state.senders_for_peer(&my_peer_id, &peer_id).client_sender.send(
+                EpochSyncBatchRequestMessage {
+                    from_peer: my_peer_id,
+                    batch_index,
+                    recv_permit: RecvMessagePermit::none(),
+                    response_permit: OutgoingPermit::fake_for_test(),
+                },
+            );
+            HandlerResult::Handled(NetworkResponses::NoResponse)
+        }
+        NetworkRequests::EpochSyncBatchResponse { peer_id, batch_index, batch } => {
+            let my_peer_id = shared_state.account_to_peer_id(&my_account_id);
+            shared_state.senders_for_peer(&my_peer_id, &peer_id).client_sender.send(
+                EpochSyncBatchResponseMessage {
+                    from_peer: my_peer_id,
+                    batch_index,
+                    batch,
                     recv_permit: RecvMessagePermit::none(),
                 },
             );

--- a/test-loop-tests/src/tests/spice/pre_activation.rs
+++ b/test-loop-tests/src/tests/spice/pre_activation.rs
@@ -130,6 +130,10 @@ fn is_spice_request(request: &NetworkRequests) -> bool {
         | NetworkRequests::PartialEncodedStateWitnessForward { .. }
         | NetworkRequests::EpochSyncRequest { .. }
         | NetworkRequests::EpochSyncResponse { .. }
+        | NetworkRequests::EpochSyncManifestRequest { .. }
+        | NetworkRequests::EpochSyncManifestResponse { .. }
+        | NetworkRequests::EpochSyncBatchRequest { .. }
+        | NetworkRequests::EpochSyncBatchResponse { .. }
         | NetworkRequests::ChunkContractAccesses { .. }
         | NetworkRequests::ContractCodeRequest { .. }
         | NetworkRequests::ContractCodeResponse { .. }

--- a/test-loop-tests/src/tests/sync/epoch_sync.rs
+++ b/test-loop-tests/src/tests/sync/epoch_sync.rs
@@ -1,10 +1,16 @@
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
+#[cfg(feature = "nightly")]
+use crate::setup::peer_manager_actor::HandlerResult;
+#[cfg(feature = "nightly")]
+use crate::setup::state::NodeExecutionData;
 use crate::utils::account::create_account_id;
 use crate::utils::node::TestLoopNode;
 use crate::utils::transactions::{BalanceMismatchError, execute_money_transfers};
 use borsh::BorshDeserialize;
 use itertools::Itertools;
+#[cfg(feature = "nightly")]
+use near_async::test_loop::data::TestLoopData;
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
 use near_chain::Error;
@@ -13,6 +19,8 @@ use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_epoch_manager::epoch_sync::{
     derive_epoch_sync_proof_from_last_block, find_target_epoch_to_produce_proof_for,
 };
+#[cfg(feature = "nightly")]
+use near_network::types::NetworkRequests;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::epoch_sync::EpochSyncProof;
 use near_primitives::merkle::PartialMerkleTree;
@@ -22,6 +30,10 @@ use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::adapter::StoreAdapter;
 use std::cell::RefCell;
 use std::rc::Rc;
+#[cfg(feature = "nightly")]
+use std::sync::Arc;
+#[cfg(feature = "nightly")]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 const NUM_CLIENTS: usize = 4;
 
@@ -159,6 +171,79 @@ fn bootstrap_node_via_epoch_sync(mut env: TestLoopEnv, source_node: usize) -> Te
     assert_eq!(sync_status_history.borrow().as_slice(), expected);
 
     env
+}
+
+/// Counts the epoch sync responses the nodes serve, split by which of the two epoch sync
+/// protocols they belong to.
+#[cfg(feature = "nightly")]
+#[derive(Clone, Default)]
+struct EpochSyncTrafficCounter {
+    monolithic_responses: Arc<AtomicUsize>,
+    manifest_responses: Arc<AtomicUsize>,
+    batch_responses: Arc<AtomicUsize>,
+}
+
+#[cfg(feature = "nightly")]
+impl EpochSyncTrafficCounter {
+    fn install(env: &mut TestLoopEnv) -> Self {
+        let counter = Self::default();
+        for node in &env.node_datas {
+            counter.install_on(&mut env.test_loop.data, node);
+        }
+        counter
+    }
+
+    fn install_on(&self, data: &mut TestLoopData, node: &NodeExecutionData) {
+        let counter = self.clone();
+        let peer_actor = data.get_mut(&node.peer_manager_sender.actor_handle());
+        peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
+            match &request {
+                NetworkRequests::EpochSyncResponse { .. } => {
+                    counter.monolithic_responses.fetch_add(1, Ordering::Relaxed);
+                }
+                NetworkRequests::EpochSyncManifestResponse { .. } => {
+                    counter.manifest_responses.fetch_add(1, Ordering::Relaxed);
+                }
+                NetworkRequests::EpochSyncBatchResponse { .. } => {
+                    counter.batch_responses.fetch_add(1, Ordering::Relaxed);
+                }
+                _ => {}
+            };
+            HandlerResult::Unhandled(request)
+        }));
+    }
+
+    /// Asserts the bootstrap went over the batched protocol and not the monolithic one.
+    fn assert_batched_sync_used(&self) {
+        assert!(
+            self.manifest_responses.load(Ordering::Relaxed) > 0,
+            "no epoch sync manifest was served"
+        );
+        assert!(
+            self.batch_responses.load(Ordering::Relaxed) > 0,
+            "no epoch sync proof batch was served"
+        );
+        assert_eq!(
+            self.monolithic_responses.load(Ordering::Relaxed),
+            0,
+            "a whole-proof epoch sync response was served while batched epoch sync is enabled",
+        );
+    }
+}
+
+#[test]
+#[cfg(feature = "nightly")]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn slow_test_batched_epoch_sync_from_genesis() {
+    init_test_logger();
+    assert!(
+        ProtocolFeature::BatchedEpochSync.enabled(PROTOCOL_VERSION),
+        "this test requires batched epoch sync to be enabled",
+    );
+    let mut env = setup_initial_blockchain(20);
+    let counter = EpochSyncTrafficCounter::install(&mut env);
+    bootstrap_node_via_epoch_sync(env, 0);
+    counter.assert_batched_sync_used();
 }
 
 // Test that a new node that only has genesis can use Epoch Sync to bring itself


### PR DESCRIPTION
## High level epoch sync protocol

```
    syncing node                                           serving peer
    ────────────                                           ────────────
    NotStarted
        │
        │──────── EpochSyncManifestRequest ──────────────────▶│
        │                                                     │  find target epoch
        │                                                     │  derive proof (reuses stored)
        │                                                     │  split → manifest + batches
        │                                                     │  compress + cache by epoch id
        │◀─────── EpochSyncManifestResponse(manifest) ────────│
    FetchingManifest
        │  1. validate manifest against itself
        │     total_epochs > 0
        │     expected_num_batches() <= MAX_NUMBER_OF_BATCHES
        │     batches_metadata.len() == expected_num_batches()
        │
    FetchingBatches                                           ┌ n = expected_num_batches()
        │──────── EpochSyncBatchRequest{0} ─────────────────▶ │ 
        │──────── EpochSyncBatchRequest{1} ─────────────────▶ │   
        │──────── EpochSyncBatchRequest{2} ─────────────────▶ │  
        │                        ...                          │  
        │──────── EpochSyncBatchRequest{n} ─────────────────▶ │  
        │                                                     │ 
        │◀─────── EpochSyncBatchResponse{i, batch} ───────────│
        │  2. is index i awaited?  ──no──▶ drop (no decode)
        │     decode
        │  3. validate batch against manifest
        │     epoch count == expected for this index
        │     index 0  → anchor on OUR genesis
        │     index >0 → first epoch id + bp hash == batches_metadata[i]
        │     └─▶ BatchStatus::Verified(epochs)
        │  ...repeat until every slot filled...
        │
    all batches in
        │  try_build  → concatenate epochs in index order
        │  4. verify_proof — induction from genesis through every epoch,
        │                    endorsement signatures, tail vs current_epoch
        │  5. stale-node gate (header head != genesis → data reset)
        │  apply to store
    Done ──▶ HeaderSync
```

And the structure diagram, renamed to match:
```
  all_epochs:  [ 0 .. 127 ][ 128 .. 255 ][ 256 ..      ]
                  batch 0      batch 1       batch 2 (remainder)
                 

  manifest = { total_epochs, batches_metadata[], last_epoch, current_epoch }
```

## Serving a batched epoch sync proof

  Both newly introduced request types are served only when `ProtocolFeature::BatchedEpochSync`  is enabled.

  - **Derived off the client thread.** On `async_computation_spawner`,
    `derive_batched_epoch_sync_proof` derives the proof exactly as the whole-proof path does, then
    `split_into_batches` divides it into the manifest plus one batch per `EPOCHS_PER_BATCH_V1`
    epochs.
 - **Cached once per epoch.** The manifest and every batch are compressed and stored in
    `last_batched_response_cache`, keyed by target epoch id; otherwise each batch request would
    re-read and re-decode the whole stored proof. TODO(kpop): see what it takes to store it in the DB instead
