### PR TITLE
feat(cloud-archive): the reader resolves each batch's shard set

### DIFF
--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -1,13 +1,16 @@
 use near_chain::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::errors::EpochError;
+use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::{get_block_shard_id, index_to_bytes};
 use near_store::adapter::StoreUpdateAdapter;
+use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::archive::cloud_storage::{
     BlockData, CloudRetrievalError, CloudStorage, EpochData, ShardData,
 };
 use near_store::{DBCol, Store, StoreUpdate};
+use std::collections::HashSet;
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
 #[derive(thiserror::Error, Debug)]
@@ -49,42 +52,115 @@ pub fn save_block_data(update: &mut StoreUpdate, block_data: &BlockData) {
     }
 }
 
-/// Downloads the batch containing `start_height`, writes its block rows from there to
-/// the batch's end in one commit, and returns that end. When an epoch ends inside the
-/// batch, the epoch starting after it is pulled too, that boundary being the only thing
-/// that names a new epoch.
+/// What one pull of a block batch found.
+pub(crate) struct BlockBatchPull {
+    /// The batch's last height.
+    pub end_height: BlockHeight,
+    /// The epoch opening inside the batch.
+    pub opening_epoch_id: Option<EpochId>,
+    /// The last block written, absent when none was.
+    pub last_present_block_hash: Option<CryptoHash>,
+}
+
+/// The last block of an epoch.
+struct EpochEnd {
+    height: BlockHeight,
+    /// The epoch the block above it opens.
+    next_epoch_id: EpochId,
+}
+
+/// Downloads the batch containing `start_height` and writes its block rows from there
+/// to the batch's end in one commit. When an epoch ends inside the batch, the epoch
+/// starting after it is pulled too.
 pub(crate) fn pull_block_batch(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_manager: &dyn EpochManagerAdapter,
     start_height: BlockHeight,
-) -> Result<BlockHeight, CloudArchivalReaderError> {
+) -> Result<BlockBatchPull, CloudArchivalReaderError> {
     let block_batch = cloud_storage.get_block_batch_for_height(start_height)?;
-    let mut next_epoch_id = None;
+    let mut last_present_block_hash = None;
+    let mut epoch_end: Option<EpochEnd> = None;
     let mut update = store.store_update();
     for block_height in start_height..=block_batch.end_height() {
         let Some(block_data) = block_batch.get_block_at_height(block_height) else {
             continue;
         };
         save_block_data(&mut update, block_data);
-        if next_epoch_id.is_none()
+        last_present_block_hash = Some(*block_data.block().header().hash());
+        if epoch_end.is_none()
             && epoch_manager.is_next_block_in_next_epoch(block_data.block_info())?
         {
-            next_epoch_id = Some(*block_data.block().header().next_epoch_id());
+            epoch_end = Some(EpochEnd {
+                height: block_height,
+                next_epoch_id: *block_data.block().header().next_epoch_id(),
+            });
         }
     }
     update.commit();
-    if let Some(next_epoch_id) = next_epoch_id {
-        pull_epoch_data(store, cloud_storage, &next_epoch_id)?;
+    if let Some(epoch_end) = &epoch_end {
+        pull_epoch_data(store, cloud_storage, &epoch_end.next_epoch_id)?;
     }
-    Ok(block_batch.end_height())
+    let opening_epoch_id =
+        epoch_end.filter(|end| end.height < block_batch.end_height()).map(|end| end.next_epoch_id);
+    Ok(BlockBatchPull {
+        end_height: block_batch.end_height(),
+        opening_epoch_id,
+        last_present_block_hash,
+    })
 }
 
-/// Writes the height the reader has taken the archive through.
-pub(crate) fn save_reader_head(store: &Store, height: BlockHeight) {
+/// Seeds the store with what the epoch manager needs to answer for `height`, and
+/// returns the hash of the nearest present block below it.
+pub(crate) fn install_anchors(
+    store: &Store,
+    cloud_storage: &CloudStorage,
+    epoch_manager: &dyn EpochManagerAdapter,
+    height: BlockHeight,
+) -> Result<CryptoHash, CloudArchivalReaderError> {
+    let (_, prev_block) = find_present_block_below(cloud_storage, height)?;
+    let prev_block_epoch_id = *prev_block.block().header().epoch_id();
+    pull_epoch_data(store, cloud_storage, &prev_block_epoch_id)?;
+
+    let prev_block_hash = *prev_block.block().header().hash();
     let mut update = store.store_update();
-    update.cloud_archival_store_update().set_reader_head(height);
+    // `get_epoch_id_from_prev_block` starts by reading this row.
+    update.insert_ser(DBCol::BlockInfo, prev_block_hash.as_ref(), prev_block.block_info());
     update.commit();
+
+    let start_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash)?;
+    if start_epoch_id != prev_block_epoch_id {
+        pull_epoch_data(store, cloud_storage, &start_epoch_id)?;
+    }
+    Ok(prev_block_hash)
+}
+
+/// The shards of both epochs a batch can hold blocks in.
+pub(crate) fn batch_shard_ids(
+    epoch_manager: &dyn EpochManagerAdapter,
+    prev_block_hash: &CryptoHash,
+    opening_epoch_id: Option<EpochId>,
+) -> Result<HashSet<ShardId>, CloudArchivalReaderError> {
+    let batch_epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
+    let mut shard_ids: HashSet<ShardId> =
+        epoch_manager.get_shard_layout(&batch_epoch_id)?.shard_ids().collect();
+    if let Some(opening_epoch_id) = opening_epoch_id {
+        shard_ids.extend(epoch_manager.get_shard_layout(&opening_epoch_id)?.shard_ids());
+    }
+    Ok(shard_ids)
+}
+
+/// Stores how far the reader has taken the archive, and returns that head.
+pub(crate) fn save_reader_head(
+    store: &Store,
+    height: BlockHeight,
+    last_present_block_hash: CryptoHash,
+) -> CloudReaderHead {
+    let head = CloudReaderHead { height, last_present_block_hash };
+    let mut update = store.store_update();
+    update.cloud_archival_store_update().set_reader_head(&head);
+    update.commit();
+    head
 }
 
 /// Writes one epoch's cloud data into `update`.
@@ -110,13 +186,14 @@ pub(crate) fn save_shard_data(update: &mut StoreUpdate, shard_id: ShardId, shard
     }
 }
 
-/// First present block at or below `height`. Errors if no such block exists
-/// in cloud (e.g. `height` is below the first archived block).
-pub fn find_present_block_at_or_below(
+/// First present block below `height`. Errors if no such block exists in cloud
+/// (e.g. `height` sits below the first archived block).
+pub fn find_present_block_below(
     cloud_storage: &CloudStorage,
     height: BlockHeight,
 ) -> Result<(BlockHeight, BlockData), CloudRetrievalError> {
-    let mut h = height;
+    assert!(height > 0, "no block sits below height 0");
+    let mut h = height - 1;
     let mut batch = cloud_storage.get_block_batch_for_height(h)?;
     loop {
         if h < batch.start_height() {
@@ -138,7 +215,7 @@ pub fn find_snapshot_at_or_before(
     height: BlockHeight,
     shard_id: ShardId,
 ) -> Result<(EpochHeight, EpochId), CloudArchivalReaderError> {
-    let (_, initial_block) = find_present_block_at_or_below(cloud_storage, height)?;
+    let (_, initial_block) = find_present_block_below(cloud_storage, height + 1)?;
     let mut epoch_id = *initial_block.block().header().epoch_id();
 
     loop {
@@ -161,8 +238,7 @@ pub fn find_snapshot_at_or_before(
         if epoch_start_block.block_info().is_genesis() {
             return Err(CloudArchivalReaderError::NoSnapshotFound);
         }
-        let (_, prev_block) =
-            find_present_block_at_or_below(cloud_storage, epoch_start_height - 1)?;
+        let (_, prev_block) = find_present_block_below(cloud_storage, epoch_start_height)?;
         epoch_id = *prev_block.block().header().epoch_id();
     }
 }
@@ -172,7 +248,7 @@ pub(crate) fn pull_epoch_data(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_id: &EpochId,
-) -> Result<EpochData, CloudRetrievalError> {
+) -> Result<(), CloudRetrievalError> {
     let epoch_data = cloud_storage.get_epoch_data(*epoch_id)?;
     let mut update = store.store_update();
     save_epoch_data(&mut update, &epoch_data);
@@ -182,5 +258,5 @@ pub(crate) fn pull_epoch_data(
         epoch_start_height = epoch_data.epoch_start_height(),
         "pulled epoch data"
     );
-    Ok(epoch_data)
+    Ok(())
 }

--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -23,6 +23,8 @@ pub enum CloudArchivalReaderError {
     Epoch(#[from] EpochError),
     #[error("walked back to genesis without finding a state snapshot")]
     NoSnapshotFound,
+    #[error("no block below {start_height}, which must be above the first archived block")]
+    NoAnchorBelow { start_height: BlockHeight },
 }
 
 /// Writes block-level columns from a cloud `BlockData` into `update`.
@@ -111,14 +113,21 @@ pub(crate) fn pull_block_batch(
 }
 
 /// Seeds the store with what the epoch manager needs to answer for `height`, and
-/// returns the hash of the nearest present block below it.
+/// returns the hash of the nearest present block below it. `height` must therefore
+/// be above the first archived block.
 pub(crate) fn install_anchors(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_manager: &dyn EpochManagerAdapter,
     height: BlockHeight,
 ) -> Result<CryptoHash, CloudArchivalReaderError> {
-    let (_, prev_block) = find_present_block_below(cloud_storage, height)?;
+    let (_, prev_block) =
+        find_present_block_below(cloud_storage, height).map_err(|err| match err {
+            CloudRetrievalError::NoBlockData { .. } => {
+                CloudArchivalReaderError::NoAnchorBelow { start_height: height }
+            }
+            err => err.into(),
+        })?;
     let prev_block_epoch_id = *prev_block.block().header().epoch_id();
     pull_epoch_data(store, cloud_storage, &prev_block_epoch_id)?;
 

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -1,6 +1,5 @@
 use crate::archive::cloud_archival_utils::{
-    find_present_block_at_or_below, pull_block_batch, pull_epoch_data, save_reader_head,
-    save_shard_data,
+    batch_shard_ids, install_anchors, pull_block_batch, save_reader_head, save_shard_data,
 };
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::types::{BlockHeight, ShardId};
@@ -10,8 +9,7 @@ use near_store::archive::cloud_storage::CloudStorage;
 /// Downloads block, epoch, and per-shard chunk data covering `[start_height,
 /// end_height]` from cloud storage and writes it into the local store.
 ///
-/// Block rows reach a little further on both sides: the walk starts at the nearest
-/// present block at or below `start_height`, and each batch is written to its own end.
+/// Rows reach past `end_height`, since each batch is written to its own end.
 pub fn bootstrap_range(
     store: &Store,
     cloud_storage: &CloudStorage,
@@ -26,40 +24,34 @@ pub fn bootstrap_range(
         end_height,
     );
 
-    // `start_height` may carry no block, so the block walk starts at the nearest present
-    // block below it and pulls that block's epoch.
-    let (block_start_height, block) = find_present_block_at_or_below(cloud_storage, start_height)?;
-    let epoch_id = *block.block().header().epoch_id();
-    let epoch_data = pull_epoch_data(store, cloud_storage, &epoch_id)?;
+    let mut prev_block_hash = install_anchors(store, cloud_storage, epoch_manager, start_height)?;
 
-    let range_length = end_height - block_start_height + 1;
+    let range_length = end_height - start_height + 1;
     let log_interval = std::cmp::max(cloud_storage.batch_size() as u64, range_length / 100);
     let mut next_log_at = log_interval;
 
     // Fetch one batch per iteration and consume all its heights, so each
     // batch blob is downloaded and decompressed once rather than per height.
-    let mut height = block_start_height;
+    let mut height = start_height;
     while height <= end_height {
-        let batch_end = pull_block_batch(store, cloud_storage, epoch_manager, height)?;
-        // A presence marker, so far: nothing reads the height it names.
-        // TODO(cloud_archival): resume from it, counting the shard rows too.
-        save_reader_head(store, batch_end);
-        height = batch_end + 1;
+        let batch_pull = pull_block_batch(store, cloud_storage, epoch_manager, height)?;
+        let shard_ids =
+            batch_shard_ids(epoch_manager, &prev_block_hash, batch_pull.opening_epoch_id)?;
+        for shard_id in shard_ids {
+            save_shard_range(store, cloud_storage, shard_id, height, batch_pull.end_height)?;
+        }
+        if let Some(block_hash) = batch_pull.last_present_block_hash {
+            prev_block_hash = block_hash;
+        }
+        height = batch_pull.end_height + 1;
+        save_reader_head(store, batch_pull.end_height, prev_block_hash);
         // Capped: a batch runs to its own end, which can be past `end_height`.
-        let done = std::cmp::min(height - block_start_height, range_length);
+        let done = std::cmp::min(height - start_height, range_length);
         if done >= next_log_at || height > end_height {
             next_log_at = done + log_interval;
             let percent_done = done * 100 / range_length;
             tracing::info!(height, end_height, percent_done, "bootstrap progress");
         }
-    }
-
-    // Reconstruct chunks over the requested range.
-    // TODO(cloud_archival): support resharding; the layout is read once, so a
-    // mid-range layout change would iterate the wrong shards.
-    let shard_layout = epoch_data.shard_layout().clone();
-    for shard_id in shard_layout.shard_ids() {
-        save_shard_range(store, cloud_storage, shard_id, start_height, end_height)?;
     }
 
     Ok(())
@@ -75,6 +67,8 @@ fn save_shard_range(
 ) -> anyhow::Result<()> {
     let mut height = start_height;
     while height <= end_height {
+        // TODO(cloud_archival): handle a shard whose blob starts above this height,
+        // which a bootstrap crossing a resharding hits.
         let batch = cloud_storage.get_shard_batch_for_height(height, shard_id)?;
         let last_in_batch = std::cmp::min(batch.end_height(), end_height);
         let mut update = store.store_update();

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -10,6 +10,9 @@ use near_store::archive::cloud_storage::CloudStorage;
 /// end_height]` from cloud storage and writes it into the local store.
 ///
 /// Rows reach past `end_height`, since each batch is written to its own end.
+///
+/// `start_height` must be above the first archived block, since the walk is anchored on
+/// the block below it.
 pub fn bootstrap_range(
     store: &Store,
     cloud_storage: &CloudStorage,

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -4,8 +4,8 @@ use crate::archive::cloud_archival_utils::{
 use near_async::time::{Clock, Duration};
 use near_chain_configs::InterruptHandle;
 use near_epoch_manager::EpochManagerAdapter;
-use near_primitives::types::BlockHeight;
 use near_store::Store;
+use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::archive::cloud_storage::CloudStorage;
 use std::sync::Arc;
@@ -13,8 +13,8 @@ use std::sync::Arc;
 /// Result of one recent-reader iteration.
 #[derive(Debug)]
 enum PullOutcome {
-    /// Took the batch ending at this height.
-    Pulled { batch_end: BlockHeight },
+    /// Took a batch and moved the reader head to this.
+    Pulled { head: CloudReaderHead },
     /// The bucket holds no block past the reader's head.
     WaitingForBlocks,
 }
@@ -48,20 +48,19 @@ impl CloudArchivalRecentReader {
         }
     }
 
-    /// The height the reader resumes at, taking the store over on the first run.
+    /// Takes the store over on the first run, otherwise returns where the reader resumes.
     ///
     /// A store a stopped node handed over carries no reader head yet and takes that
     /// node's final head, since its own head can sit on a block that later reorged.
     /// Taking it over also drops the height index above that head.
-    fn ensure_reader_head(&self) -> Result<BlockHeight, CloudArchivalReaderError> {
+    fn ensure_reader_head(&self) -> Result<CloudReaderHead, CloudArchivalReaderError> {
         if let Some(reader_head) = self.store.cloud_archival_store().reader_head() {
             return Ok(reader_head);
         }
         let final_head = self.store.chain_store().final_head()?;
         let header_head = self.store.chain_store().header_head()?;
         self.clear_height_index_range(final_head.height, header_head.height);
-        save_reader_head(&self.store, final_head.height);
-        Ok(final_head.height)
+        Ok(save_reader_head(&self.store, final_head.height, final_head.last_block_hash))
     }
 
     /// Deletes the height index rows in `(final_height, header_height]`. Above the final
@@ -82,15 +81,15 @@ impl CloudArchivalRecentReader {
     /// Follows the bucket, copying what it holds into the local store, until interrupted.
     pub async fn cloud_archival_loop(self) -> Result<(), CloudArchivalReaderError> {
         let mut reader_head = self.ensure_reader_head()?;
-        tracing::info!(target: "cloud_archival", reader_head, "following the cloud archive");
+        tracing::info!(target: "cloud_archival", ?reader_head, "following the cloud archive");
 
         while !self.interrupt.is_cancelled() {
-            let sleep_duration = match self.try_pull_next_batch(reader_head) {
+            let sleep_duration = match self.try_pull_next_batch(&reader_head) {
                 Ok(outcome) => {
                     tracing::trace!(target: "cloud_archival", ?outcome, "pull");
                     match outcome {
-                        PullOutcome::Pulled { batch_end } => {
-                            reader_head = batch_end;
+                        PullOutcome::Pulled { head } => {
+                            reader_head = head;
                             Duration::ZERO
                         }
                         PullOutcome::WaitingForBlocks => self.polling_interval,
@@ -110,21 +109,23 @@ impl CloudArchivalRecentReader {
     /// Takes the batches after `reader_head`, once the bucket has them.
     fn try_pull_next_batch(
         &self,
-        reader_head: BlockHeight,
+        reader_head: &CloudReaderHead,
     ) -> Result<PullOutcome, CloudArchivalReaderError> {
         let cloud_block_head = self.cloud_storage.get_cloud_block_head()?;
-        if !cloud_block_head.is_some_and(|cloud_head| cloud_head > reader_head) {
+        if !cloud_block_head.is_some_and(|cloud_head| cloud_head > reader_head.height) {
             return Ok(PullOutcome::WaitingForBlocks);
         }
-        let batch_end = pull_block_batch(
+        let batch_pull = pull_block_batch(
             &self.store,
             &self.cloud_storage,
             self.epoch_manager.as_ref(),
-            reader_head + 1,
+            reader_head.height + 1,
         )?;
-        // TODO(cloud_archival): write the batch's shard rows here once they become
-        // available.
-        save_reader_head(&self.store, batch_end);
-        Ok(PullOutcome::Pulled { batch_end })
+        // TODO(cloud_archival): write the batch's shard rows here once every shard it
+        // covers has published its cloud head.
+        let last_present_block_hash =
+            batch_pull.last_present_block_hash.unwrap_or(reader_head.last_present_block_hash);
+        let head = save_reader_head(&self.store, batch_pull.end_height, last_present_block_hash);
+        Ok(PullOutcome::Pulled { head })
     }
 }

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -4,6 +4,7 @@ use crate::archive::cloud_archival_utils::{
 use near_async::time::{Clock, Duration};
 use near_chain_configs::InterruptHandle;
 use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::types::BlockHeight;
 use near_store::Store;
 use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};

--- a/core/store/src/adapter/cloud_archival_store.rs
+++ b/core/store/src/adapter/cloud_archival_store.rs
@@ -5,9 +5,19 @@ use crate::db::{
     cloud_writer_shard_head_key_shard_id,
 };
 use crate::{DBCol, Store, StoreUpdate};
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, ShardId};
+use near_schema_checker_lib::ProtocolSchema;
+
+/// How far a reader has taken the archive, and the block it continues from.
+#[derive(Clone, Copy, Debug, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+pub struct CloudReaderHead {
+    /// Height every component is written through. Can name a height carrying no block.
+    pub height: BlockHeight,
+    /// Nearest present block at or below `height`.
+    pub last_present_block_hash: CryptoHash,
+}
 
 /// What the node's own store holds for cloud archival.
 #[derive(Clone)]
@@ -52,9 +62,9 @@ impl CloudArchivalStoreAdapter {
         self.store.get_ser(DBCol::BlockMisc, CLOUD_WRITER_PREV_EPOCH_END_KEY)
     }
 
-    /// Height a reader has written every component through, absent unless this store
-    /// is a reader's.
-    pub fn reader_head(&self) -> Option<BlockHeight> {
+    /// How far a reader has written every component, absent unless this store is a
+    /// reader's.
+    pub fn reader_head(&self) -> Option<CloudReaderHead> {
         self.store.get_ser(DBCol::BlockMisc, CLOUD_READER_HEAD_KEY)
     }
 
@@ -124,7 +134,7 @@ impl<'a> CloudArchivalStoreUpdateAdapter<'a> {
         self.store_update.set_ser(DBCol::BlockMisc, CLOUD_WRITER_PREV_EPOCH_END_KEY, &block_hash);
     }
 
-    pub fn set_reader_head(&mut self, height: BlockHeight) {
-        self.store_update.set_ser(DBCol::BlockMisc, CLOUD_READER_HEAD_KEY, &height);
+    pub fn set_reader_head(&mut self, head: &CloudReaderHead) {
+        self.store_update.set_ser(DBCol::BlockMisc, CLOUD_READER_HEAD_KEY, head);
     }
 }

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -385,11 +385,12 @@ impl CloudArchiveHarness {
     }
 
     /// The height the recent reader has copied through.
-    fn recent_reader_head(&self) -> BlockHeight {
+    fn recent_reader_height(&self) -> BlockHeight {
         self.recent_reader_store()
             .cloud_archival_store()
             .reader_head()
             .expect("the recent reader holds a head")
+            .height
     }
 
     fn recent_reader_store(&self) -> Store {
@@ -2033,7 +2034,7 @@ fn test_cloud_archival_recent_reader() {
     );
 
     // The reader takes whole batches, so its head may trail the bucket by one.
-    let head = h.recent_reader_head();
+    let head = h.recent_reader_height();
     let bucket_head = get_cloud_storage(&h.env, &h.writer_id)
         .get_cloud_block_head()
         .expect("reading the bucket's block head")
@@ -2074,7 +2075,7 @@ fn test_cloud_archival_skipped_run_across_batch_edge() {
     // Two epochs past the run, so both readers are clear of it when the chain stops.
     h.run_until_epoch(last_dropped / h.epoch_length + 2);
 
-    let head = h.recent_reader_head();
+    let head = h.recent_reader_height();
     let reader_store = h.recent_reader_store().chain_store();
     assert!(last_dropped <= head, "the reader stopped at {head}, below the dropped run");
     for height in &dropped_heights {

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -2143,7 +2143,7 @@ fn test_cloud_archival_reader_clears_forked_height() {
     // Two epochs past the dropped height, so the reader is clear of it when the chain stops.
     h.run_until_epoch(forked_height / h.epoch_length + 2);
 
-    let head = h.recent_reader_head();
+    let head = h.recent_reader_height();
     assert!(forked_height <= head, "the reader stopped at {head}, below the forked height");
     let batch =
         get_cloud_storage(&h.env, &h.writer_id).get_block_batch_for_height(forked_height).unwrap();

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -6,7 +6,7 @@ use near_chain::ChainStoreAccess;
 use near_chain::types::Tip;
 use near_chain_configs::{ClientConfig, CloudArchivalWriterConfig, TrackedShardsConfig};
 use near_client::archive::cloud_archival_utils::{
-    find_present_block_at_or_below, find_snapshot_at_or_before,
+    find_present_block_below, find_snapshot_at_or_before,
 };
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::archive::cloud_historical_reader::bootstrap_range;
@@ -566,7 +566,7 @@ pub fn bootstrap_historical_reader(
     // carries no data, so snap it down to the nearest present block at or below
     // it (no state changes between them).
     let (target_block_height, target_block_data) =
-        find_present_block_at_or_below(&cloud_storage, target_block_height).unwrap();
+        find_present_block_below(&cloud_storage, target_block_height + 1).unwrap();
     let target_epoch_id = *target_block_data.block().header().epoch_id();
     let target_epoch_data = cloud_storage.get_epoch_data(target_epoch_id).unwrap();
 

--- a/tools/protocol-schema-check/res/protocol_schema.toml
+++ b/tools/protocol-schema-check/res/protocol_schema.toml
@@ -100,6 +100,7 @@ ChunkStateWitness = 2526307047
 ChunkStateWitnessAck = 177881908
 ChunkStateWitnessV2 = 1907746384
 ChunkStats = 4176245277
+CloudReaderHead = 4159040927
 CodeBytes = 2940589161
 CodeHash = 457384689
 CompilationError = 3636972954


### PR DESCRIPTION
The bootstrap read the shard layout once at the start of the range, so a range crossing an epoch with a different layout asked for shards that had stopped existing and missed ones that had appeared.

Shard reconstruction moves into the batch loop and takes the shards of both epochs a batch can hold blocks in. To know which epoch a batch opens in, the reader carries the previous block rather than reading it off blocks it just downloaded, which named nothing when every height in a batch was skipped. Pulling the shards is still wrong across a resharding, since the child's blob starts above the batch window and the height-based fetch rejects it. Shards, state and resharding are the next PR, which also brings back the reader test across a resharding boundary.
