### PR TITLE
test(cloud-archive): two nodes archive the same bytes

### DIFF
--- a/core/store/src/archive/cloud_storage/mod.rs
+++ b/core/store/src/archive/cloud_storage/mod.rs
@@ -6,7 +6,7 @@ pub use crate::archive::cloud_storage::bucket_config::BucketConfig;
 pub use crate::archive::cloud_storage::epoch_data::EpochData;
 pub use crate::archive::cloud_storage::retrieve::CloudRetrievalError;
 pub use crate::archive::cloud_storage::shards::{
-    InverseStateChanges, NewChunkData, ShardBatch, ShardData,
+    InverseStateChanges, NewChunkData, ShardBatch, ShardData, archived_chunk_apply_stats,
 };
 use near_external_storage::ExternalConnection;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -6,7 +6,7 @@ use crate::trie::AccessOptions;
 use crate::{DBCol, KeyForStateChanges, ShardTries, StateSnapshotConfig, Store, TrieConfig};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_chain_primitives::Error;
-use near_primitives::chunk_apply_stats::ChunkApplyStats;
+use near_primitives::chunk_apply_stats::{BandwidthSchedulerStats, ChunkApplyStats};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{ProcessedReceiptMetadata, Receipt, ReceiptSource, ReceiptToTxInfo};
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
@@ -126,10 +126,21 @@ struct InverseDeltasContext {
 /// That field is how long the scheduler took on the node that applied the chunk, so two
 /// writers of the same shard disagree on it; every other field follows from the chunk.
 pub fn archived_chunk_apply_stats(mut stats: ChunkApplyStats) -> ChunkApplyStats {
-    match &mut stats {
-        ChunkApplyStats::V0(v0) => v0.bandwidth_scheduler.time_to_run_ms = 0,
-        ChunkApplyStats::V1(v1) => v1.bandwidth_scheduler.time_to_run_ms = 0,
-    }
+    let scheduler = match &mut stats {
+        ChunkApplyStats::V0(v0) => &mut v0.bandwidth_scheduler,
+        ChunkApplyStats::V1(v1) => &mut v1.bandwidth_scheduler,
+    };
+    // Destructured so that a field added to the scheduler's stats has to be classified here
+    // before this builds: node-dependent ones join `time_to_run_ms`, the rest are ignored.
+    let BandwidthSchedulerStats {
+        params: _,
+        prev_bandwidth_requests: _,
+        prev_bandwidth_requests_num: _,
+        time_to_run_ms,
+        granted_bandwidth: _,
+        new_bandwidth_requests: _,
+    } = scheduler;
+    *time_to_run_ms = 0;
     stats
 }
 

--- a/core/store/src/archive/cloud_storage/shards.rs
+++ b/core/store/src/archive/cloud_storage/shards.rs
@@ -122,6 +122,17 @@ struct InverseDeltasContext {
     ceiling: BlockHeight,
 }
 
+/// The stats as the archive carries them, with the bandwidth scheduler's run time zeroed.
+/// That field is how long the scheduler took on the node that applied the chunk, so two
+/// writers of the same shard disagree on it; every other field follows from the chunk.
+pub fn archived_chunk_apply_stats(mut stats: ChunkApplyStats) -> ChunkApplyStats {
+    match &mut stats {
+        ChunkApplyStats::V0(v0) => v0.bandwidth_scheduler.time_to_run_ms = 0,
+        ChunkApplyStats::V1(v1) => v1.bandwidth_scheduler.time_to_run_ms = 0,
+    }
+    stats
+}
+
 /// `Ok(None)` at skipped heights (no block). Attaches inverse state changes when
 /// `inverse_deltas_context` is set and the block is within the resharding gap.
 fn build_shard_data(

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -943,7 +943,7 @@ fn test_cloud_archival_writer_joins_later() {
 #[test]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
-fn test_cloud_archival_multi_writer_same_shards() {
+fn test_cloud_archival_two_nodes_archive_the_same_bytes() {
     let all_shard_ids = CloudArchiveHarness::all_shard_ids();
     // The parity walk below reads every height in its range, which gc would take. The
     // writer is compared against the RPC node, which tracks the same shards.

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -937,9 +937,9 @@ fn test_cloud_archival_writer_joins_later() {
     h.shutdown();
 }
 
-/// Verifies that two writers tracking all shards both produce valid data, and that they
-/// would archive the same bytes, so one writer's upload can be validated against another's.
-/// Anything a node measures for itself has to be dropped where the blob is built.
+/// A writer and an ordinary node tracking the same shards archive the same bytes, so one
+/// node's upload can be validated against another's. Anything a node measures for itself
+/// has to be dropped where the blob is built.
 #[test]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
@@ -964,7 +964,7 @@ fn test_cloud_archival_multi_writer_same_shards() {
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 // TODO(cloud_archival): un-ignore once the blob drops the bandwidth scheduler's run time.
-#[ignore]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_cloud_archival_blob_drops_node_measurements() {
     let shard_id = CloudArchiveHarness::all_shard_ids()[0];
     let mut h = CloudArchiveHarness::builder().disable_gc().build();
@@ -991,7 +991,7 @@ fn test_cloud_archival_blob_drops_node_measurements() {
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 // TODO(cloud_archival): un-ignore once the block-level blob stops carrying the writer's
 // own `ChunkHashesByHeight` rows, which two writers with different tracked shards differ on.
-#[ignore]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_cloud_archival_multi_writer_disjoint_shards() {
     let all_shard_uids = CloudArchiveHarness::all_shard_uids();
     let all_shard_ids = CloudArchiveHarness::all_shard_ids();
@@ -1994,7 +1994,7 @@ fn test_cloud_archival_writer_resharding_inverse_deltas() {
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 // TODO(cloud_archival): un-ignore once the top of the resharding gap is the sync hash
 // itself, so a gap block archives the same bytes before and after the epoch records it.
-#[ignore]
+#[cfg_attr(not(feature = "protocol_feature_spice"), ignore)]
 fn test_cloud_archival_writer_resharding_inverse_deltas_batch_size_1() {
     let mut h = CloudArchiveHarness::builder().enable_resharding().batch_size(1).build();
 

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -937,6 +937,27 @@ fn test_cloud_archival_writer_joins_later() {
     h.shutdown();
 }
 
+/// Verifies that two writers tracking all shards both produce valid data.
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_multi_writer_same_shards() {
+    let all_shard_uids = CloudArchiveHarness::all_shard_uids();
+    let all_shard_ids = CloudArchiveHarness::all_shard_ids();
+    let mut h = CloudArchiveHarness::builder().build();
+    h.add_writer_node(&WriterConfig {
+        id: "writer_b".parse().unwrap(),
+        archive_block_data: true,
+        tracked_shards: all_shard_uids,
+        snapshot_every_n_epochs: 1,
+    });
+    h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
+    h.check_data(&[(3, &all_shard_ids), (h.epoch_length + 1, &all_shard_ids)]);
+    h.assert_heads_and_gc_ok();
+
+    h.shutdown();
+}
+
 /// A writer and an ordinary node tracking the same shards archive the same bytes, so one
 /// node's upload can be validated against another's. Anything a node measures for itself
 /// has to be dropped where the blob is built.
@@ -944,12 +965,10 @@ fn test_cloud_archival_writer_joins_later() {
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_two_nodes_archive_the_same_bytes() {
-    let all_shard_ids = CloudArchiveHarness::all_shard_ids();
     // The parity walk below reads every height in its range, which gc would take. The
     // writer is compared against the RPC node, which tracks the same shards.
     let mut h = CloudArchiveHarness::builder().disable_gc().dont_take_over_rpc().build();
     h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
-    h.check_data(&[(3, &all_shard_ids), (h.epoch_length + 1, &all_shard_ids)]);
     h.assert_heads_ok_before_gc();
 
     let end = h.local_min_head();

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -4,11 +4,12 @@ use crate::setup::env::TestLoopEnv;
 use crate::utils::account::archival_account_id;
 use crate::utils::cloud_archival::{
     ReshardingInfo, WriterConfig, add_writer_node, apply_writer_settings,
-    assert_resharding_epoch_snapshot_forced, assert_store_parity, assert_writer_inverse_deltas,
-    bootstrap_historical_reader, check_account_balance, check_data_at_height_for_shards,
-    epoch_id_at, exec, gc_and_heads_sanity_checks, get_cloud_storage, get_local_min_head,
-    get_state_header_for_epoch, get_writer_handle, has_state_root, run_node_until,
-    run_receipts_of_every_kind, run_until_one_epoch_after_resharding, simulate_lagging_shard,
+    assert_blob_stats_are_archived, assert_resharding_epoch_snapshot_forced, assert_store_parity,
+    assert_writer_agrees_with_rpc_node, assert_writer_inverse_deltas, bootstrap_historical_reader,
+    check_account_balance, check_data_at_height_for_shards, epoch_id_at, exec,
+    gc_and_heads_sanity_checks, get_cloud_storage, get_local_min_head, get_state_header_for_epoch,
+    get_writer_handle, has_state_root, run_node_until, run_receipts_of_every_kind,
+    run_until_one_epoch_after_resharding, set_scheduler_run_time, simulate_lagging_shard,
     snapshots_sanity_check, stop_and_restart_node,
 };
 use borsh::to_vec;
@@ -64,6 +65,8 @@ struct CloudArchiveHarness {
     gc_num_epochs_to_keep: u64,
     /// Cloud archival batch size in blocks.
     batch_size: u32,
+    /// Whether the recent reader has taken over the RPC node.
+    rpc_taken_over: bool,
     /// Account ID of the historical reader node, set after
     /// `bootstrap_historical_reader()`.
     historical_reader_id: Option<AccountId>,
@@ -83,9 +86,9 @@ struct CloudArchiveHarnessBuilder {
     dropped_chunks_by_shard: HashMap<ShardId, Vec<bool>>,
     /// Whether to schedule a static resharding split.
     resharding_enabled: bool,
-    /// Whether to leave the recent reader's node running as an ordinary node
-    /// instead of switching it over as soon as the harness is built.
-    delay_recent_reader: bool,
+    /// Whether the RPC node keeps following the chain once the harness is built, so a
+    /// test can start the recent reader on it at a moment of its own choosing.
+    dont_take_over_rpc: bool,
     /// Cloud archival batch size in blocks.
     batch_size: u32,
     /// Delay between catch-up batches. Zero by default, so a small batch size
@@ -164,10 +167,10 @@ impl CloudArchiveHarnessBuilder {
         self
     }
 
-    /// Keeps the recent reader's node running as an ordinary node, so the test
-    /// picks the moment itself with `start_recent_reader`.
-    fn delay_recent_reader(mut self) -> Self {
-        self.delay_recent_reader = true;
+    /// Keeps the RPC node following the chain, so the test picks the moment it is taken
+    /// over with `start_recent_reader`.
+    fn dont_take_over_rpc(mut self) -> Self {
+        self.dont_take_over_rpc = true;
         self
     }
 
@@ -182,7 +185,7 @@ impl CloudArchiveHarnessBuilder {
     }
 
     fn build(self) -> CloudArchiveHarness {
-        let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
+        let user_account = CloudArchiveHarness::test_user_account();
         let archival_kind =
             if self.cold_storage { ArchivalKind::ColdAndCloud } else { ArchivalKind::Cloud };
         let writer_id = self.writer.id.clone();
@@ -268,7 +271,7 @@ impl CloudArchiveHarnessBuilder {
         if has_drops {
             env = env.warmup();
         }
-        let harness = CloudArchiveHarness {
+        let mut harness = CloudArchiveHarness {
             env,
             writer_id,
             epoch_length: CloudArchiveHarness::DEFAULT_EPOCH_LENGTH,
@@ -276,11 +279,12 @@ impl CloudArchiveHarnessBuilder {
             snapshot_every_n_epochs,
             gc_num_epochs_to_keep: self.gc_num_epochs_to_keep,
             batch_size: self.batch_size,
+            rpc_taken_over: false,
             historical_reader_id: None,
             new_shard_layout,
             resharding_boundary,
         };
-        if !self.delay_recent_reader {
+        if !self.dont_take_over_rpc {
             harness.start_recent_reader();
         }
         harness
@@ -318,7 +322,7 @@ impl CloudArchiveHarness {
             dropped_block_heights: HashSet::new(),
             dropped_chunks_by_shard: HashMap::new(),
             resharding_enabled: false,
-            delay_recent_reader: false,
+            dont_take_over_rpc: false,
             batch_size: Self::TEST_BATCH_SIZE,
             catch_up_throttle: Duration::ZERO,
             genesis_height: None,
@@ -383,7 +387,7 @@ impl CloudArchiveHarness {
 
     /// Kills the RPC node the recent reader takes over from and brings up the
     /// reader on the database that node leaves behind. No gc runs on it from here.
-    fn start_recent_reader(&self) -> CloudArchivalRecentReader {
+    fn start_recent_reader(&mut self) -> CloudArchivalRecentReader {
         let reader_id: AccountId = Self::RECENT_READER_ACCOUNT.parse().unwrap();
         let client = self.env.node_for_account(&reader_id).client();
         let epoch_manager = client.epoch_manager.clone();
@@ -405,6 +409,7 @@ impl CloudArchiveHarness {
             .spawn("cloud archival recent reader", async move {
                 reader.cloud_archival_loop().await.expect("the recent reader stopped")
             });
+        self.rpc_taken_over = true;
         handle
     }
 
@@ -468,6 +473,24 @@ impl CloudArchiveHarness {
     fn recent_reader_store(&self) -> Store {
         let reader_id: AccountId = Self::RECENT_READER_ACCOUNT.parse().unwrap();
         self.store_for(&reader_id)
+    }
+
+    /// The account of the RPC node, which tracks every shard and follows the chain until
+    /// the recent reader takes it over.
+    fn rpc_id(&self) -> AccountId {
+        assert!(
+            !self.rpc_taken_over,
+            "the RPC node has been taken over and does not follow the chain"
+        );
+        Self::RECENT_READER_ACCOUNT.parse().unwrap()
+    }
+
+    fn test_user_account() -> AccountId {
+        Self::USER_ACCOUNT.parse().unwrap()
+    }
+
+    fn rpc_store(&self) -> Store {
+        self.store_for(&self.rpc_id())
     }
 
     fn historical_reader_store(&self) -> Store {
@@ -793,7 +816,7 @@ fn test_cloud_archival_use_snapshot() {
     h.bootstrap_historical_reader(start, target);
     h.assert_reader_writer_parity(Reader::Historical, start, target);
     h.assert_reader_account_balance(
-        &CloudArchiveHarness::USER_ACCOUNT.parse().unwrap(),
+        &CloudArchiveHarness::test_user_account(),
         CloudArchiveHarness::USER_BALANCE,
     );
     h.kill_historical_reader();
@@ -914,23 +937,49 @@ fn test_cloud_archival_writer_joins_later() {
     h.shutdown();
 }
 
-/// Verifies that two writers tracking all shards both produce valid data.
+/// Verifies that two writers tracking all shards both produce valid data, and that they
+/// would archive the same bytes, so one writer's upload can be validated against another's.
+/// Anything a node measures for itself has to be dropped where the blob is built.
 #[test]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_multi_writer_same_shards() {
-    let all_shard_uids = CloudArchiveHarness::all_shard_uids();
     let all_shard_ids = CloudArchiveHarness::all_shard_ids();
-    let mut h = CloudArchiveHarness::builder().build();
-    h.add_writer_node(&WriterConfig {
-        id: "writer_b".parse().unwrap(),
-        archive_block_data: true,
-        tracked_shards: all_shard_uids,
-        snapshot_every_n_epochs: 1,
-    });
+    // The parity walk below reads every height in its range, which gc would take. The
+    // writer is compared against the RPC node, which tracks the same shards.
+    let mut h = CloudArchiveHarness::builder().disable_gc().dont_take_over_rpc().build();
     h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
     h.check_data(&[(3, &all_shard_ids), (h.epoch_length + 1, &all_shard_ids)]);
-    h.assert_heads_and_gc_ok();
+    h.assert_heads_ok_before_gc();
+
+    let end = h.local_min_head();
+    assert_writer_agrees_with_rpc_node(&h.env, &h.writer_id, &h.rpc_id(), 0, end);
+
+    h.shutdown();
+}
+
+/// The blob carries the shard's stats in the archive's form, whatever the archiving node
+/// holds in its own row.
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+// TODO(cloud_archival): un-ignore once the blob drops the bandwidth scheduler's run time.
+#[ignore]
+fn test_cloud_archival_blob_drops_node_measurements() {
+    let shard_id = CloudArchiveHarness::all_shard_ids()[0];
+    let mut h = CloudArchiveHarness::builder().disable_gc().build();
+    h.run_until_epoch(2);
+
+    // Left alone the run time is 0 or 1 ms depending on the run, so the writer's own row
+    // is forced to a value the archive has to drop, and the height archived again from it.
+    let height = h.epoch_length + 1;
+    set_scheduler_run_time(&h.writer_store(), height, shard_id);
+    h.rewind_cloud_shard_head(shard_id, height - 1);
+    h.restart_writer();
+    h.run_until_epoch(3);
+
+    let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
+    assert_blob_stats_are_archived(&cloud_storage, &h.writer_store(), height, shard_id);
 
     h.shutdown();
 }
@@ -940,12 +989,19 @@ fn test_cloud_archival_multi_writer_same_shards() {
 #[test]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
+// TODO(cloud_archival): un-ignore once the block-level blob stops carrying the writer's
+// own `ChunkHashesByHeight` rows, which two writers with different tracked shards differ on.
+#[ignore]
 fn test_cloud_archival_multi_writer_disjoint_shards() {
     let all_shard_uids = CloudArchiveHarness::all_shard_uids();
     let all_shard_ids = CloudArchiveHarness::all_shard_ids();
     // Primary writer only tracks shards 0,1.
     let mut h = CloudArchiveHarness::builder()
         .tracked_shards(vec![all_shard_uids[0], all_shard_uids[1]])
+        // The parity walk below reads every height in its range, which gc would take.
+        .disable_gc()
+        // Never started as a reader, so it stays a plain RPC node following the chain.
+        .dont_take_over_rpc()
         .build();
     h.add_writer_node(&WriterConfig {
         id: "writer_b".parse().unwrap(),
@@ -953,10 +1009,18 @@ fn test_cloud_archival_multi_writer_disjoint_shards() {
         tracked_shards: vec![all_shard_uids[2]],
         snapshot_every_n_epochs: 1,
     });
-    h.run_until_epoch(MIN_GC_NUM_EPOCHS_TO_KEEP + 2);
+    h.run_until_epoch(2);
     // Both writers start together: all shards are archived.
     h.check_data(&[(h.epoch_length / 2, &all_shard_ids), (h.epoch_length + 1, &all_shard_ids)]);
-    h.assert_heads_and_gc_ok();
+    h.assert_heads_ok_before_gc();
+
+    // The two writers together cover all shards, so a reader built from the bucket holds
+    // what a regular RPC node tracking all shards would hold.
+    let start = h.epoch_length / 2;
+    let target = h.epoch_length + h.epoch_length / 2;
+    h.bootstrap_historical_reader(start, target);
+    assert_store_parity(&h.historical_reader_store(), &h.rpc_store(), start, target);
+    h.kill_historical_reader();
 
     h.shutdown();
 }
@@ -1218,7 +1282,7 @@ fn test_cloud_archival_bootstrap_with_missing_blocks_and_chunks() {
     // was reconstructed up to the last present block at or below the target,
     // and the carried-over chunk path was traversed during state apply.
     h.assert_reader_account_balance(
-        &CloudArchiveHarness::USER_ACCOUNT.parse().unwrap(),
+        &CloudArchiveHarness::test_user_account(),
         CloudArchiveHarness::USER_BALANCE,
     );
     h.kill_historical_reader();
@@ -1398,7 +1462,7 @@ fn test_cloud_archival_missing_chunks_one_shard() {
 fn test_cloud_archival_outcomes_and_receipts() {
     let gas_limit = Gas::from_teragas(300);
     let mut h = CloudArchiveHarness::builder().disable_gc().gas_limit(gas_limit).build();
-    let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
+    let user_account = CloudArchiveHarness::test_user_account();
     let writer_store = h.writer_store();
     run_receipts_of_every_kind(&mut h.env, &h.writer_id, &user_account, gas_limit, &writer_store);
 
@@ -1667,7 +1731,7 @@ fn test_cloud_archival_reader_reconstructs_per_shard_columns() {
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_reader_reconstructs_per_shard_data_columns() {
-    let user_account: AccountId = CloudArchiveHarness::USER_ACCOUNT.parse().unwrap();
+    let user_account = CloudArchiveHarness::test_user_account();
     let mut h = CloudArchiveHarness::builder().build();
     let tx =
         h.env.validator().tx_send_money(&user_account, &h.writer_id, Balance::from_yoctonear(100));
@@ -1924,9 +1988,13 @@ fn test_cloud_archival_writer_resharding_inverse_deltas() {
 }
 
 /// The writer still attaches inverse state changes at `batch_size` 1, where the
-/// resharding boundary and the first gap block fall in separate batches.
+/// resharding boundary and the first gap block fall in separate batches, and a gap block
+/// archives the same bytes whether or not the epoch has recorded its sync hash.
 #[test]
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
+// TODO(cloud_archival): un-ignore once the top of the resharding gap is the sync hash
+// itself, so a gap block archives the same bytes before and after the epoch records it.
+#[ignore]
 fn test_cloud_archival_writer_resharding_inverse_deltas_batch_size_1() {
     let mut h = CloudArchiveHarness::builder().enable_resharding().batch_size(1).build();
 
@@ -1941,6 +2009,32 @@ fn test_cloud_archival_writer_resharding_inverse_deltas_batch_size_1() {
     );
 
     h.assert_writer_inverse_deltas(&r);
+
+    // The top of the resharding gap comes from the epoch's sync hash, which the epoch
+    // records only once that block is final. A writer at the head reaches a gap block
+    // before that row exists; one catching up reaches it after.
+    let height = r.sync_block_height - 1;
+    let archived_with_record =
+        cloud_storage.get_shard_data(height, r.child_shard).unwrap().unwrap();
+
+    // Delete the row, wind the writer back below this height, and archive it again.
+    let new_epoch_id = epoch_id_at(&cloud_storage, r.new_epoch_first_height);
+    let writer_store = h.writer_store();
+    let mut update = writer_store.store_update();
+    update.delete(DBCol::StateSyncHashes, new_epoch_id.as_ref());
+    update.commit();
+    h.rewind_cloud_shard_head(r.child_shard, height - 1);
+    h.restart_writer();
+    h.run_one_more_epoch();
+
+    let archived_without_record =
+        cloud_storage.get_shard_data(height, r.child_shard).unwrap().unwrap();
+    assert_eq!(
+        to_vec(&archived_without_record).unwrap(),
+        to_vec(&archived_with_record).unwrap(),
+        "shard {} at h={height} archived differently with and without the sync-hash row",
+        r.child_shard,
+    );
 
     h.shutdown();
 }
@@ -2165,7 +2259,7 @@ fn test_cloud_archival_resharding_gap_inverse_walk() {
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_recent_reader_waits_for_a_lagging_shard() {
     let held_shard = CloudArchiveHarness::all_shard_ids()[0];
-    let mut h = CloudArchiveHarness::builder().delay_recent_reader().disable_gc().build();
+    let mut h = CloudArchiveHarness::builder().dont_take_over_rpc().disable_gc().build();
     h.run_until_epoch(2);
     let reader = h.start_recent_reader();
 
@@ -2259,7 +2353,7 @@ fn test_cloud_archival_recent_reader_reconstructs_shard_state() {
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
 #[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_recent_reader_gc_stops_at_takeover() {
-    let mut h = CloudArchiveHarness::builder().delay_recent_reader().build();
+    let mut h = CloudArchiveHarness::builder().dont_take_over_rpc().build();
     let gced = h.epoch_length / 2;
     // One epoch past the garbage-collection window, so the probe height is below
     // the tail by the time the node switches over.
@@ -2313,7 +2407,7 @@ fn test_cloud_archival_skipped_run_across_batch_edge() {
     let mut h = CloudArchiveHarness::builder()
         .validators(12)
         .drop_blocks_at(&dropped_heights)
-        .delay_recent_reader()
+        .dont_take_over_rpc()
         .disable_gc()
         .build();
     let first_dropped = dropped_heights[0];
@@ -2365,7 +2459,7 @@ fn test_cloud_archival_reader_clears_forked_height() {
     let mut h = CloudArchiveHarness::builder()
         .validators(4)
         .drop_blocks_at(&[forked_height])
-        .delay_recent_reader()
+        .dont_take_over_rpc()
         .disable_gc()
         .build();
     // Just past the dropped height, so it lands above the handed-over final head, the

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -1,5 +1,5 @@
 use crate::setup::env::TestLoopEnv;
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, from_slice, to_vec};
 use itertools::Itertools;
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
@@ -12,6 +12,7 @@ use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::archive::cloud_historical_reader::bootstrap_range;
 use near_client::archive::cloud_reader_trie_utils::build_shard_tries;
 use near_primitives::block::Block;
+use near_primitives::chunk_apply_stats::ChunkApplyStats;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::gas::Gas;
@@ -26,10 +27,11 @@ use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochHeight, EpochId, ShardId,
 };
 use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
-use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::archive::cloud_storage::{
-    CloudStorage, is_cloud_archive_reader_bootstrapped, read_chunk_hashes,
+    CloudStorage, archived_chunk_apply_stats, is_cloud_archive_reader_bootstrapped,
+    read_chunk_hashes,
 };
 use near_store::trie::AccessOptions;
 use near_store::{COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, Store, Trie};
@@ -44,6 +46,80 @@ pub(crate) struct WriterConfig {
     pub archive_block_data: bool,
     pub tracked_shards: Vec<ShardUId>,
     pub snapshot_every_n_epochs: u64,
+}
+
+/// Records a non-zero run time for the bandwidth scheduler on one chunk's stats row.
+pub(crate) fn set_scheduler_run_time(store: &Store, height: BlockHeight, shard_id: ShardId) {
+    let block_hash = store.chain_store().get_block_hash_by_height(height).unwrap();
+    let mut stats = store.chunk_store().get_chunk_apply_stats(&block_hash, &shard_id).unwrap();
+    match &mut stats {
+        ChunkApplyStats::V0(v0) => v0.bandwidth_scheduler.time_to_run_ms = 7,
+        ChunkApplyStats::V1(v1) => v1.bandwidth_scheduler.time_to_run_ms = 7,
+    }
+    let mut update = store.store_update();
+    update.chunk_store_update().set_chunk_apply_stats(&block_hash, shard_id, &stats);
+    update.commit();
+}
+
+/// Asserts the blob at `height` carries the shard's stats in the form
+/// `archived_chunk_apply_stats` defines.
+pub(crate) fn assert_blob_stats_are_archived(
+    cloud_storage: &CloudStorage,
+    writer_store: &Store,
+    height: BlockHeight,
+    shard_id: ShardId,
+) {
+    let shard_data = cloud_storage.get_shard_data(height, shard_id).unwrap().unwrap();
+    let block_hash = writer_store.chain_store().get_block_hash_by_height(height).unwrap();
+    let node_stats =
+        writer_store.chunk_store().get_chunk_apply_stats(&block_hash, &shard_id).unwrap();
+    let archived = to_vec(&archived_chunk_apply_stats(node_stats.clone())).unwrap();
+    assert_ne!(
+        to_vec(&node_stats).unwrap(),
+        archived,
+        "the writer's own row at h={height} shard={shard_id} is already in archived form, so \
+         matching it proves nothing"
+    );
+    assert_eq!(
+        to_vec(shard_data.chunk_apply_stats()).unwrap(),
+        archived,
+        "the blob at h={height} shard={shard_id} carries the node's own stats"
+    );
+}
+
+/// Asserts the writer's store and `rpc_id`'s hold the same rows over `[start, end]`, as the
+/// archive would carry them. The writer must track every shard the node tracks. A failure
+/// names a column two nodes disagree on; where that value is one a node measured for
+/// itself, the archive has to drop it where the blob is built.
+pub(crate) fn assert_writer_agrees_with_rpc_node(
+    env: &TestLoopEnv,
+    writer_id: &AccountId,
+    rpc_id: &AccountId,
+    start: BlockHeight,
+    end: BlockHeight,
+) {
+    let writer_store = get_hot_store(env, writer_id);
+    let block_hash = writer_store.chain_store().get_block_hash_by_height(end).unwrap();
+    let epoch_id = *writer_store.epoch_store().get_block_info(&block_hash).unwrap().epoch_id();
+    let tracked_shards = |account_id: &AccountId| -> HashSet<ShardUId> {
+        env.node_for_account(account_id)
+            .client()
+            .shard_tracker
+            .get_tracked_shards_for_non_validator_in_epoch(&epoch_id)
+            .unwrap()
+            .into_iter()
+            .collect()
+    };
+    // A shard only one of them tracks has rows only that one holds, so the comparison
+    // needs the writer to cover what the node does.
+    let (writer_shards, rpc_shards) = (tracked_shards(writer_id), tracked_shards(rpc_id));
+    assert!(
+        writer_shards.is_superset(&rpc_shards),
+        "the writer tracks {writer_shards:?}, which does not cover the node's {rpc_shards:?}"
+    );
+    let rpc_store = get_hot_store(env, rpc_id);
+    assert_store_parity(&rpc_store, &writer_store, start, end);
+    assert_store_parity(&writer_store, &rpc_store, start, end);
 }
 
 /// Runs a workload producing a receipt of every kind the archive records, and asserts it
@@ -68,7 +144,8 @@ pub(crate) fn run_receipts_of_every_kind(
     let deploy_tx = env.validator().tx_deploy_test_contract(user_account);
     env.validator().submit_tx(deploy_tx);
     let epoch_length = env.validator().client().config.epoch_length;
-    run_node_until(env, writer_id, epoch_length);
+    let genesis_height = env.validator().client().chain.genesis().height();
+    run_node_until(env, writer_id, genesis_height + epoch_length);
 
     // Each call's local receipt burns more than half a chunk's gas, so the third one does
     // not fit and lands on the delayed-receipt queue instead.
@@ -94,13 +171,13 @@ pub(crate) fn run_receipts_of_every_kind(
         gas_limit,
     );
     env.validator().submit_tx(yield_tx);
-    run_node_until(env, writer_id, 3 * epoch_length);
+    run_node_until(env, writer_id, genesis_height + 3 * epoch_length);
 
     // Without a receipt of each kind in the window, a walk over it passes vacuously.
     // `verify_store` must be a node that tracks every shard: the account above may live in
     // a shard the writer does not.
     let (mut local, mut delayed, mut instant, mut receipt_to_tx_gc) = (0, 0, 0, 0);
-    for height in epoch_length / 2..=2 * epoch_length {
+    for height in genesis_height + epoch_length / 2..=genesis_height + 2 * epoch_length {
         let Ok(block_hash) = verify_store.chain_store().get_block_hash_by_height(height) else {
             continue;
         };
@@ -839,8 +916,8 @@ pub(crate) fn assert_store_parity(
 }
 
 /// Compares the writer's rows in `col` against `store`. Every in-scope writer row is
-/// present there with the same value; extra rows are allowed, e.g. because of a batch
-/// being written whole.
+/// present there with the value the archive would carry; extra rows are allowed, e.g.
+/// because of a batch being written whole.
 fn assert_keyed_parity(store: &Store, col: DBCol, writer_kvs: &BTreeMap<Vec<u8>, Vec<u8>>) {
     let store_kvs: BTreeMap<Vec<u8>, Vec<u8>> =
         store.iter(col).map(|(k, v)| (k.into_vec(), v.into_vec())).collect();
@@ -848,8 +925,22 @@ fn assert_keyed_parity(store: &Store, col: DBCol, writer_kvs: &BTreeMap<Vec<u8>,
         let store_value = store_kvs
             .get(key)
             .unwrap_or_else(|| panic!("{col} row missing from the store: {key:?}"));
-        assert_eq!(store_value, writer_value, "{col} value mismatch for {key:?}");
+        assert_eq!(
+            archived_row(col, store_value),
+            archived_row(col, writer_value),
+            "{col} value mismatch for {key:?}"
+        );
     }
+}
+
+/// A row as the archive would carry it, through the same function the writer uses, so a
+/// field one of them drops and the other keeps cannot pass unnoticed.
+fn archived_row(col: DBCol, value: &[u8]) -> Vec<u8> {
+    if col != DBCol::ChunkApplyStats {
+        return value.to_vec();
+    }
+    let stats: ChunkApplyStats = from_slice(value).expect("a ChunkApplyStats row deserializes");
+    to_vec(&archived_chunk_apply_stats(stats)).expect("a ChunkApplyStats row serializes")
 }
 
 /// Collects the writer's `BlockOrdinal` row for one block into `kvs`.
@@ -876,7 +967,7 @@ fn collect_chunk_hashes_kvs(
 ) {
     for (created_height, chunk_hashes) in read_chunk_hashes(writer_store, block).unwrap() {
         let key = index_to_bytes(created_height).to_vec();
-        let value = borsh::to_vec(&chunk_hashes).unwrap();
+        let value = to_vec(&chunk_hashes).unwrap();
         kvs.get_mut(&DBCol::ChunkHashesByHeight).unwrap().insert(key, value);
     }
 }

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -110,12 +110,12 @@ pub(crate) fn assert_writer_agrees_with_rpc_node(
             .into_iter()
             .collect()
     };
-    // A shard only one of them tracks has rows only that one holds, so the comparison
-    // needs the writer to cover what the node does.
+    // A shard only one of them tracks has rows only that one holds, and the walk below runs
+    // in both directions, so the two must track the same set.
     let (writer_shards, rpc_shards) = (tracked_shards(writer_id), tracked_shards(rpc_id));
-    assert!(
-        writer_shards.is_superset(&rpc_shards),
-        "the writer tracks {writer_shards:?}, which does not cover the node's {rpc_shards:?}"
+    assert_eq!(
+        writer_shards, rpc_shards,
+        "the writer tracks {writer_shards:?} and the node {rpc_shards:?}; the walk needs them equal"
     );
     let rpc_store = get_hot_store(env, rpc_id);
     assert_store_parity(&rpc_store, &writer_store, start, end);

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -933,8 +933,8 @@ fn assert_keyed_parity(store: &Store, col: DBCol, writer_kvs: &BTreeMap<Vec<u8>,
     }
 }
 
-/// A row as the archive would carry it, through the same function the writer uses, so a
-/// field one of them drops and the other keeps cannot pass unnoticed.
+/// A row as the archive would carry it, through `archived_chunk_apply_stats`, so a field
+/// the archive drops and a node keeps cannot pass unnoticed.
 fn archived_row(col: DBCol, value: &[u8]) -> Vec<u8> {
     if col != DBCol::ChunkApplyStats {
         return value.to_vec();


### PR DESCRIPTION
Everything the writer uploads has to be a function of the chain, so that two nodes archiving the same shard produce the same bytes and a reader does not depend on which of them uploaded last. This is the test side of that, ahead of the changes that make it hold.

The parity walk compares rows as the archive would carry them, through the same function the writer will call, so a field dropped in one place and kept in the other cannot pass unnoticed. `test_cloud_archival_multi_writer_same_shards` walks it in both directions between two nodes' stores: two nodes that applied the same chunks must agree on what they would archive.

`test_cloud_archival_blob_drops_node_measurements` reads a blob and compares its `ChunkApplyStats` against the writer's own row put through the archive. The bandwidth scheduler's run time is 0 or 1 ms depending on the run, so the writer's row is forced to a value the archive has to drop.

`test_cloud_archival_multi_writer_disjoint_shards` bootstraps a reader from what two writers with disjoint shard sets uploaded between them, and compares it against a node that followed the chain and archived nothing.

The tests that need a blob change to pass are `#[ignore]`d, each naming what un-ignores it.
