### PR TITLE
fix(spice): distribute a fallback-only chunk's witness to every validator when it is saved

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -24,7 +24,7 @@ use near_chain::spice::activation::{
     SpiceMessageGate, SpiceMessageKind, spice_enabled_at_head_on_startup, spice_enabled_for_block,
 };
 use near_chain::spice::all_stake_fallback::{
-    fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
+    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
 };
 use near_chain::spice::core::SpiceCoreReader;
 use near_chain::spice::core_writer_actor::ProcessedBlock;
@@ -637,12 +637,24 @@ impl SpiceDataDistributorActor {
                 let epoch_id = block.header().epoch_id();
                 let producers =
                     self.epoch_manager.get_epoch_chunk_producers_for_shard(epoch_id, *shard_id)?;
-                let validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
-                    epoch_id,
+                // A fallback-only chunk certifies on the whole epoch's stake, so every validator
+                // gets its witness right away.
+                let recipients = if is_fallback_only_chunk(
+                    self.epoch_manager.as_ref(),
+                    block.header(),
                     *shard_id,
-                    block.header().height(),
-                )?;
-                let recipients = validator_assignments.ordered_chunk_validators();
+                )? {
+                    all_stake_fallback_assignment(self.epoch_manager.as_ref(), epoch_id)?
+                        .ordered_chunk_validators()
+                } else {
+                    self.epoch_manager
+                        .get_chunk_validator_assignments(
+                            epoch_id,
+                            *shard_id,
+                            block.header().height(),
+                        )?
+                        .ordered_chunk_validators()
+                };
                 (recipients, producers)
             }
         };
@@ -1089,6 +1101,14 @@ impl SpiceDataDistributorActor {
                 continue;
             }
             let chunk_block = self.chain_store.get_block(&chunk_id.block_hash)?;
+            // A fallback-only chunk's witness reaches every validator in the initial distribution.
+            if is_fallback_only_chunk(
+                self.epoch_manager.as_ref(),
+                chunk_block.header(),
+                chunk_id.shard_id,
+            )? {
+                continue;
+            }
             if !fallback_eligible(
                 self.epoch_manager.as_ref(),
                 chunk_block.header(),
@@ -1123,17 +1143,7 @@ impl SpiceDataDistributorActor {
             }
             let Some(mut distribution_data) = self.get_distribution_data(&data_id, producers.len())
             else {
-                if is_fallback_only_chunk(
-                    self.epoch_manager.as_ref(),
-                    chunk_block.header(),
-                    chunk_id.shard_id,
-                )? {
-                    // Eligible from its own block, before we applied the chunk that produces the
-                    // witness. Later blocks retry.
-                    tracing::debug!(target: "spice_data_distribution", ?data_id, "witness for the fallback-only chunk not yet produced - chunk not applied");
-                } else {
-                    tracing::warn!(target: "spice_data_distribution", ?data_id, "no witness to push for the all-stake fallback");
-                }
+                tracing::warn!(target: "spice_data_distribution", ?data_id, "no witness to push for the all-stake fallback");
                 continue;
             };
             let my_part = distribution_data.parts.swap_remove(my_producer_index);
@@ -1580,17 +1590,13 @@ impl SpiceDataDistributorActor {
         };
 
         let block = self.chain_store.get_block(&chunk_id.block_hash)?;
-        let epoch_id = block.header().epoch_id();
-        let validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
-            epoch_id,
-            chunk_id.shard_id,
-            block.header().height(),
-        )?;
-        let targets: Vec<AccountId> = validator_assignments
-            .ordered_chunk_validators()
-            .into_iter()
-            .filter(|v| v != signer.validator_id())
-            .collect();
+        // The same validators the witness goes to; they wait on the accesses to validate it.
+        let data_id = SpiceDataIdentifier::Witness {
+            block_hash: chunk_id.block_hash,
+            shard_id: chunk_id.shard_id,
+        };
+        let (recipients, _producers) = self.recipients_and_producers(&data_id, &block)?;
+        let targets: Vec<AccountId> = recipients.into_iter().collect();
 
         let accesses_msg =
             SpiceChunkContractAccesses::new(chunk_id.clone(), contract_accesses, &signer);

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -3279,34 +3279,57 @@ fn test_witness_is_pushed_only_once() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
-fn test_fallback_only_witness_is_pushed_on_the_block_after_the_witness_is_saved() {
+fn test_fallback_only_witness_is_distributed_to_all_validators_when_saved() {
     // More validators than mandates per shard, so some are outside every chunk's designated set.
     let (_genesis, mut chain) = setup(2, 100);
     let chunk_id = grow_chain_to_fallback_only_chunk(&mut chain);
 
     let chunk_block = latest_block(&chain);
-    let producer = chain
+    let epoch_id = chunk_block.header().epoch_id();
+    let producers = chain
         .epoch_manager
-        .get_epoch_chunk_producers_for_shard(chunk_block.header().epoch_id(), chunk_id.shard_id)
+        .get_epoch_chunk_producers_for_shard(epoch_id, chunk_id.shard_id)
+        .unwrap();
+    let all_validators: HashSet<AccountId> = chain
+        .epoch_manager
+        .get_epoch_info(epoch_id)
         .unwrap()
-        .swap_remove(0);
+        .validators_iter()
+        .map(|validator| validator.take_account_id())
+        .filter(|validator| !producers.contains(validator))
+        .collect();
+    let chunks = chunk_block.chunks();
+    let chunk_header =
+        chunks.iter_raw().find(|chunk| chunk.shard_id() == chunk_id.shard_id).unwrap();
+    let state_witness = new_test_witness_for_chunk(&chunk_block, chunk_header);
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
-    let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
-    // A fallback-only chunk is eligible on its own block, but its witness only exists once the
-    // producer applies the chunk, which needs the previous block certified.
-    actor.handle(ProcessedBlock { block_hash: *chunk_block.hash() });
-    assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
+    let mut actor = new_actor_for_account(outgoing_sc, &chain, &producers[0]);
+    actor.handle(SpiceDistributorStateWitness { contract_accesses: HashSet::new(), state_witness });
 
-    let witness = save_test_witness_for_chunk(&chain, &chunk_id);
+    let mut accesses_targets = Vec::new();
+    let mut pushes = Vec::new();
+    while let Ok(message) = outgoing_rc.try_recv() {
+        match message {
+            OutgoingMessage::NetworkRequests {
+                request: NetworkRequests::SpiceChunkContractAccesses(targets, _),
+            } => accesses_targets.push(HashSet::from_iter(targets)),
+            OutgoingMessage::NetworkRequests {
+                request: NetworkRequests::SpicePartialData { partial_data, recipients },
+            } => pushes.push((partial_data, recipients)),
+            message => panic!("unexpected message {message:?}"),
+        }
+    }
+    assert_eq!(accesses_targets, vec![all_validators.clone()]);
+    assert_eq!(pushes.len(), 1);
+    let (partial_data, recipients) = pushes.swap_remove(0);
+    assert_eq!(partial_data.block_hash(), &chunk_id.block_hash);
+    assert_eq!(recipients, all_validators);
+
+    // The fallback push has nothing left to do for it.
     let next_block = produce_block(&mut chain, &chunk_block);
     actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
-
-    let mut pushes = drain_outgoing_partial_data(&mut outgoing_rc);
-    assert_eq!(pushes.len(), 1, "the push was not retried once the witness was saved");
-    let (partial_data, recipients) = pushes.swap_remove(0);
-    assert_eq!(partial_data.block_hash(), &witness.chunk_id().block_hash);
-    assert_eq!(recipients, fallback_witness_recipients(&chain, &chunk_id));
+    assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
 }
 
 #[test]


### PR DESCRIPTION
A fallback-only chunk (#16243) certifies on the whole epoch's stake, but its witness reached the non-designated validators only through `push_fallback_witnesses`, which runs on the next block the producer processes and only for chunks still uncertified. When the apply finished after that block was processed, the chunk certified on the designated validators' stake in the following block and the push never happened; the non-designated validators then pulled the witness for good (see #16325).

The initial distribution at save time now sends the witness of a fallback-only chunk to every validator of the epoch, and `send_contract_accesses` targets the same recipients as the witness. A witness is not validated until the accesses message for its chunk arrives, and there is no way to request it, so a validator that gets the witness without the accesses never endorses. `push_fallback_witnesses` skips fallback-only chunks, which have nothing left to push.

Not covered here: a validator that loses the accesses message still has no way to recover it, for any chunk.