### PR TITLE
chore(runtime): remove wasmtime_vm feature

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -57,7 +57,7 @@ near-o11y.workspace = true
 near-telemetry.workspace = true
 near-test-contracts.workspace = true
 near-rosetta-rpc.workspace = true
-near-vm-runner = { workspace = true, features = ["prepare"] }
+near-vm-runner.workspace = true
 near-wallet-contract.workspace = true
 nearcore.workspace = true
 node-runtime.workspace = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -13,19 +13,19 @@ publish = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, optional = true }
+anyhow.workspace = true
 blst.workspace = true
 bn.workspace = true
 borsh.workspace = true
 dashmap.workspace = true
 ed25519-dalek.workspace = true
 enum-map.workspace = true
-finite-wasm-6 = { workspace = true, optional = true }
+finite-wasm-6.workspace = true
 lru.workspace = true
 num-rational.workspace = true
 p256.workspace = true
 parking_lot.workspace = true
-prefix-sum-vec = { workspace = true, optional = true }
+prefix-sum-vec.workspace = true
 prometheus = { workspace = true, optional = true }
 rand.workspace = true
 ripemd.workspace = true
@@ -38,14 +38,14 @@ strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-wasm-encoder = { workspace = true, features = ["wasmparser"], optional = true }
-wasmparser-236 = { workspace = true, optional = true }
+wasm-encoder = { workspace = true, features = ["wasmparser"] }
+wasmparser-236.workspace = true
 wasmtime = { workspace = true, features = [
     "call-hook",
     "parallel-compilation",
     "pooling-allocator",
     "runtime",
-], optional = true }
+] }
 
 near-crypto.workspace = true
 near-o11y = { workspace = true, optional = true }
@@ -75,16 +75,7 @@ wasm-smith.workspace = true
 wat.workspace = true
 
 [features]
-default = ["wasmtime_vm"]
-wasmtime_vm = ["wasmtime", "anyhow", "prepare"]
-prepare = [
-    "finite-wasm-6",
-    "wasm-encoder",
-    "wasmparser-236",
-    "prefix-sum-vec",
-    "metrics",
-]
-
+default = ["metrics"]
 metrics = ["prometheus", "near-o11y"]
 
 nightly = [
@@ -107,7 +98,7 @@ costs_counting = []
 [[bin]]
 name = "bench-contracts-compilation"
 path = "benchmarks/compile_contracts.rs"
-required-features = ["wasmtime_vm"]
+required-features = ["metrics"]
 
 [package.metadata.cargo-machete]
 ignored = ["prometheus"]

--- a/runtime/near-vm-runner/README.md
+++ b/runtime/near-vm-runner/README.md
@@ -29,7 +29,7 @@ The entry point is the `runner::run` function.
 There are a bunch of unit-tests in this crate. You can run them with
 
 ```console
-$ cargo t -p near-vm-runner --features wasmtime_vm,near_vm
+$ cargo t -p near-vm-runner --features test_features
 ```
 
 The tests use either a short wasm snippet specified inline, or a couple of

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -33,7 +33,6 @@ use std::sync::Arc;
 #[cfg(not(windows))]
 use std::time::{Duration, Instant};
 
-#[cfg(feature = "wasmtime_vm")]
 // FIXME(ProtocolSchema): this isn't really part of the protocol schema??
 #[derive(Debug, Clone, BorshSerialize, near_schema_checker_lib::ProtocolSchema)]
 enum ContractCacheKey {
@@ -49,7 +48,6 @@ enum ContractCacheKey {
     },
 }
 
-#[cfg(feature = "wasmtime_vm")]
 pub(crate) fn get_contract_cache_key(
     code_hash: CryptoHash,
     config: &Config,
@@ -72,7 +70,6 @@ pub(crate) fn get_contract_cache_key(
 /// Use this to compare two configs without enumerating cache-key inputs by
 /// hand — adding a new field to [`ContractCacheKey`] flows through here
 /// automatically.
-#[cfg(feature = "wasmtime_vm")]
 pub fn config_cache_key_signature(config: Arc<Config>) -> CryptoHash {
     let vm_kind = config.vm_kind;
     let runtime = vm_kind

--- a/runtime/near-vm-runner/src/features.rs
+++ b/runtime/near-vm-runner/src/features.rs
@@ -37,7 +37,6 @@ impl WasmFeatures {
     }
 }
 
-#[cfg(feature = "finite-wasm-6")]
 impl From<WasmFeatures> for finite_wasm_6::wasmparser::WasmFeatures {
     fn from(f: WasmFeatures) -> Self {
         finite_wasm_6::wasmparser::WasmFeaturesInflated {
@@ -78,7 +77,6 @@ impl From<WasmFeatures> for finite_wasm_6::wasmparser::WasmFeatures {
     }
 }
 
-#[cfg(feature = "wasmtime_vm")]
 impl From<WasmFeatures> for wasmtime::Config {
     fn from(_: WasmFeatures) -> Self {
         // preparation code did all the filtering necessary already. Default configuration supports

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -47,7 +47,6 @@
 //! make imports retroactively available to old transactions. So
 //! `for_each_available_import` takes care to invoke `M!` only for currently
 //! available imports.
-#![cfg(feature = "wasmtime_vm")]
 
 macro_rules! call_with_name {
     ( $M:ident => @in $mod:ident : $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] > ) => {

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -9,20 +9,17 @@ mod imports;
 pub mod logic;
 #[cfg(feature = "metrics")]
 mod metrics;
-#[cfg(feature = "prepare")]
 pub mod prepare;
 mod profile;
 mod runner;
 #[cfg(test)]
 mod tests;
 mod utils;
-#[cfg(feature = "wasmtime_vm")]
 mod wasmtime_runner;
 
 pub use crate::logic::with_ext_cost_counter;
 #[cfg(not(windows))]
 pub use cache::FilesystemContractRuntimeCache;
-#[cfg(feature = "wasmtime_vm")]
 pub use cache::config_cache_key_signature;
 pub use cache::{
     CompiledContract, CompiledContractInfo, ContractRuntimeCache, MockContractRuntimeCache,
@@ -35,16 +32,12 @@ pub use near_primitives_core::code::ContractCode;
 pub use profile::ProfileDataV3;
 pub use runner::{Contract, PreparedContract, VM, contract_cached, prepare, run};
 
-#[cfg(any(feature = "prepare", feature = "wasmtime_vm"))]
 pub(crate) const MEMORY_EXPORT: &str = "memory";
 
-#[cfg(any(feature = "prepare", feature = "wasmtime_vm"))]
 pub(crate) const REMAINING_GAS_EXPORT: &str = "remaining_gas";
 
-#[cfg(any(feature = "prepare", feature = "wasmtime_vm"))]
 pub(crate) const START_EXPORT: &str = "start";
 
-#[cfg(any(feature = "prepare", feature = "wasmtime_vm"))]
 pub(crate) const EXPORT_PREFIX: &str = "\0";
 
 /// This is public for internal experimentation use only, and should otherwise be considered an

--- a/runtime/near-vm-runner/src/logic/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/gas_counter.rs
@@ -220,7 +220,6 @@ impl GasCounter {
     /// structure into consideration could be added. But since that would have
     /// to happen after loading, we cannot pre-charge it. This is the main
     /// motivation to (only) have this simple fee.
-    #[cfg(feature = "wasmtime_vm")]
     pub(crate) fn add_contract_loading_fee(&mut self, code_len: u64) -> Result<()> {
         self.pay_per(ExtCosts::contract_loading_bytes, code_len)?;
         self.pay_base(ExtCosts::contract_loading_base)
@@ -231,7 +230,6 @@ impl GasCounter {
     /// Does VM independent checks that happen after the host state has been set
     /// up but before loading the executable. This includes pre-charging gas
     /// costs for loading the executable, which depends on the size of the WASM code.
-    #[cfg(feature = "wasmtime_vm")]
     pub(crate) fn before_loading_executable(
         &mut self,
         config: &near_parameters::vm::Config,
@@ -255,7 +253,6 @@ impl GasCounter {
     }
 
     /// Legacy code to preserve old gas charging behaviour in old protocol versions.
-    #[cfg(feature = "wasmtime_vm")]
     pub(crate) fn after_loading_executable(
         &mut self,
         config: &near_parameters::vm::Config,

--- a/runtime/near-vm-runner/src/logic/mod.rs
+++ b/runtime/near-vm-runner/src/logic/mod.rs
@@ -1,8 +1,3 @@
-// Without a VM backend there is nothing calling the host-function support code in this module
-// (registers, gas payment helpers, bls12381 / alt_bn128 primitives, ...); it only exists to serve
-// `wasmtime_runner`. Keep the crate building as a types-only dependency in that configuration.
-#![cfg_attr(not(feature = "wasmtime_vm"), allow(dead_code))]
-
 pub(crate) mod alt_bn128;
 pub(crate) mod bls12381;
 mod context;
@@ -12,7 +7,7 @@ pub mod gas_counter;
 pub(crate) mod logic;
 pub mod mocks;
 pub mod recorded_storage_counter;
-#[cfg(all(test, feature = "wasmtime_vm"))]
+#[cfg(test)]
 mod tests;
 pub mod types;
 pub(crate) mod utils;

--- a/runtime/near-vm-runner/src/metrics.rs
+++ b/runtime/near-vm-runner/src/metrics.rs
@@ -88,7 +88,6 @@ struct Metrics {
     compiled_contract_memory_cache_hits: u64,
 }
 
-#[cfg(feature = "wasmtime_vm")]
 pub(crate) fn compilation_duration(duration: Duration) {
     METRICS.with_borrow_mut(|m| m.compilation_time += duration);
 }
@@ -98,7 +97,6 @@ pub(crate) fn record_execution_duration(duration: Duration) {
 }
 
 /// Records the result of a compiled-contract cache lookup.
-#[cfg(feature = "wasmtime_vm")]
 pub(crate) fn record_compiled_contract_cache_lookup(is_hit: bool, is_memory_hit: bool) {
     METRICS.with_borrow_mut(|m| {
         m.compiled_contract_cache_lookups += 1;

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -207,15 +207,13 @@ impl VMKindExt for VMKind {
             #[allow(deprecated)]
             Self::Wasmer0 => false,
             Self::Wasmer2 => false,
-            Self::Wasmtime => cfg!(feature = "wasmtime_vm"),
+            Self::Wasmtime => true,
             Self::NearVm => false,
         }
     }
     fn runtime(&self, config: std::sync::Arc<Config>) -> Option<Box<dyn VM>> {
         match self {
-            #[cfg(feature = "wasmtime_vm")]
             Self::Wasmtime => Some(Box::new(crate::wasmtime_runner::WasmtimeVM::new(config))),
-            #[allow(unreachable_patterns)] // reachable when some of the VMs are disabled.
             _ => {
                 let _ = config;
                 None

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -1,7 +1,6 @@
 mod cache;
 mod chain_id_integration;
 mod compile_errors;
-#[cfg(feature = "prepare")]
 mod fuzzers;
 mod ml_dsa_verify_integration;
 mod p256_verify_integration;
@@ -36,13 +35,11 @@ pub(crate) fn test_vm_config(vm_kind: Option<VMKind>) -> near_parameters::vm::Co
 }
 
 pub(crate) fn with_vm_variants(runner: impl Fn(VMKind) -> ()) {
-    #[allow(unused)]
     let run = move |kind| {
         println!("running test with {kind:?}");
         runner(kind)
     };
 
-    #[cfg(feature = "wasmtime_vm")]
     run(VMKind::Wasmtime);
 }
 

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -131,7 +131,7 @@ fn make_cached_contract_call_vm(
 }
 
 #[test]
-#[cfg(all(feature = "wasmtime_vm", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 fn test_wasmtime_artifact_output_stability() {
     use crate::prepare;
     use crate::wasmtime_runner::WasmtimeVM;
@@ -206,7 +206,6 @@ fn test_wasmtime_artifact_output_stability() {
     // can be adjusted.
 }
 
-#[cfg(feature = "wasmtime_vm")]
 fn sparse_wasm_contract() -> Vec<u8> {
     // A tiny contract declaring 1 MiB of linear memory with data bytes at
     // the extremes. Without segment-by-segment initialization, the dense
@@ -222,7 +221,6 @@ fn sparse_wasm_contract() -> Vec<u8> {
 }
 
 #[test]
-#[cfg(feature = "wasmtime_vm")]
 fn test_wasmtime_sparse_contract_compiled_size() {
     use crate::wasmtime_runner::WasmtimeVM;
     let contract = ContractCode::new(sparse_wasm_contract(), None);
@@ -237,7 +235,7 @@ fn test_wasmtime_sparse_contract_compiled_size() {
 }
 
 #[test]
-#[cfg(all(feature = "wasmtime_vm", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 fn test_wasmtime_sparse_contract_stability() {
     use crate::prepare;
     use crate::wasmtime_runner::WasmtimeVM;
@@ -306,7 +304,6 @@ impl ContractRuntimeCache for FaultingContractRuntimeCache {
 
 /// Verify that two threads racing to compile the same contract only produce one
 /// compilation, and that no lock entries leak in the global map.
-#[cfg(feature = "wasmtime_vm")]
 #[test]
 fn test_no_duplicate_compilation() {
     use crate::cache::get_contract_cache_key;

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -11,7 +11,6 @@ use near_test_contracts::ArbitraryModule;
 use std::sync::Arc;
 
 /// Finds a no-parameter exported function, something like `(func (export "entry-point"))`.
-#[cfg(feature = "prepare")]
 pub fn find_entry_point(contract: &ContractCode) -> Option<String> {
     use wasmparser_236::{Export, ExternalKind, Parser, Payload};
     let mut tys = Vec::new();
@@ -63,7 +62,6 @@ pub fn create_context(input: Vec<u8>) -> VMContext {
     }
 }
 
-#[cfg(feature = "prepare")]
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
     let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
@@ -94,7 +92,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
 }
 
 #[test]
-#[cfg(feature = "prepare")]
 fn slow_test_current_vm_does_not_crash_fuzzer() {
     let config = test_vm_config(None);
     if config.vm_kind.is_available() {
@@ -108,7 +105,6 @@ fn slow_test_current_vm_does_not_crash_fuzzer() {
 }
 
 #[test]
-#[cfg(feature = "wasmtime_vm")]
 fn slow_test_wasmtime_vm_is_reproducible_fuzzer() {
     use crate::wasmtime_runner::WasmtimeVM;
     use near_primitives_core::hash::CryptoHash;

--- a/runtime/near-vm-runner/src/tests/wasm_validation.rs
+++ b/runtime/near-vm-runner/src/tests/wasm_validation.rs
@@ -1,7 +1,5 @@
 use super::test_builder::test_builder;
-#[cfg(feature = "prepare")]
 use super::test_vm_config;
-#[cfg(feature = "prepare")]
 use crate::{MEMORY_EXPORT, REMAINING_GAS_EXPORT, START_EXPORT};
 use expect_test::expect;
 use near_primitives_core::version::ProtocolFeature;
@@ -102,7 +100,6 @@ static EXPECTED_UNSUPPORTED: &[(&str, &str)] = &[
 ];
 
 #[test]
-#[cfg(feature = "prepare")]
 fn ensure_fails_verification() {
     crate::tests::with_vm_variants(|kind| {
         let config = test_vm_config(Some(kind));
@@ -167,7 +164,6 @@ fn memory_export_method() {
         ]);
 }
 
-#[cfg(feature = "prepare")]
 #[test]
 fn memory_export_clash() {
     test_builder()
@@ -185,7 +181,6 @@ fn memory_export_clash() {
         ]);
 }
 
-#[cfg(feature = "prepare")]
 #[test]
 fn gas_export_clash() {
     test_builder()
@@ -203,7 +198,6 @@ fn gas_export_clash() {
         ]);
 }
 
-#[cfg(feature = "prepare")]
 #[test]
 fn start_export_clash() {
     test_builder()
@@ -221,7 +215,6 @@ fn start_export_clash() {
         ]);
 }
 
-#[cfg(feature = "prepare")]
 #[test]
 fn start_export_clash_duplicate() {
     test_builder()
@@ -240,7 +233,6 @@ fn start_export_clash_duplicate() {
         ]);
 }
 
-#[cfg(feature = "prepare")]
 #[test]
 fn memory_export_internal() {
     test_builder()

--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -592,6 +592,7 @@ impl WasmtimeVM {
             "wasmtime compiled contract",
         );
 
+        #[cfg(feature = "metrics")]
         crate::metrics::compilation_duration(elapsed);
         Ok(serialized)
     }
@@ -809,6 +810,7 @@ impl WasmtimeVM {
             },
         )?;
 
+        #[cfg(feature = "metrics")]
         crate::metrics::record_compiled_contract_cache_lookup(is_cache_hit, is_memory_hit);
         let config = Arc::clone(&self.config);
         let result = gas_counter.before_loading_executable(&config, &method, wasm_bytes);

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -45,7 +45,7 @@ near-parameters = { workspace = true, features = ["clap"] }
 near-primitives.workspace = true
 near-store.workspace = true
 near-test-contracts.workspace = true
-near-vm-runner = { workspace = true, features = [ "prepare" ] }
+near-vm-runner.workspace = true
 nearcore.workspace = true
 node-runtime = { workspace = true, features = ["estimator"] }
 

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -34,7 +34,7 @@ near-parameters.workspace = true
 near-primitives.workspace = true
 near-primitives-core.workspace = true
 near-store.workspace = true
-near-vm-runner = { workspace = true, features = ["wasmtime_vm"] }
+near-vm-runner.workspace = true
 near-wallet-contract.workspace = true
 
 [features]


### PR DESCRIPTION
With wasmtime being the only vm, I don't really see a reason why one would want to use vm-runner without wasmtime.

We retain the infrastructure to support multiple VMs, which we will need for Wasmtime version upgrades. But the compile-time conditional should be safe to remove.