### PR TITLE
feat(cloud-archive): the recent reader takes a batch's shards

### DIFF
--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -1,23 +1,51 @@
 use crate::archive::cloud_archival_utils::{
-    CloudArchivalReaderError, pull_block_batch, save_reader_head,
+    CloudArchivalReaderError, pull_block_batch, pull_shard_batch, save_reader_head,
+    shards_tracked_in_batch,
 };
 use near_async::time::{Clock, Duration};
 use near_chain_configs::InterruptHandle;
 use near_epoch_manager::EpochManagerAdapter;
+use near_epoch_manager::shard_tracker::ShardTracker;
+use near_primitives::hash::CryptoHash;
 use near_primitives::types::BlockHeight;
-use near_store::Store;
 use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::archive::cloud_storage::CloudStorage;
+use near_store::{ShardUId, Store};
+use std::mem;
 use std::sync::Arc;
 
 /// Result of one recent-reader iteration.
 #[derive(Debug)]
 enum PullOutcome {
-    /// Took a batch and moved the reader head to this.
+    /// Took the batches for the next window.
     Pulled { head: CloudReaderHead },
     /// The bucket holds no block past the reader's head.
     WaitingForBlocks,
+    /// This shard's data for the next window is not in the bucket.
+    WaitingForShard { shard_uid: ShardUId },
+}
+
+/// The height range the reader is taking, held until the bucket carries every component
+/// batch over it.
+#[derive(Clone)]
+struct PendingWindow {
+    /// The window's last height.
+    end_height: BlockHeight,
+    /// The last block the reader holds at or below `end_height`.
+    last_present_block_hash: CryptoHash,
+    /// The window's shards the reader has not seen in the bucket.
+    waiting_shards: Vec<ShardUId>,
+    /// The window's shards that are ready to pull.
+    ready_shards: Vec<ShardUId>,
+}
+
+impl PendingWindow {
+    /// The shard the reader checks next, and the one it waits on when the bucket does not
+    /// carry that shard over the window.
+    fn waiting_shard(&self) -> Option<ShardUId> {
+        self.waiting_shards.last().copied()
+    }
 }
 
 /// Reads recent chain data out of cloud storage into a local store.
@@ -27,8 +55,10 @@ pub struct CloudArchivalRecentReader {
     store: Store,
     cloud_storage: Arc<CloudStorage>,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
+    shard_tracker: ShardTracker,
     polling_interval: Duration,
     interrupt: InterruptHandle,
+    pending_window: Option<PendingWindow>,
 }
 
 impl CloudArchivalRecentReader {
@@ -37,6 +67,7 @@ impl CloudArchivalRecentReader {
         store: Store,
         cloud_storage: Arc<CloudStorage>,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
+        shard_tracker: ShardTracker,
         polling_interval: Duration,
     ) -> Self {
         Self {
@@ -44,8 +75,10 @@ impl CloudArchivalRecentReader {
             store,
             cloud_storage,
             epoch_manager,
+            shard_tracker,
             polling_interval,
             interrupt: InterruptHandle::new(),
+            pending_window: None,
         }
     }
 
@@ -80,7 +113,7 @@ impl CloudArchivalRecentReader {
     }
 
     /// Follows the bucket, copying what it holds into the local store, until interrupted.
-    pub async fn cloud_archival_loop(self) -> Result<(), CloudArchivalReaderError> {
+    pub async fn cloud_archival_loop(mut self) -> Result<(), CloudArchivalReaderError> {
         let mut reader_head = self.ensure_reader_head()?;
         tracing::info!(target: "cloud_archival", ?reader_head, "following the cloud archive");
 
@@ -94,6 +127,10 @@ impl CloudArchivalRecentReader {
                             Duration::ZERO
                         }
                         PullOutcome::WaitingForBlocks => self.polling_interval,
+                        PullOutcome::WaitingForShard { shard_uid } => {
+                            tracing::trace!(target: "cloud_archival", %shard_uid, "waiting on a shard");
+                            self.polling_interval
+                        }
                     }
                 }
                 Err(error) => {
@@ -107,15 +144,47 @@ impl CloudArchivalRecentReader {
         Ok(())
     }
 
-    /// Takes the batches after `reader_head`, once the bucket has them.
+    /// Takes the window after `reader_head`, once the bucket has its blocks and every
+    /// shard the reader tracks over it.
+    ///
+    /// The reader head moves only once the whole window is in, so a run that stops or
+    /// errors part way through one takes it again from that head.
     async fn try_pull_next_batch(
-        &self,
+        &mut self,
         reader_head: &CloudReaderHead,
     ) -> Result<PullOutcome, CloudArchivalReaderError> {
+        let Some(mut window) = self.get_pending_window(reader_head).await? else {
+            return Ok(PullOutcome::WaitingForBlocks);
+        };
+        let Some(shard_uids) = self.check_shards_ready(reader_head, &mut window).await? else {
+            // `check_shards_ready` returns `None` only with a shard still waiting.
+            let shard_uid = window.waiting_shard().expect("a shard held the window back");
+            self.pending_window = Some(window);
+            return Ok(PullOutcome::WaitingForShard { shard_uid });
+        };
+        for shard_uid in shard_uids {
+            pull_shard_batch(&self.store, &self.cloud_storage, shard_uid, reader_head.height + 1)
+                .await?;
+        }
+        let head = save_reader_head(&self.store, window.end_height, window.last_present_block_hash);
+        Ok(PullOutcome::Pulled { head })
+    }
+
+    /// Hands back the window the reader holds, opening the one above `reader_head` and
+    /// writing its block rows when it holds none. `None` when the bucket holds no block
+    /// past that head.
+    async fn get_pending_window(
+        &mut self,
+        reader_head: &CloudReaderHead,
+    ) -> Result<Option<PendingWindow>, CloudArchivalReaderError> {
+        if let Some(window) = self.pending_window.take() {
+            return Ok(Some(window));
+        }
         let cloud_block_head = self.cloud_storage.get_cloud_block_head().await?;
         if !cloud_block_head.is_some_and(|cloud_head| cloud_head > reader_head.height) {
-            return Ok(PullOutcome::WaitingForBlocks);
+            return Ok(None);
         }
+        // A restart pulls this batch again and writes the same rows over themselves.
         let batch_pull = pull_block_batch(
             &self.store,
             &self.cloud_storage,
@@ -123,11 +192,40 @@ impl CloudArchivalRecentReader {
             reader_head.height + 1,
         )
         .await?;
-        // TODO(cloud_archival): write the batch's shard rows here once every shard it
-        // covers has published its cloud head.
+        let window_tracked_shards = shards_tracked_in_batch(
+            self.epoch_manager.as_ref(),
+            &self.shard_tracker,
+            &reader_head.last_present_block_hash,
+            batch_pull.opening_epoch_id,
+        )?;
         let last_present_block_hash =
             batch_pull.last_present_block_hash.unwrap_or(reader_head.last_present_block_hash);
-        let head = save_reader_head(&self.store, batch_pull.end_height, last_present_block_hash);
-        Ok(PullOutcome::Pulled { head })
+        let window = PendingWindow {
+            end_height: batch_pull.end_height,
+            last_present_block_hash,
+            waiting_shards: window_tracked_shards.into_iter().collect(),
+            ready_shards: Vec::new(),
+        };
+        Ok(Some(window))
+    }
+
+    /// Returns the window's shards once the bucket carries every one of them past
+    /// `reader_head`, which is where a shard's batch over the window is complete.
+    async fn check_shards_ready(
+        &self,
+        reader_head: &CloudReaderHead,
+        window: &mut PendingWindow,
+    ) -> Result<Option<Vec<ShardUId>>, CloudArchivalReaderError> {
+        while let Some(shard_uid) = window.waiting_shard() {
+            let cloud_shard_head =
+                self.cloud_storage.get_cloud_shard_head(shard_uid.shard_id()).await?;
+            if !cloud_shard_head.is_some_and(|cloud_head| cloud_head > reader_head.height) {
+                return Ok(None);
+            }
+            window.waiting_shards.pop();
+            window.ready_shards.push(shard_uid);
+        }
+        let ready_shards = mem::take(&mut window.ready_shards);
+        Ok(Some(ready_shards))
     }
 }

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -23,7 +23,10 @@ enum PullOutcome {
     /// The bucket holds no block past the reader's head.
     WaitingForBlocks,
     /// This shard's data for the next window is not in the bucket.
-    WaitingForShard { shard_uid: ShardUId },
+    WaitingForShard {
+        #[allow(dead_code)] // Read through the derived Debug in the pull trace.
+        shard_uid: ShardUId,
+    },
 }
 
 /// The height range the reader is taking, held until the bucket carries every component
@@ -127,10 +130,7 @@ impl CloudArchivalRecentReader {
                             Duration::ZERO
                         }
                         PullOutcome::WaitingForBlocks => self.polling_interval,
-                        PullOutcome::WaitingForShard { shard_uid } => {
-                            tracing::trace!(target: "cloud_archival", %shard_uid, "waiting on a shard");
-                            self.polling_interval
-                        }
+                        PullOutcome::WaitingForShard { .. } => self.polling_interval,
                     }
                 }
                 Err(error) => {
@@ -217,6 +217,9 @@ impl CloudArchivalRecentReader {
         window: &mut PendingWindow,
     ) -> Result<Option<Vec<ShardUId>>, CloudArchivalReaderError> {
         while let Some(shard_uid) = window.waiting_shard() {
+            // TODO(cloud_archival): each head read lists the shard heads, a couple of
+            // files. Solve it properly with a get that tells a missing blob from a
+            // failed one.
             let cloud_shard_head =
                 self.cloud_storage.get_cloud_shard_head(shard_uid.shard_id()).await?;
             if !cloud_shard_head.is_some_and(|cloud_head| cloud_head > reader_head.height) {

--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -87,6 +87,15 @@ impl CloudStorage {
         Ok(batch)
     }
 
+    /// Highest height whose data for `shard_id` is in the bucket, if the writer has
+    /// published a head for that shard at all.
+    pub async fn get_cloud_shard_head(
+        &self,
+        shard_id: ShardId,
+    ) -> Result<Option<BlockHeight>, CloudRetrievalError> {
+        self.retrieve_cloud_shard_head_if_exists(shard_id).await
+    }
+
     /// Fetches `shard_id`'s batch for the window `block_height` falls in. What the batch
     /// carries can open above or end below that height, which is what a shard added or
     /// retired by a resharding looks like.

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -34,6 +34,7 @@ use near_primitives::types::{AccountId, Balance, BlockHeight, BlockHeightDelta, 
 use near_primitives::utils::get_block_shard_id_rev;
 use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
 use near_primitives::version::PROTOCOL_VERSION;
+use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::archive::cloud_storage::CloudStorage;
 use near_store::archive::cloud_storage::bucket_config::BucketConfig;
@@ -268,8 +269,6 @@ impl CloudArchiveHarnessBuilder {
 #[derive(Clone, Copy)]
 enum Reader {
     Historical,
-    // TODO(cloud_archival): construct this once the recent reader writes shard rows.
-    #[allow(dead_code)]
     Recent,
 }
 
@@ -362,7 +361,9 @@ impl CloudArchiveHarness {
     /// reader on the database that node leaves behind. No gc runs on it from here.
     fn start_recent_reader(&self) -> CloudArchivalRecentReader {
         let reader_id: AccountId = Self::RECENT_READER_ACCOUNT.parse().unwrap();
-        let epoch_manager = self.env.node_for_account(&reader_id).client().epoch_manager.clone();
+        let client = self.env.node_for_account(&reader_id).client();
+        let epoch_manager = client.epoch_manager.clone();
+        let shard_tracker = client.shard_tracker.clone();
         let cloud_storage = self.open_cloud_storage(&reader_id);
         self.env.kill_node(Self::RECENT_READER_ACCOUNT);
         let reader = CloudArchivalRecentReader::new(
@@ -370,6 +371,7 @@ impl CloudArchiveHarness {
             self.recent_reader_store(),
             cloud_storage,
             epoch_manager,
+            shard_tracker,
             Self::RECENT_READER_POLLING_INTERVAL,
         );
         let handle = reader.clone();
@@ -400,6 +402,39 @@ impl CloudArchiveHarness {
             .reader_head()
             .expect("the recent reader holds a head")
             .height
+    }
+
+    fn cloud_block_head(&self) -> BlockHeight {
+        exec(get_cloud_storage(&self.env, &self.writer_id).get_cloud_block_head())
+            .expect("reading the bucket's block head")
+            .expect("the writer published a block head")
+    }
+
+    fn cloud_shard_head(&self, shard_id: ShardId) -> BlockHeight {
+        exec(get_cloud_storage(&self.env, &self.writer_id).get_cloud_shard_head(shard_id))
+            .expect("reading the bucket's shard head")
+            .expect("the writer published a head for this shard")
+    }
+
+    /// Rewinds the bucket's head for `shard_id`, and the writer's copy, so the archive
+    /// announces less of that shard than it holds. Pause the writer first or it
+    /// republishes over this.
+    fn rewind_cloud_shard_head(&self, shard_id: ShardId, height: BlockHeight) {
+        let cloud_storage = get_cloud_storage(&self.env, &self.writer_id);
+        exec(cloud_storage.update_cloud_shard_head(shard_id, height)).unwrap();
+        let mut update = self.writer_store().store_update();
+        update.cloud_archival_store_update().set_writer_shard_head(shard_id, height);
+        update.commit();
+    }
+
+    /// Rewinds `CLOUD_READER_HEAD` so the recent reader has batches left to take.
+    fn rewind_reader_head(&self, height: BlockHeight) {
+        let store = self.recent_reader_store();
+        let last_present_block_hash = store.chain_store().get_block_hash_by_height(height).unwrap();
+        let head = CloudReaderHead { height, last_present_block_hash };
+        let mut update = store.store_update();
+        update.cloud_archival_store_update().set_reader_head(&head);
+        update.commit();
     }
 
     fn recent_reader_store(&self) -> Store {
@@ -979,6 +1014,7 @@ fn test_cloud_archival_single_skipped_slot() {
         "sync block {sync_block_height} must be past target {target}"
     );
 
+    h.assert_reader_writer_parity(Reader::Recent, start, target);
     h.bootstrap_historical_reader(start, target);
     h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.kill_historical_reader();
@@ -1054,6 +1090,7 @@ fn test_cloud_archival_fully_skipped_batch() {
     let target = h.epoch_length + h.epoch_length / 2;
     // A range spanning the skipped batch: the reader writes nothing for those heights and
     // must still match the writer everywhere else.
+    h.assert_reader_writer_parity(Reader::Recent, start, target);
     h.bootstrap_historical_reader(start, target);
     h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.kill_historical_reader();
@@ -1289,6 +1326,7 @@ fn test_cloud_archival_missing_chunks_one_shard() {
 
     let start = h.epoch_length / 2;
     let target = 3 * h.epoch_length;
+    h.assert_reader_writer_parity(Reader::Recent, start, target);
     h.bootstrap_historical_reader(start, target);
     h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.kill_historical_reader();
@@ -2022,13 +2060,74 @@ fn test_cloud_archival_resharding_gap_inverse_walk() {
     h.shutdown();
 }
 
+/// The recent reader holds its head at a shard the bucket carries no further, even
+/// though blocks and the other shards reach past it, and moves on once that shard is
+/// published again.
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_recent_reader_waits_for_a_lagging_shard() {
+    let held_shard = CloudArchiveHarness::all_shard_ids()[0];
+    let mut h = CloudArchiveHarness::builder().delay_recent_reader().disable_gc().build();
+    h.run_until_epoch(2);
+    let reader = h.start_recent_reader();
+
+    // Freeze the archive where it stands, so nothing republishes the head moved below.
+    h.pause_writer();
+    let archived_to = h.cloud_shard_head(held_shard);
+    let batch_size = BlockHeight::from(CloudArchiveHarness::TEST_BATCH_SIZE);
+    // A batch end below the shard head, and a reader head a batch below that, so the
+    // reader has whole batches to take and the held shard is what stops it.
+    let hold_at = archived_to - batch_size;
+    let reader_from = hold_at - batch_size;
+    h.rewind_cloud_shard_head(held_shard, hold_at);
+    h.rewind_reader_head(reader_from);
+
+    h.run_until_epoch(3);
+    let block_head = h.cloud_block_head();
+    assert!(
+        block_head > hold_at,
+        "blocks stopped at {block_head} too, so nothing held the reader back"
+    );
+    assert_eq!(
+        h.recent_reader_height(),
+        hold_at,
+        "the reader passed shard {held_shard}, which the bucket carries only to {hold_at}"
+    );
+    // Every other shard reaches past the hold point, so the held one is what the reader
+    // is waiting on.
+    for shard_id in CloudArchiveHarness::all_shard_ids() {
+        let shard_head = h.cloud_shard_head(shard_id);
+        if shard_id == held_shard {
+            assert_eq!(shard_head, hold_at, "shard {shard_id} left the hold point");
+        } else {
+            assert!(
+                shard_head > hold_at,
+                "shard {shard_id} stops at {shard_head} too, so it could be holding the reader"
+            );
+        }
+    }
+
+    // The writer publishes the shard again, and the head pinned to it moves on.
+    h.restart_writer();
+    h.run_until_epoch(4);
+    assert!(
+        h.recent_reader_height() > hold_at,
+        "the reader stayed at {hold_at} after shard {held_shard} caught up"
+    );
+    h.assert_reader_writer_parity(Reader::Recent, reader_from, h.recent_reader_height());
+
+    reader.stop();
+    h.shutdown();
+}
+
 /// An RPC node runs for a while, becomes the recent reader, and follows the
 /// bucket from there. What gc took before the switch stays gone, and what the
 /// reader holds afterwards is kept, because no gc runs once it has switched.
 #[test]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
-fn test_cloud_archival_recent_reader() {
+fn test_cloud_archival_recent_reader_gc_stops_at_takeover() {
     let mut h = CloudArchiveHarness::builder().delay_recent_reader().build();
     let gced = h.epoch_length / 2;
     // One epoch past the garbage-collection window, so the probe height is below
@@ -2065,8 +2164,6 @@ fn test_cloud_archival_recent_reader() {
         head + u64::from(CloudArchiveHarness::TEST_BATCH_SIZE) >= bucket_head,
         "the reader did not catch up: head {head}, bucket head {bucket_head}"
     );
-    // TODO(cloud_archival): assert reader-writer parity here once the recent reader
-    // writes shard rows.
 
     reader.stop();
     h.shutdown();
@@ -2118,8 +2215,8 @@ fn test_cloud_archival_skipped_run_across_batch_edge() {
     // A range spanning the dropped run, so the bootstrap walks both clipped batches.
     let start = first_dropped - h.epoch_length / 2;
     let target = last_dropped + h.epoch_length / 2;
+    h.assert_reader_writer_parity(Reader::Recent, start, target);
     h.bootstrap_historical_reader(start, target);
-    // TODO(cloud_archival): run this for `Reader::Recent` too, once it writes shard rows.
     h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.kill_historical_reader();
 


### PR DESCRIPTION
The recent reader wrote a batch's block rows and moved its head straight away, so the head named heights whose shard rows were not in the store. It now holds the window across polls until the bucket carries every shard it tracks over that window, writes those shards' rows, and moves the head last.

A shard counts as ready once its cloud head sits above the reader head, which is where the writer has finished that shard's batch over the window, and is what a shard retired at a resharding split reaches without ever covering the window's end. The reader waits with no deadline and names the shard it is waiting on.
