### PR TITLE
feat(cloud-archive): the reader's chunk-addressed shard columns

### DIFF
--- a/chain/chain/src/spice/chunk_application.rs
+++ b/chain/chain/src/spice/chunk_application.rs
@@ -13,6 +13,7 @@ use near_primitives::receipt::{
     ProcessedReceipt, ProcessedReceiptMetadata, ReceiptSource, ReceiptToTxInfo,
 };
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
+use near_primitives::transaction::ExecutionOutcomeWithProof;
 use near_primitives::types::{BlockExecutionResults, BlockHeight, ShardId};
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::adapter::trie_store::TrieStoreUpdateAdapter;
@@ -119,11 +120,20 @@ pub fn apply_chunk_postprocessing(
     );
 
     if config.save_tx_outcomes {
+        let outcomes_with_proofs: Vec<_> = outcomes
+            .into_iter()
+            .zip(outcome_paths)
+            .map(|(outcome_with_id, proof)| {
+                (
+                    outcome_with_id.id,
+                    ExecutionOutcomeWithProof { outcome: outcome_with_id.outcome, proof },
+                )
+            })
+            .collect();
         store_update.chain_store_update().set_outcomes_with_proofs(
             block_hash,
             shard_id,
-            outcomes,
-            outcome_paths,
+            &outcomes_with_proofs,
         );
     }
     if config.save_receipt_to_tx {

--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -3,9 +3,8 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::transaction::ExecutionOutcomeWithId;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
-use near_primitives::utils::{get_block_shard_id, index_to_bytes};
+use near_primitives::utils::index_to_bytes;
 use near_store::adapter::StoreUpdateAdapter;
 use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::archive::cloud_storage::{
@@ -238,8 +237,8 @@ pub(crate) fn save_shard_data(
     shard_uid: ShardUId,
     shard_data: &ShardData,
 ) {
-    // TODO(cloud_archival): write the shard's transaction and receipt rows, and apply
-    // per-block state deltas.
+    // TODO(cloud_archival): write the rows a transaction or receipt hash alone addresses,
+    // and apply each block's recorded changes to the shard's state.
     let block_hash = shard_data.block_hash();
     let shard_id = shard_uid.shard_id();
     let mut chunk_store_update = update.chunk_store_update();
@@ -252,25 +251,10 @@ pub(crate) fn save_shard_data(
         update.chain_store_update().set_outgoing_receipt(block_hash, shard_id, outgoing_receipts);
     }
     if let Some(incoming_receipts) = shard_data.incoming_receipts() {
-        update.set_ser(
-            DBCol::IncomingReceipts,
-            &get_block_shard_id(block_hash, shard_id),
-            incoming_receipts,
-        );
+        update.chain_store_update().set_incoming_receipt(block_hash, shard_id, incoming_receipts);
     }
     if let Some(results) = shard_data.transaction_result_for_block() {
-        let (outcomes, proofs) = results
-            .iter()
-            .map(|(outcome_id, result)| {
-                (
-                    ExecutionOutcomeWithId { id: *outcome_id, outcome: result.outcome.clone() },
-                    result.proof.clone(),
-                )
-            })
-            .unzip();
-        update
-            .chain_store_update()
-            .set_outcomes_with_proofs(block_hash, shard_id, outcomes, proofs);
+        update.chain_store_update().set_outcomes_with_proofs(block_hash, shard_id, results);
     }
     for changes in shard_data.state_changes() {
         let row_key =

--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -3,7 +3,7 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::get_block_shard_uid;
+use near_primitives::transaction::ExecutionOutcomeWithId;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::{get_block_shard_id, index_to_bytes};
 use near_store::adapter::StoreUpdateAdapter;
@@ -11,7 +11,7 @@ use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::archive::cloud_storage::{
     BlockData, CloudRetrievalError, CloudStorage, EpochData, ShardData,
 };
-use near_store::{DBCol, ShardUId, Store, StoreUpdate};
+use near_store::{DBCol, KeyForStateChanges, ShardUId, Store, StoreUpdate};
 use std::collections::{HashMap, HashSet};
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
@@ -36,20 +36,16 @@ pub fn save_block_data(update: &mut StoreUpdate, block_data: &BlockData) {
     let block_hash = *header.hash();
     let height = header.height();
 
-    // A content-addressed row is insert-only; the rest are keyed by height, hash or
-    // ordinal, so a re-pull may overwrite them.
-    update.insert_ser(DBCol::BlockHeader, block_hash.as_ref(), header);
+    // The block row is content-addressed, so it is insert-only. Every other row here is
+    // keyed by height, hash or ordinal, and a re-pull may overwrite it.
     update.insert_ser(DBCol::Block, block_hash.as_ref(), block);
-    update.insert_ser(DBCol::BlockInfo, block_hash.as_ref(), block_data.block_info());
-    update.set_ser(DBCol::BlockHeight, &index_to_bytes(height), &block_hash);
-    update.set_ser(DBCol::BlockMerkleTree, block_hash.as_ref(), block_data.block_merkle_tree());
+    let mut chain_store_update = update.chain_store_update();
+    chain_store_update.set_block_header_only(header);
+    chain_store_update.set_block_height(&block_hash, height);
+    chain_store_update.set_block_merkle_tree(&block_hash, block_data.block_merkle_tree());
     // The block's own tree holds every block below it, so its size is this block's
     // ordinal, which is the key the block-merkle-proof walk looks the hash up by.
-    update.set_ser(
-        DBCol::BlockOrdinal,
-        &index_to_bytes(block_data.block_merkle_tree().size()),
-        &block_hash,
-    );
+    chain_store_update.set_block_ordinal(block_data.block_merkle_tree().size(), &block_hash);
     update.set_ser(DBCol::NextBlockHashes, block_hash.as_ref(), block_data.next_block_hash());
     for (created_height, chunk_hashes) in block_data.chunk_hashes() {
         update.set_ser(DBCol::ChunkHashesByHeight, &index_to_bytes(*created_height), chunk_hashes);
@@ -59,12 +55,10 @@ pub fn save_block_data(update: &mut StoreUpdate, block_data: &BlockData) {
     let blocks_at_height = HashMap::from([(*header.epoch_id(), HashSet::from([block_hash]))]);
     update.set_ser(DBCol::BlockPerHeight, &index_to_bytes(height), &blocks_at_height);
 
+    let mut epoch_store_update = update.epoch_store_update();
+    epoch_store_update.set_block_info(block_data.block_info());
     for (shard_id, stake) in block_data.chunk_producers() {
-        update.insert_ser(
-            DBCol::ChunkProducers,
-            &get_block_shard_id(&block_hash, *shard_id),
-            stake,
-        );
+        epoch_store_update.set_chunk_producer(&block_hash, *shard_id, stake);
     }
 }
 
@@ -189,7 +183,7 @@ pub(crate) async fn install_anchors(
     let prev_block_hash = *prev_block.block().header().hash();
     let mut update = store.store_update();
     // `get_epoch_id_from_prev_block` starts by reading this row.
-    update.insert_ser(DBCol::BlockInfo, prev_block_hash.as_ref(), prev_block.block_info());
+    update.epoch_store_update().set_block_info(prev_block.block_info());
     update.commit();
 
     let start_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash)?;
@@ -232,10 +226,10 @@ pub(crate) fn save_reader_head(
 /// Writes one epoch's cloud data into `update`.
 pub(crate) fn save_epoch_data(update: &mut StoreUpdate, epoch_data: &EpochData) {
     let epoch_id = epoch_data.epoch_id();
-    update.set_ser(DBCol::EpochInfo, epoch_id.as_ref(), epoch_data.epoch_info());
-    update.set_ser(DBCol::EpochStart, epoch_id.as_ref(), &epoch_data.epoch_start_height());
-    let first_block_info = epoch_data.epoch_first_block_info();
-    update.insert_ser(DBCol::BlockInfo, first_block_info.hash().as_ref(), first_block_info);
+    let mut epoch_store_update = update.epoch_store_update();
+    epoch_store_update.set_epoch_info(epoch_id, epoch_data.epoch_info());
+    epoch_store_update.set_epoch_start(epoch_id, epoch_data.epoch_start_height());
+    epoch_store_update.set_block_info(epoch_data.epoch_first_block_info());
 }
 
 /// Writes one shard's columns from its cloud `ShardData` into `update`.
@@ -244,22 +238,44 @@ pub(crate) fn save_shard_data(
     shard_uid: ShardUId,
     shard_data: &ShardData,
 ) {
-    // TODO(cloud_archival): reconstruct the remaining shard columns and apply
+    // TODO(cloud_archival): write the shard's transaction and receipt rows, and apply
     // per-block state deltas.
     let block_hash = shard_data.block_hash();
-    let block_shard_id = get_block_shard_id(block_hash, shard_uid.shard_id());
-    update.set_ser(DBCol::ChunkApplyStats, &block_shard_id, shard_data.chunk_apply_stats());
-    // ChunkExtra is the one shard column keyed by the shard's uid.
-    update.set_ser(
-        DBCol::ChunkExtra,
-        &get_block_shard_uid(block_hash, &shard_uid),
-        shard_data.chunk_extra(),
-    );
+    let shard_id = shard_uid.shard_id();
+    let mut chunk_store_update = update.chunk_store_update();
+    chunk_store_update.set_chunk_apply_stats(block_hash, shard_id, shard_data.chunk_apply_stats());
+    chunk_store_update.set_chunk_extra(block_hash, &shard_uid, shard_data.chunk_extra());
     if let Some(chunk) = shard_data.chunk() {
         update.insert_ser(DBCol::Chunks, chunk.chunk_hash().as_ref(), chunk);
     }
     if let Some(outgoing_receipts) = shard_data.outgoing_receipts() {
-        update.set_ser(DBCol::OutgoingReceipts, &block_shard_id, outgoing_receipts);
+        update.chain_store_update().set_outgoing_receipt(block_hash, shard_id, outgoing_receipts);
+    }
+    if let Some(incoming_receipts) = shard_data.incoming_receipts() {
+        update.set_ser(
+            DBCol::IncomingReceipts,
+            &get_block_shard_id(block_hash, shard_id),
+            incoming_receipts,
+        );
+    }
+    if let Some(results) = shard_data.transaction_result_for_block() {
+        let (outcomes, proofs) = results
+            .iter()
+            .map(|(outcome_id, result)| {
+                (
+                    ExecutionOutcomeWithId { id: *outcome_id, outcome: result.outcome.clone() },
+                    result.proof.clone(),
+                )
+            })
+            .unzip();
+        update
+            .chain_store_update()
+            .set_outcomes_with_proofs(block_hash, shard_id, outcomes, proofs);
+    }
+    for changes in shard_data.state_changes() {
+        let row_key =
+            KeyForStateChanges::for_state_change(block_hash, &changes.trie_key, &shard_uid);
+        update.trie_store_update().set_state_changes(row_key, changes);
     }
 }
 

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -7,13 +7,11 @@ use crate::{
 use near_chain_primitives::Error;
 use near_primitives::block::{Block, BlockHeader, Tip};
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::{MerklePath, PartialMerkleTree};
+use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptToTxInfo};
 use near_primitives::sharding::{ReceiptProof, ShardProof};
 use near_primitives::state_sync::{ShardStateSyncResponseHeader, StateHeaderKey};
-use near_primitives::transaction::{
-    ExecutionOutcomeWithId, ExecutionOutcomeWithProof, SignedTransaction,
-};
+use near_primitives::transaction::{ExecutionOutcomeWithProof, SignedTransaction};
 use near_primitives::types::{BlockHeight, EpochId, NumBlocks, ShardId, SpiceChunkId};
 use near_primitives::utils::{
     get_block_shard_id, get_outcome_id_block_hash, get_receipt_proof_key,
@@ -460,7 +458,7 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
     }
 
     pub fn set_block_height(&mut self, hash: &CryptoHash, height: BlockHeight) {
-        self.store_update.set_ser(DBCol::BlockHeight, &borsh::to_vec(&height).unwrap(), hash);
+        self.store_update.set_ser(DBCol::BlockHeight, &index_to_bytes(height), hash);
     }
 
     pub fn delete_block_height(&mut self, height: BlockHeight) {
@@ -498,6 +496,19 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
         );
     }
 
+    pub fn set_incoming_receipt(
+        &mut self,
+        block_hash: &CryptoHash,
+        shard_id: ShardId,
+        incoming_receipts: &[ReceiptProof],
+    ) {
+        self.store_update.set_ser(
+            DBCol::IncomingReceipts,
+            &get_block_shard_id(block_hash, shard_id),
+            &incoming_receipts,
+        );
+    }
+
     /// Writes the `ProcessedReceiptIds` metadata index and increments the
     /// refcount of each processed `Receipt` (the `DBCol::Receipts` rc-column).
     /// The caller builds `metadata` (including any `ReceiptToTxGc` markers gated
@@ -531,16 +542,15 @@ impl<'a> ChainStoreUpdateAdapter<'a> {
         &mut self,
         block_hash: &CryptoHash,
         shard_id: ShardId,
-        outcomes: Vec<ExecutionOutcomeWithId>,
-        proofs: Vec<MerklePath>,
+        outcomes: &[(CryptoHash, ExecutionOutcomeWithProof)],
     ) {
         let mut outcome_ids = Vec::with_capacity(outcomes.len());
-        for (outcome_with_id, proof) in outcomes.into_iter().zip(proofs.into_iter()) {
-            outcome_ids.push(outcome_with_id.id);
+        for (outcome_id, outcome_with_proof) in outcomes {
+            outcome_ids.push(*outcome_id);
             self.store_update.insert_ser(
                 DBCol::TransactionResultForBlock,
-                &get_outcome_id_block_hash(&outcome_with_id.id, block_hash),
-                &ExecutionOutcomeWithProof { outcome: outcome_with_id.outcome, proof },
+                &get_outcome_id_block_hash(outcome_id, block_hash),
+                outcome_with_proof,
             );
         }
         self.store_update.set_ser(

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -58,7 +58,8 @@ pub struct NewChunkData {
     chunk_apply_stats: ChunkApplyStats,
     /// Read from `DBCol::StateChanges`.
     state_changes: Vec<RawStateChangesWithTrieKey>,
-    /// Read from `DBCol::OutcomeIds` and `DBCol::TransactionResultForBlock`.
+    /// Read from `DBCol::OutcomeIds` and `DBCol::TransactionResultForBlock`, in the
+    /// execution order that row holds.
     transaction_result_for_block: Vec<(CryptoHash, ExecutionOutcomeWithProof)>,
     /// Read from `DBCol::ProcessedReceiptIds` (entries tagged
     /// `ReceiptSource::ReceiptToTxGc`) and `DBCol::ReceiptToTx`.
@@ -190,8 +191,6 @@ fn build_transaction_result_for_block(
         )?;
         transaction_result_for_block.push((outcome_id, outcome));
     }
-    // Sort so blob bytes are deterministic regardless of chunk-apply enumeration order.
-    transaction_result_for_block.sort_by_key(|(id, _)| *id);
     Ok(transaction_result_for_block)
 }
 
@@ -321,6 +320,13 @@ impl ShardData {
         match self {
             ShardData::V1(ShardDataV1::NewChunk(d)) => &d.chunk_apply_stats,
             ShardData::V1(ShardDataV1::Carried(d)) => &d.chunk_apply_stats,
+        }
+    }
+
+    pub fn incoming_receipts(&self) -> Option<&[ReceiptProof]> {
+        match self {
+            ShardData::V1(ShardDataV1::NewChunk(d)) => d.incoming_receipts.as_deref(),
+            ShardData::V1(ShardDataV1::Carried(d)) => d.incoming_receipts.as_deref(),
         }
     }
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -880,17 +880,11 @@ impl WrappedTrieChanges {
                 continue;
             }
 
-            let storage_key = match change_with_trie_key.trie_key.get_account_id() {
-                // If a TrieKey itself doesn't identify the Shard, then we need to add shard id to the row key.
-                None => KeyForStateChanges::delayed_receipt_key_from_trie_key(
-                    block_hash,
-                    &change_with_trie_key.trie_key,
-                    &self.shard_uid,
-                ),
-                // TrieKey has enough information to identify the shard it comes from.
-                _ => KeyForStateChanges::from_trie_key(block_hash, &change_with_trie_key.trie_key),
-            };
-
+            let storage_key = KeyForStateChanges::for_state_change(
+                block_hash,
+                &change_with_trie_key.trie_key,
+                &self.shard_uid,
+            );
             store_update.set_state_changes(storage_key, &change_with_trie_key);
         }
     }
@@ -944,6 +938,19 @@ impl KeyForStateChanges {
         let mut key = Self::new(block_hash, trie_key.len());
         trie_key.append_into(&mut key.0);
         key
+    }
+
+    /// The row key of one state change. A trie key naming no account does not say which
+    /// shard it belongs to, so its row key carries the shard uid.
+    pub fn for_state_change(
+        block_hash: &CryptoHash,
+        trie_key: &TrieKey,
+        shard_uid: &ShardUId,
+    ) -> Self {
+        match trie_key.get_account_id() {
+            Some(_) => Self::from_trie_key(block_hash, trie_key),
+            None => Self::delayed_receipt_key_from_trie_key(block_hash, trie_key, shard_uid),
+        }
     }
 
     /// Without changing the existing TrieKey format, encodes ShardUId into the row key.

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -1604,11 +1604,9 @@ fn test_cloud_archival_reader_reconstructs_per_shard_columns() {
     h.shutdown();
 }
 
-/// Verifies that after reader bootstrap, the local store has entries in
-/// the per-shard data columns the reader reconstructs from chunk-apply
-/// activity: `Transactions`, `Receipts`, `TransactionResultForBlock`,
-/// `ReceiptToTx`, and `StateChanges`. The test submits a cross-shard
-/// transfer before the bootstrap range to populate them.
+/// Verifies that the reader's store has entries in the per-shard data columns
+/// the reader reconstructs from chunk-apply activity. The test submits a
+/// cross-shard transfer before the bootstrap range to populate them.
 #[test]
 // TODO(cloud_archival): un-ignore once the reader reconstructs per-shard cold columns.
 #[ignore]

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -1496,8 +1496,8 @@ fn test_cloud_archival_outcomes_and_receipts() {
     h.shutdown();
 }
 
-/// Verifies that after reader bootstrap, the local store has entries in the per-block
-/// cold columns the reader reconstructs from cloud data.
+/// Verifies that the reader's store has a row at every height in the per-block cold
+/// columns the reader reconstructs from cloud data.
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_reader_reconstructs_per_block_columns() {
@@ -1545,13 +1545,10 @@ fn test_cloud_archival_reader_reconstructs_per_block_columns() {
     h.shutdown();
 }
 
-/// Verifies that after reader bootstrap, the local store has entries in
-/// the always-populated per-shard cold columns: `Chunks`, `ChunkExtra`,
-/// `ChunkApplyStats`, `IncomingReceipts`, `OutgoingReceipts`, and
-/// `OutcomeIds`.
+/// Verifies that the reader's store has a row per shard in the per-shard cold columns, at
+/// every height in the range.
 #[test]
-// TODO(cloud_archival): un-ignore once the reader reconstructs per-shard cold columns.
-#[ignore]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_reader_reconstructs_per_shard_columns() {
     let mut h = CloudArchiveHarness::builder().build();
     h.run_until_epoch(3 + MIN_GC_NUM_EPOCHS_TO_KEEP);

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -22,7 +22,7 @@ use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId,
 };
-use near_primitives::utils::{get_block_shard_id, index_to_bytes};
+use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::archive::cloud_storage::{
@@ -745,9 +745,9 @@ fn apply_state_changes(
     assert_eq!(state_root, *expected_final_state_root);
 }
 
-/// Asserts the reader reproduces the writer's rows over `[start, end]` for every
-/// column the cloud-bootstrapped reader reconstructs today. Caller must
-/// `.disable_gc()` so the writer retains the bootstrap range.
+/// Asserts the reader reproduces the writer's rows over `[start, end]`, for the columns
+/// the filter below keeps. Caller must `.disable_gc()` so the writer retains the
+/// bootstrap range.
 pub(crate) fn assert_reader_writer_parity(
     reader: &Store,
     writer: &Store,
@@ -761,11 +761,7 @@ pub(crate) fn assert_reader_writer_parity(
                 && !matches!(
                     c,
                     // Not reconstructed yet.
-                    DBCol::IncomingReceipts
-                        | DBCol::OutcomeIds
-                        | DBCol::TransactionResultForBlock
-                        | DBCol::StateChanges
-                        | DBCol::Transactions
+                    DBCol::Transactions
                         | DBCol::Receipts
                         | DBCol::ReceiptToTx
                         | DBCol::State
@@ -829,7 +825,7 @@ fn collect_chunk_hashes_kvs(
     }
 }
 
-/// Collects the writer's per-(block, shard) column rows for one chunk into `kvs`.
+/// Collects the writer's rows for one chunk into `kvs`.
 fn collect_chunk_kvs(
     writer: &Store,
     kvs: &mut HashMap<DBCol, BTreeMap<Vec<u8>, Vec<u8>>>,
@@ -846,6 +842,16 @@ fn collect_chunk_kvs(
             kvs.get_mut(&DBCol::OutgoingReceipts)
                 .unwrap()
                 .insert(block_shard_id.clone(), value.to_vec());
+        }
+        // `TransactionResultForBlock` is keyed by outcome id followed by the block
+        // hash, so its rows are reached through this shard's own `OutcomeIds` row.
+        let outcome_ids = writer
+            .chain_store()
+            .get_outcomes_by_block_hash_and_shard_id(block_hash, chunk_header.shard_id());
+        for outcome_id in &outcome_ids {
+            let key = get_outcome_id_block_hash(outcome_id, block_hash).to_vec();
+            let value = writer.get(DBCol::TransactionResultForBlock, &key).unwrap();
+            kvs.get_mut(&DBCol::TransactionResultForBlock).unwrap().insert(key, value.to_vec());
         }
     }
     if let Some(value) = writer.get(DBCol::ChunkApplyStats, &block_shard_id) {
@@ -890,10 +896,15 @@ fn writer_kvs(
                 kvs.get_mut(&col).unwrap().insert(key, value.to_vec());
             }
         }
-        // Each of these is keyed by block hash followed by a per-shard suffix, so a
-        // prefix scan on the hash finds every shard's row without asking which shards
-        // this block's epoch had.
-        for col in [DBCol::ChunkProducers, DBCol::ChunkExtra] {
+        // Each of these is keyed by block hash followed by a suffix, so one prefix scan
+        // on the hash finds this block's rows without asking which shards its epoch had.
+        for col in [
+            DBCol::ChunkProducers,
+            DBCol::ChunkExtra,
+            DBCol::IncomingReceipts,
+            DBCol::OutcomeIds,
+            DBCol::StateChanges,
+        ] {
             for (key, value) in writer.iter_prefix(col, block_hash.as_ref()) {
                 kvs.get_mut(&col).unwrap().insert(key.into_vec(), value.into_vec());
             }


### PR DESCRIPTION
The reader now writes `IncomingReceipts`, `OutcomeIds`, `TransactionResultForBlock` and `StateChanges`, the next four columns the blob already carries. The parity walk covers them.

Every column the reader writes goes through the store adapter that owns it, rather than building its own key bytes. `KeyForStateChanges::for_state_change` is new, holding the rule that a trie key naming no account carries the shard uid in its row key; the node's own writer goes through it too. The blob also stops sorting the outcomes by id, since `OutcomeIds` holds them in execution order and consumers read that order off it.
