### PR TITLE
test: wait for failover node to catch up in shadow_tracking

### DIFF
--- a/pytest/tests/sanity/shadow_tracking.py
+++ b/pytest/tests/sanity/shadow_tracking.py
@@ -88,8 +88,14 @@ class ShadowTrackingTest(unittest.TestCase):
         nodes[3].kill()
         wait_for_blocks(nodes[4], count=3 * EPOCH_LENGTH)
         nodes[3].start(boot_node=nodes[4])
-        # Give it some time to catch up.
-        wait_for_blocks(nodes[4], count=EPOCH_LENGTH)
+        # Wait until the failover node actually catches up with the chain. It
+        # goes through epoch sync node restart so it may be offline temporarily.
+        wait_for_blocks(
+            nodes[3],
+            target=nodes[4].get_latest_block().height,
+            timeout=60,
+            tolerate_connection_errors=True,
+        )
 
         round = 0
         epoch_ids = set()


### PR DESCRIPTION
This is hopefully fixing the flaky behaviour from: https://nayduck.nearone.org/#/test/1428723

AI description:

The test restarted node3 and then waited a fixed number of blocks on the RPC node before starting the chunk checks. If node3 was still syncing when the checks started (its epoch-sync data reset wipes the data dir and puts its head back at genesis), the minimum block height across nodes pointed below the RPC node's GC tail and the block-by-height query failed with HTTP 422 (nayduck test 1428723).

Wait on node3 itself to reach the chain head instead, tolerating the connection errors caused by the epoch-sync self-restart.