### PR TITLE
fix(test): update sharded contract cargo.lock

### DIFF
--- a/runtime/near-test-contracts/sharded-contract/Cargo.lock
+++ b/runtime/near-test-contracts/sharded-contract/Cargo.lock
@@ -395,9 +395,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "near-account-id"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7d8c37ea9408d536af7e998bd0d4f9699de1f6b0d12280d28ae46977c4501"
+checksum = "7d2c8642aeca89873dbcf2a2f74ff90cd87f6691f11b66aeed2af7c136192d10"
 dependencies = [
  "borsh",
  "serde",


### PR DESCRIPTION
`near-test-contracts/sharded-contract` imports `near-account-id` via `near-primitives-core`, which uses the workspace version (3.0.0).
This means that this crate is meant to be using the `3.0.0` version of `near-account-id`

The `near-test-contracts/sharded-contract/Cargo.lock` still has `2.0.0`, building this crate automatically updates it to `3.0.0`.

Let's change the value in `Cargo.lock` to match the version from `Cargo.toml`.

Steps to reproduce this PR:
```
cd runtime/near-test-contracts/sharded-contract/
cargo build
```