### PR TITLE
feat(cloud-archive): the recent reader reconstructs shard state

### DIFF
--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -175,7 +175,6 @@ pub(crate) async fn pull_shard_batch(
 /// Applies the state changes `shard_batch` carries from just above `reader_head` to its
 /// own end, in one commit.
 pub(crate) fn apply_batch_state_changes(
-    store: &Store,
     tries: &ShardTries,
     shard_uid: ShardUId,
     shard_batch: &ShardBatch,
@@ -186,7 +185,7 @@ pub(crate) fn apply_batch_state_changes(
     let start_height = (reader_head.height + 1).max(shard_batch.start_height());
     // TODO(cloud_archival): anchor a shard a resharding added above the head.
     let prev_state_root =
-        shard_state_anchor(store, &reader_head.last_present_block_hash, shard_uid)?;
+        shard_state_anchor(tries, &reader_head.last_present_block_hash, shard_uid)?;
     let mut update = BatchTrieUpdate::new(tries, shard_uid, prev_state_root);
     for height in start_height..=shard_batch.end_height() {
         let Some(shard_data) = shard_batch.get_data_at_height(height) else {
@@ -210,12 +209,12 @@ pub(crate) fn apply_batch_state_changes(
 
 /// The state root `shard_uid` stands at under `block_hash`, which is the root the height
 /// above that block applies onto.
-fn shard_state_anchor(
-    store: &Store,
+pub(crate) fn shard_state_anchor(
+    tries: &ShardTries,
     block_hash: &CryptoHash,
     shard_uid: ShardUId,
 ) -> Result<CryptoHash, CloudArchivalReaderError> {
-    match store.chunk_store().get_chunk_extra(block_hash, &shard_uid) {
+    match tries.store().store_ref().chunk_store().get_chunk_extra(block_hash, &shard_uid) {
         Ok(chunk_extra) => Ok(*chunk_extra.state_root()),
         Err(Error::DBNotFoundErr(_)) => {
             Err(CloudArchivalReaderError::NoStateAnchor { shard_uid, block_hash: *block_hash })

--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -1,16 +1,17 @@
+use crate::archive::cloud_reader_trie_utils::BatchTrieUpdate;
 use near_chain::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
-use near_primitives::errors::EpochError;
+use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::index_to_bytes;
-use near_store::adapter::StoreUpdateAdapter;
 use near_store::adapter::cloud_archival_store::CloudReaderHead;
+use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::archive::cloud_storage::{
-    BlockData, CloudRetrievalError, CloudStorage, EpochData, NewChunkData, ShardData,
+    BlockData, CloudRetrievalError, CloudStorage, EpochData, NewChunkData, ShardBatch, ShardData,
 };
-use near_store::{DBCol, KeyForStateChanges, ShardUId, Store, StoreUpdate};
+use near_store::{DBCol, KeyForStateChanges, ShardTries, ShardUId, Store, StoreUpdate};
 use std::collections::{HashMap, HashSet};
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
@@ -22,10 +23,23 @@ pub enum CloudArchivalReaderError {
     Chain(#[from] Error),
     #[error(transparent)]
     Epoch(#[from] EpochError),
+    #[error(transparent)]
+    Storage(#[from] StorageError),
     #[error("walked back to genesis without finding a state snapshot")]
     NoSnapshotFound,
     #[error("no block below {start_height}, which must be above the first archived block")]
     NoAnchorBelow { start_height: BlockHeight },
+    #[error("no state root for shard {shard_uid} under block {block_hash}")]
+    NoStateAnchor { shard_uid: ShardUId, block_hash: CryptoHash },
+    #[error(
+        "state root at block {block_hash} shard {shard_id}: applied {applied}, recorded {recorded}"
+    )]
+    StateRootMismatch {
+        block_hash: CryptoHash,
+        shard_id: ShardId,
+        applied: CryptoHash,
+        recorded: CryptoHash,
+    },
 }
 
 /// Writes one block's cloud data into the block-level columns a reader reproduces.
@@ -125,7 +139,7 @@ pub(crate) async fn pull_shard_batch(
     cloud_storage: &CloudStorage,
     shard_uid: ShardUId,
     from_height: BlockHeight,
-) -> Result<(), CloudArchivalReaderError> {
+) -> Result<ShardBatch, CloudArchivalReaderError> {
     let shard_batch = cloud_storage.get_shard_batch(from_height, shard_uid.shard_id()).await?;
     // A shard the reader still tracks at `from_height` cannot have a batch that ended
     // below it: a retired shard's batch ends where the epoch it belonged to does.
@@ -155,7 +169,57 @@ pub(crate) async fn pull_shard_batch(
         }
     }
     update.commit();
+    Ok(shard_batch)
+}
+
+/// Applies the state changes `shard_batch` carries from just above `reader_head` to its
+/// own end, in one commit.
+pub(crate) fn apply_batch_state_changes(
+    store: &Store,
+    tries: &ShardTries,
+    shard_uid: ShardUId,
+    shard_batch: &ShardBatch,
+    reader_head: &CloudReaderHead,
+) -> Result<(), CloudArchivalReaderError> {
+    // A reader that joined mid-batch has its head inside the batch, and the heights below
+    // that head are applied already.
+    let start_height = std::cmp::max(reader_head.height + 1, shard_batch.start_height());
+    let prev_state_root =
+        shard_state_anchor(store, &reader_head.last_present_block_hash, shard_uid)?;
+    let mut update = BatchTrieUpdate::new(tries, shard_uid, prev_state_root);
+    for height in start_height..=shard_batch.end_height() {
+        let Some(shard_data) = shard_batch.get_data_at_height(height) else {
+            continue;
+        };
+        let applied = update.apply(shard_data.state_changes())?;
+        let recorded = *shard_data.chunk_extra().state_root();
+        if applied != recorded {
+            return Err(CloudArchivalReaderError::StateRootMismatch {
+                block_hash: *shard_data.block_hash(),
+                shard_id: shard_uid.shard_id(),
+                applied,
+                recorded,
+            });
+        }
+    }
+    update.commit();
     Ok(())
+}
+
+/// The state root `shard_uid` stands at under `block_hash`, which is the root the height
+/// above that block applies onto.
+fn shard_state_anchor(
+    store: &Store,
+    block_hash: &CryptoHash,
+    shard_uid: ShardUId,
+) -> Result<CryptoHash, CloudArchivalReaderError> {
+    match store.chunk_store().get_chunk_extra(block_hash, &shard_uid) {
+        Ok(chunk_extra) => Ok(*chunk_extra.state_root()),
+        Err(Error::DBNotFoundErr(_)) => {
+            Err(CloudArchivalReaderError::NoStateAnchor { shard_uid, block_hash: *block_hash })
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Seeds the store with what the epoch manager needs to answer for `height`, and
@@ -245,7 +309,6 @@ pub(crate) fn save_shard_data(
     shard_uid: ShardUId,
     shard_data: &ShardData,
 ) {
-    // TODO(cloud_archival): apply each block's recorded changes to the shard's state.
     let block_hash = shard_data.block_hash();
     let shard_id = shard_uid.shard_id();
     let mut chunk_store_update = update.chunk_store_update();

--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -183,7 +183,8 @@ pub(crate) fn apply_batch_state_changes(
 ) -> Result<(), CloudArchivalReaderError> {
     // A reader that joined mid-batch has its head inside the batch, and the heights below
     // that head are applied already.
-    let start_height = std::cmp::max(reader_head.height + 1, shard_batch.start_height());
+    let start_height = (reader_head.height + 1).max(shard_batch.start_height());
+    // TODO(cloud_archival): anchor a shard a resharding added above the head.
     let prev_state_root =
         shard_state_anchor(store, &reader_head.last_present_block_hash, shard_uid)?;
     let mut update = BatchTrieUpdate::new(tries, shard_uid, prev_state_root);
@@ -202,6 +203,7 @@ pub(crate) fn apply_batch_state_changes(
             });
         }
     }
+    // TODO(cloud_archival): consider one commit per window, so a retry refcounts once.
     update.commit();
     Ok(())
 }

--- a/chain/client/src/archive/cloud_reader_trie_utils.rs
+++ b/chain/client/src/archive/cloud_reader_trie_utils.rs
@@ -1,0 +1,117 @@
+use crate::archive::cloud_archival_utils::CloudArchivalReaderError;
+use near_primitives::errors::StorageError;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::RawStateChangesWithTrieKey;
+use near_store::adapter::StoreAdapter;
+use near_store::adapter::trie_store::{TrieStoreAdapter, TrieStoreUpdateAdapter};
+use near_store::flat::FlatStorageManager;
+use near_store::trie::AccessOptions;
+use near_store::{
+    ShardTries, ShardUId, StateSnapshotConfig, Store, Trie, TrieChanges, TrieConfig, TrieDBStorage,
+    TrieStorage,
+};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// The tries a reader applies recorded state changes into.
+pub fn build_shard_tries(store: &Store) -> ShardTries {
+    ShardTries::new(
+        store.trie_store(),
+        TrieConfig::default(),
+        FlatStorageManager::new(store.flat_store()),
+        StateSnapshotConfig::Disabled,
+    )
+}
+
+/// Trie storage for one batch: the nodes that batch has applied, over the nodes the store
+/// already holds. A height reads what the height below it wrote, and a store read does
+/// not see an uncommitted store update.
+struct BatchTrieStorage {
+    /// Behind a lock because `retrieve_raw_bytes` takes `&self` and the trie holds this
+    /// storage as `Arc<dyn TrieStorage>`, which is `Sync`.
+    uncommitted: Mutex<HashMap<CryptoHash, Arc<[u8]>>>,
+    committed: TrieDBStorage,
+}
+
+impl BatchTrieStorage {
+    fn new(store: TrieStoreAdapter, shard_uid: ShardUId) -> Self {
+        // TODO(cloud_archival): serve committed nodes through the shard cache, which needs
+        // an accessor for the one `ShardTries` holds.
+        let committed = TrieDBStorage::new(store, shard_uid);
+        // TODO(cloud_archival): consider serving the batch's own nodes out of the pending
+        // transaction, so an inserted node is held once.
+        Self { uncommitted: Mutex::new(HashMap::new()), committed }
+    }
+
+    /// Serves the nodes `trie_changes` inserted to every read that follows.
+    fn insert(&self, trie_changes: &TrieChanges) {
+        let mut uncommitted = self.uncommitted.lock();
+        for insertion in trie_changes.insertions() {
+            uncommitted.insert(*insertion.hash(), insertion.payload().into());
+        }
+    }
+}
+
+impl TrieStorage for BatchTrieStorage {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
+        if let Some(bytes) = self.uncommitted.lock().get(hash) {
+            return Ok(bytes.clone());
+        }
+        self.committed.retrieve_raw_bytes(hash)
+    }
+}
+
+/// One shard batch's trie writes: each `apply` moves the shard's state one height, and
+/// `commit` writes every height together.
+///
+/// An update dropped without `commit` writes nothing, so a batch that fails part way
+/// leaves the trie where it started.
+pub(crate) struct BatchTrieUpdate {
+    tries: ShardTries,
+    shard_uid: ShardUId,
+    store_update: TrieStoreUpdateAdapter<'static>,
+    storage: Arc<BatchTrieStorage>,
+    /// The root the heights applied so far have left.
+    state_root: CryptoHash,
+}
+
+impl BatchTrieUpdate {
+    /// Opens a batch that applies onto `state_root`.
+    pub(crate) fn new(tries: &ShardTries, shard_uid: ShardUId, state_root: CryptoHash) -> Self {
+        let storage = Arc::new(BatchTrieStorage::new(tries.store(), shard_uid));
+        Self {
+            tries: tries.clone(),
+            shard_uid,
+            store_update: tries.store_update(),
+            storage,
+            state_root,
+        }
+    }
+
+    /// Applies one height's recorded state changes and returns the root they leave.
+    pub(crate) fn apply(
+        &mut self,
+        state_changes: &[RawStateChangesWithTrieKey],
+    ) -> Result<CryptoHash, CloudArchivalReaderError> {
+        let entries = state_changes.iter().map(|change| {
+            // A key can change more than once within a block, and the last value is the
+            // one the block leaves behind.
+            let data = change.changes.last().expect("a recorded key has a change").data.clone();
+            (change.trie_key.to_vec(), data)
+        });
+        let trie = Trie::new(self.storage.clone(), self.state_root, None);
+        let trie_changes = trie.update(entries, AccessOptions::NO_SIDE_EFFECTS)?;
+        // Insertions alone, so every root the walk passes stays reachable for a query at
+        // that height.
+        self.tries.apply_insertions(&trie_changes, self.shard_uid, &mut self.store_update);
+        self.storage.insert(&trie_changes);
+        self.state_root = trie_changes.new_root;
+        Ok(self.state_root)
+    }
+
+    /// Commits the batch.
+    pub(crate) fn commit(self) {
+        self.store_update.commit();
+    }
+}

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -1,6 +1,6 @@
 use crate::archive::cloud_archival_utils::{
     CloudArchivalReaderError, apply_batch_state_changes, pull_block_batch, pull_shard_batch,
-    save_reader_head, shards_tracked_in_batch,
+    save_reader_head, shard_state_anchor, shards_tracked_in_batch,
 };
 use crate::archive::cloud_reader_trie_utils::build_shard_tries;
 use near_async::time::{Clock, Duration};
@@ -119,9 +119,29 @@ impl CloudArchivalRecentReader {
         self.interrupt.stop();
     }
 
+    /// Reads the root every shard the reader tracks at its head stands at, so a store
+    /// holding no state for one of them stops the reader here instead of on a poll it
+    /// would go on repeating.
+    fn check_state_anchors(
+        &self,
+        reader_head: &CloudReaderHead,
+    ) -> Result<(), CloudArchivalReaderError> {
+        let shard_uids = shards_tracked_in_batch(
+            self.epoch_manager.as_ref(),
+            &self.shard_tracker,
+            &reader_head.last_present_block_hash,
+            None,
+        )?;
+        for shard_uid in shard_uids {
+            shard_state_anchor(&self.tries, &reader_head.last_present_block_hash, shard_uid)?;
+        }
+        Ok(())
+    }
+
     /// Follows the bucket, copying what it holds into the local store, until interrupted.
     pub async fn cloud_archival_loop(mut self) -> Result<(), CloudArchivalReaderError> {
         let mut reader_head = self.ensure_reader_head()?;
+        self.check_state_anchors(&reader_head)?;
         tracing::info!(target: "cloud_archival", ?reader_head, "following the cloud archive");
 
         while !self.interrupt.is_cancelled() {
@@ -174,13 +194,7 @@ impl CloudArchivalRecentReader {
                 reader_head.height + 1,
             )
             .await?;
-            apply_batch_state_changes(
-                &self.store,
-                &self.tries,
-                shard_uid,
-                &shard_batch,
-                reader_head,
-            )?;
+            apply_batch_state_changes(&self.tries, shard_uid, &shard_batch, reader_head)?;
         }
         let head = save_reader_head(&self.store, window.end_height, window.last_present_block_hash);
         Ok(PullOutcome::Pulled { head })

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -1,7 +1,8 @@
 use crate::archive::cloud_archival_utils::{
-    CloudArchivalReaderError, pull_block_batch, pull_shard_batch, save_reader_head,
-    shards_tracked_in_batch,
+    CloudArchivalReaderError, apply_batch_state_changes, pull_block_batch, pull_shard_batch,
+    save_reader_head, shards_tracked_in_batch,
 };
+use crate::archive::cloud_reader_trie_utils::build_shard_tries;
 use near_async::time::{Clock, Duration};
 use near_chain_configs::InterruptHandle;
 use near_epoch_manager::EpochManagerAdapter;
@@ -11,7 +12,7 @@ use near_primitives::types::BlockHeight;
 use near_store::adapter::cloud_archival_store::CloudReaderHead;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::archive::cloud_storage::CloudStorage;
-use near_store::{ShardUId, Store};
+use near_store::{ShardTries, ShardUId, Store};
 use std::mem;
 use std::sync::Arc;
 
@@ -62,6 +63,7 @@ pub struct CloudArchivalRecentReader {
     polling_interval: Duration,
     interrupt: InterruptHandle,
     pending_window: Option<PendingWindow>,
+    tries: ShardTries,
 }
 
 impl CloudArchivalRecentReader {
@@ -73,6 +75,7 @@ impl CloudArchivalRecentReader {
         shard_tracker: ShardTracker,
         polling_interval: Duration,
     ) -> Self {
+        let tries = build_shard_tries(&store);
         Self {
             clock,
             store,
@@ -82,6 +85,7 @@ impl CloudArchivalRecentReader {
             polling_interval,
             interrupt: InterruptHandle::new(),
             pending_window: None,
+            tries,
         }
     }
 
@@ -163,8 +167,20 @@ impl CloudArchivalRecentReader {
             return Ok(PullOutcome::WaitingForShard { shard_uid });
         };
         for shard_uid in shard_uids {
-            pull_shard_batch(&self.store, &self.cloud_storage, shard_uid, reader_head.height + 1)
-                .await?;
+            let shard_batch = pull_shard_batch(
+                &self.store,
+                &self.cloud_storage,
+                shard_uid,
+                reader_head.height + 1,
+            )
+            .await?;
+            apply_batch_state_changes(
+                &self.store,
+                &self.tries,
+                shard_uid,
+                &shard_batch,
+                reader_head,
+            )?;
         }
         let head = save_reader_head(&self.store, window.end_height, window.last_present_block_hash);
         Ok(PullOutcome::Pulled { head })

--- a/chain/client/src/archive/mod.rs
+++ b/chain/client/src/archive/mod.rs
@@ -1,5 +1,6 @@
 pub mod cloud_archival_utils;
 pub mod cloud_archival_writer;
 pub mod cloud_historical_reader;
+pub mod cloud_reader_trie_utils;
 pub mod cloud_recent_reader;
 pub mod cold_store_actor;

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -5,12 +5,11 @@ use crate::utils::account::archival_account_id;
 use crate::utils::cloud_archival::{
     ReshardingInfo, WriterConfig, add_writer_node, apply_writer_settings,
     assert_reader_writer_parity, assert_resharding_epoch_snapshot_forced,
-    assert_writer_inverse_deltas, bootstrap_historical_reader, build_shard_tries,
-    check_account_balance, check_data_at_height_for_shards, count_processed_receipts, epoch_id_at,
-    exec, gc_and_heads_sanity_checks, get_cloud_storage, get_local_min_head,
-    get_state_header_for_epoch, get_writer_handle, has_state_root, run_node_until,
-    run_until_one_epoch_after_resharding, simulate_lagging_shard, snapshots_sanity_check,
-    stop_and_restart_node,
+    assert_writer_inverse_deltas, bootstrap_historical_reader, check_account_balance,
+    check_data_at_height_for_shards, count_processed_receipts, epoch_id_at, exec,
+    gc_and_heads_sanity_checks, get_cloud_storage, get_local_min_head, get_state_header_for_epoch,
+    get_writer_handle, has_state_root, run_node_until, run_until_one_epoch_after_resharding,
+    simulate_lagging_shard, snapshots_sanity_check, stop_and_restart_node,
 };
 use borsh::to_vec;
 use near_async::futures::FutureSpawnerExt;
@@ -21,6 +20,7 @@ use near_chain_configs::test_genesis::TestEpochConfigBuilder;
 use near_client::archive::cloud_archival_utils::find_snapshot_at_or_before;
 #[cfg(feature = "nightly")]
 use near_client::archive::cloud_archival_utils::save_block_data;
+use near_client::archive::cloud_reader_trie_utils::build_shard_tries;
 use near_client::archive::cloud_recent_reader::CloudArchivalRecentReader;
 use near_primitives::block::Block;
 use near_primitives::chunk_apply_stats::ChunkApplyStats;
@@ -459,6 +459,10 @@ impl CloudArchiveHarness {
         let mut update = store.store_update();
         update.cloud_archival_store_update().set_reader_head(&head);
         update.commit();
+    }
+
+    fn genesis_height(&self) -> BlockHeight {
+        self.env.node_for_account(&self.writer_id).client().chain.genesis().height()
     }
 
     fn recent_reader_store(&self) -> Store {
@@ -2258,6 +2262,40 @@ fn test_cloud_archival_recent_reader_waits_for_a_lagging_shard() {
     h.assert_reader_writer_parity(Reader::Recent, reader_from, h.recent_reader_height());
 
     reader.stop();
+    h.shutdown();
+}
+
+/// The recent reader moves each shard's state forward over the heights it takes, so every
+/// state root the writer recorded across the followed range resolves in the reader's trie.
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_recent_reader_reconstructs_shard_state() {
+    let mut h = CloudArchiveHarness::builder().build();
+    h.run_until_epoch(2);
+    let followed_to = h.recent_reader_height();
+    assert!(
+        followed_to > h.genesis_height() + h.epoch_length,
+        "the reader followed to {followed_to}, which is under one epoch"
+    );
+
+    let reader_tries = build_shard_tries(&h.recent_reader_store());
+    let writer_store = h.writer_store();
+    for height in h.genesis_height() + 1..=followed_to {
+        let block_hash = writer_store.chain_store().get_block_hash_by_height(height).unwrap();
+        for shard_uid in CloudArchiveHarness::all_shard_uids() {
+            let state_root = *writer_store
+                .chunk_store()
+                .get_chunk_extra(&block_hash, &shard_uid)
+                .unwrap()
+                .state_root();
+            assert!(
+                has_state_root(&reader_tries, shard_uid, state_root),
+                "shard {shard_uid} state at h={height} unreachable in the reader trie"
+            );
+        }
+    }
+
     h.shutdown();
 }
 

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -10,6 +10,7 @@ use near_client::archive::cloud_archival_utils::{
 };
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::archive::cloud_historical_reader::bootstrap_range;
+use near_client::archive::cloud_reader_trie_utils::build_shard_tries;
 use near_primitives::block::Block;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
@@ -29,11 +30,8 @@ use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::archive::cloud_storage::{
     CloudStorage, is_cloud_archive_reader_bootstrapped, read_chunk_hashes,
 };
-use near_store::flat::FlatStorageManager;
 use near_store::trie::AccessOptions;
-use near_store::{
-    COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, StateSnapshotConfig, Store, Trie, TrieConfig,
-};
+use near_store::{COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, Store, Trie};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
@@ -650,16 +648,6 @@ pub fn bootstrap_historical_reader(
     }
 }
 
-/// Builds a `ShardTries` over `store` with state snapshots disabled.
-pub(crate) fn build_shard_tries(store: &Store) -> ShardTries {
-    ShardTries::new(
-        store.trie_store(),
-        TrieConfig::default(),
-        FlatStorageManager::new(store.flat_store()),
-        StateSnapshotConfig::Disabled,
-    )
-}
-
 /// Whether `state_root` resolves to a reachable root node in `shard_uid`'s trie.
 pub(crate) fn has_state_root(
     tries: &ShardTries,
@@ -797,7 +785,8 @@ pub(crate) fn assert_reader_writer_parity(
     start: BlockHeight,
     end: BlockHeight,
 ) {
-    // TODO(cloud_archival): compare `DBCol::State` too, once the reader reconstructs it.
+    // TODO(cloud_archival): compare `DBCol::State` too, which needs a comparison by
+    // reachable root: the rows are keyed by node hash, so a height range cannot name them.
     let cols: Vec<DBCol> = DBCol::iter()
         .filter(|&c| is_cloud_archive_reader_bootstrapped(c) && c != DBCol::State)
         .collect();


### PR DESCRIPTION
The recent reader reconstructs each shard's state as it follows the bucket.

A shard moves forward a height at a time, applying the changes the blob records onto the root it already stands at. The result is checked against the root recorded for that height. The starting root needs no download, since the handed-over database carries a `ChunkExtra` under the block the reader head names.

Only insertions are applied, so an older height's root stays reachable. One store update covers a whole shard batch. That needs `BatchTrieStorage`, because a store read does not see an uncommitted store update, so a height's nodes are held in memory for the heights above it.
