### PR TITLE
feat(database): dry run the light client block migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Raised the minimum supported Rust version to 1.95.0. Building `nearcore` from source now requires a Rust 1.95.0 toolchain.
 * `tools/debug-ui` now builds with Vite instead of the unmaintained Create React App (`react-scripts`). Build output layout and the port 3000 dev server are unchanged, so deployment needs no change. Building now requires Node `^20.19.0 || >=22.12.0`. ([#16175](https://github.com/near/nearcore/pull/16175))
 * Stabilized `EXPERIMENTAL_tx_status` and renamed it to `tx_status`. `EXPERIMENTAL_tx_status` keeps working as a deprecated alias, with the same request and response types. **Metrics change:** the `near_rpc_wait_until_count` metric now labels `tx`, `tx_status` and `EXPERIMENTAL_tx_status` separately; previously both `tx` and `EXPERIMENTAL_tx_status` were counted under the `tx_status` label. ([#16270](https://github.com/near/nearcore/pull/16270))
+* `DBCol::EpochLightClientBlocks` now holds a versioned `StoredLightClientBlock` instead of the `LightClientBlockView` RPC type, which raises `DB_VERSION` from 50 to 51. A node started read-write migrates its hot database in place on startup, rewriting one row per epoch; the column holds a few thousand rows in total. The column is never garbage collected, so its rows were written by binaries going back to 2020 and appear in several borsh layouts; the migration reads each of them and rewrites it as the versioned type. A row that no layout reads stops the migration and names its epoch id rather than being guessed at. ([#16394](https://github.com/near/nearcore/pull/16394))
 
 ## [2.13.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,6 +4214,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rocksdb",
+ "serde_json",
  "strum",
  "tempfile",
  "zstd",

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -173,7 +173,7 @@ fn recover_shard_1_at_block_height_115185108(
 /// column held a bare `LightClientBlockView`.
 ///
 /// `InnerLite` and `ValidatorStake` vary because the view changed shape several times
-/// inside version 50. [`LightClientRowLayout`] names each shape.
+/// inside version 50. [`LightClientRowLayout`] names the shapes a stored row can be in.
 #[derive(BorshSerialize, BorshDeserialize)]
 struct UnversionedRow<InnerLite, ValidatorStake> {
     prev_block_hash: CryptoHash,
@@ -248,7 +248,6 @@ impl From<InnerLiteWithRoot> for StoredBlockHeaderInnerLiteV1 {
     }
 }
 
-/// Lifts the validator stake shape a row was written with into the current view.
 trait IntoValidatorStakeView {
     fn into_validator_stake_view(self) -> ValidatorStakeView;
 }
@@ -259,8 +258,7 @@ impl IntoValidatorStakeView for ValidatorStakeView {
     }
 }
 
-/// #4179 wrapped `ValidatorStakeView` in an enum. Before it, the bare struct that is
-/// now the `V1` payload was written on its own, with no discriminant byte.
+/// Before #4179 the struct now used as the `V1` payload was written with no discriminant byte.
 impl IntoValidatorStakeView for ValidatorStakeViewV1 {
     fn into_validator_stake_view(self) -> ValidatorStakeView {
         ValidatorStakeView::V1(self)
@@ -269,8 +267,8 @@ impl IntoValidatorStakeView for ValidatorStakeViewV1 {
 
 /// The shape a `DBCol::EpochLightClientBlocks` row was written with.
 ///
-/// The column holds one permanent row per epoch, so a database that has run since 2020
-/// holds rows from every era below.
+/// The column holds one permanent row per epoch and is never rewritten, so a long-lived
+/// database holds rows from every era below.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum LightClientRowLayout {
     /// 2020-07-06 (#2929) to 2021-04-01 (#4179): `ValidatorStakeView` was a bare struct.
@@ -314,24 +312,13 @@ where
     Some(row.into_stored())
 }
 
-/// What [`read_light_client_row`] made of a row.
-#[derive(Debug)]
-enum LightClientRowReading {
-    /// Every layout that reads the row agrees on the value.
-    Agreed { layouts: Vec<LightClientRowLayout>, stored: Box<StoredLightClientBlock> },
-    /// Several layouts read the row and disagree on the value, so it cannot be converted.
-    Ambiguous(Vec<(LightClientRowLayout, StoredLightClientBlock)>),
-    /// No layout reads the row.
-    Unknown,
-}
-
-/// Reads a `DBCol::EpochLightClientBlocks` row in every layout that ever wrote one.
+/// Reads a `DBCol::EpochLightClientBlocks` row in the layout it was written in.
 ///
-/// Borsh rejects trailing bytes, so a row reads in one layout, or in several that all
-/// yield the same value. A row with no validators, for one, reads the same whether or
-/// not `ValidatorStakeView` was versioned when it was written.
-fn read_light_client_row(value: &[u8]) -> LightClientRowReading {
-    let readings: Vec<_> = [
+/// Borsh rejects trailing and missing bytes, so at most one layout reads a stored row
+/// whole. Only a row with no validators reads in two, and both yield the same value, so
+/// the layouts are tried oldest first.
+fn read_light_client_row(value: &[u8]) -> Option<(LightClientRowLayout, StoredLightClientBlock)> {
+    let candidates = [
         (
             LightClientRowLayout::WithUnversionedValidatorStake,
             read_unversioned_row::<InnerLiteWithoutRoot, ValidatorStakeViewV1>(value),
@@ -345,18 +332,8 @@ fn read_light_client_row(value: &[u8]) -> LightClientRowReading {
             read_unversioned_row::<InnerLiteWithRoot, ValidatorStakeView>(value),
         ),
         (LightClientRowLayout::Versioned, StoredLightClientBlock::try_from_slice(value).ok()),
-    ]
-    .into_iter()
-    .filter_map(|(layout, stored)| stored.map(|stored| (layout, stored)))
-    .collect();
-
-    let Some((_, first)) = readings.first() else { return LightClientRowReading::Unknown };
-    if readings.iter().any(|(_, stored)| stored != first) {
-        return LightClientRowReading::Ambiguous(readings);
-    }
-    let layouts = readings.iter().map(|(layout, _)| *layout).collect();
-    let stored = readings.into_iter().next().expect("readings is not empty").1;
-    LightClientRowReading::Agreed { layouts, stored: Box::new(stored) }
+    ];
+    candidates.into_iter().find_map(|(layout, stored)| Some((layout, stored?)))
 }
 
 /// Migrates the database from version 50 to 51.
@@ -369,9 +346,9 @@ fn read_light_client_row(value: &[u8]) -> LightClientRowReading {
 /// This rewrites every row as [`StoredLightClientBlock`], which core/store owns and
 /// versions, so a later change to the view adds a variant instead of a migration.
 ///
-/// The view changed shape several times before that too, so a row can predate the
-/// layout released binaries write. [`read_light_client_row`] reads every historical
-/// layout, and the rows it cannot read are reported rather than guessed at.
+/// The view also changed shape before that, so a row can predate the layout released
+/// binaries write. [`LightClientRowLayout`] lists the layouts a row can still be in,
+/// and a row in none of them is reported by its epoch id rather than guessed at.
 ///
 /// Hot store only: the column is not copied to cold storage.
 fn migrate_50_to_51(hot_store: &Store) -> anyhow::Result<()> {
@@ -387,23 +364,13 @@ fn migrate_50_to_51(hot_store: &Store) -> anyhow::Result<()> {
             .map_err(|err| anyhow::anyhow!("epoch light client block key is not a hash: {err}"))?;
 
         match read_light_client_row(&value) {
-            LightClientRowReading::Agreed { layouts, .. }
-                if layouts == [LightClientRowLayout::Versioned] =>
-            {
-                already_versioned += 1;
-            }
-            LightClientRowReading::Agreed { stored, .. } => {
-                store_update.set_ser(DBCol::EpochLightClientBlocks, &key, stored.as_ref());
+            Some((LightClientRowLayout::Versioned, _)) => already_versioned += 1,
+            Some((_, stored)) => {
+                store_update.set_ser(DBCol::EpochLightClientBlocks, &key, &stored);
                 rewritten += 1;
             }
-            LightClientRowReading::Ambiguous(readings) => {
-                let layouts: Vec<_> = readings.iter().map(|(layout, _)| *layout).collect();
-                anyhow::bail!(
-                    "epoch light client block {epoch_id:?} reads differently in {layouts:?}"
-                );
-            }
-            LightClientRowReading::Unknown => {
-                anyhow::bail!("epoch light client block {epoch_id:?} reads in no known layout");
+            None => {
+                anyhow::bail!("epoch light client block {epoch_id:?} reads in no known layout")
             }
         }
     }
@@ -918,9 +885,7 @@ mod migrate_50_to_51_tests {
     }
 
     #[test]
-    fn accepts_a_row_that_reads_the_same_in_several_layouts() {
-        // With no validators the bytes carry no `ValidatorStakeView`, so the versioned
-        // and unversioned stake layouts read the row identically.
+    fn rewrites_a_row_with_no_validators() {
         let store = create_test_store();
         let key = CryptoHash::default();
         let value = unversioned_row(inner_lite_without_root(), None::<Vec<ValidatorStakeView>>, 0);

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -270,7 +270,7 @@ impl IntoValidatorStakeView for ValidatorStakeViewV1 {
 /// The column holds one permanent row per epoch and is never rewritten, so a long-lived
 /// database holds rows from every era below.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum LightClientRowLayout {
+pub enum LightClientRowLayout {
     /// 2020-07-06 (#2929) to 2021-04-01 (#4179): `ValidatorStakeView` was a bare struct.
     WithUnversionedValidatorStake,
     /// 2021-04-01 (#4179) onwards: the layout every released binary writes.
@@ -318,7 +318,7 @@ where
 /// whole. Only a row with no validators reads in two, and both yield the same value, so
 /// the layouts are tried oldest first. A row that no layout reads, or that two layouts
 /// read differently, is one no binary wrote, and is reported by its epoch id.
-fn read_light_client_row(
+pub fn read_light_client_row(
     epoch_id: &EpochId,
     value: &[u8],
 ) -> anyhow::Result<(LightClientRowLayout, StoredLightClientBlock)> {

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -10,7 +10,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::DelayedReceiptIndices;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{BlockHeight, BlockHeightDelta, EpochId, ShardId, StateChangeCause};
-use near_primitives::views::validator_stake_view::ValidatorStakeView;
+use near_primitives::views::validator_stake_view::{ValidatorStakeView, ValidatorStakeViewV1};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::trie_store::TrieStoreUpdateAdapter;
 use near_store::archive::cold_storage::{join_two_keys, rc_aware_set};
@@ -172,17 +172,41 @@ fn recover_shard_1_at_block_height_115185108(
 /// A `DBCol::EpochLightClientBlocks` row as written at database version 50, when the
 /// column held a bare `LightClientBlockView`.
 ///
-/// `InnerLite` varies because the view changed shape inside version 50: released
-/// binaries wrote [`InnerLiteWithoutRoot`], and unreleased ones that carried
-/// `chunk_execution_root` wrote [`InnerLiteWithRoot`].
+/// `InnerLite` and `ValidatorStake` vary because the view changed shape several times
+/// inside version 50. [`LightClientRowLayout`] names each shape.
 #[derive(BorshSerialize, BorshDeserialize)]
-struct UnversionedRow<InnerLite> {
+struct UnversionedRow<InnerLite, ValidatorStake> {
     prev_block_hash: CryptoHash,
     next_block_inner_hash: CryptoHash,
     inner_lite: InnerLite,
     inner_rest_hash: CryptoHash,
-    next_bps: Option<Vec<ValidatorStakeView>>,
+    next_bps: Option<Vec<ValidatorStake>>,
     approvals_after_next: Vec<Option<Box<Signature>>>,
+}
+
+/// The same row while the view still carried `approvals_next`, which #2653 removed.
+#[derive(BorshSerialize, BorshDeserialize)]
+struct UnversionedRowWithApprovalsNext<InnerLite, ValidatorStake> {
+    prev_block_hash: CryptoHash,
+    next_block_inner_hash: CryptoHash,
+    inner_lite: InnerLite,
+    inner_rest_hash: CryptoHash,
+    next_bps: Option<Vec<ValidatorStake>>,
+    approvals_next: Vec<Option<Box<Signature>>>,
+    approvals_after_next: Vec<Option<Box<Signature>>>,
+}
+
+/// `BlockHeaderInnerLiteView` before #2929 added `timestamp_nanosec` to it.
+#[derive(BorshSerialize, BorshDeserialize)]
+struct InnerLiteWithoutTimestampNanosec {
+    height: BlockHeight,
+    epoch_id: CryptoHash,
+    next_epoch_id: CryptoHash,
+    prev_state_root: CryptoHash,
+    outcome_root: CryptoHash,
+    timestamp: u64,
+    next_bp_hash: CryptoHash,
+    block_merkle_root: CryptoHash,
 }
 
 /// `BlockHeaderInnerLiteView` as every released binary wrote it.
@@ -213,6 +237,24 @@ struct InnerLiteWithRoot {
     next_bp_hash: CryptoHash,
     block_merkle_root: CryptoHash,
     chunk_execution_root: Option<CryptoHash>,
+}
+
+impl From<InnerLiteWithoutTimestampNanosec> for StoredBlockHeaderInnerLiteV1 {
+    fn from(inner_lite: InnerLiteWithoutTimestampNanosec) -> Self {
+        Self {
+            height: inner_lite.height,
+            epoch_id: inner_lite.epoch_id,
+            next_epoch_id: inner_lite.next_epoch_id,
+            prev_state_root: inner_lite.prev_state_root,
+            outcome_root: inner_lite.outcome_root,
+            timestamp: inner_lite.timestamp,
+            // #2929 added the second field and filled it from the same header value.
+            timestamp_nanosec: inner_lite.timestamp,
+            next_bp_hash: inner_lite.next_bp_hash,
+            block_merkle_root: inner_lite.block_merkle_root,
+            chunk_execution_root: None,
+        }
+    }
 }
 
 impl From<InnerLiteWithoutRoot> for StoredBlockHeaderInnerLiteV1 {
@@ -249,21 +291,155 @@ impl From<InnerLiteWithRoot> for StoredBlockHeaderInnerLiteV1 {
     }
 }
 
-/// Parses `value` as an unversioned row, if it is one, and converts it.
-fn read_unversioned_row<InnerLite>(value: &[u8]) -> Option<StoredLightClientBlock>
+/// Lifts the validator stake shape a row was written with into the current view.
+trait IntoValidatorStakeView {
+    fn into_validator_stake_view(self) -> ValidatorStakeView;
+}
+
+impl IntoValidatorStakeView for ValidatorStakeView {
+    fn into_validator_stake_view(self) -> ValidatorStakeView {
+        self
+    }
+}
+
+/// #4179 wrapped `ValidatorStakeView` in an enum. Before it, the bare struct that is
+/// now the `V1` payload was written on its own, with no discriminant byte.
+impl IntoValidatorStakeView for ValidatorStakeViewV1 {
+    fn into_validator_stake_view(self) -> ValidatorStakeView {
+        ValidatorStakeView::V1(self)
+    }
+}
+
+/// The shape a `DBCol::EpochLightClientBlocks` row was written with.
+///
+/// The column holds one permanent row per epoch, so a database that has run since 2020
+/// holds rows from every era below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LightClientRowLayout {
+    /// 2020-04-26 (#2390) to 2020-05-19 (#2653): the view carried `approvals_next` and
+    /// `inner_lite` had no `timestamp_nanosec`.
+    WithApprovalsNext,
+    /// 2020-05-19 (#2653) to 2020-07-06 (#2929): `inner_lite` had no `timestamp_nanosec`.
+    WithoutTimestampNanosec,
+    /// 2020-07-06 (#2929) to 2021-04-01 (#4179): `ValidatorStakeView` was a bare struct.
+    WithUnversionedValidatorStake,
+    /// 2021-04-01 (#4179) onwards: the layout every released binary writes.
+    Released,
+    /// After #16115 appended `chunk_execution_root`: unreleased binaries only.
+    WithChunkExecutionRoot,
+    /// A [`StoredLightClientBlock`], written by this migration.
+    Versioned,
+}
+
+impl std::fmt::Display for LightClientRowLayout {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl<InnerLite, ValidatorStake> UnversionedRow<InnerLite, ValidatorStake>
 where
-    InnerLite: BorshDeserialize,
+    ValidatorStake: IntoValidatorStakeView,
     StoredBlockHeaderInnerLiteV1: From<InnerLite>,
 {
-    let row = UnversionedRow::<InnerLite>::try_from_slice(value).ok()?;
-    Some(StoredLightClientBlock::V1(StoredLightClientBlockV1 {
-        prev_block_hash: row.prev_block_hash,
-        next_block_inner_hash: row.next_block_inner_hash,
-        inner_lite: row.inner_lite.into(),
-        inner_rest_hash: row.inner_rest_hash,
-        next_bps: row.next_bps,
-        approvals_after_next: row.approvals_after_next,
-    }))
+    fn into_stored(self) -> StoredLightClientBlock {
+        let next_bps = self.next_bps.map(|next_bps| {
+            next_bps.into_iter().map(IntoValidatorStakeView::into_validator_stake_view).collect()
+        });
+        StoredLightClientBlock::V1(StoredLightClientBlockV1 {
+            prev_block_hash: self.prev_block_hash,
+            next_block_inner_hash: self.next_block_inner_hash,
+            inner_lite: self.inner_lite.into(),
+            inner_rest_hash: self.inner_rest_hash,
+            next_bps,
+            approvals_after_next: self.approvals_after_next,
+        })
+    }
+}
+
+impl<InnerLite, ValidatorStake> UnversionedRowWithApprovalsNext<InnerLite, ValidatorStake> {
+    /// Drops `approvals_next`, which the view no longer carries.
+    fn without_approvals_next(self) -> UnversionedRow<InnerLite, ValidatorStake> {
+        UnversionedRow {
+            prev_block_hash: self.prev_block_hash,
+            next_block_inner_hash: self.next_block_inner_hash,
+            inner_lite: self.inner_lite,
+            inner_rest_hash: self.inner_rest_hash,
+            next_bps: self.next_bps,
+            approvals_after_next: self.approvals_after_next,
+        }
+    }
+}
+
+/// Parses `value` as an unversioned row, if it is one, and converts it.
+fn read_unversioned_row<InnerLite, ValidatorStake>(value: &[u8]) -> Option<StoredLightClientBlock>
+where
+    InnerLite: BorshDeserialize,
+    ValidatorStake: BorshDeserialize + IntoValidatorStakeView,
+    StoredBlockHeaderInnerLiteV1: From<InnerLite>,
+{
+    let row = UnversionedRow::<InnerLite, ValidatorStake>::try_from_slice(value).ok()?;
+    Some(row.into_stored())
+}
+
+/// Parses `value` as a row from before #2653, if it is one, and converts it.
+fn read_row_with_approvals_next(value: &[u8]) -> Option<StoredLightClientBlock> {
+    let row = UnversionedRowWithApprovalsNext::<
+        InnerLiteWithoutTimestampNanosec,
+        ValidatorStakeViewV1,
+    >::try_from_slice(value)
+    .ok()?;
+    Some(row.without_approvals_next().into_stored())
+}
+
+/// What [`read_light_client_row`] made of a row.
+#[derive(Debug)]
+pub enum LightClientRowReading {
+    /// Every layout that reads the row agrees on the value.
+    Agreed { layouts: Vec<LightClientRowLayout>, stored: Box<StoredLightClientBlock> },
+    /// Several layouts read the row and disagree on the value, so it cannot be converted.
+    Ambiguous(Vec<(LightClientRowLayout, StoredLightClientBlock)>),
+    /// No layout reads the row.
+    Unknown,
+}
+
+/// Reads a `DBCol::EpochLightClientBlocks` row in every layout that ever wrote one.
+///
+/// Borsh rejects trailing bytes, so a row reads in one layout, or in several that all
+/// yield the same value. A row with no validators, for one, reads the same whether or
+/// not `ValidatorStakeView` was versioned when it was written.
+pub fn read_light_client_row(value: &[u8]) -> LightClientRowReading {
+    let readings: Vec<_> = [
+        (LightClientRowLayout::WithApprovalsNext, read_row_with_approvals_next(value)),
+        (
+            LightClientRowLayout::WithoutTimestampNanosec,
+            read_unversioned_row::<InnerLiteWithoutTimestampNanosec, ValidatorStakeViewV1>(value),
+        ),
+        (
+            LightClientRowLayout::WithUnversionedValidatorStake,
+            read_unversioned_row::<InnerLiteWithoutRoot, ValidatorStakeViewV1>(value),
+        ),
+        (
+            LightClientRowLayout::Released,
+            read_unversioned_row::<InnerLiteWithoutRoot, ValidatorStakeView>(value),
+        ),
+        (
+            LightClientRowLayout::WithChunkExecutionRoot,
+            read_unversioned_row::<InnerLiteWithRoot, ValidatorStakeView>(value),
+        ),
+        (LightClientRowLayout::Versioned, StoredLightClientBlock::try_from_slice(value).ok()),
+    ]
+    .into_iter()
+    .filter_map(|(layout, stored)| stored.map(|stored| (layout, stored)))
+    .collect();
+
+    let Some((_, first)) = readings.first() else { return LightClientRowReading::Unknown };
+    if readings.iter().any(|(_, stored)| stored != first) {
+        return LightClientRowReading::Ambiguous(readings);
+    }
+    let layouts = readings.iter().map(|(layout, _)| *layout).collect();
+    let stored = readings.into_iter().next().expect("readings is not empty").1;
+    LightClientRowReading::Agreed { layouts, stored: Box::new(stored) }
 }
 
 /// Migrates the database from version 50 to 51.
@@ -275,6 +451,10 @@ where
 ///
 /// This rewrites every row as [`StoredLightClientBlock`], which core/store owns and
 /// versions, so a later change to the view adds a variant instead of a migration.
+///
+/// The view changed shape several times before that too, so a row can predate the
+/// layout released binaries write. [`read_light_client_row`] reads every historical
+/// layout, and the rows it cannot read are reported rather than guessed at.
 ///
 /// Hot store only: the column is not copied to cold storage.
 fn migrate_50_to_51(hot_store: &Store) -> anyhow::Result<()> {
@@ -289,26 +469,25 @@ fn migrate_50_to_51(hot_store: &Store) -> anyhow::Result<()> {
             .map(EpochId)
             .map_err(|err| anyhow::anyhow!("epoch light client block key is not a hash: {err}"))?;
 
-        // A row is unambiguous only if exactly one layout reads it whole. Borsh rejects
-        // trailing bytes, so a wrong layout almost always fails, but say so rather than
-        // guess on the rows where it would not.
-        let candidates = [
-            read_unversioned_row::<InnerLiteWithoutRoot>(&value),
-            read_unversioned_row::<InnerLiteWithRoot>(&value),
-            StoredLightClientBlock::try_from_slice(&value).ok(),
-        ];
-        let matched = candidates.iter().filter(|candidate| candidate.is_some()).count();
-        if matched > 1 {
-            anyhow::bail!("epoch light client block {epoch_id:?} reads in more than one layout");
-        }
-        let [without_root, with_root, versioned] = candidates;
-        if let Some(stored) = without_root.or(with_root) {
-            store_update.set_ser(DBCol::EpochLightClientBlocks, &key, &stored);
-            rewritten += 1;
-        } else if versioned.is_some() {
-            already_versioned += 1;
-        } else {
-            anyhow::bail!("epoch light client block {epoch_id:?} reads in no known layout");
+        match read_light_client_row(&value) {
+            LightClientRowReading::Agreed { layouts, .. }
+                if layouts == [LightClientRowLayout::Versioned] =>
+            {
+                already_versioned += 1;
+            }
+            LightClientRowReading::Agreed { stored, .. } => {
+                store_update.set_ser(DBCol::EpochLightClientBlocks, &key, stored.as_ref());
+                rewritten += 1;
+            }
+            LightClientRowReading::Ambiguous(readings) => {
+                let layouts: Vec<_> = readings.iter().map(|(layout, _)| *layout).collect();
+                anyhow::bail!(
+                    "epoch light client block {epoch_id:?} reads differently in {layouts:?}"
+                );
+            }
+            LightClientRowReading::Unknown => {
+                anyhow::bail!("epoch light client block {epoch_id:?} reads in no known layout");
+            }
         }
     }
     store_update.commit();
@@ -649,9 +828,15 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod migrate_50_to_51_tests {
-    use super::{InnerLiteWithRoot, InnerLiteWithoutRoot, UnversionedRow, migrate_50_to_51};
+    use super::{
+        InnerLiteWithRoot, InnerLiteWithoutRoot, InnerLiteWithoutTimestampNanosec, UnversionedRow,
+        UnversionedRowWithApprovalsNext, migrate_50_to_51,
+    };
     use borsh::BorshDeserialize;
+    use near_crypto::{KeyType, PublicKey};
     use near_primitives::hash::CryptoHash;
+    use near_primitives::types::Balance;
+    use near_primitives::views::validator_stake_view::{ValidatorStakeView, ValidatorStakeViewV1};
     use near_store::light_client_block::StoredLightClientBlock;
     use near_store::test_utils::create_test_store;
     use near_store::{DBCol, Store};
@@ -663,10 +848,24 @@ mod migrate_50_to_51_tests {
             next_epoch_id: CryptoHash::hash_bytes(b"next_epoch"),
             prev_state_root: CryptoHash::hash_bytes(b"state"),
             outcome_root: CryptoHash::hash_bytes(b"outcome"),
-            timestamp: 1,
-            timestamp_nanosec: 1,
+            timestamp: 7,
+            timestamp_nanosec: 9,
             next_bp_hash: CryptoHash::hash_bytes(b"bp"),
             block_merkle_root: CryptoHash::hash_bytes(b"merkle"),
+        }
+    }
+
+    fn inner_lite_without_timestamp_nanosec() -> InnerLiteWithoutTimestampNanosec {
+        let with_nanosec = inner_lite_without_root();
+        InnerLiteWithoutTimestampNanosec {
+            height: with_nanosec.height,
+            epoch_id: with_nanosec.epoch_id,
+            next_epoch_id: with_nanosec.next_epoch_id,
+            prev_state_root: with_nanosec.prev_state_root,
+            outcome_root: with_nanosec.outcome_root,
+            timestamp: with_nanosec.timestamp,
+            next_bp_hash: with_nanosec.next_bp_hash,
+            block_merkle_root: with_nanosec.block_merkle_root,
         }
     }
 
@@ -686,10 +885,23 @@ mod migrate_50_to_51_tests {
         }
     }
 
-    fn unversioned_row<InnerLite: borsh::BorshSerialize>(
+    fn validator_stake_v1(account_id: &str) -> ValidatorStakeViewV1 {
+        ValidatorStakeViewV1 {
+            account_id: account_id.parse().unwrap(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            stake: Balance::from_near(100),
+        }
+    }
+
+    fn unversioned_row<InnerLite, ValidatorStake>(
         inner_lite: InnerLite,
+        next_bps: Option<Vec<ValidatorStake>>,
         seed: u32,
-    ) -> Vec<u8> {
+    ) -> Vec<u8>
+    where
+        InnerLite: borsh::BorshSerialize,
+        ValidatorStake: borsh::BorshSerialize,
+    {
         borsh::to_vec(&UnversionedRow {
             prev_block_hash: CryptoHash::hash_bytes(b"prev"),
             next_block_inner_hash: CryptoHash::hash_bytes(b"next"),
@@ -697,10 +909,18 @@ mod migrate_50_to_51_tests {
             // The byte that a reader of the other layout would misread comes from
             // here, so vary it across rows.
             inner_rest_hash: CryptoHash::hash_bytes(&seed.to_le_bytes()),
-            next_bps: None,
+            next_bps,
             approvals_after_next: vec![None, None],
         })
         .unwrap()
+    }
+
+    fn released_row<InnerLite: borsh::BorshSerialize>(inner_lite: InnerLite, seed: u32) -> Vec<u8> {
+        unversioned_row(
+            inner_lite,
+            Some(vec![ValidatorStakeView::V1(validator_stake_v1("validator0"))]),
+            seed,
+        )
     }
 
     fn write_row(store: &Store, key: &CryptoHash, value: &[u8]) {
@@ -721,7 +941,7 @@ mod migrate_50_to_51_tests {
     fn rewrites_rows_written_by_a_released_binary() {
         let store = create_test_store();
         for seed in 0u32..2000 {
-            write_row(&store, &key_for(seed), &unversioned_row(inner_lite_without_root(), seed));
+            write_row(&store, &key_for(seed), &released_row(inner_lite_without_root(), seed));
         }
 
         // The row a released binary wrote is not readable as the versioned type. That
@@ -746,7 +966,7 @@ mod migrate_50_to_51_tests {
         let root = CryptoHash::hash_bytes(b"root");
         for (seed, chunk_execution_root) in [(0u32, None), (1, Some(root))] {
             let inner_lite = inner_lite_with_root(chunk_execution_root);
-            write_row(&store, &key_for(seed), &unversioned_row(inner_lite, seed));
+            write_row(&store, &key_for(seed), &released_row(inner_lite, seed));
         }
 
         migrate_50_to_51(&store).unwrap();
@@ -761,7 +981,7 @@ mod migrate_50_to_51_tests {
     fn leaves_rows_already_versioned_alone() {
         let store = create_test_store();
         let key = key_for(0);
-        write_row(&store, &key, &unversioned_row(inner_lite_without_root(), 0));
+        write_row(&store, &key, &released_row(inner_lite_without_root(), 0));
         migrate_50_to_51(&store).unwrap();
         let migrated = read_row(&store, &key);
 
@@ -775,6 +995,82 @@ mod migrate_50_to_51_tests {
         write_row(&store, &key_for(0), b"not a light client block");
         let err = migrate_50_to_51(&store).unwrap_err().to_string();
         assert!(err.contains("reads in no known layout"), "got: {err}");
+    }
+
+    #[test]
+    fn rewrites_rows_with_an_unversioned_validator_stake() {
+        let store = create_test_store();
+        let key = CryptoHash::default();
+        let value = unversioned_row(
+            inner_lite_without_root(),
+            Some(vec![validator_stake_v1("validator0")]),
+            0,
+        );
+        write_row(&store, &key, &value);
+
+        migrate_50_to_51(&store).unwrap();
+
+        let StoredLightClientBlock::V1(row) = read_row(&store, &key);
+        assert_eq!(row.inner_lite.height, 42);
+        assert_eq!(row.inner_lite.chunk_execution_root, None);
+        let next_bps = row.next_bps.unwrap();
+        assert_eq!(next_bps, vec![ValidatorStakeView::V1(validator_stake_v1("validator0"))]);
+    }
+
+    #[test]
+    fn rewrites_rows_without_a_timestamp_nanosec() {
+        let store = create_test_store();
+        let key = CryptoHash::default();
+        let value = unversioned_row(
+            inner_lite_without_timestamp_nanosec(),
+            Some(vec![validator_stake_v1("validator0")]),
+            0,
+        );
+        write_row(&store, &key, &value);
+
+        migrate_50_to_51(&store).unwrap();
+
+        let StoredLightClientBlock::V1(row) = read_row(&store, &key);
+        assert_eq!(row.inner_lite.timestamp, 7);
+        assert_eq!(row.inner_lite.timestamp_nanosec, 7);
+    }
+
+    #[test]
+    fn rewrites_rows_with_approvals_next() {
+        let store = create_test_store();
+        let key = CryptoHash::default();
+        let value = borsh::to_vec(&UnversionedRowWithApprovalsNext {
+            prev_block_hash: CryptoHash::hash_bytes(b"prev"),
+            next_block_inner_hash: CryptoHash::hash_bytes(b"next"),
+            inner_lite: inner_lite_without_timestamp_nanosec(),
+            inner_rest_hash: CryptoHash::hash_bytes(b"rest"),
+            next_bps: Some(vec![validator_stake_v1("validator0")]),
+            approvals_next: vec![None, None, None],
+            approvals_after_next: vec![None, None],
+        })
+        .unwrap();
+        write_row(&store, &key, &value);
+
+        migrate_50_to_51(&store).unwrap();
+
+        let StoredLightClientBlock::V1(row) = read_row(&store, &key);
+        assert_eq!(row.approvals_after_next.len(), 2);
+        assert_eq!(row.inner_lite.timestamp_nanosec, 7);
+    }
+
+    #[test]
+    fn accepts_a_row_that_reads_the_same_in_several_layouts() {
+        // With no validators the bytes carry no `ValidatorStakeView`, so the versioned
+        // and unversioned stake layouts read the row identically.
+        let store = create_test_store();
+        let key = CryptoHash::default();
+        let value = unversioned_row(inner_lite_without_root(), None::<Vec<ValidatorStakeView>>, 0);
+        write_row(&store, &key, &value);
+
+        migrate_50_to_51(&store).unwrap();
+
+        let StoredLightClientBlock::V1(row) = read_row(&store, &key);
+        assert_eq!(row.next_bps, None);
     }
 
     #[test]

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -184,31 +184,6 @@ struct UnversionedRow<InnerLite, ValidatorStake> {
     approvals_after_next: Vec<Option<Box<Signature>>>,
 }
 
-/// The same row while the view still carried `approvals_next`, which #2653 removed.
-#[derive(BorshSerialize, BorshDeserialize)]
-struct UnversionedRowWithApprovalsNext<InnerLite, ValidatorStake> {
-    prev_block_hash: CryptoHash,
-    next_block_inner_hash: CryptoHash,
-    inner_lite: InnerLite,
-    inner_rest_hash: CryptoHash,
-    next_bps: Option<Vec<ValidatorStake>>,
-    approvals_next: Vec<Option<Box<Signature>>>,
-    approvals_after_next: Vec<Option<Box<Signature>>>,
-}
-
-/// `BlockHeaderInnerLiteView` before #2929 added `timestamp_nanosec` to it.
-#[derive(BorshSerialize, BorshDeserialize)]
-struct InnerLiteWithoutTimestampNanosec {
-    height: BlockHeight,
-    epoch_id: CryptoHash,
-    next_epoch_id: CryptoHash,
-    prev_state_root: CryptoHash,
-    outcome_root: CryptoHash,
-    timestamp: u64,
-    next_bp_hash: CryptoHash,
-    block_merkle_root: CryptoHash,
-}
-
 /// `BlockHeaderInnerLiteView` as every released binary wrote it.
 #[derive(BorshSerialize, BorshDeserialize)]
 struct InnerLiteWithoutRoot {
@@ -237,24 +212,6 @@ struct InnerLiteWithRoot {
     next_bp_hash: CryptoHash,
     block_merkle_root: CryptoHash,
     chunk_execution_root: Option<CryptoHash>,
-}
-
-impl From<InnerLiteWithoutTimestampNanosec> for StoredBlockHeaderInnerLiteV1 {
-    fn from(inner_lite: InnerLiteWithoutTimestampNanosec) -> Self {
-        Self {
-            height: inner_lite.height,
-            epoch_id: inner_lite.epoch_id,
-            next_epoch_id: inner_lite.next_epoch_id,
-            prev_state_root: inner_lite.prev_state_root,
-            outcome_root: inner_lite.outcome_root,
-            timestamp: inner_lite.timestamp,
-            // #2929 added the second field and filled it from the same header value.
-            timestamp_nanosec: inner_lite.timestamp,
-            next_bp_hash: inner_lite.next_bp_hash,
-            block_merkle_root: inner_lite.block_merkle_root,
-            chunk_execution_root: None,
-        }
-    }
 }
 
 impl From<InnerLiteWithoutRoot> for StoredBlockHeaderInnerLiteV1 {
@@ -315,12 +272,7 @@ impl IntoValidatorStakeView for ValidatorStakeViewV1 {
 /// The column holds one permanent row per epoch, so a database that has run since 2020
 /// holds rows from every era below.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum LightClientRowLayout {
-    /// 2020-04-26 (#2390) to 2020-05-19 (#2653): the view carried `approvals_next` and
-    /// `inner_lite` had no `timestamp_nanosec`.
-    WithApprovalsNext,
-    /// 2020-05-19 (#2653) to 2020-07-06 (#2929): `inner_lite` had no `timestamp_nanosec`.
-    WithoutTimestampNanosec,
+enum LightClientRowLayout {
     /// 2020-07-06 (#2929) to 2021-04-01 (#4179): `ValidatorStakeView` was a bare struct.
     WithUnversionedValidatorStake,
     /// 2021-04-01 (#4179) onwards: the layout every released binary writes.
@@ -329,12 +281,6 @@ pub enum LightClientRowLayout {
     WithChunkExecutionRoot,
     /// A [`StoredLightClientBlock`], written by this migration.
     Versioned,
-}
-
-impl std::fmt::Display for LightClientRowLayout {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "{self:?}")
-    }
 }
 
 impl<InnerLite, ValidatorStake> UnversionedRow<InnerLite, ValidatorStake>
@@ -357,20 +303,6 @@ where
     }
 }
 
-impl<InnerLite, ValidatorStake> UnversionedRowWithApprovalsNext<InnerLite, ValidatorStake> {
-    /// Drops `approvals_next`, which the view no longer carries.
-    fn without_approvals_next(self) -> UnversionedRow<InnerLite, ValidatorStake> {
-        UnversionedRow {
-            prev_block_hash: self.prev_block_hash,
-            next_block_inner_hash: self.next_block_inner_hash,
-            inner_lite: self.inner_lite,
-            inner_rest_hash: self.inner_rest_hash,
-            next_bps: self.next_bps,
-            approvals_after_next: self.approvals_after_next,
-        }
-    }
-}
-
 /// Parses `value` as an unversioned row, if it is one, and converts it.
 fn read_unversioned_row<InnerLite, ValidatorStake>(value: &[u8]) -> Option<StoredLightClientBlock>
 where
@@ -382,19 +314,9 @@ where
     Some(row.into_stored())
 }
 
-/// Parses `value` as a row from before #2653, if it is one, and converts it.
-fn read_row_with_approvals_next(value: &[u8]) -> Option<StoredLightClientBlock> {
-    let row = UnversionedRowWithApprovalsNext::<
-        InnerLiteWithoutTimestampNanosec,
-        ValidatorStakeViewV1,
-    >::try_from_slice(value)
-    .ok()?;
-    Some(row.without_approvals_next().into_stored())
-}
-
 /// What [`read_light_client_row`] made of a row.
 #[derive(Debug)]
-pub enum LightClientRowReading {
+enum LightClientRowReading {
     /// Every layout that reads the row agrees on the value.
     Agreed { layouts: Vec<LightClientRowLayout>, stored: Box<StoredLightClientBlock> },
     /// Several layouts read the row and disagree on the value, so it cannot be converted.
@@ -408,13 +330,8 @@ pub enum LightClientRowReading {
 /// Borsh rejects trailing bytes, so a row reads in one layout, or in several that all
 /// yield the same value. A row with no validators, for one, reads the same whether or
 /// not `ValidatorStakeView` was versioned when it was written.
-pub fn read_light_client_row(value: &[u8]) -> LightClientRowReading {
+fn read_light_client_row(value: &[u8]) -> LightClientRowReading {
     let readings: Vec<_> = [
-        (LightClientRowLayout::WithApprovalsNext, read_row_with_approvals_next(value)),
-        (
-            LightClientRowLayout::WithoutTimestampNanosec,
-            read_unversioned_row::<InnerLiteWithoutTimestampNanosec, ValidatorStakeViewV1>(value),
-        ),
         (
             LightClientRowLayout::WithUnversionedValidatorStake,
             read_unversioned_row::<InnerLiteWithoutRoot, ValidatorStakeViewV1>(value),
@@ -828,10 +745,7 @@ fn delete_old_block_headers(store: &Store) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod migrate_50_to_51_tests {
-    use super::{
-        InnerLiteWithRoot, InnerLiteWithoutRoot, InnerLiteWithoutTimestampNanosec, UnversionedRow,
-        UnversionedRowWithApprovalsNext, migrate_50_to_51,
-    };
+    use super::{InnerLiteWithRoot, InnerLiteWithoutRoot, UnversionedRow, migrate_50_to_51};
     use borsh::BorshDeserialize;
     use near_crypto::{KeyType, PublicKey};
     use near_primitives::hash::CryptoHash;
@@ -852,20 +766,6 @@ mod migrate_50_to_51_tests {
             timestamp_nanosec: 9,
             next_bp_hash: CryptoHash::hash_bytes(b"bp"),
             block_merkle_root: CryptoHash::hash_bytes(b"merkle"),
-        }
-    }
-
-    fn inner_lite_without_timestamp_nanosec() -> InnerLiteWithoutTimestampNanosec {
-        let with_nanosec = inner_lite_without_root();
-        InnerLiteWithoutTimestampNanosec {
-            height: with_nanosec.height,
-            epoch_id: with_nanosec.epoch_id,
-            next_epoch_id: with_nanosec.next_epoch_id,
-            prev_state_root: with_nanosec.prev_state_root,
-            outcome_root: with_nanosec.outcome_root,
-            timestamp: with_nanosec.timestamp,
-            next_bp_hash: with_nanosec.next_bp_hash,
-            block_merkle_root: with_nanosec.block_merkle_root,
         }
     }
 
@@ -1015,47 +915,6 @@ mod migrate_50_to_51_tests {
         assert_eq!(row.inner_lite.chunk_execution_root, None);
         let next_bps = row.next_bps.unwrap();
         assert_eq!(next_bps, vec![ValidatorStakeView::V1(validator_stake_v1("validator0"))]);
-    }
-
-    #[test]
-    fn rewrites_rows_without_a_timestamp_nanosec() {
-        let store = create_test_store();
-        let key = CryptoHash::default();
-        let value = unversioned_row(
-            inner_lite_without_timestamp_nanosec(),
-            Some(vec![validator_stake_v1("validator0")]),
-            0,
-        );
-        write_row(&store, &key, &value);
-
-        migrate_50_to_51(&store).unwrap();
-
-        let StoredLightClientBlock::V1(row) = read_row(&store, &key);
-        assert_eq!(row.inner_lite.timestamp, 7);
-        assert_eq!(row.inner_lite.timestamp_nanosec, 7);
-    }
-
-    #[test]
-    fn rewrites_rows_with_approvals_next() {
-        let store = create_test_store();
-        let key = CryptoHash::default();
-        let value = borsh::to_vec(&UnversionedRowWithApprovalsNext {
-            prev_block_hash: CryptoHash::hash_bytes(b"prev"),
-            next_block_inner_hash: CryptoHash::hash_bytes(b"next"),
-            inner_lite: inner_lite_without_timestamp_nanosec(),
-            inner_rest_hash: CryptoHash::hash_bytes(b"rest"),
-            next_bps: Some(vec![validator_stake_v1("validator0")]),
-            approvals_next: vec![None, None, None],
-            approvals_after_next: vec![None, None],
-        })
-        .unwrap();
-        write_row(&store, &key, &value);
-
-        migrate_50_to_51(&store).unwrap();
-
-        let StoredLightClientBlock::V1(row) = read_row(&store, &key);
-        assert_eq!(row.approvals_after_next.len(), 2);
-        assert_eq!(row.inner_lite.timestamp_nanosec, 7);
     }
 
     #[test]

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -316,8 +316,12 @@ where
 ///
 /// Borsh rejects trailing and missing bytes, so at most one layout reads a stored row
 /// whole. Only a row with no validators reads in two, and both yield the same value, so
-/// the layouts are tried oldest first.
-fn read_light_client_row(value: &[u8]) -> Option<(LightClientRowLayout, StoredLightClientBlock)> {
+/// the layouts are tried oldest first. A row that no layout reads, or that two layouts
+/// read differently, is one no binary wrote, and is reported by its epoch id.
+fn read_light_client_row(
+    epoch_id: &EpochId,
+    value: &[u8],
+) -> anyhow::Result<(LightClientRowLayout, StoredLightClientBlock)> {
     let candidates = [
         (
             LightClientRowLayout::WithUnversionedValidatorStake,
@@ -333,7 +337,16 @@ fn read_light_client_row(value: &[u8]) -> Option<(LightClientRowLayout, StoredLi
         ),
         (LightClientRowLayout::Versioned, StoredLightClientBlock::try_from_slice(value).ok()),
     ];
-    candidates.into_iter().find_map(|(layout, stored)| Some((layout, stored?)))
+    let mut matched = candidates.into_iter().filter_map(|(layout, stored)| Some((layout, stored?)));
+    let Some((layout, stored)) = matched.next() else {
+        anyhow::bail!("epoch light client block {epoch_id:?} reads in no known layout");
+    };
+    if let Some((other, _)) = matched.find(|(_, candidate)| *candidate != stored) {
+        anyhow::bail!(
+            "epoch light client block {epoch_id:?} reads differently as {layout:?} and {other:?}"
+        );
+    }
+    Ok((layout, stored))
 }
 
 /// Migrates the database from version 50 to 51.
@@ -363,15 +376,12 @@ fn migrate_50_to_51(hot_store: &Store) -> anyhow::Result<()> {
             .map(EpochId)
             .map_err(|err| anyhow::anyhow!("epoch light client block key is not a hash: {err}"))?;
 
-        match read_light_client_row(&value) {
-            Some((LightClientRowLayout::Versioned, _)) => already_versioned += 1,
-            Some((_, stored)) => {
-                store_update.set_ser(DBCol::EpochLightClientBlocks, &key, &stored);
-                rewritten += 1;
-            }
-            None => {
-                anyhow::bail!("epoch light client block {epoch_id:?} reads in no known layout")
-            }
+        let (layout, stored) = read_light_client_row(&epoch_id, &value)?;
+        if layout == LightClientRowLayout::Versioned {
+            already_versioned += 1;
+        } else {
+            store_update.set_ser(DBCol::EpochLightClientBlocks, &key, &stored);
+            rewritten += 1;
         }
     }
     store_update.commit();

--- a/tools/database/Cargo.toml
+++ b/tools/database/Cargo.toml
@@ -20,6 +20,7 @@ parking_lot.workspace = true
 rand.workspace = true
 rayon.workspace = true
 rocksdb.workspace = true
+serde_json.workspace = true
 strum.workspace = true
 tempfile.workspace = true
 bytesize.workspace = true

--- a/tools/database/src/analyze_epoch_light_client_blocks.rs
+++ b/tools/database/src/analyze_epoch_light_client_blocks.rs
@@ -1,0 +1,177 @@
+use crate::utils::open_rocksdb;
+use clap::Parser;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{BlockHeight, EpochId};
+use near_store::db::Database;
+use near_store::light_client_block::StoredLightClientBlock;
+use near_store::{DBCol, Mode};
+use nearcore::migrations::{LightClientRowLayout, read_light_client_row};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Reports which layout every `DBCol::EpochLightClientBlocks` row is in, without
+/// writing anything. This is the dry run of the version 50 to 51 migration: it reads
+/// the rows with the same code the migration uses, so a clean report means the
+/// migration converts every row.
+///
+/// The database is opened read-only and directly, so neither the database version
+/// check nor any migration runs.
+#[derive(Parser)]
+pub(crate) struct AnalyzeEpochLightClientBlocksCommand {
+    /// Directory to write the rows the migration stops on, one file per epoch id, for
+    /// decoding.
+    #[arg(long)]
+    rejected_rows_dir: Option<PathBuf>,
+}
+
+/// The rows one layout accounts for. The block heights say which era the layout
+/// covers; the epoch id keys are hashes and carry no order.
+#[derive(Default)]
+struct LayoutCounts {
+    rows: usize,
+    lowest_height: Option<BlockHeight>,
+    highest_height: Option<BlockHeight>,
+}
+
+impl AnalyzeEpochLightClientBlocksCommand {
+    pub(crate) fn run(&self, home: &Path) -> anyhow::Result<()> {
+        let db = open_rocksdb(home, Mode::ReadOnly)?;
+
+        let mut counts: BTreeMap<LightClientRowLayout, LayoutCounts> = BTreeMap::new();
+        let mut rejected = Vec::new();
+        let mut total = 0;
+
+        for (key, value) in db.iter(DBCol::EpochLightClientBlocks) {
+            total += 1;
+            let epoch_id = CryptoHash::try_from(key.as_ref()).map(EpochId).map_err(|err| {
+                anyhow::anyhow!("epoch light client block key is not a hash: {err}")
+            })?;
+
+            let (layout, stored) = match read_light_client_row(&epoch_id, &value) {
+                Ok(reading) => reading,
+                Err(err) => {
+                    rejected.push((epoch_id, value.to_vec(), err));
+                    continue;
+                }
+            };
+            let StoredLightClientBlock::V1(stored) = stored;
+            let height = stored.inner_lite.height;
+            let entry = counts.entry(layout).or_default();
+            entry.rows += 1;
+            entry.lowest_height = Some(entry.lowest_height.unwrap_or(height).min(height));
+            entry.highest_height = Some(entry.highest_height.unwrap_or(height).max(height));
+        }
+
+        println!("{total} rows in {}", DBCol::EpochLightClientBlocks);
+        println!();
+        println!("rows the migration converts, by layout:");
+        for (layout, count) in &counts {
+            println!(
+                "  {:>8}  heights {}..={}  {layout:?}",
+                count.rows,
+                count.lowest_height.unwrap(),
+                count.highest_height.unwrap(),
+            );
+        }
+
+        println!();
+        println!("rows the migration stops on: {}", rejected.len());
+        for (_, value, err) in &rejected {
+            println!("  {err} ({} bytes)", value.len());
+        }
+
+        if let Some(dir) = &self.rejected_rows_dir {
+            std::fs::create_dir_all(dir)?;
+            for (epoch_id, value, _) in &rejected {
+                std::fs::write(dir.join(epoch_id.0.to_string()), value)?;
+            }
+            println!("wrote {} of them to {}", rejected.len(), dir.display());
+        }
+
+        if rejected.is_empty() {
+            println!();
+            println!("the migration converts every row in this database");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AnalyzeEpochLightClientBlocksCommand;
+    use near_primitives::hash::CryptoHash;
+    use near_store::db::{DBTransaction, Database, RocksDB};
+    use near_store::light_client_block::{
+        StoredBlockHeaderInnerLiteV1, StoredLightClientBlock, StoredLightClientBlockV1,
+    };
+    use near_store::{DBCol, Mode, StoreConfig, Temperature};
+
+    fn versioned_row() -> Vec<u8> {
+        borsh::to_vec(&StoredLightClientBlock::V1(StoredLightClientBlockV1 {
+            prev_block_hash: CryptoHash::hash_bytes(b"prev"),
+            next_block_inner_hash: CryptoHash::hash_bytes(b"next"),
+            inner_lite: StoredBlockHeaderInnerLiteV1 {
+                height: 42,
+                epoch_id: CryptoHash::hash_bytes(b"epoch"),
+                next_epoch_id: CryptoHash::hash_bytes(b"next_epoch"),
+                prev_state_root: CryptoHash::hash_bytes(b"state"),
+                outcome_root: CryptoHash::hash_bytes(b"outcome"),
+                timestamp: 7,
+                timestamp_nanosec: 7,
+                next_bp_hash: CryptoHash::hash_bytes(b"bp"),
+                block_merkle_root: CryptoHash::hash_bytes(b"merkle"),
+                chunk_execution_root: None,
+            },
+            inner_rest_hash: CryptoHash::hash_bytes(b"rest"),
+            next_bps: None,
+            approvals_after_next: vec![None],
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn writes_rejected_rows_to_a_directory() {
+        let home = tempfile::tempdir().unwrap();
+        let config = nearcore::config::Config::default();
+        std::fs::write(
+            home.path().join(nearcore::config::CONFIG_FILENAME),
+            serde_json::to_string(&config).unwrap(),
+        )
+        .unwrap();
+
+        let db_path = home.path().join("data");
+        let store_config = StoreConfig::default();
+        {
+            let db =
+                RocksDB::open(&db_path, &store_config, Mode::Create, Temperature::Hot).unwrap();
+            let mut transaction = DBTransaction::new();
+            transaction.set(
+                DBCol::EpochLightClientBlocks,
+                CryptoHash::default().as_bytes().to_vec(),
+                b"not a light client block".to_vec(),
+            );
+            transaction.set(
+                DBCol::EpochLightClientBlocks,
+                CryptoHash::hash_bytes(b"epoch").as_bytes().to_vec(),
+                versioned_row(),
+            );
+            db.write(transaction);
+        }
+
+        let rejected_rows_dir = home.path().join("rejected");
+        let command = AnalyzeEpochLightClientBlocksCommand {
+            rejected_rows_dir: Some(rejected_rows_dir.clone()),
+        };
+        command.run(home.path()).unwrap();
+
+        let dumped: Vec<_> = std::fs::read_dir(&rejected_rows_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(dumped, vec![CryptoHash::default().to_string()]);
+        assert_eq!(
+            std::fs::read(rejected_rows_dir.join(CryptoHash::default().to_string())).unwrap(),
+            b"not a light client block",
+        );
+    }
+}

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -2,6 +2,7 @@ use crate::adjust_database::ChangeDbKindCommand;
 use crate::analyze_contract_sizes::AnalyzeContractSizesCommand;
 use crate::analyze_data_size_distribution::AnalyzeDataSizeDistributionCommand;
 use crate::analyze_delayed_receipt::AnalyzeDelayedReceiptCommand;
+use crate::analyze_epoch_light_client_blocks::AnalyzeEpochLightClientBlocksCommand;
 use crate::analyze_gas_usage::AnalyzeGasUsageCommand;
 use crate::analyze_high_load::HighLoadStatsCommand;
 use crate::backfill_receipt_to_tx::BackfillReceiptToTxCommand;
@@ -31,6 +32,10 @@ pub struct DatabaseCommand {
 enum SubCommand {
     /// Analyze data size distribution in RocksDB
     AnalyzeDataSizeDistribution(AnalyzeDataSizeDistributionCommand),
+
+    /// Report which layout every EpochLightClientBlocks row is in, without writing.
+    /// This is the dry run of the version 50 to 51 migration.
+    AnalyzeEpochLightClientBlocks(AnalyzeEpochLightClientBlocksCommand),
 
     /// Analyze gas usage in a chosen sequence of blocks
     AnalyzeGasUsage(AnalyzeGasUsageCommand),
@@ -90,6 +95,7 @@ impl DatabaseCommand {
     ) -> anyhow::Result<()> {
         match &self.subcmd {
             SubCommand::AnalyzeDataSizeDistribution(cmd) => cmd.run(home),
+            SubCommand::AnalyzeEpochLightClientBlocks(cmd) => cmd.run(home),
             SubCommand::AnalyzeGasUsage(cmd) => cmd.run(home, genesis_validation),
             SubCommand::ChangeDbKind(cmd) => cmd.run(home, genesis_validation),
             SubCommand::CompactDatabase(cmd) => cmd.run(home),

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -2,6 +2,7 @@ mod adjust_database;
 mod analyze_contract_sizes;
 mod analyze_data_size_distribution;
 mod analyze_delayed_receipt;
+mod analyze_epoch_light_client_blocks;
 mod analyze_gas_usage;
 mod analyze_high_load;
 pub mod backfill_receipt_to_tx;

--- a/tools/database/src/utils.rs
+++ b/tools/database/src/utils.rs
@@ -20,7 +20,10 @@ pub(crate) fn open_rocksdb(
         &home.join(nearcore::config::CONFIG_FILENAME),
     )?;
     let store_config = &config.store;
-    let db_path = store_config.path.as_ref().cloned().unwrap_or_else(|| home.join("data"));
+    // `StoreOpener` resolves a relative `store.path` against the home directory, so an
+    // archival node whose config says `hot-data` means `<home>/hot-data`. Joining an
+    // absolute path leaves it as it is.
+    let db_path = home.join(store_config.path.as_deref().unwrap_or_else(|| Path::new("data")));
     let rocksdb =
         near_store::db::RocksDB::open(&db_path, store_config, mode, near_store::Temperature::Hot)?;
     Ok(rocksdb)


### PR DESCRIPTION
Stacked on #16396.

Migration 50 to 51 rewrites `DBCol::EpochLightClientBlocks`, whose rows outlive the binaries that wrote them. #16396 teaches it to read an older layout, but the only way to know which layouts a given database actually holds is to look. `neard database analyze-epoch-light-client-blocks` reports that without writing anything:

```
neard --home /home/ubuntu/.near database analyze-epoch-light-client-blocks \
    --unreadable-rows-dir /tmp/light-client-rows
```

```
4641 rows in EpochLightClientBlocks

rows the migration converts, by layout:
       952  heights 9863411..=55050662  [WithUnversionedValidatorStake]
      3689  heights 55093862..=214501931  [Released]

rows that read differently in several layouts: 0

rows that no layout reads: 0
```

It reads each row with the same `read_light_client_row` the migration uses, so a clean report means the migration converts every row on that node. Rows no layout reads are written to `--unreadable-rows-dir` for decoding, since those are the ones that would stop the migration. The database is opened read-only and directly, so neither the version check nor any migration runs; run it with `neard` stopped.

The height range per layout is more useful than the epoch id keys, which are hashes and carry no order. On mainnet the lowest row sits one epoch above the genesis height of 9820210, which is the genesis-epoch row that #16396 is about.

The second commit fixes `open_rocksdb`, which used `store.path` verbatim instead of resolving it against `--home`, the way `StoreOpener` does. Every archival node sets a relative `store.path` of `hot-data`, so every `neard database` subcommand failed on exactly the nodes this tool is for:

```
failed to open rocksdb instance path=hot-data mode=ReadOnly
error=IO error: No such file or directory: hot-data/CURRENT
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)