### PR TITLE
feat(cloud-archive): the historical reader reconstructs shard state

### DIFF
--- a/chain/client/src/archive/cloud_archival_utils.rs
+++ b/chain/client/src/archive/cloud_archival_utils.rs
@@ -4,6 +4,7 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::hash::CryptoHash;
+use near_primitives::state_part::StatePartId;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ShardId};
 use near_primitives::utils::index_to_bytes;
 use near_store::adapter::cloud_archival_store::CloudReaderHead;
@@ -13,6 +14,7 @@ use near_store::archive::cloud_storage::{
 };
 use near_store::{DBCol, KeyForStateChanges, ShardTries, ShardUId, Store, StoreUpdate};
 use std::collections::{HashMap, HashSet};
+use std::io;
 
 /// Errors from reader-side custom logic on top of cloud retrieval.
 #[derive(thiserror::Error, Debug)]
@@ -31,6 +33,8 @@ pub enum CloudArchivalReaderError {
     NoAnchorBelow { start_height: BlockHeight },
     #[error("no state root for shard {shard_uid} under block {block_hash}")]
     NoStateAnchor { shard_uid: ShardUId, block_hash: CryptoHash },
+    #[error("shard {shard_uid} state part {part_id:?}: {error}")]
+    StatePartDeserialization { shard_uid: ShardUId, part_id: StatePartId, error: io::Error },
     #[error(
         "state root at block {block_hash} shard {shard_id}: applied {applied}, recorded {recorded}"
     )]
@@ -172,39 +176,35 @@ pub(crate) async fn pull_shard_batch(
     Ok(shard_batch)
 }
 
-/// Applies the state changes `shard_batch` carries from just above `reader_head` to its
-/// own end, in one commit.
+/// Applies the state changes `shard_batch` records at or above `from_height` on top of
+/// `state_root`, in one commit, and returns the root the last of them leaves.
 pub(crate) fn apply_batch_state_changes(
     tries: &ShardTries,
     shard_uid: ShardUId,
     shard_batch: &ShardBatch,
-    reader_head: &CloudReaderHead,
-) -> Result<(), CloudArchivalReaderError> {
-    // A reader that joined mid-batch has its head inside the batch, and the heights below
-    // that head are applied already.
-    let start_height = (reader_head.height + 1).max(shard_batch.start_height());
-    // TODO(cloud_archival): anchor a shard a resharding added above the head.
-    let prev_state_root =
-        shard_state_anchor(tries, &reader_head.last_present_block_hash, shard_uid)?;
-    let mut update = BatchTrieUpdate::new(tries, shard_uid, prev_state_root);
+    from_height: BlockHeight,
+    mut state_root: CryptoHash,
+) -> Result<CryptoHash, CloudArchivalReaderError> {
+    let start_height = from_height.max(shard_batch.start_height());
+    let mut update = BatchTrieUpdate::new(tries, shard_uid, state_root);
     for height in start_height..=shard_batch.end_height() {
         let Some(shard_data) = shard_batch.get_data_at_height(height) else {
             continue;
         };
-        let applied = update.apply(shard_data.state_changes())?;
+        state_root = update.apply(shard_data.state_changes())?;
         let recorded = *shard_data.chunk_extra().state_root();
-        if applied != recorded {
+        if state_root != recorded {
             return Err(CloudArchivalReaderError::StateRootMismatch {
                 block_hash: *shard_data.block_hash(),
                 shard_id: shard_uid.shard_id(),
-                applied,
+                applied: state_root,
                 recorded,
             });
         }
     }
     // TODO(cloud_archival): consider one commit per window, so a retry refcounts once.
     update.commit();
-    Ok(())
+    Ok(state_root)
 }
 
 /// The state root `shard_uid` stands at under `block_hash`, which is the root the height
@@ -221,38 +221,6 @@ pub(crate) fn shard_state_anchor(
         }
         Err(error) => Err(error.into()),
     }
-}
-
-/// Seeds the store with what the epoch manager needs to answer for `height`, and
-/// returns the hash of the nearest present block below it. `height` must therefore
-/// be above the first archived block.
-pub(crate) async fn install_anchors(
-    store: &Store,
-    cloud_storage: &CloudStorage,
-    epoch_manager: &dyn EpochManagerAdapter,
-    height: BlockHeight,
-) -> Result<CryptoHash, CloudArchivalReaderError> {
-    let (_, prev_block) =
-        find_present_block_below(cloud_storage, height).await.map_err(|err| match err {
-            CloudRetrievalError::NoBlockData { .. } => {
-                CloudArchivalReaderError::NoAnchorBelow { start_height: height }
-            }
-            err => err.into(),
-        })?;
-    let prev_block_epoch_id = *prev_block.block().header().epoch_id();
-    pull_epoch_data(store, cloud_storage, &prev_block_epoch_id).await?;
-
-    let prev_block_hash = *prev_block.block().header().hash();
-    let mut update = store.store_update();
-    // `get_epoch_id_from_prev_block` starts by reading this row.
-    update.epoch_store_update().set_block_info(prev_block.block_info());
-    update.commit();
-
-    let start_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash)?;
-    if start_epoch_id != prev_block_epoch_id {
-        pull_epoch_data(store, cloud_storage, &start_epoch_id).await?;
-    }
-    Ok(prev_block_hash)
 }
 
 /// The shards this reader tracks in both epochs a batch can hold blocks in.
@@ -385,7 +353,7 @@ pub async fn find_present_block_below(
 }
 
 /// Walks epochs backward from `height` and returns the first `(epoch_height, epoch_id)`
-/// whose state-header is present in cloud for `shard_id`. Errors when the walk-back
+/// whose state snapshot is stored in cloud for `shard_id`. Errors when the walk-back
 /// reaches below the earliest archived data without finding a snapshot.
 pub async fn find_snapshot_at_or_before(
     cloud_storage: &CloudStorage,
@@ -403,7 +371,15 @@ pub async fn find_snapshot_at_or_before(
         tracing::info!(epoch_height, ?epoch_id, "probing for state snapshot");
 
         if cloud_storage.is_state_header_stored(epoch_height, epoch_id, shard_id).await? {
-            return Ok((epoch_height, epoch_id));
+            let header =
+                cloud_storage.retrieve_state_header(epoch_height, epoch_id, shard_id).await?;
+            // An epoch snapshots its sync block, a few heights into the epoch, so a
+            // `height` below that block is served by the epoch under this one.
+            // TODO(cloud_archival): stop here for a shard a resharding added, which is
+            // reached by walking the recorded inverse changes down instead.
+            if header.chunk_height_included() <= height {
+                return Ok((epoch_height, epoch_id));
+            }
         }
 
         let batch = cloud_storage.get_block_batch_for_height(epoch_start_height).await?;

--- a/chain/client/src/archive/cloud_historical_reader.rs
+++ b/chain/client/src/archive/cloud_historical_reader.rs
@@ -1,15 +1,21 @@
 use crate::archive::cloud_archival_utils::{
-    install_anchors, pull_block_batch, pull_shard_batch, save_reader_head, shards_tracked_in_batch,
+    CloudArchivalReaderError, apply_batch_state_changes, find_present_block_below,
+    find_snapshot_at_or_before, pull_block_batch, pull_epoch_data, pull_shard_batch,
+    save_reader_head, shard_state_anchor, shards_tracked_in_batch,
 };
+use crate::archive::cloud_reader_trie_utils::{build_shard_tries, install_state_snapshot};
 use near_chain_configs::TrackedShardsConfig;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
+use near_primitives::hash::CryptoHash;
 use near_primitives::types::BlockHeight;
-use near_store::Store;
-use near_store::archive::cloud_storage::CloudStorage;
+use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
+use near_store::archive::cloud_storage::{CloudRetrievalError, CloudStorage};
+use near_store::{ShardTries, ShardUId, Store};
 
 /// Downloads block, epoch, and per-shard chunk data covering `[start_height,
-/// end_height]` from cloud storage and writes it into the local store.
+/// end_height]` from cloud storage and writes it into the local store,
+/// reconstructing each shard's state as it goes.
 ///
 /// Rows reach past `end_height`, since each batch is written to its own end.
 ///
@@ -35,8 +41,9 @@ pub async fn bootstrap_range(
         tracing::warn!("tracked_shards_config selects no shards; bootstrapping block data only");
     }
 
+    let tries = build_shard_tries(store);
     let mut prev_block_hash =
-        install_anchors(store, cloud_storage, epoch_manager, start_height).await?;
+        install_anchors(cloud_storage, &tries, shard_tracker, start_height).await?;
 
     let range_length = end_height - start_height + 1;
     let log_interval = std::cmp::max(cloud_storage.batch_size() as u64, range_length / 100);
@@ -54,7 +61,11 @@ pub async fn bootstrap_range(
             batch_pull.opening_epoch_id,
         )?;
         for shard_uid in shard_uids {
-            pull_shard_batch(store, cloud_storage, shard_uid, height).await?;
+            let shard_batch = pull_shard_batch(store, cloud_storage, shard_uid, height).await?;
+            // TODO(cloud_archival): install a shard a resharding adds inside the range,
+            // which the walk did not open on.
+            let state_root = shard_state_anchor(&tries, &prev_block_hash, shard_uid)?;
+            apply_batch_state_changes(&tries, shard_uid, &shard_batch, height, state_root)?;
         }
         if let Some(block_hash) = batch_pull.last_present_block_hash {
             prev_block_hash = block_hash;
@@ -70,5 +81,105 @@ pub async fn bootstrap_range(
         }
     }
 
+    Ok(())
+}
+
+/// Seeds the store with what the epoch manager needs to answer for `start_height` and with
+/// each tracked shard's state, and returns the hash of the nearest present block below it.
+/// `start_height` must therefore be above the first archived block.
+async fn install_anchors(
+    cloud_storage: &CloudStorage,
+    tries: &ShardTries,
+    shard_tracker: &ShardTracker,
+    start_height: BlockHeight,
+) -> Result<CryptoHash, CloudArchivalReaderError> {
+    let trie_store = tries.store();
+    let store = trie_store.store_ref();
+    let epoch_manager = shard_tracker.epoch_manager().as_ref();
+    let (prev_block_height, prev_block) =
+        find_present_block_below(cloud_storage, start_height).await.map_err(|err| match err {
+            CloudRetrievalError::NoBlockData { .. } => {
+                CloudArchivalReaderError::NoAnchorBelow { start_height }
+            }
+            err => err.into(),
+        })?;
+    let prev_block_epoch_id = *prev_block.block().header().epoch_id();
+    pull_epoch_data(store, cloud_storage, &prev_block_epoch_id).await?;
+
+    let prev_block_hash = *prev_block.block().header().hash();
+    let mut update = store.store_update();
+    // `get_epoch_id_from_prev_block` starts by reading this row.
+    update.epoch_store_update().set_block_info(prev_block.block_info());
+    update.commit();
+
+    let start_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash)?;
+    if start_epoch_id != prev_block_epoch_id {
+        pull_epoch_data(store, cloud_storage, &start_epoch_id).await?;
+    }
+
+    let shard_uids = shards_tracked_in_batch(epoch_manager, shard_tracker, &prev_block_hash, None)?;
+    for shard_uid in shard_uids {
+        install_shard_state(cloud_storage, tries, shard_uid, prev_block_height, start_height)
+            .await?;
+    }
+    Ok(prev_block_hash)
+}
+
+/// Builds one shard's state up to `start_height`, the first height of the range the caller
+/// writes rows over, from the newest snapshot at or below it. Writes the chunk extra of the
+/// block at `anchor_height`, the nearest present block under the range, so the first batch
+/// finds the root to apply onto.
+async fn install_shard_state(
+    cloud_storage: &CloudStorage,
+    tries: &ShardTries,
+    shard_uid: ShardUId,
+    anchor_height: BlockHeight,
+    start_height: BlockHeight,
+) -> Result<(), CloudArchivalReaderError> {
+    let shard_id = shard_uid.shard_id();
+    let (epoch_height, epoch_id) =
+        find_snapshot_at_or_before(cloud_storage, start_height, shard_id).await?;
+    let header = cloud_storage.retrieve_state_header(epoch_height, epoch_id, shard_id).await?;
+    let mut state_root = header.chunk_prev_state_root();
+    let mut height = header.chunk_height_included();
+    tracing::info!(
+        target: "cloud_archival",
+        %shard_uid,
+        epoch_height,
+        snapshot_height = height,
+        start_height,
+        "installing a shard's state out of the bucket",
+    );
+    install_state_snapshot(cloud_storage, tries, shard_uid, epoch_height, epoch_id, &header)
+        .await?;
+
+    while height < start_height {
+        let shard_batch = cloud_storage.get_shard_batch(height, shard_id).await?;
+        state_root = apply_batch_state_changes(tries, shard_uid, &shard_batch, height, state_root)?;
+        height = shard_batch.end_height() + 1;
+    }
+    save_shard_state_anchor(tries, cloud_storage, shard_uid, anchor_height).await
+}
+
+/// Writes the chunk extra of the block at `anchor_height`. The first batch above it reads
+/// the root it applies onto from that row.
+async fn save_shard_state_anchor(
+    tries: &ShardTries,
+    cloud_storage: &CloudStorage,
+    shard_uid: ShardUId,
+    anchor_height: BlockHeight,
+) -> Result<(), CloudArchivalReaderError> {
+    let shard_id = shard_uid.shard_id();
+    let shard_batch = cloud_storage.get_shard_batch(anchor_height, shard_id).await?;
+    let shard_data = shard_batch
+        .get_data_at_height(anchor_height)
+        .ok_or(CloudRetrievalError::NoShardData { height: anchor_height, shard_id })?;
+    let mut update = tries.store().store_ref().store_update();
+    update.chunk_store_update().set_chunk_extra(
+        shard_data.block_hash(),
+        &shard_uid,
+        shard_data.chunk_extra(),
+    );
+    update.commit();
     Ok(())
 }

--- a/chain/client/src/archive/cloud_reader_trie_utils.rs
+++ b/chain/client/src/archive/cloud_reader_trie_utils.rs
@@ -1,9 +1,12 @@
 use crate::archive::cloud_archival_utils::CloudArchivalReaderError;
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::RawStateChangesWithTrieKey;
+use near_primitives::state_part::StatePartId;
+use near_primitives::state_sync::ShardStateSyncResponseHeader;
+use near_primitives::types::{EpochHeight, EpochId, RawStateChangesWithTrieKey};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::trie_store::{TrieStoreAdapter, TrieStoreUpdateAdapter};
+use near_store::archive::cloud_storage::CloudStorage;
 use near_store::flat::FlatStorageManager;
 use near_store::trie::AccessOptions;
 use near_store::{
@@ -22,6 +25,35 @@ pub fn build_shard_tries(store: &Store) -> ShardTries {
         FlatStorageManager::new(store.flat_store()),
         StateSnapshotConfig::Disabled,
     )
+}
+
+/// Downloads one shard's state snapshot and writes its parts into the trie, leaving the
+/// root the header names reachable.
+pub(crate) async fn install_state_snapshot(
+    cloud_storage: &CloudStorage,
+    tries: &ShardTries,
+    shard_uid: ShardUId,
+    epoch_height: EpochHeight,
+    epoch_id: EpochId,
+    header: &ShardStateSyncResponseHeader,
+) -> Result<(), CloudArchivalReaderError> {
+    let shard_id = shard_uid.shard_id();
+    let state_root = header.chunk_prev_state_root();
+    let num_parts = header.num_state_parts();
+    for part_index in 0..num_parts {
+        let part_id = StatePartId::new(part_index, num_parts);
+        let state_part =
+            cloud_storage.retrieve_state_part(epoch_height, epoch_id, shard_id, part_id).await?;
+        let partial_state = state_part.to_partial_state().map_err(|error| {
+            CloudArchivalReaderError::StatePartDeserialization { shard_uid, part_id, error }
+        })?;
+        let apply_result = Trie::apply_state_part(&state_root, part_id, partial_state);
+        let mut store_update = tries.store_update();
+        tries.apply_all(&apply_result.trie_changes, shard_uid, &mut store_update);
+        store_update.commit();
+    }
+    tracing::info!(target: "cloud_archival", %shard_uid, num_parts, "installed a state snapshot");
+    Ok(())
 }
 
 /// Trie storage for one batch: the nodes that batch has applied, over the nodes the store

--- a/chain/client/src/archive/cloud_recent_reader.rs
+++ b/chain/client/src/archive/cloud_recent_reader.rs
@@ -194,7 +194,18 @@ impl CloudArchivalRecentReader {
                 reader_head.height + 1,
             )
             .await?;
-            apply_batch_state_changes(&self.tries, shard_uid, &shard_batch, reader_head)?;
+            // TODO(cloud_archival): anchor a shard a resharding added above the head.
+            let state_root =
+                shard_state_anchor(&self.tries, &reader_head.last_present_block_hash, shard_uid)?;
+            // A reader that joined mid-batch has its head inside the batch, and the
+            // heights below that head are applied already.
+            apply_batch_state_changes(
+                &self.tries,
+                shard_uid,
+                &shard_batch,
+                reader_head.height + 1,
+                state_root,
+            )?;
         }
         let head = save_reader_head(&self.store, window.end_height, window.last_present_block_hash);
         Ok(PullOutcome::Pulled { head })

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -1095,6 +1095,101 @@ fn test_cloud_archival_bootstrap_snapshot_in_earlier_epoch() {
     h.shutdown();
 }
 
+/// A range whose start sits below its own epoch's snapshot anchors on the epoch under it.
+/// An epoch snapshots its sync block, a few heights in, so that snapshot stands at a root
+/// the range's first height does not apply onto.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_bootstrap_below_its_epoch_snapshot() {
+    let mut h = CloudArchiveHarness::builder().disable_gc().build();
+    h.run_until_epoch(4);
+
+    let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
+    let shard_id = CloudArchiveHarness::all_shard_ids()[0];
+    let shard_uid = CloudArchiveHarness::all_shard_uids()[0];
+
+    // Pin the corner: `start` sits below the snapshot of the epoch it falls in, so the
+    // snapshot has to resolve to an earlier one.
+    let (start, target) = (12, 18);
+    let start_epoch_id = epoch_id_at(&cloud_storage, start);
+    let own_snapshot_height = get_state_header_for_epoch(&cloud_storage, start_epoch_id, shard_id)
+        .chunk_height_included();
+    assert!(
+        own_snapshot_height > start,
+        "h={start} must sit below its epoch's snapshot at h={own_snapshot_height}"
+    );
+    let (_, resolved_epoch_id) =
+        exec(find_snapshot_at_or_before(&cloud_storage, start, shard_id)).unwrap();
+    assert_ne!(resolved_epoch_id, start_epoch_id, "the snapshot must resolve to an earlier epoch");
+
+    // The root the range's first height applies onto, which only a walk from the earlier
+    // epoch's snapshot reaches.
+    let anchor_root = *cloud_storage
+        .get_shard_data(start - 1, shard_id)
+        .unwrap()
+        .expect("the block below the range is present")
+        .chunk_extra()
+        .state_root();
+
+    h.bootstrap_historical_reader(start, target);
+
+    let tries = build_shard_tries(&h.historical_reader_store());
+    assert!(
+        has_state_root(&tries, shard_uid, anchor_root),
+        "the root h={start} applies onto must be reachable"
+    );
+
+    h.kill_historical_reader();
+    h.shutdown();
+}
+
+/// A range whose start sits above its own epoch's snapshot anchors on that snapshot, even
+/// when the batch holding the start opens below it.
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_cloud_archival_bootstrap_anchors_on_the_nearest_snapshot() {
+    let mut h = CloudArchiveHarness::builder().disable_gc().build();
+    h.run_until_epoch(4);
+
+    let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
+    let shard_id = CloudArchiveHarness::all_shard_ids()[0];
+    let shard_uid = CloudArchiveHarness::all_shard_uids()[0];
+
+    // Pin the corner: the batch holding `start` opens below the snapshot `start` resolves
+    // to, so anchoring on the batch start would reach back an epoch further.
+    let (start, target) = (14, 22);
+    let batch_start =
+        cloud_storage.get_shard_batch_for_height(start, shard_id).unwrap().start_height();
+    let (_, near_epoch_id) =
+        exec(find_snapshot_at_or_before(&cloud_storage, start, shard_id)).unwrap();
+    let (_, far_epoch_id) =
+        exec(find_snapshot_at_or_before(&cloud_storage, batch_start, shard_id)).unwrap();
+    assert_ne!(
+        near_epoch_id, far_epoch_id,
+        "h={start} and its batch start h={batch_start} must resolve to different snapshots"
+    );
+    let far_root =
+        get_state_header_for_epoch(&cloud_storage, far_epoch_id, shard_id).chunk_prev_state_root();
+    let near_root =
+        get_state_header_for_epoch(&cloud_storage, near_epoch_id, shard_id).chunk_prev_state_root();
+    assert_ne!(far_root, near_root, "the two snapshots must stand at different roots");
+
+    h.bootstrap_historical_reader(start, target);
+
+    let tries = build_shard_tries(&h.historical_reader_store());
+    assert!(
+        has_state_root(&tries, shard_uid, near_root),
+        "the snapshot at or below h={start} must be installed"
+    );
+    assert!(
+        !has_state_root(&tries, shard_uid, far_root),
+        "the earlier epoch's snapshot must not be installed"
+    );
+
+    h.kill_historical_reader();
+    h.shutdown();
+}
+
 /// Every block in a batch window is lost; the batch is uploaded with `None`
 /// at every height and archivization advances past the gap.
 #[test]
@@ -1754,25 +1849,32 @@ fn test_cloud_archival_reader_reconstructs_per_shard_data_columns() {
 /// missing-chunk height and its immediate neighbors via the block's chunk
 /// header `prev_state_root`.
 #[test]
-// TODO(cloud_archival): un-ignore once the reader reconstructs per-shard cold columns
-// and applies per-block state deltas with insertion-only trie updates.
-#[ignore]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_reader_intermediate_state_through_missing_chunk() {
     let dropped_shard = CloudArchiveHarness::all_shard_ids()[0];
     let dropped_shard_uid = CloudArchiveHarness::all_shard_uids()[0];
     let epoch_length = CloudArchiveHarness::DEFAULT_EPOCH_LENGTH;
-    // Drop the dropped_shard chunk at one mid-epoch offset; the bootstrap
-    // range below is chosen wide enough to cover `dropped_height` and its
-    // `+/- 1` neighbors.
-    let dropped_height: BlockHeight = epoch_length / 2 + 1;
+    // `drop_chunks` keys its pattern on the height within an epoch, so the offset picked
+    // here becomes an absolute height only once the epoch start is known.
+    let dropped_offset = epoch_length / 2 + 1;
     let mut pattern = vec![true; epoch_length as usize];
-    pattern[dropped_height as usize] = false;
+    pattern[dropped_offset as usize] = false;
 
     let mut h =
         CloudArchiveHarness::builder().validators(4).drop_chunks(dropped_shard, pattern).build();
     h.run_until_epoch(3 + MIN_GC_NUM_EPOCHS_TO_KEEP);
+    let cloud_storage = get_cloud_storage(&h.env, &h.writer_id);
     let start = h.epoch_length / 2;
     let target = h.epoch_length + h.epoch_length / 2;
+    let epoch_start = exec(cloud_storage.get_epoch_data(epoch_id_at(&cloud_storage, start)))
+        .unwrap()
+        .epoch_start_height();
+    let dropped_height: BlockHeight = epoch_start + dropped_offset;
+    assert!(
+        start < dropped_height && dropped_height < target,
+        "dropped height {dropped_height} must sit inside the bootstrap range"
+    );
     h.bootstrap_historical_reader(start, target);
 
     let store = h.historical_reader_store();

--- a/test-loop-tests/src/utils/cloud_archival.rs
+++ b/test-loop-tests/src/utils/cloud_archival.rs
@@ -5,9 +5,7 @@ use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
 use near_chain::types::Tip;
 use near_chain_configs::{ClientConfig, CloudArchivalWriterConfig, TrackedShardsConfig};
-use near_client::archive::cloud_archival_utils::{
-    find_present_block_below, find_snapshot_at_or_before,
-};
+use near_client::archive::cloud_archival_utils::find_present_block_below;
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::archive::cloud_historical_reader::bootstrap_range;
 use near_client::archive::cloud_reader_trie_utils::build_shard_tries;
@@ -19,7 +17,6 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{ProcessedReceiptMetadata, ReceiptSource};
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
-use near_primitives::state_part::StatePartId;
 use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
@@ -32,7 +29,7 @@ use near_store::archive::cloud_storage::{
     CloudStorage, is_cloud_archive_reader_bootstrapped, read_chunk_hashes,
 };
 use near_store::trie::AccessOptions;
-use near_store::{COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, Store, Trie};
+use near_store::{COLD_HEAD_KEY, DBCol, ShardTries, ShardUId, Store};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
@@ -636,8 +633,8 @@ pub(crate) fn add_reader_node(env: &mut TestLoopEnv, reader_id: &AccountId) -> S
     env.node_for_account(reader_id).client().chain.chain_store().store()
 }
 
-/// Bootstraps a reader node by downloading blocks from cloud and applying
-/// state sync to reconstruct the state at `target_block_height`.
+/// Bootstraps a reader node from cloud storage and checks it reconstructed every
+/// shard's state through `target_block_height`.
 pub fn bootstrap_historical_reader(
     env: &mut TestLoopEnv,
     reader_id: &AccountId,
@@ -647,8 +644,6 @@ pub fn bootstrap_historical_reader(
     add_reader_node(env, reader_id);
 
     let cloud_storage = get_cloud_storage(env, reader_id);
-
-    // Download all blocks in the range into the reader's store.
     {
         let client = env.node_for_account(reader_id).client();
         let store = client.chain.chain_store.store();
@@ -679,55 +674,25 @@ pub fn bootstrap_historical_reader(
 
     // TODO(cloud_archival): support resharding; the shard layout can change
     // between the snapshot epoch and the target, which this loop assumes constant.
-    for shard_id in target_epoch_data.shard_layout().shard_ids() {
-        let shard_uid =
-            ShardUId::from_shard_id_and_layout(shard_id, target_epoch_data.shard_layout());
-
-        // Reconstruct from the nearest snapshot at or below the bootstrap start,
-        // loaded from cloud state parts, then apply deltas forward to the target.
-        let (snapshot_epoch_height, snapshot_epoch_id) =
-            exec(find_snapshot_at_or_before(&cloud_storage, start_height, shard_id)).unwrap();
-        // Both values come off the header's single chunk, so the state root and
-        // the height it applies at cannot disagree.
-        let state_header = cloud_storage
-            .get_state_header(snapshot_epoch_height, snapshot_epoch_id, shard_id)
-            .unwrap();
-        let state_sync_state_root = state_header.chunk_prev_state_root();
-        let reconstruction_start_height = state_header.chunk_height_included();
-
-        assert!(!has_state_root(&tries, shard_uid, state_sync_state_root));
-        exec(download_and_apply_state_snapshot(
-            &tries,
-            &cloud_storage,
-            &snapshot_epoch_id,
-            snapshot_epoch_height,
-            shard_uid,
-            &state_header,
-        ));
-        assert!(has_state_root(&tries, shard_uid, state_sync_state_root));
-
+    for shard_uid in target_epoch_data.shard_layout().shard_uids() {
         let target_state_root = *cloud_storage
-            .get_shard_data(target_block_height, shard_id)
+            .get_shard_data(target_block_height, shard_uid.shard_id())
             .unwrap()
             .unwrap()
             .chunk_extra()
             .state_root();
-        assert!(!has_state_root(&tries, shard_uid, target_state_root));
-        apply_state_changes(
-            &cloud_storage,
-            &store,
-            &tries,
-            state_sync_state_root,
-            reconstruction_start_height,
-            target_block_height,
-            shard_uid,
+        assert!(
+            has_state_root(&tries, shard_uid, target_state_root),
+            "shard {shard_uid} state at h={target_block_height} unreachable in the reader trie"
         );
-        assert!(has_state_root(&tries, shard_uid, target_state_root));
 
-        // Validate the restored state by reading from the trie.
         let trie = tries.get_trie_for_shard(shard_uid, target_state_root);
-        let item_count = trie.disk_iter().unwrap().count();
-        assert!(item_count > 0, "trie for shard {shard_id} should not be empty after bootstrap");
+        let items = trie
+            .disk_iter()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap_or_else(|error| panic!("shard {shard_uid} trie is incomplete: {error}"));
+        assert!(!items.is_empty(), "trie for shard {shard_uid} holds no state after bootstrap");
     }
 }
 
@@ -739,82 +704,6 @@ pub(crate) fn has_state_root(
 ) -> bool {
     let trie = tries.get_trie_for_shard(shard_uid, state_root);
     trie.retrieve_root_node().is_ok()
-}
-
-/// Loads a shard's state snapshot by downloading its state parts from cloud and
-/// applying them straight into the trie.
-async fn download_and_apply_state_snapshot(
-    tries: &ShardTries,
-    cloud_storage: &CloudStorage,
-    epoch_id: &EpochId,
-    epoch_height: EpochHeight,
-    shard_uid: ShardUId,
-    state_header: &ShardStateSyncResponseHeader,
-) {
-    let shard_id = shard_uid.shard_id();
-    let state_root = state_header.chunk_prev_state_root();
-    let num_parts = state_header.num_state_parts();
-    for part_index in 0..num_parts {
-        let part_id = StatePartId::new(part_index, num_parts);
-        let state_part = cloud_storage
-            .retrieve_state_part(epoch_height, *epoch_id, shard_id, part_id)
-            .await
-            .unwrap();
-        let partial_state = state_part.to_partial_state().unwrap();
-        let apply_result = Trie::apply_state_part(&state_root, part_id, partial_state);
-        let mut store_update = tries.store_update();
-        tries.apply_all(&apply_result.trie_changes, shard_uid, &mut store_update);
-        store_update.commit();
-    }
-}
-
-/// Applies per-block state deltas from cloud storage to advance the trie from
-/// `start_block_height` to `target_block_height`. Both endpoints must be
-/// present; `start_block_height` must additionally have a new chunk for
-/// `shard_uid` (initial `state_root` is verified against the chunk's
-/// `prev_state_root`).
-fn apply_state_changes(
-    cloud_storage: &CloudStorage,
-    store: &Store,
-    tries: &ShardTries,
-    mut state_root: CryptoHash,
-    start_block_height: BlockHeight,
-    target_block_height: BlockHeight,
-    shard_uid: ShardUId,
-) {
-    let shard_id = shard_uid.shard_id();
-    let start_block_shard_data =
-        cloud_storage.get_shard_data(start_block_height, shard_id).unwrap().unwrap();
-    assert_eq!(
-        state_root,
-        start_block_shard_data.new_chunk().unwrap().chunk().prev_state_root(),
-        "initial state_root must match prev_state_root of the start block"
-    );
-    for block_height in start_block_height..=target_block_height {
-        let Some(shard_data) = cloud_storage.get_shard_data(block_height, shard_id).unwrap() else {
-            continue;
-        };
-        let trie = tries.get_trie_for_shard(shard_uid, state_root);
-        let trie_changes = trie
-            .update(
-                shard_data.state_changes().iter().map(|raw_state_changes_with_trie_key| {
-                    let raw_key = raw_state_changes_with_trie_key.trie_key.to_vec();
-                    // Take the final value — each key may have multiple changes within a block.
-                    let data = raw_state_changes_with_trie_key.changes.last().unwrap().data.clone();
-                    (raw_key, data)
-                }),
-                AccessOptions::NO_SIDE_EFFECTS,
-            )
-            .unwrap();
-        let mut store_update = store.trie_store().store_update();
-        state_root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
-        store_update.commit();
-        assert!(has_state_root(&tries, shard_uid, state_root));
-    }
-    let target_block_shard_data =
-        cloud_storage.get_shard_data(target_block_height, shard_id).unwrap().unwrap();
-    let expected_final_state_root = target_block_shard_data.chunk_extra().state_root();
-    assert_eq!(state_root, *expected_final_state_root);
 }
 
 /// Asserts `store` holds every row `writer` has over `[start, end]`, with the value the


### PR DESCRIPTION
The historical reader reconstructs each shard's state over the range it bootstraps.

`install_anchors` installs every tracked shard as well as the block anchor: per shard it takes the newest state snapshot at or below the range start, applies the changes recorded between that snapshot and the range, and writes the anchor block's chunk extra. Only the trie and that one row land below the range. The batch loop then reads each shard's root off that row, the way the recent reader reads its own, so `apply_batch_state_changes` takes the root and the first height to apply rather than deriving both from a reader head.

`find_snapshot_at_or_before` checks the snapshot's own height rather than only whether its epoch stored one. An epoch snapshots its sync block, a few heights in, so a range starting below that block is served by the epoch under it.

The snapshot download and the walk up move out of the testloop, which used to reconstruct state by hand after calling the bootstrap. The test asserts on what the bootstrap produced.
