### PR TITLE
chore(debug-ui): remove epoch_info fallback from fetchEpochInfoLight

### DIFF
--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -532,26 +532,12 @@ export function fetchEpochInfo(
 // Lightweight variant of the recent-epochs list that omits the heavy per-validator
 // `validator_info`. Use this for views that only need epoch metadata and
 // producer/validator counts (recent epochs, epoch shards, current peers).
-//
-// The debug-ui is released ahead of the node side, so this gracefully falls back to
-// the full `epoch_info` endpoint when talking to a node that predates
-// `epoch_info_light`. Such a node has no route for either form, so both fall through
-// to the `/debug/api/{*path}` catch-all and return 405 (we also treat 404 as missing
-// for safety, e.g. behind a proxy).
-// TODO: remove the fallback once all nodes expose `epoch_info_light`.
-export async function fetchEpochInfoLight(
+export function fetchEpochInfoLight(
     addr: string,
     epochId: string | null
 ): Promise<EpochInfoResponse> {
     const trailing = epochId ? `/${epochId}` : '';
-    try {
-        return await fetchJson(getTargetUrl(addr, `debug/api/epoch_info_light${trailing}`));
-    } catch (error) {
-        if (error instanceof HttpError && (error.status === 404 || error.status === 405)) {
-            return fetchEpochInfo(addr, epochId);
-        }
-        throw error;
-    }
+    return fetchJson(getTargetUrl(addr, `debug/api/epoch_info_light${trailing}`));
 }
 
 export function fetchPeerStore(addr: string): Promise<PeerStoreResponse> {


### PR DESCRIPTION
The fallback existed because the debug-ui is released ahead of the node side. The epoch_info_light endpoint shipped in 2.13.0, so nodes without it are no longer a concern and the fallback can go.