### PR TITLE
fix(state-sync): collect skipped data before tail update

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1643,13 +1643,17 @@ impl Chain {
 
         let tip = Tip::from_header(prev_block.header());
         let final_head = Tip::from_header(self.genesis.header());
+        let epoch_manager = self.epoch_manager.clone();
         // Update related heads now.
         let mut chain_store_update = self.mut_chain_store().store_update();
         chain_store_update.save_body_head(&tip)?;
         // Reset final head to genesis since at this point we don't have the last final block.
         chain_store_update.save_final_head(&final_head)?;
-        // TODO(#16264): the gc loops start at tail and chunk_tail, so nothing collects the heights
-        // this skips. Leaks blocks, chunks, partial chunks and their receipt refcounts.
+        chain_store_update.clear_data_before_state_sync_tail_update(
+            epoch_manager.as_ref(),
+            new_tail,
+            new_chunk_tail,
+        )?;
         // New Tail can not be earlier than `prev_block.header.inner_lite.height`
         chain_store_update.update_tail(new_tail);
         // New Chunk Tail can not be earlier than minimum of height_created in Block `prev_block`

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -43,6 +43,7 @@ enum InvalidChunkCleanup {
 pub enum GCMode {
     Fork(ShardTries),
     Canonical(ShardTries),
+    StateSync,
 }
 
 impl fmt::Debug for GCMode {
@@ -50,6 +51,7 @@ impl fmt::Debug for GCMode {
         match self {
             GCMode::Fork(_) => write!(f, "GCMode::Fork"),
             GCMode::Canonical(_) => write!(f, "GCMode::Canonical"),
+            GCMode::StateSync => write!(f, "GCMode::StateSync"),
         }
     }
 }
@@ -528,6 +530,86 @@ impl ChainStore {
 }
 
 impl<'a> ChainStoreUpdate<'a> {
+    fn indexed_heights(
+        &self,
+        col: DBCol,
+        first_height: BlockHeight,
+        end_height: BlockHeight,
+    ) -> Vec<BlockHeight> {
+        let mut heights = self
+            .store()
+            .iter_raw_bytes(col)
+            .filter_map(|(key, _)| {
+                let height = BlockHeight::from_le_bytes(key.get(..8)?.try_into().ok()?);
+                (first_height <= height && height < end_height).then_some(height)
+            })
+            .collect_vec();
+        heights.sort_unstable();
+        heights.dedup();
+        heights
+    }
+
+    /// Clears indexed data below the tails selected after state sync.
+    pub(crate) fn clear_data_before_state_sync_tail_update(
+        &mut self,
+        epoch_manager: &dyn EpochManagerAdapter,
+        new_tail: BlockHeight,
+        new_chunk_tail: BlockHeight,
+    ) -> Result<(), Error> {
+        let first_block_height = self.tail().max(self.get_genesis_height().saturating_add(1));
+        for height in self.indexed_heights(DBCol::BlockPerHeight, first_block_height, new_tail) {
+            let block_hashes = self
+                .chain_store()
+                .get_all_block_hashes_by_height(height)
+                .values()
+                .flatten()
+                .copied()
+                .collect_vec();
+            for block_hash in block_hashes {
+                self.clear_block_data(epoch_manager, block_hash, GCMode::StateSync)?;
+            }
+
+            let key = index_to_bytes(height);
+            let mut store_update = self.store().store_update();
+            store_update.delete(DBCol::BlockPerHeight, &key);
+            self.merge(store_update);
+            if self.is_height_processed(height) {
+                self.gc_col(DBCol::ProcessedBlockHeights, &key);
+            }
+        }
+
+        let first_chunk_height = self.chunk_tail();
+        let chunk_heights =
+            self.indexed_heights(DBCol::ChunkHashesByHeight, first_chunk_height, new_chunk_tail);
+        #[cfg(feature = "protocol_feature_spice")]
+        let chunk_heights = {
+            let mut chunk_heights = chunk_heights;
+            chunk_heights.extend(self.indexed_heights(
+                DBCol::spice_invalid_chunks(),
+                first_chunk_height,
+                new_chunk_tail,
+            ));
+            chunk_heights.sort_unstable();
+            chunk_heights.dedup();
+            chunk_heights
+        };
+        for height in chunk_heights {
+            self.clear_chunk_data_at_height(height)?;
+        }
+
+        for height in
+            self.indexed_heights(DBCol::HeaderHashesByHeight, first_chunk_height, new_chunk_tail)
+        {
+            #[cfg(feature = "nightly")]
+            for header_hash in self.chain_store().get_all_header_hashes_by_height(height) {
+                self.gc_chunk_producers_for_block(&header_hash);
+            }
+            self.gc_col(DBCol::HeaderHashesByHeight, &index_to_bytes(height));
+        }
+
+        Ok(())
+    }
+
     /// GC every ChunkProducers row anchored at `block_hash`. Rows are keyed by
     /// (block_hash, shard_id), so the hash prefixes all shards' rows. Callers delete alongside
     /// the block's `BlockInfo`, except the `clear_chunk_data_and_headers` sweep, which uses it
@@ -786,7 +868,9 @@ impl<'a> ChainStoreUpdate<'a> {
         self.gc_spice_core_data(&block_hash, &shard_layout);
 
         // 4. Update or delete block_hash_per_height
-        self.gc_col_block_per_height(&block_hash, height, block.header().epoch_id())?;
+        if !matches!(&gc_mode, GCMode::StateSync) {
+            self.gc_col_block_per_height(&block_hash, height, block.header().epoch_id())?;
+        }
 
         match gc_mode {
             GCMode::Fork(_) => {
@@ -804,6 +888,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 }
                 self.clear_chunk_data_and_headers(min_chunk_height)?;
             }
+            GCMode::StateSync => {}
         };
         self.merge(store_update.into());
         Ok(())
@@ -941,6 +1026,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     // If the block is on canonical chain, we delete the state that's before applying this block
                     tries.apply_deletions(&trie_changes, shard_uid, store_update);
                 }
+                GCMode::StateSync => {}
             }
 
             self.gc_col(DBCol::TrieChanges, &trie_changes_key);
@@ -1354,5 +1440,25 @@ mod tests {
         let store = chain.chain_store().store();
         assert!(chain.chain_store().chunk_tail() > height, "gc did not pass the height");
         assert!(!store.exists(DBCol::spice_invalid_chunks(), &key), "hot gc kept evidence");
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn state_sync_tail_update_deletes_invalid_chunk_evidence() {
+        let mut chain = get_chain(Clock::real());
+        let epoch_manager = chain.epoch_manager.clone();
+        let tail = chain.tail();
+        let height = chain.chain_store().chunk_tail();
+        let key = plant_invalid_chunk(&chain, height);
+
+        let mut update = chain.mut_chain_store().store_update();
+        update
+            .clear_data_before_state_sync_tail_update(epoch_manager.as_ref(), tail, height + 1)
+            .unwrap();
+        update.update_chunk_tail(height + 1);
+        update.commit().unwrap();
+
+        let store = chain.chain_store().store();
+        assert!(!store.exists(DBCol::spice_invalid_chunks(), &key));
     }
 }

--- a/chain/chain/src/tests/garbage_collection.rs
+++ b/chain/chain/src/tests/garbage_collection.rs
@@ -882,3 +882,52 @@ fn test_fork_chunk_tail_updates() {
         assert_eq!(store_update.chunk_tail(), 0);
     }
 }
+
+#[test]
+fn test_state_sync_tail_update_clears_skipped_heights() {
+    let mut chain = get_chain(Clock::real());
+    let epoch_manager = chain.epoch_manager.clone();
+    let signer = Arc::new(create_test_signer("test1"));
+    let mut prev_block = chain.get_block_by_height(0).unwrap();
+    let mut blocks = vec![prev_block.clone()];
+    for height in 1..=6 {
+        add_block(
+            &mut chain,
+            epoch_manager.as_ref(),
+            &mut prev_block,
+            &mut blocks,
+            signer.clone(),
+            height,
+        );
+    }
+
+    let new_tail = 5;
+    let new_chunk_tail = 5;
+    let mut store_update = chain.mut_chain_store().store_update();
+    store_update
+        .clear_data_before_state_sync_tail_update(epoch_manager.as_ref(), new_tail, new_chunk_tail)
+        .unwrap();
+    store_update.update_tail(new_tail);
+    store_update.update_chunk_tail(new_chunk_tail);
+    store_update.commit().unwrap();
+
+    assert!(chain.get_block(blocks[0].hash()).is_ok());
+    for block in &blocks[1..new_tail as usize] {
+        assert!(chain.get_block(block.hash()).is_err());
+        assert!(
+            chain
+                .mut_chain_store()
+                .get_all_block_hashes_by_height(block.header().height())
+                .is_empty()
+        );
+    }
+    assert!(chain.get_block(blocks[new_tail as usize].hash()).is_ok());
+    assert!(chain.get_block(blocks[6].hash()).is_ok());
+
+    for height in 0..new_chunk_tail {
+        assert!(chain.mut_chain_store().get_all_header_hashes_by_height(height).is_empty());
+    }
+    assert!(!chain.mut_chain_store().get_all_header_hashes_by_height(new_chunk_tail).is_empty());
+    assert_eq!(chain.tail(), new_tail);
+    assert_eq!(chain.chain_store().chunk_tail(), new_chunk_tail);
+}

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -150,6 +150,11 @@ epoch sync boundary and the sync point are not processed. This is fine for
 non-archival nodes, as that data would be garbage collected after a few epochs
 anyway.
 
+When state sync completes, the node deletes indexed block and chunk data below
+the new storage tails in the same database transaction that advances those
+tails. This keeps skipped heights reachable by cleanup until their data is
+removed.
+
 This step never runs on archival nodes — they need the complete history and
 cannot have gaps.
 


### PR DESCRIPTION
## Problem

`reset_heads_post_state_sync` advanced `tail` and `chunk_tail` without collecting indexed rows below the new values. Normal garbage collection starts from those tails, so it could never reach the skipped rows.

The unreachable data included block records, chunk bodies, partial chunks, transactions, receipt references, height indexes, and SPICE invalid-chunk evidence.

## Solution

This change adds a state-sync garbage-collection mode and runs it before the new tails become effective.

The cleanup performs these operations:

- Scan persisted height indexes instead of iterating every numeric height between the old and new tails.
- Remove block data for stored heights below `new_tail` while keeping genesis and the selected new tail.
- Remove chunk data for stored heights below `new_chunk_tail` through the existing chunk cleanup path.
- Include height-keyed `SpiceInvalidChunks` rows even when `ChunkHashesByHeight` has no entry for that height.
- Remove skipped header height indexes and nightly `ChunkProducers` rows.
- Delete stored trie-change records without applying or reverting them because state sync has already reconstructed the active state.
- Commit cleanup, head changes, and both tail changes through one `ChainStoreUpdate`.

The indexed scan makes work proportional to stored rows. It does not scan the full chain-height gap on a fresh node.

## Atomicity

The operation can issue multiple deletes because each stored block, chunk, receipt reference, and height index requires its own write. All writes are merged into the same database transaction that saves the state-sync head and advances both tails. A crash cannot persist a tail that has skipped uncollected indexed data.

## Documentation

The sync architecture document now states that state-sync completion collects indexed data below the new storage tails in the same transaction that advances them.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package near-chain --features test_features -- tests::garbage_collection::test_state_sync_tail_update_clears_skipped_heights --exact --show-output`
- `cargo test --package near-chain --all-features --features test_features -- garbage_collection::tests::state_sync_tail_update_deletes_invalid_chunk_evidence --exact --show-output`
- `cargo test --package near-chain --features test_features -- tests::garbage_collection::test_clear_old_data --exact --show-output`
- `cargo test --package near-chain --all-features --features test_features -- garbage_collection::tests::hot_gc_deletes_invalid_chunk_evidence --exact --show-output`
- `cargo test --package test-loop-tests --features test_features -- tests::sync::gc::test_gc_boundary_after_sync --exact --show-output`
- `RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets`

Fixes #16264