### PR TITLE
fix(chain): reject u64::MAX prev_height in verify_block_endorsements

### DIFF
--- a/chain/chain/src/approval_verification.rs
+++ b/chain/chain/src/approval_verification.rs
@@ -51,8 +51,14 @@ pub fn verify_approvals_and_threshold_orphan(
     epoch_info: Arc<EpochInfo>,
 ) -> Result<(), Error> {
     let block_approvers = get_heuristic_block_approvers_ordered(&epoch_info);
+    // `prev_block_height` comes from an unvalidated header when the caller has no ancestry to
+    // check it against, so use checked_add to avoid an arithmetic overflow panic (which would
+    // crash the node) when the height is u64::MAX.
+    let Some(prev_block_height_plus_one) = prev_block_height.checked_add(1) else {
+        return Err(Error::InvalidBlockHeight(prev_block_height));
+    };
     let message_to_sign = Approval::get_data_for_sig(
-        &if prev_block_height + 1 == block_height {
+        &if prev_block_height_plus_one == block_height {
             ApprovalInner::Endorsement(*prev_block_hash)
         } else {
             ApprovalInner::Skip(prev_block_height)
@@ -90,4 +96,39 @@ fn get_heuristic_block_approvers_ordered(epoch_info: &EpochInfo) -> Vec<Approval
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verify_approvals_and_threshold_orphan;
+    use assert_matches::assert_matches;
+    use near_chain_primitives::error::Error;
+    use near_epoch_manager::test_utils::epoch_info;
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::shard_layout::ShardLayout;
+    use near_primitives::types::Balance;
+    use near_primitives::version::PROTOCOL_VERSION;
+    use std::sync::Arc;
+
+    #[test]
+    fn verify_approvals_and_threshold_orphan_rejects_max_prev_height() {
+        let epoch_info = Arc::new(epoch_info(
+            0,
+            vec![("test1".parse().unwrap(), Balance::from_near(1))],
+            vec![0],
+            vec![vec![0]],
+            PROTOCOL_VERSION,
+            ShardLayout::single_shard(),
+        ));
+        let err = verify_approvals_and_threshold_orphan(
+            &|_, _| true,
+            &CryptoHash::default(),
+            u64::MAX,
+            0,
+            &[],
+            epoch_info,
+        )
+        .unwrap_err();
+        assert_matches!(err, Error::InvalidBlockHeight(u64::MAX));
+    }
 }

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -611,6 +611,20 @@ impl BlockHeader {
         }
     }
 
+    pub fn set_prev_height(&mut self, value: BlockHeight) {
+        match self {
+            BlockHeader::BlockHeaderV1(_)
+            | BlockHeader::BlockHeaderV2(_)
+            | BlockHeader::BlockHeaderV3(_) => {
+                unreachable!("old header should not appear in tests")
+            }
+            BlockHeader::BlockHeaderV4(header) => header.inner_rest.prev_height = value,
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.prev_height = value,
+            BlockHeader::BlockHeaderV6(header) => header.inner_rest.prev_height = value,
+            BlockHeader::BlockHeaderV7(header) => header.inner_rest.prev_height = value,
+        }
+    }
+
     pub fn set_epoch_id(&mut self, value: EpochId) {
         match self {
             BlockHeader::BlockHeaderV1(_)

--- a/runtime/near-test-contracts/sharded-contract/Cargo.lock
+++ b/runtime/near-test-contracts/sharded-contract/Cargo.lock
@@ -395,9 +395,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "near-account-id"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7d8c37ea9408d536af7e998bd0d4f9699de1f6b0d12280d28ae46977c4501"
+checksum = "7d2c8642aeca89873dbcf2a2f74ff90cd87f6691f11b66aeed2af7c136192d10"
 dependencies = [
  "borsh",
  "serde",

--- a/test-loop-tests/src/tests/sync/adversarial_height.rs
+++ b/test-loop-tests/src/tests/sync/adversarial_height.rs
@@ -12,13 +12,17 @@ use crate::setup::peer_manager_actor::TestLoopNetworkBlockInfo;
 use crate::tests::sync::util::far_horizon_height;
 use crate::utils::account::create_account_id;
 use crate::utils::transactions::{execute_money_transfers, make_accounts};
-use near_async::messaging::Sender;
+use near_async::messaging::{CanSend as _, Sender};
 use near_chain_configs::TrackedShardsConfig;
+use near_client::BlockResponse;
 use near_crypto::{KeyType, SecretKey};
 use near_network::types::PeerInfo;
+use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::network::PeerId;
+use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::Balance;
+use std::sync::Arc;
 
 #[test]
 // TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
@@ -185,5 +189,53 @@ fn test_stale_node_syncs() {
     assert!(
         env.test_loop.is_denylisted(restart_id),
         "stale node should reach epoch sync and trigger the data reset"
+    );
+}
+
+#[test]
+// TODO(spice-test): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_max_prev_height_does_not_abort_node() {
+    init_test_logger();
+
+    let epoch_length = 10;
+    let mut env = TestLoopBuilder::new()
+        .validators(4, 0)
+        .num_shards(4)
+        .epoch_length(epoch_length)
+        .track_all_shards()
+        .build();
+    env.node_runner(0).run_until_head_height(2 * epoch_length);
+
+    // A real block re-signed by the producer the victim samples for the forged
+    // height, so it passes the producer signature check that guards the
+    // ancestry-free approval verification.
+    let head = env.node(0).head();
+    let head_block = env.node(0).head_block();
+    let forged_height = head.height + far_horizon_height(epoch_length);
+    let block_producer = env
+        .node(0)
+        .client()
+        .epoch_manager
+        .get_block_producer(&head.epoch_id, forged_height)
+        .unwrap();
+    let mut forged_block = head_block.as_ref().clone();
+    forged_block.mut_header().set_height(forged_height);
+    forged_block.mut_header().set_prev_height(u64::MAX);
+    forged_block.mut_header().resign(&create_test_signer(block_producer.as_str()));
+
+    let adversary = PeerId::new(SecretKey::from_seed(KeyType::ED25519, "adversary").public_key());
+    let sync_history = track_sync_status(&mut env.test_loop, &env.node_datas, 0);
+    env.node_datas[0].client_sender.send(
+        BlockResponse { block: Arc::new(forged_block), peer_id: adversary, was_requested: false }
+            .span_wrap(),
+    );
+    env.node_runner(0).run_for_number_of_blocks(2 * epoch_length as usize);
+
+    assert!(env.node(0).head().height > head.height, "victim should keep following the chain");
+    assert!(
+        sync_history.borrow().iter().all(|status| status == "NoSync"),
+        "victim must not enter any sync phase after the max prev_height claim, saw {:?}",
+        sync_history.borrow(),
     );
 }


### PR DESCRIPTION
`verify_approvals_and_threshold_orphan` computed `prev_block_height + 1` on a height taken from a block header it has no ancestry to check against.

Use `checked_add(1)` and return `Error::InvalidBlockHeight` on overflow, matching `EpochSync::verify_block_endorsements` (`chain/client/src/sync/epoch.rs:540`).