### PR TITLE
fix(state-sync): bind from_shard_id to receipt proof merkle index

### DIFF
--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -11,7 +11,7 @@ use near_chain_primitives::error::{Error, LogTransientStorageError};
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::{merklize, verify_path};
+use near_primitives::merkle::{merklize, verify_path, verify_path_with_index};
 use near_primitives::sharding::{
     ChunkHashHeight, ReceiptList, ReceiptProof, ShardChunk, ShardChunkHeader, ShardProof,
 };
@@ -180,9 +180,11 @@ impl ChainStateSyncAdapter {
             let ReceiptProofResponse(block_hash, receipt_proofs) = receipt_response;
             let block_header = self.chain_store.get_block_header(&block_hash)?.clone();
             let block = self.chain_store.get_block(&block_hash)?;
+            let block_shard_layout =
+                self.epoch_manager.get_shard_layout(block_header.epoch_id())?;
+            let block_chunks = block.chunks();
             let (block_receipts_root, block_receipts_proofs) = merklize(
-                &block
-                    .chunks()
+                &block_chunks
                     .iter()
                     .map(|chunk| *chunk.prev_outgoing_receipts_root())
                     .collect::<Vec<CryptoHash>>(),
@@ -199,20 +201,25 @@ impl ChainStateSyncAdapter {
                 let ReceiptProof(receipts, shard_proof) = receipt_proof;
                 let ShardProof { from_shard_id, to_shard_id: _, proof } = shard_proof;
                 let receipts_hash = CryptoHash::hash_borsh(ReceiptList(shard_id, receipts));
-                let from_shard_index = prev_shard_layout.get_shard_index(*from_shard_id)?;
+                // `block_receipts_proofs` is merklized over this block's chunks, so the leaf index
+                // comes from this block's layout. `get_incoming_receipts_for_shard` walks back
+                // across epoch boundaries, so it need not be the sync block's layout.
+                let from_shard_index = block_shard_layout.get_shard_index(*from_shard_id)?;
 
-                let root_proof = *block.chunks()[from_shard_index].prev_outgoing_receipts_root();
-                root_proofs_cur
-                    .push(RootProof(root_proof, block_receipts_proofs[from_shard_index].clone()));
-
-                // Make sure we send something reasonable.
-                assert_eq!(block_header.prev_chunk_outgoing_receipts_root(), &block_receipts_root);
-                assert!(verify_path(root_proof, proof, &receipts_hash));
-                assert!(verify_path(
-                    block_receipts_root,
-                    &block_receipts_proofs[from_shard_index],
-                    &root_proof,
-                ));
+                let (Some(from_chunk), Some(block_receipts_proof)) = (
+                    block_chunks.get(from_shard_index),
+                    block_receipts_proofs.get(from_shard_index),
+                ) else {
+                    return Err(Error::InvalidReceiptsProof);
+                };
+                let root_proof = *from_chunk.prev_outgoing_receipts_root();
+                if block_header.prev_chunk_outgoing_receipts_root() != &block_receipts_root
+                    || !verify_path(root_proof, proof, &receipts_hash)
+                    || !verify_path(block_receipts_root, block_receipts_proof, &root_proof)
+                {
+                    return Err(Error::InvalidReceiptsProof);
+                }
+                root_proofs_cur.push(RootProof(root_proof, block_receipts_proof.clone()));
             }
             root_proofs.push(root_proofs_cur);
         }
@@ -460,6 +467,8 @@ impl ChainStateSyncAdapter {
             hash_to_compare = *header.prev_hash();
 
             let block_header = self.chain_store.get_block_header(block_hash)?;
+            let block_shard_layout =
+                self.epoch_manager.get_shard_layout(block_header.epoch_id())?;
             // 4c. Checking len of receipt_proofs for current block
             if receipt_proofs.len() != shard_state_header.root_proofs()[i].len()
                 || receipt_proofs.len() != block_header.chunks_included() as usize
@@ -491,12 +500,22 @@ impl ChainStateSyncAdapter {
                     byzantine_assert!(false);
                     return Err(Error::Other("set_shard_state failed: invalid proofs".into()));
                 }
-                // 4f. Proving the outgoing_receipts_root matches that in the block
-                if !verify_path(
-                    *block_header.prev_chunk_outgoing_receipts_root(),
-                    block_proof,
-                    root,
-                ) {
+                // 4f. Proving the outgoing_receipts_root matches that in the block, at the chunk
+                // index `from_shard_id` names. No merkle root covers that field, so the index check
+                // is what binds it. A shard with no new chunk keeps the previous chunk header, so
+                // its leaf repeats an older root; the index must name a chunk this block included.
+                let from_shard_index = block_shard_layout.get_shard_index(*from_shard_id)?;
+                let has_new_chunk =
+                    block_header.chunk_mask().get(from_shard_index).copied().unwrap_or(false);
+                if !has_new_chunk
+                    || !verify_path_with_index(
+                        *block_header.prev_chunk_outgoing_receipts_root(),
+                        block_proof,
+                        root,
+                        from_shard_index as u64,
+                        block_shard_layout.num_shards(),
+                    )
+                {
                     byzantine_assert!(false);
                     return Err(Error::Other("set_shard_state failed: invalid proofs".into()));
                 }

--- a/runtime/near-test-contracts/sharded-contract/Cargo.lock
+++ b/runtime/near-test-contracts/sharded-contract/Cargo.lock
@@ -395,9 +395,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "near-account-id"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7d8c37ea9408d536af7e998bd0d4f9699de1f6b0d12280d28ae46977c4501"
+checksum = "7d2c8642aeca89873dbcf2a2f74ff90cd87f6691f11b66aeed2af7c136192d10"
 dependencies = [
  "borsh",
  "serde",

--- a/test-loop-tests/src/tests/sync/mod.rs
+++ b/test-loop-tests/src/tests/sync/mod.rs
@@ -8,6 +8,7 @@ mod migration_epoch_sync_proof;
 mod near_horizon;
 // `pub(crate)` for the shuffling assertions, reused by `tests::early_kickout_e2e`.
 pub(crate) mod state_sync;
+mod state_sync_receipt_proof_labels;
 mod sync_then_catchup;
 mod syncing;
 pub(crate) mod util;

--- a/test-loop-tests/src/tests/sync/state_sync_receipt_proof_labels.rs
+++ b/test-loop-tests/src/tests/sync/state_sync_receipt_proof_labels.rs
@@ -1,0 +1,171 @@
+// No merkle root covers `ShardProof::from_shard_id`, and `compute_state_response_header` uses it as
+// a chunk index. `set_state_header` binds it by checking the label against the merkle path index,
+// and by requiring that index to name a chunk the block included.
+
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::drop_condition::DropCondition;
+use crate::setup::env::TestLoopEnv;
+use near_async::time::Duration;
+use near_chain::Chain;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::merklize;
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::state_sync::{RootProof, ShardStateSyncResponseHeader};
+use near_primitives::types::ShardId;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn await_sync_hash(env: &mut TestLoopEnv) -> CryptoHash {
+    // Past the genesis epoch, so the layout lookup the check performs uses a real epoch id.
+    env.node_runner(0).run_until_new_epoch();
+    env.node_runner(0).run_until(
+        |node| node.client().chain.get_sync_hash(&node.head().last_block_hash).unwrap().is_some(),
+        Duration::seconds(20),
+    );
+    let node = env.node(0);
+    node.client().chain.get_sync_hash(&node.head().last_block_hash).unwrap().unwrap()
+}
+
+/// Only the labels move. The receipts and the paths stay as they were, and the set of labels is
+/// unchanged, so the uniqueness check and every merkle check still pass.
+fn swap_first_two_from_shard_ids(header: &mut ShardStateSyncResponseHeader) {
+    let ShardStateSyncResponseHeader::V2(header) = header else {
+        panic!("expected a V2 state sync header");
+    };
+    for response in &mut header.incoming_receipts_proofs {
+        let proofs = Arc::make_mut(&mut response.1);
+        assert!(proofs.len() >= 2, "need two receipt proofs per block to swap labels");
+        let first_label = proofs[0].1.from_shard_id;
+        proofs[0].1.from_shard_id = proofs[1].1.from_shard_id;
+        proofs[1].1.from_shard_id = first_label;
+        assert_ne!(proofs[0].1.from_shard_id, first_label, "both proofs carried one label");
+    }
+}
+
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_set_state_header_rejects_swapped_from_shard_id() {
+    init_test_logger();
+    // The sync hash is stored only after it becomes final. With the default epoch length of 5 that
+    // happens after the head moves to the next epoch, so `await_sync_hash` never finds one.
+    let mut env = TestLoopBuilder::new()
+        .validators(2, 0)
+        .num_shards(2)
+        .epoch_length(10)
+        .track_all_shards()
+        .build();
+
+    let sync_hash = await_sync_hash(&mut env);
+    let shard_id = ShardId::new(0);
+    let genuine_header = env
+        .node(0)
+        .client()
+        .chain
+        .state_sync_adapter
+        .compute_state_response_header(shard_id, sync_hash)
+        .unwrap();
+
+    let victim = &env.node(1).client().chain.state_sync_adapter;
+    victim.set_state_header(shard_id, sync_hash, genuine_header.clone()).unwrap();
+
+    let mut tampered_header = genuine_header;
+    swap_first_two_from_shard_ids(&mut tampered_header);
+
+    let rejection = victim.set_state_header(shard_id, sync_hash, tampered_header).unwrap_err();
+    assert!(
+        rejection.to_string().contains("invalid proofs"),
+        "unexpected rejection: {rejection:?}"
+    );
+}
+
+/// Points one proof at a shard that produced no chunk in its block. Such a shard keeps the previous
+/// chunk header, so its leaf in the receipts-root tree repeats an older root, and the proof that
+/// verified against that root at its own height still verifies here.
+fn point_proof_at_shard_without_a_chunk(
+    chain: &Chain,
+    header: &mut ShardStateSyncResponseHeader,
+    shard_layout: &ShardLayout,
+) -> ShardId {
+    let ShardStateSyncResponseHeader::V2(header) = header else {
+        panic!("expected a V2 state sync header");
+    };
+    // Responses run newest first, so the block before `responses[i]` is `responses[i + 1]`.
+    for i in 0..header.incoming_receipts_proofs.len() - 1 {
+        let block = chain.get_block(&header.incoming_receipts_proofs[i].0).unwrap();
+        let Some(stale_index) = block.chunks().iter().position(|chunk| !chunk.is_new_chunk())
+        else {
+            continue;
+        };
+        let stale_shard_id = shard_layout.get_shard_id(stale_index).unwrap();
+        let earlier_proof_from_stale_shard = header.incoming_receipts_proofs[i + 1]
+            .1
+            .iter()
+            .find(|proof| proof.1.from_shard_id == stale_shard_id)
+            .expect("previous block has no proof from the shard whose chunk is stale")
+            .clone();
+
+        let (_, receipts_root_paths) = merklize(
+            &block
+                .chunks()
+                .iter_raw()
+                .map(|chunk| *chunk.prev_outgoing_receipts_root())
+                .collect::<Vec<CryptoHash>>(),
+        );
+        let stale_root =
+            *block.chunks().iter_raw().nth(stale_index).unwrap().prev_outgoing_receipts_root();
+
+        let proofs = Arc::make_mut(&mut header.incoming_receipts_proofs[i].1);
+        assert_ne!(proofs[0].1.from_shard_id, stale_shard_id);
+        proofs[0] = earlier_proof_from_stale_shard;
+        header.root_proofs[i][0] = RootProof(stale_root, receipts_root_paths[stale_index].clone());
+        return stale_shard_id;
+    }
+    panic!("no block in the receipt range has a shard without a new chunk");
+}
+
+#[test]
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
+fn test_set_state_header_rejects_from_shard_id_without_a_chunk() {
+    init_test_logger();
+    let mut env = TestLoopBuilder::new()
+        .validators(2, 0)
+        .num_shards(2)
+        .epoch_length(10)
+        .track_all_shards()
+        .delay_warmup()
+        .build()
+        .drop(DropCondition::ChunksProducedByHeight(HashMap::from([(
+            ShardId::new(1),
+            vec![true, true, true, false, false],
+        )])))
+        .warmup();
+
+    let sync_hash = await_sync_hash(&mut env);
+    let shard_id = ShardId::new(0);
+    let node = env.node(0);
+    let epoch_id = *node.client().chain.get_block_header(&sync_hash).unwrap().epoch_id();
+    let shard_layout = node.client().epoch_manager.get_shard_layout(&epoch_id).unwrap();
+    let genuine_header = node
+        .client()
+        .chain
+        .state_sync_adapter
+        .compute_state_response_header(shard_id, sync_hash)
+        .unwrap();
+
+    let mut tampered_header = genuine_header.clone();
+    let stale_shard_id = point_proof_at_shard_without_a_chunk(
+        &node.client().chain,
+        &mut tampered_header,
+        &shard_layout,
+    );
+
+    let victim = &env.node(1).client().chain.state_sync_adapter;
+    victim.set_state_header(shard_id, sync_hash, genuine_header).unwrap();
+
+    let rejection = victim.set_state_header(shard_id, sync_hash, tampered_header).unwrap_err();
+    assert!(
+        rejection.to_string().contains("invalid proofs"),
+        "planted a proof from shard {stale_shard_id}, unexpected rejection: {rejection:?}"
+    );
+}


### PR DESCRIPTION
`ShardProof::from_shard_id` is covered by no merkle root, and `set_state_header` checked only that the labels within one block's receipt proofs are distinct (check 4d). A label-only permutation leaves the receipts, the paths, and the roots untouched, so it passes every merkle check.

The label is then used as an index. `compute_state_response_header` re-derives a chunk index from the stored `from_shard_id` and reads `block.chunks()` and the merklized outgoing receipt roots at that position, guarded by plain `assert!`.

Changes:

- Check 4f now uses `verify_path_with_index`, which also verifies that the merkle path's shape matches the leaf index `from_shard_id` names. A path's direction sequence determines its leaf index uniquely, so this ties the label to the chunk whose outgoing receipt root the proof verifies against. It also rejects an out-of-range `from_shard_id` under V0/V1 layouts, where `ShardLayout::get_shard_index` returns the raw shard id with no membership test.
- Check 4f also requires that index to name a chunk the block included. A shard with no new chunk keeps the previous chunk header, so its leaf repeats an older root and a proof that verified against that root at an earlier height still verifies here.
- Both sides now resolve the shard index from the receipt block's own epoch layout. `block_receipts_proofs` is merklized over that block's chunks, so its leaf indices are shard indices in that block's layout, and the stored labels were written during that block's processing. The serving side previously used `prev_shard_layout`, the sync block's layout. `get_incoming_receipts_for_shard` walks receipt blocks back across epoch boundaries and handles layout changes, so across a resharding boundary the two layouts differ and the old code selected the wrong leaf.
- `compute_state_response_header` returns `Error::InvalidReceiptsProof` instead of tripping three `assert!`/`assert_eq!` calls that are live in release, and reads the chunk arrays with `get` instead of indexing. That path reads data back from the store, which is the case `byzantine_assert!` exists for.

No consensus effect and no divergence: `collect_receipts` discards the `ShardProof`, so a permuted label does not change receipt order or apply results. It corrupts an index, not the data the index reaches.

The equivalent index check already exists on the chunk path (`chain/chunks/src/shards_manager_actor.rs:1292`), in chunk state witness validation (`chain/chain/src/stateless_validation/chunk_validation.rs:540`), and in the spice data path (`chain/client/src/spice/data_manager/item.rs:180`). State sync ingest was the remaining gap.