### PR TITLE
refactor(cloud-archive): the reader awaits its reads

### DIFF
--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -74,13 +74,13 @@ struct EpochEnd {
 /// Downloads the batch containing `start_height` and writes its block rows from there
 /// to the batch's end in one commit. When an epoch ends inside the batch, the epoch
 /// starting after it is pulled too.
-pub(crate) fn pull_block_batch(
+pub(crate) async fn pull_block_batch(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_manager: &dyn EpochManagerAdapter,
     start_height: BlockHeight,
 ) -> Result<BlockBatchPull, CloudArchivalReaderError> {
-    let block_batch = cloud_storage.get_block_batch_for_height(start_height)?;
+    let block_batch = cloud_storage.get_block_batch_for_height(start_height).await?;
     let mut last_present_block_hash = None;
     let mut epoch_end: Option<EpochEnd> = None;
     let mut update = store.store_update();
@@ -101,7 +101,7 @@ pub(crate) fn pull_block_batch(
     }
     update.commit();
     if let Some(epoch_end) = &epoch_end {
-        pull_epoch_data(store, cloud_storage, &epoch_end.next_epoch_id)?;
+        pull_epoch_data(store, cloud_storage, &epoch_end.next_epoch_id).await?;
     }
     let opening_epoch_id =
         epoch_end.filter(|end| end.height < block_batch.end_height()).map(|end| end.next_epoch_id);
@@ -115,21 +115,21 @@ pub(crate) fn pull_block_batch(
 /// Seeds the store with what the epoch manager needs to answer for `height`, and
 /// returns the hash of the nearest present block below it. `height` must therefore
 /// be above the first archived block.
-pub(crate) fn install_anchors(
+pub(crate) async fn install_anchors(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_manager: &dyn EpochManagerAdapter,
     height: BlockHeight,
 ) -> Result<CryptoHash, CloudArchivalReaderError> {
     let (_, prev_block) =
-        find_present_block_below(cloud_storage, height).map_err(|err| match err {
+        find_present_block_below(cloud_storage, height).await.map_err(|err| match err {
             CloudRetrievalError::NoBlockData { .. } => {
                 CloudArchivalReaderError::NoAnchorBelow { start_height: height }
             }
             err => err.into(),
         })?;
     let prev_block_epoch_id = *prev_block.block().header().epoch_id();
-    pull_epoch_data(store, cloud_storage, &prev_block_epoch_id)?;
+    pull_epoch_data(store, cloud_storage, &prev_block_epoch_id).await?;
 
     let prev_block_hash = *prev_block.block().header().hash();
     let mut update = store.store_update();
@@ -139,7 +139,7 @@ pub(crate) fn install_anchors(
 
     let start_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash)?;
     if start_epoch_id != prev_block_epoch_id {
-        pull_epoch_data(store, cloud_storage, &start_epoch_id)?;
+        pull_epoch_data(store, cloud_storage, &start_epoch_id).await?;
     }
     Ok(prev_block_hash)
 }
@@ -197,16 +197,16 @@ pub(crate) fn save_shard_data(update: &mut StoreUpdate, shard_id: ShardId, shard
 
 /// First present block below `height`. Errors if no such block exists in cloud
 /// (e.g. `height` sits below the first archived block).
-pub fn find_present_block_below(
+pub async fn find_present_block_below(
     cloud_storage: &CloudStorage,
     height: BlockHeight,
 ) -> Result<(BlockHeight, BlockData), CloudRetrievalError> {
     assert!(height > 0, "no block sits below height 0");
     let mut h = height - 1;
-    let mut batch = cloud_storage.get_block_batch_for_height(h)?;
+    let mut batch = cloud_storage.get_block_batch_for_height(h).await?;
     loop {
         if h < batch.start_height() {
-            batch = cloud_storage.get_block_batch_for_height(h)?;
+            batch = cloud_storage.get_block_batch_for_height(h).await?;
         }
         if let Some(block) = batch.get_block_at_height(h) {
             return Ok((h, block.clone()));
@@ -219,26 +219,26 @@ pub fn find_present_block_below(
 /// Walks epochs backward from `height` and returns the first `(epoch_height, epoch_id)`
 /// whose state-header is present in cloud for `shard_id`. Errors when the walk-back
 /// reaches below the earliest archived data without finding a snapshot.
-pub fn find_snapshot_at_or_before(
+pub async fn find_snapshot_at_or_before(
     cloud_storage: &CloudStorage,
     height: BlockHeight,
     shard_id: ShardId,
 ) -> Result<(EpochHeight, EpochId), CloudArchivalReaderError> {
-    let (_, initial_block) = find_present_block_below(cloud_storage, height + 1)?;
+    let (_, initial_block) = find_present_block_below(cloud_storage, height + 1).await?;
     let mut epoch_id = *initial_block.block().header().epoch_id();
 
     loop {
-        let epoch_data = cloud_storage.get_epoch_data(epoch_id)?;
+        let epoch_data = cloud_storage.get_epoch_data(epoch_id).await?;
         let epoch_height = epoch_data.epoch_info().epoch_height();
         let epoch_start_height = epoch_data.epoch_start_height();
 
         tracing::info!(epoch_height, ?epoch_id, "probing for state snapshot");
 
-        if cloud_storage.is_state_header_stored(epoch_height, epoch_id, shard_id)? {
+        if cloud_storage.is_state_header_stored(epoch_height, epoch_id, shard_id).await? {
             return Ok((epoch_height, epoch_id));
         }
 
-        let batch = cloud_storage.get_block_batch_for_height(epoch_start_height)?;
+        let batch = cloud_storage.get_block_batch_for_height(epoch_start_height).await?;
         // Epoch start is by chain definition always produced; if it's None in cloud
         // we don't have earlier chain data, so the walk-back can't continue.
         let Some(epoch_start_block) = batch.get_block_at_height(epoch_start_height) else {
@@ -247,18 +247,18 @@ pub fn find_snapshot_at_or_before(
         if epoch_start_block.block_info().is_genesis() {
             return Err(CloudArchivalReaderError::NoSnapshotFound);
         }
-        let (_, prev_block) = find_present_block_below(cloud_storage, epoch_start_height)?;
+        let (_, prev_block) = find_present_block_below(cloud_storage, epoch_start_height).await?;
         epoch_id = *prev_block.block().header().epoch_id();
     }
 }
 
 /// Downloads one epoch's data out of the bucket and writes it into the store.
-pub(crate) fn pull_epoch_data(
+pub(crate) async fn pull_epoch_data(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_id: &EpochId,
 ) -> Result<(), CloudRetrievalError> {
-    let epoch_data = cloud_storage.get_epoch_data(*epoch_id)?;
+    let epoch_data = cloud_storage.get_epoch_data(*epoch_id).await?;
     let mut update = store.store_update();
     save_epoch_data(&mut update, &epoch_data);
     update.commit();

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -13,7 +13,7 @@ use near_store::archive::cloud_storage::CloudStorage;
 ///
 /// `start_height` must be above the first archived block, since the walk is anchored on
 /// the block below it.
-pub fn bootstrap_range(
+pub async fn bootstrap_range(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_manager: &dyn EpochManagerAdapter,
@@ -27,7 +27,8 @@ pub fn bootstrap_range(
         end_height,
     );
 
-    let mut prev_block_hash = install_anchors(store, cloud_storage, epoch_manager, start_height)?;
+    let mut prev_block_hash =
+        install_anchors(store, cloud_storage, epoch_manager, start_height).await?;
 
     let range_length = end_height - start_height + 1;
     let log_interval = std::cmp::max(cloud_storage.batch_size() as u64, range_length / 100);
@@ -37,11 +38,11 @@ pub fn bootstrap_range(
     // batch blob is downloaded and decompressed once rather than per height.
     let mut height = start_height;
     while height <= end_height {
-        let batch_pull = pull_block_batch(store, cloud_storage, epoch_manager, height)?;
+        let batch_pull = pull_block_batch(store, cloud_storage, epoch_manager, height).await?;
         let shard_ids =
             batch_shard_ids(epoch_manager, &prev_block_hash, batch_pull.opening_epoch_id)?;
         for shard_id in shard_ids {
-            save_shard_range(store, cloud_storage, shard_id, height, batch_pull.end_height)?;
+            save_shard_range(store, cloud_storage, shard_id, height, batch_pull.end_height).await?;
         }
         if let Some(block_hash) = batch_pull.last_present_block_hash {
             prev_block_hash = block_hash;
@@ -61,7 +62,7 @@ pub fn bootstrap_range(
 }
 
 /// Writes one shard's data across `[start_height, end_height]`.
-fn save_shard_range(
+async fn save_shard_range(
     store: &Store,
     cloud_storage: &CloudStorage,
     shard_id: ShardId,
@@ -72,7 +73,7 @@ fn save_shard_range(
     while height <= end_height {
         // TODO(cloud_archival): handle a shard whose blob starts above this height,
         // which a bootstrap crossing a resharding hits.
-        let batch = cloud_storage.get_shard_batch_for_height(height, shard_id)?;
+        let batch = cloud_storage.get_shard_batch_for_height(height, shard_id).await?;
         let last_in_batch = std::cmp::min(batch.end_height(), end_height);
         let mut update = store.store_update();
         for h in height..=last_in_batch {

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -85,7 +85,7 @@ impl CloudArchivalRecentReader {
         tracing::info!(target: "cloud_archival", ?reader_head, "following the cloud archive");
 
         while !self.interrupt.is_cancelled() {
-            let sleep_duration = match self.try_pull_next_batch(&reader_head) {
+            let sleep_duration = match self.try_pull_next_batch(&reader_head).await {
                 Ok(outcome) => {
                     tracing::trace!(target: "cloud_archival", ?outcome, "pull");
                     match outcome {
@@ -108,11 +108,11 @@ impl CloudArchivalRecentReader {
     }
 
     /// Takes the batches after `reader_head`, once the bucket has them.
-    fn try_pull_next_batch(
+    async fn try_pull_next_batch(
         &self,
         reader_head: &CloudReaderHead,
     ) -> Result<PullOutcome, CloudArchivalReaderError> {
-        let cloud_block_head = self.cloud_storage.get_cloud_block_head()?;
+        let cloud_block_head = self.cloud_storage.get_cloud_block_head().await?;
         if !cloud_block_head.is_some_and(|cloud_head| cloud_head > reader_head.height) {
             return Ok(PullOutcome::WaitingForBlocks);
         }
@@ -121,7 +121,8 @@ impl CloudArchivalRecentReader {
             &self.cloud_storage,
             self.epoch_manager.as_ref(),
             reader_head.height + 1,
-        )?;
+        )
+        .await?;
         // TODO(cloud_archival): write the batch's shard rows here once every shard it
         // covers has published its cloud head.
         let last_present_block_hash =

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -7,7 +7,6 @@ pub use crate::archive::cloud_storage::epoch_data::EpochData;
 pub use crate::archive::cloud_storage::retrieve::CloudRetrievalError;
 pub use crate::archive::cloud_storage::shards::{InverseStateChanges, ShardBatch, ShardData};
 use near_external_storage::ExternalConnection;
-use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 
 pub mod config;
@@ -17,6 +16,8 @@ pub mod archive;
 pub mod bucket_config;
 pub mod metrics;
 pub mod retrieve;
+#[cfg(feature = "test_features")]
+pub mod test_utils;
 
 pub(super) mod batch;
 pub(super) mod blocks;
@@ -47,45 +48,38 @@ impl CloudStorage {
         self.bucket_config.batch_size()
     }
 
-    pub fn get_state_header(
-        &self,
-        epoch_height: EpochHeight,
-        epoch_id: EpochId,
-        shard_id: ShardId,
-    ) -> Result<ShardStateSyncResponseHeader, CloudRetrievalError> {
-        let fut = self.retrieve_state_header(epoch_height, epoch_id, shard_id);
-        block_on_future(fut)
-    }
-
-    pub fn is_state_header_stored(
+    pub async fn is_state_header_stored(
         &self,
         epoch_height: EpochHeight,
         epoch_id: EpochId,
         shard_id: ShardId,
     ) -> Result<bool, CloudRetrievalError> {
         let dir = ListableCloudDir::StateHeader { epoch_height, epoch_id, shard_id };
-        block_on_future(self.dir_contains(&dir, "header"))
+        self.dir_contains(&dir, "header").await
     }
 
-    pub fn get_epoch_data(&self, epoch_id: EpochId) -> Result<EpochData, CloudRetrievalError> {
-        block_on_future(self.retrieve_epoch_data(epoch_id))
+    pub async fn get_epoch_data(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<EpochData, CloudRetrievalError> {
+        self.retrieve_epoch_data(epoch_id).await
     }
 
     /// Highest height whose block data is in the bucket, if the writer has
     /// published a block head at all.
-    pub fn get_cloud_block_head(&self) -> Result<Option<BlockHeight>, CloudRetrievalError> {
-        block_on_future(self.retrieve_cloud_block_head_if_exists())
+    pub async fn get_cloud_block_head(&self) -> Result<Option<BlockHeight>, CloudRetrievalError> {
+        self.retrieve_cloud_block_head_if_exists().await
     }
 
     /// Fetches the full block batch containing `block_height`. There is no
     /// single-block fetch on purpose, so callers cannot accidentally call one
     /// in a loop over consecutive heights.
-    pub fn get_block_batch_for_height(
+    pub async fn get_block_batch_for_height(
         &self,
         block_height: BlockHeight,
     ) -> Result<BlockBatch, CloudRetrievalError> {
         let batch_id = compute_batch_id(block_height, self.batch_size());
-        let batch = block_on_future(self.retrieve_block_batch(batch_id))?;
+        let batch = self.retrieve_block_batch(batch_id).await?;
         if block_height < batch.start_height() || block_height > batch.end_height() {
             // Batch is partial and doesn't cover the requested height (e.g. pre-writer-init).
             return Err(CloudRetrievalError::NoBlockData { height: block_height });
@@ -95,50 +89,19 @@ impl CloudStorage {
 
     /// Fetches the full shard batch containing `block_height`. See
     /// `get_block_batch_for_height`.
-    pub fn get_shard_batch_for_height(
+    pub async fn get_shard_batch_for_height(
         &self,
         block_height: BlockHeight,
         shard_id: ShardId,
     ) -> Result<ShardBatch, CloudRetrievalError> {
         let batch_id = compute_batch_id(block_height, self.batch_size());
-        let batch = block_on_future(self.retrieve_shard_batch(shard_id, batch_id))?;
+        let batch = self.retrieve_shard_batch(shard_id, batch_id).await?;
         if block_height < batch.start_height() || block_height > batch.end_height() {
             // Batch is partial and doesn't cover the requested height (e.g. pre-resharding child).
             return Err(CloudRetrievalError::NoShardData { height: block_height, shard_id });
         }
         Ok(batch)
     }
-
-    /// Test-only: fetch a single block's data. Production callers must go
-    /// through `get_block_batch_for_height` so consecutive-height loops
-    /// reuse the batch. Tests don't care about that cost. Returns `Ok(None)`
-    /// when the height has no block (skipped slot).
-    #[cfg(feature = "test_features")]
-    pub fn get_block_data(
-        &self,
-        block_height: BlockHeight,
-    ) -> Result<Option<BlockData>, CloudRetrievalError> {
-        let batch = self.get_block_batch_for_height(block_height)?;
-        Ok(batch.get_block_at_height(block_height).cloned())
-    }
-
-    /// Test-only: fetch a single shard's data. See `get_block_data`. Returns
-    /// `Ok(None)` when the height has no block.
-    #[cfg(feature = "test_features")]
-    pub fn get_shard_data(
-        &self,
-        block_height: BlockHeight,
-        shard_id: ShardId,
-    ) -> Result<Option<ShardData>, CloudRetrievalError> {
-        let batch = self.get_shard_batch_for_height(block_height, shard_id)?;
-        Ok(batch.get_data_at_height(block_height).cloned())
-    }
-}
-
-// TODO(cloud_archival): This is a temporary solution for development.
-// Ensure the final implementation does not negatively impact or crash the application.
-fn block_on_future<F: Future>(fut: F) -> F::Output {
-    futures::executor::block_on(fut)
 }
 
 /// Columns the cloud-archive reader reproduces from cloud data.

--- a/core/store/src/archive/cloud_storage/test_utils.rs
+++ b/core/store/src/archive/cloud_storage/test_utils.rs
@@ -1,0 +1,40 @@
+use crate::archive::cloud_storage::{BlockData, CloudRetrievalError, CloudStorage, ShardData};
+use near_primitives::state_sync::ShardStateSyncResponseHeader;
+use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
+
+/// Single-item fetches, and the state header, in the blocking form tests call them in.
+/// Production callers go through the batch fetches on `CloudStorage`, so consecutive-height
+/// loops reuse a batch, and await them rather than blocking a thread on the retrieval.
+impl CloudStorage {
+    pub fn get_state_header(
+        &self,
+        epoch_height: EpochHeight,
+        epoch_id: EpochId,
+        shard_id: ShardId,
+    ) -> Result<ShardStateSyncResponseHeader, CloudRetrievalError> {
+        block_on_future(self.retrieve_state_header(epoch_height, epoch_id, shard_id))
+    }
+
+    /// One block's data. `Ok(None)` when the height has no block, a skipped slot.
+    pub fn get_block_data(
+        &self,
+        block_height: BlockHeight,
+    ) -> Result<Option<BlockData>, CloudRetrievalError> {
+        let batch = block_on_future(self.get_block_batch_for_height(block_height))?;
+        Ok(batch.get_block_at_height(block_height).cloned())
+    }
+
+    /// One shard's data at one height. `Ok(None)` when the height has no block.
+    pub fn get_shard_data(
+        &self,
+        block_height: BlockHeight,
+        shard_id: ShardId,
+    ) -> Result<Option<ShardData>, CloudRetrievalError> {
+        let batch = block_on_future(self.get_shard_batch_for_height(block_height, shard_id))?;
+        Ok(batch.get_data_at_height(block_height).cloned())
+    }
+}
+
+fn block_on_future<F: Future>(fut: F) -> F::Output {
+    futures::executor::block_on(fut)
+}

--- a/core/store/src/archive/cloud_storage/test_utils.rs
+++ b/core/store/src/archive/cloud_storage/test_utils.rs
@@ -1,6 +1,7 @@
 use crate::archive::cloud_storage::{BlockData, CloudRetrievalError, CloudStorage, ShardData};
 use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
+use std::future::Future;
 
 /// Single-item fetches, and the state header, in the blocking form tests call them in.
 /// Production callers go through the batch fetches on `CloudStorage`, so consecutive-height

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -6,7 +6,7 @@ use crate::utils::cloud_archival::{
     ReshardingInfo, WriterConfig, add_writer_node, apply_writer_settings,
     assert_reader_writer_parity, assert_resharding_epoch_snapshot_forced,
     assert_writer_inverse_deltas, bootstrap_historical_reader, build_shard_tries,
-    check_account_balance, check_data_at_height_for_shards, epoch_id_at,
+    check_account_balance, check_data_at_height_for_shards, epoch_id_at, exec,
     gc_and_heads_sanity_checks, get_cloud_storage, get_local_min_head, get_state_header_for_epoch,
     get_writer_handle, has_state_root, run_node_until, run_until_one_epoch_after_resharding,
     simulate_lagging_shard, snapshots_sanity_check, stop_and_restart_node,
@@ -483,8 +483,7 @@ impl CloudArchiveHarness {
     }
 
     fn block_batch_exists_at(&self, block_height: BlockHeight) -> bool {
-        get_cloud_storage(&self.env, &self.writer_id)
-            .get_block_batch_for_height(block_height)
+        exec(get_cloud_storage(&self.env, &self.writer_id).get_block_batch_for_height(block_height))
             .is_ok()
     }
 
@@ -880,11 +879,11 @@ fn test_cloud_archival_custom_snapshot_cadence() {
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
 
     // Epoch 4 was snapshotted: first probe hits.
-    let hit_at_45 = find_snapshot_at_or_before(&cloud_storage, 45, shard_id).unwrap();
+    let hit_at_45 = exec(find_snapshot_at_or_before(&cloud_storage, 45, shard_id)).unwrap();
     assert_eq!(hit_at_45, (4, epoch_id_at(&cloud_storage, 45)));
 
     // Epoch 3 was skipped: probe misses, walks back to epoch 2.
-    let hit_at_35 = find_snapshot_at_or_before(&cloud_storage, 35, shard_id).unwrap();
+    let hit_at_35 = exec(find_snapshot_at_or_before(&cloud_storage, 35, shard_id)).unwrap();
     assert_eq!(hit_at_35, (2, epoch_id_at(&cloud_storage, 25)));
 
     h.shutdown();
@@ -909,7 +908,7 @@ fn test_cloud_archival_find_snapshot_with_missing_epoch_boundary() {
     h.assert_snapshots_ok();
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
-    let batch = cloud_storage.get_block_batch_for_height(dropped_height).unwrap();
+    let batch = exec(cloud_storage.get_block_batch_for_height(dropped_height)).unwrap();
     assert!(
         batch.get_block_at_height(dropped_height).is_none(),
         "block at h={dropped_height} must be None in cloud"
@@ -919,7 +918,7 @@ fn test_cloud_archival_find_snapshot_with_missing_epoch_boundary() {
     // Probe at height 35 (epoch 3, no snapshot). The walk-back lands on
     // `epoch_start_3 - 1 = 29` which is the dropped block; the function must
     // walk further down to a present block in epoch 2 and find its snapshot.
-    let hit = find_snapshot_at_or_before(&cloud_storage, 35, shard_id).unwrap();
+    let hit = exec(find_snapshot_at_or_before(&cloud_storage, 35, shard_id)).unwrap();
     assert_eq!(hit, (2, epoch_id_at(&cloud_storage, 25)));
 
     h.shutdown();
@@ -941,7 +940,7 @@ fn test_cloud_archival_single_skipped_slot() {
     h.run_until_epoch(3);
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
-    let batch = cloud_storage.get_block_batch_for_height(dropped_height).unwrap();
+    let batch = exec(cloud_storage.get_block_batch_for_height(dropped_height)).unwrap();
     assert!(batch.get_block_at_height(dropped_height).is_none());
     assert!(h.local_min_head() > dropped_height);
     h.assert_heads_ok_before_gc();
@@ -950,7 +949,7 @@ fn test_cloud_archival_single_skipped_slot() {
     let epoch_of = |height| epoch_id_at(&cloud_storage, height);
     // start and target straddle an epoch boundary, so reconstruction crosses it.
     assert_ne!(epoch_of(start), epoch_of(target), "start and target must be in different epochs");
-    let target_epoch_data = cloud_storage.get_epoch_data(epoch_of(target)).unwrap();
+    let target_epoch_data = exec(cloud_storage.get_epoch_data(epoch_of(target))).unwrap();
     // The dropped slot is in the target epoch within the bootstrap range; it
     // pushes that epoch's sync block past the target, so the reader cannot use
     // the target epoch's own snapshot and must walk back to an earlier one.
@@ -991,7 +990,7 @@ fn test_cloud_archival_bootstrap_snapshot_in_earlier_epoch() {
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
     let shard_id = CloudArchiveHarness::all_shard_ids()[0];
     let (_, snapshot_epoch_id) =
-        find_snapshot_at_or_before(&cloud_storage, start, shard_id).unwrap();
+        exec(find_snapshot_at_or_before(&cloud_storage, start, shard_id)).unwrap();
     let start_epoch_id = epoch_id_at(&cloud_storage, start);
     assert_ne!(snapshot_epoch_id, start_epoch_id, "snapshot must resolve to an earlier epoch");
 
@@ -1016,7 +1015,7 @@ fn test_cloud_archival_fully_skipped_batch() {
     h.run_until_epoch(3);
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
-    let batch = cloud_storage.get_block_batch_for_height(12).unwrap();
+    let batch = exec(cloud_storage.get_block_batch_for_height(12)).unwrap();
     for h_drop in &dropped_heights {
         assert!(
             batch.get_block_at_height(*h_drop).is_none(),
@@ -1034,7 +1033,7 @@ fn test_cloud_archival_fully_skipped_batch() {
     let epoch_above = epoch_id_at(&cloud_storage, first_above_gap);
     assert_ne!(epoch_below, epoch_above, "the gap must straddle an epoch boundary");
     assert_eq!(
-        cloud_storage.get_epoch_data(epoch_above).unwrap().epoch_start_height(),
+        exec(cloud_storage.get_epoch_data(epoch_above)).unwrap().epoch_start_height(),
         first_above_gap,
         "the epoch above the gap must start at its first present block"
     );
@@ -1094,7 +1093,7 @@ fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
     // Confirm the drops actually landed in cloud storage before bootstrap.
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
     for &dropped in &[start, target] {
-        let batch = cloud_storage.get_block_batch_for_height(dropped).unwrap();
+        let batch = exec(cloud_storage.get_block_batch_for_height(dropped)).unwrap();
         assert!(
             batch.get_block_at_height(dropped).is_none(),
             "block at h={dropped} must be None in cloud"
@@ -1104,7 +1103,7 @@ fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
     // the target's epoch is missing in cloud for the dropped shard.
     let target_epoch_id = epoch_id_at(&cloud_storage, 25);
     let target_epoch_start =
-        cloud_storage.get_epoch_data(target_epoch_id).unwrap().epoch_start_height();
+        exec(cloud_storage.get_epoch_data(target_epoch_id)).unwrap().epoch_start_height();
     let chunk_drop_height = target_epoch_start + 5;
     assert!(
         cloud_storage
@@ -1166,7 +1165,7 @@ fn test_cloud_archival_anchor_below_sync_prev() {
     // back from the archive head so the one we pick is finished and snapshotted.
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
     let epoch_id = epoch_id_at(&cloud_storage, h.local_min_head() - EPOCH_LENGTH);
-    let epoch_data = cloud_storage.get_epoch_data(epoch_id).unwrap();
+    let epoch_data = exec(cloud_storage.get_epoch_data(epoch_id)).unwrap();
     let epoch_start = epoch_data.epoch_start_height();
 
     // The snapshot is taken at the first height where every shard has had two new
@@ -1251,7 +1250,8 @@ fn test_cloud_archival_missing_chunks_one_shard() {
     for epoch in [1u64, 2] {
         let probe = epoch * h.epoch_length + h.epoch_length / 2;
         let epoch_id = epoch_id_at(&cloud_storage, probe);
-        let epoch_start = cloud_storage.get_epoch_data(epoch_id).unwrap().epoch_start_height();
+        let epoch_start =
+            exec(cloud_storage.get_epoch_data(epoch_id)).unwrap().epoch_start_height();
         for offset in dropped_offsets {
             let height = epoch_start + offset;
             let dropped = cloud_storage.get_shard_data(height, dropped_shard).unwrap().unwrap();
@@ -1675,7 +1675,7 @@ fn test_cloud_archival_writer_resharding_batch_boundary() {
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
     let shard_batch =
-        |height, shard| cloud_storage.get_shard_batch_for_height(height, shard).unwrap();
+        |height, shard| exec(cloud_storage.get_shard_batch_for_height(height, shard)).unwrap();
     let spans_boundary = |start: BlockHeight, end: BlockHeight| {
         start <= r.resharding_block_height && end > r.resharding_block_height
     };
@@ -1695,7 +1695,8 @@ fn test_cloud_archival_writer_resharding_batch_boundary() {
         spans_boundary(carried_batch.start_height(), carried_batch.end_height()),
         "carried-over shard batch must span the resharding boundary"
     );
-    let block_batch = cloud_storage.get_block_batch_for_height(r.resharding_block_height).unwrap();
+    let block_batch =
+        exec(cloud_storage.get_block_batch_for_height(r.resharding_block_height)).unwrap();
     assert!(
         spans_boundary(block_batch.start_height(), block_batch.end_height()),
         "block batch must span the resharding boundary"
@@ -1729,7 +1730,7 @@ fn test_cloud_archival_writer_resharding_on_batch_boundary() {
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
     let shard_batch =
-        |height, shard| cloud_storage.get_shard_batch_for_height(height, shard).unwrap();
+        |height, shard| exec(cloud_storage.get_shard_batch_for_height(height, shard)).unwrap();
 
     assert_eq!(
         shard_batch(r.resharding_block_height, r.parent_shard).end_height(),
@@ -1756,7 +1757,8 @@ fn test_cloud_archival_writer_resharding_inverse_deltas() {
     let r = h.run_until_one_epoch_after_resharding();
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
-    let gap_batch = cloud_storage.get_block_batch_for_height(r.new_epoch_first_height).unwrap();
+    let gap_batch =
+        exec(cloud_storage.get_block_batch_for_height(r.new_epoch_first_height)).unwrap();
     assert!(
         gap_batch.start_height() <= r.resharding_block_height,
         "the gap block must share the batch that straddles the resharding boundary"
@@ -1777,7 +1779,8 @@ fn test_cloud_archival_writer_resharding_inverse_deltas_batch_size_1() {
     let r = h.run_until_one_epoch_after_resharding();
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
-    let gap_batch = cloud_storage.get_block_batch_for_height(r.new_epoch_first_height).unwrap();
+    let gap_batch =
+        exec(cloud_storage.get_block_batch_for_height(r.new_epoch_first_height)).unwrap();
     assert!(
         gap_batch.start_height() > r.resharding_block_height,
         "the resharding boundary and the first gap block must fall in separate batches"
@@ -2035,8 +2038,7 @@ fn test_cloud_archival_recent_reader() {
 
     // The reader takes whole batches, so its head may trail the bucket by one.
     let head = h.recent_reader_height();
-    let bucket_head = get_cloud_storage(&h.env, &h.writer_id)
-        .get_cloud_block_head()
+    let bucket_head = exec(get_cloud_storage(&h.env, &h.writer_id).get_cloud_block_head())
         .expect("reading the bucket's block head")
         .expect("the writer published a block head");
     assert!(head <= bucket_head, "the reader passed the bucket: {head} over {bucket_head}");
@@ -2146,7 +2148,8 @@ fn test_cloud_archival_reader_clears_forked_height() {
     let head = h.recent_reader_height();
     assert!(forked_height <= head, "the reader stopped at {head}, below the forked height");
     let batch =
-        get_cloud_storage(&h.env, &h.writer_id).get_block_batch_for_height(forked_height).unwrap();
+        exec(get_cloud_storage(&h.env, &h.writer_id).get_block_batch_for_height(forked_height))
+            .unwrap();
     assert!(
         batch.get_block_at_height(forked_height).is_none(),
         "the archive must report h={forked_height} empty"

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -126,7 +126,7 @@ pub fn run_until_one_epoch_after_resharding(
     }
 }
 
-fn execute_future<F: Future>(fut: F) -> F::Output {
+pub(crate) fn exec<F: Future>(fut: F) -> F::Output {
     // If this causes issues, use the testloop future spawner and wait for 0 blocks so the
     // event loop can run it.
     futures::executor::block_on(fut)
@@ -169,8 +169,7 @@ pub fn gc_and_heads_sanity_checks(
     let head = chain_store.head().unwrap();
     let shard_layout = client.epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
     for shard_id in shard_layout.shard_ids() {
-        let ext_shard_head =
-            execute_future(cloud_storage.retrieve_cloud_shard_head_if_exists(shard_id));
+        let ext_shard_head = exec(cloud_storage.retrieve_cloud_shard_head_if_exists(shard_id));
         match ext_shard_head {
             Ok(Some(shard_head)) => {
                 assert!(
@@ -234,7 +233,8 @@ pub(crate) fn get_state_header_for_epoch(
     epoch_id: EpochId,
     shard_id: ShardId,
 ) -> ShardStateSyncResponseHeader {
-    let epoch_height = cloud_storage.get_epoch_data(epoch_id).unwrap().epoch_info().epoch_height();
+    let epoch_height =
+        exec(cloud_storage.get_epoch_data(epoch_id)).unwrap().epoch_info().epoch_height();
     cloud_storage.get_state_header(epoch_height, epoch_id, shard_id).unwrap()
 }
 
@@ -275,7 +275,7 @@ pub(crate) fn simulate_lagging_shard(
     let node_data = env.get_node_data_by_account_id(writer_id);
     let identifier = node_data.identifier.clone();
     let node_state = env.kill_node(&identifier);
-    execute_future(cloud_storage.update_cloud_shard_head(shard_id, target_height)).unwrap();
+    exec(cloud_storage.update_cloud_shard_head(shard_id, target_height)).unwrap();
     let new_identifier = format!("{}-restart", identifier);
     env.restart_node(&new_identifier, node_state);
 }
@@ -376,7 +376,7 @@ pub fn snapshots_sanity_check(
         let mut num_shards_with_snapshot = 0;
         for shard_id in &shards {
             let fut = cloud_storage.retrieve_state_header(epoch_height, epoch_id, *shard_id);
-            let state_header = execute_future(fut);
+            let state_header = exec(fut);
             if state_header.is_ok() {
                 num_shards_with_snapshot += 1;
             }
@@ -391,7 +391,7 @@ pub fn snapshots_sanity_check(
                 shards.len(),
             )
         }
-        if cloud_storage.get_epoch_data(epoch_id).is_ok() {
+        if exec(cloud_storage.get_epoch_data(epoch_id)).is_ok() {
             epoch_heights_with_epoch_data.insert(epoch_height);
         }
     }
@@ -525,7 +525,7 @@ pub fn assert_resharding_epoch_snapshot_forced(
         "test needs the resharding epoch off the snapshot cadence"
     );
     for &shard_uid in &info.new_shard_uids {
-        let state_header = execute_future(cloud_storage.retrieve_state_header(
+        let state_header = exec(cloud_storage.retrieve_state_header(
             resharding_epoch_height,
             resharding_epoch_id,
             shard_uid.shard_id(),
@@ -552,13 +552,13 @@ pub fn bootstrap_historical_reader(
         let client = env.node_for_account(reader_id).client();
         let store = client.chain.chain_store.store();
         let epoch_manager = client.epoch_manager.clone();
-        bootstrap_range(
+        exec(bootstrap_range(
             &store,
             &cloud_storage,
             epoch_manager.as_ref(),
             start_height,
             target_block_height,
-        )
+        ))
         .expect("bootstrap_range should succeed");
     }
 
@@ -566,9 +566,9 @@ pub fn bootstrap_historical_reader(
     // carries no data, so snap it down to the nearest present block at or below
     // it (no state changes between them).
     let (target_block_height, target_block_data) =
-        find_present_block_below(&cloud_storage, target_block_height + 1).unwrap();
+        exec(find_present_block_below(&cloud_storage, target_block_height + 1)).unwrap();
     let target_epoch_id = *target_block_data.block().header().epoch_id();
-    let target_epoch_data = cloud_storage.get_epoch_data(target_epoch_id).unwrap();
+    let target_epoch_data = exec(cloud_storage.get_epoch_data(target_epoch_id)).unwrap();
 
     let chain = &env.node_for_account(reader_id).client().chain;
     let store = chain.chain_store.store();
@@ -583,7 +583,7 @@ pub fn bootstrap_historical_reader(
         // Reconstruct from the nearest snapshot at or below the bootstrap start,
         // loaded from cloud state parts, then apply deltas forward to the target.
         let (snapshot_epoch_height, snapshot_epoch_id) =
-            find_snapshot_at_or_before(&cloud_storage, start_height, shard_id).unwrap();
+            exec(find_snapshot_at_or_before(&cloud_storage, start_height, shard_id)).unwrap();
         // Both values come off the header's single chunk, so the state root and
         // the height it applies at cannot disagree.
         let state_header = cloud_storage
@@ -593,7 +593,7 @@ pub fn bootstrap_historical_reader(
         let reconstruction_start_height = state_header.chunk_height_included();
 
         assert!(!has_state_root(&tries, shard_uid, state_sync_state_root));
-        execute_future(download_and_apply_state_snapshot(
+        exec(download_and_apply_state_snapshot(
             &tries,
             &cloud_storage,
             &snapshot_epoch_id,

--- a/tools/cloud-archive/src/bootstrap_reader.rs
+++ b/tools/cloud-archive/src/bootstrap_reader.rs
@@ -41,20 +41,20 @@ impl BootstrapReaderCmd {
             .cloud_storage_context()
             .context("cloud_archival not configured in config.json")?;
 
-        // Opening cloud storage and every retrieval below run on tokio, and this command
-        // is not async. Multi-threaded on purpose: the retrievals are polled by a foreign
-        // executor, so tokio's driver needs worker threads of its own to make progress.
+        // Opening cloud storage builds an HTTP client that captures a runtime handle, and
+        // this command is not async.
         let tokio_runtime = Runtime::new().expect("failed to create the tokio runtime");
-        let _runtime_guard = tokio_runtime.enter();
-
-        let storage = NodeStorage::opener(
-            home_dir,
-            &near_config.config.store,
-            near_config.config.cold_store.as_ref(),
-            Some(cloud_storage_context),
-        )
-        .open_in_mode(Mode::ReadWrite)
-        .context("failed to open storage")?;
+        let storage = {
+            let _runtime_guard = tokio_runtime.enter();
+            NodeStorage::opener(
+                home_dir,
+                &near_config.config.store,
+                near_config.config.cold_store.as_ref(),
+                Some(cloud_storage_context),
+            )
+            .open_in_mode(Mode::ReadWrite)
+            .context("failed to open storage")?
+        };
 
         let store = storage.get_hot_store();
         let cloud_storage =
@@ -66,13 +66,13 @@ impl BootstrapReaderCmd {
             Some(home_dir),
         );
 
-        bootstrap_range(
+        tokio_runtime.block_on(bootstrap_range(
             &store,
             &cloud_storage,
             epoch_manager.as_ref(),
             self.start_height,
             self.end_height,
-        )?;
+        ))?;
 
         tracing::info!(
             start_height = self.start_height,


### PR DESCRIPTION
Every read from the bucket went through `futures::executor::block_on`, so a retrieval parked the calling thread while a foreign executor drove the future underneath it. The reader now awaits its reads, all the way out to `bootstrap_range` and the recent reader's loop.

`bootstrap-reader` is not async and now drives the walk on its own runtime, which shrinks the runtime guard there to the one thing that still needs it, opening cloud storage.

That left the single-item fetches only tests reach, and the blocking helper behind them, as the last users of `block_on`. They move to `cloud_storage/test_utils.rs` behind one `test_features` gate, so nothing outside tests blocks on a retrieval any more.
