### PR TITLE
fix(spice): send a fallback-only chunk's witness to every validator through the fallback push

### DIFF
--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -24,7 +24,7 @@ use near_chain::spice::activation::{
     SpiceMessageGate, SpiceMessageKind, spice_enabled_at_head_on_startup, spice_enabled_for_block,
 };
 use near_chain::spice::all_stake_fallback::{
-    fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
+    all_stake_fallback_assignment, fallback_eligible, fallback_endorsers, is_fallback_only_chunk,
 };
 use near_chain::spice::core::SpiceCoreReader;
 use near_chain::spice::core_writer_actor::ProcessedBlock;
@@ -351,6 +351,18 @@ impl Handler<SpiceDistributorStateWitness> for SpiceDataDistributorActor {
         SpiceDistributorStateWitness { state_witness, contract_accesses }: SpiceDistributorStateWitness,
     ) {
         let chunk_id = state_witness.chunk_id().clone();
+
+        // A fallback-only chunk certifies on the whole epoch's stake, so every validator gets its
+        // witness through the fallback push instead, on the next block we process. That push is
+        // what the schedule exercises, and nobody can certify the chunk before it.
+        match self.is_fallback_only_chunk(&chunk_id) {
+            Ok(false) => {}
+            Ok(true) => return,
+            Err(err) => {
+                tracing::error!(target: "spice_data_distribution", ?err, ?chunk_id, "failed to check whether the chunk is fallback-only");
+                return;
+            }
+        }
 
         // Send contract accesses to chunk validators before distributing the witness.
         // Even when empty, this signals to validators that no contracts need to be fetched,
@@ -1108,29 +1120,41 @@ impl SpiceDataDistributorActor {
             else {
                 continue;
             };
-            let recipients: HashSet<AccountId> = fallback_endorsers(
+            let fallback_only = is_fallback_only_chunk(
                 self.epoch_manager.as_ref(),
-                chunk_block.header().epoch_id(),
+                chunk_block.header(),
                 chunk_id.shard_id,
-                chunk_block.header().height(),
-            )?
-            .into_iter()
-            .filter(|account_id| !producers.contains(account_id))
-            .collect();
+            )?;
+            // A fallback-only chunk had no initial distribution, so its designated validators
+            // need the push as well.
+            let endorsers = if fallback_only {
+                all_stake_fallback_assignment(
+                    self.epoch_manager.as_ref(),
+                    chunk_block.header().epoch_id(),
+                )?
+                .ordered_chunk_validators()
+            } else {
+                fallback_endorsers(
+                    self.epoch_manager.as_ref(),
+                    chunk_block.header().epoch_id(),
+                    chunk_id.shard_id,
+                    chunk_block.header().height(),
+                )?
+            };
+            let recipients: HashSet<AccountId> = endorsers
+                .into_iter()
+                .filter(|account_id| !producers.contains(account_id))
+                .collect();
             debug_assert!(!recipients.contains(me));
             if recipients.is_empty() {
                 continue;
             }
             let Some(mut distribution_data) = self.get_distribution_data(&data_id, producers.len())
             else {
-                if is_fallback_only_chunk(
-                    self.epoch_manager.as_ref(),
-                    chunk_block.header(),
-                    chunk_id.shard_id,
-                )? {
-                    // Eligible from its own block, before we applied the chunk that produces the
-                    // witness. Later blocks retry.
-                    tracing::debug!(target: "spice_data_distribution", ?data_id, "witness for the fallback-only chunk not yet produced - chunk not applied");
+                if fallback_only {
+                    // Expected on the chunk's own block: it is eligible before the apply that
+                    // produces the witness. The first block we process after the apply pushes it.
+                    tracing::debug!(target: "spice_data_distribution", ?data_id, "witness for the fallback-only chunk not produced yet");
                 } else {
                     tracing::warn!(target: "spice_data_distribution", ?data_id, "no witness to push for the all-stake fallback");
                 }
@@ -1433,6 +1457,11 @@ impl SpiceDataDistributorActor {
                 },
             ));
         }
+    }
+
+    fn is_fallback_only_chunk(&self, chunk_id: &SpiceChunkId) -> Result<bool, Error> {
+        let block_header = self.chain_store.get_block_header(&chunk_id.block_hash)?;
+        Ok(is_fallback_only_chunk(self.epoch_manager.as_ref(), &block_header, chunk_id.shard_id)?)
     }
 
     fn get_distribution_data(

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -3298,15 +3298,50 @@ fn test_fallback_only_witness_is_pushed_on_the_block_after_the_witness_is_saved(
     actor.handle(ProcessedBlock { block_hash: *chunk_block.hash() });
     assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
 
+    // Saving the witness distributes nothing: every validator gets it through the push.
     let witness = save_test_witness_for_chunk(&chain, &chunk_id);
+    actor.handle(SpiceDistributorStateWitness {
+        contract_accesses: HashSet::new(),
+        state_witness: witness.clone(),
+    });
+    assert!(outgoing_rc.try_recv().is_err());
+
     let next_block = produce_block(&mut chain, &chunk_block);
     actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
 
-    let mut pushes = drain_outgoing_partial_data(&mut outgoing_rc);
+    let epoch_id = chunk_block.header().epoch_id();
+    let producers: HashSet<AccountId> = chain
+        .epoch_manager
+        .get_epoch_chunk_producers_for_shard(epoch_id, chunk_id.shard_id)
+        .unwrap()
+        .into_iter()
+        .collect();
+    let all_validators: HashSet<AccountId> = chain
+        .epoch_manager
+        .get_epoch_info(epoch_id)
+        .unwrap()
+        .validators_iter()
+        .map(|validator| validator.take_account_id())
+        .filter(|validator| !producers.contains(validator))
+        .collect();
+    let mut accesses_targets = Vec::new();
+    let mut pushes = Vec::new();
+    while let Ok(message) = outgoing_rc.try_recv() {
+        match message {
+            OutgoingMessage::NetworkRequests {
+                request: NetworkRequests::SpiceChunkContractAccesses(targets, _),
+            } => accesses_targets.push(HashSet::from_iter(targets)),
+            OutgoingMessage::NetworkRequests {
+                request: NetworkRequests::SpicePartialData { partial_data, recipients },
+            } => pushes.push((partial_data, recipients)),
+            message => panic!("unexpected message {message:?}"),
+        }
+    }
+    assert_eq!(accesses_targets, vec![all_validators.clone()]);
     assert_eq!(pushes.len(), 1, "the push was not retried once the witness was saved");
     let (partial_data, recipients) = pushes.swap_remove(0);
     assert_eq!(partial_data.block_hash(), &witness.chunk_id().block_hash);
-    assert_eq!(recipients, fallback_witness_recipients(&chain, &chunk_id));
+    assert_eq!(recipients, all_validators);
 }
 
 #[test]
@@ -3342,20 +3377,33 @@ fn test_fallback_witness_is_requested_only_after_the_pull_grace() {
 /// A producer's own part of `chunk_id`'s witness, the same content a fallback push carries.
 fn pushed_witness_data(chain: &Chain, chunk_id: &SpiceChunkId) -> SpicePartialData {
     let block = chain.chain_store.get_block(&chunk_id.block_hash).unwrap();
-    let chunks = block.chunks();
-    let chunk_header =
-        chunks.iter_raw().find(|chunk| chunk.shard_id() == chunk_id.shard_id).unwrap();
-    let state_witness = new_test_witness_for_chunk(&block, chunk_header);
     let producer = chain
         .epoch_manager
         .get_epoch_chunk_producers_for_shard(block.header().epoch_id(), chunk_id.shard_id)
         .unwrap()
         .swap_remove(0);
-    let (incoming, _) = get_incoming_data(
-        &producer,
-        chain,
-        SpiceDistributorStateWitness { contract_accesses: HashSet::new(), state_witness },
-    );
+    let fallback_only =
+        is_fallback_only_chunk(chain.epoch_manager.as_ref(), block.header(), chunk_id.shard_id)
+            .unwrap();
+    let (incoming, _) = if fallback_only {
+        // A fallback-only chunk has no initial distribution: the push carries its witness.
+        save_test_witness_for_chunk(chain, chunk_id);
+        get_incoming_data(
+            &producer,
+            chain,
+            ProcessedBlock { block_hash: *latest_block(chain).hash() },
+        )
+    } else {
+        let chunks = block.chunks();
+        let chunk_header =
+            chunks.iter_raw().find(|chunk| chunk.shard_id() == chunk_id.shard_id).unwrap();
+        let state_witness = new_test_witness_for_chunk(&block, chunk_header);
+        get_incoming_data(
+            &producer,
+            chain,
+            SpiceDistributorStateWitness { contract_accesses: HashSet::new(), state_witness },
+        )
+    };
     incoming.data
 }
 


### PR DESCRIPTION
Alternative to #16326.

A fallback-only chunk (#16243) certifies on the whole epoch's stake, but its witness reached the non-designated validators only through `push_fallback_witnesses`, which runs on the next block the producer processes and only for chunks still uncertified. The designated validators got the witness at save time, so when the apply finished after that block was processed, the chunk certified on their stake in the following block and the push never happened; the non-designated validators then pulled the witness for good (see #16325).

A fallback-only chunk now skips the initial distribution at save time. Its witness and contract accesses go out through the fallback push, on the first block the producer processes after the apply, to every validator of the epoch. Nobody can certify the chunk before that push, so it cannot be skipped, and every scheduled chunk exercises the fallback push path for every validator, which is what the schedule is for. Certification of a scheduled chunk lands one block later than before.

Not covered here: a validator that loses the accesses message still has no way to recover it, for any chunk.