### PR TITLE
fix(workflows): fix build custom binary workflow

### DIFF
--- a/.github/workflows/neard_custom_binary.yml
+++ b/.github/workflows/neard_custom_binary.yml
@@ -39,6 +39,13 @@ jobs:
           role-to-assume: arn:aws:iam::590184106962:role/GitHubActionsRunner
           aws-region: us-west-1
 
+      - name: Checkout workflow repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/install-clang
+
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
         uses: actions/checkout@v4
@@ -46,7 +53,6 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false
 
-      - uses: ./.github/actions/install-clang
       - name: Neard binary build and upload to S3
         env:
           WITH_DEBUG_INFO: ${{ inputs.with-debug-info && '1' || '' }}


### PR DESCRIPTION
The neard_custom_binary workflow didn't work when using the workflow from master branch and binary from 2.13-release branch.

The reason is that it checked out to the 2.13-release branch and tried to install clang, but the required files were not present.

Fix by first checking out to the workflow branch, installing clang, and then checking out to the binary branch to build the binary.

example run: https://github.com/near/nearcore-private/actions/runs/33534599998
