### PR TITLE
fix(spice): stop waiting on data of dead forks and final certified chunks

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -1025,8 +1025,15 @@ impl SpiceDataDistributorActor {
         let mut unneeded = Vec::new();
         for id in self.waiting_on_data.keys() {
             let block_hash = id.block_hash();
-            let Ok(height) = self.chain_store.get_block_height(block_hash) else {
-                continue;
+            let height = match self.chain_store.get_block_height(block_hash) {
+                Ok(height) => height,
+                Err(err) => {
+                    // The rules below should have dropped the entry before its block was
+                    // collected.
+                    tracing::error!(target: "spice_data_distribution", ?err, ?id, "block for which we wait on data is gone; stop waiting on it");
+                    unneeded.push((id.clone(), false));
+                    continue;
+                }
             };
             if height > final_head.height {
                 continue;

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -26,7 +26,7 @@ use near_chain::spice::activation::{
 use near_chain::spice::all_stake_fallback::{
     fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
 };
-use near_chain::spice::core::SpiceCoreReader;
+use near_chain::spice::core::{SpiceCoreReader, get_last_certified_block_header};
 use near_chain::spice::core_writer_actor::ProcessedBlock;
 use near_chain::stateless_validation::metrics::PROCESS_CONTRACT_CODE_REQUEST_TIME;
 use near_chain_configs::MutableValidatorSigner;
@@ -1000,6 +1000,51 @@ impl SpiceDataDistributorActor {
         self.pending_partial_data.len()
     }
 
+    #[cfg(any(test, feature = "test_features"))]
+    pub fn waiting_on_data_ids(&self) -> Vec<SpiceDataIdentifier> {
+        self.waiting_on_data.keys().cloned().collect()
+    }
+
+    /// Data of a block on a dead fork (below the final head, off the canonical chain) is never
+    /// applied. A witness of a chunk certified as of the final head is never endorsed, and the
+    /// producers collect it (see `clear_witnesses_data`). Neither may ever arrive.
+    fn stop_waiting_on_data_for_dead_forks_and_final_certified_blocks(&mut self) {
+        let Ok(final_head) = self.chain_store.final_head() else {
+            return;
+        };
+        let last_certified_height = match get_last_certified_block_header(
+            &self.chain_store,
+            &final_head.last_block_hash,
+        ) {
+            Ok(header) => header.height(),
+            Err(err) => {
+                tracing::debug!(target: "spice_data_distribution", ?err, "no last certified block to stop waiting on witnesses at");
+                return;
+            }
+        };
+        let mut unneeded = Vec::new();
+        for id in self.waiting_on_data.keys() {
+            let block_hash = id.block_hash();
+            let Ok(height) = self.chain_store.get_block_height(block_hash) else {
+                continue;
+            };
+            if height > final_head.height {
+                continue;
+            }
+            let on_dead_fork =
+                self.chain_store.get_block_hash_by_height(height).ok().as_ref() != Some(block_hash);
+            let certified = matches!(id, SpiceDataIdentifier::Witness { .. })
+                && height <= last_certified_height;
+            if on_dead_fork || certified {
+                unneeded.push((id.clone(), on_dead_fork));
+            }
+        }
+        for (id, on_dead_fork) in unneeded {
+            tracing::debug!(target: "spice_data_distribution", ?id, on_dead_fork, last_certified_height, "data is no longer needed; stop waiting on it");
+            self.waiting_on_data.remove(&id);
+        }
+    }
+
     // TODO(spice): Implement a state machine to track all the data we produce or may need. This
     // would help make sure that we cannot have and request data at the same time.
     /// As a non-designated epoch validator, certify overdue chunks via the all-stake fallback:
@@ -1372,6 +1417,7 @@ impl SpiceDataDistributorActor {
     }
 
     fn schedule_data_fetching(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
+        self.stop_waiting_on_data_for_dead_forks_and_final_certified_blocks();
         self.request_waiting_on_data();
         self.request_round = self.request_round.wrapping_add(1);
 

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -113,6 +113,14 @@ fn produce_block(chain: &mut Chain, prev_block: &Block) -> Arc<Block> {
     block
 }
 
+fn produce_blocks_until_final(chain: &mut Chain, block: &Block) -> Arc<Block> {
+    let mut head = produce_block(chain, block);
+    while chain.chain_store.final_head().unwrap().height < block.header().height() {
+        head = produce_block(chain, &head);
+    }
+    head
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq)]
 enum OutgoingMessage {
@@ -1083,12 +1091,16 @@ fn test_incoming_partial_data_for_already_known_receipts() {
     );
 }
 
-fn record_endorsement(chain: &Chain, chunk_id: SpiceChunkId, validator: &AccountId) {
-    let signer = create_test_signer(validator.as_str());
-    let execution_result = ChunkExecutionResult {
+fn test_execution_result() -> ChunkExecutionResult {
+    ChunkExecutionResult {
         chunk_extra: ChunkExtra::new_with_only_state_root(&CryptoHash::default()),
         outgoing_receipts_root: CryptoHash::default(),
-    };
+    }
+}
+
+fn record_endorsement(chain: &Chain, chunk_id: SpiceChunkId, validator: &AccountId) {
+    let signer = create_test_signer(validator.as_str());
+    let execution_result = test_execution_result();
     let mut core_writer_actor = SpiceCoreWriterActor::new(
         chain.runtime_adapter.store().chain_store(),
         chain.epoch_manager.clone(),
@@ -3116,6 +3128,166 @@ fn produce_block_carrying_endorsement(
     )
     .unwrap();
     block
+}
+
+fn endorsement_core_statement(chunk_id: &SpiceChunkId, endorser: AccountId) -> SpiceCoreStatement {
+    let signer = create_test_signer(endorser.as_str());
+    SpiceChunkEndorsement::new(chunk_id.clone(), test_execution_result(), &signer)
+        .into_verified(&signer.public_key())
+        .unwrap()
+        .to_stored()
+        .into_core_statement(chunk_id.clone(), endorser)
+}
+
+/// Endorsements of `chunk_id` by every validator that may endorse it on chain: the designated
+/// set, or all of the epoch's validators for a fallback-only chunk.
+fn certifying_endorsements(chain: &Chain, chunk_id: &SpiceChunkId) -> Vec<SpiceCoreStatement> {
+    let epoch_manager = chain.epoch_manager.as_ref();
+    let chunk_block_header = chain.chain_store.get_block_header(&chunk_id.block_hash).unwrap();
+    let epoch_id = chunk_block_header.epoch_id();
+    if is_fallback_only_chunk(epoch_manager, &chunk_block_header, chunk_id.shard_id).unwrap() {
+        epoch_manager
+            .get_epoch_info(epoch_id)
+            .unwrap()
+            .validators_iter()
+            .map(|validator| endorsement_core_statement(chunk_id, validator.take_account_id()))
+            .collect()
+    } else {
+        epoch_manager
+            .get_chunk_validator_assignments(
+                epoch_id,
+                chunk_id.shard_id,
+                chunk_block_header.height(),
+            )
+            .unwrap()
+            .ordered_chunk_validators()
+            .into_iter()
+            .map(|endorser| endorsement_core_statement(chunk_id, endorser))
+            .collect()
+    }
+}
+
+/// Produces a block whose core statements certify every chunk still uncertified as of
+/// `prev_block`: enough endorsements and the execution result for each of them.
+fn produce_block_certifying_uncertified_chunks(
+    chain: &mut Chain,
+    prev_block: &Block,
+) -> Arc<Block> {
+    let mut core_statements = Vec::new();
+    for chunk_info in chain.spice_core_reader.get_uncertified_chunks(prev_block.hash()).unwrap() {
+        let chunk_id = chunk_info.chunk_id;
+        core_statements.extend(certifying_endorsements(chain, &chunk_id));
+        core_statements.push(SpiceCoreStatement::ChunkExecutionResult {
+            chunk_id,
+            execution_result: test_execution_result(),
+        });
+    }
+    let block =
+        build_block_with_core_statements(chain.epoch_manager.as_ref(), prev_block, core_statements);
+    process_block_sync(
+        chain,
+        block.clone().into(),
+        Provenance::PRODUCED,
+        &mut BlockProcessingArtifact::default(),
+    )
+    .unwrap();
+    block
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_stops_waiting_on_witness_once_its_block_is_final_certified() {
+    let (_genesis, mut chain) = setup_with_shard_layout(1, 1, ShardLayout::single_shard());
+    let block = latest_block(&chain);
+    let validator = non_producer_witness_validator_account(&chain);
+    let next_block = produce_block(&mut chain, &block);
+    save_final_execution_head(&chain, &block);
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);
+    let mut fake_runner = FakeDelayedActionRunner::default();
+    actor.start_actor(&mut fake_runner);
+    fake_runner.run_queued_actions(&mut actor);
+    assert!(
+        !drain_outgoing_witness_request_producers(&mut outgoing_rc, next_block.hash()).is_empty()
+    );
+
+    let shard_id = witness_shard_id(&next_block);
+    let certifying_block = produce_block_certifying_uncertified_chunks(&mut chain, &next_block);
+    let head = produce_blocks_until_final(&mut chain, &certifying_block);
+
+    actor.handle(ProcessedBlock { block_hash: *head.hash() });
+    fake_runner.run_queued_actions(&mut actor);
+    assert!(
+        !actor
+            .waiting_on_data_ids()
+            .contains(&SpiceDataIdentifier::Witness { block_hash: *next_block.hash(), shard_id })
+    );
+    assert!(
+        drain_outgoing_witness_request_producers(&mut outgoing_rc, next_block.hash()).is_empty()
+    );
+}
+
+/// Entries the actor holds for one block, counted by data kind.
+#[derive(Debug, PartialEq)]
+struct WaitingCounts {
+    witnesses: usize,
+    receipt_proofs: usize,
+}
+
+fn waiting_counts_of(actor: &SpiceDataDistributorActor, block_hash: &CryptoHash) -> WaitingCounts {
+    let mut counts = WaitingCounts { witnesses: 0, receipt_proofs: 0 };
+    for id in actor.waiting_on_data_ids() {
+        if id.block_hash() != block_hash {
+            continue;
+        }
+        match id {
+            SpiceDataIdentifier::Witness { .. } => counts.witnesses += 1,
+            SpiceDataIdentifier::ReceiptProof { .. } => counts.receipt_proofs += 1,
+        }
+    }
+    counts
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_stops_waiting_on_data_of_a_fork_block_below_the_final_head() {
+    let (genesis, mut chain) = setup(2, 0);
+    let (_from_shard_id, to_shard_id) =
+        genesis.config.shard_layout.shard_ids().collect_tuple().unwrap();
+    // Tracks only its shard, so it waits on the other shard's witness and receipt proofs.
+    let recipient = chunk_producer_for_shard(&chain, to_shard_id);
+    let block = latest_block(&chain);
+    let next_block = produce_block(&mut chain, &block);
+    let fork_block = produce_block(&mut chain, &block);
+    save_final_execution_head(&chain, &block);
+
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &recipient);
+    let mut fake_runner = FakeDelayedActionRunner::default();
+    actor.start_actor(&mut fake_runner);
+    fake_runner.run_queued_actions(&mut actor);
+    let fork_counts = waiting_counts_of(&actor, fork_block.hash());
+    assert!(fork_counts.witnesses > 0);
+    assert!(fork_counts.receipt_proofs > 0);
+    let next_counts = waiting_counts_of(&actor, next_block.hash());
+    drain_outgoing_data_requests(&mut outgoing_rc);
+
+    let head = produce_blocks_until_final(&mut chain, &next_block);
+
+    actor.handle(ProcessedBlock { block_hash: *head.hash() });
+    fake_runner.run_queued_actions(&mut actor);
+    assert_eq!(
+        waiting_counts_of(&actor, fork_block.hash()),
+        WaitingCounts { witnesses: 0, receipt_proofs: 0 }
+    );
+    assert_eq!(waiting_counts_of(&actor, next_block.hash()), next_counts);
+    let requested_blocks: HashSet<_> = drain_outgoing_data_requests(&mut outgoing_rc)
+        .into_iter()
+        .map(|(data_id, _requester)| *data_id.block_hash())
+        .collect();
+    assert!(!requested_blocks.contains(fork_block.hash()));
+    assert!(requested_blocks.contains(next_block.hash()));
 }
 
 #[test]


### PR DESCRIPTION
The spice nightly benchmark crashed 2 of 4 nodes at `data_distributor_actor.rs:1411`, the `expect` in `request_waiting_on_data`, on a block GC had collected. Reproduced on a forknet; both leaked entries were witnesses of fallback-only slot chunks (#16243).

A validator that is neither designated for such a chunk nor tracking its shard starts waiting on the witness at the chunk's own block, since the chunk is fallback-eligible right away. It only receives the witness through the producer's fallback push (the initial distribution goes to the designated validators), and that push can be skipped for good.

`push_fallback_witnesses` runs when the producer processes a block, over that block's uncertified chunks, and pushes a chunk's witness only if the chunk is already applied. At the chunk's own block it is not applied yet. The producer's own endorsement is made when the apply finishes, and with the designated validators' endorsements it certifies the chunk in the next block produced. If the producer processes no block between finishing the apply and that certifying block, the chunk is never both applied and uncertified at a block it processes, so it is never pushed.

Once the certification is final the producer's witness GC deletes the witness, every pull gets nothing, and nothing removes the entry. Three epochs later GC deletes the block and the next request round panics.

The distributor now prunes `waiting_on_data` before every request round: witnesses of chunks at or below the last certified height as of the final head (the condition `clear_witnesses_data` deletes them under), and all data of a block below the final head that is not on the canonical chain.

We may consider pushing a fallback-only chunk's witness to the non-designated validators at apply time as separate change.