### PR TITLE
feat(spice): pull recovery for receipts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,6 +4477,7 @@ dependencies = [
  "near-time",
  "nearcore",
  "parking_lot 0.12.1",
+ "rand 0.8.5",
  "reqwest 0.13.2",
  "serde_json",
  "tempfile",

--- a/chain/client/src/spice/chunk_executor_actor/coordinator.rs
+++ b/chain/client/src/spice/chunk_executor_actor/coordinator.rs
@@ -165,6 +165,33 @@ impl ChunkExecutorActor {
             .find(|executor| executor.shard_uid().shard_id() == shard_id)
     }
 
+    /// The executor that receipts from `source_block_hash` to `to_shard` route to.
+    /// They are applied in the block after the source block, so the shard is resolved
+    /// in that block's layout. A tracked shard whose executor reconcile has not created
+    /// yet (before the first processed block, or across an epoch boundary) gets one
+    /// here instead of the delivery being dropped. `None` if the shard is not tracked.
+    fn executor_for_incoming_receipt(
+        &mut self,
+        source_block_hash: &CryptoHash,
+        to_shard: ShardId,
+    ) -> Result<Option<&mut PerShardChunkExecutor>, Error> {
+        let existing =
+            self.per_shard_executors.keys().find(|uid| uid.shard_id() == to_shard).copied();
+        let shard_uid = match existing {
+            Some(shard_uid) => shard_uid,
+            None => {
+                let tracked =
+                    self.shard_tracker.tracked_shard_uids_this_or_next_epoch(source_block_hash)?;
+                let Some(shard_uid) = tracked.into_iter().find(|uid| uid.shard_id() == to_shard)
+                else {
+                    return Ok(None);
+                };
+                shard_uid
+            }
+        };
+        Ok(Some(self.get_or_create_per_shard_executor(shard_uid)))
+    }
+
     /// Spawn executors for shards tracked this or next epoch and evict ones no
     /// longer tracked. The this-or-next-epoch set matches the
     /// `should_apply_chunk(IsCaughtUp, ..)` gate the monolithic executor used:
@@ -382,6 +409,7 @@ impl Handler<ExecutorIncomingUnverifiedReceipts> for ChunkExecutorActor {
         let ExecutorIncomingUnverifiedReceipts { data_id, receipt_proof } = receipts;
         let DataId::ReceiptProof { source, to_shard } = &data_id;
         let block_hash = source.block_hash;
+        let to_shard_id = *to_shard;
         tracing::debug!(
             target: "chunk_executor",
             %block_hash,
@@ -390,18 +418,16 @@ impl Handler<ExecutorIncomingUnverifiedReceipts> for ChunkExecutorActor {
         );
         // Route to the destination shard's executor, which owns the buffer for
         // receipts addressed to it.
-        let to_shard_id = *to_shard;
-        // TODO(spice-resharding): a receipt for a shard this node *does* track can be
-        // dropped here if it arrives before reconcile created the executor (startup /
-        // catch-up, or around an epoch boundary). Reconcile from the source block's
-        // parent and retry the lookup before treating the shard as untracked.
-        // TODO(spice-data-distribution): a dropped delivery leaves the data manager's item
-        // parked with no verification result until it expires; once pulls exist that is a
-        // proof never re-fetched. Create the executor for a shard tracked as of the source
-        // block instead of dropping (#16275).
-        let Some(executor) = self.executor_for_shard_id(to_shard_id) else {
-            tracing::debug!(target: "chunk_executor", %block_hash, ?to_shard_id, "receipt for untracked shard; dropping");
-            return;
+        let executor = match self.executor_for_incoming_receipt(&block_hash, to_shard_id) {
+            Ok(Some(executor)) => executor,
+            Ok(None) => {
+                tracing::debug!(target: "chunk_executor", %block_hash, ?to_shard_id, "receipt for untracked shard; dropping");
+                return;
+            }
+            Err(err) => {
+                tracing::error!(target: "chunk_executor", ?err, %block_hash, ?to_shard_id, "failed to resolve the executor for incoming receipts");
+                return;
+            }
         };
         if let Err(err) = executor.handle_incoming_receipt(data_id, receipt_proof) {
             tracing::error!(target: "chunk_executor", ?err, ?block_hash, "failed while handling incoming receipt");

--- a/chain/client/src/spice/chunk_executor_actor/per_shard.rs
+++ b/chain/client/src/spice/chunk_executor_actor/per_shard.rs
@@ -8,7 +8,8 @@ use super::storage::{
 };
 use crate::spice::chunk_validator_actor::send_spice_chunk_endorsement;
 use crate::spice::data_distributor_actor::{
-    SpiceDataDistributorAdapter, SpiceDistributorOutgoingReceipts, SpiceDistributorStateWitness,
+    MissingReceiptProofs, SpiceDataDistributorAdapter, SpiceDistributorOutgoingReceipts,
+    SpiceDistributorStateWitness,
 };
 use crate::spice::data_manager::DataId;
 use near_async::futures::AsyncComputationSpawner;
@@ -318,6 +319,20 @@ impl PerShardChunkExecutor {
             );
             if proofs.len() != prev_block_shard_uids.len() {
                 tracing::debug!(target: "chunk_executor", %block_hash, %prev_block_hash, ?shard_uid, have=proofs.len(), want=prev_block_shard_uids.len(), "not ready: missing incoming receipts");
+                let have: HashSet<ShardId> =
+                    proofs.iter().map(|proof| proof.1.from_shard_id).collect();
+                let data_ids = prev_block_shard_uids
+                    .iter()
+                    .map(|uid| uid.shard_id())
+                    .filter(|from_shard| !have.contains(from_shard))
+                    .map(|from_shard| DataId::ReceiptProof {
+                        source: SpiceChunkId { block_hash: prev_block_hash, shard_id: from_shard },
+                        to_shard: shard_id,
+                    })
+                    .collect();
+                self.data_distributor_adapter
+                    .missing_receipt_proofs
+                    .send(MissingReceiptProofs { data_ids });
                 return Ok(ApplyOutcome::NotReady);
             }
             proofs

--- a/chain/client/src/spice/chunk_executor_actor/testonly.rs
+++ b/chain/client/src/spice/chunk_executor_actor/testonly.rs
@@ -94,6 +94,7 @@ impl TestonlySyncChunkExecutorActor {
             }),
             witness: noop().into_sender(),
             data_verification: noop().into_sender(),
+            missing_receipt_proofs: noop().into_sender(),
         };
         Self {
             actor: ChunkExecutorActor::new(

--- a/chain/client/src/spice/data_distributor_actor.rs
+++ b/chain/client/src/spice/data_distributor_actor.rs
@@ -8,7 +8,8 @@ use crate::spice::chunk_validator_actor::{
 };
 pub use crate::spice::data_manager::DataId;
 use crate::spice::data_manager::{
-    DataManagerError, Policies, ReceivedParts, SpiceData, SpiceDataManager, VerifiedCodedPart,
+    DataManagerError, Policies, PullRequest, ReceivedParts, SpiceData, SpiceDataManager,
+    VerifiedCodedPart, WakeAt, rotated_source_index,
 };
 use itertools::Itertools as _;
 use lru::LruCache;
@@ -18,6 +19,7 @@ use near_async::futures::DelayedActionRunner;
 use near_async::futures::DelayedActionRunnerExt as _;
 use near_async::messaging::CanSend;
 use near_async::messaging::Handler;
+use near_async::messaging::HandlerWithContext;
 use near_async::messaging::IntoSender;
 use near_async::messaging::Sender;
 use near_async::time::{Clock, Duration};
@@ -74,16 +76,16 @@ use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::adapter::trie_store::TrieStoreAdapter;
 use near_store::{TrieDBStorage, TrieStorage};
+use rand::rngs::StdRng;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash as _, Hasher as _};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use strum::IntoStaticStr;
+use time::ext::InstantExt as _;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -264,6 +266,8 @@ pub struct SpiceDataDistributorActor {
     /// Fetch engine for receipt proofs; witnesses stay on `waiting_on_data` until they
     /// switch over too.
     data_manager: SpiceDataManager,
+
+    clock: Clock,
 }
 
 struct DistributionData {
@@ -292,6 +296,7 @@ pub struct SpiceDataDistributorAdapter {
     pub receipts: Sender<SpiceDistributorOutgoingReceipts>,
     pub witness: Sender<SpiceDistributorStateWitness>,
     pub data_verification: Sender<DataVerification>,
+    pub missing_receipt_proofs: Sender<MissingReceiptProofs>,
 }
 
 struct DataPartsEntry {
@@ -338,11 +343,19 @@ pub enum DataVerification {
     Failed(DataId),
 }
 
-impl Handler<DataVerification> for SpiceDataDistributorActor {
-    fn handle(&mut self, verification: DataVerification) {
+/// The consumer needed these items' data and found it not (fully) arrived: the pull
+/// trigger. Sent by the chunk executor when an apply attempt finds receipt proofs
+/// missing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MissingReceiptProofs {
+    pub data_ids: Vec<DataId>,
+}
+
+impl HandlerWithContext<DataVerification> for SpiceDataDistributorActor {
+    fn handle(&mut self, verification: DataVerification, ctx: &mut dyn DelayedActionRunner<Self>) {
         let (data_id, result) = match verification {
             DataVerification::Ok(data_id) => {
-                let result = self.data_manager.on_verified(&data_id);
+                let result = self.data_manager.on_verified(&data_id).map(|()| WakeAt(None));
                 (data_id, result)
             }
             DataVerification::Failed(data_id) => {
@@ -350,10 +363,24 @@ impl Handler<DataVerification> for SpiceDataDistributorActor {
                 (data_id, result)
             }
         };
-        if let Err(err) = result {
+        match result {
+            Ok(wake) => self.set_pull_wake_timer(ctx, wake),
             // A verification result can race item expiry, so failing to apply one is not an error.
-            tracing::debug!(target: "spice_data_distribution", ?err, ?data_id, "ignoring expired data verification result");
+            Err(err) => {
+                tracing::debug!(target: "spice_data_distribution", ?err, ?data_id, "ignoring expired data verification result");
+            }
         }
+    }
+}
+
+impl HandlerWithContext<MissingReceiptProofs> for SpiceDataDistributorActor {
+    fn handle(
+        &mut self,
+        MissingReceiptProofs { data_ids }: MissingReceiptProofs,
+        ctx: &mut dyn DelayedActionRunner<Self>,
+    ) {
+        let wake = self.data_manager.start_pulling(&data_ids);
+        self.set_pull_wake_timer(ctx, wake);
     }
 }
 
@@ -408,10 +435,11 @@ impl Handler<SpiceDistributorStateWitness> for SpiceDataDistributorActor {
     }
 }
 
-impl Handler<SpiceIncomingPartialData> for SpiceDataDistributorActor {
+impl HandlerWithContext<SpiceIncomingPartialData> for SpiceDataDistributorActor {
     fn handle(
         &mut self,
         SpiceIncomingPartialData { data, recv_permit: _recv_permit }: SpiceIncomingPartialData,
+        ctx: &mut dyn DelayedActionRunner<Self>,
     ) {
         let block_hash = *data.block_hash();
         if !self.spice_gate.should_process(
@@ -422,17 +450,19 @@ impl Handler<SpiceIncomingPartialData> for SpiceDataDistributorActor {
             return;
         }
         let sender = data.sender().clone();
-        if let Err(err) = self.receive_data(data) {
-            if let Some(Error::DataIsIrrelevant(data_id)) = err.inner() {
-                self.waiting_on_data.remove(&data_id);
-                tracing::debug!(target: "spice_data_distribution", ?err, ?data_id, ?sender, "received irrelevant data");
-                return;
+        match self.receive_data(data) {
+            Ok(wake) => self.set_pull_wake_timer(ctx, wake),
+            Err(err) => {
+                if let Some(Error::DataIsIrrelevant(data_id)) = err.inner() {
+                    self.waiting_on_data.remove(&data_id);
+                    tracing::debug!(target: "spice_data_distribution", ?err, ?data_id, ?sender, "received irrelevant data");
+                    return;
+                }
+                // TODO(spice): Implement banning or de-prioritization of nodes from which we receive
+                // invalid data.
+                tracing::error!(target: "spice_data_distribution", ?err, ?block_hash, ?sender, "failed to handle receiving partial data");
             }
-            // TODO(spice): Implement banning or de-prioritization of nodes from which we receive
-            // invalid data.
-            tracing::error!(target: "spice_data_distribution", ?err, ?block_hash, ?sender, "failed to handle receiving partial data");
-            return;
-        };
+        }
     }
 }
 
@@ -477,8 +507,12 @@ impl Handler<SpiceContractCodeResponseMessage> for SpiceDataDistributorActor {
     }
 }
 
-impl Handler<ProcessedBlock> for SpiceDataDistributorActor {
-    fn handle(&mut self, ProcessedBlock { block_hash }: ProcessedBlock) {
+impl HandlerWithContext<ProcessedBlock> for SpiceDataDistributorActor {
+    fn handle(
+        &mut self,
+        ProcessedBlock { block_hash }: ProcessedBlock,
+        ctx: &mut dyn DelayedActionRunner<Self>,
+    ) {
         // A pre-spice block distributes no receipts or witnesses and produces no
         // endorsements, so there is nothing to wait on or contribute for it.
         match spice_enabled_for_block(&self.chain_store, &block_hash) {
@@ -498,8 +532,11 @@ impl Handler<ProcessedBlock> for SpiceDataDistributorActor {
         if let Err(err) = self.start_waiting_on_data(&block_hash) {
             tracing::error!(target: "spice_data_distribution", ?err, ?block_hash, "failure when starting waiting on data");
         }
-        if let Err(err) = self.process_pending_partial_data(&block_hash) {
-            tracing::error!(target: "spice_data_distribution", ?err, ?block_hash, "failure when processing pending partial data");
+        match self.process_pending_partial_data(&block_hash) {
+            Ok(wake) => self.set_pull_wake_timer(ctx, wake),
+            Err(err) => {
+                tracing::error!(target: "spice_data_distribution", ?err, ?block_hash, "failure when processing pending partial data");
+            }
         }
         match self.chain_store.spice_final_execution_head() {
             Ok(head) => self.data_manager.on_final_execution_head(head.height),
@@ -513,6 +550,7 @@ impl Handler<ProcessedBlock> for SpiceDataDistributorActor {
 impl SpiceDataDistributorActor {
     pub fn new(
         clock: Clock,
+        rng: StdRng,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         chain_store: ChainStoreAdapter,
         validator_signer: MutableValidatorSigner,
@@ -529,12 +567,14 @@ impl SpiceDataDistributorActor {
         const PROCESSED_CONTRACT_CODE_REQUESTS_CACHE_SIZE: NonZeroUsize =
             NonZeroUsize::new(30).unwrap();
         let data_manager = SpiceDataManager::new(
-            clock,
+            clock.clone(),
+            rng,
             DATA_PARTS_RATIO,
             Policies::new(chain_store.clone(), epoch_manager.clone(), shard_tracker.clone()),
         );
         Self {
             data_manager,
+            clock,
             // TODO(spice): Evaluate whether the same data parts ratio makes sense for all data
             // distributed.
             rs_encoders: ReedSolomonEncoderCache::new(DATA_PARTS_RATIO),
@@ -589,6 +629,37 @@ impl SpiceDataDistributorActor {
         {
             *self.malformed_data_requests.entry(*reason).or_default() += 1;
         }
+    }
+
+    /// Runs the engine's due pulls at `wake`. A timer made stale by a re-schedule still
+    /// fires and is harmless: the engine finds nothing due.
+    fn set_pull_wake_timer(&self, ctx: &mut dyn DelayedActionRunner<Self>, wake: WakeAt) {
+        let WakeAt(Some(at)) = wake else {
+            return;
+        };
+        let delay = at.signed_duration_since(self.clock.now()).max(Duration::ZERO);
+        ctx.run_later("spice data pull wake", delay, |actor, ctx| {
+            actor.process_due_pulls(ctx);
+        });
+    }
+
+    fn process_due_pulls(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
+        // TODO(spice): Allow requesting data without signer using route back.
+        let signer = self.validator_signer.get();
+        let me = signer.as_ref().map(|signer| signer.validator_id());
+        let (requests, wake) = self.data_manager.on_wake(self.clock.now(), me);
+        for PullRequest { producer, wants } in requests {
+            let requester = me.expect("a request is only built with a signer").clone();
+            let wants =
+                wants.into_iter().map(|(id, ordinals)| (SpiceDataIdentifier::from(&id), ordinals));
+            self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                NetworkRequests::SpiceDataRequest {
+                    request: SpiceDataRequest::new(wants.collect(), requester),
+                    producer,
+                },
+            ));
+        }
+        self.set_pull_wake_timer(ctx, wake);
     }
 
     // TODO(spice): before distributing persist data keyed by id to allow it being re-requested.
@@ -707,13 +778,17 @@ impl SpiceDataDistributorActor {
         Ok((recipients_set, producers))
     }
 
-    pub(crate) fn receive_data(&mut self, data: SpicePartialData) -> Result<(), ReceiveDataError> {
+    pub(crate) fn receive_data(
+        &mut self,
+        data: SpicePartialData,
+    ) -> Result<WakeAt, ReceiveDataError> {
         let block_hash = data.block_hash();
         let block = match self.chain_store.get_block(block_hash) {
             Ok(block) => block,
             Err(near_chain::Error::DBNotFoundErr(_)) => {
                 return self
                     .add_pending_partial_data(data)
+                    .map(|()| WakeAt(None))
                     .map_err(ReceiveDataError::ReceivingDataWithoutBlock);
             }
             Err(err) => return Err(err.into()),
@@ -754,7 +829,7 @@ impl SpiceDataDistributorActor {
         &mut self,
         partial_data: SpicePartialData,
         block: &Block,
-    ) -> Result<(), Error> {
+    ) -> Result<WakeAt, Error> {
         let sender_validator = self
             .epoch_manager
             .get_validator_by_account_id(block.header().epoch_id(), partial_data.sender())?;
@@ -769,7 +844,7 @@ impl SpiceDataDistributorActor {
         &mut self,
         SpiceVerifiedPartialData { id, commitment, parts, sender }: SpiceVerifiedPartialData,
         block: &Block,
-    ) -> Result<(), Error> {
+    ) -> Result<WakeAt, Error> {
         self.verify_data_id(&id, block)?;
         let (_recipients, producers) = self.recipients_and_producers(&id, block)?;
         if !producers.contains(&sender) {
@@ -793,18 +868,19 @@ impl SpiceDataDistributorActor {
                     Ok(ReceivedParts::Complete(SpiceData::ReceiptProof(receipt_proof))) => {
                         self.executor_sender
                             .send(ExecutorIncomingUnverifiedReceipts { data_id, receipt_proof });
-                        Ok(())
+                        Ok(WakeAt(None))
                     }
                     Ok(ReceivedParts::Complete(SpiceData::StateWitness(_))) => {
                         unreachable!("decode checked the data against its receipt-proof id")
                     }
-                    Ok(ReceivedParts::Collecting) => Ok(()),
+                    Ok(ReceivedParts::Collecting(wake)) => Ok(wake),
                     Ok(ReceivedParts::NotWanted) => Err(Error::DataIsIrrelevant(id)),
                     Err(err) => Err(err.into()),
                 }
             }
             SpiceDataIdentifier::Witness { .. } => {
-                self.receive_witness_data_with_block(id, commitment, parts, block, &producers)
+                self.receive_witness_data_with_block(id, commitment, parts, block, &producers)?;
+                Ok(WakeAt(None))
             }
         }
     }
@@ -1027,25 +1103,28 @@ impl SpiceDataDistributorActor {
         Ok(false)
     }
 
-    fn process_pending_partial_data(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
+    fn process_pending_partial_data(&mut self, block_hash: &CryptoHash) -> Result<WakeAt, Error> {
         let ready_data = self.pending_partial_data.pop(&block_hash).unwrap_or_default();
+        let mut wake = WakeAt(None);
         if ready_data.is_empty() {
-            return Ok(());
+            return Ok(wake);
         }
         let block = self.chain_store.get_block(&block_hash)?;
         for data in ready_data {
             let data_id = data.id.clone();
             let commitment = data.commitment.clone();
-            if let Err(err) = self.receive_verified_data_with_block(data, &block) {
-                if let Error::DataIsIrrelevant(_) = err {
+            match self.receive_verified_data_with_block(data, &block) {
+                Ok(data_wake) => wake = wake.earliest(data_wake),
+                Err(err @ Error::DataIsIrrelevant(_)) => {
                     self.waiting_on_data.remove(&data_id);
                     tracing::debug!(target: "spice_data_distribution", ?err, ?data_id, ?commitment, "processing irrelevant data");
-                } else {
+                }
+                Err(err) => {
                     tracing::error!(target: "spice_data_distribution", ?err, ?data_id, ?commitment, "failed to process partial data");
                 }
             }
         }
-        Ok(())
+        Ok(wake)
     }
 
     #[cfg(test)]
@@ -1498,8 +1577,7 @@ impl SpiceDataDistributorActor {
             // TODO(spice): Request data only we know may be available. (For example based on
             // execution and certification heads.)
             let total_parts = producers.len();
-            let producer_index =
-                producer_index_to_request_from(total_parts, id, me, self.request_round);
+            let producer_index = rotated_source_index(total_parts, id, me, self.request_round);
             self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::SpiceDataRequest {
                     // TODO(spice): Batch the ids that resolve to the same producer.
@@ -1860,19 +1938,4 @@ fn validate_wants(wants: &BTreeMap<SpiceDataIdentifier, BTreeSet<u64>>) -> Resul
         return Err(Error::MalformedRequest(MalformedDataRequest::TooManyOrdinals));
     }
     Ok(())
-}
-
-/// The starting producer index is derived from a hash of (data_id, requester), so requests for the
-/// same data are spread across producers instead of all landing on one. Adding `round` advances the
-/// index each tick, so retries move along rather than repeatedly targeting an unresponsive producer.
-fn producer_index_to_request_from(
-    num_producers: usize,
-    data_id: &SpiceDataIdentifier,
-    requester: &AccountId,
-    round: u64,
-) -> usize {
-    let mut hasher = DefaultHasher::new();
-    data_id.hash(&mut hasher);
-    requester.hash(&mut hasher);
-    (hasher.finish().wrapping_add(round) % num_producers as u64) as usize
 }

--- a/chain/client/src/spice/data_manager/fetchable.rs
+++ b/chain/client/src/spice/data_manager/fetchable.rs
@@ -5,14 +5,15 @@ use near_chain_primitives::ApplyChunksMode;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::block_header::BlockHeader;
+use near_primitives::types::AccountId;
 use near_primitives::types::ShardId;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use std::sync::Arc;
 
-/// Policy to query a fetchable data type's chain-dependent properties: relevance and
-/// doneness. Implementations carry the engine's only chain dependencies.
-/// Everything else about fetching is generic.
+/// Policy to query a fetchable data type's chain-dependent properties: relevance,
+/// doneness and who holds the data. Implementations carry the engine's only chain
+/// dependencies. Everything else about fetching is generic.
 pub(crate) trait DataPolicy {
     /// The ids of this type that this node needs from `block`.
     // TODO(spice-data-distribution): each id comes with a tri-state `Interest` when the
@@ -21,6 +22,10 @@ pub(crate) trait DataPolicy {
 
     /// Whether the durable artifact this item exists to obtain is already in the store.
     fn is_done(&self, id: &DataId) -> Result<bool, Error>;
+
+    /// The nodes that hold the item's full data and can serve a pull. Their count is
+    /// the number of parts the data is coded into.
+    fn sources(&self, id: &DataId) -> Result<Vec<AccountId>, Error>;
 }
 
 /// Receipt proofs: produced by the source chunk's producers, needed by nodes that apply
@@ -75,5 +80,13 @@ impl DataPolicy for ReceiptProofPolicy {
             *to_shard,
             source.shard_id,
         ))
+    }
+
+    fn sources(&self, id: &DataId) -> Result<Vec<AccountId>, Error> {
+        let DataId::ReceiptProof { source, .. } = id;
+        let block_header = self.chain_store.get_block_header(&source.block_hash)?;
+        Ok(self
+            .epoch_manager
+            .get_epoch_chunk_producers_for_shard(block_header.epoch_id(), source.shard_id)?)
     }
 }

--- a/chain/client/src/spice/data_manager/item.rs
+++ b/chain/client/src/spice/data_manager/item.rs
@@ -9,7 +9,7 @@ use near_primitives::reed_solomon::{
     ReedSolomonEncoderSerialize, ReedSolomonPartsTracker, reed_solomon_part_length,
 };
 use near_primitives::sharding::ReceiptProof;
-use near_primitives::spice::partial_data::SpiceDataCommitment;
+use near_primitives::spice::partial_data::{SpiceDataCommitment, SpiceDataIdentifier};
 use near_primitives::spice::state_witness::SpiceChunkStateWitness;
 use near_primitives::types::{AccountId, BlockHeight, ShardId, SpiceChunkId};
 use rand::Rng;
@@ -21,7 +21,7 @@ use time::ext::InstantExt as _;
 /// Identity of one piece of distributed data the engine tracks.
 // TODO(spice-data-distribution): witnesses and contract code move here when their
 // paths switch to the engine (#16275).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DataId {
     /// `source` is the chunk whose execution produced the receipts; `to_shard` is their
     /// destination. Produced by `source`'s producers, needed by next-block producers of
@@ -54,6 +54,18 @@ impl DataId {
             return Err(AssembledDataError::InvalidFromShardId);
         }
         Ok(())
+    }
+}
+
+impl From<&DataId> for SpiceDataIdentifier {
+    fn from(id: &DataId) -> Self {
+        match id {
+            DataId::ReceiptProof { source, to_shard } => SpiceDataIdentifier::ReceiptProof {
+                block_hash: source.block_hash,
+                from_shard_id: source.shard_id,
+                to_shard_id: *to_shard,
+            },
+        }
     }
 }
 
@@ -137,8 +149,6 @@ impl FetchItem {
 
     /// Starts a speculative pull: a waiting item begins collecting before any part
     /// arrived. Does nothing unless the item is waiting for the push.
-    // TODO(spice-data-distribution): production callers land with the pull path (#16275).
-    #[allow(dead_code)]
     pub(crate) fn start_pulling(&mut self, encoder: Arc<ReedSolomonEncoder>) -> bool {
         if !matches!(self.state, FetchState::WaitingForPush) {
             return false;
@@ -240,12 +250,21 @@ pub(crate) struct PullTiming {
     pub(crate) backoff: Backoff,
     /// The currently scheduled wake-up; a popped scheduler entry with any other instant is stale.
     pub(crate) next_deadline: Option<Instant>,
+    /// Pull requests sent for this item so far; rotates the source, so a retry moves to
+    /// another producer even when the backoff ladder did not advance.
+    pub(crate) requests_sent: u64,
 }
 
 impl PullTiming {
     /// True if an outstanding request already asks for `ordinal`.
     pub(crate) fn has_in_flight_request_for(&self, ordinal: u64) -> bool {
         self.in_flight.iter().any(|request| request.ordinals.contains(&ordinal))
+    }
+
+    /// Drops the outstanding requests to `source`: it responded, so it is neither
+    /// currently asked nor a timeout candidate.
+    pub(crate) fn clear_in_flight_from(&mut self, source: &AccountId) {
+        self.in_flight.retain(|request| &request.source != source);
     }
 
     /// Removes and returns the requests unanswered for at least `request_timeout`;
@@ -412,15 +431,11 @@ impl Assembly {
         Ok(result)
     }
 
-    // TODO(spice-data-distribution): production callers land with the pull path (#16275).
-    #[allow(dead_code)]
     pub(crate) fn is_complete(&self) -> bool {
         self.trackers.values().any(CodedTracker::is_complete)
     }
 
     /// Ordinals to ask for: an ordinal is skipped only if held under every commitment.
-    // TODO(spice-data-distribution): production callers land with the pull path (#16275).
-    #[allow(dead_code)]
     pub(crate) fn missing_ordinals(&self) -> Vec<u64> {
         (0..self.encoder.total_parts())
             .filter(|ordinal| {

--- a/chain/client/src/spice/data_manager/item.rs
+++ b/chain/client/src/spice/data_manager/item.rs
@@ -1,4 +1,5 @@
 use super::DataManagerError;
+use super::scheduler::{Backoff, TimingConfig};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_async::time::{Clock, Instant};
 use near_primitives::hash::{CryptoHash, hash};
@@ -11,9 +12,11 @@ use near_primitives::sharding::ReceiptProof;
 use near_primitives::spice::partial_data::SpiceDataCommitment;
 use near_primitives::spice::state_witness::SpiceChunkStateWitness;
 use near_primitives::types::{AccountId, BlockHeight, ShardId, SpiceChunkId};
+use rand::Rng;
 use std::collections::{HashMap, HashSet};
-use std::mem::replace;
+use std::mem::{replace, take};
 use std::sync::Arc;
+use time::ext::InstantExt as _;
 
 /// Identity of one piece of distributed data the engine tracks.
 // TODO(spice-data-distribution): witnesses and contract code move here when their
@@ -110,17 +113,26 @@ pub(crate) struct FetchItem {
     pub(crate) height: BlockHeight,
     /// When the first unit arrived; `None` until then. Anchors the wait-for-push grace clock.
     pub(crate) first_unit_at: Option<Instant>,
+    pub(crate) pull: PullTiming,
 }
 
 impl FetchItem {
     pub(crate) fn waiting_for_push(height: BlockHeight) -> Self {
-        Self { state: FetchState::WaitingForPush, height, first_unit_at: None }
+        Self {
+            state: FetchState::WaitingForPush,
+            height,
+            first_unit_at: None,
+            pull: PullTiming::default(),
+        }
     }
 
     // TODO(spice-data-distribution): production callers land with the pull path (#16275).
     #[allow(dead_code)]
     pub(crate) fn collecting(encoder: Arc<ReedSolomonEncoder>, height: BlockHeight) -> Self {
-        Self { state: FetchState::Collecting(Assembly::new(encoder)), height, first_unit_at: None }
+        Self {
+            state: FetchState::Collecting(Assembly::new(encoder)),
+            ..Self::waiting_for_push(height)
+        }
     }
 
     /// Starts a speculative pull: a waiting item begins collecting before any part
@@ -217,6 +229,69 @@ impl FetchItem {
             state => (state, Err(DataManagerError::NotDelivered)),
         })
     }
+}
+
+/// Timing state for one item's pulls.
+#[derive(Debug, Default)]
+pub(crate) struct PullTiming {
+    /// Outstanding pull requests
+    pub(crate) in_flight: Vec<InFlightRequest>,
+    /// Retry ladder position for this item's pulls.
+    pub(crate) backoff: Backoff,
+    /// The currently scheduled wake-up; a popped scheduler entry with any other instant is stale.
+    pub(crate) next_deadline: Option<Instant>,
+}
+
+impl PullTiming {
+    /// True if an outstanding request already asks for `ordinal`.
+    pub(crate) fn has_in_flight_request_for(&self, ordinal: u64) -> bool {
+        self.in_flight.iter().any(|request| request.ordinals.contains(&ordinal))
+    }
+
+    /// Removes and returns the requests unanswered for at least `request_timeout`;
+    /// their ordinals may be requested again.
+    /// Leaves `backoff` untouched: timing out is not a retry decision.
+    pub(crate) fn take_timed_out_requests(
+        &mut self,
+        config: &TimingConfig,
+        now: Instant,
+    ) -> Vec<InFlightRequest> {
+        let (timed_out, live): (Vec<_>, Vec<_>) =
+            take(&mut self.in_flight).into_iter().partition(|request| {
+                now.signed_duration_since(request.sent_at) >= config.request_timeout
+            });
+        self.in_flight = live;
+        timed_out
+    }
+
+    /// Recomputes the next deadline: the sooner of the next backoff interval and the
+    /// oldest outstanding request's timeout. Sets and returns `next_deadline`.
+    #[must_use = "the returned deadline must be scheduled, or the item is never woken"]
+    pub(crate) fn reschedule(
+        &mut self,
+        config: &TimingConfig,
+        now: Instant,
+        rng: &mut impl Rng,
+    ) -> Instant {
+        let backoff_deadline = now.add_signed(self.backoff.next_interval(config, rng));
+        let timeout_deadline = self
+            .in_flight
+            .iter()
+            .map(|request| request.sent_at.add_signed(config.request_timeout))
+            .min();
+        let deadline = timeout_deadline.map_or(backoff_deadline, |at| at.min(backoff_deadline));
+        self.next_deadline = Some(deadline);
+        deadline
+    }
+}
+
+/// One outstanding pull request to one peer.
+#[derive(Debug)]
+pub(crate) struct InFlightRequest {
+    pub(crate) source: AccountId,
+    pub(crate) sent_at: Instant,
+    /// Requested part ordinals.
+    pub(crate) ordinals: Vec<u64>,
 }
 
 /// A coded part whose merkle proof was verified against its commitment's root;

--- a/chain/client/src/spice/data_manager/mod.rs
+++ b/chain/client/src/spice/data_manager/mod.rs
@@ -8,8 +8,8 @@ pub(crate) use fetchable::DataPolicy;
 use fetchable::ReceiptProofPolicy;
 pub use item::DataId;
 pub(crate) use item::{AssembledDataError, SpiceData, VerifiedCodedPart};
-use item::{FetchItem, Item, PartInsertResult};
-use near_async::time::Clock;
+use item::{FetchItem, FetchState, InFlightRequest, Item, PartInsertResult};
+use near_async::time::{Clock, Instant};
 use near_chain::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
@@ -18,9 +18,15 @@ use near_primitives::reed_solomon::ReedSolomonEncoderCache;
 use near_primitives::spice::partial_data::{SpiceDataCommitment, SpiceDataPart};
 use near_primitives::types::{AccountId, BlockHeight};
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use rand::rngs::StdRng;
+pub(crate) use scheduler::WakeAt;
+use scheduler::{DeadlineScheduler, TimingConfig};
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::hash::{Hash, Hasher as _};
 use std::sync::Arc;
+use time::ext::InstantExt as _;
 
 /// Scheduling class of an item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,6 +34,8 @@ pub(crate) enum Lane {
     /// Consensus-critical: this node is an assigned validator or producer for it.
     Priority,
     /// RPC, state-sync or catch-up traffic; never starves `Priority`.
+    // TODO(spice-data-distribution): constructed once lanes are classified per item (#16275).
+    #[allow(dead_code)]
     Background,
 }
 
@@ -84,12 +92,33 @@ pub(crate) enum DataManagerError {
 #[must_use]
 #[derive(Debug)]
 pub(crate) enum ReceivedParts {
-    /// Parts accepted; the item is still collecting.
-    Collecting,
+    /// Parts accepted; the item is still collecting. Carries the wake-up this call scheduled, if any.
+    Collecting(WakeAt),
     /// The parts completed the item; the data is handed to the consumer.
     Complete(SpiceData),
     /// No item tracks the id, or the item is past collecting (delivered or processed).
     NotWanted,
+}
+
+/// One pull request to send: the ordinals still missing for each item `producer` holds.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PullRequest {
+    pub(crate) producer: AccountId,
+    pub(crate) wants: BTreeMap<DataId, BTreeSet<u64>>,
+}
+
+/// Index of the source to ask in `round`. The start is a hash of the id and the
+/// requester, so requesters spread over the sources; each round moves one along.
+pub(crate) fn rotated_source_index(
+    num_sources: usize,
+    id: &impl Hash,
+    requester: &AccountId,
+    round: u64,
+) -> usize {
+    let mut hasher = DefaultHasher::new();
+    id.hash(&mut hasher);
+    requester.hash(&mut hasher);
+    (hasher.finish().wrapping_add(round) % num_sources as u64) as usize
 }
 
 /// The per-data-type policies, one per [`DataId`] variant.
@@ -123,34 +152,83 @@ impl DataPolicy for Policies {
     fn is_done(&self, id: &DataId) -> Result<bool, Error> {
         self.for_id(id).is_done(id)
     }
+
+    fn sources(&self, id: &DataId) -> Result<Vec<AccountId>, Error> {
+        self.for_id(id).sources(id)
+    }
 }
 
 /// Owns the per-item fetch lifecycle: what this node still needs, the parts received so
 /// far and who sent them, and when an item stops being relevant.
 /// Validation results are reported back via [`Self::on_verified`]/[`Self::on_failed`].
+/// Calls that can schedule a pull return a [`WakeAt`]: the instant to call
+/// [`Self::on_wake`] at, when the earliest deadline changed since the last one returned.
 // TODO(spice-data-distribution): only receipt proofs route here; witnesses still live
 // on the old actor path (#16275).
-pub(crate) struct SpiceDataManager {
+pub(crate) struct SpiceDataManager<P: DataPolicy = Policies> {
     clock: Clock,
+    /// Jitters the retry intervals; injected so tests are deterministic.
+    rng: StdRng,
+    timing: TimingConfig,
     encoders: ReedSolomonEncoderCache,
-    policies: Policies,
+    policies: P,
     /// All tracked items, in any state.
     items: HashMap<DataId, Item>,
     /// Ids of tracked items, indexed by their block's height as captured when first tracked
     items_by_height: BTreeMap<BlockHeight, Vec<DataId>>,
+    /// Pull wake-ups for the items. Entries cannot be removed, so a completed or
+    /// re-scheduled item leaves stale ones behind; [`Self::on_wake`] filters them.
+    scheduler: DeadlineScheduler<DataId>,
     /// Highest final execution head reported; `None` until the first report. Items at
     /// or below it can never be applied.
     final_execution_head: Option<BlockHeight>,
 }
 
-impl SpiceDataManager {
-    pub(crate) fn new(clock: Clock, data_parts_ratio: f64, policies: Policies) -> Self {
+/// Marks `at` as the item's pull wake-up.
+// TODO(spice-data-distribution): classify the scheduling lane per item; everything is
+// priority until a lower-priority consumer exists (#16275).
+fn schedule_pull_wake(
+    scheduler: &mut DeadlineScheduler<DataId>,
+    item: &mut FetchItem,
+    id: &DataId,
+    at: Instant,
+) {
+    item.pull.next_deadline = Some(at);
+    scheduler.schedule(id.clone(), at, Lane::Priority);
+}
+
+/// The source to ask for `id` in rotation `round`; `None` if none can be resolved.
+fn select_source(
+    policies: &impl DataPolicy,
+    id: &DataId,
+    requester: &AccountId,
+    round: u64,
+) -> Option<AccountId> {
+    let mut sources = match policies.sources(id) {
+        Ok(sources) => sources,
+        Err(err) => {
+            tracing::error!(target: "spice_data_distribution", ?err, ?id, "failed to resolve the sources to pull from");
+            return None;
+        }
+    };
+    if sources.is_empty() {
+        return None;
+    }
+    let index = rotated_source_index(sources.len(), id, requester, round);
+    Some(sources.swap_remove(index))
+}
+
+impl<P: DataPolicy> SpiceDataManager<P> {
+    pub(crate) fn new(clock: Clock, rng: StdRng, data_parts_ratio: f64, policies: P) -> Self {
         Self {
             clock,
+            rng,
+            timing: TimingConfig::default(),
             encoders: ReedSolomonEncoderCache::new(data_parts_ratio),
             policies,
             items: HashMap::new(),
             items_by_height: BTreeMap::new(),
+            scheduler: DeadlineScheduler::default(),
             final_execution_head: None,
         }
     }
@@ -182,7 +260,9 @@ impl SpiceDataManager {
     /// commitment and inserts it. A completing insert checks the decoded data against
     /// the committed hash and the id: a failure bans the commitment, a match returns the
     /// data for handoff to the consumer, leaving the item parked until the consumer's
-    /// (local) verification result arrives. Errors are attributable to the sender.
+    /// (local) verification result arrives. Errors are attributable to the sender. A
+    /// pull scheduled by a message that then fails on a later part is reported by the
+    /// next call that returns a wake-up.
     pub(crate) fn on_parts_received(
         &mut self,
         sender: &AccountId,
@@ -194,6 +274,8 @@ impl SpiceDataManager {
         let Some(Item::Fetch(item)) = self.items.get_mut(id) else {
             return Ok(ReceivedParts::NotWanted);
         };
+        item.pull.clear_in_flight_from(sender);
+        let mut had_units = item.first_unit_at.is_some();
         let encoder = self.encoders.entry(total_parts);
         // TODO(spice-data-distribution): verify every part before inserting any; today
         // the first bad part aborts the loop without undoing earlier inserts (#16275).
@@ -206,12 +288,21 @@ impl SpiceDataManager {
                     tracing::debug!(target: "spice_data_distribution", ?id, ?contributors, "commitment decoded to garbage");
                     return Err(DataManagerError::GarbageCommitment(error));
                 }
-                Ok(PartInsertResult::Accepted | PartInsertResult::Duplicate) => {}
+                Ok(PartInsertResult::Accepted | PartInsertResult::Duplicate) => {
+                    // The first unit proves the data exists; give the other producers'
+                    // pushes a moment to land, then pull whatever is still missing.
+                    if !had_units && item.first_unit_at.is_some() {
+                        had_units = true;
+                        let at =
+                            self.clock.now().add_signed(self.timing.pull_delay_after_first_unit);
+                        schedule_pull_wake(&mut self.scheduler, item, id, at);
+                    }
+                }
                 Err(DataManagerError::NotCollecting) => return Ok(ReceivedParts::NotWanted),
                 Err(err) => return Err(err),
             }
         }
-        Ok(ReceivedParts::Collecting)
+        Ok(ReceivedParts::Collecting(self.scheduler.take_wake()))
     }
 
     /// Consumer validated and persisted the delivered data (so `is_done` holds for it from now on).
@@ -227,14 +318,142 @@ impl SpiceDataManager {
     /// Consumer rejected the delivered data: the delivered commitment is banned and
     /// collecting resumes from the remaining trackers. A verification result for an
     /// expired item is rejected without effect.
-    pub(crate) fn on_failed(&mut self, id: &DataId) -> Result<(), DataManagerError> {
+    pub(crate) fn on_failed(&mut self, id: &DataId) -> Result<WakeAt, DataManagerError> {
         let Some(Item::Fetch(item)) = self.items.get_mut(id) else {
             return Err(DataManagerError::UnknownItem);
         };
         // TODO(spice-data-distribution): feed the contributors into reputation (#16275).
         let contributors = item.mark_failed()?;
         tracing::debug!(target: "spice_data_distribution", ?id, ?contributors, "delivered data failed consumer validation");
-        Ok(())
+        // The residual is incomplete, so the pull for the gaps is due immediately.
+        schedule_pull_wake(&mut self.scheduler, item, id, self.clock.now());
+        Ok(self.scheduler.take_wake())
+    }
+
+    /// The consumer needed `ids` and their data has not arrived — the pull trigger. A
+    /// still-waiting item starts collecting, with its first pull scheduled after
+    /// `pull_delay_after_gate` to let a straggler push land. No effect on an unknown
+    /// item or one already past waiting.
+    pub(crate) fn start_pulling(&mut self, ids: &[DataId]) -> WakeAt {
+        for id in ids {
+            let Some(Item::Fetch(item)) = self.items.get_mut(id) else {
+                continue;
+            };
+            if !matches!(item.state, FetchState::WaitingForPush) {
+                continue;
+            }
+            let total_parts = match self.policies.sources(id) {
+                Ok(sources) if !sources.is_empty() => sources.len(),
+                Ok(_) => {
+                    tracing::error!(target: "spice_data_distribution", ?id, "no sources to pull from");
+                    continue;
+                }
+                Err(err) => {
+                    tracing::error!(target: "spice_data_distribution", ?err, ?id, "failed to resolve the sources to pull from");
+                    continue;
+                }
+            };
+            let encoder = self.encoders.entry(total_parts);
+            assert!(item.start_pulling(encoder), "a waiting item starts pulling");
+            let at = self.clock.now().add_signed(self.timing.pull_delay_after_gate);
+            schedule_pull_wake(&mut self.scheduler, item, id, at);
+        }
+        self.scheduler.take_wake()
+    }
+
+    /// A pull wake-up fired. Runs the retry decision for every item whose deadline is
+    /// due and returns the requests to send, one per producer, with the next wake-up.
+    /// Without a `requester` nothing is sent, but the items stay scheduled. A stale
+    /// wake-up is harmless: it finds nothing due.
+    pub(crate) fn on_wake(
+        &mut self,
+        now: Instant,
+        requester: Option<&AccountId>,
+    ) -> (Vec<PullRequest>, WakeAt) {
+        let mut wants_by_producer: BTreeMap<AccountId, BTreeMap<DataId, BTreeSet<u64>>> =
+            BTreeMap::new();
+        for id in self.due_items(now) {
+            if let Some((producer, ordinals)) = self.retry(&id, now, requester) {
+                wants_by_producer
+                    .entry(producer)
+                    .or_default()
+                    .insert(id, ordinals.into_iter().collect());
+            }
+        }
+        let requests = wants_by_producer
+            .into_iter()
+            .map(|(producer, wants)| PullRequest { producer, wants })
+            .collect();
+        (requests, self.scheduler.take_wake())
+    }
+
+    /// Pops the due pull wake-ups and keeps the ones that are still real: the item
+    /// exists, is still collecting, and the popped instant is its current deadline.
+    /// Without the last check every completion or re-schedule would fire a spurious
+    /// pull off the entry it left behind.
+    fn due_items(&mut self, now: Instant) -> Vec<DataId> {
+        self.scheduler
+            .pop_due(now)
+            .into_iter()
+            .filter(|(id, at)| {
+                let Some(Item::Fetch(item)) = self.items.get(id) else {
+                    return false;
+                };
+                matches!(item.state, FetchState::Collecting(_))
+                    && item.pull.next_deadline == Some(*at)
+            })
+            .map(|(id, _)| id)
+            .collect()
+    }
+
+    /// The retry decision for one due item: drops the timed-out requests, picks the
+    /// rotated source for the ordinals still missing and not in flight, records the
+    /// request, and reschedules the item whether or not one goes out. A wake caused by a
+    /// request timeout re-requests without advancing the backoff ladder: timing out is
+    /// the peer's failure, not a retry.
+    // TODO(spice-data-distribution): stripe the missing set across several sources,
+    // preferring ones that have not already sent an ordinal (#16275).
+    fn retry(
+        &mut self,
+        id: &DataId,
+        now: Instant,
+        requester: Option<&AccountId>,
+    ) -> Option<(AccountId, Vec<u64>)> {
+        let Some(Item::Fetch(item)) = self.items.get_mut(id) else {
+            return None;
+        };
+        // TODO(spice-data-distribution): feed the timed-out sources into reputation (#16275).
+        let timed_out = item.pull.take_timed_out_requests(&self.timing, now);
+        let FetchState::Collecting(assembly) = &item.state else {
+            return None;
+        };
+        debug_assert!(!assembly.is_complete(), "a collecting item cannot be complete");
+        let missing: Vec<u64> = assembly
+            .missing_ordinals()
+            .into_iter()
+            .filter(|ordinal| !item.pull.has_in_flight_request_for(*ordinal))
+            .collect();
+        let source = match requester {
+            Some(requester) if !missing.is_empty() => {
+                select_source(&self.policies, id, requester, item.pull.requests_sent)
+            }
+            _ => None,
+        };
+        let request = source.map(|source| (source, missing));
+        if let Some((source, ordinals)) = &request {
+            item.pull.in_flight.push(InFlightRequest {
+                source: source.clone(),
+                sent_at: now,
+                ordinals: ordinals.clone(),
+            });
+            item.pull.requests_sent += 1;
+            if timed_out.is_empty() {
+                item.pull.backoff.note_retry();
+            }
+        }
+        let at = item.pull.reschedule(&self.timing, now, &mut self.rng);
+        schedule_pull_wake(&mut self.scheduler, item, id, at);
+        request
     }
 
     /// The final execution head advanced: the chain is past every item at or below it,

--- a/chain/client/src/spice/data_manager/mod.rs
+++ b/chain/client/src/spice/data_manager/mod.rs
@@ -2,6 +2,7 @@
 
 mod fetchable;
 mod item;
+mod scheduler;
 
 pub(crate) use fetchable::DataPolicy;
 use fetchable::ReceiptProofPolicy;
@@ -17,8 +18,40 @@ use near_primitives::reed_solomon::ReedSolomonEncoderCache;
 use near_primitives::spice::partial_data::{SpiceDataCommitment, SpiceDataPart};
 use near_primitives::types::{AccountId, BlockHeight};
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
+
+/// Scheduling class of an item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Lane {
+    /// Consensus-critical: this node is an assigned validator or producer for it.
+    Priority,
+    /// RPC, state-sync or catch-up traffic; never starves `Priority`.
+    Background,
+}
+
+impl Lane {
+    /// Urgency rank; greater is more urgent, so `max` escalates.
+    fn rank(self) -> u8 {
+        match self {
+            Lane::Background => 0,
+            Lane::Priority => 1,
+        }
+    }
+}
+
+impl Ord for Lane {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.rank().cmp(&other.rank())
+    }
+}
+
+impl PartialOrd for Lane {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/chain/client/src/spice/data_manager/scheduler.rs
+++ b/chain/client/src/spice/data_manager/scheduler.rs
@@ -17,6 +17,12 @@ pub(crate) struct TimingConfig {
     pub(crate) backoff_cap: Duration,
     /// Every interval is jittered by up to this fraction in either direction.
     pub(crate) jitter_frac: f64,
+    /// After a pull trigger opens for an item, how long to wait for a straggler push
+    /// before the first pull.
+    pub(crate) pull_delay_after_gate: Duration,
+    /// After an item's first unit arrives, how long to wait for the other producers'
+    /// pushes before pulling the still-missing ordinals.
+    pub(crate) pull_delay_after_first_unit: Duration,
 }
 
 impl Default for TimingConfig {
@@ -27,6 +33,8 @@ impl Default for TimingConfig {
             backoff_multiplier: 2,
             backoff_cap: Duration::seconds(2),
             jitter_frac: 0.25,
+            pull_delay_after_gate: Duration::milliseconds(200),
+            pull_delay_after_first_unit: Duration::milliseconds(200),
         }
     }
 }
@@ -93,6 +101,17 @@ impl<K> Eq for Deadline<K> {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WakeAt(pub(crate) Option<Instant>);
 
+impl WakeAt {
+    /// The earlier of two wake-ups. One timer for it is enough: processing it reports
+    /// the later one again.
+    pub(crate) fn earliest(self, other: WakeAt) -> WakeAt {
+        match (self.0, other.0) {
+            (Some(a), Some(b)) => WakeAt(Some(a.min(b))),
+            (a, b) => WakeAt(a.or(b)),
+        }
+    }
+}
+
 /// Wake-ups for keyed items, earliest first.
 /// Scheduling a key again does not cancel its earlier wake-up; a superseded wake-up still pops, and the
 /// caller can tell it apart by its instant no longer matching the item's `next_deadline`.
@@ -113,8 +132,8 @@ impl<K> DeadlineScheduler<K> {
         self.heap.push(Deadline { at, lane, key });
     }
 
-    /// The earliest entry's instant if it is not covered by the last reported one: it was
-    /// scheduled ahead of it, or the reported one has popped. Stale entries included.
+    /// The earliest scheduled wake, unless a call already returned an instant at or before
+    /// it that has not popped yet.
     pub(crate) fn take_wake(&mut self) -> WakeAt {
         let Some(front) = self.heap.peek().map(|deadline| deadline.at) else {
             return WakeAt(None);

--- a/chain/client/src/spice/data_manager/scheduler.rs
+++ b/chain/client/src/spice/data_manager/scheduler.rs
@@ -1,0 +1,141 @@
+use super::Lane;
+use near_async::time::{Duration, Instant};
+use rand::Rng;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+/// Retry and request timing parameters.
+#[derive(Debug, Clone)]
+pub(crate) struct TimingConfig {
+    /// How long a pull request may go unanswered before it counts as timed out.
+    pub(crate) request_timeout: Duration,
+    /// First interval of the retry ladder.
+    pub(crate) backoff_base: Duration,
+    /// Geometric growth factor of the retry periods.
+    pub(crate) backoff_multiplier: u32,
+    /// Upper bound the retry period is capped at.
+    pub(crate) backoff_cap: Duration,
+    /// Every interval is jittered by up to this fraction in either direction.
+    pub(crate) jitter_frac: f64,
+}
+
+impl Default for TimingConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: Duration::seconds(1),
+            backoff_base: Duration::milliseconds(200),
+            backoff_multiplier: 2,
+            backoff_cap: Duration::seconds(2),
+            jitter_frac: 0.25,
+        }
+    }
+}
+
+/// Keeps track of retry progress.
+#[derive(Debug, Default)]
+pub(crate) struct Backoff {
+    retries: u32,
+}
+
+impl Backoff {
+    /// Next retry interval, jittered
+    pub(crate) fn next_interval(&self, config: &TimingConfig, rng: &mut impl Rng) -> Duration {
+        let unjittered = (config.backoff_base.as_seconds_f64()
+            * f64::from(config.backoff_multiplier).powf(f64::from(self.retries)))
+        .min(config.backoff_cap.as_seconds_f64());
+        let jitter = rng.gen_range(-config.jitter_frac..=config.jitter_frac);
+        Duration::seconds_f64(unjittered * (1.0 + jitter))
+    }
+
+    pub(crate) fn note_retry(&mut self) {
+        self.retries = self.retries.saturating_add(1);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn retries(&self) -> u32 {
+        self.retries
+    }
+}
+
+/// A queued wake-up for `key`.
+#[derive(Debug)]
+struct Deadline<K> {
+    at: Instant,
+    lane: Lane,
+    key: K,
+}
+
+// Max-heap order: earliest `at` on top, `Priority` before `Background` for the same instant.
+// The key does not participate.
+impl<K> Ord for Deadline<K> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.at.cmp(&self.at).then_with(|| self.lane.cmp(&other.lane))
+    }
+}
+
+impl<K> PartialOrd for Deadline<K> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K> PartialEq for Deadline<K> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<K> Eq for Deadline<K> {}
+
+/// Instant the caller must call [`DeadlineScheduler::pop_due`] at; `None` when a wake-up
+/// already reported covers the earliest entry.
+#[must_use = "an unreported wake-up is never processed"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WakeAt(pub(crate) Option<Instant>);
+
+/// Wake-ups for keyed items, earliest first.
+/// Scheduling a key again does not cancel its earlier wake-up; a superseded wake-up still pops, and the
+/// caller can tell it apart by its instant no longer matching the item's `next_deadline`.
+pub(crate) struct DeadlineScheduler<K> {
+    heap: BinaryHeap<Deadline<K>>,
+    /// The earliest entry's instant as last reported by [`Self::take_wake`], until it pops.
+    reported: Option<Instant>,
+}
+
+impl<K> Default for DeadlineScheduler<K> {
+    fn default() -> Self {
+        Self { heap: BinaryHeap::new(), reported: None }
+    }
+}
+
+impl<K> DeadlineScheduler<K> {
+    pub(crate) fn schedule(&mut self, key: K, at: Instant, lane: Lane) {
+        self.heap.push(Deadline { at, lane, key });
+    }
+
+    /// The earliest entry's instant if it is not covered by the last reported one: it was
+    /// scheduled ahead of it, or the reported one has popped. Stale entries included.
+    pub(crate) fn take_wake(&mut self) -> WakeAt {
+        let Some(front) = self.heap.peek().map(|deadline| deadline.at) else {
+            return WakeAt(None);
+        };
+        if self.reported.is_some_and(|reported| reported <= front) {
+            return WakeAt(None);
+        }
+        self.reported = Some(front);
+        WakeAt(Some(front))
+    }
+
+    /// Pops every entry due at or before `now`, paired with the instant it was scheduled for.
+    pub(crate) fn pop_due(&mut self, now: Instant) -> Vec<(K, Instant)> {
+        if self.reported.is_some_and(|reported| reported <= now) {
+            self.reported = None;
+        }
+        let mut due = Vec::new();
+        while self.heap.peek().is_some_and(|deadline| deadline.at <= now) {
+            let deadline = self.heap.pop().unwrap();
+            due.push((deadline.key, deadline.at));
+        }
+        due
+    }
+}

--- a/chain/client/src/spice/data_manager/tests.rs
+++ b/chain/client/src/spice/data_manager/tests.rs
@@ -1,4 +1,6 @@
-use super::item::{Assembly, FetchItem, FetchState, InFlightRequest, PartInsertResult, PullTiming};
+use super::item::{
+    Assembly, FetchItem, FetchState, InFlightRequest, Item, PartInsertResult, PullTiming,
+};
 use super::scheduler::{Backoff, DeadlineScheduler, TimingConfig, WakeAt};
 use super::*;
 use assert_matches::assert_matches;
@@ -11,9 +13,9 @@ use near_primitives::spice::partial_data::SpiceDataCommitment;
 use near_primitives::types::{AccountId, ShardId};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::slice::from_ref;
 use std::sync::Arc;
-use time::ext::InstantExt as _;
 
 /// Data parts of the encoder every test here uses: `max((5 * 0.6) as usize, 1)`.
 const DATA_PARTS: usize = 3;
@@ -635,6 +637,7 @@ mod manager {
     use near_chain::{Block, BlockProcessingArtifact, Chain, ChainStoreAccess, Provenance};
     use near_chain_configs::{MutableConfigValue, TrackedShardsConfig};
     use near_epoch_manager::shard_tracker::ShardTracker;
+    use near_primitives::block_header::BlockHeader;
     use near_primitives::spice::partial_data::SpiceDataPart;
     use near_primitives::test_utils::{TestBlockBuilder, create_test_signer};
     use near_primitives::types::EpochId;
@@ -665,9 +668,55 @@ mod manager {
         (chain, blocks)
     }
 
+    /// The chain's policies with a fixed source list in place of the chain's single
+    /// chunk producer.
+    struct TestPolicy {
+        chain: Policies,
+        sources: Vec<AccountId>,
+    }
+
+    impl DataPolicy for TestPolicy {
+        fn needed_ids(&self, block: &BlockHeader) -> Result<Vec<DataId>, Error> {
+            self.chain.needed_ids(block)
+        }
+
+        fn is_done(&self, id: &DataId) -> Result<bool, Error> {
+            self.chain.is_done(id)
+        }
+
+        fn sources(&self, _id: &DataId) -> Result<Vec<AccountId>, Error> {
+            Ok(self.sources.clone())
+        }
+    }
+
+    /// The sources every item here pulls from; one per part.
+    fn sources() -> Vec<AccountId> {
+        (0..TOTAL_PARTS).map(|i| account(&format!("producer{i}.near"))).collect()
+    }
+
+    fn requester() -> AccountId {
+        account("me.near")
+    }
+
+    fn requested_ids(requests: &[PullRequest]) -> Vec<DataId> {
+        requests.iter().flat_map(|request| request.wants.keys().cloned()).collect()
+    }
+
     /// Manager whose policy applies shard 1 only: of a block's four proofs it needs
     /// `(0 -> 1)`, unless that proof is on disk.
-    fn manager(chain: &Chain) -> SpiceDataManager {
+    fn manager(chain: &Chain) -> SpiceDataManager<TestPolicy> {
+        manager_with_clock(chain, FakeClock::default().clock())
+    }
+
+    fn manager_with_clock(chain: &Chain, clock: Clock) -> SpiceDataManager<TestPolicy> {
+        manager_with_sources(chain, clock, sources())
+    }
+
+    fn manager_with_sources(
+        chain: &Chain,
+        clock: Clock,
+        sources: Vec<AccountId>,
+    ) -> SpiceDataManager<TestPolicy> {
         let shard_layout = chain.epoch_manager.get_shard_layout(&EpochId::default()).unwrap();
         let tracked = ShardUId::from_shard_id_and_layout(ShardId::new(1), &shard_layout);
         let shard_tracker = ShardTracker::new(
@@ -675,14 +724,16 @@ mod manager {
             chain.epoch_manager.clone(),
             MutableConfigValue::new(None, "validator_signer"),
         );
+        let policies = Policies::new(
+            chain.chain_store.store().chain_store(),
+            chain.epoch_manager.clone(),
+            shard_tracker,
+        );
         SpiceDataManager::new(
-            FakeClock::default().clock(),
+            clock,
+            StdRng::seed_from_u64(0),
             0.6,
-            Policies::new(
-                chain.chain_store.store().chain_store(),
-                chain.epoch_manager.clone(),
-                shard_tracker,
-            ),
+            TestPolicy { chain: policies, sources },
         )
     }
 
@@ -861,7 +912,7 @@ mod manager {
             .on_parts_received(&account("alice.near"), &id, &commitment, parts, TOTAL_PARTS)
             .unwrap();
         assert_matches!(delivered, ReceivedParts::Complete(SpiceData::ReceiptProof(_)));
-        manager.on_failed(&id).unwrap();
+        assert_matches!(manager.on_failed(&id).unwrap(), WakeAt(Some(_)));
 
         // The item resumed collecting, with the delivered commitment banned.
         assert!(manager.is_tracking(&id));
@@ -905,6 +956,407 @@ mod manager {
             TOTAL_PARTS,
         );
         assert_matches!(result, Err(DataManagerError::BannedCommitment));
+    }
+
+    fn fetch_item<'a>(manager: &'a SpiceDataManager<TestPolicy>, id: &DataId) -> &'a FetchItem {
+        let Some(Item::Fetch(item)) = manager.items.get(id) else {
+            panic!("no fetch item for {id:?}");
+        };
+        item
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn tracking_schedules_no_pull() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let mut manager = manager(&chain);
+
+        manager.on_block(blocks[0].header()).unwrap();
+
+        assert_eq!(manager.scheduler.take_wake(), WakeAt(None));
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn start_pulling_flips_a_waiting_item_and_schedules_after_the_gate_delay() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+
+        let wake = manager.start_pulling(from_ref(&id));
+
+        let expected = clock.now().add_signed(TimingConfig::default().pull_delay_after_gate);
+        let item = fetch_item(&manager, &id);
+        assert!(matches!(item.state, FetchState::Collecting(_)));
+        assert_eq!(item.pull.next_deadline, Some(expected));
+        assert_eq!(wake, WakeAt(Some(expected)));
+
+        // A repeated trigger is a no-op: the item is already pulling.
+        assert_eq!(manager.start_pulling(from_ref(&id)), WakeAt(None));
+        clock.advance(TimingConfig::default().pull_delay_after_gate);
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        assert_eq!(requested_ids(&requests), vec![id]);
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn start_pulling_ignores_unknown_items() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let mut manager = manager(&chain);
+
+        assert_eq!(manager.start_pulling(&[receipt_id(&blocks[0], 0, 1)]), WakeAt(None));
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn the_first_unit_schedules_the_pull_after_its_delay() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        let encoder = encoder();
+        let (commitment, mut parts) = encode_to_wire(&encoder, &receipt_data(0, 1));
+        let second_part = parts.split_off(1).remove(0);
+        let first_part = parts;
+        let expected = clock.now().add_signed(TimingConfig::default().pull_delay_after_first_unit);
+
+        assert_matches!(
+            manager
+                .on_parts_received(
+                    &account("alice.near"),
+                    &id,
+                    &commitment,
+                    first_part,
+                    TOTAL_PARTS
+                )
+                .unwrap(),
+            ReceivedParts::Collecting(WakeAt(Some(at))) if at == expected
+        );
+        assert_eq!(fetch_item(&manager, &id).pull.next_deadline, Some(expected));
+
+        // Later units do not push the deadline back, and report no new wake-up.
+        clock.advance(Duration::milliseconds(50));
+        assert_matches!(
+            manager
+                .on_parts_received(
+                    &account("bob.near"),
+                    &id,
+                    &commitment,
+                    vec![second_part],
+                    TOTAL_PARTS,
+                )
+                .unwrap(),
+            ReceivedParts::Collecting(WakeAt(None))
+        );
+        assert_eq!(fetch_item(&manager, &id).pull.next_deadline, Some(expected));
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn a_pull_scheduled_by_a_message_that_then_fails_is_reported_by_the_next_call() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        let encoder = encoder();
+        let (commitment, mut parts) = encode_to_wire(&encoder, &receipt_data(0, 1));
+        parts.truncate(2);
+        // The second part's proof no longer matches its ordinal.
+        parts[1].part_ord = 4;
+        let expected = clock.now().add_signed(TimingConfig::default().pull_delay_after_first_unit);
+
+        assert_matches!(
+            manager.on_parts_received(&account("alice.near"), &id, &commitment, parts, TOTAL_PARTS),
+            Err(DataManagerError::InvalidMerkleProof)
+        );
+
+        // The accepted first part scheduled the pull; a call that schedules nothing itself
+        // reports it.
+        assert_eq!(fetch_item(&manager, &id).pull.next_deadline, Some(expected));
+        assert_eq!(manager.start_pulling(from_ref(&id)), WakeAt(Some(expected)));
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn a_failed_verification_result_makes_the_pull_due_immediately() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        let encoder = encoder();
+        let (commitment, mut parts) = encode_to_wire(&encoder, &receipt_data(0, 1));
+        parts.truncate(DATA_PARTS);
+        let delivered = manager
+            .on_parts_received(&account("alice.near"), &id, &commitment, parts, TOTAL_PARTS)
+            .unwrap();
+        assert_matches!(delivered, ReceivedParts::Complete(_));
+
+        assert_eq!(manager.on_failed(&id).unwrap(), WakeAt(Some(clock.now())));
+
+        assert_eq!(fetch_item(&manager, &id).pull.next_deadline, Some(clock.now()));
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        assert_eq!(requested_ids(&requests), vec![id]);
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn on_wake_discards_a_pop_for_an_expired_item() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        assert_matches!(manager.start_pulling(from_ref(&id)), WakeAt(Some(_)));
+
+        manager.on_final_execution_head(block.header().height());
+
+        clock.advance(TimingConfig::default().pull_delay_after_gate);
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        assert_eq!(requests, vec![]);
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn on_wake_discards_a_pop_for_an_item_no_longer_collecting() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        let encoder = encoder();
+        let (commitment, mut parts) = encode_to_wire(&encoder, &receipt_data(0, 1));
+        parts.truncate(DATA_PARTS);
+        let rest = parts.split_off(1);
+        // The first part schedules a pull; the remaining parts deliver the item before
+        // the deadline fires.
+        assert_matches!(
+            manager
+                .on_parts_received(&account("alice.near"), &id, &commitment, parts, TOTAL_PARTS)
+                .unwrap(),
+            ReceivedParts::Collecting(_)
+        );
+        assert!(fetch_item(&manager, &id).pull.next_deadline.is_some());
+        let delivered = manager
+            .on_parts_received(&account("bob.near"), &id, &commitment, rest, TOTAL_PARTS)
+            .unwrap();
+        assert_matches!(delivered, ReceivedParts::Complete(_));
+
+        clock.advance(TimingConfig::default().pull_delay_after_first_unit);
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        assert_eq!(requests, vec![]);
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn on_wake_discards_a_superseded_pop_and_keeps_the_current_one() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        let encoder = encoder();
+        let (commitment, mut parts) = encode_to_wire(&encoder, &receipt_data(0, 1));
+        parts.truncate(DATA_PARTS);
+        let rest = parts.split_off(1);
+        // The first part leaves its wake-up in the heap; the failed verification result after
+        // delivery schedules a second, immediate one and makes it the item's deadline.
+        assert_matches!(
+            manager
+                .on_parts_received(&account("alice.near"), &id, &commitment, parts, TOTAL_PARTS)
+                .unwrap(),
+            ReceivedParts::Collecting(_)
+        );
+        let delivered = manager
+            .on_parts_received(&account("bob.near"), &id, &commitment, rest, TOTAL_PARTS)
+            .unwrap();
+        assert_matches!(delivered, ReceivedParts::Complete(_));
+        clock.advance(Duration::milliseconds(50));
+        assert_eq!(manager.on_failed(&id).unwrap(), WakeAt(Some(clock.now())));
+
+        clock.advance(TimingConfig::default().pull_delay_after_first_unit);
+        // Both wake-ups are due; only the one matching the item's deadline survives, so
+        // the item is retried once.
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        assert_eq!(requested_ids(&requests), vec![id.clone()]);
+        assert_eq!(fetch_item(&manager, &id).pull.requests_sent, 1);
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn on_wake_requests_missing_ordinals_not_in_flight_and_reschedules() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        let encoder = encoder();
+        let (commitment, mut parts) = encode_to_wire(&encoder, &receipt_data(0, 1));
+        parts.truncate(1);
+        assert_matches!(
+            manager
+                .on_parts_received(&account("alice.near"), &id, &commitment, parts, TOTAL_PARTS)
+                .unwrap(),
+            ReceivedParts::Collecting(_)
+        );
+        clock.advance(TimingConfig::default().pull_delay_after_first_unit);
+
+        let (requests, wake) = manager.on_wake(clock.now(), Some(&requester()));
+
+        // The held ordinal 0 is not re-requested.
+        let [request] = requests.as_slice() else { panic!("expected one request") };
+        assert!(sources().contains(&request.producer));
+        assert_eq!(request.wants, BTreeMap::from([(id.clone(), BTreeSet::from([1, 2, 3, 4]))]));
+        let item = fetch_item(&manager, &id);
+        assert_eq!(item.pull.backoff.retries(), 1);
+        assert!(item.pull.has_in_flight_request_for(1));
+        let deadline = item.pull.next_deadline.unwrap();
+        assert!(deadline > clock.now());
+        assert_eq!(wake, WakeAt(Some(deadline)));
+        assert_eq!(manager.on_wake(clock.now(), Some(&requester())).0, vec![]);
+
+        // With everything missing already in flight there is nothing to request, the
+        // ladder does not advance, and the item is still rescheduled.
+        clock.advance(deadline.signed_duration_since(clock.now()));
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        assert_eq!(requests, vec![]);
+        let item = fetch_item(&manager, &id);
+        assert_eq!(item.pull.backoff.retries(), 1);
+        assert!(item.pull.next_deadline.is_some_and(|next| next > clock.now()));
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn on_wake_without_a_requester_sends_nothing_and_keeps_the_item_scheduled() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        assert_matches!(manager.start_pulling(from_ref(&id)), WakeAt(Some(_)));
+        clock.advance(TimingConfig::default().pull_delay_after_gate);
+
+        let (requests, wake) = manager.on_wake(clock.now(), None);
+
+        assert_eq!(requests, vec![]);
+        let item = fetch_item(&manager, &id);
+        assert_eq!(item.pull.requests_sent, 0);
+        assert!(item.pull.in_flight.is_empty());
+        let deadline = item.pull.next_deadline.unwrap();
+        assert!(deadline > clock.now());
+        assert_eq!(wake, WakeAt(Some(deadline)));
+
+        // A requester appearing later is served from the kept schedule.
+        clock.advance(deadline.signed_duration_since(clock.now()));
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        assert_eq!(requested_ids(&requests), vec![id]);
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn on_wake_batches_the_items_due_together_by_producer() {
+        let (chain, blocks) = chain_with_blocks(2);
+        let clock = FakeClock::default();
+        // One source, so every item's request goes to the same producer.
+        let producer = account("producer.near");
+        let mut manager = manager_with_sources(&chain, clock.clock(), vec![producer.clone()]);
+        let ids = [receipt_id(&blocks[0], 0, 1), receipt_id(&blocks[1], 0, 1)];
+        for block in &blocks {
+            manager.on_block(block.header()).unwrap();
+        }
+        assert_matches!(manager.start_pulling(&ids), WakeAt(Some(_)));
+        clock.advance(TimingConfig::default().pull_delay_after_gate);
+
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+
+        // The single source means the data is coded into one part.
+        let wants = ids.iter().map(|id| (id.clone(), BTreeSet::from([0]))).collect();
+        assert_eq!(requests, vec![PullRequest { producer, wants }]);
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn a_timeout_wake_rotates_the_source_without_advancing_the_backoff() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        assert_matches!(manager.start_pulling(from_ref(&id)), WakeAt(Some(_)));
+        clock.advance(TimingConfig::default().pull_delay_after_gate);
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        let [request] = requests.as_slice() else { panic!("expected one request") };
+        let first_source = request.producer.clone();
+        assert!(sources().contains(&first_source));
+        assert_eq!(request.wants, BTreeMap::from([(id.clone(), BTreeSet::from([0, 1, 2, 3, 4]))]));
+
+        // Ride the backoff wakes (nothing to request: everything is in flight) until
+        // the first request times out.
+        let request_timeout = TimingConfig::default().request_timeout;
+        let sent_at = clock.now();
+        loop {
+            let deadline = fetch_item(&manager, &id).pull.next_deadline.unwrap();
+            clock.advance(deadline.signed_duration_since(clock.now()));
+            if clock.now().signed_duration_since(sent_at) >= request_timeout {
+                break;
+            }
+            let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+            assert_eq!(requests, vec![]);
+        }
+
+        let retries_before = fetch_item(&manager, &id).pull.backoff.retries();
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        // The rotation round advanced with the first request, so the retry moves on
+        // from the first source even though the ladder does not.
+        let [request] = requests.as_slice() else { panic!("expected one request") };
+        assert_ne!(request.producer, first_source);
+        assert!(sources().contains(&request.producer));
+        assert_eq!(request.wants, BTreeMap::from([(id.clone(), BTreeSet::from([0, 1, 2, 3, 4]))]));
+        let item = fetch_item(&manager, &id);
+        assert_eq!(item.pull.backoff.retries(), retries_before);
+        assert_eq!(item.pull.in_flight.len(), 1);
+        assert_eq!(item.pull.in_flight[0].source, request.producer);
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+    fn a_unit_from_a_source_clears_its_in_flight_request() {
+        let (chain, blocks) = chain_with_blocks(1);
+        let block = &blocks[0];
+        let id = receipt_id(block, 0, 1);
+        let clock = FakeClock::default();
+        let mut manager = manager_with_clock(&chain, clock.clock());
+        manager.on_block(block.header()).unwrap();
+        assert_matches!(manager.start_pulling(from_ref(&id)), WakeAt(Some(_)));
+        clock.advance(TimingConfig::default().pull_delay_after_gate);
+        let (requests, _) = manager.on_wake(clock.now(), Some(&requester()));
+        let [request] = requests.as_slice() else { panic!("expected one request") };
+        let source = request.producer.clone();
+        assert!(fetch_item(&manager, &id).pull.has_in_flight_request_for(0));
+
+        let encoder = encoder();
+        let (commitment, mut parts) = encode_to_wire(&encoder, &receipt_data(0, 1));
+        parts.truncate(1);
+        assert_matches!(
+            manager.on_parts_received(&source, &id, &commitment, parts, TOTAL_PARTS).unwrap(),
+            ReceivedParts::Collecting(_)
+        );
+
+        assert!(fetch_item(&manager, &id).pull.in_flight.is_empty());
     }
 }
 

--- a/chain/client/src/spice/data_manager/tests.rs
+++ b/chain/client/src/spice/data_manager/tests.rs
@@ -1,15 +1,19 @@
-use super::item::{Assembly, FetchItem, FetchState, PartInsertResult};
+use super::item::{Assembly, FetchItem, FetchState, InFlightRequest, PartInsertResult, PullTiming};
+use super::scheduler::{Backoff, DeadlineScheduler, TimingConfig, WakeAt};
 use super::*;
 use assert_matches::assert_matches;
-use near_async::time::{Clock, Duration, FakeClock};
+use near_async::time::{Clock, Duration, FakeClock, Instant};
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::merkle::merklize;
 use near_primitives::reed_solomon::{ReedSolomonEncoder, reed_solomon_part_length};
 use near_primitives::sharding::{ReceiptProof, ShardProof};
 use near_primitives::spice::partial_data::SpiceDataCommitment;
 use near_primitives::types::{AccountId, ShardId};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use std::collections::HashSet;
 use std::sync::Arc;
+use time::ext::InstantExt as _;
 
 /// Data parts of the encoder every test here uses: `max((5 * 0.6) as usize, 1)`.
 const DATA_PARTS: usize = 3;
@@ -902,4 +906,239 @@ mod manager {
         );
         assert_matches!(result, Err(DataManagerError::BannedCommitment));
     }
+}
+
+fn assert_duration_eq(actual: Duration, expected: Duration) {
+    let difference = (actual - expected).abs();
+    assert!(difference <= Duration::nanoseconds(1), "{actual} != {expected}");
+}
+
+fn in_flight_request(source: &str, sent_at: Instant, ordinals: &[u64]) -> InFlightRequest {
+    InFlightRequest { source: account(source), sent_at, ordinals: ordinals.to_vec() }
+}
+
+fn no_jitter_config() -> TimingConfig {
+    TimingConfig { jitter_frac: 0.0, ..TimingConfig::default() }
+}
+
+#[test]
+fn pop_due_yields_entries_earliest_first_and_leaves_future_ones() {
+    let now = FakeClock::default().now();
+    let mut scheduler = DeadlineScheduler::default();
+    scheduler.schedule("c", now.add_signed(Duration::seconds(3)), Lane::Background);
+    scheduler.schedule("a", now.add_signed(Duration::seconds(1)), Lane::Background);
+    scheduler.schedule("b", now.add_signed(Duration::seconds(2)), Lane::Background);
+    scheduler.schedule("d", now.add_signed(Duration::seconds(10)), Lane::Priority);
+
+    assert_eq!(
+        scheduler.pop_due(now.add_signed(Duration::seconds(3))),
+        vec![
+            ("a", now.add_signed(Duration::seconds(1))),
+            ("b", now.add_signed(Duration::seconds(2))),
+            ("c", now.add_signed(Duration::seconds(3))),
+        ]
+    );
+    assert_eq!(scheduler.pop_due(now.add_signed(Duration::seconds(3))), vec![]);
+    assert_eq!(
+        scheduler.pop_due(now.add_signed(Duration::seconds(10))),
+        vec![("d", now.add_signed(Duration::seconds(10)))]
+    );
+}
+
+#[test]
+fn priority_pops_before_background_within_one_instant() {
+    let now = FakeClock::default().now();
+    let mut scheduler = DeadlineScheduler::default();
+    let at = now.add_signed(Duration::seconds(1));
+    scheduler.schedule("background", at, Lane::Background);
+    scheduler.schedule("priority", at, Lane::Priority);
+
+    assert_eq!(scheduler.pop_due(at), vec![("priority", at), ("background", at)]);
+}
+
+#[test]
+fn take_wake_reports_a_new_earliest_entry_once() {
+    let now = FakeClock::default().now();
+    let mut scheduler = DeadlineScheduler::default();
+    assert_eq!(scheduler.take_wake(), WakeAt(None));
+
+    let later = now.add_signed(Duration::seconds(5));
+    scheduler.schedule("later", later, Lane::Priority);
+    assert_eq!(scheduler.take_wake(), WakeAt(Some(later)));
+    // Already reported, and an entry behind it changes nothing.
+    assert_eq!(scheduler.take_wake(), WakeAt(None));
+    scheduler.schedule("even later", later.add_signed(Duration::seconds(1)), Lane::Priority);
+    assert_eq!(scheduler.take_wake(), WakeAt(None));
+
+    // An entry ahead of the reported one is reported.
+    let sooner = now.add_signed(Duration::seconds(1));
+    scheduler.schedule("sooner", sooner, Lane::Priority);
+    assert_eq!(scheduler.take_wake(), WakeAt(Some(sooner)));
+}
+
+#[test]
+fn take_wake_reports_the_next_entry_after_the_reported_one_pops() {
+    let now = FakeClock::default().now();
+    let mut scheduler = DeadlineScheduler::default();
+    let first = now.add_signed(Duration::seconds(1));
+    let second = now.add_signed(Duration::seconds(2));
+    scheduler.schedule("first", first, Lane::Priority);
+    scheduler.schedule("second", second, Lane::Priority);
+    assert_eq!(scheduler.take_wake(), WakeAt(Some(first)));
+
+    // A pop before the reported instant leaves it reported.
+    assert_eq!(scheduler.pop_due(now), vec![]);
+    assert_eq!(scheduler.take_wake(), WakeAt(None));
+
+    assert_eq!(scheduler.pop_due(first), vec![("first", first)]);
+    assert_eq!(scheduler.take_wake(), WakeAt(Some(second)));
+    assert_eq!(scheduler.pop_due(second), vec![("second", second)]);
+    assert_eq!(scheduler.take_wake(), WakeAt(None));
+}
+
+#[test]
+fn lane_max_escalates_to_priority() {
+    assert_eq!(Lane::Priority.max(Lane::Background), Lane::Priority);
+    assert!(Lane::Priority > Lane::Background);
+}
+
+#[test]
+fn backoff_interval_grows_geometrically_then_pins_at_the_cap() {
+    let config = no_jitter_config();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut backoff = Backoff::default();
+    for expected_ms in [200, 400, 800, 1600, 2000, 2000] {
+        assert_duration_eq(
+            backoff.next_interval(&config, &mut rng),
+            Duration::milliseconds(expected_ms),
+        );
+        backoff.note_retry();
+    }
+}
+
+#[test]
+fn backoff_jitter_stays_within_its_fraction_and_the_interval_stays_positive() {
+    let config = TimingConfig::default();
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut backoff = Backoff::default();
+    for retries in 0..6 {
+        let unjittered = (config.backoff_base.as_seconds_f64() * f64::from(2u32.pow(retries)))
+            .min(config.backoff_cap.as_seconds_f64());
+        let samples: Vec<f64> =
+            (0..200).map(|_| backoff.next_interval(&config, &mut rng).as_seconds_f64()).collect();
+        for sample in &samples {
+            assert!(*sample > 0.0);
+            assert!(*sample >= unjittered * (1.0 - config.jitter_frac) - 1e-9);
+            assert!(*sample <= unjittered * (1.0 + config.jitter_frac) + 1e-9);
+        }
+        // The jitter must actually spread samples to both sides.
+        assert!(samples.iter().any(|sample| *sample > unjittered));
+        assert!(samples.iter().any(|sample| *sample < unjittered));
+        backoff.note_retry();
+    }
+}
+
+#[test]
+fn take_timed_out_requests_returns_elapsed_entries_and_keeps_live_ones() {
+    let config = TimingConfig::default();
+    let clock = FakeClock::default();
+    let sent_first = clock.now();
+    let mut pull = PullTiming::default();
+    pull.in_flight.push(in_flight_request("alice.near", sent_first, &[0, 1]));
+    clock.advance(Duration::milliseconds(500));
+    pull.in_flight.push(in_flight_request("bob.near", clock.now(), &[2]));
+    clock.advance(Duration::milliseconds(500));
+
+    let timed_out = pull.take_timed_out_requests(&config, clock.now());
+
+    assert_eq!(timed_out.len(), 1);
+    assert_eq!(timed_out[0].source, account("alice.near"));
+    assert_eq!(timed_out[0].ordinals, vec![0, 1]);
+    assert_eq!(pull.in_flight.len(), 1);
+    assert_eq!(pull.in_flight[0].source, account("bob.near"));
+}
+
+#[test]
+fn a_timeout_wake_leaves_backoff_retries_unchanged() {
+    let config = no_jitter_config();
+    let clock = FakeClock::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut pull = PullTiming::default();
+    pull.in_flight.push(in_flight_request("alice.near", clock.now(), &[0]));
+    pull.backoff.note_retry();
+    pull.backoff.note_retry();
+    clock.advance(Duration::seconds(2));
+
+    pull.take_timed_out_requests(&config, clock.now());
+    let _ = pull.reschedule(&config, clock.now(), &mut rng);
+
+    assert_eq!(pull.backoff.retries(), 2);
+}
+
+#[test]
+fn has_in_flight_request_for_matches_only_requested_ordinals() {
+    let clock = FakeClock::default();
+    let mut pull = PullTiming::default();
+    pull.in_flight.push(in_flight_request("alice.near", clock.now(), &[1, 3]));
+
+    assert!(pull.has_in_flight_request_for(1));
+    assert!(pull.has_in_flight_request_for(3));
+    assert!(!pull.has_in_flight_request_for(2));
+}
+
+#[test]
+fn reschedule_picks_the_oldest_request_timeout_when_it_precedes_the_backoff() {
+    let config = no_jitter_config();
+    let clock = FakeClock::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    let sent_first = clock.now();
+    let mut pull = PullTiming::default();
+    pull.in_flight.push(in_flight_request("alice.near", sent_first, &[0]));
+    clock.advance(Duration::milliseconds(300));
+    pull.in_flight.push(in_flight_request("bob.near", clock.now(), &[1]));
+    clock.advance(Duration::milliseconds(600));
+
+    // The backoff would fire at +1100ms; alice's request times out at +1000ms.
+    let deadline = pull.reschedule(&config, clock.now(), &mut rng);
+
+    assert_eq!(deadline, sent_first.add_signed(config.request_timeout));
+    assert_eq!(pull.next_deadline, Some(deadline));
+}
+
+#[test]
+fn reschedule_uses_the_backoff_interval_when_no_request_times_out_sooner() {
+    let config = no_jitter_config();
+    let clock = FakeClock::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut pull = PullTiming::default();
+
+    let deadline = pull.reschedule(&config, clock.now(), &mut rng);
+    assert_eq!(deadline, clock.now().add_signed(config.backoff_base));
+
+    // A fresh request's timeout is further away than the backoff, so it does not win.
+    pull.in_flight.push(in_flight_request("alice.near", clock.now(), &[0]));
+    let deadline = pull.reschedule(&config, clock.now(), &mut rng);
+    assert_eq!(deadline, clock.now().add_signed(config.backoff_base));
+    assert_eq!(pull.next_deadline, Some(deadline));
+}
+
+#[test]
+fn reschedule_supersedes_the_previous_deadline_so_a_stale_pop_mismatches() {
+    let config = no_jitter_config();
+    let clock = FakeClock::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut pull = PullTiming::default();
+    let mut scheduler = DeadlineScheduler::default();
+
+    let stale = pull.reschedule(&config, clock.now(), &mut rng);
+    scheduler.schedule("item", stale, Lane::Priority);
+    clock.advance(Duration::milliseconds(50));
+    let current = pull.reschedule(&config, clock.now(), &mut rng);
+    scheduler.schedule("item", current, Lane::Priority);
+
+    clock.advance(Duration::seconds(10));
+    let popped = scheduler.pop_due(clock.now());
+    assert_eq!(popped, vec![("item", stale), ("item", current)]);
+    assert_ne!(pull.next_deadline, Some(stale));
+    assert_eq!(pull.next_deadline, Some(current));
 }

--- a/chain/client/src/spice/tests/chunk_executor_actor.rs
+++ b/chain/client/src/spice/tests/chunk_executor_actor.rs
@@ -4,6 +4,7 @@ use crate::spice::chunk_executor_actor::{
 };
 use crate::spice::chunk_executor_actor::{ExecutorApplyChunksDone, get_witness};
 use crate::spice::data_distributor_actor::DataVerification;
+use crate::spice::data_distributor_actor::MissingReceiptProofs;
 use crate::spice::data_distributor_actor::SpiceDataDistributorAdapter;
 use crate::spice::data_distributor_actor::SpiceDistributorOutgoingReceipts;
 use crate::spice::data_distributor_actor::SpiceDistributorStateWitness;
@@ -95,6 +96,7 @@ enum OutgoingMessage {
     SpiceDistributorOutgoingReceipts(SpiceDistributorOutgoingReceipts),
     SpiceDistributorStateWitness(SpiceDistributorStateWitness),
     DataVerification(DataVerification),
+    MissingReceiptProofs(MissingReceiptProofs),
 }
 
 // We don't derive clone because it's desirable to not have clone for spice distributor message to
@@ -122,6 +124,9 @@ impl Clone for OutgoingMessage {
             }),
             OutgoingMessage::DataVerification(verification) => {
                 OutgoingMessage::DataVerification(verification.clone())
+            }
+            OutgoingMessage::MissingReceiptProofs(missing) => {
+                OutgoingMessage::MissingReceiptProofs(missing.clone())
             }
         }
     }
@@ -192,8 +197,16 @@ impl TestActor {
                 }
             }),
             data_verification: Sender::from_fn({
+                let outgoing_sc = outgoing_sc.clone();
                 move |message| {
                     outgoing_sc.unbounded_send(OutgoingMessage::DataVerification(message)).unwrap();
+                }
+            }),
+            missing_receipt_proofs: Sender::from_fn({
+                move |message| {
+                    outgoing_sc
+                        .unbounded_send(OutgoingMessage::MissingReceiptProofs(message))
+                        .unwrap();
                 }
             }),
         };
@@ -370,6 +383,9 @@ fn simulate_single_outgoing_message(actors: &mut [TestActor], message: &Outgoing
         }
         OutgoingMessage::SpiceDistributorStateWitness(_) => {}
         OutgoingMessage::DataVerification(_) => {}
+        // These tests bypass real distribution: receipts reach the actors directly above,
+        // so a transient missing-receipts report has nothing to trigger.
+        OutgoingMessage::MissingReceiptProofs(_) => {}
     }
 }
 
@@ -965,6 +981,55 @@ fn test_verifying_an_invalid_network_receipt_reports_failed() {
     });
 
     assert_eq!(drain_verifications(&mut outgoing_rc), vec![DataVerification::Failed(data_id)]);
+}
+
+/// A pulled receipt proof can be delivered before the first processed block creates
+/// the destination shard's executor (a restart, or an epoch boundary).
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_receipt_delivered_before_the_first_processed_block_is_verified_once_results_land() {
+    let (outgoing_sc, mut outgoing_rc) = unbounded();
+    let mut actors = setup_with_shards(2, outgoing_sc);
+    let genesis_block = actors[0].chain.genesis_block();
+    let block = produce_block(&mut actors, &genesis_block);
+    // Only the source shard's node executes; the recipient has not processed a block yet.
+    actors[1].handle_with_internal_events(ProcessedBlock { block_hash: *block.hash() });
+    assert!(block_executed(&actors[1], &block));
+    let mut receipt_proof = None;
+    while let Ok(Some(message)) = outgoing_rc.try_next() {
+        let OutgoingMessage::SpiceDistributorOutgoingReceipts(SpiceDistributorOutgoingReceipts {
+            receipt_proofs,
+            ..
+        }) = message
+        else {
+            continue;
+        };
+        receipt_proof = receipt_proof.or_else(|| {
+            receipt_proofs.into_iter().find(|proof| {
+                actors[0].actor.shard_tracker.cares_about_shard(block.hash(), proof.1.to_shard_id)
+            })
+        });
+    }
+    let receipt_proof = receipt_proof.expect("the source shard sends a proof to the recipient");
+    let data_id = DataId::receipt_proof(
+        *block.hash(),
+        receipt_proof.1.from_shard_id,
+        receipt_proof.1.to_shard_id,
+    );
+
+    actors[0].handle_with_internal_events(ExecutorIncomingUnverifiedReceipts {
+        data_id: data_id.clone(),
+        receipt_proof,
+    });
+    // Buffered, not dropped: the source block's execution results are not in yet.
+    assert_eq!(drain_verifications(&mut outgoing_rc), vec![]);
+
+    actors[0].handle_with_internal_events(ProcessedBlock { block_hash: *block.hash() });
+    assert!(block_executed(&actors[0], &block));
+    record_endorsements(&mut actors, &block);
+    actors[0].handle_with_internal_events(ExecutionResultEndorsed { block_hash: *block.hash() });
+
+    assert_eq!(drain_verifications(&mut outgoing_rc), vec![DataVerification::Ok(data_id)]);
 }
 
 /// First receipt proof the actors sent out; drops every other queued message.

--- a/chain/client/src/spice/tests/data_distributor_actor.rs
+++ b/chain/client/src/spice/tests/data_distributor_actor.rs
@@ -3,8 +3,9 @@ use crate::spice::chunk_executor_actor::{
 };
 use crate::spice::chunk_validator_actor::SpiceChunkStateWitnessMessage;
 use crate::spice::data_distributor_actor::{
-    Error, FALLBACK_WITNESS_PULL_GRACE, FALLBACK_WITNESS_PUSH_LOOKAHEAD, MAX_REQUESTED_DATA_IDS,
-    MAX_REQUESTED_PARTS, MalformedDataRequest, ReceiveDataError, SpiceDataDistributorActor,
+    DATA_PARTS_RATIO, DataVerification, Error, FALLBACK_WITNESS_PULL_GRACE,
+    FALLBACK_WITNESS_PUSH_LOOKAHEAD, MAX_REQUESTED_DATA_IDS, MAX_REQUESTED_PARTS,
+    MalformedDataRequest, ReceiveDataError, SpiceDataDistributorActor,
     SpiceDistributorOutgoingReceipts, SpiceDistributorStateWitness,
 };
 use crate::spice::data_manager::{AssembledDataError, DataId, DataManagerError};
@@ -13,7 +14,7 @@ use itertools::Itertools as _;
 use near_async::messaging::Actor;
 use near_async::messaging::{Handler, IntoAsyncSender, IntoSender, Sender, noop};
 use near_async::test_utils::FakeDelayedActionRunner;
-use near_async::time::Clock;
+use near_async::time::{Clock, FakeClock};
 use near_chain::Block;
 use near_chain::ChainStoreAccess;
 use near_chain::spice::activation::SpiceMessageKind;
@@ -47,7 +48,8 @@ use near_primitives::block_body::SpiceCoreStatement;
 use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
 use near_primitives::hash::hash;
-use near_primitives::merkle::merklize;
+use near_primitives::merkle::{Direction, MerklePathItem, merklize};
+use near_primitives::reed_solomon::reed_solomon_num_data_parts;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ReceiptProof;
 use near_primitives::sharding::ShardChunkHeader;
@@ -76,12 +78,15 @@ use near_store::ShardUId;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::StoreUpdateAdapter;
 use near_store::adapter::trie_store::TrieStoreAdapter;
+use rand::SeedableRng as _;
+use rand::rngs::StdRng;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::num::NonZero;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use with_ctx::{handle, handle_with_runner};
 
 fn build_block(epoch_manager: &dyn EpochManagerAdapter, prev_block: &Block) -> Arc<Block> {
     build_block_with_core_statements(epoch_manager, prev_block, vec![])
@@ -177,6 +182,36 @@ fn new_test_witness(block: &Block) -> SpiceChunkStateWitness {
     new_test_witness_for_chunk(block, chunk_header)
 }
 
+/// Own module so `HandlerWithContext` stays out of the file's scope: importing it there
+/// would make every plain `actor.handle(..)` call ambiguous against the `Handler` blanket.
+mod with_ctx {
+    use crate::spice::data_distributor_actor::SpiceDataDistributorActor;
+    use near_async::messaging::HandlerWithContext;
+    use near_async::test_utils::FakeDelayedActionRunner;
+
+    /// Drives a context-taking handler with the given timer runner.
+    pub(super) fn handle_with_runner<M>(
+        actor: &mut SpiceDataDistributorActor,
+        msg: M,
+        runner: &mut FakeDelayedActionRunner<SpiceDataDistributorActor>,
+    ) where
+        M: Send + 'static,
+        SpiceDataDistributorActor: HandlerWithContext<M>,
+    {
+        HandlerWithContext::handle(actor, msg, runner);
+    }
+
+    /// Drives a context-taking handler, discarding any timers it sets. Tests that
+    /// assert on the timers use [`handle_with_runner`] with their own runner.
+    pub(super) fn handle<M>(actor: &mut SpiceDataDistributorActor, msg: M)
+    where
+        M: Send + 'static,
+        SpiceDataDistributorActor: HandlerWithContext<M>,
+    {
+        handle_with_runner(actor, msg, &mut FakeDelayedActionRunner::default());
+    }
+}
+
 fn setup(num_chunk_producers: usize, num_validators: usize) -> (Genesis, Chain) {
     setup_with_shard_layout(num_chunk_producers, num_validators, ShardLayout::multi_shard(2, 0))
 }
@@ -243,15 +278,25 @@ fn new_chain(chain: &Chain, genesis: &Genesis) -> Chain {
 struct ActorBuilder {
     validator: Option<AccountId>,
     tracked_shards_config: TrackedShardsConfig,
+    clock: Clock,
 }
 
 impl ActorBuilder {
     fn new(validator: Option<AccountId>) -> Self {
-        Self { validator, tracked_shards_config: TrackedShardsConfig::NoShards }
+        Self {
+            validator,
+            tracked_shards_config: TrackedShardsConfig::NoShards,
+            clock: Clock::real(),
+        }
     }
 
     fn tracked_shards_config(mut self, config: TrackedShardsConfig) -> Self {
         self.tracked_shards_config = config;
+        self
+    }
+
+    fn clock(mut self, clock: Clock) -> Self {
+        self.clock = clock;
         self
     }
 
@@ -294,7 +339,8 @@ impl ActorBuilder {
             }),
         };
         SpiceDataDistributorActor::new(
-            Clock::real(),
+            self.clock,
+            StdRng::seed_from_u64(42),
             epoch_manager.clone(),
             chain.chain_store.store().chain_store(),
             validator_signer,
@@ -551,10 +597,13 @@ fn test_witness_can_be_reconstructed_impl(num_chunk_producers: usize, num_valida
             continue;
         };
         assert!(recipients.contains(validator));
-        receiver.handle(SpiceIncomingPartialData {
-            data: partial_data.clone(),
-            recv_permit: RecvMessagePermit::none(),
-        });
+        handle(
+            &mut receiver,
+            SpiceIncomingPartialData {
+                data: partial_data.clone(),
+                recv_permit: RecvMessagePermit::none(),
+            },
+        );
     }
     let message = receiver_messages_rc.try_recv().unwrap();
     assert_matches!(receiver_messages_rc.try_recv(), Err(TryRecvError::Empty));
@@ -697,10 +746,13 @@ fn test_receipts_can_be_reconstructed_impl(num_chunk_producers: usize) {
             panic!()
         };
         assert!(recipients.contains(receiver_account));
-        receiver.handle(SpiceIncomingPartialData {
-            data: partial_data.clone(),
-            recv_permit: RecvMessagePermit::none(),
-        });
+        handle(
+            &mut receiver,
+            SpiceIncomingPartialData {
+                data: partial_data.clone(),
+                recv_permit: RecvMessagePermit::none(),
+            },
+        );
     }
     let message = receiver_messages_rc.try_recv().unwrap();
     assert_matches!(receiver_messages_rc.try_recv(), Err(TryRecvError::Empty));
@@ -951,7 +1003,7 @@ macro_rules! test_invalid_incoming_partial_data {
                         assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
                         assert_matches!(result, Err(ReceiveDataError::ReceivingDataWithBlock($error)));
                     }
-                    actor.handle(incoming_data);
+                    handle(&mut actor, incoming_data);
                     assert_matches!(outgoing_rc.try_recv(), Ok(_));
                 }
             )+
@@ -1125,7 +1177,7 @@ fn test_incoming_partial_data_is_already_decoded() {
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &recipient);
     let data = incoming_data.data.clone();
-    actor.handle(incoming_data);
+    handle(&mut actor, incoming_data);
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
     let result = actor.receive_data(data);
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
@@ -1241,7 +1293,7 @@ fn test_incoming_partial_data_for_witness_with_receipt_id() {
             receipt_proofs: vec![honest_proof],
         },
     );
-    actor.handle(honest_data);
+    handle(&mut actor, honest_data);
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
 }
 
@@ -1292,7 +1344,7 @@ fn test_incoming_partial_data_for_receipts_with_non_matching_from_shard_id() {
             receipt_proofs: vec![honest_proof],
         },
     );
-    actor.handle(honest_data);
+    handle(&mut actor, honest_data);
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
 }
 
@@ -1343,8 +1395,103 @@ fn test_incoming_partial_data_for_receipts_with_non_matching_to_shard_id() {
             receipt_proofs: vec![honest_proof],
         },
     );
-    actor.handle(honest_data);
+    handle(&mut actor, honest_data);
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
+}
+
+/// The verification-window recovery: a decoded commitment the consumer rejects resumes
+/// collecting, and its pull is due immediately — the request goes out at once, for the
+/// ordinals the residual does not hold.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_failed_verification_pulls_the_missing_ordinals_at_once() {
+    let (_genesis, chain) = setup(8, 0);
+    let block = latest_block(&chain);
+    let honest_proof = new_test_receipt_proof(&block);
+    let producers = producers_of_receipt_proof(&chain, &block, &honest_proof);
+    let data_parts = reed_solomon_num_data_parts(producers.len(), DATA_PARTS_RATIO);
+    assert!(data_parts >= 2, "one honest part alone must not decode");
+    assert!(producers.len() >= 2 * data_parts, "not enough unbound producers to recover from");
+    let recipient = recipients_of_receipt_proof(&chain, &block, &honest_proof)
+        .into_iter()
+        .find(|account| !producers.contains(account))
+        .unwrap();
+
+    let clock = FakeClock::default();
+    let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
+    let mut actor =
+        ActorBuilder::new(Some(recipient.clone())).clock(clock.clock()).build(outgoing_sc, &chain);
+    let mut runner = FakeDelayedActionRunner::default();
+
+    let push_from = |producer: &AccountId, proof: &ReceiptProof| {
+        let (incoming, _recipient) = get_incoming_data(
+            producer,
+            &chain,
+            SpiceDistributorOutgoingReceipts {
+                block_hash: *block.hash(),
+                receipt_proofs: vec![proof.clone()],
+            },
+        );
+        incoming
+    };
+
+    // One honest part, then a fake commitment for the same id (same shards, different
+    // content) decoded from `data_parts` fabricated parts.
+    handle_with_runner(&mut actor, push_from(&producers[0], &honest_proof), &mut runner);
+    let mut fake_proof = honest_proof.clone();
+    fake_proof
+        .1
+        .proof
+        .push(MerklePathItem { hash: CryptoHash::default(), direction: Direction::Left });
+    for producer in &producers[1..=data_parts] {
+        handle_with_runner(&mut actor, push_from(producer, &fake_proof), &mut runner);
+    }
+    let message = outgoing_rc.try_recv().unwrap();
+    let OutgoingMessage::ExecutorIncomingUnverifiedReceipts(ExecutorIncomingUnverifiedReceipts {
+        data_id,
+        receipt_proof,
+    }) = message
+    else {
+        panic!("expected the fake commitment delivered");
+    };
+    assert_eq!(receipt_proof, fake_proof);
+    assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
+
+    handle_with_runner(&mut actor, DataVerification::Failed(data_id.clone()), &mut runner);
+
+    // The clock never advances: the request the failed verification result triggered is immediate,
+    // and asks only for the ordinals the residual honest part does not cover.
+    runner.run_queued_actions(&mut actor);
+    let message = outgoing_rc.try_recv().unwrap();
+    let OutgoingMessage::NetworkRequests {
+        request: NetworkRequests::SpiceDataRequest { request, producer },
+    } = message
+    else {
+        panic!("expected an immediate data request");
+    };
+    assert!(producers.contains(&producer));
+    let (wants, requester) = request.into_parts();
+    assert_eq!(requester, recipient);
+    let missing: BTreeSet<u64> = (1..producers.len() as u64).collect();
+    assert_eq!(wants, BTreeMap::from([(SpiceDataIdentifier::from(&data_id), missing)]));
+    assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
+
+    // Honest parts from producers not bound to the banned commitment complete the item,
+    // and the consumer's verification result settles it.
+    for producer in &producers[data_parts + 1..2 * data_parts] {
+        handle_with_runner(&mut actor, push_from(producer, &honest_proof), &mut runner);
+    }
+    let message = outgoing_rc.try_recv().unwrap();
+    let OutgoingMessage::ExecutorIncomingUnverifiedReceipts(ExecutorIncomingUnverifiedReceipts {
+        data_id,
+        receipt_proof,
+    }) = message
+    else {
+        panic!("expected the honest proof delivered");
+    };
+    assert_eq!(receipt_proof, honest_proof);
+    handle_with_runner(&mut actor, DataVerification::Ok(data_id), &mut runner);
+    assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
 }
 
 #[test]
@@ -1370,7 +1517,7 @@ fn test_incoming_partial_data_for_receipt_with_witness_id() {
             Err(ReceiveDataError::ReceivingDataWithBlock(Error::IdAndDataMismatch))
         );
     }
-    actor.handle(incoming_data);
+    handle(&mut actor, incoming_data);
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
 }
 
@@ -1425,7 +1572,7 @@ fn test_incoming_partial_data_for_witness_with_wrong_shard_id() {
             Err(ReceiveDataError::ReceivingDataWithBlock(Error::InvalidDecodedWitnessShardId))
         );
     }
-    actor.handle(incoming_data);
+    handle(&mut actor, incoming_data);
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
 }
 
@@ -1462,7 +1609,7 @@ fn test_incoming_partial_data_for_witness_with_wrong_block_hash() {
             Err(ReceiveDataError::ReceivingDataWithBlock(Error::InvalidDecodedWitnessBlockHash))
         );
     }
-    actor.handle(incoming_data);
+    handle(&mut actor, incoming_data);
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
 }
 
@@ -1630,7 +1777,7 @@ fn test_incoming_data_is_processed_with_block_arriving_late() {
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &receiver_chain, &recipient);
 
-    actor.handle(incoming_data);
+    handle(&mut actor, incoming_data);
     assert_eq!(actor.pending_partial_data_size(), 1);
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
 
@@ -1641,7 +1788,7 @@ fn test_incoming_data_is_processed_with_block_arriving_late() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
     assert_matches!(outgoing_rc.try_recv(), Ok(_));
     assert_eq!(actor.pending_partial_data_size(), 0);
 }
@@ -1974,7 +2121,7 @@ fn test_requesting_witness_for_new_block_when_validator() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
 
     fake_runner.run_queued_actions(&mut actor);
     let requests = drain_outgoing_data_requests(&mut outgoing_rc);
@@ -2015,7 +2162,7 @@ fn test_not_requesting_witness_for_new_block_when_not_validator() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
 
     fake_runner.run_queued_actions(&mut actor);
     let requests = drain_outgoing_data_requests(&mut outgoing_rc);
@@ -2052,7 +2199,7 @@ fn test_not_requesting_witness_for_new_block_without_signer() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
 
     fake_runner.run_queued_actions(&mut actor);
     let requests = drain_outgoing_data_requests(&mut outgoing_rc);
@@ -2089,7 +2236,7 @@ fn test_waiting_on_receipts_we_do_not_produce_for_new_block() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
 
     fake_runner.run_queued_actions(&mut actor);
     assert!(actor.is_tracking(&data_id));
@@ -2131,7 +2278,7 @@ fn test_not_waiting_on_receipts_we_produce_for_new_block() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
 
     fake_runner.run_queued_actions(&mut actor);
     assert!(!actor.is_tracking(&data_id));
@@ -2172,7 +2319,7 @@ fn test_not_requesting_witnesses_we_produce_for_new_block() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
 
     fake_runner.run_queued_actions(&mut actor);
     let requests = drain_outgoing_data_requests(&mut outgoing_rc);
@@ -2209,8 +2356,8 @@ fn test_not_requesting_data_we_already_received() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
-    actor.handle(incoming_data);
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, incoming_data);
 
     fake_runner.run_queued_actions(&mut actor);
     let requests = drain_outgoing_data_requests(&mut outgoing_rc);
@@ -2240,7 +2387,7 @@ fn test_not_requesting_data_we_already_received_before_block() {
     let mut actor = ActorBuilder::new(Some(recipient)).build(outgoing_sc, &receiver_chain);
     let mut fake_runner = FakeDelayedActionRunner::default();
     actor.start_actor(&mut fake_runner);
-    actor.handle(incoming_data);
+    handle(&mut actor, incoming_data);
     process_block_sync(
         &mut receiver_chain,
         next_block.clone().into(),
@@ -2248,7 +2395,7 @@ fn test_not_requesting_data_we_already_received_before_block() {
         &mut BlockProcessingArtifact::default(),
     )
     .unwrap();
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
 
     fake_runner.run_queued_actions(&mut actor);
     let requests = drain_outgoing_data_requests(&mut outgoing_rc);
@@ -2287,10 +2434,10 @@ fn test_handling_data_request_with_receipts_in_store() {
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &recipient_chain, &recipient);
-    actor.handle(SpiceIncomingPartialData {
-        data: partial_data,
-        recv_permit: RecvMessagePermit::none(),
-    });
+    handle(
+        &mut actor,
+        SpiceIncomingPartialData { data: partial_data, recv_permit: RecvMessagePermit::none() },
+    );
 
     let message = outgoing_rc.try_recv().unwrap();
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
@@ -2340,10 +2487,10 @@ fn test_handling_data_request_with_witness_in_store() {
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &recipient_chain, &recipient);
-    actor.handle(SpiceIncomingPartialData {
-        data: partial_data,
-        recv_permit: RecvMessagePermit::none(),
-    });
+    handle(
+        &mut actor,
+        SpiceIncomingPartialData { data: partial_data, recv_permit: RecvMessagePermit::none() },
+    );
 
     let message = outgoing_rc.try_recv().unwrap();
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
@@ -2858,10 +3005,10 @@ fn test_requesting_receipts_when_not_validator() {
     let mut actor = ActorBuilder::new(Some(requester))
         .tracked_shards_config(TrackedShardsConfig::Shards(vec![to_shard_uid]))
         .build(outgoing_sc, &requester_chain);
-    actor.handle(SpiceIncomingPartialData {
-        data: partial_data,
-        recv_permit: RecvMessagePermit::none(),
-    });
+    handle(
+        &mut actor,
+        SpiceIncomingPartialData { data: partial_data, recv_permit: RecvMessagePermit::none() },
+    );
 
     let message = outgoing_rc.try_recv().unwrap();
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
@@ -3310,7 +3457,7 @@ fn test_stops_waiting_on_witness_once_its_block_is_final_certified() {
     let certifying_block = produce_block_certifying_uncertified_chunks(&mut chain, &next_block);
     let head = produce_blocks_until_final(&mut chain, &certifying_block);
 
-    actor.handle(ProcessedBlock { block_hash: *head.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *head.hash() });
     fake_runner.run_queued_actions(&mut actor);
     assert!(
         !actor
@@ -3361,7 +3508,7 @@ fn test_stops_waiting_on_data_of_a_fork_block_below_the_final_head() {
 
     let head = produce_blocks_until_final(&mut chain, &next_block);
 
-    actor.handle(ProcessedBlock { block_hash: *head.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *head.hash() });
     fake_runner.run_queued_actions(&mut actor);
     // The dead fork's witness is purged at the final head; the canonical block's stays.
     assert_eq!(waiting_witness_count_of(&actor, fork_block.hash()), 0);
@@ -3380,7 +3527,7 @@ fn test_stops_waiting_on_data_of_a_fork_block_below_the_final_head() {
     // Once the final execution head passes their height, the dead fork's item and the
     // executed canonical block's item are both moot and expire.
     save_final_execution_head(&chain, &next_block);
-    actor.handle(ProcessedBlock { block_hash: *head.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *head.hash() });
     fake_runner.run_queued_actions(&mut actor);
     assert!(!actor.is_tracking(&proof_id(&fork_block)));
     assert!(!actor.is_tracking(&proof_id(&next_block)));
@@ -3412,14 +3559,14 @@ fn test_fallback_endorsement_is_broadcast_on_every_block_until_it_is_on_chain() 
 
     let mut block = latest_block(&chain);
     for _ in 0..3 {
-        actor.handle(ProcessedBlock { block_hash: *block.hash() });
+        handle(&mut actor, ProcessedBlock { block_hash: *block.hash() });
         assert!(broadcast_endorsement_chunk_ids(&mut outgoing_rc).contains(&chunk_id));
         block = produce_block(&mut chain, &block);
     }
 
     let carrying_block =
         produce_block_carrying_endorsement(&mut chain, &block, &chunk_id, &validator);
-    actor.handle(ProcessedBlock { block_hash: *carrying_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *carrying_block.hash() });
     assert!(!broadcast_endorsement_chunk_ids(&mut outgoing_rc).contains(&chunk_id));
 }
 
@@ -3510,7 +3657,7 @@ fn test_witness_is_pushed_when_fallback_opens() {
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
-    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *head_block.hash() });
 
     let mut pushes = drain_outgoing_partial_data(&mut outgoing_rc);
     assert_eq!(pushes.len(), 1);
@@ -3537,11 +3684,11 @@ fn test_witness_is_pushed_only_once() {
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
-    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *head_block.hash() });
     assert_eq!(drain_outgoing_partial_data(&mut outgoing_rc).len(), 1);
 
     let next_block = produce_block(&mut chain, &head_block);
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
     assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
 }
 
@@ -3563,12 +3710,12 @@ fn test_fallback_only_witness_is_pushed_on_the_block_after_the_witness_is_saved(
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &producer);
     // A fallback-only chunk is eligible on its own block, but its witness only exists once the
     // producer applies the chunk, which needs the previous block certified.
-    actor.handle(ProcessedBlock { block_hash: *chunk_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *chunk_block.hash() });
     assert!(drain_outgoing_partial_data(&mut outgoing_rc).is_empty());
 
     let witness = save_test_witness_for_chunk(&chain, &chunk_id);
     let next_block = produce_block(&mut chain, &chunk_block);
-    actor.handle(ProcessedBlock { block_hash: *next_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *next_block.hash() });
 
     let mut pushes = drain_outgoing_partial_data(&mut outgoing_rc);
     assert_eq!(pushes.len(), 1, "the push was not retried once the witness was saved");
@@ -3594,7 +3741,7 @@ fn test_fallback_witness_is_requested_only_after_the_pull_grace() {
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);
     let mut fake_runner = FakeDelayedActionRunner::default();
     actor.start_actor(&mut fake_runner);
-    actor.handle(ProcessedBlock { block_hash: *head_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *head_block.hash() });
 
     fake_runner.run_queued_actions(&mut actor);
     assert!(!requested_witness_chunk_ids(&mut outgoing_rc).contains(&chunk_id));
@@ -3672,13 +3819,13 @@ fn test_pushed_fallback_only_witness_waits_for_its_block_to_arrive() {
 
     // A fallback-only chunk is eligible on its own block, so the push can reach a receiver that
     // does not have that block yet. The parts wait for it rather than being refused.
-    actor.handle(SpiceIncomingPartialData { data, recv_permit: RecvMessagePermit::none() });
+    handle(&mut actor, SpiceIncomingPartialData { data, recv_permit: RecvMessagePermit::none() });
     assert_eq!(actor.pending_partial_data_size(), 1);
     assert_matches!(outgoing_rc.try_recv(), Err(TryRecvError::Empty));
 
     let chunk_block = chain.chain_store.get_block(&chunk_id.block_hash).unwrap();
     catch_up_to(&mut receiver_chain, &chain, &chunk_block);
-    actor.handle(ProcessedBlock { block_hash: *chunk_block.hash() });
+    handle(&mut actor, ProcessedBlock { block_hash: *chunk_block.hash() });
 
     let message = outgoing_rc.try_recv().unwrap();
     let OutgoingMessage::ChunkStateWitnessMessage(SpiceChunkStateWitnessMessage {
@@ -3706,7 +3853,7 @@ fn test_pushed_fallback_witness_is_kept_when_head_is_within_the_lookahead() {
 
     let (outgoing_sc, mut outgoing_rc) = unbounded_channel();
     let mut actor = new_actor_for_account(outgoing_sc, &chain, &validator);
-    actor.handle(SpiceIncomingPartialData { data, recv_permit: RecvMessagePermit::none() });
+    handle(&mut actor, SpiceIncomingPartialData { data, recv_permit: RecvMessagePermit::none() });
 
     let message = outgoing_rc.try_recv().unwrap();
     let OutgoingMessage::ChunkStateWitnessMessage(SpiceChunkStateWitnessMessage {

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -16,6 +16,7 @@ axum.workspace = true
 axum-test.workspace = true
 borsh.workspace = true
 parking_lot.workspace = true
+rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 tokio.workspace = true

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -32,6 +32,8 @@ use near_store::test_utils::create_test_store;
 use near_time::Clock;
 use nearcore::NightshadeRuntime;
 use parking_lot::RwLock;
+use rand::SeedableRng as _;
+use rand::rngs::StdRng;
 use std::sync::Arc;
 
 pub const TEST_SEED: RngSeed = [3; 32];
@@ -215,6 +217,7 @@ pub fn create_test_setup_with_accounts_and_validity(
 
         let spice_data_distributor_actor = SpiceDataDistributorActor::new(
             Clock::real(),
+            StdRng::seed_from_u64(42),
             epoch_manager.clone(),
             runtime.store().chain_store(),
             signer.clone(),

--- a/cspell.json
+++ b/cspell.json
@@ -493,6 +493,7 @@
         "unflushed",
         "unioned",
         "unittests",
+        "unjittered",
         "unlabel",
         "unlimit",
         "unorphaned",

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -53,6 +53,8 @@ use near_store::metrics::spawn_db_metrics_loop;
 use near_store::{NodeStorage, Store, StoreOpenerError};
 use near_telemetry::TelemetryActor;
 use parking_lot::RwLock;
+use rand::SeedableRng as _;
+use rand::rngs::StdRng;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -290,6 +292,7 @@ fn spawn_spice_actors(
 
     let spice_data_distributor_actor = SpiceDataDistributorActor::new(
         Clock::real(),
+        StdRng::from_entropy(),
         epoch_manager.clone(),
         runtime.store().chain_store(),
         validator_signer.clone(),

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -39,6 +39,7 @@ use near_epoch_manager::shard_tracker::ShardTracker;
 use near_jsonrpc::client::RpcTransport;
 use near_jsonrpc::sharded_rpc::ShardedRpcPool;
 use near_primitives::genesis::GenesisId;
+use near_primitives::hash::hash;
 use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
 use near_store::adapter::StoreAdapter;
@@ -49,6 +50,8 @@ use near_vm_runner::{
 };
 use nearcore::state_sync::StateSyncDumper;
 use parking_lot::RwLock;
+use rand::SeedableRng as _;
+use rand::rngs::StdRng;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use tokio::sync::broadcast;
@@ -459,6 +462,10 @@ pub fn setup_client(
 
     let spice_data_distributor_actor = SpiceDataDistributorActor::new(
         test_loop.clock(),
+        // Deterministic, and different per node so the nodes' retry jitter does not line up.
+        StdRng::seed_from_u64(u64::from_le_bytes(
+            hash(account_id.as_bytes()).0[..8].try_into().unwrap(),
+        )),
         epoch_manager.clone(),
         runtime_adapter.store().chain_store(),
         validator_signer.clone(),

--- a/test-loop-tests/src/tests/processed_receipts_gc.rs
+++ b/test-loop-tests/src/tests/processed_receipts_gc.rs
@@ -612,9 +612,6 @@ fn test_promise_resume_receipt_to_tx_gc() {
 /// GC handles this via `ReceiptSource::ReceiptToTxGc` entries in ProcessedReceiptIds,
 /// which track all receipt IDs with ReceiptToTx entries and clean them up.
 #[test]
-// TODO(spice-data-distribution): tests marked ignore under spice need receipt-proof pull
-// recovery — tracking-only nodes get no receipt-proof pushes; re-enable with (#16275).
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_cross_shard_receipt_to_tx_gc_on_source_only_node() {
     init_test_logger();
 

--- a/test-loop-tests/src/tests/sharded_rpc.rs
+++ b/test-loop-tests/src/tests/sharded_rpc.rs
@@ -185,9 +185,6 @@ fn test_rpc_query_unknown_access_key_error_format() {
 
 /// Standard `query` ViewCode should be forwarded to the right shard.
 #[test]
-// TODO(spice-data-distribution): tests marked ignore under spice need receipt-proof pull
-// recovery — tracking-only nodes get no receipt-proof pushes; re-enable with (#16275).
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_query_view_code_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -219,7 +216,6 @@ fn test_rpc_query_view_code_forwarding() {
 
 /// Standard `query` ViewState should be forwarded to the right shard.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_query_view_state_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -308,7 +304,6 @@ fn test_rpc_query_view_access_key_list_forwarding() {
 
 /// Standard `query` CallFunction should be forwarded to the right shard.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_query_call_function_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -387,7 +382,6 @@ fn test_rpc_query_view_gas_key_nonces_forwarding() {
 
 /// Standard `query` ViewGlobalContractCodeByAccountId should be forwarded to the right shard.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_query_view_global_contract_code_by_account_id_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -440,7 +434,6 @@ fn test_rpc_query_view_global_contract_code_by_account_id_forwarding() {
 /// Cross-shard CallFunction that triggers a VM error should return the backward-compatible
 /// error format from `process_query_response`.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_query_call_function_error_format() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -550,7 +543,6 @@ fn test_rpc_receipt_forwarding() {
 
 /// EXPERIMENTAL_view_code queries should be forwarded to the right shard.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_experimental_view_code_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -578,7 +570,6 @@ fn test_rpc_experimental_view_code_forwarding() {
 
 /// EXPERIMENTAL_view_state queries should be forwarded to the right shard.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_experimental_view_state_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -729,7 +720,6 @@ fn test_rpc_experimental_view_gas_key_nonces_forwarding() {
 
 /// EXPERIMENTAL_call_function queries should be forwarded to the right shard.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_experimental_call_function_forwarding() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -953,7 +943,6 @@ fn test_rpc_experimental_view_code_error_format() {
 
 /// Cross-shard EXPERIMENTAL_call_function on a nonexistent method should return a proper error.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_experimental_call_function_error_format() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -1044,7 +1033,6 @@ fn test_rpc_view_account_finality_final() {
 /// Queries with Finality::DoomSlug should route correctly and reference a
 /// near-final block.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_view_account_finality_doomslug() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -1085,7 +1073,6 @@ fn test_rpc_view_account_finality_doomslug() {
 /// Note: this test verifies routing, not that the result comes from the final
 /// block's state specifically.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_call_function_finality_final() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -1408,7 +1395,6 @@ fn test_rpc_light_client_proof_unknown_outcome() {
 /// `block_effects` should scatter-gather across shards: an RPC node tracking
 /// only one shard should return changes for ALL shards by forwarding to peers.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_changes_in_block_scatter_gather() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -1466,7 +1452,6 @@ fn test_rpc_changes_in_block_scatter_gather() {
 /// accounts on different shards from a node that only tracks one shard should
 /// return results for all requested accounts.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_changes_scatter_gather() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -1628,7 +1613,6 @@ fn test_rpc_changes_empty_account_ids_scatter_gather() {
 /// `changes` with SingleAccessKeyChanges variant should scatter-gather
 /// correctly, routing by the access key's account_id to the right shard.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_changes_single_access_key_scatter_gather() {
     init_test_logger();
     let mut h = TwoShardHarness::new();

--- a/test-loop-tests/src/tests/sharded_rpc_reliability.rs
+++ b/test-loop-tests/src/tests/sharded_rpc_reliability.rs
@@ -241,9 +241,6 @@ fn test_rpc_parallel_take_first_partial_failure() {
 /// its local changes — not changes from other shards. This prevents
 /// forwarding loops in the scatter-gather protocol.
 #[test]
-// TODO(spice-data-distribution): tests marked ignore under spice need receipt-proof pull
-// recovery — tracking-only nodes get no receipt-proof pushes; re-enable with (#16275).
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_block_effects_coordinator_bypass() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -323,7 +320,6 @@ fn test_rpc_block_effects_coordinator_bypass() {
 /// must reject with SHARD_NOT_APPLIED rather than silently returning empty
 /// data — otherwise partial results look identical to genuinely empty ones.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_changes_coordinator_bypass() {
     init_test_logger();
     let mut h = TwoShardHarness::new();
@@ -445,7 +441,6 @@ fn test_rpc_block_effects_bogus_block_hash() {
 /// (simulating a stale node) rather than timing out. The retry loop must still
 /// fall back to rpc2.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_block_effects_scatter_gather_retry() {
     init_test_logger();
     let mut h = ThreeNodeHarness::new();
@@ -539,7 +534,6 @@ fn test_rpc_block_effects_scatter_gather_retry() {
 /// given shard" once rpc0 and rpc2 are excluded. The log trace (rpc0 failure
 /// → retry → rpc2 failure → give-up) confirms both candidates were tried.
 #[test]
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_block_effects_scatter_gather_all_nodes_fail() {
     init_test_logger();
     let mut h = ThreeNodeHarness::new();

--- a/test-loop-tests/src/tests/single_shard_tracking.rs
+++ b/test-loop-tests/src/tests/single_shard_tracking.rs
@@ -27,9 +27,6 @@ const GC_NUM_EPOCHS_TO_KEEP: u64 = MIN_GC_NUM_EPOCHS_TO_KEEP;
 /// Ensure that shard data is stored only for the shards it is tracking.
 /// Verify that old data is garbage collected for all shards.
 #[test]
-// TODO(spice-data-distribution): tests marked ignore under spice need receipt-proof pull
-// recovery — tracking-only nodes get no receipt-proof pushes; re-enable with (#16275).
-#[cfg_attr(feature = "protocol_feature_spice", ignore = "needs receipt-proof pull recovery")]
 fn test_rpc_single_shard_tracking() {
     init_test_logger();
     let validator = "cp0";

--- a/test-loop-tests/src/tests/spice/basic.rs
+++ b/test-loop-tests/src/tests/spice/basic.rs
@@ -447,10 +447,7 @@ fn test_restart_rpc_node() {
 }
 
 #[test]
-// A restarted producer catches up only by re-requesting the receipt-proof pushes it
-// missed while down, and receipt proofs currently have no pull path.
-// TODO(spice-data-distribution): re-enable once receipt proofs have a pull path (#16275).
-#[ignore = "needs receipt-proof pull recovery"]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_restart_producer_node() {
     init_test_logger();
 
@@ -522,7 +519,11 @@ fn test_restart_producer_node() {
         env.node_for_account(&stable_account).head().height
     );
 
-    env.runner_for_account(&restart_account).run_for_number_of_blocks(10);
+    // Catch-up re-requests the missed receipt proofs one height at a time: only the
+    // execution frontier's apply attempt can see which proofs it misses, and each
+    // height waits out the pull's grace delay. Most of the block budget goes to that
+    // walk, since syncing the block backlog itself advances the head almost instantly.
+    env.runner_for_account(&restart_account).run_for_number_of_blocks(20);
 
     let view_account_result =
         env.node_for_account(&restart_account).view_account_query(&receiver).unwrap();

--- a/test-loop-tests/src/tests/spice/data_faults.rs
+++ b/test-loop-tests/src/tests/spice/data_faults.rs
@@ -133,6 +133,47 @@ fn test_spice_partial_data_faults_with_dropped_pushes() {
     assert_endorsed(&observed, &recipients);
 }
 
+/// The receipt-proof twin of `dropped_pushes`: drop the receipt proofs most of one
+/// shard's producers send, leaving too few pushed parts to decode, so the other shard's
+/// producers can only keep applying — and certification advancing — by requesting the
+/// data from the producer still answering. Contrast `starve_receipt_proofs`, where the
+/// whole shard goes silent and certification stops for good.
+#[test]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
+fn test_spice_partial_data_faults_with_dropped_receipt_proof_pushes() {
+    let Setup { mut env, producers, recipients, faults, observed } = setup_with_shards(2, 8);
+    let mut shards = shard_producers(&env, &recipients[0]);
+    shards.sort_by_key(|(shard_id, _)| *shard_id);
+    let [(_, silenced_shard), (_, other_shard)] = &shards[..] else {
+        panic!("expected two shards")
+    };
+    assert_eq!(silenced_shard.len() + other_shard.len(), producers.len());
+    // With four producers per shard a proof decodes from two parts, so three silent
+    // producers leave one pushed part — not enough without requesting.
+    let silent = &silenced_shard[1..];
+    assert!(
+        silenced_shard.len() - silent.len()
+            < reed_solomon_num_data_parts(silenced_shard.len(), DATA_PARTS_RATIO),
+        "the producers left alone still push enough parts to decode, so recovery never runs"
+    );
+    faults.lock().only_kind = Some(SpiceDataKind::ReceiptProof);
+    faults.lock().drop_from.extend(silent.iter().cloned());
+
+    run_past_certified_frontier(&mut env, &recipients[0], 2 * PULL_HEIGHTS);
+
+    let observed = observed.lock();
+    assert!(observed.dropped > 0, "no receipt proof was dropped");
+    // The dropped proofs' recipients are the other shard's producers; every one of them
+    // has to request the missing parts to keep applying its shard.
+    for recipient in other_shard {
+        assert!(
+            observed.data_requests.contains_key(recipient),
+            "{recipient} never had to request the dropped receipt proofs"
+        );
+    }
+    assert_endorsed(&observed, &recipients);
+}
+
 #[test]
 #[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_spice_partial_data_faults_with_delayed_pushes() {


### PR DESCRIPTION
Pull starts are event-driven: the executor reports the receipt proofs an apply attempt found missing, an item's first received unit schedules a pull for the rest after a short delay, and a  failed verification result makes the pull due at once.
Items are woken by a deadline heap with a jittered geometric backoff; a request left unanswered past request_timeout wakes the item early.
A due item re-requests the ordinals still missing and not in flight from one rotated producer and reschedules either way.

Also fixes the executor dropping a receipt delivery that arrives before the first processed block created the destination shard's executor, which left the engine's item parked with no   verification result.

Retires `DATA_REQUEST_INTERVAL` for receipt proofs and re-enables test_restart_producer_node and the tracking-only-node tests [#16316](https://github.com/near/nearcore/pull/16316) ignored.