### PR TITLE
fix(audit): ignore wasmtime wasi problem

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -41,6 +41,11 @@ ignore = [
     # never mixes Engine-owned objects.
     "RUSTSEC-2026-0222",
 
+    # RUSTSEC-2026-0269: the sandbox escape is in Wasmtime's WASI filesystem
+    # implementation. Nearcore uses Wasmtime to execute contracts with its own
+    # host functions and does not enable or link Wasmtime's WASI support.
+    "RUSTSEC-2026-0269",
+
     # bitmaps is unmaintained (repo archived 2026-05-03), but imbl depends on it
     # and every version is affected, so there is nothing to upgrade to. imbl is
     # itself the maintained replacement for im, which nearcore used before.


### PR DESCRIPTION
Cargo audit is failing because of an issue in wasmtime 0.45.0: https://rustsec.org/advisories/RUSTSEC-2026-0269

This issue doesn't affect near, as we don't use the wasi filesystem API.

An alternative solution would be to bump wasmtime to `46.0.3` or higher

```
Crate:     wasmtime
Version:   45.0.0
Title:     Filesystem sandbox escape when paths or symlinks contain trailing slashes
Date:      2026-08-20
ID:        RUSTSEC-2026-0269
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0269
Severity:  8.8 (high)
Solution:  Upgrade to >=24.0.13, <25.0.0 OR >=36.0.14, <37.0.0 OR >=46.0.3, <47.0.0 OR >=47.0.4
Dependency tree:
wasmtime 45.0.0
└── near-vm-runner 0.0.0
```