### PR TITLE
fix(spice): validate a witness from its own contract accesses when no accesses message arrived

### DIFF
--- a/chain/client/src/spice/chunk_validator_actor.rs
+++ b/chain/client/src/spice/chunk_validator_actor.rs
@@ -78,6 +78,9 @@ struct TrustedAccesses {
     /// Contracts not yet available (not in cache and not yet received).
     /// Empty means all contracts are ready.
     missing: HashSet<CodeHash>,
+    /// Taken from the witness itself rather than from `sender`'s message. The witness is what
+    /// accesses messages are checked against, so no message can invalidate it.
+    from_witness: bool,
 }
 
 /// Tracks the state of a chunk that is waiting on contract bytes and/or its witness.
@@ -313,6 +316,7 @@ impl SpiceChunkValidatorActor {
                 self.partial_chunk_data
                     .get_or_insert_mut(chunk_id.clone(), PartialChunkData::new)
                     .witness = Some(witness);
+                self.trust_witness_accesses_and_request_missing_code(&chunk_id, &signer)?;
                 // Eagerly check the trusted accesses against the witness.
                 // If the trusted sender is wrong, discard and try the next one
                 // before waiting for contract code that will never arrive.
@@ -629,7 +633,7 @@ impl SpiceChunkValidatorActor {
             ));
         }
 
-        entry.trusted = Some(TrustedAccesses { sender, missing });
+        entry.trusted = Some(TrustedAccesses { sender, missing, from_witness: false });
 
         let signer = self
             .validator_signer
@@ -683,6 +687,63 @@ impl SpiceChunkValidatorActor {
         Ok(())
     }
 
+    /// The witness lists the contracts its chunk accessed; the accesses message only lets the code
+    /// be fetched before the witness is reassembled. Without one, a producer is asked for the code.
+    fn trust_witness_accesses_and_request_missing_code(
+        &mut self,
+        chunk_id: &SpiceChunkId,
+        signer: &ValidatorSigner,
+    ) -> Result<(), Error> {
+        let Some(entry) = self.partial_chunk_data.peek(chunk_id) else {
+            return Ok(());
+        };
+        if entry.trusted.is_some() {
+            return Ok(());
+        }
+        let Some(witness) = &entry.witness else {
+            return Ok(());
+        };
+        let all_contracts = witness.contract_accesses().clone();
+        // A chunk cannot access that many contracts, so the witness is not one to validate.
+        if all_contracts.len() > MAX_CONTRACTS_PER_REQUEST {
+            tracing::warn!(
+                target: "spice_chunk_validator",
+                ?chunk_id,
+                num_contracts = all_contracts.len(),
+                "witness lists more contracts than a chunk can access"
+            );
+            return Ok(());
+        }
+        let epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
+        // TODO(spice-data-distribution): this always asks the first producer; spread requesters
+        // over the producers and retry with another one if it does not answer.
+        let sender = self
+            .epoch_manager
+            .get_epoch_chunk_producers_for_shard(&epoch_id, chunk_id.shard_id)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::Other("chunk has no producers".to_owned()))?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let runtime_config = self.runtime_adapter.get_runtime_config(protocol_version);
+        let cache = self.runtime_adapter.compiled_contract_cache();
+        let missing: HashSet<_> = all_contracts
+            .iter()
+            .filter(|h| !contracts_cache_contains_contract(cache, h, runtime_config))
+            .cloned()
+            .collect();
+        if !missing.is_empty() {
+            let request = SpiceContractCodeRequest::new(chunk_id.clone(), missing.clone(), signer);
+            self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                NetworkRequests::SpiceContractCodeRequest(sender.clone(), request),
+            ));
+        }
+        let Some(entry) = self.partial_chunk_data.get_mut(chunk_id) else {
+            return Ok(());
+        };
+        entry.trusted = Some(TrustedAccesses { sender, missing, from_witness: true });
+        Ok(())
+    }
+
     /// Eagerly checks the trusted contract accesses against the witness.
     /// If both are present and they don't match, invalidates the trusted
     /// sender and tries the next one. This catches malicious senders early,
@@ -698,6 +759,9 @@ impl SpiceChunkValidatorActor {
         let (Some(witness), Some(trusted)) = (&entry.witness, &entry.trusted) else {
             return Ok(());
         };
+        if trusted.from_witness {
+            return Ok(());
+        }
         let Some(trusted_accesses) = entry.received_accesses.get(&trusted.sender) else {
             return Ok(());
         };
@@ -761,10 +825,11 @@ impl SpiceChunkValidatorActor {
             tracing::debug!(
                 target: "spice_chunk_validator",
                 ?chunk_id,
-                "no valid contract accesses available; waiting for new accesses message"
+                "no valid contract accesses message left; using the witness's own accesses"
             );
             self.partial_chunk_data.put(chunk_id.clone(), partial);
-            return Ok(());
+            self.trust_witness_accesses_and_request_missing_code(chunk_id, &signer)?;
+            return self.try_assemble_and_validate_chunk(chunk_id, signer);
         };
         let sender = sender.clone();
         let next_accesses = next_accesses.clone();
@@ -787,7 +852,7 @@ impl SpiceChunkValidatorActor {
             ));
         }
 
-        partial.trusted = Some(TrustedAccesses { sender, missing });
+        partial.trusted = Some(TrustedAccesses { sender, missing, from_witness: false });
         self.partial_chunk_data.put(chunk_id.clone(), partial);
         self.validate_trusted_accesses(chunk_id, signer.clone())?;
         self.try_assemble_and_validate_chunk(chunk_id, signer)

--- a/chain/client/src/spice/chunk_validator_actor.rs
+++ b/chain/client/src/spice/chunk_validator_actor.rs
@@ -437,6 +437,7 @@ impl SpiceChunkValidatorActor {
             self.partial_chunk_data
                 .get_or_insert_mut(chunk_id.clone(), PartialChunkData::new)
                 .witness = Some(witness);
+            self.trust_witness_accesses_and_request_missing_code(&chunk_id, &signer)?;
             self.validate_trusted_accesses(&chunk_id, signer.clone())?;
             if let Err(err) = self.try_assemble_and_validate_chunk(&chunk_id, signer.clone()) {
                 self.requeue_waiting_witnesses(&block_hash, unready_witnesses);

--- a/chain/client/src/spice/tests/chunk_validator_actor.rs
+++ b/chain/client/src/spice/tests/chunk_validator_actor.rs
@@ -230,6 +230,33 @@ fn test_witness_arriving_before_block() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_witness_arriving_before_block_without_accesses_message() {
+    let mut actor = setup();
+    let head = actor.chain_store.head().unwrap();
+    let prev_block = actor.chain_store.get_block(&head.last_block_hash).unwrap();
+
+    let starting_state_root = test_starting_state_root(&actor);
+    record_execution_results(&actor, &prev_block, starting_state_root);
+
+    let block = build_block(&actor.chain, &prev_block);
+    let witness_message = valid_witness_message(&actor, &block, &prev_block, &starting_state_root);
+    actor.handle(witness_message.span_wrap());
+    assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_none());
+
+    process_block_sync(
+        &mut actor.chain,
+        block.clone().into(),
+        Provenance::PRODUCED,
+        &mut BlockProcessingArtifact::default(),
+    )
+    .unwrap();
+    actor.handle(ProcessedBlock { block_hash: *block.hash() });
+    assert_no_contract_requests(&mut actor.network_rc);
+    assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_some());
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_witness_arriving_before_execution_results_for_parent() {
     let mut actor = setup();
     let head = actor.chain_store.head().unwrap();

--- a/chain/client/src/spice/tests/chunk_validator_actor.rs
+++ b/chain/client/src/spice/tests/chunk_validator_actor.rs
@@ -643,6 +643,10 @@ fn drain_contract_requests(
     requests
 }
 
+fn assert_no_contract_requests(network_rc: &mut UnboundedReceiver<PeerManagerMessageRequest>) {
+    assert_matches!(drain_contract_requests(network_rc).as_slice(), []);
+}
+
 fn invalid_witness_message(
     actor: &TestActor,
     block: &Block,
@@ -683,7 +687,6 @@ fn test_empty_contract_accesses_finalizes_witness() {
     assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_some());
 }
 
-/// Witness arrives before accesses with no contracts — still finalizes.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_witness_before_empty_accesses() {
@@ -696,15 +699,51 @@ fn test_witness_before_empty_accesses() {
     record_execution_results(&actor, &prev_block, starting_state_root);
 
     let witness_message = valid_witness_message(&actor, &block, &prev_block, &starting_state_root);
-
-    // Witness first, then empty accesses.
     actor.handle(witness_message.span_wrap());
-    assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_none());
+    assert_no_contract_requests(&mut actor.network_rc);
+    assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_some());
 
     let accesses = make_contract_accesses(&block, HashSet::new());
     actor.handle(SpiceChunkContractAccessesMessage(accesses, RecvMessagePermit::none()));
+    assert_no_contract_requests(&mut actor.network_rc);
+}
 
-    assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_some());
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_witness_without_accesses_message_requests_its_missing_contracts() {
+    let mut actor = setup();
+    let head = actor.chain_store.head().unwrap();
+    let block = actor.chain_store.get_block(&head.last_block_hash).unwrap();
+    let prev_block = actor.chain_store.get_block(&head.prev_block_hash).unwrap();
+
+    let starting_state_root = test_starting_state_root(&actor);
+    record_execution_results(&actor, &prev_block, starting_state_root);
+
+    let hash_a: CodeHash = hash(b"contract_a").into();
+    let hash_b: CodeHash = hash(b"contract_b").into();
+    let contracts = HashSet::from([hash_a, hash_b]);
+    let witness_message = valid_witness_message_with_accesses(
+        &actor,
+        &block,
+        &prev_block,
+        &starting_state_root,
+        &contracts,
+    );
+    actor.handle(witness_message.span_wrap());
+
+    let requests = drain_contract_requests(&mut actor.network_rc);
+    assert_eq!(requests, vec![contracts.clone()]);
+    assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_none());
+
+    let accesses = make_contract_accesses(&block, contracts);
+    actor.handle(SpiceChunkContractAccessesMessage(accesses, RecvMessagePermit::none()));
+    assert_no_contract_requests(&mut actor.network_rc);
+
+    // A message that disagrees with the witness does not displace the witness's own accesses.
+    let hash_c: CodeHash = hash(b"contract_c").into();
+    let disagreeing = make_contract_accesses(&block, HashSet::from([hash_c]));
+    actor.handle(SpiceChunkContractAccessesMessage(disagreeing, RecvMessagePermit::none()));
+    assert_no_contract_requests(&mut actor.network_rc);
 }
 
 /// Contract accesses with missing contracts sends a request.
@@ -725,8 +764,6 @@ fn test_contract_accesses_sends_request_for_missing() {
     assert_eq!(requests[0], HashSet::from([hash_a, hash_b]));
 }
 
-/// Contract accesses signed by a non-chunk-producer are rejected — no requests are sent,
-/// and the chunk does not finalize.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_contract_accesses_invalid_signature_rejected() {
@@ -741,14 +778,14 @@ fn test_contract_accesses_invalid_signature_rejected() {
     let witness_message = valid_witness_message(&actor, &block, &prev_block, &starting_state_root);
 
     // Sign accesses with a key that does not belong to the chunk producer.
+    let hash_a: CodeHash = hash(b"contract_a").into();
     let accesses =
-        make_contract_accesses_with_signer(&block, HashSet::new(), "not-a-chunk-producer");
+        make_contract_accesses_with_signer(&block, HashSet::from([hash_a]), "not-a-chunk-producer");
     actor.handle(SpiceChunkContractAccessesMessage(accesses, RecvMessagePermit::none()));
     actor.handle(witness_message.span_wrap());
 
-    // No contract requests should be sent, and no endorsement should be recorded.
     assert!(drain_contract_requests(&mut actor.network_rc).is_empty());
-    assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_none());
+    assert!(actor.core_reader.get_block_execution_results(block.header()).unwrap().is_some());
 }
 
 fn setup_two_validators() -> TestActor {
@@ -811,9 +848,8 @@ fn test_correct_accesses_first_then_malicious() {
     assert!(!drain_endorsements(&mut actor.network_rc).is_empty());
 }
 
-/// When malicious contract accesses arrive first and the correct one arrives second,
-/// the validator detects the mismatch, falls back to the correct accesses, and
-/// validation succeeds.
+/// When malicious contract accesses arrive first, the validator detects the mismatch against the
+/// witness and validates from the witness's own accesses; a correct message later adds nothing.
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_malicious_accesses_first_then_correct() {
@@ -835,18 +871,15 @@ fn test_malicious_accesses_first_then_correct() {
     actor.handle(SpiceChunkContractAccessesMessage(malicious_accesses, RecvMessagePermit::none()));
     drain_contract_requests(&mut actor.network_rc);
 
-    // Send witness — can't finalize yet because the trusted accesses are wrong
-    // and no correct alternative is available yet.
     actor.handle(witness_message.span_wrap());
-    assert!(drain_endorsements(&mut actor.network_rc).is_empty());
+    assert!(!drain_endorsements(&mut actor.network_rc).is_empty());
 
     // Correct accesses (empty set) from validator-1 arrive.
     let correct_accesses =
         make_contract_accesses_with_signer(&block, HashSet::new(), "test-validator-1");
     actor.handle(SpiceChunkContractAccessesMessage(correct_accesses, RecvMessagePermit::none()));
-
-    // Now validation should succeed after falling back to the correct accesses.
-    assert!(!drain_endorsements(&mut actor.network_rc).is_empty());
+    assert!(drain_endorsements(&mut actor.network_rc).is_empty());
+    assert_no_contract_requests(&mut actor.network_rc);
 }
 
 /// Validates that MAX_CONTRACTS_PER_REQUEST is large enough to cover the maximum

--- a/test-loop-tests/src/setup/spice_partial_data_faults.rs
+++ b/test-loop-tests/src/setup/spice_partial_data_faults.rs
@@ -55,6 +55,8 @@ pub struct SpicePartialDataFaults {
     pub equivocate_from: HashSet<AccountId>,
     /// Limits every fault above to one kind of data. `None` faults both kinds.
     pub only_kind: Option<SpiceDataKind>,
+    /// Contract accesses these accounts send never arrive. Partial data is unaffected.
+    pub drop_contract_accesses_from: HashSet<AccountId>,
 }
 
 /// Which kind of partial data a fault applies to.
@@ -90,6 +92,8 @@ pub struct SpicePartialDataObserved {
     pub delayed: usize,
     pub corrupted: usize,
     pub equivocated: usize,
+    /// Contract accesses messages dropped.
+    pub dropped_contract_accesses: usize,
     /// Data requests seen per requesting node. Empty on a healthy chain, where pushes are enough,
     /// so it shows which nodes a fault pushed onto the recovery path.
     // TODO(spice-data-distribution): record the producer asked and the ordinals requested, so a
@@ -165,6 +169,19 @@ fn install_spice_partial_data_fault_handler(
                 .insert(chunk_id);
         }
         _ => {}
+    }));
+
+    let accesses_state = state.clone();
+    let accesses_sender = me.clone();
+    peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {
+        let NetworkRequests::SpiceChunkContractAccesses(_, _) = &request else {
+            return HandlerResult::Unhandled(request);
+        };
+        if !accesses_state.faults.lock().drop_contract_accesses_from.contains(&accesses_sender) {
+            return HandlerResult::Unhandled(request);
+        }
+        accesses_state.observed.lock().dropped_contract_accesses += 1;
+        HandlerResult::Handled(NetworkResponses::NoResponse)
     }));
 
     peer_actor.register_override_handler(Box::new(move |request| -> HandlerResult {

--- a/test-loop-tests/src/setup/spice_partial_data_faults.rs
+++ b/test-loop-tests/src/setup/spice_partial_data_faults.rs
@@ -38,8 +38,8 @@ pub struct SpicePartialDataFaultState {
 /// takes effect on the next message.
 ///
 /// Keying by sender covers every way partial data leaves a node: the push, the all-stake fallback
-/// push, and the response to a data request. Contract accesses and contract code travel as their
-/// own messages and are never faulted.
+/// push, and the response to a data request. Contract accesses travel as their own message and
+/// are dropped separately by `drop_contract_accesses_from`; contract code is never faulted.
 // TODO(spice-data-distribution): fault contract code responses too, so a test can drop them or
 // answer with bytes that do not hash to the requested code.
 #[derive(Default)]

--- a/test-loop-tests/src/tests/spice/all_stake_fallback.rs
+++ b/test-loop-tests/src/tests/spice/all_stake_fallback.rs
@@ -200,6 +200,34 @@ fn slow_test_spice_all_stake_fallback_certifies_without_witness_requests() {
 
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn slow_test_spice_all_stake_fallback_certifies_without_accesses_messages() {
+    init_test_logger();
+
+    let (accounts, genesis, epoch_config_store) = FallbackSetup::new().build();
+    // The non-designated validators get the witness through the fallback push but never the
+    // producers' contract accesses, so they can only endorse from what the witness itself lists.
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(accounts.clone())
+        .build()
+        .drop(DropCondition::DesignatedSpiceEndorsements);
+    let (faults, observed) = env.install_spice_partial_data_faults();
+    faults.lock().drop_contract_accesses_from.extend(accounts);
+    assert_fallback_has_enough_stake(&env.node(0));
+
+    let target = env.node(0).last_certified_block_header().height() + 4;
+    env.node_runner(0).run_until(
+        |node| node.last_certified_block_header().height() >= target,
+        Duration::seconds(300),
+    );
+    let frontier = env.node(0).last_certified_block_header();
+    assert_certified_via_fallback(&env.node(0), frontier.as_ref());
+    assert!(observed.lock().dropped_contract_accesses > 0, "no accesses message was dropped");
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn slow_test_spice_all_stake_fallback_certifies_across_epoch_boundary() {
     init_test_logger();
 

--- a/test-loop-tests/src/tests/spice/data_faults.rs
+++ b/test-loop-tests/src/tests/spice/data_faults.rs
@@ -116,11 +116,14 @@ fn test_spice_partial_data_faults_with_dropped_pushes() {
         "the producers left alone still push enough parts to decode, so recovery never runs"
     );
     faults.lock().drop_from.extend(silent.iter().cloned());
+    // With every accesses message gone too, a recipient has nothing but what it pulls.
+    faults.lock().drop_contract_accesses_from.extend(producers.iter().cloned());
 
     run_past_certified_frontier(&mut env, &recipients[0], PULL_HEIGHTS);
 
     let observed = observed.lock();
     assert!(observed.dropped > 0, "no push was dropped");
+    assert!(observed.dropped_contract_accesses > 0, "no accesses message was dropped");
     for recipient in &recipients {
         assert!(
             observed.data_requests.contains_key(recipient),
@@ -196,6 +199,20 @@ fn test_spice_partial_data_faults_with_equivocating_producer() {
         observed.data_requests.is_empty(),
         "the conflicting commitment pushed a recipient into pulling"
     );
+    assert_endorsed(&observed, &recipients);
+}
+
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_partial_data_faults_with_dropped_contract_accesses() {
+    let Setup { mut env, producers, recipients, faults, observed } = setup();
+    faults.lock().drop_contract_accesses_from.extend(producers.iter().cloned());
+
+    run_past_certified_frontier(&mut env, &recipients[0], PUSH_HEIGHTS);
+
+    let observed = observed.lock();
+    assert!(observed.dropped_contract_accesses > 0, "no accesses message was dropped");
+    assert!(observed.data_requests.is_empty(), "the pushed parts were enough; nothing to pull");
     assert_endorsed(&observed, &recipients);
 }
 


### PR DESCRIPTION
A chunk validator did not validate a witness until it had a `SpiceChunkContractAccesses` message for the chunk, and nothing requests that message: it is pushed once by the producer, and a validator that loses it keeps the reassembled witness until it is evicted and never endorses the chunk. Witness parts can be pulled, accesses cannot, so the pull path never recovered a lost push either.

The witness itself lists the contracts its chunk accessed; the accesses message only lets the code be fetched before the witness is reassembled. When a witness is ready and no accesses message has been trusted, or every received one disagreed with the witness, the validator now takes the list from the witness, requests any missing code from a producer of the chunk, and proceeds. A trusted set taken from the witness is not displaced by any later message.

Adds a `drop_contract_accesses_from` fault to the spice partial data fault injection, with tests where the recipients get the witness by push or by pull but never an accesses message, and one for the all-stake fallback.