### PR TITLE
test: prevent chunk producer kickout in sanity/transactions.py

### DIFF
--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -3,9 +3,9 @@
 # gets properly processed (to simplify debugging when the code is completely
 # broken). If one transaction goes through, sends batches of transactions
 # and ensures the balances get to the expected state in a timely manner.
-# Sets epoch length to 10
+# Sets epoch length to 20
 
-import sys, time, base58, random
+import sys, time, base58
 import pathlib
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
@@ -23,10 +23,16 @@ nodes = start_cluster(
     num_shards=4,
     config=None,
     extra_state_dumper=True,
-    genesis_config_changes=[["min_gas_price", "0"],
-                            ["max_inflation_rate", [0, 1]],
-                            ["epoch_length", 10],
-                            ["block_producer_kickout_threshold", 70]],
+    # Low kickout thresholds because validators miss their first few blocks and
+    # chunks on cluster startup (the boot node starts producing blocks before
+    # the other nodes are up).
+    genesis_config_changes=[
+        ["min_gas_price", "0"],
+        ["max_inflation_rate", [0, 1]],
+        ["epoch_length", 20],
+        ["block_producer_kickout_threshold", 70],
+        ["chunk_producer_kickout_threshold", 70],
+    ],
     client_config_changes={
         0: {
             "consensus": {


### PR DESCRIPTION
This is hopefully fixing the flakiness in transactions.py: https://nayduck.nearone.org/#/test/1429095 

The issue was: 
* slow startup for some nodes -> missing chunks -> kickouts -> shard reassignment -> state sync -> state sync being slower than epoch -> chunk producer not caught up -> chunk producer dropping transactions

The fix is to decrease kickout thresholds and increase epoch length. 

AI summary:

The test only lowered block_producer_kickout_threshold, leaving the chunk producer threshold at the default 90%. Validators regularly miss their first couple of chunks on cluster startup (the boot node starts producing blocks before the other nodes are up), which got them kicked out at the end of the first epoch. The remaining chunk producers were then assigned shards they don't track, and when the resulting state sync outlasted the 10-block epoch, transactions forwarded to them were dropped ("Node has not caught up yet") and never retried, failing the balance convergence assert.

Lower chunk_producer_kickout_threshold to 70 so the startup hiccup doesn't trigger kickouts, and bump epoch_length to 20 for extra margin.