### PR TITLE
fix(state-sync): re-apply state parts after a finished apply

### DIFF
--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -18,7 +18,7 @@ use near_primitives::state_part::{StatePart, StatePartId, StatePartIndex};
 use near_primitives::state_sync::StatePartKey;
 use near_primitives::types::{EpochId, ShardId};
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
-use near_store::flat::{FlatStorageManager, FlatStorageReadyStatus, FlatStorageStatus};
+use near_store::flat::{FlatStorageReadyStatus, FlatStorageStatus};
 use near_store::{DBCol, ShardUId, Store};
 use parking_lot::Mutex;
 use rand::prelude::SliceRandom;
@@ -146,7 +146,7 @@ pub(super) async fn run_state_sync_for_shard(
     runtime.get_tries().unload_memtrie(&shard_uid);
 
     let flat_storage_manager = runtime.get_flat_storage_manager();
-    if keep_applied_state_parts(&flat_storage_manager, &store, shard_uid, sync_hash, num_parts) {
+    if keep_applied_state_parts(&store, shard_uid, sync_hash, num_parts) {
         tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "resuming an unfinished apply, keeping the state parts already applied");
     } else {
         tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
@@ -254,14 +254,13 @@ pub(super) async fn run_state_sync_for_shard(
 /// empty after a restart, and `init_flat_storage` only fills it for the head epoch's layout,
 /// which excludes a shard being state synced while the head is still at genesis.
 fn keep_applied_state_parts(
-    flat_storage_manager: &FlatStorageManager,
     store: &Store,
     shard_uid: ShardUId,
     sync_hash: CryptoHash,
     num_parts: u64,
 ) -> bool {
     let previous_apply_completed = matches!(
-        flat_storage_manager.get_flat_storage_status(shard_uid),
+        store.flat_store().get_flat_storage_status(shard_uid),
         FlatStorageStatus::Ready(_)
     );
     let apply_parts_started = any(0..num_parts, |part_idx| {
@@ -430,16 +429,15 @@ mod tests {
 
     #[test]
     fn applied_parts_kept_while_apply_is_unfinished() {
-        let (runtime, store, _tmp_dir) = create_test_runtime_and_store();
+        let (_runtime, store, _tmp_dir) = create_test_runtime_and_store();
         let shard_layout = ShardLayout::single_shard();
         let shard_id = shard_layout.get_shard_id(0).unwrap();
         let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
         let sync_hash = CryptoHash::default();
-        let flat_storage_manager = runtime.get_flat_storage_manager();
 
         mark_part_applied(&store, sync_hash, shard_id, 0);
 
-        assert!(keep_applied_state_parts(&flat_storage_manager, &store, shard_uid, sync_hash, 2));
+        assert!(keep_applied_state_parts(&store, shard_uid, sync_hash, 2));
     }
 
     #[test]
@@ -457,7 +455,7 @@ mod tests {
         set_flat_storage_ready(&store, shard_uid);
         assert!(flat_storage_manager.get_flat_storage_for_shard(shard_uid).is_none());
 
-        assert!(!keep_applied_state_parts(&flat_storage_manager, &store, shard_uid, sync_hash, 2));
+        assert!(!keep_applied_state_parts(&store, shard_uid, sync_hash, 2));
     }
 
     #[tokio::test]

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -146,14 +146,7 @@ pub(super) async fn run_state_sync_for_shard(
     runtime.get_tries().unload_memtrie(&shard_uid);
 
     let flat_storage_manager = runtime.get_flat_storage_manager();
-    if keep_applied_state_parts(
-        &flat_storage_manager,
-        &store,
-        shard_uid,
-        shard_id,
-        sync_hash,
-        num_parts,
-    ) {
+    if keep_applied_state_parts(&flat_storage_manager, &store, shard_uid, sync_hash, num_parts) {
         tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "resuming an unfinished apply, keeping the state parts already applied");
     } else {
         tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
@@ -264,7 +257,6 @@ fn keep_applied_state_parts(
     flat_storage_manager: &FlatStorageManager,
     store: &Store,
     shard_uid: ShardUId,
-    shard_id: ShardId,
     sync_hash: CryptoHash,
     num_parts: u64,
 ) -> bool {
@@ -273,7 +265,7 @@ fn keep_applied_state_parts(
         FlatStorageStatus::Ready(_)
     );
     let apply_parts_started = any(0..num_parts, |part_idx| {
-        let key = StatePartKey(sync_hash, shard_id, part_idx);
+        let key = StatePartKey(sync_hash, shard_uid.shard_id(), part_idx);
         let key_bytes = borsh::to_vec(&key).unwrap();
         store.exists(DBCol::StatePartsApplied, &key_bytes)
     });
@@ -446,14 +438,7 @@ mod tests {
 
         mark_part_applied(&store, sync_hash, shard_id, 0);
 
-        assert!(keep_applied_state_parts(
-            &flat_storage_manager,
-            &store,
-            shard_uid,
-            shard_id,
-            sync_hash,
-            2
-        ));
+        assert!(keep_applied_state_parts(&flat_storage_manager, &store, shard_uid, sync_hash, 2));
     }
 
     #[test]
@@ -471,14 +456,7 @@ mod tests {
         set_flat_storage_ready(&store, shard_uid);
         assert!(flat_storage_manager.get_flat_storage_for_shard(shard_uid).is_none());
 
-        assert!(!keep_applied_state_parts(
-            &flat_storage_manager,
-            &store,
-            shard_uid,
-            shard_id,
-            sync_hash,
-            2
-        ));
+        assert!(!keep_applied_state_parts(&flat_storage_manager, &store, shard_uid, sync_hash, 2));
     }
 
     #[tokio::test]

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -145,13 +145,6 @@ pub(super) async fn run_state_sync_for_shard(
     *status.lock() = ShardSyncStatus::StateApplyInProgress { done: 0, total: num_parts };
     runtime.get_tries().unload_memtrie(&shard_uid);
 
-    // `StatePartsApplied` markers only describe what is on disk while an apply is still
-    // unfinished. Once an earlier sync for this shard reached `Ready`, finalize advanced the
-    // state past those parts and deleted the nodes they wrote, so every part must be applied
-    // again. Read the status from the database, not from the flat storage registry: the
-    // registry is empty after a restart, and `init_flat_storage` only fills it for shards of
-    // the head epoch's layout, which excludes a shard being state synced while the head is
-    // still at genesis.
     let flat_storage_manager = runtime.get_flat_storage_manager();
     if keep_applied_state_parts(
         &flat_storage_manager,
@@ -165,12 +158,11 @@ pub(super) async fn run_state_sync_for_shard(
     } else {
         tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
         let mut store_update = store.store_update();
-        // The registry-scoped call clears the on-disk state only for a shard registered in
-        // this process. A shard being state synced is not registered after a restart, so fall
-        // back to removing values, deltas and status directly.
-        let removed = flat_storage_manager
+        // A shard being state synced is usually absent from the registry, and then this
+        // clears nothing.
+        let cleared_via_registry = flat_storage_manager
             .remove_flat_storage_for_shard(shard_uid, &mut store_update.flat_store_update())?;
-        if !removed {
+        if !cleared_via_registry {
             store_update.flat_store_update().remove_flat_storage(shard_uid);
         }
         for part_idx in 0..num_parts {
@@ -261,12 +253,13 @@ pub(super) async fn run_state_sync_for_shard(
 
 /// Whether the parts recorded in `StatePartsApplied` still describe the state on disk.
 ///
-/// They do only while an apply is unfinished. Once an earlier sync for this shard reached
-/// `Ready`, finalize advanced the state past those parts and deleted the nodes they wrote, so
-/// they must all be applied again. The status comes from the database rather than the flat
-/// storage registry: the registry is empty after a restart, and `init_flat_storage` only fills
-/// it for shards of the head epoch's layout, which excludes a shard being state synced while
-/// the head is still at genesis.
+/// They do only while an apply is unfinished. `Ready` means an earlier sync already applied
+/// every part, after which finalize applies a chunk on top and refcount-deletes the base nodes
+/// the new root does not share, so the parts must be applied again.
+///
+/// The status comes from the database rather than the flat storage registry: the registry is
+/// empty after a restart, and `init_flat_storage` only fills it for the head epoch's layout,
+/// which excludes a shard being state synced while the head is still at genesis.
 fn keep_applied_state_parts(
     flat_storage_manager: &FlatStorageManager,
     store: &Store,
@@ -275,7 +268,7 @@ fn keep_applied_state_parts(
     sync_hash: CryptoHash,
     num_parts: u64,
 ) -> bool {
-    let previous_sync_finished = matches!(
+    let previous_apply_completed = matches!(
         flat_storage_manager.get_flat_storage_status(shard_uid),
         FlatStorageStatus::Ready(_)
     );
@@ -284,7 +277,7 @@ fn keep_applied_state_parts(
         let key_bytes = borsh::to_vec(&key).unwrap();
         store.exists(DBCol::StatePartsApplied, &key_bytes)
     });
-    apply_parts_started && !previous_sync_finished
+    apply_parts_started && !previous_apply_completed
 }
 
 fn create_flat_storage_for_shard(

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -18,7 +18,7 @@ use near_primitives::state_part::{StatePart, StatePartId, StatePartIndex};
 use near_primitives::state_sync::StatePartKey;
 use near_primitives::types::{EpochId, ShardId};
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
-use near_store::flat::{FlatStorageReadyStatus, FlatStorageStatus};
+use near_store::flat::{FlatStorageManager, FlatStorageReadyStatus, FlatStorageStatus};
 use near_store::{DBCol, ShardUId, Store};
 use parking_lot::Mutex;
 use rand::prelude::SliceRandom;
@@ -145,35 +145,34 @@ pub(super) async fn run_state_sync_for_shard(
     *status.lock() = ShardSyncStatus::StateApplyInProgress { done: 0, total: num_parts };
     runtime.get_tries().unload_memtrie(&shard_uid);
 
-    // Clear flat storage before applying state parts.
-    //
-    // If flat storage is already loaded in memory, it means a previous state
-    // sync completed and flat state may have been modified by subsequent block
-    // processing. We must clear everything and re-apply from scratch.
-    //
-    // If flat storage is NOT in memory but some parts were already applied
-    // (i.e. we crashed mid-sync and are resuming), skip cleanup to preserve
-    // the progress made so far.
+    // `StatePartsApplied` markers only describe what is on disk while an apply is still
+    // unfinished. Once an earlier sync for this shard reached `Ready`, finalize advanced the
+    // state past those parts and deleted the nodes they wrote, so every part must be applied
+    // again. Read the status from the database, not from the flat storage registry: the
+    // registry is empty after a restart, and `init_flat_storage` only fills it for shards of
+    // the head epoch's layout, which excludes a shard being state synced while the head is
+    // still at genesis.
     let flat_storage_manager = runtime.get_flat_storage_manager();
-    let flat_storage_exists = flat_storage_manager.get_flat_storage_for_shard(shard_uid).is_some();
-    let apply_parts_started = any(0..num_parts, |part_idx| {
-        let key = StatePartKey(sync_hash, shard_id, part_idx);
-        let key_bytes = borsh::to_vec(&key).unwrap();
-        store.exists(DBCol::StatePartsApplied, &key_bytes)
-    });
-    if apply_parts_started && !flat_storage_exists {
-        tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "not clearing flat storage before applying state parts because some parts were already applied");
+    if keep_applied_state_parts(
+        &flat_storage_manager,
+        &store,
+        shard_uid,
+        shard_id,
+        sync_hash,
+        num_parts,
+    ) {
+        tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "resuming an unfinished apply, keeping the state parts already applied");
     } else {
-        if flat_storage_exists && apply_parts_started {
-            tracing::debug!(target: "sync", ?shard_id, ?sync_hash,
-                "clearing completed flat storage and re-applying state parts");
-        } else {
-            tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
-        }
+        tracing::debug!(target: "sync", ?shard_id, ?sync_hash, "clearing flat storage before applying state parts");
         let mut store_update = store.store_update();
-        flat_storage_manager
+        // The registry-scoped call clears the on-disk state only for a shard registered in
+        // this process. A shard being state synced is not registered after a restart, so fall
+        // back to removing values, deltas and status directly.
+        let removed = flat_storage_manager
             .remove_flat_storage_for_shard(shard_uid, &mut store_update.flat_store_update())?;
-        // Also clear StatePartsApplied markers so the parts are re-applied.
+        if !removed {
+            store_update.flat_store_update().remove_flat_storage(shard_uid);
+        }
         for part_idx in 0..num_parts {
             let key = StatePartKey(sync_hash, shard_id, part_idx);
             let key_bytes = borsh::to_vec(&key).unwrap();
@@ -258,6 +257,34 @@ pub(super) async fn run_state_sync_for_shard(
     *status.lock() = ShardSyncStatus::StateSyncDone;
 
     Ok(())
+}
+
+/// Whether the parts recorded in `StatePartsApplied` still describe the state on disk.
+///
+/// They do only while an apply is unfinished. Once an earlier sync for this shard reached
+/// `Ready`, finalize advanced the state past those parts and deleted the nodes they wrote, so
+/// they must all be applied again. The status comes from the database rather than the flat
+/// storage registry: the registry is empty after a restart, and `init_flat_storage` only fills
+/// it for shards of the head epoch's layout, which excludes a shard being state synced while
+/// the head is still at genesis.
+fn keep_applied_state_parts(
+    flat_storage_manager: &FlatStorageManager,
+    store: &Store,
+    shard_uid: ShardUId,
+    shard_id: ShardId,
+    sync_hash: CryptoHash,
+    num_parts: u64,
+) -> bool {
+    let previous_sync_finished = matches!(
+        flat_storage_manager.get_flat_storage_status(shard_uid),
+        FlatStorageStatus::Ready(_)
+    );
+    let apply_parts_started = any(0..num_parts, |part_idx| {
+        let key = StatePartKey(sync_hash, shard_id, part_idx);
+        let key_bytes = borsh::to_vec(&key).unwrap();
+        store.exists(DBCol::StatePartsApplied, &key_bytes)
+    });
+    apply_parts_started && !previous_sync_finished
 }
 
 fn create_flat_storage_for_shard(
@@ -391,6 +418,74 @@ mod tests {
         );
 
         (runtime, store, tmp_dir)
+    }
+
+    fn mark_part_applied(store: &Store, sync_hash: CryptoHash, shard_id: ShardId, part_id: u64) {
+        let key_bytes = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id)).unwrap();
+        let mut store_update = store.store_update();
+        store_update.set_ser(DBCol::StatePartsApplied, &key_bytes, &true);
+        store_update.commit();
+    }
+
+    fn set_flat_storage_ready(store: &Store, shard_uid: ShardUId) {
+        let mut store_update = store.flat_store().store_update();
+        store_update.set_flat_storage_status(
+            shard_uid,
+            FlatStorageStatus::Ready(FlatStorageReadyStatus {
+                flat_head: near_store::flat::BlockInfo {
+                    hash: CryptoHash::default(),
+                    prev_hash: CryptoHash::default(),
+                    height: 1,
+                },
+            }),
+        );
+        store_update.commit();
+    }
+
+    #[test]
+    fn applied_parts_kept_while_apply_is_unfinished() {
+        let (runtime, store, _tmp_dir) = create_test_runtime_and_store();
+        let shard_layout = ShardLayout::single_shard();
+        let shard_id = shard_layout.get_shard_id(0).unwrap();
+        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+        let sync_hash = CryptoHash::default();
+        let flat_storage_manager = runtime.get_flat_storage_manager();
+
+        mark_part_applied(&store, sync_hash, shard_id, 0);
+
+        assert!(keep_applied_state_parts(
+            &flat_storage_manager,
+            &store,
+            shard_uid,
+            shard_id,
+            sync_hash,
+            2
+        ));
+    }
+
+    #[test]
+    fn applied_parts_discarded_after_a_finished_sync() {
+        let (runtime, store, _tmp_dir) = create_test_runtime_and_store();
+        let shard_layout = ShardLayout::single_shard();
+        let shard_id = shard_layout.get_shard_id(0).unwrap();
+        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+        let sync_hash = CryptoHash::default();
+        let flat_storage_manager = runtime.get_flat_storage_manager();
+
+        mark_part_applied(&store, sync_hash, shard_id, 0);
+        // A finished sync leaves `Ready` on disk while the registry stays empty across a
+        // restart, which is what a bootstrapping node looks like when it resumes.
+        set_flat_storage_ready(&store, shard_uid);
+        assert!(flat_storage_manager.get_flat_storage_for_shard(shard_uid).is_none());
+
+        assert!(!keep_applied_state_parts(
+            &flat_storage_manager,
+            &store,
+            shard_uid,
+            shard_id,
+            sync_hash,
+            2
+        ));
     }
 
     #[tokio::test]

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -375,6 +375,7 @@ mod tests {
     use near_primitives::state::PartialState;
     use near_primitives::state_sync::StatePartKey;
     use near_primitives::types::EpochId;
+    use near_store::flat::BlockInfo;
     use near_store::genesis::initialize_genesis_state;
     use near_store::test_utils::create_test_store;
     use std::sync::Arc;
@@ -417,7 +418,7 @@ mod tests {
         store_update.set_flat_storage_status(
             shard_uid,
             FlatStorageStatus::Ready(FlatStorageReadyStatus {
-                flat_head: near_store::flat::BlockInfo {
+                flat_head: BlockInfo {
                     hash: CryptoHash::default(),
                     prev_hash: CryptoHash::default(),
                     height: 1,

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -405,14 +405,17 @@ mod tests {
         (runtime, store, tmp_dir)
     }
 
-    fn mark_part_applied(store: &Store, sync_hash: CryptoHash, shard_id: ShardId, part_id: u64) {
-        let key_bytes = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id)).unwrap();
+    #[test]
+    fn applied_parts_kept_only_while_apply_is_unfinished() {
+        let store = create_test_store();
+        let shard_uid = ShardUId::single_shard();
+        let sync_hash = CryptoHash::default();
+        let key_bytes = borsh::to_vec(&StatePartKey(sync_hash, shard_uid.shard_id(), 0)).unwrap();
         let mut store_update = store.store_update();
         store_update.set_ser(DBCol::StatePartsApplied, &key_bytes, &true);
         store_update.commit();
-    }
+        assert!(keep_applied_state_parts(&store, shard_uid, sync_hash, 2));
 
-    fn set_flat_storage_ready(store: &Store, shard_uid: ShardUId) {
         let mut store_update = store.flat_store().store_update();
         store_update.set_flat_storage_status(
             shard_uid,
@@ -425,36 +428,6 @@ mod tests {
             }),
         );
         store_update.commit();
-    }
-
-    #[test]
-    fn applied_parts_kept_while_apply_is_unfinished() {
-        let (_runtime, store, _tmp_dir) = create_test_runtime_and_store();
-        let shard_layout = ShardLayout::single_shard();
-        let shard_id = shard_layout.get_shard_id(0).unwrap();
-        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
-        let sync_hash = CryptoHash::default();
-
-        mark_part_applied(&store, sync_hash, shard_id, 0);
-
-        assert!(keep_applied_state_parts(&store, shard_uid, sync_hash, 2));
-    }
-
-    #[test]
-    fn applied_parts_discarded_after_a_finished_sync() {
-        let (runtime, store, _tmp_dir) = create_test_runtime_and_store();
-        let shard_layout = ShardLayout::single_shard();
-        let shard_id = shard_layout.get_shard_id(0).unwrap();
-        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
-        let sync_hash = CryptoHash::default();
-        let flat_storage_manager = runtime.get_flat_storage_manager();
-
-        mark_part_applied(&store, sync_hash, shard_id, 0);
-        // A finished sync leaves `Ready` on disk while the registry stays empty across a
-        // restart, which is what a bootstrapping node looks like when it resumes.
-        set_flat_storage_ready(&store, shard_uid);
-        assert!(flat_storage_manager.get_flat_storage_for_shard(shard_uid).is_none());
-
         assert!(!keep_applied_state_parts(&store, shard_uid, sync_hash, 2));
     }
 

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -180,6 +180,12 @@ sync (headers are already downloaded); if not, it redoes epoch sync with a
 fresh proof. Previously downloaded state parts are preserved in the DB, so
 the node does not re-download parts that were already saved before the crash.
 
+Applied state parts are tracked in `DBCol::StatePartsApplied`. On restart,
+state sync keeps them only while the flat storage status for the shard is not
+yet `Ready`. A `Ready` status means an earlier sync applied every part and
+finalized the shard, which modifies the trie on top of the parts, so the node
+clears flat storage and applies every part again.
+
 ## Side topic: how blocks are added to the chain?
 
 A node can receive a Block in two ways:


### PR DESCRIPTION
A node that restarts during state sync can skip re-applying the state parts of a shard whose apply already finished, compute a state root that exists nowhere on the chain, and abort with `InvalidStateRoot` telling the operator to start again from an empty data directory.

`run_state_sync_for_shard` decided whether the `StatePartsApplied` markers still described the state on disk by asking the flat storage registry. That registry is process-local and empty after a restart, and `init_flat_storage` refills it only for shards in the head epoch's layout. A bootstrapping node keeps its head at genesis, whose layout on mainnet is V0, while it syncs shards of the current layout, so the shard being synced is never registered and the markers are always trusted. Every part is then skipped and finalize re-applies the sync block's chunk on a base state that the earlier finalize already moved past and partly refcount-deleted.

The status now comes from the database instead. The clearing path also removes the shard's flat state directly when `remove_flat_storage_for_shard` reports it cleared nothing, which is the usual case for a shard this process never registered.

Verified on mainnet against the same data directory: with the previous logic a node restarted after one shard finished skipped all 143 of its parts and aborted with a state root of `Hjac72P5vM...` against the committed `68KUKjMT3m...`; with this change it re-applies them, finalizes with the committed root, and keeps syncing.