### PR TITLE
fix(state-sync): bound the number of entries in a state part

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -544,11 +544,13 @@ impl NightshadeRuntime {
         part_id: StatePartId,
         part: &StatePart,
     ) -> StatePartValidationResult {
-        let partial_state = part.to_partial_state();
-        let Ok(partial_state) = part.to_partial_state() else {
-            // Deserialization error means we've got the data from malicious peer
-            tracing::error!(target: "state-parts", ?partial_state, "state part deserialization error");
-            return StatePartValidationResult::Invalid;
+        let partial_state = match part.to_partial_state() {
+            Ok(partial_state) => partial_state,
+            Err(err) => {
+                // Deserialization error means we've got the data from malicious peer
+                tracing::error!(target: "state-parts", ?err, "state part deserialization error");
+                return StatePartValidationResult::Invalid;
+            }
         };
         match Trie::validate_state_part(state_root, part_id, partial_state) {
             Ok(_) => StatePartValidationResult::Valid,

--- a/core/primitives/src/state.rs
+++ b/core/primitives/src/state.rs
@@ -34,10 +34,46 @@ impl Debug for PartialState {
     }
 }
 
+/// Bytes borsh writes before the first entry: the variant discriminant and the
+/// `u32` entry count.
+pub const PARTIAL_STATE_HEADER_LEN: usize = size_of::<u8>() + size_of::<u32>();
+
 impl PartialState {
     pub fn len(&self) -> usize {
         let Self::TrieValues(values) = self;
         values.len()
+    }
+
+    /// Rejects an entry count above `max_entries`, reading only the header. Each
+    /// `TrieValues` entry is an `Arc<[u8]>` and costs a heap allocation as borsh
+    /// decodes it, so the count has to be taken from the length prefix first.
+    pub fn check_entry_limit(header: &[u8], max_entries: u32) -> borsh::io::Result<()> {
+        let mut reader = header;
+        let discriminant = u8::deserialize_reader(&mut reader)?;
+        if discriminant != 0 {
+            return Err(borsh::io::Error::new(
+                borsh::io::ErrorKind::InvalidData,
+                "unknown PartialState variant",
+            ));
+        }
+        let entries = u32::deserialize_reader(&mut reader)?;
+        if entries > max_entries {
+            return Err(borsh::io::Error::new(
+                borsh::io::ErrorKind::InvalidData,
+                "state part entry limit exceeded",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Deserializes a partial state, rejecting an entry count above `max_entries`
+    /// before any entry is read.
+    pub fn try_from_slice_with_entry_limit(
+        bytes: &[u8],
+        max_entries: u32,
+    ) -> borsh::io::Result<Self> {
+        Self::check_entry_limit(bytes, max_entries)?;
+        Self::try_from_slice(bytes)
     }
 }
 

--- a/core/primitives/src/state_part.rs
+++ b/core/primitives/src/state_part.rs
@@ -1,4 +1,5 @@
-use crate::state::PartialState;
+use crate::state::{PARTIAL_STATE_HEADER_LEN, PartialState};
+use crate::state_sync::STATE_PART_MEMORY_LIMIT;
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytesize::MIB;
 use near_schema_checker_lib::ProtocolSchema;
@@ -14,6 +15,26 @@ use near_schema_checker_lib::ProtocolSchema;
 /// node size.
 // TODO(#14340): Try to lower the upper bound, e.g. determine the maximum trie node size.
 const PART_SIZE_LIMIT: u64 = 512 * MIB;
+
+/// Lower bound for the `memory_usage` a single part entry contributes.
+///
+/// `memory_usage_direct` charges `TRIE_COSTS.node_cost` per node and
+/// `memory_usage_value` charges it again per value, so entries of both kinds cost
+/// at least this much. near-store owns `TRIE_COSTS` and tests the two agree.
+pub const MIN_MEMORY_USAGE_PER_PART_ENTRY: u64 = 50;
+
+/// Upper bound for the number of trie values in a decompressed part.
+///
+/// `PART_SIZE_LIMIT` caps bytes only, and an entry can be four bytes on the wire,
+/// so it alone allows over a hundred million entries. Parts are cut by trie
+/// memory usage instead, so one holds at most `STATE_PART_MEMORY_LIMIT` divided
+/// by `MIN_MEMORY_USAGE_PER_PART_ENTRY`. The doubling covers the approximate part
+/// boundary and the boundary proof nodes, which sit outside the split.
+///
+/// Largest part seen on mainnet or testnet on 2026-08-25, over every shard, was
+/// 440,488 entries: 1.4x under the undoubled bound, 2.9x under this one.
+const PART_ENTRY_LIMIT: u32 =
+    (2 * STATE_PART_MEMORY_LIMIT.0 / MIN_MEMORY_USAGE_PER_PART_ENTRY) as u32;
 
 /// Index of a state part, in the range `0..num_parts`.
 pub type StatePartIndex = u64;
@@ -54,7 +75,7 @@ pub enum StatePart {
 
 impl StatePartV0 {
     fn to_partial_state(&self) -> borsh::io::Result<PartialState> {
-        PartialState::try_from_slice(&self.0)
+        PartialState::try_from_slice_with_entry_limit(&self.0, PART_ENTRY_LIMIT)
     }
 }
 
@@ -72,7 +93,14 @@ impl StatePartV1 {
         // We add +1 so we can detect when decompressed size exceeds the limit
         let mut decoder_with_limit = std::io::Read::take(decoder, PART_SIZE_LIMIT + 1);
 
-        let mut decoded = Vec::new();
+        // Reject an oversized entry count before the rest of the stream is
+        // decompressed into memory.
+        let mut header = [0u8; PARTIAL_STATE_HEADER_LEN];
+        std::io::Read::read_exact(&mut decoder_with_limit, &mut header)?;
+        PartialState::check_entry_limit(&header, PART_ENTRY_LIMIT)?;
+
+        // Seeding with the header keeps the `PART_SIZE_LIMIT + 1` budget accurate.
+        let mut decoded = header.to_vec();
         std::io::Read::read_to_end(&mut decoder_with_limit, &mut decoded)?;
         if decoded.len() > PART_SIZE_LIMIT as usize {
             return Err(borsh::io::Error::new(
@@ -118,7 +146,7 @@ impl StatePart {
 #[cfg(test)]
 mod tests {
     use crate::state::PartialState;
-    use crate::state_part::{PART_SIZE_LIMIT, StatePart, StatePartV0};
+    use crate::state_part::{PART_ENTRY_LIMIT, PART_SIZE_LIMIT, StatePart, StatePartV0};
     use itertools::Itertools;
     use std::sync::Arc;
 
@@ -149,6 +177,29 @@ mod tests {
         let state_part_v1_bytes = state_part_v1.to_bytes();
         let state_part_v1_reconstructed = StatePart::from_bytes(state_part_v1_bytes).unwrap();
         assert_eq!(state_part_v1, state_part_v1_reconstructed);
+    }
+
+    fn partial_state_with_empty_values(num_values: usize) -> PartialState {
+        PartialState::TrieValues(vec![Arc::from(&b""[..]); num_values])
+    }
+
+    #[test]
+    fn test_state_part_entry_count_at_limit_is_accepted() {
+        let partial_state = partial_state_with_empty_values(PART_ENTRY_LIMIT as usize);
+        let state_part = StatePart::from_partial_state(partial_state, 1);
+        assert_eq!(state_part.to_partial_state().unwrap().len(), PART_ENTRY_LIMIT as usize);
+    }
+
+    #[test]
+    fn test_state_part_entry_count_bomb() {
+        let partial_state = partial_state_with_empty_values(PART_ENTRY_LIMIT as usize + 1);
+        let state_part = StatePart::from_partial_state(partial_state, 1);
+        // The part is well under the byte cap, so only the entry count rejects it.
+        assert!(state_part.payload_length() < PART_SIZE_LIMIT as usize);
+
+        let err = state_part.to_partial_state().unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "state part entry limit exceeded");
     }
 
     #[test]

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -154,6 +154,7 @@ impl<'a> AccessOptions<'a> {
     }
 }
 
+// MIN_MEMORY_USAGE_PER_PART_ENTRY in near-primitives mirrors node_cost; a test keeps them equal.
 const TRIE_COSTS: TrieCosts = TrieCosts { byte_of_key: 2, byte_of_value: 1, node_cost: 50 };
 
 #[derive(Clone, Copy, Hash)]
@@ -1897,6 +1898,15 @@ mod tests {
 
     type TrieChanges = Vec<(Vec<u8>, Option<Vec<u8>>)>;
     const SHARD_VERSION: u32 = 1;
+
+    #[test]
+    fn state_part_entry_limit_uses_the_real_node_cost() {
+        assert_eq!(
+            TRIE_COSTS.node_cost,
+            near_primitives::state_part::MIN_MEMORY_USAGE_PER_PART_ENTRY,
+            "near-primitives bounds state part entries by this cost and cannot see TRIE_COSTS"
+        );
+    }
 
     fn test_clear_trie(
         tries: &ShardTries,


### PR DESCRIPTION
`validate_state_part` bounded a part's decompressed size with the 512 MiB `PART_SIZE_LIMIT` but never its entry count. Validation hashes every entry and collects them into a `HashMap`, and `TrieMemoryPartialStorage::new` sizes a `DashSet` to the distinct key count, all before the root traversal that would reject the part. So the entry count needs a bound of its own.

`PartialState::try_from_slice_with_entry_limit` now checks the count from the length prefix, before borsh allocates a single entry.

The bound is derived rather than tuned: parts are cut by trie memory usage and one covers at most `STATE_PART_MEMORY_LIMIT`, while `memory_usage_direct` charges `TRIE_COSTS.node_cost` per node and `memory_usage_value` charges it again per value, so every entry costs at least 50. That gives 629,145 entries, doubled to 1,258,291 to cover the approximate part boundary and the boundary proof nodes, which sit outside the memory split.

Checked against real parts on 2026-08-25: the largest part across every shard of both mainnet and testnet held 440,488 entries, 2.9x under the limit. `MIN_MEMORY_USAGE_PER_PART_ENTRY` has to be spelled out in near-primitives because it cannot reach `TRIE_COSTS`, so a test in near-store asserts the two agree.

Also removes a duplicate decode in `validate_state_part_impl`. The first `Result` was shadowed rather than dropped, so both decoded copies of the part stayed alive through validation.