### PR TITLE
chore(universal-accounts): use AccountType for 0u addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3904,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7d8c37ea9408d536af7e998bd0d4f9699de1f6b0d12280d28ae46977c4501"
+checksum = "7d2c8642aeca89873dbcf2a2f74ff90cd87f6691f11b66aeed2af7c136192d10"
 dependencies = [
  "borsh",
  "schemars 1.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ itoa = "1.0"
 json_comments = "0.2.1"
 lru = "0.18.2"
 named-lock = "0.4.1"
-near-account-id = { version = "2.0.0", features = [
+near-account-id = { version = "3.0.0", features = [
     "internal_unstable",
     "serde",
     "borsh",

--- a/core/parameters/src/cost.rs
+++ b/core/parameters/src/cost.rs
@@ -779,15 +779,18 @@ pub fn transfer_exec_fee(
     receiver_account_type: AccountType,
 ) -> ParameterCost {
     let transfer_fee = cfg.fee(ActionCosts::transfer).exec_fee();
-    // A `0u` receiver has no `AccountType` variant and reads as `NamedAccount`,
-    // so it is handled before the match. Like a deterministic account, the
-    // transfer creates it; its keys arrive later with the state init.
+    // Only the caller knows whether universal accounts are enabled, so the surcharge
+    // is decided here. Like a deterministic account, the transfer creates it; its
+    // keys arrive later with the state init.
     if receiver_is_universal {
         return transfer_fee.checked_add(cfg.fee(ActionCosts::create_account).exec_fee()).unwrap();
     }
     match (eth_implicit_accounts_enabled, receiver_account_type) {
         // Regular transfer to a named account.
         (_, AccountType::NamedAccount) => transfer_fee,
+        // Reached before the feature activates, when the caller resolved
+        // `receiver_is_universal` to false. No account is created, so no surcharge.
+        (_, AccountType::UniversalAccount) => transfer_fee,
         // No account will be created, just a regular transfer.
         (false, AccountType::EthImplicitAccount) => transfer_fee,
         // Extra fee for the CreateAccount.
@@ -815,7 +818,7 @@ pub fn transfer_send_fee(
     receiver_account_type: AccountType,
 ) -> ParameterCost {
     let transfer_fee = cfg.fee(ActionCosts::transfer).send_fee(sender_is_receiver);
-    // See `transfer_exec_fee`: `0u` receivers are not an `AccountType`.
+    // See `transfer_exec_fee` for why the surcharge is decided here.
     if receiver_is_universal {
         return transfer_fee
             .checked_add(cfg.fee(ActionCosts::create_account).send_fee(sender_is_receiver))
@@ -824,6 +827,9 @@ pub fn transfer_send_fee(
     match (eth_implicit_accounts_enabled, receiver_account_type) {
         // Regular transfer to a named account.
         (_, AccountType::NamedAccount) => transfer_fee,
+        // Reached before the feature activates, when the caller resolved
+        // `receiver_is_universal` to false. No account is created, so no surcharge.
+        (_, AccountType::UniversalAccount) => transfer_fee,
         // No account will be created, just a regular transfer.
         (false, AccountType::EthImplicitAccount) => transfer_fee,
         // Extra fee for the CreateAccount.
@@ -968,4 +974,30 @@ pub fn universal_state_init_content_terms(
         // Each installed key is a full-access key write, priced the same as `AddKey`.
         (ActionCosts::add_full_access_key, counts.num_keys),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RuntimeFeesConfig;
+
+    /// The account type is the same on every protocol version, so a `0u` receiver
+    /// reaches these before the feature activates and must cost a plain transfer.
+    #[test]
+    fn universal_receiver_pays_plain_transfer_until_enabled() {
+        let cfg = RuntimeFeesConfig::test();
+        let transfer_exec = cfg.fee(ActionCosts::transfer).exec_fee();
+        let create_exec = cfg.fee(ActionCosts::create_account).exec_fee();
+
+        assert_eq!(
+            transfer_exec_fee(&cfg, true, false, AccountType::UniversalAccount),
+            transfer_exec,
+            "a 0u receiver costs a plain transfer before the feature is on"
+        );
+        assert_eq!(
+            transfer_exec_fee(&cfg, true, true, AccountType::UniversalAccount),
+            transfer_exec.checked_add(create_exec).unwrap(),
+            "and one create_account once it is"
+        );
+    }
 }

--- a/core/parameters/src/cost.rs
+++ b/core/parameters/src/cost.rs
@@ -775,37 +775,36 @@ impl StorageUsageConfig {
 pub fn transfer_exec_fee(
     cfg: &RuntimeFeesConfig,
     eth_implicit_accounts_enabled: bool,
-    receiver_is_universal: bool,
+    universal_accounts_enabled: bool,
     receiver_account_type: AccountType,
 ) -> ParameterCost {
     let transfer_fee = cfg.fee(ActionCosts::transfer).exec_fee();
-    // Only the caller knows whether universal accounts are enabled, so the surcharge
-    // is decided here. Like a deterministic account, the transfer creates it; its
-    // keys arrive later with the state init.
-    if receiver_is_universal {
-        return transfer_fee.checked_add(cfg.fee(ActionCosts::create_account).exec_fee()).unwrap();
-    }
-    match (eth_implicit_accounts_enabled, receiver_account_type) {
+    let create_account_fee = cfg.fee(ActionCosts::create_account).exec_fee();
+    match receiver_account_type {
         // Regular transfer to a named account.
-        (_, AccountType::NamedAccount) => transfer_fee,
-        // Reached before the feature activates, when the caller resolved
-        // `receiver_is_universal` to false. No account is created, so no surcharge.
-        (_, AccountType::UniversalAccount) => transfer_fee,
-        // No account will be created, just a regular transfer.
-        (false, AccountType::EthImplicitAccount) => transfer_fee,
-        // Extra fee for the CreateAccount.
-        (true, AccountType::EthImplicitAccount) => {
-            transfer_fee.checked_add(cfg.fee(ActionCosts::create_account).exec_fee()).unwrap()
+        AccountType::NamedAccount => transfer_fee,
+        // Like a deterministic account, the transfer creates it; its keys arrive
+        // later with the state init.
+        AccountType::UniversalAccount if universal_accounts_enabled => {
+            transfer_fee.checked_add(create_account_fee).unwrap()
         }
+        // No account will be created, just a regular transfer.
+        AccountType::UniversalAccount => transfer_fee,
+        // Extra fee for the CreateAccount.
+        AccountType::EthImplicitAccount if eth_implicit_accounts_enabled => {
+            transfer_fee.checked_add(create_account_fee).unwrap()
+        }
+        // No account will be created, just a regular transfer.
+        AccountType::EthImplicitAccount => transfer_fee,
         // Extra fees for the CreateAccount and AddFullAccessKey.
-        (_, AccountType::NearImplicitAccount) => transfer_fee
-            .checked_add(cfg.fee(ActionCosts::create_account).exec_fee())
+        AccountType::NearImplicitAccount => transfer_fee
+            .checked_add(create_account_fee)
             .unwrap()
             .checked_add(cfg.fee(ActionCosts::add_full_access_key).exec_fee())
             .unwrap(),
         // Extra fees for the implied CreateAccount action.
-        (_, AccountType::NearDeterministicAccount) => {
-            transfer_fee.checked_add(cfg.fee(ActionCosts::create_account).exec_fee()).unwrap()
+        AccountType::NearDeterministicAccount => {
+            transfer_fee.checked_add(create_account_fee).unwrap()
         }
     }
 }
@@ -814,38 +813,37 @@ pub fn transfer_send_fee(
     cfg: &RuntimeFeesConfig,
     sender_is_receiver: bool,
     eth_implicit_accounts_enabled: bool,
-    receiver_is_universal: bool,
+    universal_accounts_enabled: bool,
     receiver_account_type: AccountType,
 ) -> ParameterCost {
     let transfer_fee = cfg.fee(ActionCosts::transfer).send_fee(sender_is_receiver);
-    // See `transfer_exec_fee` for why the surcharge is decided here.
-    if receiver_is_universal {
-        return transfer_fee
-            .checked_add(cfg.fee(ActionCosts::create_account).send_fee(sender_is_receiver))
-            .unwrap();
-    }
-    match (eth_implicit_accounts_enabled, receiver_account_type) {
+    let create_account_fee = cfg.fee(ActionCosts::create_account).send_fee(sender_is_receiver);
+    match receiver_account_type {
         // Regular transfer to a named account.
-        (_, AccountType::NamedAccount) => transfer_fee,
-        // Reached before the feature activates, when the caller resolved
-        // `receiver_is_universal` to false. No account is created, so no surcharge.
-        (_, AccountType::UniversalAccount) => transfer_fee,
+        AccountType::NamedAccount => transfer_fee,
+        // Like a deterministic account, the transfer creates it; its keys arrive
+        // later with the state init.
+        AccountType::UniversalAccount if universal_accounts_enabled => {
+            transfer_fee.checked_add(create_account_fee).unwrap()
+        }
         // No account will be created, just a regular transfer.
-        (false, AccountType::EthImplicitAccount) => transfer_fee,
+        AccountType::UniversalAccount => transfer_fee,
         // Extra fee for the CreateAccount.
-        (true, AccountType::EthImplicitAccount) => transfer_fee
-            .checked_add(cfg.fee(ActionCosts::create_account).send_fee(sender_is_receiver))
-            .unwrap(),
+        AccountType::EthImplicitAccount if eth_implicit_accounts_enabled => {
+            transfer_fee.checked_add(create_account_fee).unwrap()
+        }
+        // No account will be created, just a regular transfer.
+        AccountType::EthImplicitAccount => transfer_fee,
         // Extra fees for the CreateAccount and AddFullAccessKey.
-        (_, AccountType::NearImplicitAccount) => transfer_fee
-            .checked_add(cfg.fee(ActionCosts::create_account).send_fee(sender_is_receiver))
+        AccountType::NearImplicitAccount => transfer_fee
+            .checked_add(create_account_fee)
             .unwrap()
             .checked_add(cfg.fee(ActionCosts::add_full_access_key).send_fee(sender_is_receiver))
             .unwrap(),
         // Extra fees for the implied  CreateAccount action.
-        (_, AccountType::NearDeterministicAccount) => transfer_fee
-            .checked_add(cfg.fee(ActionCosts::create_account).send_fee(sender_is_receiver))
-            .unwrap(),
+        AccountType::NearDeterministicAccount => {
+            transfer_fee.checked_add(create_account_fee).unwrap()
+        }
     }
 }
 
@@ -998,6 +996,11 @@ mod tests {
             transfer_exec_fee(&cfg, true, true, AccountType::UniversalAccount),
             transfer_exec.checked_add(create_exec).unwrap(),
             "and one create_account once it is"
+        );
+        assert_eq!(
+            transfer_exec_fee(&cfg, true, true, AccountType::NamedAccount),
+            transfer_exec,
+            "the flag on its own does not price another receiver as a creation"
         );
     }
 }

--- a/core/parameters/src/parameter.rs
+++ b/core/parameters/src/parameter.rs
@@ -249,13 +249,11 @@ pub enum Parameter {
     FixContractLoadingCost,
     FixContractLoadingError,
     VmKind,
-    // TODO(eth-implicit): delete this. MIN_SUPPORTED_PROTOCOL_VERSION has passed
-    // the activation version 70. Removing it makes the runtime-config rows naming
-    // it fail to parse, which is how those get found.
+    // TODO(eth-implicit): delete this. MIN_SUPPORTED_PROTOCOL_VERSION is past
+    // protocol version 70, where the feature is enabled.
     EthImplicitAccounts,
-    // TODO(universal-accounts): delete once MIN_SUPPORTED_PROTOCOL_VERSION passes
-    // the activation version. Removing it makes the runtime-config rows naming it
-    // fail to parse, which is how those get found.
+    // TODO(universal-accounts): delete this once MIN_SUPPORTED_PROTOCOL_VERSION is
+    // past the protocol version where the feature is enabled.
     UniversalAccounts,
     FixMlDsaCostCharging,
     DiscardCustomSections,

--- a/core/parameters/src/parameter.rs
+++ b/core/parameters/src/parameter.rs
@@ -249,7 +249,13 @@ pub enum Parameter {
     FixContractLoadingCost,
     FixContractLoadingError,
     VmKind,
+    // TODO(eth-implicit): delete this. MIN_SUPPORTED_PROTOCOL_VERSION has passed
+    // the activation version 70. Removing it makes the runtime-config rows naming
+    // it fail to parse, which is how those get found.
     EthImplicitAccounts,
+    // TODO(universal-accounts): delete once MIN_SUPPORTED_PROTOCOL_VERSION passes
+    // the activation version. Removing it makes the runtime-config rows naming it
+    // fail to parse, which is how those get found.
     UniversalAccounts,
     FixMlDsaCostCharging,
     DiscardCustomSections,

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -218,10 +218,16 @@ pub struct Config {
     pub fix_contract_loading_error: bool,
 
     /// Enable the `EthImplicitAccounts` protocol feature.
+    // TODO(eth-implicit): delete this. It has been always true since
+    // MIN_SUPPORTED_PROTOCOL_VERSION passed the activation version 70. Removing it
+    // is a compile error at every reader, which is how the rest gets found.
     pub eth_implicit_accounts: bool,
 
     /// Enable the `UniversalAccounts` protocol feature, which makes `0u` ids
     /// implicit so a transfer can fund one before its state init is applied.
+    // TODO(universal-accounts): delete this once MIN_SUPPORTED_PROTOCOL_VERSION
+    // passes the activation version, after which it is always true. Removing it is
+    // a compile error at every reader, which is how the rest gets found.
     pub universal_accounts: bool,
 
     /// Whether to discard custom sections.

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -218,16 +218,14 @@ pub struct Config {
     pub fix_contract_loading_error: bool,
 
     /// Enable the `EthImplicitAccounts` protocol feature.
-    // TODO(eth-implicit): delete this. It has been always true since
-    // MIN_SUPPORTED_PROTOCOL_VERSION passed the activation version 70. Removing it
-    // is a compile error at every reader, which is how the rest gets found.
+    // TODO(eth-implicit): delete this. MIN_SUPPORTED_PROTOCOL_VERSION is past
+    // protocol version 70, where the feature is enabled.
     pub eth_implicit_accounts: bool,
 
     /// Enable the `UniversalAccounts` protocol feature, which makes `0u` ids
     /// implicit so a transfer can fund one before its state init is applied.
-    // TODO(universal-accounts): delete this once MIN_SUPPORTED_PROTOCOL_VERSION
-    // passes the activation version, after which it is always true. Removing it is
-    // a compile error at every reader, which is how the rest gets found.
+    // TODO(universal-accounts): delete this once MIN_SUPPORTED_PROTOCOL_VERSION is
+    // past the protocol version where the feature is enabled.
     pub universal_accounts: bool,
 
     /// Whether to discard custom sections.

--- a/core/primitives-core/src/universal_account_id.rs
+++ b/core/primitives-core/src/universal_account_id.rs
@@ -129,7 +129,7 @@ mod tests {
     /// the prefix, the alphabet or the padding rule stops it being one. An edit that keeps
     /// all four is the address of a different hash, so it stays universal.
     #[test]
-    fn an_edited_encoder_output_is_not_universal() {
+    fn only_canonical_encodings_classify_as_universal() {
         let account_type = |id: &str| id.parse::<AccountId>().ok().map(|id| id.get_account_type());
         let valid = encode_universal_account_id(&[0x11; 32]).as_str().to_owned();
         assert_eq!(account_type(&valid), Some(AccountType::UniversalAccount));

--- a/core/primitives-core/src/universal_account_id.rs
+++ b/core/primitives-core/src/universal_account_id.rs
@@ -125,6 +125,77 @@ mod tests {
         }
     }
 
+    /// What the encoder emits is a universal account, and an edit that breaks the length,
+    /// the prefix, the alphabet or the padding rule stops it being one. An edit that keeps
+    /// all four is the address of a different hash, so it stays universal.
+    #[test]
+    fn an_edited_encoder_output_is_not_universal() {
+        let account_type = |id: &str| id.parse::<AccountId>().ok().map(|id| id.get_account_type());
+        let valid = encode_universal_account_id(&[0x11; 32]).as_str().to_owned();
+        assert_eq!(account_type(&valid), Some(AccountType::UniversalAccount));
+
+        // One symbol short, and one symbol too many.
+        assert_eq!(account_type(&valid[..UAID_LEN - 1]), Some(AccountType::NamedAccount));
+        assert_eq!(account_type(&format!("{valid}0")), Some(AccountType::NamedAccount));
+
+        // Right length, wrong prefix. The all-hex bodies are the ones the other two
+        // prefixed account types would take if their own length rule ever went.
+        let mut wrong_prefix = valid.clone();
+        wrong_prefix.replace_range(0..UAID_PREFIX.len(), "0s");
+        assert_eq!(account_type(&wrong_prefix), Some(AccountType::NamedAccount));
+        for prefix in ["0s", "0x"] {
+            let hex_body = format!("{prefix}{}", "0".repeat(UAID_DATA_SYMBOLS));
+            assert_eq!(hex_body.len(), UAID_LEN);
+            assert_eq!(account_type(&hex_body), Some(AccountType::NamedAccount));
+        }
+
+        // A universal id inside a longer name is a named account.
+        assert_eq!(account_type(&format!("{valid}.near")), Some(AccountType::NamedAccount));
+        assert_eq!(account_type(&format!("sub.{valid}")), Some(AccountType::NamedAccount));
+
+        // Every byte in a body position, so the alphabet rule is pinned whole rather than
+        // at a few sampled characters. A symbol addresses another hash; anything else
+        // either stops being an account id or becomes a named one.
+        let middle = UAID_LEN / 2;
+        for byte in 0..=u8::MAX {
+            let mut bytes = valid.clone().into_bytes();
+            bytes[middle] = byte;
+            let Ok(edited) = String::from_utf8(bytes) else {
+                continue;
+            };
+            match account_type(&edited) {
+                Some(AccountType::UniversalAccount) => {
+                    assert!(CROCKFORD.contains(&byte), "byte {byte} must not be universal")
+                }
+                Some(other) => {
+                    assert!(!CROCKFORD.contains(&byte), "byte {byte} must stay universal");
+                    assert_eq!(other, AccountType::NamedAccount, "byte {byte}");
+                }
+                None => assert!(!CROCKFORD.contains(&byte), "byte {byte} must parse"),
+            }
+        }
+
+        // Every symbol in the final position. It carries one hash bit and four padding
+        // bits, so only the two spellings that leave the padding clear are universal.
+        let mut accepted = 0;
+        for &symbol in CROCKFORD {
+            let mut bytes = valid.clone().into_bytes();
+            *bytes.last_mut().unwrap() = symbol;
+            let edited = String::from_utf8(bytes).unwrap();
+            if account_type(&edited) == Some(AccountType::UniversalAccount) {
+                accepted += 1;
+                assert!(
+                    matches!(symbol, b'0' | b'g'),
+                    "symbol {} left padding set",
+                    symbol as char
+                );
+            } else {
+                assert_eq!(account_type(&edited), Some(AccountType::NamedAccount));
+            }
+        }
+        assert_eq!(accepted, 2);
+    }
+
     /// What this encoder emits is what `AccountType` calls a universal account, so
     /// the two cannot drift apart.
     #[test]

--- a/core/primitives-core/src/universal_account_id.rs
+++ b/core/primitives-core/src/universal_account_id.rs
@@ -164,14 +164,20 @@ mod tests {
                 continue;
             };
             match account_type(&edited) {
-                Some(AccountType::UniversalAccount) => {
-                    assert!(CROCKFORD.contains(&byte), "byte {byte} must not be universal")
-                }
+                Some(AccountType::UniversalAccount) => assert!(
+                    CROCKFORD.contains(&byte),
+                    "byte {byte} is not a symbol, so it must not classify universal"
+                ),
                 Some(other) => {
-                    assert!(!CROCKFORD.contains(&byte), "byte {byte} must stay universal");
+                    assert!(
+                        !CROCKFORD.contains(&byte),
+                        "byte {byte} is a symbol, so it must classify universal"
+                    );
                     assert_eq!(other, AccountType::NamedAccount, "byte {byte}");
                 }
-                None => assert!(!CROCKFORD.contains(&byte), "byte {byte} must parse"),
+                None => {
+                    assert!(!CROCKFORD.contains(&byte), "byte {byte} is a symbol, so it must parse")
+                }
             }
         }
 

--- a/core/primitives-core/src/universal_account_id.rs
+++ b/core/primitives-core/src/universal_account_id.rs
@@ -1,17 +1,18 @@
-//! Codec for `0u` universal account ids (UAIDs).
+//! Encoder for `0u` universal account ids (UAIDs).
 //!
 //! A UAID encodes a 32-byte hash as `0u` + 52 Crockford-base32 symbols of the hash
 //! = 54 characters, all lowercase `[0-9a-z]`, which is a valid NEAR account id.
 //!
-//! This is a pure codec: it turns a hash into an address and back. Hashing a
-//! `StateInit` into the 32-byte input lives with the account-id derivation, not here.
+//! This turns a hash into an address. Hashing a `StateInit` into the 32-byte input
+//! lives with the account-id derivation, not here, and `AccountType` decides whether
+//! a given account id is one of these.
 //!
 //! The base32 is implemented here rather than taken from a crate: it is a handful of
 //! lines and not worth a dependency in this foundational crate. The implementation was
 //! cross-checked against the `data-encoding` crate over 40M random cases with zero
 //! correctness divergence and on-par performance.
 
-// cspell:words crockford uaid nbits kats multibyte
+// cspell:words crockford uaid nbits kats
 
 use crate::types::AccountId;
 
@@ -25,33 +26,6 @@ pub const UAID_LEN: usize = UAID_PREFIX.len() + UAID_DATA_SYMBOLS;
 /// Crockford base32, lowercase, excluding `i l o u` to reduce transcription errors.
 const CROCKFORD: &[u8; 32] = b"0123456789abcdefghjkmnpqrstvwxyz"; // cspell:disable-line
 
-/// Reverse lookup: ascii byte -> symbol value, or `-1` if not a Crockford symbol.
-/// Strict: no uppercase and no digit/letter aliases, so decoding is canonical.
-const DECODE: [i8; 256] = build_decode_table();
-
-const fn build_decode_table() -> [i8; 256] {
-    let mut table = [-1i8; 256];
-    let mut i = 0;
-    while i < 32 {
-        table[CROCKFORD[i] as usize] = i as i8;
-        i += 1;
-    }
-    table
-}
-
-/// Error returned when parsing a `0u` universal account id.
-#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
-pub enum ParseUaidError {
-    #[error("invalid universal account id length")]
-    BadLength,
-    #[error("invalid universal account id prefix")]
-    BadPrefix,
-    #[error("invalid character in universal account id")]
-    InvalidSymbol,
-    #[error("non-canonical universal account id encoding: padding bits set")]
-    NonCanonical,
-}
-
 /// Encode a 32-byte hash as a `0u` universal account id.
 pub fn encode_universal_account_id(hash: &[u8; 32]) -> AccountId {
     let data = base32_encode(hash);
@@ -63,44 +37,6 @@ pub fn encode_universal_account_id(hash: &[u8; 32]) -> AccountId {
     debug_assert_eq!(s.len(), UAID_LEN);
     // Safe: the emitted charset and length are always a valid account id.
     s.parse::<AccountId>().expect("uaid codec must produce a valid account id")
-}
-
-/// Parse and fully validate a `0u` universal account id (prefix, length, charset,
-/// canonicity), returning its 32-byte hash.
-pub fn decode_universal_account_id(id: &str) -> Result<[u8; 32], ParseUaidError> {
-    let bytes = id.as_bytes();
-    if bytes.len() != UAID_LEN {
-        return Err(ParseUaidError::BadLength);
-    }
-    if !id.starts_with(UAID_PREFIX) {
-        return Err(ParseUaidError::BadPrefix);
-    }
-    let body: &[u8; UAID_DATA_SYMBOLS] =
-        bytes[UAID_PREFIX.len()..].try_into().map_err(|_| ParseUaidError::BadLength)?;
-    let mut data = [0u8; UAID_DATA_SYMBOLS];
-    for (slot, &c) in data.iter_mut().zip(body) {
-        *slot = decode_symbol(c)?;
-    }
-    base32_decode(&data)
-}
-
-/// Whether `id` is structurally a UAID. No allocation.
-/// Used later by account-type classification.
-///
-/// TODO(universal-accounts): `AccountType` has no variant for `0u` ids, so they
-/// classify as `NamedAccount` and every caller has to test the prefix by hand.
-/// Once `near-account-id` gains an `AccountType::Universal`, drop this and let
-/// the callers match on the account type like the other implicit kinds do.
-pub fn is_universal_account_id(id: &str) -> bool {
-    decode_universal_account_id(id).is_ok()
-}
-
-fn decode_symbol(c: u8) -> Result<u8, ParseUaidError> {
-    let v = DECODE[c as usize];
-    if v < 0 {
-        return Err(ParseUaidError::InvalidSymbol);
-    }
-    Ok(v as u8)
 }
 
 /// 32 bytes -> 52 five-bit symbol values, MSB-first. The 256 bits leave 1 bit in
@@ -127,34 +63,10 @@ fn base32_encode(hash: &[u8; 32]) -> [u8; UAID_DATA_SYMBOLS] {
     out
 }
 
-/// 52 symbol values -> 32 bytes. Rejects a non-canonical final symbol (padding bits set).
-fn base32_decode(data: &[u8; UAID_DATA_SYMBOLS]) -> Result<[u8; 32], ParseUaidError> {
-    let mut out = [0u8; 32];
-    let mut acc: u32 = 0;
-    let mut nbits: u32 = 0;
-    let mut idx = 0;
-    for &v in data {
-        acc = (acc << 5) | v as u32;
-        nbits += 5;
-        while nbits >= 8 {
-            nbits -= 8;
-            out[idx] = ((acc >> nbits) & 0xff) as u8;
-            idx += 1;
-            acc &= (1u32 << nbits) - 1;
-        }
-    }
-    debug_assert_eq!(idx, 32);
-    debug_assert_eq!(nbits, 4);
-    // The 4 leftover bits are padding and must be zero for a canonical encoding.
-    if acc != 0 {
-        return Err(ParseUaidError::NonCanonical);
-    }
-    Ok(out)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::account::id::AccountType;
 
     #[test]
     fn layout_constants() {
@@ -196,106 +108,8 @@ mod tests {
         for &(hash, expected) in KATS {
             let id = encode_universal_account_id(hash);
             assert_eq!(id.as_str(), expected, "encode mismatch for {hash:?}");
-            assert_eq!(decode_universal_account_id(expected).unwrap(), *hash);
             assert_eq!(id.len(), UAID_LEN);
         }
-    }
-
-    #[test]
-    fn round_trip() {
-        for seed in 0u16..=255 {
-            let mut hash = [0u8; 32];
-            for (i, b) in hash.iter_mut().enumerate() {
-                *b = (seed as u8).wrapping_add(i as u8).wrapping_mul(31);
-            }
-            let id = encode_universal_account_id(&hash);
-            assert_eq!(decode_universal_account_id(id.as_str()).unwrap(), hash);
-            assert!(is_universal_account_id(id.as_str()));
-        }
-    }
-
-    /// The last symbol holds 1 real hash bit (its top bit) and 4 padding bits (its
-    /// low 4 bits), which must be zero. So only 2 of the 32 symbols are valid
-    /// there; anything else is a second spelling of the same address. Sweep all 32
-    /// to pin the accepted set exactly, not just to reject a few known-bad ones.
-    #[test]
-    fn accepts_exactly_the_canonical_encodings() {
-        let base = encode_universal_account_id(&[0x5a; 32]).as_str().to_owned();
-        let mut accepted = 0;
-        for (v, &sym) in CROCKFORD.iter().enumerate() {
-            let mut bytes = base.clone().into_bytes();
-            *bytes.last_mut().unwrap() = sym;
-            let s = String::from_utf8(bytes).unwrap();
-            match decode_universal_account_id(&s) {
-                Ok(hash) => {
-                    assert_eq!(v & 0b1111, 0, "final symbol {} has padding set", sym as char);
-                    assert_eq!(encode_universal_account_id(&hash).as_str(), s);
-                    accepted += 1;
-                }
-                Err(e) => {
-                    assert_ne!(v & 0b1111, 0, "canonical final symbol {} rejected", sym as char);
-                    assert_eq!(e, ParseUaidError::NonCanonical, "final symbol {}", sym as char);
-                }
-            }
-        }
-        assert_eq!(accepted, 2);
-    }
-
-    #[test]
-    fn rejects_structural_errors() {
-        let valid = encode_universal_account_id(&[0x11; 32]).as_str().to_owned();
-
-        // Wrong length.
-        assert_eq!(
-            decode_universal_account_id(&valid[..UAID_LEN - 1]),
-            Err(ParseUaidError::BadLength)
-        );
-        assert_eq!(
-            decode_universal_account_id(&format!("{valid}0")),
-            Err(ParseUaidError::BadLength)
-        );
-
-        // Wrong prefix, same length.
-        let mut wrong_prefix = valid.clone();
-        wrong_prefix.replace_range(0..2, "0s");
-        assert_eq!(decode_universal_account_id(&wrong_prefix), Err(ParseUaidError::BadPrefix));
-
-        // Out-of-alphabet characters in the body: the excluded glyphs and uppercase.
-        for bad in ['i', 'l', 'o', 'u', 'A', 'Z'] {
-            let mut bytes = valid.clone().into_bytes();
-            bytes[UAID_PREFIX.len()] = bad as u8;
-            let s = String::from_utf8(bytes).unwrap();
-            assert_eq!(
-                decode_universal_account_id(&s),
-                Err(ParseUaidError::InvalidSymbol),
-                "char {bad} should be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_more_structural_errors() {
-        let valid = encode_universal_account_id(&[0x11; 32]).as_str().to_owned();
-
-        // Empty string.
-        assert_eq!(decode_universal_account_id(""), Err(ParseUaidError::BadLength));
-
-        // Too long via a multibyte char (byte length, not char count, matters).
-        assert_eq!(
-            decode_universal_account_id(&format!("{valid}é")),
-            Err(ParseUaidError::BadLength)
-        );
-
-        // Exactly UAID_LEN bytes but with a multibyte char in the body.
-        let body_tail = &valid[UAID_PREFIX.len() + 2..];
-        let multibyte = format!("{UAID_PREFIX}é{body_tail}"); // 'é' occupies 2 bytes
-        assert_eq!(multibyte.len(), UAID_LEN);
-        assert_eq!(decode_universal_account_id(&multibyte), Err(ParseUaidError::InvalidSymbol));
-
-        // Uppercase body: Crockford decoding is strict lowercase, no aliases.
-        let upper = format!("{UAID_PREFIX}{}", valid[UAID_PREFIX.len()..].to_uppercase());
-        assert_eq!(upper.len(), UAID_LEN);
-        assert_eq!(decode_universal_account_id(&upper), Err(ParseUaidError::InvalidSymbol));
     }
 
     #[test]
@@ -311,18 +125,20 @@ mod tests {
         }
     }
 
+    /// What this encoder emits is what `AccountType` calls a universal account, so
+    /// the two cannot drift apart.
     #[test]
-    fn is_universal_agrees_with_decode() {
-        let valid = encode_universal_account_id(&[0x33; 32]).as_str().to_owned();
-        assert!(is_universal_account_id(&valid));
-        assert!(!is_universal_account_id("alice.near"));
-        assert!(!is_universal_account_id(&valid[..UAID_LEN - 1]));
+    fn encoder_output_classifies_as_universal() {
+        for &(hash, _) in KATS {
+            let id = encode_universal_account_id(hash);
+            assert_eq!(id.get_account_type(), AccountType::UniversalAccount, "{id}");
+        }
+        for seed in 0u8..64 {
+            let id = encode_universal_account_id(&[seed.wrapping_mul(37); 32]);
+            assert_eq!(id.get_account_type(), AccountType::UniversalAccount, "{id}");
+        }
 
-        // A set padding bit in the final symbol is not a UAID.
-        let mut bytes = valid.into_bytes();
-        let last = bytes.last_mut().unwrap();
-        *last = CROCKFORD[DECODE[*last as usize] as usize ^ 1];
-        let bad = String::from_utf8(bytes).unwrap();
-        assert!(!is_universal_account_id(&bad));
+        let named: AccountId = "alice.near".parse().unwrap();
+        assert_ne!(named.get_account_type(), AccountType::UniversalAccount);
     }
 }

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -465,30 +465,22 @@ where
     Serializable(object)
 }
 
-/// From `near-account-id` version `1.0.0-alpha.2`, `is_implicit` returns true for ETH-implicit accounts.
-/// This function is a wrapper for `is_implicit` method so that we can easily differentiate its behavior
-/// based on whether ETH-implicit accounts are enabled.
-///
-/// A universal account counts as implicit only once the protocol enables them,
-/// which the account type on its own cannot express.
+/// Whether a transfer to this account id creates it implicitly. `AccountType::is_implicit`
+/// cannot answer on its own, since a recently introduced kind may still sit behind a
+/// protocol flag. The match is exhaustive so a kind added later has to say which flag
+/// guards it, if any.
 pub fn account_is_implicit(
     account_id: &AccountId,
     eth_implicit_accounts_enabled: bool,
     universal_accounts_enabled: bool,
 ) -> bool {
-    let account_type = account_id.get_account_type();
-    // The flag decides for a universal account, since `is_implicit()` below carries
-    // no protocol version.
-    if account_type == AccountType::UniversalAccount {
-        return universal_accounts_enabled;
-    }
-    if account_type == AccountType::EthImplicitAccount {
-        return eth_implicit_accounts_enabled;
-    }
-    if eth_implicit_accounts_enabled {
-        account_type.is_implicit()
-    } else {
-        account_type == AccountType::NearImplicitAccount
+    match account_id.get_account_type() {
+        AccountType::NamedAccount => false,
+        AccountType::NearImplicitAccount => true,
+        // A deterministic account has no flag of its own and rides the eth-implicit one.
+        AccountType::NearDeterministicAccount => eth_implicit_accounts_enabled,
+        AccountType::EthImplicitAccount => eth_implicit_accounts_enabled,
+        AccountType::UniversalAccount => universal_accounts_enabled,
     }
 }
 

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -482,6 +482,9 @@ pub fn account_is_implicit(
     if account_type == AccountType::UniversalAccount {
         return universal_accounts_enabled;
     }
+    if account_type == AccountType::EthImplicitAccount {
+        return eth_implicit_accounts_enabled;
+    }
     if eth_implicit_accounts_enabled {
         account_type.is_implicit()
     } else {

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -10,9 +10,7 @@ use near_crypto::{ED25519PublicKey, Secp256K1PublicKey};
 use near_primitives_core::account::id::{AccountId, AccountType};
 use near_primitives_core::deterministic_account_id::DeterministicAccountStateInit;
 use near_primitives_core::types::BlockHeight;
-use near_primitives_core::universal_account_id::{
-    encode_universal_account_id, is_universal_account_id,
-};
+use near_primitives_core::universal_account_id::encode_universal_account_id;
 use serde;
 use std::convert::AsRef;
 use std::fmt;
@@ -471,22 +469,23 @@ where
 /// This function is a wrapper for `is_implicit` method so that we can easily differentiate its behavior
 /// based on whether ETH-implicit accounts are enabled.
 ///
-/// `0u` universal ids are handled separately: `AccountType` has no variant for
-/// them, so they parse as `NamedAccount` and are recognized by their prefix.
+/// A universal account counts as implicit only once the protocol enables them,
+/// which the account type on its own cannot express.
 pub fn account_is_implicit(
     account_id: &AccountId,
     eth_implicit_accounts_enabled: bool,
     universal_accounts_enabled: bool,
 ) -> bool {
-    // TODO(universal-accounts): replace with an `AccountType::Universal` check
-    // once `near-account-id` supports 0u accounts.
-    if universal_accounts_enabled && is_universal_account_id(account_id.as_str()) {
-        return true;
+    let account_type = account_id.get_account_type();
+    // The flag decides for a universal account, since `is_implicit()` below carries
+    // no protocol version.
+    if account_type == AccountType::UniversalAccount {
+        return universal_accounts_enabled;
     }
     if eth_implicit_accounts_enabled {
-        account_id.get_account_type().is_implicit()
+        account_type.is_implicit()
     } else {
-        account_id.get_account_type() == AccountType::NearImplicitAccount
+        account_type == AccountType::NearImplicitAccount
     }
 }
 
@@ -559,6 +558,17 @@ mod tests {
     use super::*;
     use near_crypto::{KeyType, PublicKey};
 
+    /// `AccountType` carries no protocol version, so this is the only thing keeping
+    /// a universal account from reading as implicit before the feature activates.
+    #[test]
+    fn universal_account_is_implicit_only_when_enabled() {
+        let universal = encode_universal_account_id(&[0x33; 32]);
+        assert!(account_is_implicit(&universal, true, true));
+        assert!(account_is_implicit(&universal, false, true));
+        assert!(!account_is_implicit(&universal, true, false));
+        assert!(!account_is_implicit(&universal, false, false));
+    }
+
     #[test]
     fn test_derive_near_implicit_account_id() {
         let public_key = PublicKey::from_seed(KeyType::ED25519, "test");
@@ -581,8 +591,6 @@ mod tests {
         use crate::universal_state_init::{UniversalStateInit, UniversalStateInitV1};
         use near_crypto::{MlDsa65PublicKeyHandle, PublicKeyHandle};
         use near_primitives_core::global_contract::GlobalContractIdentifier;
-        use near_primitives_core::universal_account_id::decode_universal_account_id;
-        use sha3::{Digest, Sha3_256};
         use std::collections::{BTreeMap, BTreeSet};
 
         let key_only = UniversalStateInit::V1(UniversalStateInitV1 {
@@ -611,9 +619,6 @@ mod tests {
             assert_eq!(id.as_str(), expected);
             // The producer-side shorthand agrees with hashing the bytes it wrote.
             assert_eq!(state_init.derive_account_id(), id);
-            // The id decodes back to SHA3-256 of those bytes.
-            let hash: [u8; 32] = Sha3_256::digest(&raw.0).into();
-            assert_eq!(decode_universal_account_id(id.as_str()).unwrap(), hash);
         }
     }
 

--- a/integration-tests/src/tests/features/delegate_action.rs
+++ b/integration-tests/src/tests/features/delegate_action.rs
@@ -953,9 +953,9 @@ fn meta_tx_create_and_use_eth_implicit_account() {
 /// pays for the storage and the user could delete the account and cash in,
 /// hence this workflow is not ideal from all circumstances.
 ///
-/// Using the account should only work for NEAR-implicit accounts,
-/// as ETH-implicit accounts do not have access keys
-/// and they can only be used by calling associated smart contract.
+/// Using the account should only work for NEAR-implicit accounts. The other implicit
+/// kinds get no access key from the transfer, so they are reachable only through the
+/// contract or state init behind them.
 fn meta_tx_create_implicit_account(new_account: AccountId) {
     let relayer = bob_account();
     let sender = alice_account();

--- a/integration-tests/src/tests/features/delegate_action.rs
+++ b/integration-tests/src/tests/features/delegate_action.rs
@@ -1001,8 +1001,9 @@ fn meta_tx_create_implicit_account(new_account: AccountId) {
 
     if new_account.get_account_type() == AccountType::EthImplicitAccount
         || new_account.get_account_type() == AccountType::NearDeterministicAccount
+        || new_account.get_account_type() == AccountType::UniversalAccount
     {
-        // ETH-implicit account must not have access key added.
+        // The transfer must not add an access key to such an account.
         assert!(node.user().is_locked(&new_account).unwrap());
         // We will not attempt to make a transfer from this account.
         return;

--- a/integration-tests/src/tests/features/delegate_action.rs
+++ b/integration-tests/src/tests/features/delegate_action.rs
@@ -108,6 +108,9 @@ fn check_meta_tx_execution(
         AccountType::NearDeterministicAccount => {
             panic!("NEAR deterministic accounts usually have no access key");
         }
+        AccountType::UniversalAccount => {
+            panic!("universal accounts take their keys from the state init");
+        }
         AccountType::NamedAccount => PublicKey::from_seed(KeyType::ED25519, sender.as_ref()),
     };
     let user_nonce_before = node_user.get_access_key(&sender, &user_pub_key).unwrap().nonce;
@@ -968,6 +971,8 @@ fn meta_tx_create_implicit_account(new_account: AccountId) {
         AccountType::NearDeterministicAccount => Balance::ZERO,
         // ETH-implicit accounts fit within zero-balance account limit.
         AccountType::EthImplicitAccount => Balance::ZERO,
+        // Universal accounts fit within zero-balance account limit.
+        AccountType::UniversalAccount => Balance::ZERO,
         AccountType::NamedAccount => panic!("must be implicit"),
     };
     let actions = vec![Action::Transfer(TransferAction { deposit: initial_amount })];
@@ -976,6 +981,7 @@ fn meta_tx_create_implicit_account(new_account: AccountId) {
         AccountType::NearImplicitAccount => fee_helper.create_account_transfer_full_key_cost(),
         AccountType::NearDeterministicAccount => fee_helper.create_account_transfer_cost(),
         AccountType::EthImplicitAccount => fee_helper.create_account_transfer_cost(),
+        AccountType::UniversalAccount => fee_helper.create_account_transfer_cost(),
         AccountType::NamedAccount => panic!("must be implicit"),
     };
     check_meta_tx_no_fn_call(

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -511,6 +511,7 @@ pub fn transfer_tokens_to_implicit_account(node: impl Node, public_key: PublicKe
         AccountType::NearImplicitAccount => fee_helper.create_account_transfer_full_key_cost(),
         AccountType::NearDeterministicAccount => fee_helper.create_account_transfer_cost(),
         AccountType::EthImplicitAccount => fee_helper.create_account_transfer_cost(),
+        AccountType::UniversalAccount => fee_helper.create_account_transfer_cost(),
         AccountType::NamedAccount => std::panic!("must be implicit"),
     };
 
@@ -551,6 +552,10 @@ pub fn transfer_tokens_to_implicit_account(node: impl Node, public_key: PublicKe
         }
         AccountType::EthImplicitAccount => {
             // A transfer to ETH-implicit address does not create access key.
+            assert!(view_access_key.is_err());
+        }
+        AccountType::UniversalAccount => {
+            // A transfer to a universal address does not create an access key.
             assert!(view_access_key.is_err());
         }
         AccountType::NamedAccount => std::panic!("must be implicit"),
@@ -634,7 +639,9 @@ pub fn trying_to_create_implicit_account(node: impl Node, public_key: PublicKey)
                     create_account_fee.checked_add(add_access_key_fee).unwrap().gas,
                 ))
                 .unwrap(),
-            AccountType::EthImplicitAccount | AccountType::NearDeterministicAccount => {
+            AccountType::EthImplicitAccount
+            | AccountType::NearDeterministicAccount
+            | AccountType::UniversalAccount => {
                 // This test uses `node_user.create_account` method that is normally used for NamedAccounts and should fail here.
                 fee_helper
                     .create_account_transfer_full_key_cost_fail_on_create_account()

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -27,12 +27,11 @@ use near_parameters::{
     universal_state_init_content_terms, universal_state_init_size_terms,
 };
 use near_primitives_core::account::AccountContract;
+use near_primitives_core::account::id::AccountType;
 use near_primitives_core::config::INLINE_DISK_VALUE_THRESHOLD;
 use near_primitives_core::hash::{CryptoHash, YieldId};
 use near_primitives_core::types::{AccountId, Balance, EpochHeight, Gas, GasWeight, StorageUsage};
-use near_primitives_core::universal_account_id::{
-    encode_universal_account_id, is_universal_account_id,
-};
+use near_primitives_core::universal_account_id::encode_universal_account_id;
 use near_primitives_core::universal_state_init::RawStateInit;
 use std::rc::Rc;
 
@@ -3506,10 +3505,8 @@ pub fn promise_batch_action_transfer(
 
     let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
     let receiver_id = ctx.ext.get_receipt_receiver(receipt_idx);
-    // TODO(universal-accounts): replace with an `AccountType::Universal` check
-    // once `near-account-id` supports 0u accounts.
-    let receiver_is_universal =
-        ctx.config.universal_accounts && is_universal_account_id(receiver_id.as_str());
+    let receiver_is_universal = ctx.config.universal_accounts
+        && receiver_id.get_account_type() == AccountType::UniversalAccount;
     let send_fee = transfer_send_fee(
         &ctx.fees_config,
         sir,

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -27,7 +27,6 @@ use near_parameters::{
     universal_state_init_content_terms, universal_state_init_size_terms,
 };
 use near_primitives_core::account::AccountContract;
-use near_primitives_core::account::id::AccountType;
 use near_primitives_core::config::INLINE_DISK_VALUE_THRESHOLD;
 use near_primitives_core::hash::{CryptoHash, YieldId};
 use near_primitives_core::types::{AccountId, Balance, EpochHeight, Gas, GasWeight, StorageUsage};
@@ -3505,19 +3504,17 @@ pub fn promise_batch_action_transfer(
 
     let (receipt_idx, sir) = promise_idx_to_receipt_idx_with_sir(ctx, promise_idx)?;
     let receiver_id = ctx.ext.get_receipt_receiver(receipt_idx);
-    let receiver_is_universal = ctx.config.universal_accounts
-        && receiver_id.get_account_type() == AccountType::UniversalAccount;
     let send_fee = transfer_send_fee(
         &ctx.fees_config,
         sir,
         ctx.config.eth_implicit_accounts,
-        receiver_is_universal,
+        ctx.config.universal_accounts,
         receiver_id.get_account_type(),
     );
     let exec_fee = transfer_exec_fee(
         &ctx.fees_config,
         ctx.config.eth_implicit_accounts,
-        receiver_is_universal,
+        ctx.config.universal_accounts,
         receiver_id.get_account_type(),
     );
     let burn_cost = send_fee;

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -265,19 +265,16 @@ pub(crate) fn action_implicit_account_creation_transfer(
                 &apply_state.config.fees.storage_usage_config,
             ));
         }
-        AccountType::UniversalAccount => {
-            // The account type is the same on every protocol version, so this arm
-            // relies on `account_is_implicit` having refused before the feature is
-            // enabled. Re-check that upstream gate if this ever trips.
-            debug_assert!(apply_state.config.wasm_config.universal_accounts);
+        AccountType::UniversalAccount if apply_state.config.wasm_config.universal_accounts => {
             *account = Some(Account::new_uninitialized(
                 deposit,
                 fee_config.storage_usage_config.num_bytes_account,
             ));
         }
         // This panic is unreachable as this is an implicit account creation transfer.
-        // `check_account_existence` would fail because `account_is_implicit` would return false for a Named account.
-        AccountType::NamedAccount => panic!("must be implicit"),
+        // `check_account_existence` would fail because `account_is_implicit` would return false
+        // for such a receiver.
+        AccountType::NamedAccount | AccountType::UniversalAccount => panic!("must be implicit"),
     }
 }
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -32,7 +32,6 @@ use near_primitives::types::{
 use near_primitives::utils::account_is_implicit;
 use near_primitives::version::ProtocolVersion;
 use near_primitives_core::account::id::AccountType;
-use near_primitives_core::universal_account_id::is_universal_account_id;
 use near_primitives_core::version::ProtocolFeature;
 use near_store::{
     StorageError, TrieUpdate, compute_gas_key_balance_sum, get_access_key, get_gas_key_nonce,
@@ -223,18 +222,6 @@ pub(crate) fn action_implicit_account_creation_transfer(
     epoch_info_provider: &dyn EpochInfoProvider,
 ) {
     *actor_id = account_id.clone();
-    // TODO(universal-accounts): replace with an `AccountType::Universal` variant in the match
-    // below once `near-account-id` supports 0u accounts. For now this needs to be checked before
-    // the match, because 0u account is parsed as `AccountType::NamedAccount` and would panic.
-    if apply_state.config.wasm_config.universal_accounts
-        && is_universal_account_id(account_id.as_str())
-    {
-        *account = Some(Account::new_uninitialized(
-            deposit,
-            fee_config.storage_usage_config.num_bytes_account,
-        ));
-        return;
-    }
     match account_id.get_account_type() {
         AccountType::NearImplicitAccount => {
             let mut access_key = AccessKey::full_access();
@@ -276,6 +263,16 @@ pub(crate) fn action_implicit_account_creation_transfer(
             *account = Some(create_deterministic_account(
                 deposit,
                 &apply_state.config.fees.storage_usage_config,
+            ));
+        }
+        AccountType::UniversalAccount => {
+            // The account type is the same on every protocol version, so this arm
+            // relies on `account_is_implicit` having refused before the feature is
+            // enabled. Re-check that upstream gate if this ever trips.
+            debug_assert!(apply_state.config.wasm_config.universal_accounts);
+            *account = Some(Account::new_uninitialized(
+                deposit,
+                fee_config.storage_usage_config.num_bytes_account,
             ));
         }
         // This panic is unreachable as this is an implicit account creation transfer.

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -12,18 +12,10 @@ use near_parameters::{
     gas_key_transfer_send_fee, transfer_exec_fee, transfer_send_fee,
     universal_state_init_content_terms, universal_state_init_size_terms,
 };
-use near_primitives::account::id::AccountType;
 pub use near_primitives::num_rational::Rational32;
 use near_primitives::transaction::{Action, DeployContractAction, Transaction};
 use near_primitives::types::{AccountId, Balance, Compute, Gas};
 use near_primitives::universal_state_init::{RawStateInit, state_init_counts};
-
-/// Whether a transfer to `receiver_id` creates a `0u` universal account, which
-/// carries the same implied `CreateAccount` fee as a deterministic account.
-fn receiver_is_universal(config: &RuntimeConfig, receiver_id: &AccountId) -> bool {
-    config.wasm_config.universal_accounts
-        && receiver_id.get_account_type() == AccountType::UniversalAccount
-}
 
 /// Describes the cost of converting this transaction into a receipt.
 #[derive(Debug)]
@@ -131,7 +123,7 @@ pub fn total_send_fees(
                     fees,
                     sender_is_receiver,
                     config.wasm_config.eth_implicit_accounts,
-                    receiver_is_universal(config, receiver_id),
+                    config.wasm_config.universal_accounts,
                     receiver_id.get_account_type(),
                 )
             }
@@ -370,7 +362,7 @@ pub fn exec_fee(
             transfer_exec_fee(
                 fees,
                 config.wasm_config.eth_implicit_accounts,
-                receiver_is_universal(config, receiver_id),
+                config.wasm_config.universal_accounts,
                 receiver_id.get_account_type(),
             )
         }

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -12,18 +12,17 @@ use near_parameters::{
     gas_key_transfer_send_fee, transfer_exec_fee, transfer_send_fee,
     universal_state_init_content_terms, universal_state_init_size_terms,
 };
+use near_primitives::account::id::AccountType;
 pub use near_primitives::num_rational::Rational32;
 use near_primitives::transaction::{Action, DeployContractAction, Transaction};
 use near_primitives::types::{AccountId, Balance, Compute, Gas};
 use near_primitives::universal_state_init::{RawStateInit, state_init_counts};
-use near_primitives_core::universal_account_id::is_universal_account_id;
 
 /// Whether a transfer to `receiver_id` creates a `0u` universal account, which
 /// carries the same implied `CreateAccount` fee as a deterministic account.
 fn receiver_is_universal(config: &RuntimeConfig, receiver_id: &AccountId) -> bool {
-    // TODO(universal-accounts): replace with an `AccountType::Universal` check
-    // once `near-account-id` supports 0u accounts.
-    config.wasm_config.universal_accounts && is_universal_account_id(receiver_id.as_str())
+    config.wasm_config.universal_accounts
+        && receiver_id.get_account_type() == AccountType::UniversalAccount
 }
 
 /// Describes the cost of converting this transaction into a receipt.

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -155,5 +155,6 @@ pub fn map_account(
         AccountType::EthImplicitAccount => account_id.clone(),
         AccountType::NamedAccount => account_id.clone(),
         AccountType::NearDeterministicAccount => account_id.clone(),
+        AccountType::UniversalAccount => account_id.clone(),
     }
 }


### PR DESCRIPTION
near-account-id 3.0.0 has `AccountType::UniversalAccount` (near/near-account-id-rs#61), so nearcore no longer has to check a `0u` address by its prefix. `is_universal_account_id` and its five callers go, and the pin moves to 3.0.0. Each caller keeps its `universal_accounts` flag, because the account type says nothing about protocol version.

One place needed care. `account_is_implicit` checked the flag, then fell through to `AccountType::is_implicit()`, which has no flag and now says true for a universal account, so it answers that case itself. Two tests cover what the compiler cannot see. One checks that a universal account counts as implicit only once the feature is on. The other checks the transfer fee is unchanged until then.

It also drops the code that turns a `0u` address back into a hash, since the prefix test was the only thing outside tests using it. Four of its tests go too, and one of those pinned the rule that an address can only end in `0` or `g`, which the crate now checks itself. Finally, a TODO on the universal and eth flags, so neither is forgotten once MIN_SUPPORTED_PROTOCOL_VERSION passes its activation version. For eth that is already the case.
