### PR TITLE
feat(spice): data manager deadline scheduler

### DIFF
--- a/chain/client/src/spice/data_manager/item.rs
+++ b/chain/client/src/spice/data_manager/item.rs
@@ -1,3 +1,4 @@
+use super::scheduler::{Backoff, TimingConfig};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_async::time::{Clock, Instant};
 use near_primitives::hash::hash;
@@ -10,9 +11,11 @@ use near_primitives::sharding::ReceiptProof;
 use near_primitives::spice::partial_data::SpiceDataCommitment;
 use near_primitives::spice::state_witness::SpiceChunkStateWitness;
 use near_primitives::types::AccountId;
+use rand::Rng;
 use std::collections::{HashMap, HashSet};
-use std::mem::replace;
+use std::mem::{replace, take};
 use std::sync::Arc;
+use time::ext::InstantExt as _;
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub(crate) enum SpiceData {
@@ -55,17 +58,18 @@ fn transition<T>(state: &mut FetchState, f: impl FnOnce(FetchState) -> (FetchSta
 
 pub(crate) struct FetchItem {
     pub(crate) state: FetchState,
-    /// When the first unit arrived; `None` until then. Anchors the wait-for-push grace clock.
+    /// When the first unit arrived; `None` until then.
     pub(crate) first_unit_at: Option<Instant>,
+    pub(crate) pull: PullTiming,
 }
 
 impl FetchItem {
     pub(crate) fn waiting_for_push() -> Self {
-        Self { state: FetchState::WaitingForPush, first_unit_at: None }
+        Self { state: FetchState::WaitingForPush, first_unit_at: None, pull: PullTiming::default() }
     }
 
     pub(crate) fn collecting(encoder: Arc<ReedSolomonEncoder>) -> Self {
-        Self { state: FetchState::Collecting(Assembly::new(encoder)), first_unit_at: None }
+        Self { state: FetchState::Collecting(Assembly::new(encoder)), ..Self::waiting_for_push() }
     }
 
     /// Starts a speculative pull: a waiting item begins collecting before any part
@@ -156,6 +160,69 @@ impl FetchItem {
             state => (state, Err(AssemblyError::NotDelivered)),
         })
     }
+}
+
+/// Timing state for one item's pulls.
+#[derive(Debug, Default)]
+pub(crate) struct PullTiming {
+    /// Outstanding pull requests
+    pub(crate) in_flight: Vec<InFlightRequest>,
+    /// Retry ladder position for this item's pulls.
+    pub(crate) backoff: Backoff,
+    /// The currently scheduled wake-up; a popped scheduler entry with any other instant is stale.
+    pub(crate) next_deadline: Option<Instant>,
+}
+
+impl PullTiming {
+    /// True if an outstanding request already asks for `ordinal`.
+    pub(crate) fn has_in_flight_request_for(&self, ordinal: u64) -> bool {
+        self.in_flight.iter().any(|request| request.ordinals.contains(&ordinal))
+    }
+
+    /// Removes and returns the requests unanswered for at least `request_timeout`;
+    /// their ordinals may be requested again.
+    /// Leaves `backoff` untouched: timing out is not a retry decision.
+    pub(crate) fn take_timed_out_requests(
+        &mut self,
+        config: &TimingConfig,
+        now: Instant,
+    ) -> Vec<InFlightRequest> {
+        let (timed_out, live): (Vec<_>, Vec<_>) =
+            take(&mut self.in_flight).into_iter().partition(|request| {
+                now.signed_duration_since(request.sent_at) >= config.request_timeout
+            });
+        self.in_flight = live;
+        timed_out
+    }
+
+    /// Recomputes the next deadline: the sooner of the next backoff interval and the
+    /// oldest outstanding request's timeout. Sets and returns `next_deadline`.
+    #[must_use = "the returned deadline must be scheduled, or the item is never woken"]
+    pub(crate) fn reschedule(
+        &mut self,
+        config: &TimingConfig,
+        now: Instant,
+        rng: &mut impl Rng,
+    ) -> Instant {
+        let backoff_deadline = now.add_signed(self.backoff.next_interval(config, rng));
+        let timeout_deadline = self
+            .in_flight
+            .iter()
+            .map(|request| request.sent_at.add_signed(config.request_timeout))
+            .min();
+        let deadline = timeout_deadline.map_or(backoff_deadline, |at| at.min(backoff_deadline));
+        self.next_deadline = Some(deadline);
+        deadline
+    }
+}
+
+/// One outstanding pull request to one peer.
+#[derive(Debug)]
+pub(crate) struct InFlightRequest {
+    pub(crate) source: AccountId,
+    pub(crate) sent_at: Instant,
+    /// Requested part ordinals.
+    pub(crate) ordinals: Vec<u64>,
 }
 
 /// A coded part whose merkle proof was verified against its commitment's root;

--- a/chain/client/src/spice/data_manager/mod.rs
+++ b/chain/client/src/spice/data_manager/mod.rs
@@ -4,10 +4,45 @@
 #![allow(dead_code, unused_imports)]
 
 mod item;
+mod scheduler;
 
 pub(crate) use item::{
-    Assembly, AssemblyError, FetchItem, FetchState, PartInsertResult, SpiceData, VerifiedCodedPart,
+    Assembly, AssemblyError, FetchItem, FetchState, InFlightRequest, PartInsertResult, PullTiming,
+    SpiceData, VerifiedCodedPart,
 };
+pub(crate) use scheduler::{Backoff, DeadlineScheduler, TimingConfig};
+use std::cmp::Ordering;
+
+/// Scheduling class of an item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Lane {
+    /// Consensus-critical: this node is an assigned validator or producer for it.
+    Priority,
+    /// RPC, state-sync or catch-up traffic; never starves `Priority`.
+    Background,
+}
+
+impl Lane {
+    /// Urgency rank; greater is more urgent, so `max` escalates.
+    fn rank(self) -> u8 {
+        match self {
+            Lane::Background => 0,
+            Lane::Priority => 1,
+        }
+    }
+}
+
+impl Ord for Lane {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.rank().cmp(&other.rank())
+    }
+}
+
+impl PartialOrd for Lane {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/chain/client/src/spice/data_manager/scheduler.rs
+++ b/chain/client/src/spice/data_manager/scheduler.rs
@@ -1,0 +1,117 @@
+use super::Lane;
+use near_async::time::{Duration, Instant};
+use rand::Rng;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+/// Retry and request timing parameters.
+#[derive(Debug, Clone)]
+pub(crate) struct TimingConfig {
+    /// How long a pull request may go unanswered before it counts as timed out.
+    pub(crate) request_timeout: Duration,
+    /// First interval of the retry ladder.
+    pub(crate) backoff_base: Duration,
+    /// Geometric growth factor of the retry periods.
+    pub(crate) backoff_multiplier: u32,
+    /// Upper bound the retry period is capped at.
+    pub(crate) backoff_cap: Duration,
+    /// Every interval is jittered by up to this fraction in either direction.
+    pub(crate) jitter_frac: f64,
+}
+
+impl Default for TimingConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: Duration::seconds(1),
+            backoff_base: Duration::milliseconds(200),
+            backoff_multiplier: 2,
+            backoff_cap: Duration::seconds(2),
+            jitter_frac: 0.25,
+        }
+    }
+}
+
+/// Keeps track of retry progress.
+#[derive(Debug, Default)]
+pub(crate) struct Backoff {
+    retries: u32,
+}
+
+impl Backoff {
+    /// Next retry interval, jittered
+    pub(crate) fn next_interval(&self, config: &TimingConfig, rng: &mut impl Rng) -> Duration {
+        let unjittered = (config.backoff_base.as_seconds_f64()
+            * f64::from(config.backoff_multiplier).powf(f64::from(self.retries)))
+        .min(config.backoff_cap.as_seconds_f64());
+        let jitter = rng.gen_range(-config.jitter_frac..=config.jitter_frac);
+        Duration::seconds_f64(unjittered * (1.0 + jitter))
+    }
+
+    pub(crate) fn note_retry(&mut self) {
+        self.retries = self.retries.saturating_add(1);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn retries(&self) -> u32 {
+        self.retries
+    }
+}
+
+/// A queued wake-up for `key`.
+#[derive(Debug)]
+struct Deadline<K> {
+    at: Instant,
+    lane: Lane,
+    key: K,
+}
+
+// Max-heap order: earliest `at` on top, `Priority` before `Background` for the same instant.
+// The key does not participate.
+impl<K> Ord for Deadline<K> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.at.cmp(&self.at).then_with(|| self.lane.cmp(&other.lane))
+    }
+}
+
+impl<K> PartialOrd for Deadline<K> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K> PartialEq for Deadline<K> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<K> Eq for Deadline<K> {}
+
+/// Wake-ups for keyed items, earliest first.
+/// Scheduling a key again does not cancel its earlier wake-up; a superseded wake-up still pops, and the
+/// caller can tell it apart by its instant no longer matching the item's `next_deadline`.
+pub(crate) struct DeadlineScheduler<K> {
+    heap: BinaryHeap<Deadline<K>>,
+}
+
+impl<K> Default for DeadlineScheduler<K> {
+    fn default() -> Self {
+        Self { heap: BinaryHeap::new() }
+    }
+}
+
+impl<K> DeadlineScheduler<K> {
+    pub(crate) fn schedule(&mut self, key: K, at: Instant, lane: Lane) {
+        self.heap.push(Deadline { at, lane, key });
+    }
+
+    /// Pops every entry due at or before `now`, paired with the instant it was scheduled for.
+    pub(crate) fn pop_due(&mut self, now: Instant) -> Vec<(K, Instant)> {
+        let mut due = Vec::new();
+        while self.heap.peek().is_some_and(|deadline| deadline.at <= now) {
+            let deadline = self.heap.pop().unwrap();
+            due.push((deadline.key, deadline.at));
+        }
+        due
+    }
+}

--- a/chain/client/src/spice/data_manager/tests.rs
+++ b/chain/client/src/spice/data_manager/tests.rs
@@ -1,14 +1,17 @@
 use super::*;
 use assert_matches::assert_matches;
-use near_async::time::{Clock, Duration, FakeClock};
+use near_async::time::{Clock, Duration, FakeClock, Instant};
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::merkle::merklize;
 use near_primitives::reed_solomon::{ReedSolomonEncoder, reed_solomon_part_length};
 use near_primitives::sharding::{ReceiptProof, ShardProof};
 use near_primitives::spice::partial_data::SpiceDataCommitment;
 use near_primitives::types::{AccountId, ShardId};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use std::collections::HashSet;
 use std::sync::Arc;
+use time::ext::InstantExt as _;
 
 /// Data parts of the encoder every test here uses: `max((5 * 0.6) as usize, 1)`.
 const DATA_PARTS: usize = 3;
@@ -553,4 +556,199 @@ fn garbage_decode_of_the_only_tracker_resets_the_timer() {
     assert!(assembly.is_banned(&garbage));
     // No parts are left held, so the timer no longer counts from the garbage part.
     assert_eq!(item.first_unit_at, None);
+}
+
+fn assert_duration_eq(actual: Duration, expected: Duration) {
+    let difference = (actual - expected).abs();
+    assert!(difference <= Duration::nanoseconds(1), "{actual} != {expected}");
+}
+
+fn in_flight_request(source: &str, sent_at: Instant, ordinals: &[u64]) -> InFlightRequest {
+    InFlightRequest { source: account(source), sent_at, ordinals: ordinals.to_vec() }
+}
+
+fn no_jitter_config() -> TimingConfig {
+    TimingConfig { jitter_frac: 0.0, ..TimingConfig::default() }
+}
+
+#[test]
+fn pop_due_yields_entries_earliest_first_and_leaves_future_ones() {
+    let now = FakeClock::default().now();
+    let mut scheduler = DeadlineScheduler::default();
+    scheduler.schedule("c", now.add_signed(Duration::seconds(3)), Lane::Background);
+    scheduler.schedule("a", now.add_signed(Duration::seconds(1)), Lane::Background);
+    scheduler.schedule("b", now.add_signed(Duration::seconds(2)), Lane::Background);
+    scheduler.schedule("d", now.add_signed(Duration::seconds(10)), Lane::Priority);
+
+    assert_eq!(
+        scheduler.pop_due(now.add_signed(Duration::seconds(3))),
+        vec![
+            ("a", now.add_signed(Duration::seconds(1))),
+            ("b", now.add_signed(Duration::seconds(2))),
+            ("c", now.add_signed(Duration::seconds(3))),
+        ]
+    );
+    assert_eq!(scheduler.pop_due(now.add_signed(Duration::seconds(3))), vec![]);
+    assert_eq!(
+        scheduler.pop_due(now.add_signed(Duration::seconds(10))),
+        vec![("d", now.add_signed(Duration::seconds(10)))]
+    );
+}
+
+#[test]
+fn priority_pops_before_background_within_one_instant() {
+    let now = FakeClock::default().now();
+    let mut scheduler = DeadlineScheduler::default();
+    let at = now.add_signed(Duration::seconds(1));
+    scheduler.schedule("background", at, Lane::Background);
+    scheduler.schedule("priority", at, Lane::Priority);
+
+    assert_eq!(scheduler.pop_due(at), vec![("priority", at), ("background", at)]);
+}
+
+#[test]
+fn lane_max_escalates_to_priority() {
+    assert_eq!(Lane::Priority.max(Lane::Background), Lane::Priority);
+    assert!(Lane::Priority > Lane::Background);
+}
+
+#[test]
+fn backoff_interval_grows_geometrically_then_pins_at_the_cap() {
+    let config = no_jitter_config();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut backoff = Backoff::default();
+    for expected_ms in [200, 400, 800, 1600, 2000, 2000] {
+        assert_duration_eq(
+            backoff.next_interval(&config, &mut rng),
+            Duration::milliseconds(expected_ms),
+        );
+        backoff.note_retry();
+    }
+}
+
+#[test]
+fn backoff_jitter_stays_within_its_fraction_and_the_interval_stays_positive() {
+    let config = TimingConfig::default();
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut backoff = Backoff::default();
+    for retries in 0..6 {
+        let unjittered = (config.backoff_base.as_seconds_f64() * f64::from(2u32.pow(retries)))
+            .min(config.backoff_cap.as_seconds_f64());
+        let samples: Vec<f64> =
+            (0..200).map(|_| backoff.next_interval(&config, &mut rng).as_seconds_f64()).collect();
+        for sample in &samples {
+            assert!(*sample > 0.0);
+            assert!(*sample >= unjittered * (1.0 - config.jitter_frac) - 1e-9);
+            assert!(*sample <= unjittered * (1.0 + config.jitter_frac) + 1e-9);
+        }
+        // The jitter must actually spread samples to both sides.
+        assert!(samples.iter().any(|sample| *sample > unjittered));
+        assert!(samples.iter().any(|sample| *sample < unjittered));
+        backoff.note_retry();
+    }
+}
+
+#[test]
+fn take_timed_out_requests_returns_elapsed_entries_and_keeps_live_ones() {
+    let config = TimingConfig::default();
+    let clock = FakeClock::default();
+    let sent_first = clock.now();
+    let mut pull = PullTiming::default();
+    pull.in_flight.push(in_flight_request("alice.near", sent_first, &[0, 1]));
+    clock.advance(Duration::milliseconds(500));
+    pull.in_flight.push(in_flight_request("bob.near", clock.now(), &[2]));
+    clock.advance(Duration::milliseconds(500));
+
+    let timed_out = pull.take_timed_out_requests(&config, clock.now());
+
+    assert_eq!(timed_out.len(), 1);
+    assert_eq!(timed_out[0].source, account("alice.near"));
+    assert_eq!(timed_out[0].ordinals, vec![0, 1]);
+    assert_eq!(pull.in_flight.len(), 1);
+    assert_eq!(pull.in_flight[0].source, account("bob.near"));
+}
+
+#[test]
+fn a_timeout_wake_leaves_backoff_retries_unchanged() {
+    let config = no_jitter_config();
+    let clock = FakeClock::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut pull = PullTiming::default();
+    pull.in_flight.push(in_flight_request("alice.near", clock.now(), &[0]));
+    pull.backoff.note_retry();
+    pull.backoff.note_retry();
+    clock.advance(Duration::seconds(2));
+
+    pull.take_timed_out_requests(&config, clock.now());
+    let _ = pull.reschedule(&config, clock.now(), &mut rng);
+
+    assert_eq!(pull.backoff.retries(), 2);
+}
+
+#[test]
+fn has_in_flight_request_for_matches_only_requested_ordinals() {
+    let clock = FakeClock::default();
+    let mut pull = PullTiming::default();
+    pull.in_flight.push(in_flight_request("alice.near", clock.now(), &[1, 3]));
+
+    assert!(pull.has_in_flight_request_for(1));
+    assert!(pull.has_in_flight_request_for(3));
+    assert!(!pull.has_in_flight_request_for(2));
+}
+
+#[test]
+fn reschedule_picks_the_oldest_request_timeout_when_it_precedes_the_backoff() {
+    let config = no_jitter_config();
+    let clock = FakeClock::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    let sent_first = clock.now();
+    let mut pull = PullTiming::default();
+    pull.in_flight.push(in_flight_request("alice.near", sent_first, &[0]));
+    clock.advance(Duration::milliseconds(300));
+    pull.in_flight.push(in_flight_request("bob.near", clock.now(), &[1]));
+    clock.advance(Duration::milliseconds(600));
+
+    // The backoff would fire at +1100ms; alice's request times out at +1000ms.
+    let deadline = pull.reschedule(&config, clock.now(), &mut rng);
+
+    assert_eq!(deadline, sent_first.add_signed(config.request_timeout));
+    assert_eq!(pull.next_deadline, Some(deadline));
+}
+
+#[test]
+fn reschedule_uses_the_backoff_interval_when_no_request_times_out_sooner() {
+    let config = no_jitter_config();
+    let clock = FakeClock::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut pull = PullTiming::default();
+
+    let deadline = pull.reschedule(&config, clock.now(), &mut rng);
+    assert_eq!(deadline, clock.now().add_signed(config.backoff_base));
+
+    // A fresh request's timeout is further away than the backoff, so it does not win.
+    pull.in_flight.push(in_flight_request("alice.near", clock.now(), &[0]));
+    let deadline = pull.reschedule(&config, clock.now(), &mut rng);
+    assert_eq!(deadline, clock.now().add_signed(config.backoff_base));
+    assert_eq!(pull.next_deadline, Some(deadline));
+}
+
+#[test]
+fn reschedule_supersedes_the_previous_deadline_so_a_stale_pop_mismatches() {
+    let config = no_jitter_config();
+    let clock = FakeClock::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut pull = PullTiming::default();
+    let mut scheduler = DeadlineScheduler::default();
+
+    let stale = pull.reschedule(&config, clock.now(), &mut rng);
+    scheduler.schedule("item", stale, Lane::Priority);
+    clock.advance(Duration::milliseconds(50));
+    let current = pull.reschedule(&config, clock.now(), &mut rng);
+    scheduler.schedule("item", current, Lane::Priority);
+
+    clock.advance(Duration::seconds(10));
+    let popped = scheduler.pop_due(clock.now());
+    assert_eq!(popped, vec![("item", stale), ("item", current)]);
+    assert_ne!(pull.next_deadline, Some(stale));
+    assert_eq!(pull.next_deadline, Some(current));
 }

--- a/cspell.json
+++ b/cspell.json
@@ -492,6 +492,7 @@
         "unflushed",
         "unioned",
         "unittests",
+        "unjittered",
         "unlabel",
         "unlimit",
         "unorphaned",


### PR DESCRIPTION
Generic deadline heap (earliest first, priority-first within an instant), jittered geometric backoff, and in-flight request timing on `FetchItem`:
 duplicate-request suppression, timeout extraction, and the next-deadline rule `min(next backoff, oldest in-flight + request_timeout)`.

Part of #16275 (B2, closes #16277).