### PR TITLE
feat(cloud-archive): the reader takes partial shard batches

### DIFF
--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -123,9 +123,27 @@ pub(crate) async fn pull_shard_batch(
     from_height: BlockHeight,
 ) -> Result<(), CloudArchivalReaderError> {
     let shard_batch = cloud_storage.get_shard_batch(from_height, shard_uid.shard_id()).await?;
+    // A shard the reader still tracks at `from_height` cannot have a batch that ended
+    // below it: a retired shard's batch ends where the epoch it belonged to does.
+    if shard_batch.end_height() < from_height {
+        return Err(CloudRetrievalError::NoShardData {
+            height: from_height,
+            shard_id: shard_uid.shard_id(),
+        }
+        .into());
+    }
     // TODO(cloud_archival): in case of resharding, install the shard's state from its epoch
     // snapshot and walk the recorded inverse changes down.
-    let start_height = std::cmp::max(from_height, shard_batch.start_height());
+    let mut start_height = from_height;
+    if shard_batch.start_height() > from_height {
+        tracing::info!(
+            %shard_uid,
+            from_height,
+            batch_start = shard_batch.start_height(),
+            "shard opens inside the batch, so a resharding added it there",
+        );
+        start_height = shard_batch.start_height();
+    }
     let mut update = store.store_update();
     for height in start_height..=shard_batch.end_height() {
         if let Some(shard_data) = shard_batch.get_data_at_height(height) {

--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -114,8 +114,9 @@ pub(crate) async fn pull_block_batch(
     })
 }
 
-/// Downloads the batch of `shard_id` data that `from_height` falls in and writes the rows
-/// it holds at that height and above in one commit.
+/// Downloads `shard_uid`'s batch for the window `from_height` falls in and writes the
+/// rows it carries at or above that height, in one commit. A batch that opens above
+/// `from_height`, which is a shard a resharding added there, is written from its own start.
 pub(crate) async fn pull_shard_batch(
     store: &Store,
     cloud_storage: &CloudStorage,

--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -1,7 +1,9 @@
 use near_chain::Error;
 use near_epoch_manager::EpochManagerAdapter;
+use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::get_block_shard_uid;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::{get_block_shard_id, index_to_bytes};
 use near_store::adapter::StoreUpdateAdapter;
@@ -9,7 +11,7 @@ use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::archive::cloud_storage::{
     BlockData, CloudRetrievalError, CloudStorage, EpochData, ShardData,
 };
-use near_store::{DBCol, Store, StoreUpdate};
+use near_store::{DBCol, ShardUId, Store, StoreUpdate};
 use std::collections::HashSet;
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
@@ -112,6 +114,28 @@ pub(crate) async fn pull_block_batch(
     })
 }
 
+/// Downloads the batch of `shard_id` data that `from_height` falls in and writes the rows
+/// it holds at that height and above in one commit.
+pub(crate) async fn pull_shard_batch(
+    store: &Store,
+    cloud_storage: &CloudStorage,
+    shard_uid: ShardUId,
+    from_height: BlockHeight,
+) -> Result<(), CloudArchivalReaderError> {
+    let shard_batch = cloud_storage.get_shard_batch(from_height, shard_uid.shard_id()).await?;
+    // TODO(cloud_archival): in case of resharding, install the shard's state from its epoch
+    // snapshot and walk the recorded inverse changes down.
+    let start_height = std::cmp::max(from_height, shard_batch.start_height());
+    let mut update = store.store_update();
+    for height in start_height..=shard_batch.end_height() {
+        if let Some(shard_data) = shard_batch.get_data_at_height(height) {
+            save_shard_data(&mut update, shard_uid, shard_data);
+        }
+    }
+    update.commit();
+    Ok(())
+}
+
 /// Seeds the store with what the epoch manager needs to answer for `height`, and
 /// returns the hash of the nearest present block below it. `height` must therefore
 /// be above the first archived block.
@@ -144,19 +168,21 @@ pub(crate) async fn install_anchors(
     Ok(prev_block_hash)
 }
 
-/// The shards of both epochs a batch can hold blocks in.
-pub(crate) fn batch_shard_ids(
+/// The shards this reader tracks in both epochs a batch can hold blocks in.
+pub(crate) fn shards_tracked_in_batch(
     epoch_manager: &dyn EpochManagerAdapter,
+    shard_tracker: &ShardTracker,
     prev_block_hash: &CryptoHash,
     opening_epoch_id: Option<EpochId>,
-) -> Result<HashSet<ShardId>, CloudArchivalReaderError> {
+) -> Result<HashSet<ShardUId>, CloudArchivalReaderError> {
     let batch_epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
-    let mut shard_ids: HashSet<ShardId> =
-        epoch_manager.get_shard_layout(&batch_epoch_id)?.shard_ids().collect();
-    if let Some(opening_epoch_id) = opening_epoch_id {
-        shard_ids.extend(epoch_manager.get_shard_layout(&opening_epoch_id)?.shard_ids());
+    let mut epoch_ids = vec![batch_epoch_id];
+    epoch_ids.extend(opening_epoch_id);
+    let mut shard_uids = HashSet::new();
+    for epoch_id in epoch_ids {
+        shard_uids.extend(shard_tracker.get_tracked_shards_for_non_validator_in_epoch(&epoch_id)?);
     }
-    Ok(shard_ids)
+    Ok(shard_uids)
 }
 
 /// Stores how far the reader has taken the archive, and returns that head.
@@ -182,11 +208,22 @@ pub(crate) fn save_epoch_data(update: &mut StoreUpdate, epoch_data: &EpochData) 
 }
 
 /// Writes one shard's columns from its cloud `ShardData` into `update`.
-pub(crate) fn save_shard_data(update: &mut StoreUpdate, shard_id: ShardId, shard_data: &ShardData) {
+pub(crate) fn save_shard_data(
+    update: &mut StoreUpdate,
+    shard_uid: ShardUId,
+    shard_data: &ShardData,
+) {
     // TODO(cloud_archival): reconstruct the remaining shard columns and apply
     // per-block state deltas.
-    let block_shard_id = get_block_shard_id(shard_data.block_hash(), shard_id);
+    let block_hash = shard_data.block_hash();
+    let block_shard_id = get_block_shard_id(block_hash, shard_uid.shard_id());
     update.set_ser(DBCol::ChunkApplyStats, &block_shard_id, shard_data.chunk_apply_stats());
+    // ChunkExtra is the one shard column keyed by the shard's uid.
+    update.set_ser(
+        DBCol::ChunkExtra,
+        &get_block_shard_uid(block_hash, &shard_uid),
+        shard_data.chunk_extra(),
+    );
     if let Some(chunk) = shard_data.chunk() {
         update.insert_ser(DBCol::Chunks, chunk.chunk_hash().as_ref(), chunk);
     }

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -1,8 +1,9 @@
 use crate::archive::cloud_archival_utils::{
-    batch_shard_ids, install_anchors, pull_block_batch, save_reader_head, save_shard_data,
+    install_anchors, pull_block_batch, pull_shard_batch, save_reader_head, shards_tracked_in_batch,
 };
 use near_epoch_manager::EpochManagerAdapter;
-use near_primitives::types::{BlockHeight, ShardId};
+use near_epoch_manager::shard_tracker::ShardTracker;
+use near_primitives::types::BlockHeight;
 use near_store::Store;
 use near_store::archive::cloud_storage::CloudStorage;
 
@@ -17,6 +18,7 @@ pub async fn bootstrap_range(
     store: &Store,
     cloud_storage: &CloudStorage,
     epoch_manager: &dyn EpochManagerAdapter,
+    shard_tracker: &ShardTracker,
     start_height: BlockHeight,
     end_height: BlockHeight,
 ) -> anyhow::Result<()> {
@@ -39,10 +41,14 @@ pub async fn bootstrap_range(
     let mut height = start_height;
     while height <= end_height {
         let batch_pull = pull_block_batch(store, cloud_storage, epoch_manager, height).await?;
-        let shard_ids =
-            batch_shard_ids(epoch_manager, &prev_block_hash, batch_pull.opening_epoch_id)?;
-        for shard_id in shard_ids {
-            save_shard_range(store, cloud_storage, shard_id, height, batch_pull.end_height).await?;
+        let shard_uids = shards_tracked_in_batch(
+            epoch_manager,
+            shard_tracker,
+            &prev_block_hash,
+            batch_pull.opening_epoch_id,
+        )?;
+        for shard_uid in shard_uids {
+            pull_shard_batch(store, cloud_storage, shard_uid, height).await?;
         }
         if let Some(block_hash) = batch_pull.last_present_block_hash {
             prev_block_hash = block_hash;
@@ -58,31 +64,5 @@ pub async fn bootstrap_range(
         }
     }
 
-    Ok(())
-}
-
-/// Writes one shard's data across `[start_height, end_height]`.
-async fn save_shard_range(
-    store: &Store,
-    cloud_storage: &CloudStorage,
-    shard_id: ShardId,
-    start_height: BlockHeight,
-    end_height: BlockHeight,
-) -> anyhow::Result<()> {
-    let mut height = start_height;
-    while height <= end_height {
-        // TODO(cloud_archival): handle a shard whose blob starts above this height,
-        // which a bootstrap crossing a resharding hits.
-        let batch = cloud_storage.get_shard_batch_for_height(height, shard_id).await?;
-        let last_in_batch = std::cmp::min(batch.end_height(), end_height);
-        let mut update = store.store_update();
-        for h in height..=last_in_batch {
-            if let Some(shard_data) = batch.get_data_at_height(h) {
-                save_shard_data(&mut update, shard_id, shard_data);
-            }
-        }
-        update.commit();
-        height = last_in_batch + 1;
-    }
     Ok(())
 }

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -1,6 +1,7 @@
 use crate::archive::cloud_archival_utils::{
     install_anchors, pull_block_batch, pull_shard_batch, save_reader_head, shards_tracked_in_batch,
 };
+use near_chain_configs::TrackedShardsConfig;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::types::BlockHeight;
@@ -28,6 +29,11 @@ pub async fn bootstrap_range(
         start_height,
         end_height,
     );
+    // `tracked_shards_config` defaults to `NoShards`, so a config that never named a
+    // shard bootstraps block data alone.
+    if matches!(shard_tracker.tracked_shards_config(), TrackedShardsConfig::NoShards) {
+        tracing::warn!("tracked_shards_config selects no shards; bootstrapping block data only");
+    }
 
     let mut prev_block_hash =
         install_anchors(store, cloud_storage, epoch_manager, start_height).await?;

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -87,20 +87,16 @@ impl CloudStorage {
         Ok(batch)
     }
 
-    /// Fetches the full shard batch containing `block_height`. See
-    /// `get_block_batch_for_height`.
-    pub async fn get_shard_batch_for_height(
+    /// Fetches the batch of `shard_id` data that `block_height` falls in. The batch can
+    /// open above or end below that height, which is what a shard added or retired by a
+    /// resharding looks like.
+    pub async fn get_shard_batch(
         &self,
         block_height: BlockHeight,
         shard_id: ShardId,
     ) -> Result<ShardBatch, CloudRetrievalError> {
         let batch_id = compute_batch_id(block_height, self.batch_size());
-        let batch = self.retrieve_shard_batch(shard_id, batch_id).await?;
-        if block_height < batch.start_height() || block_height > batch.end_height() {
-            // Batch is partial and doesn't cover the requested height (e.g. pre-resharding child).
-            return Err(CloudRetrievalError::NoShardData { height: block_height, shard_id });
-        }
-        Ok(batch)
+        self.retrieve_shard_batch(shard_id, batch_id).await
     }
 }
 

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -87,9 +87,9 @@ impl CloudStorage {
         Ok(batch)
     }
 
-    /// Fetches the batch of `shard_id` data that `block_height` falls in. The batch can
-    /// open above or end below that height, which is what a shard added or retired by a
-    /// resharding looks like.
+    /// Fetches `shard_id`'s batch for the window `block_height` falls in. What the batch
+    /// carries can open above or end below that height, which is what a shard added or
+    /// retired by a resharding looks like.
     pub async fn get_shard_batch(
         &self,
         block_height: BlockHeight,

--- a/core/store/src/archive/cloud_storage/test_utils.rs
+++ b/core/store/src/archive/cloud_storage/test_utils.rs
@@ -1,4 +1,6 @@
-use crate::archive::cloud_storage::{BlockData, CloudRetrievalError, CloudStorage, ShardData};
+use crate::archive::cloud_storage::{
+    BlockData, CloudRetrievalError, CloudStorage, ShardBatch, ShardData,
+};
 use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use std::future::Future;
@@ -25,13 +27,27 @@ impl CloudStorage {
         Ok(batch.get_block_at_height(block_height).cloned())
     }
 
+    /// The batch of `shard_id` data covering `block_height`, rejecting one that opens
+    /// above or ends below it.
+    pub fn get_shard_batch_for_height(
+        &self,
+        block_height: BlockHeight,
+        shard_id: ShardId,
+    ) -> Result<ShardBatch, CloudRetrievalError> {
+        let batch = block_on_future(self.get_shard_batch(block_height, shard_id))?;
+        if block_height < batch.start_height() || block_height > batch.end_height() {
+            return Err(CloudRetrievalError::NoShardData { height: block_height, shard_id });
+        }
+        Ok(batch)
+    }
+
     /// One shard's data at one height. `Ok(None)` when the height has no block.
     pub fn get_shard_data(
         &self,
         block_height: BlockHeight,
         shard_id: ShardId,
     ) -> Result<Option<ShardData>, CloudRetrievalError> {
-        let batch = block_on_future(self.get_shard_batch_for_height(block_height, shard_id))?;
+        let batch = self.get_shard_batch_for_height(block_height, shard_id)?;
         Ok(batch.get_data_at_height(block_height).cloned())
     }
 }

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -264,6 +264,15 @@ impl CloudArchiveHarnessBuilder {
     }
 }
 
+/// Which reader a check runs against.
+#[derive(Clone, Copy)]
+enum Reader {
+    Historical,
+    // TODO(cloud_archival): construct this once the recent reader writes shard rows.
+    #[allow(dead_code)]
+    Recent,
+}
+
 impl CloudArchiveHarness {
     const DEFAULT_EPOCH_LENGTH: BlockHeightDelta = 10;
     /// The node the recent reader takes over from. Every test runs one.
@@ -439,13 +448,15 @@ impl CloudArchiveHarness {
         );
     }
 
-    fn assert_reader_writer_parity(&self, start: BlockHeight, end: BlockHeight) {
-        assert_reader_writer_parity(
-            &self.historical_reader_store(),
-            &self.writer_store(),
-            start,
-            end,
-        );
+    fn reader_store(&self, reader: Reader) -> Store {
+        match reader {
+            Reader::Historical => self.historical_reader_store(),
+            Reader::Recent => self.recent_reader_store(),
+        }
+    }
+
+    fn assert_reader_writer_parity(&self, reader: Reader, start: BlockHeight, end: BlockHeight) {
+        assert_reader_writer_parity(&self.reader_store(reader), &self.writer_store(), start, end);
     }
 
     fn assert_reader_account_balance(&self, account: &AccountId, expected: Balance) {
@@ -681,8 +692,8 @@ fn test_cloud_archival_batching_blob_per_batch() {
 /// state snapshot and per-block state deltas.
 #[test]
 // TODO(cloud_archival): assert the balance against a bootstrapped block once the
-// reader reconstructs ChunkExtra. The query resolves against the chain head, which
-// is genesis here, so the balance comes out of genesis state.
+// reader carries a chain head above genesis. The query resolves against that head,
+// which is genesis here, so the balance comes out of genesis state.
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_use_snapshot() {
@@ -696,7 +707,7 @@ fn test_cloud_archival_use_snapshot() {
     let start = h.epoch_length / 2;
     let target = h.epoch_length + h.epoch_length / 2;
     h.bootstrap_historical_reader(start, target);
-    h.assert_reader_writer_parity(start, target);
+    h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.assert_reader_account_balance(
         &CloudArchiveHarness::USER_ACCOUNT.parse().unwrap(),
         CloudArchiveHarness::USER_BALANCE,
@@ -969,7 +980,7 @@ fn test_cloud_archival_single_skipped_slot() {
     );
 
     h.bootstrap_historical_reader(start, target);
-    h.assert_reader_writer_parity(start, target);
+    h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.kill_historical_reader();
 
     h.shutdown();
@@ -1044,14 +1055,14 @@ fn test_cloud_archival_fully_skipped_batch() {
     // A range spanning the skipped batch: the reader writes nothing for those heights and
     // must still match the writer everywhere else.
     h.bootstrap_historical_reader(start, target);
-    h.assert_reader_writer_parity(start, target);
+    h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.kill_historical_reader();
 
     let gap_target = first_above_gap + h.epoch_length / 2;
     // The corner case the skipped batch creates, covered here: a start height with no
     // block of its own, above the last block of one epoch and below the first of the next.
     h.bootstrap_historical_reader(dropped_heights[0], gap_target);
-    h.assert_reader_writer_parity(dropped_heights[0], gap_target);
+    h.assert_reader_writer_parity(Reader::Historical, dropped_heights[0], gap_target);
     h.kill_historical_reader();
 
     h.shutdown();
@@ -1063,8 +1074,8 @@ fn test_cloud_archival_fully_skipped_batch() {
 /// path during state apply.
 #[test]
 // TODO(cloud_archival): assert the balance against a bootstrapped block once the
-// reader reconstructs ChunkExtra. The query resolves against the chain head, which
-// is genesis here, so the balance comes out of genesis state.
+// reader carries a chain head above genesis. The query resolves against that head,
+// which is genesis here, so the balance comes out of genesis state.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
     assert_eq!(CloudArchiveHarness::DEFAULT_EPOCH_LENGTH, 10);
@@ -1116,7 +1127,7 @@ fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
     );
 
     h.bootstrap_historical_reader(start, target);
-    h.assert_reader_writer_parity(start, target);
+    h.assert_reader_writer_parity(Reader::Historical, start, target);
     // A correct balance proves bootstrap completed without panic, the trie
     // was reconstructed up to the last present block at or below the target,
     // and the carried-over chunk path was traversed during state apply.
@@ -1279,7 +1290,7 @@ fn test_cloud_archival_missing_chunks_one_shard() {
     let start = h.epoch_length / 2;
     let target = 3 * h.epoch_length;
     h.bootstrap_historical_reader(start, target);
-    h.assert_reader_writer_parity(start, target);
+    h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.kill_historical_reader();
 
     h.shutdown();
@@ -1413,7 +1424,7 @@ fn test_cloud_archival_outcomes_and_receipts() {
     assert!(total_receipt_to_tx > 0, "no receipt_to_tx entries were compared");
 
     h.bootstrap_historical_reader(start, end);
-    h.assert_reader_writer_parity(start, end);
+    h.assert_reader_writer_parity(Reader::Historical, start, end);
     h.kill_historical_reader();
 
     h.shutdown();
@@ -1675,7 +1686,7 @@ fn test_cloud_archival_writer_resharding_batch_boundary() {
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
     let shard_batch =
-        |height, shard| exec(cloud_storage.get_shard_batch_for_height(height, shard)).unwrap();
+        |height, shard| cloud_storage.get_shard_batch_for_height(height, shard).unwrap();
     let spans_boundary = |start: BlockHeight, end: BlockHeight| {
         start <= r.resharding_block_height && end > r.resharding_block_height
     };
@@ -1712,6 +1723,10 @@ fn test_cloud_archival_writer_resharding_batch_boundary() {
         "removed parent's local shard head must stop at the resharding block"
     );
 
+    // TODO(cloud_archival): once state reconstruction crosses a resharding, bootstrap from
+    // the height below the resharding block to the height above it and compare against the
+    // writer. Both readers take the batch clamp and the two-layout shard set from there.
+
     h.shutdown();
 }
 
@@ -1730,7 +1745,7 @@ fn test_cloud_archival_writer_resharding_on_batch_boundary() {
 
     let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
     let shard_batch =
-        |height, shard| exec(cloud_storage.get_shard_batch_for_height(height, shard)).unwrap();
+        |height, shard| cloud_storage.get_shard_batch_for_height(height, shard).unwrap();
 
     assert_eq!(
         shard_batch(r.resharding_block_height, r.parent_shard).end_height(),
@@ -1742,6 +1757,10 @@ fn test_cloud_archival_writer_resharding_on_batch_boundary() {
         r.resharding_block_height + 1,
         "new child shard batch must start in the next batch, after the boundary"
     );
+
+    // TODO(cloud_archival): once state reconstruction crosses a resharding, bootstrap over
+    // the resharding block and the height above it, where both readers must leave the child
+    // out of the first batch.
 
     h.shutdown();
 }
@@ -2046,8 +2065,8 @@ fn test_cloud_archival_recent_reader() {
         head + u64::from(CloudArchiveHarness::TEST_BATCH_SIZE) >= bucket_head,
         "the reader did not catch up: head {head}, bucket head {bucket_head}"
     );
-    // TODO(cloud_archival): assert reader-writer parity here once the follower writes
-    // shard rows.
+    // TODO(cloud_archival): assert reader-writer parity here once the recent reader
+    // writes shard rows.
 
     reader.stop();
     h.shutdown();
@@ -2100,7 +2119,8 @@ fn test_cloud_archival_skipped_run_across_batch_edge() {
     let start = first_dropped - h.epoch_length / 2;
     let target = last_dropped + h.epoch_length / 2;
     h.bootstrap_historical_reader(start, target);
-    h.assert_reader_writer_parity(start, target);
+    // TODO(cloud_archival): run this for `Reader::Recent` too, once it writes shard rows.
+    h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.kill_historical_reader();
 
     reader.stop();

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -534,6 +534,22 @@ pub fn assert_resharding_epoch_snapshot_forced(
     }
 }
 
+/// Brings up a reader node tracking every shard, and returns its store.
+pub(crate) fn add_reader_node(env: &mut TestLoopEnv, reader_id: &AccountId) -> Store {
+    let node_state = env
+        .node_state_builder()
+        .account_id(reader_id)
+        .cloud_storage(true)
+        // TODO(cloud_archival): cover with test a reader on `TrackedShardsConfig::Shards`,
+        // where `shards_tracked_in_batch` returns a subset of the layout.
+        .config_modifier(|config| {
+            config.tracked_shards_config = TrackedShardsConfig::AllShards;
+        })
+        .build();
+    env.add_node(reader_id.as_ref(), node_state);
+    env.node_for_account(reader_id).client().chain.chain_store().store()
+}
+
 /// Bootstraps a reader node by downloading blocks from cloud and applying
 /// state sync to reconstruct the state at `target_block_height`.
 pub fn bootstrap_historical_reader(
@@ -542,8 +558,7 @@ pub fn bootstrap_historical_reader(
     start_height: BlockHeight,
     target_block_height: BlockHeight,
 ) {
-    let node_state = env.node_state_builder().account_id(reader_id).cloud_storage(true).build();
-    env.add_node(reader_id.as_ref(), node_state);
+    add_reader_node(env, reader_id);
 
     let cloud_storage = get_cloud_storage(env, reader_id);
 
@@ -552,10 +567,12 @@ pub fn bootstrap_historical_reader(
         let client = env.node_for_account(reader_id).client();
         let store = client.chain.chain_store.store();
         let epoch_manager = client.epoch_manager.clone();
+        let shard_tracker = client.shard_tracker.clone();
         exec(bootstrap_range(
             &store,
             &cloud_storage,
             epoch_manager.as_ref(),
+            &shard_tracker,
             start_height,
             target_block_height,
         ))
@@ -743,7 +760,6 @@ pub(crate) fn assert_reader_writer_parity(
                     DBCol::NextBlockHashes
                         | DBCol::BlockPerHeight
                         | DBCol::ChunkHashesByHeight
-                        | DBCol::ChunkExtra
                         | DBCol::IncomingReceipts
                         | DBCol::OutcomeIds
                         | DBCol::TransactionResultForBlock
@@ -842,12 +858,16 @@ fn writer_kvs(
                 kvs.get_mut(&col).unwrap().insert(key, value.to_vec());
             }
         }
-        // ChunkProducers rows are keyed by block hash across all shards of the
-        // anchor's own epoch, so one prefix scan captures every row for this block.
-        for (key, value) in writer.iter_prefix(DBCol::ChunkProducers, block_hash.as_ref()) {
-            kvs.get_mut(&DBCol::ChunkProducers).unwrap().insert(key.into_vec(), value.into_vec());
+        // Each of these is keyed by block hash followed by a per-shard suffix, so a
+        // prefix scan on the hash finds every shard's row without asking which shards
+        // this block's epoch had.
+        for col in [DBCol::ChunkProducers, DBCol::ChunkExtra] {
+            for (key, value) in writer.iter_prefix(col, block_hash.as_ref()) {
+                kvs.get_mut(&col).unwrap().insert(key.into_vec(), value.into_vec());
+            }
         }
-        let block = writer_store.get_block(&block_hash).expect("block exists, checked above");
+        let block =
+            writer_store.get_block(&block_hash).expect("the caller disabled garbage collection");
         for chunk_header in block.chunks().iter_raw() {
             collect_chunk_kvs(writer, kvs, &block_hash, chunk_header, h);
         }

--- a/tools/cloud-archive/src/bootstrap_reader.rs
+++ b/tools/cloud-archive/src/bootstrap_reader.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use near_chain_configs::GenesisValidationMode;
 use near_client::archive::cloud_historical_reader::bootstrap_range;
 use near_epoch_manager::EpochManager;
+use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::types::BlockHeight;
 use near_store::{Mode, NodeStorage};
 use std::path::Path;
@@ -66,10 +67,17 @@ impl BootstrapReaderCmd {
             Some(home_dir),
         );
 
+        let shard_tracker = ShardTracker::new(
+            near_config.client_config.tracked_shards_config.clone(),
+            epoch_manager.clone(),
+            near_config.validator_signer,
+        );
+
         tokio_runtime.block_on(bootstrap_range(
             &store,
             &cloud_storage,
             epoch_manager.as_ref(),
+            &shard_tracker,
             self.start_height,
             self.end_height,
         ))?;


### PR DESCRIPTION
A shard's batch can cover fewer heights than the window it sits in, because a shard a resharding adds starts above that window's start. `pull_shard_batch` writes the rows the batch holds, from the batch's own start rather than from the height the walk asked for.

The shard set for a batch comes from `ShardTracker` per epoch and carries uids, because `DBCol::ChunkExtra` is keyed by uid, and that column is what the reader now writes on top of what it wrote before.
